### PR TITLE
8303799: [BACKOUT] JDK-8302801 Remove fdlibm C sources

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,7 @@ define SetupBuildLauncherBody
           $$(shell $(FIND) $(SUPPORT_OUTPUTDIR)/modules_libs/java.base -name "*.a") \
           $(SUPPORT_OUTPUTDIR)/modules_libs/jdk.jdwp.agent/libdt_socket.a \
           $(SUPPORT_OUTPUTDIR)/modules_libs/jdk.jdwp.agent/libjdwp.a \
+          $(SUPPORT_OUTPUTDIR)/native/java.base/$(LIBRARY_PREFIX)fdlibm$(STATIC_LIBRARY_SUFFIX) \
           -framework CoreFoundation \
           -framework Foundation \
           -framework SystemConfiguration \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -24,6 +24,43 @@
 #
 
 ##########################################################################################
+# libfdlibm is statically linked with libjava below and not delivered into the
+# product on its own.
+
+BUILD_LIBFDLIBM_OPTIMIZATION := NONE
+
+# If FDLIBM_CFLAGS is non-empty we know that we can optimize
+# fdlibm when adding those extra C flags. Currently GCC,
+# and clang only.
+ifneq ($(FDLIBM_CFLAGS), )
+  BUILD_LIBFDLIBM_OPTIMIZATION := LOW
+endif
+
+LIBFDLIBM_SRC := $(TOPDIR)/src/java.base/share/native/libfdlibm
+LIBFDLIBM_CFLAGS := -I$(LIBFDLIBM_SRC) $(FDLIBM_CFLAGS)
+
+$(eval $(call SetupNativeCompilation, BUILD_LIBFDLIBM, \
+    NAME := fdlibm, \
+    TYPE := STATIC_LIBRARY, \
+    OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE), \
+    SRC := $(LIBFDLIBM_SRC), \
+    OPTIMIZATION := $(BUILD_LIBFDLIBM_OPTIMIZATION), \
+    CFLAGS := $(CFLAGS_JDKLIB) $(LIBFDLIBM_CFLAGS), \
+    CFLAGS_windows_debug := -DLOGGING, \
+    CFLAGS_aix := -qfloat=nomaf, \
+    DISABLED_WARNINGS_gcc := sign-compare, \
+    DISABLED_WARNINGS_gcc_k_rem_pio2.c := maybe-uninitialized, \
+    DISABLED_WARNINGS_clang := sign-compare, \
+    DISABLED_WARNINGS_microsoft := 4146, \
+    DISABLED_WARNINGS_microsoft_e_exp.c := 4244, \
+    DISABLED_WARNINGS_microsoft_s_ceil.c := 4018, \
+    DISABLED_WARNINGS_microsoft_s_expm1.c := 4244, \
+    DISABLED_WARNINGS_microsoft_s_floor.c := 4018, \
+    ARFLAGS := $(ARFLAGS), \
+    OBJECT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libfdlibm, \
+))
+
+##########################################################################################
 
 LIBVERIFY_OPTIMIZATION := HIGH
 ifeq ($(call isTargetOs, linux), true)
@@ -59,12 +96,14 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LIBJAVA_CFLAGS), \
     jdk_util.c_CFLAGS := $(VERSION_CFLAGS), \
+    EXTRA_HEADER_DIRS := libfdlibm, \
     WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc_ProcessImpl_md.c := unused-result, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LDFLAGS_macosx := -L$(SUPPORT_OUTPUTDIR)/native/$(MODULE)/, \
     LDFLAGS_windows := -delayload:shell32.dll, \
+    LIBS := $(BUILD_LIBFDLIBM_TARGET), \
     LIBS_unix := -ljvm, \
     LIBS_linux := $(LIBDL), \
     LIBS_aix := $(LIBDL) $(LIBM),\
@@ -80,6 +119,7 @@ TARGETS += $(BUILD_LIBJAVA)
 
 $(BUILD_LIBJAVA): $(BUILD_LIBVERIFY)
 
+$(BUILD_LIBJAVA): $(BUILD_LIBFDLIBM)
 
 ##########################################################################################
 

--- a/src/hotspot/os/windows/sharedRuntimeRem.cpp
+++ b/src/hotspot/os/windows/sharedRuntimeRem.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,13 @@
 #include "runtime/sharedRuntime.hpp"
 
 #ifdef _WIN64
-// These are copied defines originally from fdlibm.h.
+// These are copied defines from fdlibm.h, this allows us to keep the code
+// the same as in the JDK, for easier maintenance.
 
 #define __HI(x) *(1+(int*)&x)
 #define __LO(x) *(int*)&x
 
-// This code is a copy of __ieee754_fmod() formerly from the JDK's libfdlibm and is
+// This code is a copy of __ieee754_fmod() from the JDK's libfdlibm and is
 // used as a workaround for issues with the Windows x64 CRT implementation
 // of fmod. Microsoft has acknowledged that this is an issue in Visual Studio
 // 2012 and forward, but has not provided a time frame for a fix other than that

--- a/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,14 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/sharedRuntimeMath.hpp"
 
-// This file contains copies of the C fdlibm routines originally used
-// by StrictMath. The StrictMath sin, cos, and tan methods now use a
-// Java port of the algorithm in java.lang.Fdlibm.java.
+// This file contains copies of the fdlibm routines used by
+// StrictMath. It turns out that it is almost always required to use
+// these runtime routines; the Intel CPU doesn't meet the Java
+// specification for sin/cos outside a certain limited argument range,
+// and the SPARC CPU doesn't appear to have sin/cos instructions. It
+// also turns out that avoiding the indirect call through function
+// pointer out to libjava.so in SharedRuntime speeds these routines up
+// by roughly 15% on both Win32/x86 and Solaris/SPARC.
 
 /*
  * __kernel_rem_pio2(x,y,e0,nx,prec,ipio2)

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -42,28 +42,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * Library," <a
  * href="https://www.netlib.org/fdlibm/">{@code fdlibm}</a>. These
  * algorithms, which are written in the C programming language, are
- * then to be understood to be transliterated into Java and executed
- * with all floating-point and integer operations following the rules
- * of Java arithmetic. The following transformations are used in the
- * transliteration:
- *
- * <ul>
- * <li>Extraction and setting of the high and low halves of a 64-bit
- * {@code double} in C is expressed using Java platform methods that
- * perform bit-wise conversions {@linkplain
- * Double#doubleToRawLongBits(double) from {@code double} to {@code
- * long}} and {@linkplain Double#longBitsToDouble(long) {@code long}
- * to {@code double}}.
- *
- * <li>Unsigned {@code int} values in C are mapped to signed {@code
- * int} values in Java with updates to operations to replicate
- * unsigned semantics where the results on the same textual operation
- * would differ. For example, {@code >>} shifts on unsigned C values
- * are replaced with {@code >>>} shifts on signed Java values. Sized
- * comparisons on unsigned C values ({@code <}, {@code <=}, {@code >},
- * {@code >=}) are replaced with semantically equivalent calls to
- * {@link Integer#compareUnsigned(int, int) compareUnsigned}.
- * </ul>
+ * then to be understood as executed with all floating-point
+ * operations following the rules of Java floating-point arithmetic.
  *
  * <p>The Java math library is defined with respect to
  * {@code fdlibm} version 5.3. Where {@code fdlibm} provides

--- a/src/java.base/share/native/libfdlibm/e_acos.c
+++ b/src/java.base/share/native/libfdlibm/e_acos.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_acos(x)
+ * Method :
+ *      acos(x)  = pi/2 - asin(x)
+ *      acos(-x) = pi/2 + asin(x)
+ * For |x|<=0.5
+ *      acos(x) = pi/2 - (x + x*x^2*R(x^2))     (see asin.c)
+ * For x>0.5
+ *      acos(x) = pi/2 - (pi/2 - 2asin(sqrt((1-x)/2)))
+ *              = 2asin(sqrt((1-x)/2))
+ *              = 2s + 2s*z*R(z)        ...z=(1-x)/2, s=sqrt(z)
+ *              = 2f + (2c + 2s*z*R(z))
+ *     where f=hi part of s, and c = (z-f*f)/(s+f) is the correction term
+ *     for f so that f+c ~ sqrt(z).
+ * For x<-0.5
+ *      acos(x) = pi - 2asin(sqrt((1-|x|)/2))
+ *              = pi - 0.5*(s+s*z*R(z)), where z=(1-|x|)/2,s=sqrt(z)
+ *
+ * Special cases:
+ *      if x is NaN, return x itself;
+ *      if |x|>1, return NaN with invalid signal.
+ *
+ * Function needed: sqrt
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+one=  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+pi =  3.14159265358979311600e+00, /* 0x400921FB, 0x54442D18 */
+pio2_hi =  1.57079632679489655800e+00, /* 0x3FF921FB, 0x54442D18 */
+pio2_lo =  6.12323399573676603587e-17, /* 0x3C91A626, 0x33145C07 */
+pS0 =  1.66666666666666657415e-01, /* 0x3FC55555, 0x55555555 */
+pS1 = -3.25565818622400915405e-01, /* 0xBFD4D612, 0x03EB6F7D */
+pS2 =  2.01212532134862925881e-01, /* 0x3FC9C155, 0x0E884455 */
+pS3 = -4.00555345006794114027e-02, /* 0xBFA48228, 0xB5688F3B */
+pS4 =  7.91534994289814532176e-04, /* 0x3F49EFE0, 0x7501B288 */
+pS5 =  3.47933107596021167570e-05, /* 0x3F023DE1, 0x0DFDF709 */
+qS1 = -2.40339491173441421878e+00, /* 0xC0033A27, 0x1C8A2D4B */
+qS2 =  2.02094576023350569471e+00, /* 0x40002AE5, 0x9C598AC8 */
+qS3 = -6.88283971605453293030e-01, /* 0xBFE6066C, 0x1B8D0159 */
+qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
+
+#ifdef __STDC__
+        double __ieee754_acos(double x)
+#else
+        double __ieee754_acos(x)
+        double x;
+#endif
+{
+        double z,p,q,r,w,s,c,df;
+        int hx,ix;
+        hx = __HI(x);
+        ix = hx&0x7fffffff;
+        if(ix>=0x3ff00000) {    /* |x| >= 1 */
+            if(((ix-0x3ff00000)|__LO(x))==0) {  /* |x|==1 */
+                if(hx>0) return 0.0;            /* acos(1) = 0  */
+                else return pi+2.0*pio2_lo;     /* acos(-1)= pi */
+            }
+            return (x-x)/(x-x);         /* acos(|x|>1) is NaN */
+        }
+        if(ix<0x3fe00000) {     /* |x| < 0.5 */
+            if(ix<=0x3c600000) return pio2_hi+pio2_lo;/*if|x|<2**-57*/
+            z = x*x;
+            p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
+            q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
+            r = p/q;
+            return pio2_hi - (x - (pio2_lo-x*r));
+        } else  if (hx<0) {             /* x < -0.5 */
+            z = (one+x)*0.5;
+            p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
+            q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
+            s = sqrt(z);
+            r = p/q;
+            w = r*s-pio2_lo;
+            return pi - 2.0*(s+w);
+        } else {                        /* x > 0.5 */
+            z = (one-x)*0.5;
+            s = sqrt(z);
+            df = s;
+            __LO(df) = 0;
+            c  = (z-df*df)/(s+df);
+            p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
+            q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
+            r = p/q;
+            w = r*s+c;
+            return 2.0*(df+w);
+        }
+}

--- a/src/java.base/share/native/libfdlibm/e_asin.c
+++ b/src/java.base/share/native/libfdlibm/e_asin.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_asin(x)
+ * Method :
+ *      Since  asin(x) = x + x^3/6 + x^5*3/40 + x^7*15/336 + ...
+ *      we approximate asin(x) on [0,0.5] by
+ *              asin(x) = x + x*x^2*R(x^2)
+ *      where
+ *              R(x^2) is a rational approximation of (asin(x)-x)/x^3
+ *      and its remez error is bounded by
+ *              |(asin(x)-x)/x^3 - R(x^2)| < 2^(-58.75)
+ *
+ *      For x in [0.5,1]
+ *              asin(x) = pi/2-2*asin(sqrt((1-x)/2))
+ *      Let y = (1-x), z = y/2, s := sqrt(z), and pio2_hi+pio2_lo=pi/2;
+ *      then for x>0.98
+ *              asin(x) = pi/2 - 2*(s+s*z*R(z))
+ *                      = pio2_hi - (2*(s+s*z*R(z)) - pio2_lo)
+ *      For x<=0.98, let pio4_hi = pio2_hi/2, then
+ *              f = hi part of s;
+ *              c = sqrt(z) - f = (z-f*f)/(s+f)         ...f+c=sqrt(z)
+ *      and
+ *              asin(x) = pi/2 - 2*(s+s*z*R(z))
+ *                      = pio4_hi+(pio4-2s)-(2s*z*R(z)-pio2_lo)
+ *                      = pio4_hi+(pio4-2f)-(2s*z*R(z)-(pio2_lo+2c))
+ *
+ * Special cases:
+ *      if x is NaN, return x itself;
+ *      if |x|>1, return NaN with invalid signal.
+ *
+ */
+
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+one =  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+huge =  1.000e+300,
+pio2_hi =  1.57079632679489655800e+00, /* 0x3FF921FB, 0x54442D18 */
+pio2_lo =  6.12323399573676603587e-17, /* 0x3C91A626, 0x33145C07 */
+pio4_hi =  7.85398163397448278999e-01, /* 0x3FE921FB, 0x54442D18 */
+        /* coefficient for R(x^2) */
+pS0 =  1.66666666666666657415e-01, /* 0x3FC55555, 0x55555555 */
+pS1 = -3.25565818622400915405e-01, /* 0xBFD4D612, 0x03EB6F7D */
+pS2 =  2.01212532134862925881e-01, /* 0x3FC9C155, 0x0E884455 */
+pS3 = -4.00555345006794114027e-02, /* 0xBFA48228, 0xB5688F3B */
+pS4 =  7.91534994289814532176e-04, /* 0x3F49EFE0, 0x7501B288 */
+pS5 =  3.47933107596021167570e-05, /* 0x3F023DE1, 0x0DFDF709 */
+qS1 = -2.40339491173441421878e+00, /* 0xC0033A27, 0x1C8A2D4B */
+qS2 =  2.02094576023350569471e+00, /* 0x40002AE5, 0x9C598AC8 */
+qS3 = -6.88283971605453293030e-01, /* 0xBFE6066C, 0x1B8D0159 */
+qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
+
+#ifdef __STDC__
+        double __ieee754_asin(double x)
+#else
+        double __ieee754_asin(x)
+        double x;
+#endif
+{
+        double t=0,w,p,q,c,r,s;
+        int hx,ix;
+        hx = __HI(x);
+        ix = hx&0x7fffffff;
+        if(ix>= 0x3ff00000) {           /* |x|>= 1 */
+            if(((ix-0x3ff00000)|__LO(x))==0)
+                    /* asin(1)=+-pi/2 with inexact */
+                return x*pio2_hi+x*pio2_lo;
+            return (x-x)/(x-x);         /* asin(|x|>1) is NaN */
+        } else if (ix<0x3fe00000) {     /* |x|<0.5 */
+            if(ix<0x3e400000) {         /* if |x| < 2**-27 */
+                if(huge+x>one) return x;/* return x with inexact if x!=0*/
+            } else
+                t = x*x;
+            p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
+            q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
+            w = p/q;
+            return x+x*w;
+        }
+        /* 1> |x|>= 0.5 */
+        w = one-fabs(x);
+        t = w*0.5;
+        p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
+        q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
+        s = sqrt(t);
+        if(ix>=0x3FEF3333) {    /* if |x| > 0.975 */
+            w = p/q;
+            t = pio2_hi-(2.0*(s+s*w)-pio2_lo);
+        } else {
+            w  = s;
+            __LO(w) = 0;
+            c  = (t-w*w)/(s+w);
+            r  = p/q;
+            p  = 2.0*s*r-(pio2_lo-2.0*c);
+            q  = pio4_hi-2.0*w;
+            t  = pio4_hi-(p-q);
+        }
+        if(hx>0) return t; else return -t;
+}

--- a/src/java.base/share/native/libfdlibm/e_atan2.c
+++ b/src/java.base/share/native/libfdlibm/e_atan2.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 1998, 2004, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_atan2(y,x)
+ * Method :
+ *      1. Reduce y to positive by atan2(y,x)=-atan2(-y,x).
+ *      2. Reduce x to positive by (if x and y are unexceptional):
+ *              ARG (x+iy) = arctan(y/x)           ... if x > 0,
+ *              ARG (x+iy) = pi - arctan[y/(-x)]   ... if x < 0,
+ *
+ * Special cases:
+ *
+ *      ATAN2((anything), NaN ) is NaN;
+ *      ATAN2(NAN , (anything) ) is NaN;
+ *      ATAN2(+-0, +(anything but NaN)) is +-0  ;
+ *      ATAN2(+-0, -(anything but NaN)) is +-pi ;
+ *      ATAN2(+-(anything but 0 and NaN), 0) is +-pi/2;
+ *      ATAN2(+-(anything but INF and NaN), +INF) is +-0 ;
+ *      ATAN2(+-(anything but INF and NaN), -INF) is +-pi;
+ *      ATAN2(+-INF,+INF ) is +-pi/4 ;
+ *      ATAN2(+-INF,-INF ) is +-3pi/4;
+ *      ATAN2(+-INF, (anything but,0,NaN, and INF)) is +-pi/2;
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+tiny  = 1.0e-300,
+zero  = 0.0,
+pi_o_4  = 7.8539816339744827900E-01, /* 0x3FE921FB, 0x54442D18 */
+pi_o_2  = 1.5707963267948965580E+00, /* 0x3FF921FB, 0x54442D18 */
+pi      = 3.1415926535897931160E+00, /* 0x400921FB, 0x54442D18 */
+pi_lo   = 1.2246467991473531772E-16; /* 0x3CA1A626, 0x33145C07 */
+
+#ifdef __STDC__
+        double __ieee754_atan2(double y, double x)
+#else
+        double __ieee754_atan2(y,x)
+        double  y,x;
+#endif
+{
+        double z;
+        int k,m,hx,hy,ix,iy;
+        unsigned lx,ly;
+
+        hx = __HI(x); ix = hx&0x7fffffff;
+        lx = __LO(x);
+        hy = __HI(y); iy = hy&0x7fffffff;
+        ly = __LO(y);
+        if(((ix|((lx|-lx)>>31))>0x7ff00000)||
+           ((iy|((ly|-ly)>>31))>0x7ff00000))    /* x or y is NaN */
+           return x+y;
+        if(((hx-0x3ff00000)|lx)==0) return atan(y);   /* x=1.0 */
+        m = ((hy>>31)&1)|((hx>>30)&2);  /* 2*sign(x)+sign(y) */
+
+    /* when y = 0 */
+        if((iy|ly)==0) {
+            switch(m) {
+                case 0:
+                case 1: return y;       /* atan(+-0,+anything)=+-0 */
+                case 2: return  pi+tiny;/* atan(+0,-anything) = pi */
+                case 3: return -pi-tiny;/* atan(-0,-anything) =-pi */
+            }
+        }
+    /* when x = 0 */
+        if((ix|lx)==0) return (hy<0)?  -pi_o_2-tiny: pi_o_2+tiny;
+
+    /* when x is INF */
+        if(ix==0x7ff00000) {
+            if(iy==0x7ff00000) {
+                switch(m) {
+                    case 0: return  pi_o_4+tiny;/* atan(+INF,+INF) */
+                    case 1: return -pi_o_4-tiny;/* atan(-INF,+INF) */
+                    case 2: return  3.0*pi_o_4+tiny;/*atan(+INF,-INF)*/
+                    case 3: return -3.0*pi_o_4-tiny;/*atan(-INF,-INF)*/
+                }
+            } else {
+                switch(m) {
+                    case 0: return  zero  ;     /* atan(+...,+INF) */
+                    case 1: return -1.0*zero  ; /* atan(-...,+INF) */
+                    case 2: return  pi+tiny  ;  /* atan(+...,-INF) */
+                    case 3: return -pi-tiny  ;  /* atan(-...,-INF) */
+                }
+            }
+        }
+    /* when y is INF */
+        if(iy==0x7ff00000) return (hy<0)? -pi_o_2-tiny: pi_o_2+tiny;
+
+    /* compute y/x */
+        k = (iy-ix)>>20;
+        if(k > 60) z=pi_o_2+0.5*pi_lo;  /* |y/x| >  2**60 */
+        else if(hx<0&&k<-60) z=0.0;     /* |y|/x < -2**60 */
+        else z=atan(fabs(y/x));         /* safe to do y/x */
+        switch (m) {
+            case 0: return       z  ;   /* atan(+,+) */
+            case 1: __HI(z) ^= 0x80000000;
+                    return       z  ;   /* atan(-,+) */
+            case 2: return  pi-(z-pi_lo);/* atan(+,-) */
+            default: /* case 3 */
+                    return  (z-pi_lo)-pi;/* atan(-,-) */
+        }
+}

--- a/src/java.base/share/native/libfdlibm/e_atanh.c
+++ b/src/java.base/share/native/libfdlibm/e_atanh.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_atanh(x)
+ * Method :
+ *    1.Reduced x to positive by atanh(-x) = -atanh(x)
+ *    2.For x>=0.5
+ *                  1              2x                          x
+ *      atanh(x) = --- * log(1 + -------) = 0.5 * log1p(2 * --------)
+ *                  2             1 - x                      1 - x
+ *
+ *      For x<0.5
+ *      atanh(x) = 0.5*log1p(2x+2x*x/(1-x))
+ *
+ * Special cases:
+ *      atanh(x) is NaN if |x| > 1 with signal;
+ *      atanh(NaN) is that NaN with no signal;
+ *      atanh(+-1) is +-INF with signal.
+ *
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double one = 1.0, huge = 1e300;
+#else
+static double one = 1.0, huge = 1e300;
+#endif
+
+static double zero = 0.0;
+
+#ifdef __STDC__
+        double __ieee754_atanh(double x)
+#else
+        double __ieee754_atanh(x)
+        double x;
+#endif
+{
+        double t;
+        int hx,ix;
+        unsigned lx;
+        hx = __HI(x);           /* high word */
+        lx = __LO(x);           /* low word */
+        ix = hx&0x7fffffff;
+        if ((ix|((lx|(-lx))>>31))>0x3ff00000) /* |x|>1 */
+            return (x-x)/(x-x);
+        if(ix==0x3ff00000)
+            return x/zero;
+        if(ix<0x3e300000&&(huge+x)>zero) return x;      /* x<2**-28 */
+        __HI(x) = ix;           /* x <- |x| */
+        if(ix<0x3fe00000) {             /* x < 0.5 */
+            t = x+x;
+            t = 0.5*log1p(t+t*x/(one-x));
+        } else
+            t = 0.5*log1p((x+x)/(one-x));
+        if(hx>=0) return t; else return -t;
+}

--- a/src/java.base/share/native/libfdlibm/e_cosh.c
+++ b/src/java.base/share/native/libfdlibm/e_cosh.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_cosh(x)
+ * Method :
+ * mathematically cosh(x) if defined to be (exp(x)+exp(-x))/2
+ *      1. Replace x by |x| (cosh(x) = cosh(-x)).
+ *      2.
+ *                                                      [ exp(x) - 1 ]^2
+ *          0        <= x <= ln2/2  :  cosh(x) := 1 + -------------------
+ *                                                         2*exp(x)
+ *
+ *                                                exp(x) +  1/exp(x)
+ *          ln2/2    <= x <= 22     :  cosh(x) := -------------------
+ *                                                        2
+ *          22       <= x <= lnovft :  cosh(x) := exp(x)/2
+ *          lnovft   <= x <= ln2ovft:  cosh(x) := exp(x/2)/2 * exp(x/2)
+ *          ln2ovft  <  x           :  cosh(x) := huge*huge (overflow)
+ *
+ * Special cases:
+ *      cosh(x) is |x| if x is +INF, -INF, or NaN.
+ *      only cosh(0)=1 is exact for finite x.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double one = 1.0, half=0.5, huge = 1.0e300;
+#else
+static double one = 1.0, half=0.5, huge = 1.0e300;
+#endif
+
+#ifdef __STDC__
+        double __ieee754_cosh(double x)
+#else
+        double __ieee754_cosh(x)
+        double x;
+#endif
+{
+        double t,w;
+        int ix;
+        unsigned lx;
+
+    /* High word of |x|. */
+        ix = __HI(x);
+        ix &= 0x7fffffff;
+
+    /* x is INF or NaN */
+        if(ix>=0x7ff00000) return x*x;
+
+    /* |x| in [0,0.5*ln2], return 1+expm1(|x|)^2/(2*exp(|x|)) */
+        if(ix<0x3fd62e43) {
+            t = expm1(fabs(x));
+            w = one+t;
+            if (ix<0x3c800000) return w;        /* cosh(tiny) = 1 */
+            return one+(t*t)/(w+w);
+        }
+
+    /* |x| in [0.5*ln2,22], return (exp(|x|)+1/exp(|x|)/2; */
+        if (ix < 0x40360000) {
+                t = __ieee754_exp(fabs(x));
+                return half*t+half/t;
+        }
+
+    /* |x| in [22, log(maxdouble)] return half*exp(|x|) */
+        if (ix < 0x40862E42)  return half*__ieee754_exp(fabs(x));
+
+    /* |x| in [log(maxdouble), overflowthresold] */
+        lx = *( (((*(unsigned*)&one)>>29)) + (unsigned*)&x);
+        if (ix<0x408633CE ||
+              ((ix==0x408633ce)&&(lx<=(unsigned)0x8fb9f87d))) {
+            w = __ieee754_exp(half*fabs(x));
+            t = half*w;
+            return t*w;
+        }
+
+    /* |x| > overflowthresold, cosh(x) overflow */
+        return huge*huge;
+}

--- a/src/java.base/share/native/libfdlibm/e_exp.c
+++ b/src/java.base/share/native/libfdlibm/e_exp.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_exp(x)
+ * Returns the exponential of x.
+ *
+ * Method
+ *   1. Argument reduction:
+ *      Reduce x to an r so that |r| <= 0.5*ln2 ~ 0.34658.
+ *      Given x, find r and integer k such that
+ *
+ *               x = k*ln2 + r,  |r| <= 0.5*ln2.
+ *
+ *      Here r will be represented as r = hi-lo for better
+ *      accuracy.
+ *
+ *   2. Approximation of exp(r) by a special rational function on
+ *      the interval [0,0.34658]:
+ *      Write
+ *          R(r**2) = r*(exp(r)+1)/(exp(r)-1) = 2 + r*r/6 - r**4/360 + ...
+ *      We use a special Reme algorithm on [0,0.34658] to generate
+ *      a polynomial of degree 5 to approximate R. The maximum error
+ *      of this polynomial approximation is bounded by 2**-59. In
+ *      other words,
+ *          R(z) ~ 2.0 + P1*z + P2*z**2 + P3*z**3 + P4*z**4 + P5*z**5
+ *      (where z=r*r, and the values of P1 to P5 are listed below)
+ *      and
+ *          |                  5          |     -59
+ *          | 2.0+P1*z+...+P5*z   -  R(z) | <= 2
+ *          |                             |
+ *      The computation of exp(r) thus becomes
+ *                             2*r
+ *              exp(r) = 1 + -------
+ *                            R - r
+ *                                 r*R1(r)
+ *                     = 1 + r + ----------- (for better accuracy)
+ *                                2 - R1(r)
+ *      where
+ *                               2       4             10
+ *              R1(r) = r - (P1*r  + P2*r  + ... + P5*r   ).
+ *
+ *   3. Scale back to obtain exp(x):
+ *      From step 1, we have
+ *         exp(x) = 2^k * exp(r)
+ *
+ * Special cases:
+ *      exp(INF) is INF, exp(NaN) is NaN;
+ *      exp(-INF) is 0, and
+ *      for finite argument, only exp(0)=1 is exact.
+ *
+ * Accuracy:
+ *      according to an error analysis, the error is always less than
+ *      1 ulp (unit in the last place).
+ *
+ * Misc. info.
+ *      For IEEE double
+ *          if x >  7.09782712893383973096e+02 then exp(x) overflow
+ *          if x < -7.45133219101941108420e+02 then exp(x) underflow
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+one     = 1.0,
+halF[2] = {0.5,-0.5,},
+huge    = 1.0e+300,
+twom1000= 9.33263618503218878990e-302,     /* 2**-1000=0x01700000,0*/
+o_threshold=  7.09782712893383973096e+02,  /* 0x40862E42, 0xFEFA39EF */
+u_threshold= -7.45133219101941108420e+02,  /* 0xc0874910, 0xD52D3051 */
+ln2HI[2]   ={ 6.93147180369123816490e-01,  /* 0x3fe62e42, 0xfee00000 */
+             -6.93147180369123816490e-01,},/* 0xbfe62e42, 0xfee00000 */
+ln2LO[2]   ={ 1.90821492927058770002e-10,  /* 0x3dea39ef, 0x35793c76 */
+             -1.90821492927058770002e-10,},/* 0xbdea39ef, 0x35793c76 */
+invln2 =  1.44269504088896338700e+00, /* 0x3ff71547, 0x652b82fe */
+P1   =  1.66666666666666019037e-01, /* 0x3FC55555, 0x5555553E */
+P2   = -2.77777777770155933842e-03, /* 0xBF66C16C, 0x16BEBD93 */
+P3   =  6.61375632143793436117e-05, /* 0x3F11566A, 0xAF25DE2C */
+P4   = -1.65339022054652515390e-06, /* 0xBEBBBD41, 0xC5D26BF1 */
+P5   =  4.13813679705723846039e-08; /* 0x3E663769, 0x72BEA4D0 */
+
+
+#ifdef __STDC__
+        double __ieee754_exp(double x)  /* default IEEE double exp */
+#else
+        double __ieee754_exp(x) /* default IEEE double exp */
+        double x;
+#endif
+{
+        double y,hi=0,lo=0,c,t;
+        int k=0,xsb;
+        unsigned hx;
+
+        hx  = __HI(x);  /* high word of x */
+        xsb = (hx>>31)&1;               /* sign bit of x */
+        hx &= 0x7fffffff;               /* high word of |x| */
+
+    /* filter out non-finite argument */
+        if(hx >= 0x40862E42) {                  /* if |x|>=709.78... */
+            if(hx>=0x7ff00000) {
+                if(((hx&0xfffff)|__LO(x))!=0)
+                     return x+x;                /* NaN */
+                else return (xsb==0)? x:0.0;    /* exp(+-inf)={inf,0} */
+            }
+            if(x > o_threshold) return huge*huge; /* overflow */
+            if(x < u_threshold) return twom1000*twom1000; /* underflow */
+        }
+
+    /* argument reduction */
+        if(hx > 0x3fd62e42) {           /* if  |x| > 0.5 ln2 */
+            if(hx < 0x3FF0A2B2) {       /* and |x| < 1.5 ln2 */
+                hi = x-ln2HI[xsb]; lo=ln2LO[xsb]; k = 1-xsb-xsb;
+            } else {
+                k  = invln2*x+halF[xsb];
+                t  = k;
+                hi = x - t*ln2HI[0];    /* t*ln2HI is exact here */
+                lo = t*ln2LO[0];
+            }
+            x  = hi - lo;
+        }
+        else if(hx < 0x3e300000)  {     /* when |x|<2**-28 */
+            if(huge+x>one) return one+x;/* trigger inexact */
+        }
+        else k = 0;
+
+    /* x is now in primary range */
+        t  = x*x;
+        c  = x - t*(P1+t*(P2+t*(P3+t*(P4+t*P5))));
+        if(k==0)        return one-((x*c)/(c-2.0)-x);
+        else            y = one-((lo-(x*c)/(2.0-c))-hi);
+        if(k >= -1021) {
+            __HI(y) += (k<<20); /* add k to y's exponent */
+            return y;
+        } else {
+            __HI(y) += ((k+1000)<<20);/* add k to y's exponent */
+            return y*twom1000;
+        }
+}

--- a/src/java.base/share/native/libfdlibm/e_fmod.c
+++ b/src/java.base/share/native/libfdlibm/e_fmod.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * __ieee754_fmod(x,y)
+ * Return x mod y in exact arithmetic
+ * Method: shift and subtract
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double one = 1.0, Zero[] = {0.0, -0.0,};
+#else
+static double one = 1.0, Zero[] = {0.0, -0.0,};
+#endif
+
+#ifdef __STDC__
+        double __ieee754_fmod(double x, double y)
+#else
+        double __ieee754_fmod(x,y)
+        double x,y ;
+#endif
+{
+        int n,hx,hy,hz,ix,iy,sx,i;
+        unsigned lx,ly,lz;
+
+        hx = __HI(x);           /* high word of x */
+        lx = __LO(x);           /* low  word of x */
+        hy = __HI(y);           /* high word of y */
+        ly = __LO(y);           /* low  word of y */
+        sx = hx&0x80000000;             /* sign of x */
+        hx ^=sx;                /* |x| */
+        hy &= 0x7fffffff;       /* |y| */
+
+    /* purge off exception values */
+        if((hy|ly)==0||(hx>=0x7ff00000)||       /* y=0,or x not finite */
+          ((hy|((ly|-ly)>>31))>0x7ff00000))     /* or y is NaN */
+            return (x*y)/(x*y);
+        if(hx<=hy) {
+            if((hx<hy)||(lx<ly)) return x;      /* |x|<|y| return x */
+            if(lx==ly)
+                return Zero[(unsigned)sx>>31];  /* |x|=|y| return x*0*/
+        }
+
+    /* determine ix = ilogb(x) */
+        if(hx<0x00100000) {     /* subnormal x */
+            if(hx==0) {
+                for (ix = -1043, i=lx; i>0; i<<=1) ix -=1;
+            } else {
+                for (ix = -1022,i=(hx<<11); i>0; i<<=1) ix -=1;
+            }
+        } else ix = (hx>>20)-1023;
+
+    /* determine iy = ilogb(y) */
+        if(hy<0x00100000) {     /* subnormal y */
+            if(hy==0) {
+                for (iy = -1043, i=ly; i>0; i<<=1) iy -=1;
+            } else {
+                for (iy = -1022,i=(hy<<11); i>0; i<<=1) iy -=1;
+            }
+        } else iy = (hy>>20)-1023;
+
+    /* set up {hx,lx}, {hy,ly} and align y to x */
+        if(ix >= -1022)
+            hx = 0x00100000|(0x000fffff&hx);
+        else {          /* subnormal x, shift x to normal */
+            n = -1022-ix;
+            if(n<=31) {
+                hx = (hx<<n)|(lx>>(32-n));
+                lx <<= n;
+            } else {
+                hx = lx<<(n-32);
+                lx = 0;
+            }
+        }
+        if(iy >= -1022)
+            hy = 0x00100000|(0x000fffff&hy);
+        else {          /* subnormal y, shift y to normal */
+            n = -1022-iy;
+            if(n<=31) {
+                hy = (hy<<n)|(ly>>(32-n));
+                ly <<= n;
+            } else {
+                hy = ly<<(n-32);
+                ly = 0;
+            }
+        }
+
+    /* fix point fmod */
+        n = ix - iy;
+        while(n--) {
+            hz=hx-hy;lz=lx-ly; if(lx<ly) hz -= 1;
+            if(hz<0){hx = hx+hx+(lx>>31); lx = lx+lx;}
+            else {
+                if((hz|lz)==0)          /* return sign(x)*0 */
+                    return Zero[(unsigned)sx>>31];
+                hx = hz+hz+(lz>>31); lx = lz+lz;
+            }
+        }
+        hz=hx-hy;lz=lx-ly; if(lx<ly) hz -= 1;
+        if(hz>=0) {hx=hz;lx=lz;}
+
+    /* convert back to floating value and restore the sign */
+        if((hx|lx)==0)                  /* return sign(x)*0 */
+            return Zero[(unsigned)sx>>31];
+        while(hx<0x00100000) {          /* normalize x */
+            hx = hx+hx+(lx>>31); lx = lx+lx;
+            iy -= 1;
+        }
+        if(iy>= -1022) {        /* normalize output */
+            hx = ((hx-0x00100000)|((iy+1023)<<20));
+            __HI(x) = hx|sx;
+            __LO(x) = lx;
+        } else {                /* subnormal output */
+            n = -1022 - iy;
+            if(n<=20) {
+                lx = (lx>>n)|((unsigned)hx<<(32-n));
+                hx >>= n;
+            } else if (n<=31) {
+                lx = (hx<<(32-n))|(lx>>n); hx = sx;
+            } else {
+                lx = hx>>(n-32); hx = sx;
+            }
+            __HI(x) = hx|sx;
+            __LO(x) = lx;
+            x *= one;           /* create necessary signal */
+        }
+        return x;               /* exact output */
+}

--- a/src/java.base/share/native/libfdlibm/e_log.c
+++ b/src/java.base/share/native/libfdlibm/e_log.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_log(x)
+ * Return the logarithm of x
+ *
+ * Method :
+ *   1. Argument Reduction: find k and f such that
+ *                      x = 2^k * (1+f),
+ *         where  sqrt(2)/2 < 1+f < sqrt(2) .
+ *
+ *   2. Approximation of log(1+f).
+ *      Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+ *               = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+ *               = 2s + s*R
+ *      We use a special Reme algorithm on [0,0.1716] to generate
+ *      a polynomial of degree 14 to approximate R The maximum error
+ *      of this polynomial approximation is bounded by 2**-58.45. In
+ *      other words,
+ *                      2      4      6      8      10      12      14
+ *          R(z) ~ Lg1*s +Lg2*s +Lg3*s +Lg4*s +Lg5*s  +Lg6*s  +Lg7*s
+ *      (the values of Lg1 to Lg7 are listed in the program)
+ *      and
+ *          |      2          14          |     -58.45
+ *          | Lg1*s +...+Lg7*s    -  R(z) | <= 2
+ *          |                             |
+ *      Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+ *      In order to guarantee error in log below 1ulp, we compute log
+ *      by
+ *              log(1+f) = f - s*(f - R)        (if f is not too large)
+ *              log(1+f) = f - (hfsq - s*(hfsq+R)).     (better accuracy)
+ *
+ *      3. Finally,  log(x) = k*ln2 + log(1+f).
+ *                          = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+ *         Here ln2 is split into two floating point number:
+ *                      ln2_hi + ln2_lo,
+ *         where n*ln2_hi is always exact for |n| < 2000.
+ *
+ * Special cases:
+ *      log(x) is NaN with signal if x < 0 (including -INF) ;
+ *      log(+INF) is +INF; log(0) is -INF with signal;
+ *      log(NaN) is that NaN with no signal.
+ *
+ * Accuracy:
+ *      according to an error analysis, the error is always less than
+ *      1 ulp (unit in the last place).
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+ln2_hi  =  6.93147180369123816490e-01,  /* 3fe62e42 fee00000 */
+ln2_lo  =  1.90821492927058770002e-10,  /* 3dea39ef 35793c76 */
+two54   =  1.80143985094819840000e+16,  /* 43500000 00000000 */
+Lg1 = 6.666666666666735130e-01,  /* 3FE55555 55555593 */
+Lg2 = 3.999999999940941908e-01,  /* 3FD99999 9997FA04 */
+Lg3 = 2.857142874366239149e-01,  /* 3FD24924 94229359 */
+Lg4 = 2.222219843214978396e-01,  /* 3FCC71C5 1D8E78AF */
+Lg5 = 1.818357216161805012e-01,  /* 3FC74664 96CB03DE */
+Lg6 = 1.531383769920937332e-01,  /* 3FC39A09 D078C69F */
+Lg7 = 1.479819860511658591e-01;  /* 3FC2F112 DF3E5244 */
+
+static double zero   =  0.0;
+
+#ifdef __STDC__
+        double __ieee754_log(double x)
+#else
+        double __ieee754_log(x)
+        double x;
+#endif
+{
+        double hfsq,f,s,z,R,w,t1,t2,dk;
+        int k,hx,i,j;
+        unsigned lx;
+
+        hx = __HI(x);           /* high word of x */
+        lx = __LO(x);           /* low  word of x */
+
+        k=0;
+        if (hx < 0x00100000) {                  /* x < 2**-1022  */
+            if (((hx&0x7fffffff)|lx)==0)
+                return -two54/zero;             /* log(+-0)=-inf */
+            if (hx<0) return (x-x)/zero;        /* log(-#) = NaN */
+            k -= 54; x *= two54; /* subnormal number, scale up x */
+            hx = __HI(x);               /* high word of x */
+        }
+        if (hx >= 0x7ff00000) return x+x;
+        k += (hx>>20)-1023;
+        hx &= 0x000fffff;
+        i = (hx+0x95f64)&0x100000;
+        __HI(x) = hx|(i^0x3ff00000);    /* normalize x or x/2 */
+        k += (i>>20);
+        f = x-1.0;
+        if((0x000fffff&(2+hx))<3) {     /* |f| < 2**-20 */
+            if(f==zero) {
+                if (k==0) return zero;
+                else {dk=(double)k; return dk*ln2_hi+dk*ln2_lo;}
+            }
+            R = f*f*(0.5-0.33333333333333333*f);
+            if(k==0) return f-R; else {dk=(double)k;
+                     return dk*ln2_hi-((R-dk*ln2_lo)-f);}
+        }
+        s = f/(2.0+f);
+        dk = (double)k;
+        z = s*s;
+        i = hx-0x6147a;
+        w = z*z;
+        j = 0x6b851-hx;
+        t1= w*(Lg2+w*(Lg4+w*Lg6));
+        t2= z*(Lg1+w*(Lg3+w*(Lg5+w*Lg7)));
+        i |= j;
+        R = t2+t1;
+        if(i>0) {
+            hfsq=0.5*f*f;
+            if(k==0) return f-(hfsq-s*(hfsq+R)); else
+                     return dk*ln2_hi-((hfsq-(s*(hfsq+R)+dk*ln2_lo))-f);
+        } else {
+            if(k==0) return f-s*(f-R); else
+                     return dk*ln2_hi-((s*(f-R)-dk*ln2_lo)-f);
+        }
+}

--- a/src/java.base/share/native/libfdlibm/e_log10.c
+++ b/src/java.base/share/native/libfdlibm/e_log10.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_log10(x)
+ * Return the base 10 logarithm of x
+ *
+ * Method :
+ *      Let log10_2hi = leading 40 bits of log10(2) and
+ *          log10_2lo = log10(2) - log10_2hi,
+ *          ivln10   = 1/log(10) rounded.
+ *      Then
+ *              n = ilogb(x),
+ *              if(n<0)  n = n+1;
+ *              x = scalbn(x,-n);
+ *              log10(x) := n*log10_2hi + (n*log10_2lo + ivln10*log(x))
+ *
+ * Note 1:
+ *      To guarantee log10(10**n)=n, where 10**n is normal, the rounding
+ *      mode must set to Round-to-Nearest.
+ * Note 2:
+ *      [1/log(10)] rounded to 53 bits has error  .198   ulps;
+ *      log10 is monotonic at all binary break points.
+ *
+ * Special cases:
+ *      log10(x) is NaN with signal if x < 0;
+ *      log10(+INF) is +INF with no signal; log10(0) is -INF with signal;
+ *      log10(NaN) is that NaN with no signal;
+ *      log10(10**N) = N  for N=0,1,...,22.
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following constants.
+ * The decimal values may be used, provided that the compiler will convert
+ * from decimal to binary accurately enough to produce the hexadecimal values
+ * shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+two54      =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
+ivln10     =  4.34294481903251816668e-01, /* 0x3FDBCB7B, 0x1526E50E */
+log10_2hi  =  3.01029995663611771306e-01, /* 0x3FD34413, 0x509F6000 */
+log10_2lo  =  3.69423907715893078616e-13; /* 0x3D59FEF3, 0x11F12B36 */
+
+static double zero   =  0.0;
+
+#ifdef __STDC__
+        double __ieee754_log10(double x)
+#else
+        double __ieee754_log10(x)
+        double x;
+#endif
+{
+        double y,z;
+        int i,k,hx;
+        unsigned lx;
+
+        hx = __HI(x);   /* high word of x */
+        lx = __LO(x);   /* low word of x */
+
+        k=0;
+        if (hx < 0x00100000) {                  /* x < 2**-1022  */
+            if (((hx&0x7fffffff)|lx)==0)
+                return -two54/zero;             /* log(+-0)=-inf */
+            if (hx<0) return (x-x)/zero;        /* log(-#) = NaN */
+            k -= 54; x *= two54; /* subnormal number, scale up x */
+            hx = __HI(x);                /* high word of x */
+        }
+        if (hx >= 0x7ff00000) return x+x;
+        k += (hx>>20)-1023;
+        i  = ((unsigned)k&0x80000000)>>31;
+        hx = (hx&0x000fffff)|((0x3ff-i)<<20);
+        y  = (double)(k+i);
+        __HI(x) = hx;
+        z  = y*log10_2lo + ivln10*__ieee754_log(x);
+        return  z+y*log10_2hi;
+}

--- a/src/java.base/share/native/libfdlibm/e_rem_pio2.c
+++ b/src/java.base/share/native/libfdlibm/e_rem_pio2.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_rem_pio2(x,y)
+ *
+ * return the remainder of x rem pi/2 in y[0]+y[1]
+ * use __kernel_rem_pio2()
+ */
+
+#include "fdlibm.h"
+
+/*
+ * Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi
+ */
+#ifdef __STDC__
+static const int two_over_pi[] = {
+#else
+static int two_over_pi[] = {
+#endif
+0xA2F983, 0x6E4E44, 0x1529FC, 0x2757D1, 0xF534DD, 0xC0DB62,
+0x95993C, 0x439041, 0xFE5163, 0xABDEBB, 0xC561B7, 0x246E3A,
+0x424DD2, 0xE00649, 0x2EEA09, 0xD1921C, 0xFE1DEB, 0x1CB129,
+0xA73EE8, 0x8235F5, 0x2EBB44, 0x84E99C, 0x7026B4, 0x5F7E41,
+0x3991D6, 0x398353, 0x39F49C, 0x845F8B, 0xBDF928, 0x3B1FF8,
+0x97FFDE, 0x05980F, 0xEF2F11, 0x8B5A0A, 0x6D1F6D, 0x367ECF,
+0x27CB09, 0xB74F46, 0x3F669E, 0x5FEA2D, 0x7527BA, 0xC7EBE5,
+0xF17B3D, 0x0739F7, 0x8A5292, 0xEA6BFB, 0x5FB11F, 0x8D5D08,
+0x560330, 0x46FC7B, 0x6BABF0, 0xCFBC20, 0x9AF436, 0x1DA9E3,
+0x91615E, 0xE61B08, 0x659985, 0x5F14A0, 0x68408D, 0xFFD880,
+0x4D7327, 0x310606, 0x1556CA, 0x73A8C9, 0x60E27B, 0xC08C6B,
+};
+
+#ifdef __STDC__
+static const int npio2_hw[] = {
+#else
+static int npio2_hw[] = {
+#endif
+0x3FF921FB, 0x400921FB, 0x4012D97C, 0x401921FB, 0x401F6A7A, 0x4022D97C,
+0x4025FDBB, 0x402921FB, 0x402C463A, 0x402F6A7A, 0x4031475C, 0x4032D97C,
+0x40346B9C, 0x4035FDBB, 0x40378FDB, 0x403921FB, 0x403AB41B, 0x403C463A,
+0x403DD85A, 0x403F6A7A, 0x40407E4C, 0x4041475C, 0x4042106C, 0x4042D97C,
+0x4043A28C, 0x40446B9C, 0x404534AC, 0x4045FDBB, 0x4046C6CB, 0x40478FDB,
+0x404858EB, 0x404921FB,
+};
+
+/*
+ * invpio2:  53 bits of 2/pi
+ * pio2_1:   first  33 bit of pi/2
+ * pio2_1t:  pi/2 - pio2_1
+ * pio2_2:   second 33 bit of pi/2
+ * pio2_2t:  pi/2 - (pio2_1+pio2_2)
+ * pio2_3:   third  33 bit of pi/2
+ * pio2_3t:  pi/2 - (pio2_1+pio2_2+pio2_3)
+ */
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+zero =  0.00000000000000000000e+00, /* 0x00000000, 0x00000000 */
+half =  5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
+two24 =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
+invpio2 =  6.36619772367581382433e-01, /* 0x3FE45F30, 0x6DC9C883 */
+pio2_1  =  1.57079632673412561417e+00, /* 0x3FF921FB, 0x54400000 */
+pio2_1t =  6.07710050650619224932e-11, /* 0x3DD0B461, 0x1A626331 */
+pio2_2  =  6.07710050630396597660e-11, /* 0x3DD0B461, 0x1A600000 */
+pio2_2t =  2.02226624879595063154e-21, /* 0x3BA3198A, 0x2E037073 */
+pio2_3  =  2.02226624871116645580e-21, /* 0x3BA3198A, 0x2E000000 */
+pio2_3t =  8.47842766036889956997e-32; /* 0x397B839A, 0x252049C1 */
+
+#ifdef __STDC__
+        int __ieee754_rem_pio2(double x, double *y)
+#else
+        int __ieee754_rem_pio2(x,y)
+        double x,y[];
+#endif
+{
+        double z,w,t,r,fn;
+        double tx[3];
+        int e0,i,j,nx,n,ix,hx;
+
+        hx = __HI(x);           /* high word of x */
+        ix = hx&0x7fffffff;
+        if(ix<=0x3fe921fb)   /* |x| ~<= pi/4 , no need for reduction */
+            {y[0] = x; y[1] = 0; return 0;}
+        if(ix<0x4002d97c) {  /* |x| < 3pi/4, special case with n=+-1 */
+            if(hx>0) {
+                z = x - pio2_1;
+                if(ix!=0x3ff921fb) {    /* 33+53 bit pi is good enough */
+                    y[0] = z - pio2_1t;
+                    y[1] = (z-y[0])-pio2_1t;
+                } else {                /* near pi/2, use 33+33+53 bit pi */
+                    z -= pio2_2;
+                    y[0] = z - pio2_2t;
+                    y[1] = (z-y[0])-pio2_2t;
+                }
+                return 1;
+            } else {    /* negative x */
+                z = x + pio2_1;
+                if(ix!=0x3ff921fb) {    /* 33+53 bit pi is good enough */
+                    y[0] = z + pio2_1t;
+                    y[1] = (z-y[0])+pio2_1t;
+                } else {                /* near pi/2, use 33+33+53 bit pi */
+                    z += pio2_2;
+                    y[0] = z + pio2_2t;
+                    y[1] = (z-y[0])+pio2_2t;
+                }
+                return -1;
+            }
+        }
+        if(ix<=0x413921fb) { /* |x| ~<= 2^19*(pi/2), medium size */
+            t  = fabs(x);
+            n  = (int) (t*invpio2+half);
+            fn = (double)n;
+            r  = t-fn*pio2_1;
+            w  = fn*pio2_1t;    /* 1st round good to 85 bit */
+            if(n<32&&ix!=npio2_hw[n-1]) {
+                y[0] = r-w;     /* quick check no cancellation */
+            } else {
+                j  = ix>>20;
+                y[0] = r-w;
+                i = j-(((__HI(y[0]))>>20)&0x7ff);
+                if(i>16) {  /* 2nd iteration needed, good to 118 */
+                    t  = r;
+                    w  = fn*pio2_2;
+                    r  = t-w;
+                    w  = fn*pio2_2t-((t-r)-w);
+                    y[0] = r-w;
+                    i = j-(((__HI(y[0]))>>20)&0x7ff);
+                    if(i>49)  { /* 3rd iteration need, 151 bits acc */
+                        t  = r; /* will cover all possible cases */
+                        w  = fn*pio2_3;
+                        r  = t-w;
+                        w  = fn*pio2_3t-((t-r)-w);
+                        y[0] = r-w;
+                    }
+                }
+            }
+            y[1] = (r-y[0])-w;
+            if(hx<0)    {y[0] = -y[0]; y[1] = -y[1]; return -n;}
+            else         return n;
+        }
+    /*
+     * all other (large) arguments
+     */
+        if(ix>=0x7ff00000) {            /* x is inf or NaN */
+            y[0]=y[1]=x-x; return 0;
+        }
+    /* set z = scalbn(|x|,ilogb(x)-23) */
+        __LO(z) = __LO(x);
+        e0      = (ix>>20)-1046;        /* e0 = ilogb(z)-23; */
+        __HI(z) = ix - (e0<<20);
+        for(i=0;i<2;i++) {
+                tx[i] = (double)((int)(z));
+                z     = (z-tx[i])*two24;
+        }
+        tx[2] = z;
+        nx = 3;
+        while(tx[nx-1]==zero) nx--;     /* skip zero term */
+        n  =  __kernel_rem_pio2(tx,y,e0,nx,2,two_over_pi);
+        if(hx<0) {y[0] = -y[0]; y[1] = -y[1]; return -n;}
+        return n;
+}

--- a/src/java.base/share/native/libfdlibm/e_remainder.c
+++ b/src/java.base/share/native/libfdlibm/e_remainder.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_remainder(x,p)
+ * Return :
+ *      returns  x REM p  =  x - [x/p]*p as if in infinite
+ *      precise arithmetic, where [x/p] is the (infinite bit)
+ *      integer nearest x/p (in half way case choose the even one).
+ * Method :
+ *      Based on fmod() return x-[x/p]chopped*p exactlp.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double zero = 0.0;
+#else
+static double zero = 0.0;
+#endif
+
+
+#ifdef __STDC__
+        double __ieee754_remainder(double x, double p)
+#else
+        double __ieee754_remainder(x,p)
+        double x,p;
+#endif
+{
+        int hx,hp;
+        unsigned sx,lx,lp;
+        double p_half;
+
+        hx = __HI(x);           /* high word of x */
+        lx = __LO(x);           /* low  word of x */
+        hp = __HI(p);           /* high word of p */
+        lp = __LO(p);           /* low  word of p */
+        sx = hx&0x80000000;
+        hp &= 0x7fffffff;
+        hx &= 0x7fffffff;
+
+    /* purge off exception values */
+        if((hp|lp)==0) return (x*p)/(x*p);      /* p = 0 */
+        if((hx>=0x7ff00000)||                   /* x not finite */
+          ((hp>=0x7ff00000)&&                   /* p is NaN */
+          (((hp-0x7ff00000)|lp)!=0)))
+            return (x*p)/(x*p);
+
+
+        if (hp<=0x7fdfffff) x = __ieee754_fmod(x,p+p);  /* now x < 2p */
+        if (((hx-hp)|(lx-lp))==0) return zero*x;
+        x  = fabs(x);
+        p  = fabs(p);
+        if (hp<0x00200000) {
+            if(x+x>p) {
+                x-=p;
+                if(x+x>=p) x -= p;
+            }
+        } else {
+            p_half = 0.5*p;
+            if(x>p_half) {
+                x-=p;
+                if(x>=p_half) x -= p;
+            }
+        }
+        __HI(x) ^= sx;
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/e_scalb.c
+++ b/src/java.base/share/native/libfdlibm/e_scalb.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * __ieee754_scalb(x, fn) is provide for
+ * passing various standard test suite. One
+ * should use scalbn() instead.
+ */
+
+#include "fdlibm.h"
+
+#ifdef _SCALB_INT
+#ifdef __STDC__
+        double __ieee754_scalb(double x, int fn)
+#else
+        double __ieee754_scalb(x,fn)
+        double x; int fn;
+#endif
+#else
+#ifdef __STDC__
+        double __ieee754_scalb(double x, double fn)
+#else
+        double __ieee754_scalb(x,fn)
+        double x, fn;
+#endif
+#endif
+{
+#ifdef _SCALB_INT
+        return scalbn(x,fn);
+#else
+        if (isnan(x)||isnan(fn)) return x*fn;
+        if (!finite(fn)) {
+            if(fn>0.0) return x*fn;
+            else       return x/(-fn);
+        }
+        if (rint(fn)!=fn) return (fn-fn)/(fn-fn);
+        if ( fn > 65000.0) return scalbn(x, 65000);
+        if (-fn > 65000.0) return scalbn(x,-65000);
+        return scalbn(x,(int)fn);
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/e_sinh.c
+++ b/src/java.base/share/native/libfdlibm/e_sinh.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_sinh(x)
+ * Method :
+ * mathematically sinh(x) if defined to be (exp(x)-exp(-x))/2
+ *      1. Replace x by |x| (sinh(-x) = -sinh(x)).
+ *      2.
+ *                                                  E + E/(E+1)
+ *          0        <= x <= 22     :  sinh(x) := --------------, E=expm1(x)
+ *                                                      2
+ *
+ *          22       <= x <= lnovft :  sinh(x) := exp(x)/2
+ *          lnovft   <= x <= ln2ovft:  sinh(x) := exp(x/2)/2 * exp(x/2)
+ *          ln2ovft  <  x           :  sinh(x) := x*shuge (overflow)
+ *
+ * Special cases:
+ *      sinh(x) is |x| if x is +INF, -INF, or NaN.
+ *      only sinh(0)=0 is exact for finite x.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double one = 1.0, shuge = 1.0e307;
+#else
+static double one = 1.0, shuge = 1.0e307;
+#endif
+
+#ifdef __STDC__
+        double __ieee754_sinh(double x)
+#else
+        double __ieee754_sinh(x)
+        double x;
+#endif
+{
+        double t,w,h;
+        int ix,jx;
+        unsigned lx;
+
+    /* High word of |x|. */
+        jx = __HI(x);
+        ix = jx&0x7fffffff;
+
+    /* x is INF or NaN */
+        if(ix>=0x7ff00000) return x+x;
+
+        h = 0.5;
+        if (jx<0) h = -h;
+    /* |x| in [0,22], return sign(x)*0.5*(E+E/(E+1))) */
+        if (ix < 0x40360000) {          /* |x|<22 */
+            if (ix<0x3e300000)          /* |x|<2**-28 */
+                if(shuge+x>one) return x;/* sinh(tiny) = tiny with inexact */
+            t = expm1(fabs(x));
+            if(ix<0x3ff00000) return h*(2.0*t-t*t/(t+one));
+            return h*(t+t/(t+one));
+        }
+
+    /* |x| in [22, log(maxdouble)] return 0.5*exp(|x|) */
+        if (ix < 0x40862E42)  return h*__ieee754_exp(fabs(x));
+
+    /* |x| in [log(maxdouble), overflowthresold] */
+        lx = *( (((*(unsigned*)&one)>>29)) + (unsigned*)&x);
+        if (ix<0x408633CE || ((ix==0x408633ce)&&(lx<=(unsigned)0x8fb9f87d))) {
+            w = __ieee754_exp(0.5*fabs(x));
+            t = h*w;
+            return t*w;
+        }
+
+    /* |x| > overflowthresold, sinh(x) overflow */
+        return x*shuge;
+}

--- a/src/java.base/share/native/libfdlibm/e_sqrt.c
+++ b/src/java.base/share/native/libfdlibm/e_sqrt.c
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __ieee754_sqrt(x)
+ * Return correctly rounded sqrt.
+ *           ------------------------------------------
+ *           |  Use the hardware sqrt if you have one |
+ *           ------------------------------------------
+ * Method:
+ *   Bit by bit method using integer arithmetic. (Slow, but portable)
+ *   1. Normalization
+ *      Scale x to y in [1,4) with even powers of 2:
+ *      find an integer k such that  1 <= (y=x*2^(2k)) < 4, then
+ *              sqrt(x) = 2^k * sqrt(y)
+ *   2. Bit by bit computation
+ *      Let q  = sqrt(y) truncated to i bit after binary point (q = 1),
+ *           i                                                   0
+ *                                     i+1         2
+ *          s  = 2*q , and      y  =  2   * ( y - q  ).         (1)
+ *           i      i            i                 i
+ *
+ *      To compute q    from q , one checks whether
+ *                  i+1       i
+ *
+ *                            -(i+1) 2
+ *                      (q + 2      ) <= y.                     (2)
+ *                        i
+ *                                                            -(i+1)
+ *      If (2) is false, then q   = q ; otherwise q   = q  + 2      .
+ *                             i+1   i             i+1   i
+ *
+ *      With some algebraic manipulation, it is not difficult to see
+ *      that (2) is equivalent to
+ *                             -(i+1)
+ *                      s  +  2       <= y                      (3)
+ *                       i                i
+ *
+ *      The advantage of (3) is that s  and y  can be computed by
+ *                                    i      i
+ *      the following recurrence formula:
+ *          if (3) is false
+ *
+ *          s     =  s  ,       y    = y   ;                    (4)
+ *           i+1      i          i+1    i
+ *
+ *          otherwise,
+ *                         -i                     -(i+1)
+ *          s     =  s  + 2  ,  y    = y  -  s  - 2             (5)
+ *           i+1      i          i+1    i     i
+ *
+ *      One may easily use induction to prove (4) and (5).
+ *      Note. Since the left hand side of (3) contain only i+2 bits,
+ *            it does not necessary to do a full (53-bit) comparison
+ *            in (3).
+ *   3. Final rounding
+ *      After generating the 53 bits result, we compute one more bit.
+ *      Together with the remainder, we can decide whether the
+ *      result is exact, bigger than 1/2ulp, or less than 1/2ulp
+ *      (it will never equal to 1/2ulp).
+ *      The rounding mode can be detected by checking whether
+ *      huge + tiny is equal to huge, and whether huge - tiny is
+ *      equal to huge for some floating point number "huge" and "tiny".
+ *
+ * Special cases:
+ *      sqrt(+-0) = +-0         ... exact
+ *      sqrt(inf) = inf
+ *      sqrt(-ve) = NaN         ... with invalid signal
+ *      sqrt(NaN) = NaN         ... with invalid signal for signaling NaN
+ *
+ * Other methods : see the appended file at the end of the program below.
+ *---------------
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static  const double    one     = 1.0, tiny=1.0e-300;
+#else
+static  double  one     = 1.0, tiny=1.0e-300;
+#endif
+
+#ifdef __STDC__
+        double __ieee754_sqrt(double x)
+#else
+        double __ieee754_sqrt(x)
+        double x;
+#endif
+{
+        double z;
+        int     sign = (int)0x80000000;
+        unsigned r,t1,s1,ix1,q1;
+        int ix0,s0,q,m,t,i;
+
+        ix0 = __HI(x);                  /* high word of x */
+        ix1 = __LO(x);          /* low word of x */
+
+    /* take care of Inf and NaN */
+        if((ix0&0x7ff00000)==0x7ff00000) {
+            return x*x+x;               /* sqrt(NaN)=NaN, sqrt(+inf)=+inf
+                                           sqrt(-inf)=sNaN */
+        }
+    /* take care of zero */
+        if(ix0<=0) {
+            if(((ix0&(~sign))|ix1)==0) return x;/* sqrt(+-0) = +-0 */
+            else if(ix0<0)
+                return (x-x)/(x-x);             /* sqrt(-ve) = sNaN */
+        }
+    /* normalize x */
+        m = (ix0>>20);
+        if(m==0) {                              /* subnormal x */
+            while(ix0==0) {
+                m -= 21;
+                ix0 |= (ix1>>11); ix1 <<= 21;
+            }
+            for(i=0;(ix0&0x00100000)==0;i++) ix0<<=1;
+            m -= i-1;
+            ix0 |= (ix1>>(32-i));
+            ix1 <<= i;
+        }
+        m -= 1023;      /* unbias exponent */
+        ix0 = (ix0&0x000fffff)|0x00100000;
+        if(m&1){        /* odd m, double x to make it even */
+            ix0 += ix0 + ((ix1&sign)>>31);
+            ix1 += ix1;
+        }
+        m >>= 1;        /* m = [m/2] */
+
+    /* generate sqrt(x) bit by bit */
+        ix0 += ix0 + ((ix1&sign)>>31);
+        ix1 += ix1;
+        q = q1 = s0 = s1 = 0;   /* [q,q1] = sqrt(x) */
+        r = 0x00200000;         /* r = moving bit from right to left */
+
+        while(r!=0) {
+            t = s0+r;
+            if(t<=ix0) {
+                s0   = t+r;
+                ix0 -= t;
+                q   += r;
+            }
+            ix0 += ix0 + ((ix1&sign)>>31);
+            ix1 += ix1;
+            r>>=1;
+        }
+
+        r = sign;
+        while(r!=0) {
+            t1 = s1+r;
+            t  = s0;
+            if((t<ix0)||((t==ix0)&&(t1<=ix1))) {
+                s1  = t1+r;
+                if(((t1&sign)==sign)&&(s1&sign)==0) s0 += 1;
+                ix0 -= t;
+                if (ix1 < t1) ix0 -= 1;
+                ix1 -= t1;
+                q1  += r;
+            }
+            ix0 += ix0 + ((ix1&sign)>>31);
+            ix1 += ix1;
+            r>>=1;
+        }
+
+    /* use floating add to find out rounding direction */
+        if((ix0|ix1)!=0) {
+            z = one-tiny; /* trigger inexact flag */
+            if (z>=one) {
+                z = one+tiny;
+                if (q1==(unsigned)0xffffffff) { q1=0; q += 1;}
+                else if (z>one) {
+                    if (q1==(unsigned)0xfffffffe) q+=1;
+                    q1+=2;
+                } else
+                    q1 += (q1&1);
+            }
+        }
+        ix0 = (q>>1)+0x3fe00000;
+        ix1 =  q1>>1;
+        if ((q&1)==1) ix1 |= sign;
+        ix0 += (m <<20);
+        __HI(z) = ix0;
+        __LO(z) = ix1;
+        return z;
+}
+
+/*
+Other methods  (use floating-point arithmetic)
+-------------
+(This is a copy of a drafted paper by Prof W. Kahan
+and K.C. Ng, written in May, 1986)
+
+        Two algorithms are given here to implement sqrt(x)
+        (IEEE double precision arithmetic) in software.
+        Both supply sqrt(x) correctly rounded. The first algorithm (in
+        Section A) uses newton iterations and involves four divisions.
+        The second one uses reciproot iterations to avoid division, but
+        requires more multiplications. Both algorithms need the ability
+        to chop results of arithmetic operations instead of round them,
+        and the INEXACT flag to indicate when an arithmetic operation
+        is executed exactly with no roundoff error, all part of the
+        standard (IEEE 754-1985). The ability to perform shift, add,
+        subtract and logical AND operations upon 32-bit words is needed
+        too, though not part of the standard.
+
+A.  sqrt(x) by Newton Iteration
+
+   (1)  Initial approximation
+
+        Let x0 and x1 be the leading and the trailing 32-bit words of
+        a floating point number x (in IEEE double format) respectively
+
+            1    11                  52                           ...widths
+           ------------------------------------------------------
+        x: |s|    e     |             f                         |
+           ------------------------------------------------------
+              msb    lsb  msb                                 lsb ...order
+
+
+             ------------------------        ------------------------
+        x0:  |s|   e    |    f1     |    x1: |          f2           |
+             ------------------------        ------------------------
+
+        By performing shifts and subtracts on x0 and x1 (both regarded
+        as integers), we obtain an 8-bit approximation of sqrt(x) as
+        follows.
+
+                k  := (x0>>1) + 0x1ff80000;
+                y0 := k - T1[31&(k>>15)].       ... y ~ sqrt(x) to 8 bits
+        Here k is a 32-bit integer and T1[] is an integer array containing
+        correction terms. Now magically the floating value of y (y's
+        leading 32-bit word is y0, the value of its trailing word is 0)
+        approximates sqrt(x) to almost 8-bit.
+
+        Value of T1:
+        static int T1[32]= {
+        0,      1024,   3062,   5746,   9193,   13348,  18162,  23592,
+        29598,  36145,  43202,  50740,  58733,  67158,  75992,  85215,
+        83599,  71378,  60428,  50647,  41945,  34246,  27478,  21581,
+        16499,  12183,  8588,   5674,   3403,   1742,   661,    130,};
+
+    (2) Iterative refinement
+
+        Apply Heron's rule three times to y, we have y approximates
+        sqrt(x) to within 1 ulp (Unit in the Last Place):
+
+                y := (y+x/y)/2          ... almost 17 sig. bits
+                y := (y+x/y)/2          ... almost 35 sig. bits
+                y := y-(y-x/y)/2        ... within 1 ulp
+
+
+        Remark 1.
+            Another way to improve y to within 1 ulp is:
+
+                y := (y+x/y)            ... almost 17 sig. bits to 2*sqrt(x)
+                y := y - 0x00100006     ... almost 18 sig. bits to sqrt(x)
+
+                                2
+                            (x-y )*y
+                y := y + 2* ----------  ...within 1 ulp
+                               2
+                             3y  + x
+
+
+        This formula has one division fewer than the one above; however,
+        it requires more multiplications and additions. Also x must be
+        scaled in advance to avoid spurious overflow in evaluating the
+        expression 3y*y+x. Hence it is not recommended uless division
+        is slow. If division is very slow, then one should use the
+        reciproot algorithm given in section B.
+
+    (3) Final adjustment
+
+        By twiddling y's last bit it is possible to force y to be
+        correctly rounded according to the prevailing rounding mode
+        as follows. Let r and i be copies of the rounding mode and
+        inexact flag before entering the square root program. Also we
+        use the expression y+-ulp for the next representable floating
+        numbers (up and down) of y. Note that y+-ulp = either fixed
+        point y+-1, or multiply y by nextafter(1,+-inf) in chopped
+        mode.
+
+                I := FALSE;     ... reset INEXACT flag I
+                R := RZ;        ... set rounding mode to round-toward-zero
+                z := x/y;       ... chopped quotient, possibly inexact
+                If(not I) then {        ... if the quotient is exact
+                    if(z=y) {
+                        I := i;  ... restore inexact flag
+                        R := r;  ... restore rounded mode
+                        return sqrt(x):=y.
+                    } else {
+                        z := z - ulp;   ... special rounding
+                    }
+                }
+                i := TRUE;              ... sqrt(x) is inexact
+                If (r=RN) then z=z+ulp  ... rounded-to-nearest
+                If (r=RP) then {        ... round-toward-+inf
+                    y = y+ulp; z=z+ulp;
+                }
+                y := y+z;               ... chopped sum
+                y0:=y0-0x00100000;      ... y := y/2 is correctly rounded.
+                I := i;                 ... restore inexact flag
+                R := r;                 ... restore rounded mode
+                return sqrt(x):=y.
+
+    (4) Special cases
+
+        Square root of +inf, +-0, or NaN is itself;
+        Square root of a negative number is NaN with invalid signal.
+
+
+B.  sqrt(x) by Reciproot Iteration
+
+   (1)  Initial approximation
+
+        Let x0 and x1 be the leading and the trailing 32-bit words of
+        a floating point number x (in IEEE double format) respectively
+        (see section A). By performing shifs and subtracts on x0 and y0,
+        we obtain a 7.8-bit approximation of 1/sqrt(x) as follows.
+
+            k := 0x5fe80000 - (x0>>1);
+            y0:= k - T2[63&(k>>14)].    ... y ~ 1/sqrt(x) to 7.8 bits
+
+        Here k is a 32-bit integer and T2[] is an integer array
+        containing correction terms. Now magically the floating
+        value of y (y's leading 32-bit word is y0, the value of
+        its trailing word y1 is set to zero) approximates 1/sqrt(x)
+        to almost 7.8-bit.
+
+        Value of T2:
+        static int T2[64]= {
+        0x1500, 0x2ef8, 0x4d67, 0x6b02, 0x87be, 0xa395, 0xbe7a, 0xd866,
+        0xf14a, 0x1091b,0x11fcd,0x13552,0x14999,0x15c98,0x16e34,0x17e5f,
+        0x18d03,0x19a01,0x1a545,0x1ae8a,0x1b5c4,0x1bb01,0x1bfde,0x1c28d,
+        0x1c2de,0x1c0db,0x1ba73,0x1b11c,0x1a4b5,0x1953d,0x18266,0x16be0,
+        0x1683e,0x179d8,0x18a4d,0x19992,0x1a789,0x1b445,0x1bf61,0x1c989,
+        0x1d16d,0x1d77b,0x1dddf,0x1e2ad,0x1e5bf,0x1e6e8,0x1e654,0x1e3cd,
+        0x1df2a,0x1d635,0x1cb16,0x1be2c,0x1ae4e,0x19bde,0x1868e,0x16e2e,
+        0x1527f,0x1334a,0x11051,0xe951, 0xbe01, 0x8e0d, 0x5924, 0x1edd,};
+
+    (2) Iterative refinement
+
+        Apply Reciproot iteration three times to y and multiply the
+        result by x to get an approximation z that matches sqrt(x)
+        to about 1 ulp. To be exact, we will have
+                -1ulp < sqrt(x)-z<1.0625ulp.
+
+        ... set rounding mode to Round-to-nearest
+           y := y*(1.5-0.5*x*y*y)       ... almost 15 sig. bits to 1/sqrt(x)
+           y := y*((1.5-2^-30)+0.5*x*y*y)... about 29 sig. bits to 1/sqrt(x)
+        ... special arrangement for better accuracy
+           z := x*y                     ... 29 bits to sqrt(x), with z*y<1
+           z := z + 0.5*z*(1-z*y)       ... about 1 ulp to sqrt(x)
+
+        Remark 2. The constant 1.5-2^-30 is chosen to bias the error so that
+        (a) the term z*y in the final iteration is always less than 1;
+        (b) the error in the final result is biased upward so that
+                -1 ulp < sqrt(x) - z < 1.0625 ulp
+            instead of |sqrt(x)-z|<1.03125ulp.
+
+    (3) Final adjustment
+
+        By twiddling y's last bit it is possible to force y to be
+        correctly rounded according to the prevailing rounding mode
+        as follows. Let r and i be copies of the rounding mode and
+        inexact flag before entering the square root program. Also we
+        use the expression y+-ulp for the next representable floating
+        numbers (up and down) of y. Note that y+-ulp = either fixed
+        point y+-1, or multiply y by nextafter(1,+-inf) in chopped
+        mode.
+
+        R := RZ;                ... set rounding mode to round-toward-zero
+        switch(r) {
+            case RN:            ... round-to-nearest
+               if(x<= z*(z-ulp)...chopped) z = z - ulp; else
+               if(x<= z*(z+ulp)...chopped) z = z; else z = z+ulp;
+               break;
+            case RZ:case RM:    ... round-to-zero or round-to--inf
+               R:=RP;           ... reset rounding mod to round-to-+inf
+               if(x<z*z ... rounded up) z = z - ulp; else
+               if(x>=(z+ulp)*(z+ulp) ...rounded up) z = z+ulp;
+               break;
+            case RP:            ... round-to-+inf
+               if(x>(z+ulp)*(z+ulp)...chopped) z = z+2*ulp; else
+               if(x>z*z ...chopped) z = z+ulp;
+               break;
+        }
+
+        Remark 3. The above comparisons can be done in fixed point. For
+        example, to compare x and w=z*z chopped, it suffices to compare
+        x1 and w1 (the trailing parts of x and w), regarding them as
+        two's complement integers.
+
+        ...Is z an exact square root?
+        To determine whether z is an exact square root of x, let z1 be the
+        trailing part of z, and also let x0 and x1 be the leading and
+        trailing parts of x.
+
+        If ((z1&0x03ffffff)!=0) ... not exact if trailing 26 bits of z!=0
+            I := 1;             ... Raise Inexact flag: z is not exact
+        else {
+            j := 1 - [(x0>>20)&1]       ... j = logb(x) mod 2
+            k := z1 >> 26;              ... get z's 25-th and 26-th
+                                            fraction bits
+            I := i or (k&j) or ((k&(j+j+1))!=(x1&3));
+        }
+        R:= r           ... restore rounded mode
+        return sqrt(x):=z.
+
+        If multiplication is cheaper then the foregoing red tape, the
+        Inexact flag can be evaluated by
+
+            I := i;
+            I := (z*z!=x) or I.
+
+        Note that z*z can overwrite I; this value must be sensed if it is
+        True.
+
+        Remark 4. If z*z = x exactly, then bit 25 to bit 0 of z1 must be
+        zero.
+
+                    --------------------
+                z1: |        f2        |
+                    --------------------
+                bit 31             bit 0
+
+        Further more, bit 27 and 26 of z1, bit 0 and 1 of x1, and the odd
+        or even of logb(x) have the following relations:
+
+        -------------------------------------------------
+        bit 27,26 of z1         bit 1,0 of x1   logb(x)
+        -------------------------------------------------
+        00                      00              odd and even
+        01                      01              even
+        10                      10              odd
+        10                      00              even
+        11                      01              even
+        -------------------------------------------------
+
+    (4) Special cases (see (4) of Section A).
+
+ */

--- a/src/java.base/share/native/libfdlibm/fdlibm.h
+++ b/src/java.base/share/native/libfdlibm/fdlibm.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _ALLBSD_SOURCE
+#include <machine/endian.h>
+#elif defined(__linux__)
+#define __USE_BSD 1
+#include <endian.h>
+#endif
+#include "jfdlibm.h"
+
+#ifdef __NEWVALID       /* special setup for Sun test regime */
+#if defined(i386) || defined(i486) || \
+    defined(intel) || defined(x86) || defined(arm) || \
+    defined(i86pc) || defined(ia64)
+#define _LITTLE_ENDIAN
+#endif
+#endif
+
+#ifdef _LITTLE_ENDIAN
+#define __HI(x) *(1+(int*)&x)
+#define __LO(x) *(int*)&x
+#define __HIp(x) *(1+(int*)x)
+#define __LOp(x) *(int*)x
+#else
+#define __HI(x) *(int*)&x
+#define __LO(x) *(1+(int*)&x)
+#define __HIp(x) *(int*)x
+#define __LOp(x) *(1+(int*)x)
+#endif
+
+#ifndef __P
+#ifdef __STDC__
+#define __P(p)  p
+#else
+#define __P(p)  ()
+#endif
+#endif
+
+/*
+ * ANSI/POSIX
+ */
+
+extern int signgam;
+
+#define MAXFLOAT        ((float)3.40282346638528860e+38)
+
+enum fdversion {fdlibm_ieee = -1, fdlibm_svid, fdlibm_xopen, fdlibm_posix};
+
+#define _LIB_VERSION_TYPE enum fdversion
+#define _LIB_VERSION _fdlib_version
+
+/* if global variable _LIB_VERSION is not desirable, one may
+ * change the following to be a constant by:
+ *      #define _LIB_VERSION_TYPE const enum version
+ * In that case, after one initializes the value _LIB_VERSION (see
+ * s_lib_version.c) during compile time, it cannot be modified
+ * in the middle of a program
+ */
+extern  _LIB_VERSION_TYPE  _LIB_VERSION;
+
+#define _IEEE_  fdlibm_ieee
+#define _SVID_  fdlibm_svid
+#define _XOPEN_ fdlibm_xopen
+#define _POSIX_ fdlibm_posix
+
+struct exception {
+        int type;
+        char *name;
+        double arg1;
+        double arg2;
+        double retval;
+};
+
+#define HUGE            MAXFLOAT
+
+/*
+ * set X_TLOSS = pi*2**52, which is possibly defined in <values.h>
+ * (one may replace the following line by "#include <values.h>")
+ */
+
+#define X_TLOSS         1.41484755040568800000e+16
+
+#define DOMAIN          1
+#define SING            2
+#define OVERFLOW        3
+#define UNDERFLOW       4
+#define TLOSS           5
+#define PLOSS           6
+
+/*
+ * ANSI/POSIX
+ */
+extern double acos __P((double));
+extern double asin __P((double));
+extern double atan __P((double));
+extern double atan2 __P((double, double));
+extern double cos __P((double));
+extern double sin __P((double));
+extern double tan __P((double));
+
+extern double cosh __P((double));
+extern double sinh __P((double));
+extern double tanh __P((double));
+
+extern double exp __P((double));
+extern double frexp __P((double, int *));
+extern double ldexp __P((double, int));
+extern double log __P((double));
+extern double log10 __P((double));
+extern double modf __P((double, double *));
+
+extern double sqrt __P((double));
+
+extern double ceil __P((double));
+extern double fabs __P((double));
+extern double floor __P((double));
+extern double fmod __P((double, double));
+
+extern double hypot __P((double, double));
+extern int isnan __P((double));
+extern int finite __P((double));
+
+extern double atanh __P((double));
+extern double cbrt __P((double));
+extern double logb __P((double));
+extern double nextafter __P((double, double));
+extern double remainder __P((double, double));
+#ifdef _SCALB_INT
+extern double scalb __P((double, int));
+#else
+extern double scalb __P((double, double));
+#endif
+
+extern int matherr __P((struct exception *));
+
+/*
+ * IEEE Test Vector
+ */
+extern double significand __P((double));
+
+/*
+ * Functions callable from C, intended to support IEEE arithmetic.
+ */
+extern double copysign __P((double, double));
+extern int ilogb __P((double));
+extern double rint __P((double));
+extern double scalbn __P((double, int));
+
+/*
+ * BSD math library entry points
+ */
+extern double expm1 __P((double));
+extern double log1p __P((double));
+
+/* ieee style elementary functions */
+extern double __ieee754_sqrt __P((double));
+extern double __ieee754_acos __P((double));
+extern double __ieee754_log __P((double));
+extern double __ieee754_atanh __P((double));
+extern double __ieee754_asin __P((double));
+extern double __ieee754_atan2 __P((double,double));
+extern double __ieee754_exp __P((double));
+extern double __ieee754_cosh __P((double));
+extern double __ieee754_fmod __P((double,double));
+extern double __ieee754_log10 __P((double));
+extern double __ieee754_sinh __P((double));
+extern double __ieee754_hypot __P((double,double));
+extern double __ieee754_remainder __P((double,double));
+extern int    __ieee754_rem_pio2 __P((double,double*));
+#ifdef _SCALB_INT
+extern double __ieee754_scalb __P((double,int));
+#else
+extern double __ieee754_scalb __P((double,double));
+#endif
+
+/* fdlibm kernel function */
+extern double __kernel_standard __P((double,double,int));
+extern double __kernel_sin __P((double,double,int));
+extern double __kernel_cos __P((double,double));
+extern double __kernel_tan __P((double,double,int));
+extern int    __kernel_rem_pio2 __P((double*,double*,int,int,int,const int*));

--- a/src/java.base/share/native/libfdlibm/jfdlibm.h
+++ b/src/java.base/share/native/libfdlibm/jfdlibm.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 1998, 2012, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef _JFDLIBM_H
+#define _JFDLIBM_H
+
+#define _IEEE_LIBM
+
+/*
+ * In order to resolve the conflict between fdlibm and compilers
+ * (such as keywords and built-in functions), the following
+ * function names have to be re-mapped.
+ */
+
+#define huge    HUGE_NUMBER
+#define acos    jacos
+#define asin    jasin
+#define atan    jatan
+#define atan2   jatan2
+#define cos     jcos
+#define exp     jexp
+#define log     jlog
+#define log10   jlog10
+#define pow     jpow
+#define sin     jsin
+#define sqrt    jsqrt
+#define cbrt    jcbrt
+#define tan     jtan
+#define floor   jfloor
+#define ceil    jceil
+#define cosh    jcosh
+#define fmod    jmod
+#define log10   jlog10
+#define sinh    jsinh
+#define fabs    jfabs
+#define tanh    jtanh
+#define remainder jremainder
+#define hypot   jhypot
+#define log1p   jlog1p
+#define expm1   jexpm1
+
+#if defined(__linux__) || defined(_ALLBSD_SOURCE)
+#define __ieee754_sqrt          __j__ieee754_sqrt
+#define __ieee754_acos          __j__ieee754_acos
+#define __ieee754_log           __j__ieee754_log
+#define __ieee754_atanh         __j__ieee754_atanh
+#define __ieee754_asin          __j__ieee754_asin
+#define __ieee754_atan2         __j__ieee754_atan2
+#define __ieee754_exp           __j__ieee754_exp
+#define __ieee754_cosh          __j__ieee754_cosh
+#define __ieee754_fmod          __j__ieee754_fmod
+#define __ieee754_pow           __j__ieee754_pow
+#define __ieee754_log10         __j__ieee754_log10
+#define __ieee754_sinh          __j__ieee754_sinh
+#define __ieee754_hypot         __j__ieee754_hypot
+#define __ieee754_remainder     __j__ieee754_remainder
+#define __ieee754_rem_pio2      __j__ieee754_rem_pio2
+#define __ieee754_scalb         __j__ieee754_scalb
+#define __kernel_standard       __j__kernel_standard
+#define __kernel_sin            __j__kernel_sin
+#define __kernel_cos            __j__kernel_cos
+#define __kernel_tan            __j__kernel_tan
+#define __kernel_rem_pio2       __j__kernel_rem_pio2
+#define __ieee754_log1p         __j__ieee754_log1p
+#define __ieee754_expm1         __j__ieee754_expm1
+#endif
+#endif/*_JFDLIBM_H*/

--- a/src/java.base/share/native/libfdlibm/k_cos.c
+++ b/src/java.base/share/native/libfdlibm/k_cos.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * __kernel_cos( x,  y )
+ * kernel cos function on [-pi/4, pi/4], pi/4 ~ 0.785398164
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ *
+ * Algorithm
+ *      1. Since cos(-x) = cos(x), we need only to consider positive x.
+ *      2. if x < 2^-27 (hx<0x3e400000 0), return 1 with inexact if x!=0.
+ *      3. cos(x) is approximated by a polynomial of degree 14 on
+ *         [0,pi/4]
+ *                                       4            14
+ *              cos(x) ~ 1 - x*x/2 + C1*x + ... + C6*x
+ *         where the remez error is
+ *
+ *      |              2     4     6     8     10    12     14 |     -58
+ *      |cos(x)-(1-.5*x +C1*x +C2*x +C3*x +C4*x +C5*x  +C6*x  )| <= 2
+ *      |                                                      |
+ *
+ *                     4     6     8     10    12     14
+ *      4. let r = C1*x +C2*x +C3*x +C4*x +C5*x  +C6*x  , then
+ *             cos(x) = 1 - x*x/2 + r
+ *         since cos(x+y) ~ cos(x) - sin(x)*y
+ *                        ~ cos(x) - x*y,
+ *         a correction term is necessary in cos(x) and hence
+ *              cos(x+y) = 1 - (x*x/2 - (r - x*y))
+ *         For better accuracy when x > 0.3, let qx = |x|/4 with
+ *         the last 32 bits mask off, and if x > 0.78125, let qx = 0.28125.
+ *         Then
+ *              cos(x+y) = (1-qx) - ((x*x/2-qx) - (r-x*y)).
+ *         Note that 1-qx and (x*x/2-qx) is EXACT here, and the
+ *         magnitude of the latter is at least a quarter of x*x/2,
+ *         thus, reducing the rounding error in the subtraction.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+one =  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+C1  =  4.16666666666666019037e-02, /* 0x3FA55555, 0x5555554C */
+C2  = -1.38888888888741095749e-03, /* 0xBF56C16C, 0x16C15177 */
+C3  =  2.48015872894767294178e-05, /* 0x3EFA01A0, 0x19CB1590 */
+C4  = -2.75573143513906633035e-07, /* 0xBE927E4F, 0x809C52AD */
+C5  =  2.08757232129817482790e-09, /* 0x3E21EE9E, 0xBDB4B1C4 */
+C6  = -1.13596475577881948265e-11; /* 0xBDA8FAE9, 0xBE8838D4 */
+
+#ifdef __STDC__
+        double __kernel_cos(double x, double y)
+#else
+        double __kernel_cos(x, y)
+        double x,y;
+#endif
+{
+        double a,hz,z,r,qx;
+        int ix;
+        ix = __HI(x)&0x7fffffff;        /* ix = |x|'s high word*/
+        if(ix<0x3e400000) {                     /* if x < 2**27 */
+            if(((int)x)==0) return one;         /* generate inexact */
+        }
+        z  = x*x;
+        r  = z*(C1+z*(C2+z*(C3+z*(C4+z*(C5+z*C6)))));
+        if(ix < 0x3FD33333)                     /* if |x| < 0.3 */
+            return one - (0.5*z - (z*r - x*y));
+        else {
+            if(ix > 0x3fe90000) {               /* x > 0.78125 */
+                qx = 0.28125;
+            } else {
+                __HI(qx) = ix-0x00200000;       /* x/4 */
+                __LO(qx) = 0;
+            }
+            hz = 0.5*z-qx;
+            a  = one-qx;
+            return a - (hz - (z*r-x*y));
+        }
+}

--- a/src/java.base/share/native/libfdlibm/k_rem_pio2.c
+++ b/src/java.base/share/native/libfdlibm/k_rem_pio2.c
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * __kernel_rem_pio2(x,y,e0,nx,prec,ipio2)
+ * double x[],y[]; int e0,nx,prec; int ipio2[];
+ *
+ * __kernel_rem_pio2 return the last three digits of N with
+ *              y = x - N*pi/2
+ * so that |y| < pi/2.
+ *
+ * The method is to compute the integer (mod 8) and fraction parts of
+ * (2/pi)*x without doing the full multiplication. In general we
+ * skip the part of the product that are known to be a huge integer (
+ * more accurately, = 0 mod 8 ). Thus the number of operations are
+ * independent of the exponent of the input.
+ *
+ * (2/pi) is represented by an array of 24-bit integers in ipio2[].
+ *
+ * Input parameters:
+ *      x[]     The input value (must be positive) is broken into nx
+ *              pieces of 24-bit integers in double precision format.
+ *              x[i] will be the i-th 24 bit of x. The scaled exponent
+ *              of x[0] is given in input parameter e0 (i.e., x[0]*2^e0
+ *              match x's up to 24 bits.
+ *
+ *              Example of breaking a double positive z into x[0]+x[1]+x[2]:
+ *                      e0 = ilogb(z)-23
+ *                      z  = scalbn(z,-e0)
+ *              for i = 0,1,2
+ *                      x[i] = floor(z)
+ *                      z    = (z-x[i])*2**24
+ *
+ *
+ *      y[]     output result in an array of double precision numbers.
+ *              The dimension of y[] is:
+ *                      24-bit  precision       1
+ *                      53-bit  precision       2
+ *                      64-bit  precision       2
+ *                      113-bit precision       3
+ *              The actual value is the sum of them. Thus for 113-bit
+ *              precision, one may have to do something like:
+ *
+ *              long double t,w,r_head, r_tail;
+ *              t = (long double)y[2] + (long double)y[1];
+ *              w = (long double)y[0];
+ *              r_head = t+w;
+ *              r_tail = w - (r_head - t);
+ *
+ *      e0      The exponent of x[0]
+ *
+ *      nx      dimension of x[]
+ *
+ *      prec    an integer indicating the precision:
+ *                      0       24  bits (single)
+ *                      1       53  bits (double)
+ *                      2       64  bits (extended)
+ *                      3       113 bits (quad)
+ *
+ *      ipio2[]
+ *              integer array, contains the (24*i)-th to (24*i+23)-th
+ *              bit of 2/pi after binary point. The corresponding
+ *              floating value is
+ *
+ *                      ipio2[i] * 2^(-24(i+1)).
+ *
+ * External function:
+ *      double scalbn(), floor();
+ *
+ *
+ * Here is the description of some local variables:
+ *
+ *      jk      jk+1 is the initial number of terms of ipio2[] needed
+ *              in the computation. The recommended value is 2,3,4,
+ *              6 for single, double, extended,and quad.
+ *
+ *      jz      local integer variable indicating the number of
+ *              terms of ipio2[] used.
+ *
+ *      jx      nx - 1
+ *
+ *      jv      index for pointing to the suitable ipio2[] for the
+ *              computation. In general, we want
+ *                      ( 2^e0*x[0] * ipio2[jv-1]*2^(-24jv) )/8
+ *              is an integer. Thus
+ *                      e0-3-24*jv >= 0 or (e0-3)/24 >= jv
+ *              Hence jv = max(0,(e0-3)/24).
+ *
+ *      jp      jp+1 is the number of terms in PIo2[] needed, jp = jk.
+ *
+ *      q[]     double array with integral value, representing the
+ *              24-bits chunk of the product of x and 2/pi.
+ *
+ *      q0      the corresponding exponent of q[0]. Note that the
+ *              exponent for q[i] would be q0-24*i.
+ *
+ *      PIo2[]  double precision array, obtained by cutting pi/2
+ *              into 24 bits chunks.
+ *
+ *      f[]     ipio2[] in floating point
+ *
+ *      iq[]    integer array by breaking up q[] in 24-bits chunk.
+ *
+ *      fq[]    final product of x*(2/pi) in fq[0],..,fq[jk]
+ *
+ *      ih      integer. If >0 it indicates q[] is >= 0.5, hence
+ *              it also indicates the *sign* of the result.
+ *
+ */
+
+
+/*
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const int init_jk[] = {2,3,4,6}; /* initial value for jk */
+#else
+static int init_jk[] = {2,3,4,6};
+#endif
+
+#ifdef __STDC__
+static const double PIo2[] = {
+#else
+static double PIo2[] = {
+#endif
+  1.57079625129699707031e+00, /* 0x3FF921FB, 0x40000000 */
+  7.54978941586159635335e-08, /* 0x3E74442D, 0x00000000 */
+  5.39030252995776476554e-15, /* 0x3CF84698, 0x80000000 */
+  3.28200341580791294123e-22, /* 0x3B78CC51, 0x60000000 */
+  1.27065575308067607349e-29, /* 0x39F01B83, 0x80000000 */
+  1.22933308981111328932e-36, /* 0x387A2520, 0x40000000 */
+  2.73370053816464559624e-44, /* 0x36E38222, 0x80000000 */
+  2.16741683877804819444e-51, /* 0x3569F31D, 0x00000000 */
+};
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+zero   = 0.0,
+one    = 1.0,
+two24   =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
+twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
+
+#ifdef __STDC__
+        int __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec, const int *ipio2)
+#else
+        int __kernel_rem_pio2(x,y,e0,nx,prec,ipio2)
+        double x[], y[]; int e0,nx,prec; int ipio2[];
+#endif
+{
+        int jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;
+        double z,fw,f[20],fq[20],q[20];
+
+    /* initialize jk*/
+        jk = init_jk[prec];
+        jp = jk;
+
+    /* determine jx,jv,q0, note that 3>q0 */
+        jx =  nx-1;
+        jv = (e0-3)/24; if(jv<0) jv=0;
+        q0 =  e0-24*(jv+1);
+
+    /* set up f[0] to f[jx+jk] where f[jx+jk] = ipio2[jv+jk] */
+        j = jv-jx; m = jx+jk;
+        for(i=0;i<=m;i++,j++) f[i] = (j<0)? zero : (double) ipio2[j];
+
+    /* compute q[0],q[1],...q[jk] */
+        for (i=0;i<=jk;i++) {
+            for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j];
+            q[i] = fw;
+        }
+
+        jz = jk;
+recompute:
+    /* distill q[] into iq[] reversingly */
+        for(i=0,j=jz,z=q[jz];j>0;i++,j--) {
+            fw    =  (double)((int)(twon24* z));
+            iq[i] =  (int)(z-two24*fw);
+            z     =  q[j-1]+fw;
+        }
+
+    /* compute n */
+        z  = scalbn(z,q0);              /* actual value of z */
+        z -= 8.0*floor(z*0.125);                /* trim off integer >= 8 */
+        n  = (int) z;
+        z -= (double)n;
+        ih = 0;
+        if(q0>0) {      /* need iq[jz-1] to determine n */
+            i  = (iq[jz-1]>>(24-q0)); n += i;
+            iq[jz-1] -= i<<(24-q0);
+            ih = iq[jz-1]>>(23-q0);
+        }
+        else if(q0==0) ih = iq[jz-1]>>23;
+        else if(z>=0.5) ih=2;
+
+        if(ih>0) {      /* q > 0.5 */
+            n += 1; carry = 0;
+            for(i=0;i<jz ;i++) {        /* compute 1-q */
+                j = iq[i];
+                if(carry==0) {
+                    if(j!=0) {
+                        carry = 1; iq[i] = 0x1000000- j;
+                    }
+                } else  iq[i] = 0xffffff - j;
+            }
+            if(q0>0) {          /* rare case: chance is 1 in 12 */
+                switch(q0) {
+                case 1:
+                   iq[jz-1] &= 0x7fffff; break;
+                case 2:
+                   iq[jz-1] &= 0x3fffff; break;
+                }
+            }
+            if(ih==2) {
+                z = one - z;
+                if(carry!=0) z -= scalbn(one,q0);
+            }
+        }
+
+    /* check if recomputation is needed */
+        if(z==zero) {
+            j = 0;
+            for (i=jz-1;i>=jk;i--) j |= iq[i];
+            if(j==0) { /* need recomputation */
+                for(k=1;iq[jk-k]==0;k++);   /* k = no. of terms needed */
+
+                for(i=jz+1;i<=jz+k;i++) {   /* add q[jz+1] to q[jz+k] */
+                    f[jx+i] = (double) ipio2[jv+i];
+                    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j];
+                    q[i] = fw;
+                }
+                jz += k;
+                goto recompute;
+            }
+        }
+
+    /* chop off zero terms */
+        if(z==0.0) {
+            jz -= 1; q0 -= 24;
+            while(iq[jz]==0) { jz--; q0-=24;}
+        } else { /* break z into 24-bit if necessary */
+            z = scalbn(z,-q0);
+            if(z>=two24) {
+                fw = (double)((int)(twon24*z));
+                iq[jz] = (int)(z-two24*fw);
+                jz += 1; q0 += 24;
+                iq[jz] = (int) fw;
+            } else iq[jz] = (int) z ;
+        }
+
+    /* convert integer "bit" chunk to floating-point value */
+        fw = scalbn(one,q0);
+        for(i=jz;i>=0;i--) {
+            q[i] = fw*(double)iq[i]; fw*=twon24;
+        }
+
+    /* compute PIo2[0,...,jp]*q[jz,...,0] */
+        for(i=jz;i>=0;i--) {
+            for(fw=0.0,k=0;k<=jp&&k<=jz-i;k++) fw += PIo2[k]*q[i+k];
+            fq[jz-i] = fw;
+        }
+
+    /* compress fq[] into y[] */
+        switch(prec) {
+            case 0:
+                fw = 0.0;
+                for (i=jz;i>=0;i--) fw += fq[i];
+                y[0] = (ih==0)? fw: -fw;
+                break;
+            case 1:
+            case 2:
+                fw = 0.0;
+                for (i=jz;i>=0;i--) fw += fq[i];
+                y[0] = (ih==0)? fw: -fw;
+                fw = fq[0]-fw;
+                for (i=1;i<=jz;i++) fw += fq[i];
+                y[1] = (ih==0)? fw: -fw;
+                break;
+            case 3:     /* painful */
+                for (i=jz;i>0;i--) {
+                    fw      = fq[i-1]+fq[i];
+                    fq[i]  += fq[i-1]-fw;
+                    fq[i-1] = fw;
+                }
+                for (i=jz;i>1;i--) {
+                    fw      = fq[i-1]+fq[i];
+                    fq[i]  += fq[i-1]-fw;
+                    fq[i-1] = fw;
+                }
+                for (fw=0.0,i=jz;i>=2;i--) fw += fq[i];
+                if(ih==0) {
+                    y[0] =  fq[0]; y[1] =  fq[1]; y[2] =  fw;
+                } else {
+                    y[0] = -fq[0]; y[1] = -fq[1]; y[2] = -fw;
+                }
+        }
+        return n&7;
+}

--- a/src/java.base/share/native/libfdlibm/k_sin.c
+++ b/src/java.base/share/native/libfdlibm/k_sin.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __kernel_sin( x, y, iy)
+ * kernel sin function on [-pi/4, pi/4], pi/4 ~ 0.7854
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ * Input iy indicates whether y is 0. (if iy=0, y assume to be 0).
+ *
+ * Algorithm
+ *      1. Since sin(-x) = -sin(x), we need only to consider positive x.
+ *      2. if x < 2^-27 (hx<0x3e400000 0), return x with inexact if x!=0.
+ *      3. sin(x) is approximated by a polynomial of degree 13 on
+ *         [0,pi/4]
+ *                               3            13
+ *              sin(x) ~ x + S1*x + ... + S6*x
+ *         where
+ *
+ *      |sin(x)         2     4     6     8     10     12  |     -58
+ *      |----- - (1+S1*x +S2*x +S3*x +S4*x +S5*x  +S6*x   )| <= 2
+ *      |  x                                               |
+ *
+ *      4. sin(x+y) = sin(x) + sin'(x')*y
+ *                  ~ sin(x) + (1-x*x/2)*y
+ *         For better accuracy, let
+ *                   3      2      2      2      2
+ *              r = x *(S2+x *(S3+x *(S4+x *(S5+x *S6))))
+ *         then                   3    2
+ *              sin(x) = x + (S1*x + (x *(r-y/2)+y))
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+half =  5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
+S1  = -1.66666666666666324348e-01, /* 0xBFC55555, 0x55555549 */
+S2  =  8.33333333332248946124e-03, /* 0x3F811111, 0x1110F8A6 */
+S3  = -1.98412698298579493134e-04, /* 0xBF2A01A0, 0x19C161D5 */
+S4  =  2.75573137070700676789e-06, /* 0x3EC71DE3, 0x57B1FE7D */
+S5  = -2.50507602534068634195e-08, /* 0xBE5AE5E6, 0x8A2B9CEB */
+S6  =  1.58969099521155010221e-10; /* 0x3DE5D93A, 0x5ACFD57C */
+
+#ifdef __STDC__
+        double __kernel_sin(double x, double y, int iy)
+#else
+        double __kernel_sin(x, y, iy)
+        double x,y; int iy;             /* iy=0 if y is zero */
+#endif
+{
+        double z,r,v;
+        int ix;
+        ix = __HI(x)&0x7fffffff;        /* high word of x */
+        if(ix<0x3e400000)                       /* |x| < 2**-27 */
+           {if((int)x==0) return x;}            /* generate inexact */
+        z       =  x*x;
+        v       =  z*x;
+        r       =  S2+z*(S3+z*(S4+z*(S5+z*S6)));
+        if(iy==0) return x+v*(S1+z*r);
+        else      return x-((z*(half*y-v*r)-y)-v*S1);
+}

--- a/src/java.base/share/native/libfdlibm/k_standard.c
+++ b/src/java.base/share/native/libfdlibm/k_standard.c
@@ -1,0 +1,748 @@
+/*
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "fdlibm.h"
+#include <errno.h>
+
+#ifndef _USE_WRITE
+#include <stdio.h>                      /* fputs(), stderr */
+#define WRITE2(u,v)     fputs(u, stderr)
+#else   /* !defined(_USE_WRITE) */
+#include <unistd.h>                     /* write */
+#define WRITE2(u,v)     write(2, u, v)
+#undef fflush
+#endif  /* !defined(_USE_WRITE) */
+
+static double zero = 0.0;       /* used as const */
+
+/*
+ * Standard conformance (non-IEEE) on exception cases.
+ * Mapping:
+ *      1 -- acos(|x|>1)
+ *      2 -- asin(|x|>1)
+ *      3 -- atan2(+-0,+-0)
+ *      4 -- hypot overflow
+ *      5 -- cosh overflow
+ *      6 -- exp overflow
+ *      7 -- exp underflow
+ *      8 -- y0(0)
+ *      9 -- y0(-ve)
+ *      10-- y1(0)
+ *      11-- y1(-ve)
+ *      12-- yn(0)
+ *      13-- yn(-ve)
+ *      14-- lgamma(finite) overflow
+ *      15-- lgamma(-integer)
+ *      16-- log(0)
+ *      17-- log(x<0)
+ *      18-- log10(0)
+ *      19-- log10(x<0)
+ *      20-- pow(0.0,0.0)
+ *      21-- pow(x,y) overflow
+ *      22-- pow(x,y) underflow
+ *      23-- pow(0,negative)
+ *      24-- pow(neg,non-integral)
+ *      25-- sinh(finite) overflow
+ *      26-- sqrt(negative)
+ *      27-- fmod(x,0)
+ *      28-- remainder(x,0)
+ *      29-- acosh(x<1)
+ *      30-- atanh(|x|>1)
+ *      31-- atanh(|x|=1)
+ *      32-- scalb overflow
+ *      33-- scalb underflow
+ *      34-- j0(|x|>X_TLOSS)
+ *      35-- y0(x>X_TLOSS)
+ *      36-- j1(|x|>X_TLOSS)
+ *      37-- y1(x>X_TLOSS)
+ *      38-- jn(|x|>X_TLOSS, n)
+ *      39-- yn(x>X_TLOSS, n)
+ *      40-- gamma(finite) overflow
+ *      41-- gamma(-integer)
+ *      42-- pow(NaN,0.0)
+ */
+
+
+#ifdef __STDC__
+        double __kernel_standard(double x, double y, int type)
+#else
+        double __kernel_standard(x,y,type)
+        double x,y; int type;
+#endif
+{
+        struct exception exc;
+#ifndef HUGE_VAL        /* this is the only routine that uses HUGE_VAL */
+#define HUGE_VAL inf
+        double inf = 0.0;
+
+        __HI(inf) = 0x7ff00000; /* set inf to infinite */
+#endif
+
+#ifdef _USE_WRITE
+        (void) fflush(stdout);
+#endif
+        exc.arg1 = x;
+        exc.arg2 = y;
+        switch(type) {
+            case 1:
+                /* acos(|x|>1) */
+                exc.type = DOMAIN;
+                exc.name = "acos";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if(_LIB_VERSION == _SVID_) {
+                    (void) WRITE2("acos: DOMAIN error\n", 19);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 2:
+                /* asin(|x|>1) */
+                exc.type = DOMAIN;
+                exc.name = "asin";
+                exc.retval = zero;
+                if(_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if(_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("asin: DOMAIN error\n", 19);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 3:
+                /* atan2(+-0,+-0) */
+                exc.arg1 = y;
+                exc.arg2 = x;
+                exc.type = DOMAIN;
+                exc.name = "atan2";
+                exc.retval = zero;
+                if(_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if(_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("atan2: DOMAIN error\n", 20);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 4:
+                /* hypot(finite,finite) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "hypot";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 5:
+                /* cosh(finite) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "cosh";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 6:
+                /* exp(finite) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "exp";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 7:
+                /* exp(finite) underflow */
+                exc.type = UNDERFLOW;
+                exc.name = "exp";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 8:
+                /* y0(0) = -inf */
+                exc.type = DOMAIN;      /* should be SING for IEEE */
+                exc.name = "y0";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("y0: DOMAIN error\n", 17);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 9:
+                /* y0(x<0) = NaN */
+                exc.type = DOMAIN;
+                exc.name = "y0";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("y0: DOMAIN error\n", 17);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 10:
+                /* y1(0) = -inf */
+                exc.type = DOMAIN;      /* should be SING for IEEE */
+                exc.name = "y1";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("y1: DOMAIN error\n", 17);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 11:
+                /* y1(x<0) = NaN */
+                exc.type = DOMAIN;
+                exc.name = "y1";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("y1: DOMAIN error\n", 17);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 12:
+                /* yn(n,0) = -inf */
+                exc.type = DOMAIN;      /* should be SING for IEEE */
+                exc.name = "yn";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("yn: DOMAIN error\n", 17);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 13:
+                /* yn(x<0) = NaN */
+                exc.type = DOMAIN;
+                exc.name = "yn";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("yn: DOMAIN error\n", 17);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 14:
+                /* lgamma(finite) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "lgamma";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 15:
+                /* lgamma(-integer) or lgamma(0) */
+                exc.type = SING;
+                exc.name = "lgamma";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("lgamma: SING error\n", 19);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 16:
+                /* log(0) */
+                exc.type = SING;
+                exc.name = "log";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("log: SING error\n", 16);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 17:
+                /* log(x<0) */
+                exc.type = DOMAIN;
+                exc.name = "log";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("log: DOMAIN error\n", 18);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 18:
+                /* log10(0) */
+                exc.type = SING;
+                exc.name = "log10";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("log10: SING error\n", 18);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 19:
+                /* log10(x<0) */
+                exc.type = DOMAIN;
+                exc.name = "log10";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = -HUGE;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("log10: DOMAIN error\n", 20);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 20:
+                /* pow(0.0,0.0) */
+                /* error only if _LIB_VERSION == _SVID_ */
+                exc.type = DOMAIN;
+                exc.name = "pow";
+                exc.retval = zero;
+                if (_LIB_VERSION != _SVID_) exc.retval = 1.0;
+                else if (!matherr(&exc)) {
+                        (void) WRITE2("pow(0,0): DOMAIN error\n", 23);
+                        errno = EDOM;
+                }
+                break;
+            case 21:
+                /* pow(x,y) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "pow";
+                if (_LIB_VERSION == _SVID_) {
+                  exc.retval = HUGE;
+                  y *= 0.5;
+                  if(x<zero&&rint(y)!=y) exc.retval = -HUGE;
+                } else {
+                  exc.retval = HUGE_VAL;
+                  y *= 0.5;
+                  if(x<zero&&rint(y)!=y) exc.retval = -HUGE_VAL;
+                }
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 22:
+                /* pow(x,y) underflow */
+                exc.type = UNDERFLOW;
+                exc.name = "pow";
+                exc.retval =  zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 23:
+                /* 0**neg */
+                exc.type = DOMAIN;
+                exc.name = "pow";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = zero;
+                else
+                  exc.retval = -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("pow(0,neg): DOMAIN error\n", 25);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 24:
+                /* neg**non-integral */
+                exc.type = DOMAIN;
+                exc.name = "pow";
+                if (_LIB_VERSION == _SVID_)
+                    exc.retval = zero;
+                else
+                    exc.retval = zero/zero;     /* X/Open allow NaN */
+                if (_LIB_VERSION == _POSIX_)
+                   errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("neg**non-integral: DOMAIN error\n", 32);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 25:
+                /* sinh(finite) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "sinh";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = ( (x>zero) ? HUGE : -HUGE);
+                else
+                  exc.retval = ( (x>zero) ? HUGE_VAL : -HUGE_VAL);
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 26:
+                /* sqrt(x<0) */
+                exc.type = DOMAIN;
+                exc.name = "sqrt";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = zero;
+                else
+                  exc.retval = zero/zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("sqrt: DOMAIN error\n", 19);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 27:
+                /* fmod(x,0) */
+                exc.type = DOMAIN;
+                exc.name = "fmod";
+                if (_LIB_VERSION == _SVID_)
+                    exc.retval = x;
+                else
+                    exc.retval = zero/zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                    (void) WRITE2("fmod:  DOMAIN error\n", 20);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 28:
+                /* remainder(x,0) */
+                exc.type = DOMAIN;
+                exc.name = "remainder";
+                exc.retval = zero/zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                    (void) WRITE2("remainder: DOMAIN error\n", 24);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 29:
+                /* acosh(x<1) */
+                exc.type = DOMAIN;
+                exc.name = "acosh";
+                exc.retval = zero/zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                    (void) WRITE2("acosh: DOMAIN error\n", 20);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 30:
+                /* atanh(|x|>1) */
+                exc.type = DOMAIN;
+                exc.name = "atanh";
+                exc.retval = zero/zero;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                    (void) WRITE2("atanh: DOMAIN error\n", 20);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 31:
+                /* atanh(|x|=1) */
+                exc.type = SING;
+                exc.name = "atanh";
+                exc.retval = x/zero;    /* sign(x)*inf */
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                    (void) WRITE2("atanh: SING error\n", 18);
+                  }
+                  errno = EDOM;
+                }
+                break;
+            case 32:
+                /* scalb overflow; SVID also returns +-HUGE_VAL */
+                exc.type = OVERFLOW;
+                exc.name = "scalb";
+                exc.retval = x > zero ? HUGE_VAL : -HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 33:
+                /* scalb underflow */
+                exc.type = UNDERFLOW;
+                exc.name = "scalb";
+                exc.retval = copysign(zero,x);
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        errno = ERANGE;
+                }
+                break;
+            case 34:
+                /* j0(|x|>X_TLOSS) */
+                exc.type = TLOSS;
+                exc.name = "j0";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        if (_LIB_VERSION == _SVID_) {
+                                (void) WRITE2(exc.name, 2);
+                                (void) WRITE2(": TLOSS error\n", 14);
+                        }
+                        errno = ERANGE;
+                }
+                break;
+            case 35:
+                /* y0(x>X_TLOSS) */
+                exc.type = TLOSS;
+                exc.name = "y0";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        if (_LIB_VERSION == _SVID_) {
+                                (void) WRITE2(exc.name, 2);
+                                (void) WRITE2(": TLOSS error\n", 14);
+                        }
+                        errno = ERANGE;
+                }
+                break;
+            case 36:
+                /* j1(|x|>X_TLOSS) */
+                exc.type = TLOSS;
+                exc.name = "j1";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        if (_LIB_VERSION == _SVID_) {
+                                (void) WRITE2(exc.name, 2);
+                                (void) WRITE2(": TLOSS error\n", 14);
+                        }
+                        errno = ERANGE;
+                }
+                break;
+            case 37:
+                /* y1(x>X_TLOSS) */
+                exc.type = TLOSS;
+                exc.name = "y1";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        if (_LIB_VERSION == _SVID_) {
+                                (void) WRITE2(exc.name, 2);
+                                (void) WRITE2(": TLOSS error\n", 14);
+                        }
+                        errno = ERANGE;
+                }
+                break;
+            case 38:
+                /* jn(|x|>X_TLOSS) */
+                exc.type = TLOSS;
+                exc.name = "jn";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        if (_LIB_VERSION == _SVID_) {
+                                (void) WRITE2(exc.name, 2);
+                                (void) WRITE2(": TLOSS error\n", 14);
+                        }
+                        errno = ERANGE;
+                }
+                break;
+            case 39:
+                /* yn(x>X_TLOSS) */
+                exc.type = TLOSS;
+                exc.name = "yn";
+                exc.retval = zero;
+                if (_LIB_VERSION == _POSIX_)
+                        errno = ERANGE;
+                else if (!matherr(&exc)) {
+                        if (_LIB_VERSION == _SVID_) {
+                                (void) WRITE2(exc.name, 2);
+                                (void) WRITE2(": TLOSS error\n", 14);
+                        }
+                        errno = ERANGE;
+                }
+                break;
+            case 40:
+                /* gamma(finite) overflow */
+                exc.type = OVERFLOW;
+                exc.name = "gamma";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = ERANGE;
+                else if (!matherr(&exc)) {
+                  errno = ERANGE;
+                }
+                break;
+            case 41:
+                /* gamma(-integer) or gamma(0) */
+                exc.type = SING;
+                exc.name = "gamma";
+                if (_LIB_VERSION == _SVID_)
+                  exc.retval = HUGE;
+                else
+                  exc.retval = HUGE_VAL;
+                if (_LIB_VERSION == _POSIX_)
+                  errno = EDOM;
+                else if (!matherr(&exc)) {
+                  if (_LIB_VERSION == _SVID_) {
+                        (void) WRITE2("gamma: SING error\n", 18);
+                      }
+                  errno = EDOM;
+                }
+                break;
+            case 42:
+                /* pow(NaN,0.0) */
+                /* error only if _LIB_VERSION == _SVID_ & _XOPEN_ */
+                exc.type = DOMAIN;
+                exc.name = "pow";
+                exc.retval = x;
+                if (_LIB_VERSION == _IEEE_ ||
+                    _LIB_VERSION == _POSIX_) exc.retval = 1.0;
+                else if (!matherr(&exc)) {
+                        errno = EDOM;
+                }
+                break;
+            default:
+                exc.retval = zero / zero;
+                errno = EINVAL;
+                break;
+        }
+        return exc.retval;
+}

--- a/src/java.base/share/native/libfdlibm/k_tan.c
+++ b/src/java.base/share/native/libfdlibm/k_tan.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 1998, 2004, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* __kernel_tan( x, y, k )
+ * kernel tan function on [-pi/4, pi/4], pi/4 ~ 0.7854
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ * Input k indicates whether tan (if k=1) or
+ * -1/tan (if k= -1) is returned.
+ *
+ * Algorithm
+ *      1. Since tan(-x) = -tan(x), we need only to consider positive x.
+ *      2. if x < 2^-28 (hx<0x3e300000 0), return x with inexact if x!=0.
+ *      3. tan(x) is approximated by a odd polynomial of degree 27 on
+ *         [0,0.67434]
+ *                               3             27
+ *              tan(x) ~ x + T1*x + ... + T13*x
+ *         where
+ *
+ *              |tan(x)         2     4            26   |     -59.2
+ *              |----- - (1+T1*x +T2*x +.... +T13*x    )| <= 2
+ *              |  x                                    |
+ *
+ *         Note: tan(x+y) = tan(x) + tan'(x)*y
+ *                        ~ tan(x) + (1+x*x)*y
+ *         Therefore, for better accuracy in computing tan(x+y), let
+ *                   3      2      2       2       2
+ *              r = x *(T2+x *(T3+x *(...+x *(T12+x *T13))))
+ *         then
+ *                                  3    2
+ *              tan(x+y) = x + (T1*x + (x *(r+y)+y))
+ *
+ *      4. For x in [0.67434,pi/4],  let y = pi/4 - x, then
+ *              tan(x) = tan(pi/4-y) = (1-tan(y))/(1+tan(y))
+ *                     = 1 - 2*(tan(y) - (tan(y)^2)/(1+tan(y)))
+ */
+
+#include "fdlibm.h"
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+one   =  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+pio4  =  7.85398163397448278999e-01, /* 0x3FE921FB, 0x54442D18 */
+pio4lo=  3.06161699786838301793e-17, /* 0x3C81A626, 0x33145C07 */
+T[] =  {
+  3.33333333333334091986e-01, /* 0x3FD55555, 0x55555563 */
+  1.33333333333201242699e-01, /* 0x3FC11111, 0x1110FE7A */
+  5.39682539762260521377e-02, /* 0x3FABA1BA, 0x1BB341FE */
+  2.18694882948595424599e-02, /* 0x3F9664F4, 0x8406D637 */
+  8.86323982359930005737e-03, /* 0x3F8226E3, 0xE96E8493 */
+  3.59207910759131235356e-03, /* 0x3F6D6D22, 0xC9560328 */
+  1.45620945432529025516e-03, /* 0x3F57DBC8, 0xFEE08315 */
+  5.88041240820264096874e-04, /* 0x3F4344D8, 0xF2F26501 */
+  2.46463134818469906812e-04, /* 0x3F3026F7, 0x1A8D1068 */
+  7.81794442939557092300e-05, /* 0x3F147E88, 0xA03792A6 */
+  7.14072491382608190305e-05, /* 0x3F12B80F, 0x32F0A7E9 */
+ -1.85586374855275456654e-05, /* 0xBEF375CB, 0xDB605373 */
+  2.59073051863633712884e-05, /* 0x3EFB2A70, 0x74BF7AD4 */
+};
+
+#ifdef __STDC__
+        double __kernel_tan(double x, double y, int iy)
+#else
+        double __kernel_tan(x, y, iy)
+        double x,y; int iy;
+#endif
+{
+        double z,r,v,w,s;
+        int ix,hx;
+        hx = __HI(x);   /* high word of x */
+        ix = hx&0x7fffffff;     /* high word of |x| */
+        if(ix<0x3e300000) {                     /* x < 2**-28 */
+          if((int)x==0) {                       /* generate inexact */
+            if (((ix | __LO(x)) | (iy + 1)) == 0)
+              return one / fabs(x);
+            else {
+              if (iy == 1)
+                return x;
+              else {    /* compute -1 / (x+y) carefully */
+                double a, t;
+
+                z = w = x + y;
+                __LO(z) = 0;
+                v = y - (z - x);
+                t = a = -one / w;
+                __LO(t) = 0;
+                s = one + t * z;
+                return t + a * (s + t * v);
+                }
+              }
+          }
+        }
+        if(ix>=0x3FE59428) {                    /* |x|>=0.6744 */
+            if(hx<0) {x = -x; y = -y;}
+            z = pio4-x;
+            w = pio4lo-y;
+            x = z+w; y = 0.0;
+        }
+        z       =  x*x;
+        w       =  z*z;
+    /* Break x^5*(T[1]+x^2*T[2]+...) into
+     *    x^5(T[1]+x^4*T[3]+...+x^20*T[11]) +
+     *    x^5(x^2*(T[2]+x^4*T[4]+...+x^22*[T12]))
+     */
+        r = T[1]+w*(T[3]+w*(T[5]+w*(T[7]+w*(T[9]+w*T[11]))));
+        v = z*(T[2]+w*(T[4]+w*(T[6]+w*(T[8]+w*(T[10]+w*T[12])))));
+        s = z*x;
+        r = y + z*(s*(r+v)+y);
+        r += T[0]*s;
+        w = x+r;
+        if(ix>=0x3FE59428) {
+            v = (double)iy;
+            return (double)(1-((hx>>30)&2))*(v-2.0*(x-(w*w/(w+v)-r)));
+        }
+        if(iy==1) return w;
+        else {          /* if allow error up to 2 ulp,
+                           simply return -1.0/(x+r) here */
+     /*  compute -1.0/(x+r) accurately */
+            double a,t;
+            z  = w;
+            __LO(z) = 0;
+            v  = r-(z - x);     /* z+v = r+x */
+            t = a  = -1.0/w;    /* a = -1.0/w */
+            __LO(t) = 0;
+            s  = 1.0+t*z;
+            return t+a*(s+t*v);
+        }
+}

--- a/src/java.base/share/native/libfdlibm/s_atan.c
+++ b/src/java.base/share/native/libfdlibm/s_atan.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* atan(x)
+ * Method
+ *   1. Reduce x to positive by atan(x) = -atan(-x).
+ *   2. According to the integer k=4t+0.25 chopped, t=x, the argument
+ *      is further reduced to one of the following intervals and the
+ *      arctangent of t is evaluated by the corresponding formula:
+ *
+ *      [0,7/16]      atan(x) = t-t^3*(a1+t^2*(a2+...(a10+t^2*a11)...)
+ *      [7/16,11/16]  atan(x) = atan(1/2) + atan( (t-0.5)/(1+t/2) )
+ *      [11/16.19/16] atan(x) = atan( 1 ) + atan( (t-1)/(1+t) )
+ *      [19/16,39/16] atan(x) = atan(3/2) + atan( (t-1.5)/(1+1.5t) )
+ *      [39/16,INF]   atan(x) = atan(INF) + atan( -1/t )
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double atanhi[] = {
+#else
+static double atanhi[] = {
+#endif
+  4.63647609000806093515e-01, /* atan(0.5)hi 0x3FDDAC67, 0x0561BB4F */
+  7.85398163397448278999e-01, /* atan(1.0)hi 0x3FE921FB, 0x54442D18 */
+  9.82793723247329054082e-01, /* atan(1.5)hi 0x3FEF730B, 0xD281F69B */
+  1.57079632679489655800e+00, /* atan(inf)hi 0x3FF921FB, 0x54442D18 */
+};
+
+#ifdef __STDC__
+static const double atanlo[] = {
+#else
+static double atanlo[] = {
+#endif
+  2.26987774529616870924e-17, /* atan(0.5)lo 0x3C7A2B7F, 0x222F65E2 */
+  3.06161699786838301793e-17, /* atan(1.0)lo 0x3C81A626, 0x33145C07 */
+  1.39033110312309984516e-17, /* atan(1.5)lo 0x3C700788, 0x7AF0CBBD */
+  6.12323399573676603587e-17, /* atan(inf)lo 0x3C91A626, 0x33145C07 */
+};
+
+#ifdef __STDC__
+static const double aT[] = {
+#else
+static double aT[] = {
+#endif
+  3.33333333333329318027e-01, /* 0x3FD55555, 0x5555550D */
+ -1.99999999998764832476e-01, /* 0xBFC99999, 0x9998EBC4 */
+  1.42857142725034663711e-01, /* 0x3FC24924, 0x920083FF */
+ -1.11111104054623557880e-01, /* 0xBFBC71C6, 0xFE231671 */
+  9.09088713343650656196e-02, /* 0x3FB745CD, 0xC54C206E */
+ -7.69187620504482999495e-02, /* 0xBFB3B0F2, 0xAF749A6D */
+  6.66107313738753120669e-02, /* 0x3FB10D66, 0xA0D03D51 */
+ -5.83357013379057348645e-02, /* 0xBFADDE2D, 0x52DEFD9A */
+  4.97687799461593236017e-02, /* 0x3FA97B4B, 0x24760DEB */
+ -3.65315727442169155270e-02, /* 0xBFA2B444, 0x2C6A6C2F */
+  1.62858201153657823623e-02, /* 0x3F90AD3A, 0xE322DA11 */
+};
+
+#ifdef __STDC__
+        static const double
+#else
+        static double
+#endif
+one   = 1.0,
+huge   = 1.0e300;
+
+#ifdef __STDC__
+        double atan(double x)
+#else
+        double atan(x)
+        double x;
+#endif
+{
+        double w,s1,s2,z;
+        int ix,hx,id;
+
+        hx = __HI(x);
+        ix = hx&0x7fffffff;
+        if(ix>=0x44100000) {    /* if |x| >= 2^66 */
+            if(ix>0x7ff00000||
+                (ix==0x7ff00000&&(__LO(x)!=0)))
+                return x+x;             /* NaN */
+            if(hx>0) return  atanhi[3]+atanlo[3];
+            else     return -atanhi[3]-atanlo[3];
+        } if (ix < 0x3fdc0000) {        /* |x| < 0.4375 */
+            if (ix < 0x3e200000) {      /* |x| < 2^-29 */
+                if(huge+x>one) return x;        /* raise inexact */
+            }
+            id = -1;
+        } else {
+        x = fabs(x);
+        if (ix < 0x3ff30000) {          /* |x| < 1.1875 */
+            if (ix < 0x3fe60000) {      /* 7/16 <=|x|<11/16 */
+                id = 0; x = (2.0*x-one)/(2.0+x);
+            } else {                    /* 11/16<=|x|< 19/16 */
+                id = 1; x  = (x-one)/(x+one);
+            }
+        } else {
+            if (ix < 0x40038000) {      /* |x| < 2.4375 */
+                id = 2; x  = (x-1.5)/(one+1.5*x);
+            } else {                    /* 2.4375 <= |x| < 2^66 */
+                id = 3; x  = -1.0/x;
+            }
+        }}
+    /* end of argument reduction */
+        z = x*x;
+        w = z*z;
+    /* break sum from i=0 to 10 aT[i]z**(i+1) into odd and even poly */
+        s1 = z*(aT[0]+w*(aT[2]+w*(aT[4]+w*(aT[6]+w*(aT[8]+w*aT[10])))));
+        s2 = w*(aT[1]+w*(aT[3]+w*(aT[5]+w*(aT[7]+w*aT[9]))));
+        if (id<0) return x - x*(s1+s2);
+        else {
+            z = atanhi[id] - ((x*(s1+s2) - atanlo[id]) - x);
+            return (hx<0)? -z:z;
+        }
+}

--- a/src/java.base/share/native/libfdlibm/s_ceil.c
+++ b/src/java.base/share/native/libfdlibm/s_ceil.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ceil(x)
+ * Return x rounded toward -inf to integral value
+ * Method:
+ *      Bit twiddling.
+ * Exception:
+ *      Inexact flag raised if x not equal to ceil(x).
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double huge = 1.0e300;
+#else
+static double huge = 1.0e300;
+#endif
+
+#ifdef __STDC__
+        double ceil(double x)
+#else
+        double ceil(x)
+        double x;
+#endif
+{
+        int i0,i1,j0;
+        unsigned i,j;
+        i0 =  __HI(x);
+        i1 =  __LO(x);
+        j0 = ((i0>>20)&0x7ff)-0x3ff;
+        if(j0<20) {
+            if(j0<0) {  /* raise inexact if x != 0 */
+                if(huge+x>0.0) {/* return 0*sign(x) if |x|<1 */
+                    if(i0<0) {i0=0x80000000;i1=0;}
+                    else if((i0|i1)!=0) { i0=0x3ff00000;i1=0;}
+                }
+            } else {
+                i = (0x000fffff)>>j0;
+                if(((i0&i)|i1)==0) return x; /* x is integral */
+                if(huge+x>0.0) {        /* raise inexact flag */
+                    if(i0>0) i0 += (0x00100000)>>j0;
+                    i0 &= (~i); i1=0;
+                }
+            }
+        } else if (j0>51) {
+            if(j0==0x400) return x+x;   /* inf or NaN */
+            else return x;              /* x is integral */
+        } else {
+            i = ((unsigned)(0xffffffff))>>(j0-20);
+            if((i1&i)==0) return x;     /* x is integral */
+            if(huge+x>0.0) {            /* raise inexact flag */
+                if(i0>0) {
+                    if(j0==20) i0+=1;
+                    else {
+                        j = i1 + (1<<(52-j0));
+                        if(j<i1) i0+=1; /* got a carry */
+                        i1 = j;
+                    }
+                }
+                i1 &= (~i);
+            }
+        }
+        __HI(x) = i0;
+        __LO(x) = i1;
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/s_copysign.c
+++ b/src/java.base/share/native/libfdlibm/s_copysign.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * copysign(double x, double y)
+ * copysign(x,y) returns a value with the magnitude of x and
+ * with the sign bit of y.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double copysign(double x, double y)
+#else
+        double copysign(x,y)
+        double x,y;
+#endif
+{
+        __HI(x) = (__HI(x)&0x7fffffff)|(__HI(y)&0x80000000);
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/s_cos.c
+++ b/src/java.base/share/native/libfdlibm/s_cos.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* cos(x)
+ * Return cosine function of x.
+ *
+ * kernel function:
+ *      __kernel_sin            ... sine function on [-pi/4,pi/4]
+ *      __kernel_cos            ... cosine function on [-pi/4,pi/4]
+ *      __ieee754_rem_pio2      ... argument reduction routine
+ *
+ * Method.
+ *      Let S,C and T denote the sin, cos and tan respectively on
+ *      [-PI/4, +PI/4]. Reduce the argument x to y1+y2 = x-k*pi/2
+ *      in [-pi/4 , +pi/4], and let n = k mod 4.
+ *      We have
+ *
+ *          n        sin(x)      cos(x)        tan(x)
+ *     ----------------------------------------------------------
+ *          0          S           C             T
+ *          1          C          -S            -1/T
+ *          2         -S          -C             T
+ *          3         -C           S            -1/T
+ *     ----------------------------------------------------------
+ *
+ * Special cases:
+ *      Let trig be any of sin, cos, or tan.
+ *      trig(+-INF)  is NaN, with signals;
+ *      trig(NaN)    is that NaN;
+ *
+ * Accuracy:
+ *      TRIG(x) returns trig(x) nearly rounded
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double cos(double x)
+#else
+        double cos(x)
+        double x;
+#endif
+{
+        double y[2],z=0.0;
+        int n, ix;
+
+    /* High word of x. */
+        ix = __HI(x);
+
+    /* |x| ~< pi/4 */
+        ix &= 0x7fffffff;
+        if(ix <= 0x3fe921fb) return __kernel_cos(x,z);
+
+    /* cos(Inf or NaN) is NaN */
+        else if (ix>=0x7ff00000) return x-x;
+
+    /* argument reduction needed */
+        else {
+            n = __ieee754_rem_pio2(x,y);
+            switch(n&3) {
+                case 0: return  __kernel_cos(y[0],y[1]);
+                case 1: return -__kernel_sin(y[0],y[1],1);
+                case 2: return -__kernel_cos(y[0],y[1]);
+                default:
+                        return  __kernel_sin(y[0],y[1],1);
+            }
+        }
+}

--- a/src/java.base/share/native/libfdlibm/s_expm1.c
+++ b/src/java.base/share/native/libfdlibm/s_expm1.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* expm1(x)
+ * Returns exp(x)-1, the exponential of x minus 1.
+ *
+ * Method
+ *   1. Argument reduction:
+ *      Given x, find r and integer k such that
+ *
+ *               x = k*ln2 + r,  |r| <= 0.5*ln2 ~ 0.34658
+ *
+ *      Here a correction term c will be computed to compensate
+ *      the error in r when rounded to a floating-point number.
+ *
+ *   2. Approximating expm1(r) by a special rational function on
+ *      the interval [0,0.34658]:
+ *      Since
+ *          r*(exp(r)+1)/(exp(r)-1) = 2+ r^2/6 - r^4/360 + ...
+ *      we define R1(r*r) by
+ *          r*(exp(r)+1)/(exp(r)-1) = 2+ r^2/6 * R1(r*r)
+ *      That is,
+ *          R1(r**2) = 6/r *((exp(r)+1)/(exp(r)-1) - 2/r)
+ *                   = 6/r * ( 1 + 2.0*(1/(exp(r)-1) - 1/r))
+ *                   = 1 - r^2/60 + r^4/2520 - r^6/100800 + ...
+ *      We use a special Reme algorithm on [0,0.347] to generate
+ *      a polynomial of degree 5 in r*r to approximate R1. The
+ *      maximum error of this polynomial approximation is bounded
+ *      by 2**-61. In other words,
+ *          R1(z) ~ 1.0 + Q1*z + Q2*z**2 + Q3*z**3 + Q4*z**4 + Q5*z**5
+ *      where   Q1  =  -1.6666666666666567384E-2,
+ *              Q2  =   3.9682539681370365873E-4,
+ *              Q3  =  -9.9206344733435987357E-6,
+ *              Q4  =   2.5051361420808517002E-7,
+ *              Q5  =  -6.2843505682382617102E-9;
+ *      (where z=r*r, and the values of Q1 to Q5 are listed below)
+ *      with error bounded by
+ *          |                  5           |     -61
+ *          | 1.0+Q1*z+...+Q5*z   -  R1(z) | <= 2
+ *          |                              |
+ *
+ *      expm1(r) = exp(r)-1 is then computed by the following
+ *      specific way which minimize the accumulation rounding error:
+ *                             2     3
+ *                            r     r    [ 3 - (R1 + R1*r/2)  ]
+ *            expm1(r) = r + --- + --- * [--------------------]
+ *                            2     2    [ 6 - r*(3 - R1*r/2) ]
+ *
+ *      To compensate the error in the argument reduction, we use
+ *              expm1(r+c) = expm1(r) + c + expm1(r)*c
+ *                         ~ expm1(r) + c + r*c
+ *      Thus c+r*c will be added in as the correction terms for
+ *      expm1(r+c). Now rearrange the term to avoid optimization
+ *      screw up:
+ *                      (      2                                    2 )
+ *                      ({  ( r    [ R1 -  (3 - R1*r/2) ]  )  }    r  )
+ *       expm1(r+c)~r - ({r*(--- * [--------------------]-c)-c} - --- )
+ *                      ({  ( 2    [ 6 - r*(3 - R1*r/2) ]  )  }    2  )
+ *                      (                                             )
+ *
+ *                 = r - E
+ *   3. Scale back to obtain expm1(x):
+ *      From step 1, we have
+ *         expm1(x) = either 2^k*[expm1(r)+1] - 1
+ *                  = or     2^k*[expm1(r) + (1-2^-k)]
+ *   4. Implementation notes:
+ *      (A). To save one multiplication, we scale the coefficient Qi
+ *           to Qi*2^i, and replace z by (x^2)/2.
+ *      (B). To achieve maximum accuracy, we compute expm1(x) by
+ *        (i)   if x < -56*ln2, return -1.0, (raise inexact if x!=inf)
+ *        (ii)  if k=0, return r-E
+ *        (iii) if k=-1, return 0.5*(r-E)-0.5
+ *        (iv)  if k=1 if r < -0.25, return 2*((r+0.5)- E)
+ *                     else          return  1.0+2.0*(r-E);
+ *        (v)   if (k<-2||k>56) return 2^k(1-(E-r)) - 1 (or exp(x)-1)
+ *        (vi)  if k <= 20, return 2^k((1-2^-k)-(E-r)), else
+ *        (vii) return 2^k(1-((E+2^-k)-r))
+ *
+ * Special cases:
+ *      expm1(INF) is INF, expm1(NaN) is NaN;
+ *      expm1(-INF) is -1, and
+ *      for finite argument, only expm1(0)=0 is exact.
+ *
+ * Accuracy:
+ *      according to an error analysis, the error is always less than
+ *      1 ulp (unit in the last place).
+ *
+ * Misc. info.
+ *      For IEEE double
+ *          if x >  7.09782712893383973096e+02 then expm1(x) overflow
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+one             = 1.0,
+huge            = 1.0e+300,
+tiny            = 1.0e-300,
+o_threshold     = 7.09782712893383973096e+02,/* 0x40862E42, 0xFEFA39EF */
+ln2_hi          = 6.93147180369123816490e-01,/* 0x3fe62e42, 0xfee00000 */
+ln2_lo          = 1.90821492927058770002e-10,/* 0x3dea39ef, 0x35793c76 */
+invln2          = 1.44269504088896338700e+00,/* 0x3ff71547, 0x652b82fe */
+        /* scaled coefficients related to expm1 */
+Q1  =  -3.33333333333331316428e-02, /* BFA11111 111110F4 */
+Q2  =   1.58730158725481460165e-03, /* 3F5A01A0 19FE5585 */
+Q3  =  -7.93650757867487942473e-05, /* BF14CE19 9EAADBB7 */
+Q4  =   4.00821782732936239552e-06, /* 3ED0CFCA 86E65239 */
+Q5  =  -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
+
+#ifdef __STDC__
+        double expm1(double x)
+#else
+        double expm1(x)
+        double x;
+#endif
+{
+        double y,hi,lo,c=0,t,e,hxs,hfx,r1;
+        int k,xsb;
+        unsigned hx;
+
+        hx  = __HI(x);  /* high word of x */
+        xsb = hx&0x80000000;            /* sign bit of x */
+        if(xsb==0) y=x; else y= -x;     /* y = |x| */
+        hx &= 0x7fffffff;               /* high word of |x| */
+
+    /* filter out huge and non-finite argument */
+        if(hx >= 0x4043687A) {                  /* if |x|>=56*ln2 */
+            if(hx >= 0x40862E42) {              /* if |x|>=709.78... */
+                if(hx>=0x7ff00000) {
+                    if(((hx&0xfffff)|__LO(x))!=0)
+                         return x+x;     /* NaN */
+                    else return (xsb==0)? x:-1.0;/* exp(+-inf)={inf,-1} */
+                }
+                if(x > o_threshold) return huge*huge; /* overflow */
+            }
+            if(xsb!=0) { /* x < -56*ln2, return -1.0 with inexact */
+                if(x+tiny<0.0)          /* raise inexact */
+                return tiny-one;        /* return -1 */
+            }
+        }
+
+    /* argument reduction */
+        if(hx > 0x3fd62e42) {           /* if  |x| > 0.5 ln2 */
+            if(hx < 0x3FF0A2B2) {       /* and |x| < 1.5 ln2 */
+                if(xsb==0)
+                    {hi = x - ln2_hi; lo =  ln2_lo;  k =  1;}
+                else
+                    {hi = x + ln2_hi; lo = -ln2_lo;  k = -1;}
+            } else {
+                k  = invln2*x+((xsb==0)?0.5:-0.5);
+                t  = k;
+                hi = x - t*ln2_hi;      /* t*ln2_hi is exact here */
+                lo = t*ln2_lo;
+            }
+            x  = hi - lo;
+            c  = (hi-x)-lo;
+        }
+        else if(hx < 0x3c900000) {      /* when |x|<2**-54, return x */
+            t = huge+x; /* return x with inexact flags when x!=0 */
+            return x - (t-(huge+x));
+        }
+        else k = 0;
+
+    /* x is now in primary range */
+        hfx = 0.5*x;
+        hxs = x*hfx;
+        r1 = one+hxs*(Q1+hxs*(Q2+hxs*(Q3+hxs*(Q4+hxs*Q5))));
+        t  = 3.0-r1*hfx;
+        e  = hxs*((r1-t)/(6.0 - x*t));
+        if(k==0) return x - (x*e-hxs);          /* c is 0 */
+        else {
+            e  = (x*(e-c)-c);
+            e -= hxs;
+            if(k== -1) return 0.5*(x-e)-0.5;
+            if(k==1) {
+                if(x < -0.25) return -2.0*(e-(x+0.5));
+                else          return  one+2.0*(x-e);
+            }
+            if (k <= -2 || k>56) {   /* suffice to return exp(x)-1 */
+                y = one-(e-x);
+                __HI(y) += (k<<20);     /* add k to y's exponent */
+                return y-one;
+            }
+            t = one;
+            if(k<20) {
+                __HI(t) = 0x3ff00000 - (0x200000>>k);  /* t=1-2^-k */
+                y = t-(e-x);
+                __HI(y) += (k<<20);     /* add k to y's exponent */
+           } else {
+                __HI(t)  = ((0x3ff-k)<<20);     /* 2^-k */
+                y = x-(e+t);
+                y += one;
+                __HI(y) += (k<<20);     /* add k to y's exponent */
+            }
+        }
+        return y;
+}

--- a/src/java.base/share/native/libfdlibm/s_fabs.c
+++ b/src/java.base/share/native/libfdlibm/s_fabs.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * fabs(x) returns the absolute value of x.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double fabs(double x)
+#else
+        double fabs(x)
+        double x;
+#endif
+{
+        __HI(x) &= 0x7fffffff;
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/s_finite.c
+++ b/src/java.base/share/native/libfdlibm/s_finite.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * finite(x) returns 1 is x is finite, else 0;
+ * no branching!
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        int finite(double x)
+#else
+        int finite(x)
+        double x;
+#endif
+{
+        int hx;
+        hx = __HI(x);
+        return  (unsigned)((hx&0x7fffffff)-0x7ff00000)>>31;
+}

--- a/src/java.base/share/native/libfdlibm/s_floor.c
+++ b/src/java.base/share/native/libfdlibm/s_floor.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * floor(x)
+ * Return x rounded toward -inf to integral value
+ * Method:
+ *      Bit twiddling.
+ * Exception:
+ *      Inexact flag raised if x not equal to floor(x).
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double huge = 1.0e300;
+#else
+static double huge = 1.0e300;
+#endif
+
+#ifdef __STDC__
+        double floor(double x)
+#else
+        double floor(x)
+        double x;
+#endif
+{
+        int i0,i1,j0;
+        unsigned i,j;
+        i0 =  __HI(x);
+        i1 =  __LO(x);
+        j0 = ((i0>>20)&0x7ff)-0x3ff;
+        if(j0<20) {
+            if(j0<0) {  /* raise inexact if x != 0 */
+                if(huge+x>0.0) {/* return 0*sign(x) if |x|<1 */
+                    if(i0>=0) {i0=i1=0;}
+                    else if(((i0&0x7fffffff)|i1)!=0)
+                        { i0=0xbff00000;i1=0;}
+                }
+            } else {
+                i = (0x000fffff)>>j0;
+                if(((i0&i)|i1)==0) return x; /* x is integral */
+                if(huge+x>0.0) {        /* raise inexact flag */
+                    if(i0<0) i0 += (0x00100000)>>j0;
+                    i0 &= (~i); i1=0;
+                }
+            }
+        } else if (j0>51) {
+            if(j0==0x400) return x+x;   /* inf or NaN */
+            else return x;              /* x is integral */
+        } else {
+            i = ((unsigned)(0xffffffff))>>(j0-20);
+            if((i1&i)==0) return x;     /* x is integral */
+            if(huge+x>0.0) {            /* raise inexact flag */
+                if(i0<0) {
+                    if(j0==20) i0+=1;
+                    else {
+                        j = i1+(1<<(52-j0));
+                        if(j<i1) i0 +=1 ;       /* got a carry */
+                        i1=j;
+                    }
+                }
+                i1 &= (~i);
+            }
+        }
+        __HI(x) = i0;
+        __LO(x) = i1;
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/s_frexp.c
+++ b/src/java.base/share/native/libfdlibm/s_frexp.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * for non-zero x
+ *      x = frexp(arg,&exp);
+ * return a double fp quantity x such that 0.5 <= |x| <1.0
+ * and the corresponding binary exponent "exp". That is
+ *      arg = x*2^exp.
+ * If arg is inf, 0.0, or NaN, then frexp(arg,&exp) returns arg
+ * with *exp=0.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+two54 =  1.80143985094819840000e+16; /* 0x43500000, 0x00000000 */
+
+#ifdef __STDC__
+        double frexp(double x, int *eptr)
+#else
+        double frexp(x, eptr)
+        double x; int *eptr;
+#endif
+{
+        int  hx, ix, lx;
+        hx = __HI(x);
+        ix = 0x7fffffff&hx;
+        lx = __LO(x);
+        *eptr = 0;
+        if(ix>=0x7ff00000||((ix|lx)==0)) return x;      /* 0,inf,nan */
+        if (ix<0x00100000) {            /* subnormal */
+            x *= two54;
+            hx = __HI(x);
+            ix = hx&0x7fffffff;
+            *eptr = -54;
+        }
+        *eptr += (ix>>20)-1022;
+        hx = (hx&0x800fffff)|0x3fe00000;
+        __HI(x) = hx;
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/s_ilogb.c
+++ b/src/java.base/share/native/libfdlibm/s_ilogb.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* ilogb(double x)
+ * return the binary exponent of non-zero x
+ * ilogb(0) = 0x80000001
+ * ilogb(inf/NaN) = 0x7fffffff (no signal is raised)
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        int ilogb(double x)
+#else
+        int ilogb(x)
+        double x;
+#endif
+{
+        int hx,lx,ix;
+
+        hx  = (__HI(x))&0x7fffffff;     /* high word of x */
+        if(hx<0x00100000) {
+            lx = __LO(x);
+            if((hx|lx)==0)
+                return 0x80000001;      /* ilogb(0) = 0x80000001 */
+            else                        /* subnormal x */
+                if(hx==0) {
+                    for (ix = -1043; lx>0; lx<<=1) ix -=1;
+                } else {
+                    for (ix = -1022,hx<<=11; hx>0; hx<<=1) ix -=1;
+                }
+            return ix;
+        }
+        else if (hx<0x7ff00000) return (hx>>20)-1023;
+        else return 0x7fffffff;
+}

--- a/src/java.base/share/native/libfdlibm/s_isnan.c
+++ b/src/java.base/share/native/libfdlibm/s_isnan.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * isnan(x) returns 1 is x is nan, else 0;
+ * no branching!
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        int isnan(double x)
+#else
+        int isnan(x)
+        double x;
+#endif
+{
+        int hx,lx;
+        hx = (__HI(x)&0x7fffffff);
+        lx = __LO(x);
+        hx |= (unsigned)(lx|(-lx))>>31;
+        hx = 0x7ff00000 - hx;
+        return ((unsigned)(hx))>>31;
+}

--- a/src/java.base/share/native/libfdlibm/s_ldexp.c
+++ b/src/java.base/share/native/libfdlibm/s_ldexp.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "fdlibm.h"
+#include <errno.h>
+
+#ifdef __STDC__
+        double ldexp(double value, int exp)
+#else
+        double ldexp(value, exp)
+        double value; int exp;
+#endif
+{
+        if(!finite(value)||value==0.0) return value;
+        value = scalbn(value,exp);
+        if(!finite(value)||value==0.0) errno = ERANGE;
+        return value;
+}

--- a/src/java.base/share/native/libfdlibm/s_lib_version.c
+++ b/src/java.base/share/native/libfdlibm/s_lib_version.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * MACRO for standards
+ */
+
+#include "fdlibm.h"
+
+/*
+ * define and initialize _LIB_VERSION
+ */
+#ifdef _POSIX_MODE
+_LIB_VERSION_TYPE _LIB_VERSION = _POSIX_;
+#else
+#ifdef _XOPEN_MODE
+_LIB_VERSION_TYPE _LIB_VERSION = _XOPEN_;
+#else
+#ifdef _SVID3_MODE
+_LIB_VERSION_TYPE _LIB_VERSION = _SVID_;
+#else                                   /* default _IEEE_MODE */
+_LIB_VERSION_TYPE _LIB_VERSION = _IEEE_;
+#endif
+#endif
+#endif

--- a/src/java.base/share/native/libfdlibm/s_log1p.c
+++ b/src/java.base/share/native/libfdlibm/s_log1p.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 1998, 2003, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* double log1p(double x)
+ *
+ * Method :
+ *   1. Argument Reduction: find k and f such that
+ *                      1+x = 2^k * (1+f),
+ *         where  sqrt(2)/2 < 1+f < sqrt(2) .
+ *
+ *      Note. If k=0, then f=x is exact. However, if k!=0, then f
+ *      may not be representable exactly. In that case, a correction
+ *      term is need. Let u=1+x rounded. Let c = (1+x)-u, then
+ *      log(1+x) - log(u) ~ c/u. Thus, we proceed to compute log(u),
+ *      and add back the correction term c/u.
+ *      (Note: when x > 2**53, one can simply return log(x))
+ *
+ *   2. Approximation of log1p(f).
+ *      Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+ *               = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+ *               = 2s + s*R
+ *      We use a special Reme algorithm on [0,0.1716] to generate
+ *      a polynomial of degree 14 to approximate R The maximum error
+ *      of this polynomial approximation is bounded by 2**-58.45. In
+ *      other words,
+ *                      2      4      6      8      10      12      14
+ *          R(z) ~ Lp1*s +Lp2*s +Lp3*s +Lp4*s +Lp5*s  +Lp6*s  +Lp7*s
+ *      (the values of Lp1 to Lp7 are listed in the program)
+ *      and
+ *          |      2          14          |     -58.45
+ *          | Lp1*s +...+Lp7*s    -  R(z) | <= 2
+ *          |                             |
+ *      Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+ *      In order to guarantee error in log below 1ulp, we compute log
+ *      by
+ *              log1p(f) = f - (hfsq - s*(hfsq+R)).
+ *
+ *      3. Finally, log1p(x) = k*ln2 + log1p(f).
+ *                           = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+ *         Here ln2 is split into two floating point number:
+ *                      ln2_hi + ln2_lo,
+ *         where n*ln2_hi is always exact for |n| < 2000.
+ *
+ * Special cases:
+ *      log1p(x) is NaN with signal if x < -1 (including -INF) ;
+ *      log1p(+INF) is +INF; log1p(-1) is -INF with signal;
+ *      log1p(NaN) is that NaN with no signal.
+ *
+ * Accuracy:
+ *      according to an error analysis, the error is always less than
+ *      1 ulp (unit in the last place).
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
+ * to produce the hexadecimal values shown.
+ *
+ * Note: Assuming log() return accurate answer, the following
+ *       algorithm can be used to compute log1p(x) to within a few ULP:
+ *
+ *              u = 1+x;
+ *              if(u==1.0) return x ; else
+ *                         return log(u)*(x/(u-1.0));
+ *
+ *       See HP-15C Advanced Functions Handbook, p.193.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+ln2_hi  =  6.93147180369123816490e-01,  /* 3fe62e42 fee00000 */
+ln2_lo  =  1.90821492927058770002e-10,  /* 3dea39ef 35793c76 */
+two54   =  1.80143985094819840000e+16,  /* 43500000 00000000 */
+Lp1 = 6.666666666666735130e-01,  /* 3FE55555 55555593 */
+Lp2 = 3.999999999940941908e-01,  /* 3FD99999 9997FA04 */
+Lp3 = 2.857142874366239149e-01,  /* 3FD24924 94229359 */
+Lp4 = 2.222219843214978396e-01,  /* 3FCC71C5 1D8E78AF */
+Lp5 = 1.818357216161805012e-01,  /* 3FC74664 96CB03DE */
+Lp6 = 1.531383769920937332e-01,  /* 3FC39A09 D078C69F */
+Lp7 = 1.479819860511658591e-01;  /* 3FC2F112 DF3E5244 */
+
+static double zero = 0.0;
+
+#ifdef __STDC__
+        double log1p(double x)
+#else
+        double log1p(x)
+        double x;
+#endif
+{
+        double hfsq,f=0,c=0,s,z,R,u;
+        int k,hx,hu=0,ax;
+
+        hx = __HI(x);           /* high word of x */
+        ax = hx&0x7fffffff;
+
+        k = 1;
+        if (hx < 0x3FDA827A) {                  /* x < 0.41422  */
+            if(ax>=0x3ff00000) {                /* x <= -1.0 */
+                /*
+                 * Added redundant test against hx to work around VC++
+                 * code generation problem.
+                 */
+                if(x==-1.0 && (hx==0xbff00000)) /* log1p(-1)=-inf */
+                  return -two54/zero;
+                else
+                  return (x-x)/(x-x);           /* log1p(x<-1)=NaN */
+            }
+            if(ax<0x3e200000) {                 /* |x| < 2**-29 */
+                if(two54+x>zero                 /* raise inexact */
+                    &&ax<0x3c900000)            /* |x| < 2**-54 */
+                    return x;
+                else
+                    return x - x*x*0.5;
+            }
+            if(hx>0||hx<=((int)0xbfd2bec3)) {
+                k=0;f=x;hu=1;}  /* -0.2929<x<0.41422 */
+        }
+        if (hx >= 0x7ff00000) return x+x;
+        if(k!=0) {
+            if(hx<0x43400000) {
+                u  = 1.0+x;
+                hu = __HI(u);           /* high word of u */
+                k  = (hu>>20)-1023;
+                c  = (k>0)? 1.0-(u-x):x-(u-1.0);/* correction term */
+                c /= u;
+            } else {
+                u  = x;
+                hu = __HI(u);           /* high word of u */
+                k  = (hu>>20)-1023;
+                c  = 0;
+            }
+            hu &= 0x000fffff;
+            if(hu<0x6a09e) {
+                __HI(u) = hu|0x3ff00000;        /* normalize u */
+            } else {
+                k += 1;
+                __HI(u) = hu|0x3fe00000;        /* normalize u/2 */
+                hu = (0x00100000-hu)>>2;
+            }
+            f = u-1.0;
+        }
+        hfsq=0.5*f*f;
+        if(hu==0) {     /* |f| < 2**-20 */
+            if(f==zero) { if(k==0) return zero;
+                          else {c += k*ln2_lo; return k*ln2_hi+c;}}
+            R = hfsq*(1.0-0.66666666666666666*f);
+            if(k==0) return f-R; else
+                     return k*ln2_hi-((R-(k*ln2_lo+c))-f);
+        }
+        s = f/(2.0+f);
+        z = s*s;
+        R = z*(Lp1+z*(Lp2+z*(Lp3+z*(Lp4+z*(Lp5+z*(Lp6+z*Lp7))))));
+        if(k==0) return f-(hfsq-s*(hfsq+R)); else
+                 return k*ln2_hi-((hfsq-(s*(hfsq+R)+(k*ln2_lo+c)))-f);
+}

--- a/src/java.base/share/native/libfdlibm/s_logb.c
+++ b/src/java.base/share/native/libfdlibm/s_logb.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * double logb(x)
+ * IEEE 754 logb. Included to pass IEEE test suite. Not recommend.
+ * Use ilogb instead.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double logb(double x)
+#else
+        double logb(x)
+        double x;
+#endif
+{
+        int lx,ix;
+        ix = (__HI(x))&0x7fffffff;      /* high |x| */
+        lx = __LO(x);                   /* low x */
+        if((ix|lx)==0) return -1.0/fabs(x);
+        if(ix>=0x7ff00000) return x*x;
+        if((ix>>=20)==0)                        /* IEEE 754 logb */
+                return -1022.0;
+        else
+                return (double) (ix-1023);
+}

--- a/src/java.base/share/native/libfdlibm/s_matherr.c
+++ b/src/java.base/share/native/libfdlibm/s_matherr.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        int matherr(struct exception *x)
+#else
+        int matherr(x)
+        struct exception *x;
+#endif
+{
+        int n=0;
+        if(x->arg1!=x->arg1) return 0;
+        return n;
+}

--- a/src/java.base/share/native/libfdlibm/s_modf.c
+++ b/src/java.base/share/native/libfdlibm/s_modf.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * modf(double x, double *iptr)
+ * return fraction part of x, and return x's integral part in *iptr.
+ * Method:
+ *      Bit twiddling.
+ *
+ * Exception:
+ *      No exception.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double one = 1.0;
+#else
+static double one = 1.0;
+#endif
+
+#ifdef __STDC__
+        double modf(double x, double *iptr)
+#else
+        double modf(x, iptr)
+        double x,*iptr;
+#endif
+{
+        int i0,i1,j0;
+        unsigned i;
+        i0 =  __HI(x);          /* high x */
+        i1 =  __LO(x);          /* low  x */
+        j0 = ((i0>>20)&0x7ff)-0x3ff;    /* exponent of x */
+        if(j0<20) {                     /* integer part in high x */
+            if(j0<0) {                  /* |x|<1 */
+                __HIp(iptr) = i0&0x80000000;
+                __LOp(iptr) = 0;                /* *iptr = +-0 */
+                return x;
+            } else {
+                i = (0x000fffff)>>j0;
+                if(((i0&i)|i1)==0) {            /* x is integral */
+                    *iptr = x;
+                    __HI(x) &= 0x80000000;
+                    __LO(x)  = 0;       /* return +-0 */
+                    return x;
+                } else {
+                    __HIp(iptr) = i0&(~i);
+                    __LOp(iptr) = 0;
+                    return x - *iptr;
+                }
+            }
+        } else if (j0>51) {             /* no fraction part */
+            *iptr = x*one;
+            __HI(x) &= 0x80000000;
+            __LO(x)  = 0;       /* return +-0 */
+            return x;
+        } else {                        /* fraction part in low x */
+            i = ((unsigned)(0xffffffff))>>(j0-20);
+            if((i1&i)==0) {             /* x is integral */
+                *iptr = x;
+                __HI(x) &= 0x80000000;
+                __LO(x)  = 0;   /* return +-0 */
+                return x;
+            } else {
+                __HIp(iptr) = i0;
+                __LOp(iptr) = i1&(~i);
+                return x - *iptr;
+            }
+        }
+}

--- a/src/java.base/share/native/libfdlibm/s_nextafter.c
+++ b/src/java.base/share/native/libfdlibm/s_nextafter.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* IEEE functions
+ *      nextafter(x,y)
+ *      return the next machine floating-point number of x in the
+ *      direction toward y.
+ *   Special cases:
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double nextafter(double x, double y)
+#else
+        double nextafter(x,y)
+        double x,y;
+#endif
+{
+        int     hx,hy,ix,iy;
+        unsigned lx,ly;
+
+        hx = __HI(x);           /* high word of x */
+        lx = __LO(x);           /* low  word of x */
+        hy = __HI(y);           /* high word of y */
+        ly = __LO(y);           /* low  word of y */
+        ix = hx&0x7fffffff;             /* |x| */
+        iy = hy&0x7fffffff;             /* |y| */
+
+        if(((ix>=0x7ff00000)&&((ix-0x7ff00000)|lx)!=0) ||   /* x is nan */
+           ((iy>=0x7ff00000)&&((iy-0x7ff00000)|ly)!=0))     /* y is nan */
+           return x+y;
+        if(x==y) return x;              /* x=y, return x */
+        if((ix|lx)==0) {                        /* x == 0 */
+            __HI(x) = hy&0x80000000;    /* return +-minsubnormal */
+            __LO(x) = 1;
+            y = x*x;
+            if(y==x) return y; else return x;   /* raise underflow flag */
+        }
+        if(hx>=0) {                             /* x > 0 */
+            if(hx>hy||((hx==hy)&&(lx>ly))) {    /* x > y, x -= ulp */
+                if(lx==0) hx -= 1;
+                lx -= 1;
+            } else {                            /* x < y, x += ulp */
+                lx += 1;
+                if(lx==0) hx += 1;
+            }
+        } else {                                /* x < 0 */
+            if(hy>=0||hx>hy||((hx==hy)&&(lx>ly))){/* x < y, x -= ulp */
+                if(lx==0) hx -= 1;
+                lx -= 1;
+            } else {                            /* x > y, x += ulp */
+                lx += 1;
+                if(lx==0) hx += 1;
+            }
+        }
+        hy = hx&0x7ff00000;
+        if(hy>=0x7ff00000) return x+x;  /* overflow  */
+        if(hy<0x00100000) {             /* underflow */
+            y = x*x;
+            if(y!=x) {          /* raise underflow flag */
+                __HI(y) = hx; __LO(y) = lx;
+                return y;
+            }
+        }
+        __HI(x) = hx; __LO(x) = lx;
+        return x;
+}

--- a/src/java.base/share/native/libfdlibm/s_rint.c
+++ b/src/java.base/share/native/libfdlibm/s_rint.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * rint(x)
+ * Return x rounded to integral value according to the prevailing
+ * rounding mode.
+ * Method:
+ *      Using floating addition.
+ * Exception:
+ *      Inexact flag raised if x not equal to rint(x).
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+TWO52[2]={
+  4.50359962737049600000e+15, /* 0x43300000, 0x00000000 */
+ -4.50359962737049600000e+15, /* 0xC3300000, 0x00000000 */
+};
+
+#ifdef __STDC__
+        double rint(double x)
+#else
+        double rint(x)
+        double x;
+#endif
+{
+        int i0,j0,sx;
+        unsigned i,i1;
+        double w,t;
+        i0 =  __HI(x);
+        sx = (i0>>31)&1;
+        i1 =  __LO(x);
+        j0 = ((i0>>20)&0x7ff)-0x3ff;
+        if(j0<20) {
+            if(j0<0) {
+                if(((i0&0x7fffffff)|i1)==0) return x;
+                i1 |= (i0&0x0fffff);
+                i0 &= 0xfffe0000;
+                i0 |= ((i1|-i1)>>12)&0x80000;
+                __HI(x)=i0;
+                w = TWO52[sx]+x;
+                t =  w-TWO52[sx];
+                i0 = __HI(t);
+                __HI(t) = (i0&0x7fffffff)|(sx<<31);
+                return t;
+            } else {
+                i = (0x000fffff)>>j0;
+                if(((i0&i)|i1)==0) return x; /* x is integral */
+                i>>=1;
+                if(((i0&i)|i1)!=0) {
+                    if(j0==19) i1 = 0x40000000; else
+                    i0 = (i0&(~i))|((0x20000)>>j0);
+                }
+            }
+        } else if (j0>51) {
+            if(j0==0x400) return x+x;   /* inf or NaN */
+            else return x;              /* x is integral */
+        } else {
+            i = ((unsigned)(0xffffffff))>>(j0-20);
+            if((i1&i)==0) return x;     /* x is integral */
+            i>>=1;
+            if((i1&i)!=0) i1 = (i1&(~i))|((0x40000000)>>(j0-20));
+        }
+        __HI(x) = i0;
+        __LO(x) = i1;
+        w = TWO52[sx]+x;
+        return w-TWO52[sx];
+}

--- a/src/java.base/share/native/libfdlibm/s_scalbn.c
+++ b/src/java.base/share/native/libfdlibm/s_scalbn.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * scalbn (double x, int n)
+ * scalbn(x,n) returns x* 2**n  computed by  exponent
+ * manipulation rather than by actually performing an
+ * exponentiation or a multiplication.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
+twom54  =  5.55111512312578270212e-17, /* 0x3C900000, 0x00000000 */
+huge   = 1.0e+300,
+tiny   = 1.0e-300;
+
+#ifdef __STDC__
+        double scalbn (double x, int n)
+#else
+        double scalbn (x,n)
+        double x; int n;
+#endif
+{
+        int  k,hx,lx;
+        hx = __HI(x);
+        lx = __LO(x);
+        k = (hx&0x7ff00000)>>20;                /* extract exponent */
+        if (k==0) {                             /* 0 or subnormal x */
+            if ((lx|(hx&0x7fffffff))==0) return x; /* +-0 */
+            x *= two54;
+            hx = __HI(x);
+            k = ((hx&0x7ff00000)>>20) - 54;
+            if (n< -50000) return tiny*x;       /*underflow*/
+            }
+        if (k==0x7ff) return x+x;               /* NaN or Inf */
+        k = k+n;
+        if (k >  0x7fe) return huge*copysign(huge,x); /* overflow  */
+        if (k > 0)                              /* normal result */
+            {__HI(x) = (hx&0x800fffff)|(k<<20); return x;}
+        if (k <= -54) {
+            if (n > 50000)      /* in case integer overflow in n+k */
+                return huge*copysign(huge,x);   /*overflow*/
+            else return tiny*copysign(tiny,x);  /*underflow*/
+        }
+        k += 54;                                /* subnormal result */
+        __HI(x) = (hx&0x800fffff)|(k<<20);
+        return x*twom54;
+}

--- a/src/java.base/share/native/libfdlibm/s_signgam.c
+++ b/src/java.base/share/native/libfdlibm/s_signgam.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "fdlibm.h"
+int signgam = 0;

--- a/src/java.base/share/native/libfdlibm/s_significand.c
+++ b/src/java.base/share/native/libfdlibm/s_significand.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * significand(x) computes just
+ *      scalb(x, (double) -ilogb(x)),
+ * for exercising the fraction-part(F) IEEE 754-1985 test vector.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double significand(double x)
+#else
+        double significand(x)
+        double x;
+#endif
+{
+        return __ieee754_scalb(x,(double) -ilogb(x));
+}

--- a/src/java.base/share/native/libfdlibm/s_sin.c
+++ b/src/java.base/share/native/libfdlibm/s_sin.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* sin(x)
+ * Return sine function of x.
+ *
+ * kernel function:
+ *      __kernel_sin            ... sine function on [-pi/4,pi/4]
+ *      __kernel_cos            ... cose function on [-pi/4,pi/4]
+ *      __ieee754_rem_pio2      ... argument reduction routine
+ *
+ * Method.
+ *      Let S,C and T denote the sin, cos and tan respectively on
+ *      [-PI/4, +PI/4]. Reduce the argument x to y1+y2 = x-k*pi/2
+ *      in [-pi/4 , +pi/4], and let n = k mod 4.
+ *      We have
+ *
+ *          n        sin(x)      cos(x)        tan(x)
+ *     ----------------------------------------------------------
+ *          0          S           C             T
+ *          1          C          -S            -1/T
+ *          2         -S          -C             T
+ *          3         -C           S            -1/T
+ *     ----------------------------------------------------------
+ *
+ * Special cases:
+ *      Let trig be any of sin, cos, or tan.
+ *      trig(+-INF)  is NaN, with signals;
+ *      trig(NaN)    is that NaN;
+ *
+ * Accuracy:
+ *      TRIG(x) returns trig(x) nearly rounded
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double sin(double x)
+#else
+        double sin(x)
+        double x;
+#endif
+{
+        double y[2],z=0.0;
+        int n, ix;
+
+    /* High word of x. */
+        ix = __HI(x);
+
+    /* |x| ~< pi/4 */
+        ix &= 0x7fffffff;
+        if(ix <= 0x3fe921fb) return __kernel_sin(x,z,0);
+
+    /* sin(Inf or NaN) is NaN */
+        else if (ix>=0x7ff00000) return x-x;
+
+    /* argument reduction needed */
+        else {
+            n = __ieee754_rem_pio2(x,y);
+            switch(n&3) {
+                case 0: return  __kernel_sin(y[0],y[1],1);
+                case 1: return  __kernel_cos(y[0],y[1]);
+                case 2: return -__kernel_sin(y[0],y[1],1);
+                default:
+                        return -__kernel_cos(y[0],y[1]);
+            }
+        }
+}

--- a/src/java.base/share/native/libfdlibm/s_tan.c
+++ b/src/java.base/share/native/libfdlibm/s_tan.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* tan(x)
+ * Return tangent function of x.
+ *
+ * kernel function:
+ *      __kernel_tan            ... tangent function on [-pi/4,pi/4]
+ *      __ieee754_rem_pio2      ... argument reduction routine
+ *
+ * Method.
+ *      Let S,C and T denote the sin, cos and tan respectively on
+ *      [-PI/4, +PI/4]. Reduce the argument x to y1+y2 = x-k*pi/2
+ *      in [-pi/4 , +pi/4], and let n = k mod 4.
+ *      We have
+ *
+ *          n        sin(x)      cos(x)        tan(x)
+ *     ----------------------------------------------------------
+ *          0          S           C             T
+ *          1          C          -S            -1/T
+ *          2         -S          -C             T
+ *          3         -C           S            -1/T
+ *     ----------------------------------------------------------
+ *
+ * Special cases:
+ *      Let trig be any of sin, cos, or tan.
+ *      trig(+-INF)  is NaN, with signals;
+ *      trig(NaN)    is that NaN;
+ *
+ * Accuracy:
+ *      TRIG(x) returns trig(x) nearly rounded
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double tan(double x)
+#else
+        double tan(x)
+        double x;
+#endif
+{
+        double y[2],z=0.0;
+        int n, ix;
+
+    /* High word of x. */
+        ix = __HI(x);
+
+    /* |x| ~< pi/4 */
+        ix &= 0x7fffffff;
+        if(ix <= 0x3fe921fb) return __kernel_tan(x,z,1);
+
+    /* tan(Inf or NaN) is NaN */
+        else if (ix>=0x7ff00000) return x-x;            /* NaN */
+
+    /* argument reduction needed */
+        else {
+            n = __ieee754_rem_pio2(x,y);
+            return __kernel_tan(y[0],y[1],1-((n&1)<<1)); /*   1 -- n even
+                                                        -1 -- n odd */
+        }
+}

--- a/src/java.base/share/native/libfdlibm/s_tanh.c
+++ b/src/java.base/share/native/libfdlibm/s_tanh.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Tanh(x)
+ * Return the Hyperbolic Tangent of x
+ *
+ * Method :
+ *                                     x    -x
+ *                                    e  - e
+ *      0. tanh(x) is defined to be -----------
+ *                                     x    -x
+ *                                    e  + e
+ *      1. reduce x to non-negative by tanh(-x) = -tanh(x).
+ *      2.  0      <= x <= 2**-55 : tanh(x) := x*(one+x)
+ *                                              -t
+ *          2**-55 <  x <=  1     : tanh(x) := -----; t = expm1(-2x)
+ *                                             t + 2
+ *                                                   2
+ *          1      <= x <=  22.0  : tanh(x) := 1-  ----- ; t=expm1(2x)
+ *                                                 t + 2
+ *          22.0   <  x <= INF    : tanh(x) := 1.
+ *
+ * Special cases:
+ *      tanh(NaN) is NaN;
+ *      only tanh(0)=0 is exact for finite argument.
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double one=1.0, two=2.0, tiny = 1.0e-300;
+#else
+static double one=1.0, two=2.0, tiny = 1.0e-300;
+#endif
+
+#ifdef __STDC__
+        double tanh(double x)
+#else
+        double tanh(x)
+        double x;
+#endif
+{
+        double t,z;
+        int jx,ix;
+
+    /* High word of |x|. */
+        jx = __HI(x);
+        ix = jx&0x7fffffff;
+
+    /* x is INF or NaN */
+        if(ix>=0x7ff00000) {
+            if (jx>=0) return one/x+one;    /* tanh(+-inf)=+-1 */
+            else       return one/x-one;    /* tanh(NaN) = NaN */
+        }
+
+    /* |x| < 22 */
+        if (ix < 0x40360000) {          /* |x|<22 */
+            if (ix<0x3c800000)          /* |x|<2**-55 */
+                return x*(one+x);       /* tanh(small) = small */
+            if (ix>=0x3ff00000) {       /* |x|>=1  */
+                t = expm1(two*fabs(x));
+                z = one - two/(t+two);
+            } else {
+                t = expm1(-two*fabs(x));
+                z= -t/(t+two);
+            }
+    /* |x| > 22, return +-1 */
+        } else {
+            z = one - tiny;             /* raised inexact flag */
+        }
+        return (jx>=0)? z: -z;
+}

--- a/src/java.base/share/native/libfdlibm/w_acos.c
+++ b/src/java.base/share/native/libfdlibm/w_acos.c
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrap_acos(x)
+ */
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double acos(double x)           /* wrapper acos */
+#else
+        double acos(x)                  /* wrapper acos */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_acos(x);
+#else
+        double z;
+        z = __ieee754_acos(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x)) return z;
+        if(fabs(x)>1.0) {
+                return __kernel_standard(x,x,1); /* acos(|x|>1) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_asin.c
+++ b/src/java.base/share/native/libfdlibm/w_asin.c
@@ -1,0 +1,53 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper asin(x)
+ */
+
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double asin(double x)           /* wrapper asin */
+#else
+        double asin(x)                  /* wrapper asin */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_asin(x);
+#else
+        double z;
+        z = __ieee754_asin(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x)) return z;
+        if(fabs(x)>1.0) {
+                return __kernel_standard(x,x,2); /* asin(|x|>1) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_atan2.c
+++ b/src/java.base/share/native/libfdlibm/w_atan2.c
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper atan2(y,x)
+ */
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double atan2(double y, double x)        /* wrapper atan2 */
+#else
+        double atan2(y,x)                       /* wrapper atan2 */
+        double y,x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_atan2(y,x);
+#else
+        double z;
+        z = __ieee754_atan2(y,x);
+        if(_LIB_VERSION == _IEEE_||isnan(x)||isnan(y)) return z;
+        if(x==0.0&&y==0.0) {
+                return __kernel_standard(y,x,3); /* atan2(+-0,+-0) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_atanh.c
+++ b/src/java.base/share/native/libfdlibm/w_atanh.c
@@ -1,0 +1,55 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * wrapper atanh(x)
+ */
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double atanh(double x)          /* wrapper atanh */
+#else
+        double atanh(x)                 /* wrapper atanh */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_atanh(x);
+#else
+        double z,y;
+        z = __ieee754_atanh(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x)) return z;
+        y = fabs(x);
+        if(y>=1.0) {
+            if(y>1.0)
+                return __kernel_standard(x,x,30); /* atanh(|x|>1) */
+            else
+                return __kernel_standard(x,x,31); /* atanh(|x|==1) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_cosh.c
+++ b/src/java.base/share/native/libfdlibm/w_cosh.c
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper cosh(x)
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double cosh(double x)           /* wrapper cosh */
+#else
+        double cosh(x)                  /* wrapper cosh */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_cosh(x);
+#else
+        double z;
+        z = __ieee754_cosh(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x)) return z;
+        if(fabs(x)>7.10475860073943863426e+02) {
+                return __kernel_standard(x,x,5); /* cosh overflow */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_exp.c
+++ b/src/java.base/share/native/libfdlibm/w_exp.c
@@ -1,0 +1,62 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper exp(x)
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+o_threshold=  7.09782712893383973096e+02,  /* 0x40862E42, 0xFEFA39EF */
+u_threshold= -7.45133219101941108420e+02;  /* 0xc0874910, 0xD52D3051 */
+
+#ifdef __STDC__
+        double exp(double x)            /* wrapper exp */
+#else
+        double exp(x)                   /* wrapper exp */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_exp(x);
+#else
+        double z;
+        z = __ieee754_exp(x);
+        if(_LIB_VERSION == _IEEE_) return z;
+        if(finite(x)) {
+            if(x>o_threshold)
+                return __kernel_standard(x,x,6); /* exp overflow */
+            else if(x<u_threshold)
+                return __kernel_standard(x,x,7); /* exp underflow */
+        }
+        return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_fmod.c
+++ b/src/java.base/share/native/libfdlibm/w_fmod.c
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper fmod(x,y)
+ */
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double fmod(double x, double y) /* wrapper fmod */
+#else
+        double fmod(x,y)                /* wrapper fmod */
+        double x,y;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_fmod(x,y);
+#else
+        double z;
+        z = __ieee754_fmod(x,y);
+        if(_LIB_VERSION == _IEEE_ ||isnan(y)||isnan(x)) return z;
+        if(y==0.0) {
+                return __kernel_standard(x,y,27); /* fmod(x,0) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_log.c
+++ b/src/java.base/share/native/libfdlibm/w_log.c
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper log(x)
+ */
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double log(double x)            /* wrapper log */
+#else
+        double log(x)                   /* wrapper log */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_log(x);
+#else
+        double z;
+        z = __ieee754_log(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x) || x > 0.0) return z;
+        if(x==0.0)
+            return __kernel_standard(x,x,16); /* log(0) */
+        else
+            return __kernel_standard(x,x,17); /* log(x<0) */
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_log10.c
+++ b/src/java.base/share/native/libfdlibm/w_log10.c
@@ -1,0 +1,55 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper log10(X)
+ */
+
+#include "fdlibm.h"
+
+
+#ifdef __STDC__
+        double log10(double x)          /* wrapper log10 */
+#else
+        double log10(x)                 /* wrapper log10 */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_log10(x);
+#else
+        double z;
+        z = __ieee754_log10(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x)) return z;
+        if(x<=0.0) {
+            if(x==0.0)
+                return __kernel_standard(x,x,18); /* log10(0) */
+            else
+                return __kernel_standard(x,x,19); /* log10(x<0) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_remainder.c
+++ b/src/java.base/share/native/libfdlibm/w_remainder.c
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper remainder(x,p)
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double remainder(double x, double y)    /* wrapper remainder */
+#else
+        double remainder(x,y)                   /* wrapper remainder */
+        double x,y;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_remainder(x,y);
+#else
+        double z;
+        z = __ieee754_remainder(x,y);
+        if(_LIB_VERSION == _IEEE_ || isnan(y)) return z;
+        if(y==0.0)
+            return __kernel_standard(x,y,28); /* remainder(x,0) */
+        else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_scalb.c
+++ b/src/java.base/share/native/libfdlibm/w_scalb.c
@@ -1,0 +1,69 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper scalb(double x, double fn) is provide for
+ * passing various standard test suite. One
+ * should use scalbn() instead.
+ */
+
+#include "fdlibm.h"
+
+#include <errno.h>
+
+#ifdef __STDC__
+#ifdef _SCALB_INT
+        double scalb(double x, int fn)          /* wrapper scalb */
+#else
+        double scalb(double x, double fn)       /* wrapper scalb */
+#endif
+#else
+        double scalb(x,fn)                      /* wrapper scalb */
+#ifdef _SCALB_INT
+        double x; int fn;
+#else
+        double x,fn;
+#endif
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_scalb(x,fn);
+#else
+        double z;
+        z = __ieee754_scalb(x,fn);
+        if(_LIB_VERSION == _IEEE_) return z;
+        if(!(finite(z)||isnan(z))&&finite(x)) {
+            return __kernel_standard(x,(double)fn,32); /* scalb overflow */
+        }
+        if(z==0.0&&z!=x) {
+            return __kernel_standard(x,(double)fn,33); /* scalb underflow */
+        }
+#ifndef _SCALB_INT
+        if(!finite(fn)) errno = ERANGE;
+#endif
+        return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_sinh.c
+++ b/src/java.base/share/native/libfdlibm/w_sinh.c
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper sinh(x)
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double sinh(double x)           /* wrapper sinh */
+#else
+        double sinh(x)                  /* wrapper sinh */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_sinh(x);
+#else
+        double z;
+        z = __ieee754_sinh(x);
+        if(_LIB_VERSION == _IEEE_) return z;
+        if(!finite(z)&&finite(x)) {
+            return __kernel_standard(x,x,25); /* sinh overflow */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libfdlibm/w_sqrt.c
+++ b/src/java.base/share/native/libfdlibm/w_sqrt.c
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * wrapper sqrt(x)
+ */
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+        double sqrt(double x)           /* wrapper sqrt */
+#else
+        double sqrt(x)                  /* wrapper sqrt */
+        double x;
+#endif
+{
+#ifdef _IEEE_LIBM
+        return __ieee754_sqrt(x);
+#else
+        double z;
+        z = __ieee754_sqrt(x);
+        if(_LIB_VERSION == _IEEE_ || isnan(x)) return z;
+        if(x<0.0) {
+            return __kernel_standard(x,x,26); /* sqrt(negative) */
+        } else
+            return z;
+#endif
+}

--- a/src/java.base/share/native/libjava/StrictMath.c
+++ b/src/java.base/share/native/libjava/StrictMath.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 1994, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "fdlibm.h"
+
+#include "java_lang_StrictMath.h"
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_cos(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jcos((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_sin(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jsin((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_tan(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jtan((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_asin(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jasin((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_acos(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jacos((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_atan(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jatan((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_log(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jlog((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_log10(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jlog10((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_sqrt(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jsqrt((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_atan2(JNIEnv *env, jclass unused, jdouble d1, jdouble d2)
+{
+    return (jdouble) jatan2((double)d1, (double)d2);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_IEEEremainder(JNIEnv *env, jclass unused,
+                                  jdouble dividend,
+                                  jdouble divisor)
+{
+    return (jdouble) jremainder(dividend, divisor);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_cosh(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jcosh((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_sinh(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jsinh((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_tanh(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jtanh((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_log1p(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jlog1p((double)d);
+}
+
+JNIEXPORT jdouble JNICALL
+Java_java_lang_StrictMath_expm1(JNIEnv *env, jclass unused, jdouble d)
+{
+    return (jdouble) jexpm1((double)d);
+}


### PR DESCRIPTION
This reverts commit b5b5cba7feb0e7ef957fd6bef1e591fdb6fdaa9f.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303799](https://bugs.openjdk.org/browse/JDK-8303799): [BACKOUT] JDK-8302801  Remove fdlibm C sources


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12916/head:pull/12916` \
`$ git checkout pull/12916`

Update a local copy of the PR: \
`$ git checkout pull/12916` \
`$ git pull https://git.openjdk.org/jdk pull/12916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12916`

View PR using the GUI difftool: \
`$ git pr show -t 12916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12916.diff">https://git.openjdk.org/jdk/pull/12916.diff</a>

</details>
