### PR TITLE
8303804: Fix some errors of If-VectorTest and CMove-VectorTest

### DIFF
--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -1192,7 +1192,8 @@ void ArchDesc::buildMustCloneMap(FILE *fp_hpp, FILE *fp_cpp) {
          || strcmp(idealName,"OverflowMulI") == 0
          || strcmp(idealName,"OverflowMulL") == 0
          || strcmp(idealName,"Bool") == 0
-         || strcmp(idealName,"Binary") == 0 ) {
+         || strcmp(idealName,"Binary") == 0
+         || strcmp(idealName,"VectorTest") == 0 ) {
       // Removed ConI from the must_clone list.  CPUs that cannot use
       // large constants as immediates manifest the constant as an
       // instruction.  The must_clone flag prevents the constant from

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3985,7 +3985,8 @@ void ArchDesc::buildMachNode(FILE *fp_cpp, InstructForm *inst, const char *inden
 
   // Fill in the bottom_type where requested
   if (inst->captures_bottom_type(_globalNames)) {
-    if (strncmp("MachCall", inst->mach_base_class(_globalNames), strlen("MachCall"))) {
+    if (strncmp("MachCall", inst->mach_base_class(_globalNames), strlen("MachCall"))
+      && strncmp("MachIf", inst->mach_base_class(_globalNames), strlen("MachIf"))) {
       fprintf(fp_cpp, "%s node->_bottom_type = _leaf->bottom_type();\n", indent);
     }
   }

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3985,8 +3985,8 @@ void ArchDesc::buildMachNode(FILE *fp_cpp, InstructForm *inst, const char *inden
 
   // Fill in the bottom_type where requested
   if (inst->captures_bottom_type(_globalNames)) {
-    if (strncmp("MachCall", inst->mach_base_class(_globalNames), strlen("MachCall"))
-      && strncmp("MachIf", inst->mach_base_class(_globalNames), strlen("MachIf"))) {
+    if (strncmp("MachCall", inst->mach_base_class(_globalNames), strlen("MachCall")) != 0
+      && strncmp("MachIf", inst->mach_base_class(_globalNames), strlen("MachIf")) != 0) {
       fprintf(fp_cpp, "%s node->_bottom_type = _leaf->bottom_type();\n", indent);
     }
   }


### PR DESCRIPTION
After https://bugs.openjdk.org/browse/JDK-8292289 ,  the base class of VectorTestNode changed from Node to CmpNode. So I add two match rule into ad file.

match(If cop (VectorTest op1 op2));
match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));

First error, rule1 shouldn't generate the statement "node->_bottom_type = _leaf->bottom_type();".
Second error, both rule1 and rule2 need to use VectorTestNode, the VectorTestNode should be cloned like CmpNode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303804](https://bugs.openjdk.org/browse/JDK-8303804): Fix some errors of If-VectorTest and CMove-VectorTest


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) ⚠️ Review applies to [bfba75dd](https://git.openjdk.org/jdk/pull/12917/files/bfba75dd1bde072d2278e3b954239ad97ff4c507)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12917/head:pull/12917` \
`$ git checkout pull/12917`

Update a local copy of the PR: \
`$ git checkout pull/12917` \
`$ git pull https://git.openjdk.org/jdk.git pull/12917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12917`

View PR using the GUI difftool: \
`$ git pr show -t 12917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12917.diff">https://git.openjdk.org/jdk/pull/12917.diff</a>

</details>
