### PR TITLE
8303809: Dispose context in SPNEGO NegotiatorImpl

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -520,6 +520,11 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
         s.defaultWriteObject ();
     }
 
+    /**
+     * Releases any system or cryptographic resources.
+     * It is up to implementors to override disposeContext()
+     * to take necessary action.
+     */
     public void disposeContext() {
         // do nothing
     }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -519,4 +519,8 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
         s2 = new String (pw.getPassword());
         s.defaultWriteObject ();
     }
+
+    public void disposeContext() {
+        // do nothing
+    }
 }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -2009,6 +2009,12 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             if (serverAuthKey != null) {
                 AuthenticationInfo.endAuthRequest(serverAuthKey);
             }
+            if (proxyAuthentication != null) {
+                proxyAuthentication.disposeContext();
+            }
+            if (serverAuthentication != null) {
+                serverAuthentication.disposeContext();
+            }
         }
     }
 
@@ -2251,6 +2257,9 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
         } finally  {
             if (proxyAuthKey != null) {
                 AuthenticationInfo.endAuthRequest(proxyAuthKey);
+            }
+            if (proxyAuthentication != null) {
+                proxyAuthentication.disposeContext();
             }
         }
 
@@ -2502,6 +2511,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             }
             if (ret != null) {
                 if (!ret.setHeaders(this, p, raw)) {
+                    ret.disposeContext();
                     ret = null;
                 }
             }
@@ -2674,6 +2684,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
 
             if (ret != null ) {
                 if (!ret.setHeaders(this, p, raw)) {
+                    ret.disposeContext();
                     ret = null;
                 }
             }
@@ -2700,6 +2711,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     DigestAuthentication da = (DigestAuthentication)
                         currentProxyCredentials;
                     da.checkResponse (raw, method, getRequestURI());
+                    currentProxyCredentials.disposeContext();
                     currentProxyCredentials = null;
                 }
             }
@@ -2710,6 +2722,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     DigestAuthentication da = (DigestAuthentication)
                         currentServerCredentials;
                     da.checkResponse (raw, method, url);
+                    currentServerCredentials.disposeContext();
                     currentServerCredentials = null;
                 }
             }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -251,7 +251,7 @@ class NegotiateAuthentication extends AuthenticationInfo {
         if (negotiator != null) {
             try {
                 negotiator.disposeContext();
-            } catch(IOException ioEx) {
+            } catch (IOException ioEx) {
                 //do not rethrow IOException
             }
             negotiator = null;

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -251,7 +251,7 @@ class NegotiateAuthentication extends AuthenticationInfo {
         if (negotiator != null) {
             try {
                 negotiator.disposeContext();
-            }catch(IOException ioEx) {
+            } catch(IOException ioEx) {
                 //do not rethrow IOException
             }
             negotiator = null;

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -242,6 +242,22 @@ class NegotiateAuthentication extends AuthenticationInfo {
         return negotiator.nextToken(token);
     }
 
+    /**
+     * Releases any system resources and cryptographic information stored in
+     * the context object and invalidates the context.
+     */
+    @Override
+    public void disposeContext() {
+        if (negotiator != null) {
+            try {
+                negotiator.disposeContext();
+            }catch(IOException ioEx) {
+                //do not rethrow IOException
+            }
+            negotiator = null;
+        }
+    }
+
     // MS will send a final WWW-Authenticate even if the status is already
     // 200 OK. The token can be fed into initSecContext() again to determine
     // if the server can be trusted. This is not the same concept as Digest's

--- a/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
@@ -83,6 +83,6 @@ public abstract class Negotiator {
         }
     }
 
-    public abstract void disposeContext() throws IOException;
+    public void disposeContext() throws IOException { };
 }
 

--- a/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
@@ -82,5 +82,7 @@ public abstract class Negotiator {
             logger.finest("NegotiateAuthentication: " + e);
         }
     }
+
+    public abstract void disposeContext() throws IOException;
 }
 

--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -127,6 +127,11 @@ public class NegotiatorImpl extends Negotiator {
                         "fallback to other scheme if allowed. Reason:");
                 e.printStackTrace();
             }
+            try {
+                disposeContext();
+            } catch(Exception ex) {
+                //dispose context silently
+            }
             throw new IOException("Negotiate support not initiated", e);
         }
     }
@@ -149,6 +154,9 @@ public class NegotiatorImpl extends Negotiator {
     @Override
     public byte[] nextToken(byte[] token) throws IOException {
         try {
+            if (context == null) {
+                throw new IOException("Negotiate support cannot continue. Context is invalidated");
+            }
             return context.initSecContext(token, 0, token.length);
         } catch (GSSException e) {
             if (DEBUG) {
@@ -157,5 +165,27 @@ public class NegotiatorImpl extends Negotiator {
             }
             throw new IOException("Negotiate support cannot continue", e);
         }
+    }
+
+    /**
+     * Releases any system resources and cryptographic information stored in
+     * the context object and invalidates the context.
+     *
+     * @throws IOException containing a reason of failure in the cause
+     */
+    @Override
+    public void disposeContext() throws IOException {
+        try {
+            if (context != null) {
+                context.dispose();
+            }
+        }catch (GSSException e) {
+            if (DEBUG) {
+                System.out.println("Cannot release resources. Reason:");
+                e.printStackTrace();
+            }
+            throw new IOException("Cannot release resources", e);
+        };
+        context = null;
     }
 }

--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -129,7 +129,7 @@ public class NegotiatorImpl extends Negotiator {
             }
             try {
                 disposeContext();
-            } catch(Exception ex) {
+            } catch (Exception ex) {
                 //dispose context silently
             }
             throw new IOException("Negotiate support not initiated", e);

--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -179,7 +179,7 @@ public class NegotiatorImpl extends Negotiator {
             if (context != null) {
                 context.dispose();
             }
-        }catch (GSSException e) {
+        } catch (GSSException e) {
             if (DEBUG) {
                 System.out.println("Cannot release resources. Reason:");
                 e.printStackTrace();


### PR DESCRIPTION
This patch fixes a possible native memory leak in case of a custom native GSS provider.
The actual leak was reported in production.

sun/security/jgss, sun/security/krb5, sun/net/www/protocol/http jtreg tests are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8303809](https://bugs.openjdk.org/browse/JDK-8303809): Dispose context in SPNEGO NegotiatorImpl


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to [75584998](https://git.openjdk.org/jdk/pull/12920/files/7558499852bc52efc0a5edeaeb7e7f1d61dbd59d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12920/head:pull/12920` \
`$ git checkout pull/12920`

Update a local copy of the PR: \
`$ git checkout pull/12920` \
`$ git pull https://git.openjdk.org/jdk pull/12920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12920`

View PR using the GUI difftool: \
`$ git pr show -t 12920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12920.diff">https://git.openjdk.org/jdk/pull/12920.diff</a>

</details>
