### PR TITLE
JDK-8303817: Add constexpr for natural malloc alignment

### DIFF
--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -27,6 +27,7 @@
 #define SHARE_SERVICES_MALLOCHEADER_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
@@ -155,7 +156,6 @@ public:
 };
 
 // This needs to be true on both 64-bit and 32-bit platforms
-STATIC_ASSERT(sizeof(MallocHeader) == (sizeof(uint64_t) * 2));
-
+STATIC_ASSERT(is_aligned(sizeof(MallocHeader), minimum_malloc_alignment));
 
 #endif // SHARE_SERVICES_MALLOCHEADER_HPP

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1302,4 +1302,14 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
 template<typename T>
 std::add_rvalue_reference_t<T> declval() noexcept;
 
+// The minimum natural alignment malloc should guarantee
+// Note that in practice libc's will typically use higher alignments
+// (typically 8 for 32-bit, 16 for 64-bit) but that's not guaranteed.
+union AllTheBigTypes {
+  void* p;
+  uint64_t i64;
+  long double d;
+};
+constexpr int minimum_malloc_alignment = alignof(AllTheBigTypes);
+
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP

--- a/test/hotspot/gtest/utilities/test_align.cpp
+++ b/test/hotspot/gtest/utilities/test_align.cpp
@@ -195,3 +195,9 @@ TEST(Align, alignments) {
 
   test_alignments<int8_t, int8_t>();
 }
+
+TEST(Align, test_minimum_malloc_alignment) {
+  // Test for reasonable values (ranges can go from 4 to 16 on our platforms)
+  ASSERT_GT(minimum_malloc_alignment, 0);
+  ASSERT_LE(minimum_malloc_alignment, 16);
+}


### PR DESCRIPTION
I miss having an easy way to get the alignment the libc guarantees for malloc. Let's add this, and we can use this right away with NMT's MallocHeader.

Tests: manually built and tested x64 linux (clang + GCC) and x86 linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303817](https://bugs.openjdk.org/browse/JDK-8303817): Add constexpr for natural malloc alignment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12921/head:pull/12921` \
`$ git checkout pull/12921`

Update a local copy of the PR: \
`$ git checkout pull/12921` \
`$ git pull https://git.openjdk.org/jdk pull/12921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12921`

View PR using the GUI difftool: \
`$ git pr show -t 12921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12921.diff">https://git.openjdk.org/jdk/pull/12921.diff</a>

</details>
