### PR TITLE
8303814: getLastErrorString should avoid charset conversions

### DIFF
--- a/src/java.base/share/native/libjava/io_util.c
+++ b/src/java.base/share/native/libjava/io_util.c
@@ -204,16 +204,11 @@ writeBytes(JNIEnv *env, jobject this, jbyteArray bytes,
 void
 throwFileNotFoundException(JNIEnv *env, jstring path)
 {
-    char buf[256];
-    size_t n;
     jobject x;
-    jstring why = NULL;
+    jstring why;
 
-    n = getLastErrorString(buf, sizeof(buf));
-    if (n > 0) {
-        why = JNU_NewStringPlatform(env, buf);
-        CHECK_NULL(why);
-    }
+    why = getLastErrorString(env);
+    JNU_CHECK_EXCEPTION(env);
     x = JNU_NewObjectByName(env,
                             "java/io/FileNotFoundException",
                             "(Ljava/lang/String;Ljava/lang/String;)V",

--- a/src/java.base/share/native/libjava/io_util.c
+++ b/src/java.base/share/native/libjava/io_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -130,11 +130,11 @@ JNU_ThrowByNameWithMessageAndLastError
     jstring s = getLastErrorString(env);
     if (s != NULL) {
         jobject x = NULL;
-        if (messagelen) {
+        if (messagelen > 0) {
             jstring s2 = NULL;
             size_t messageextlen = messagelen + 4;
             char *str1 = (char *)malloc((messageextlen) * sizeof(char));
-            if (str1 == 0) {
+            if (str1 == NULL) {
                 JNU_ThrowOutOfMemoryError(env, 0);
                 return;
             }
@@ -162,7 +162,7 @@ JNU_ThrowByNameWithMessageAndLastError
     }
 
     if (!(*env)->ExceptionOccurred(env)) {
-        if (messagelen) {
+        if (messagelen > 0) {
             JNU_ThrowByName(env, name, message);
         } else {
             JNU_ThrowByName(env, name, "no further information");

--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -336,8 +336,7 @@ void* getProcessHandle();
 void buildJniFunctionName(const char *sym, const char *cname,
                           char *jniEntryName);
 
-JNIEXPORT size_t JNICALL
-getLastErrorString(char *buf, size_t len);
+jstring getLastErrorString(JNIEnv *env);
 
 JNIEXPORT int JNICALL
 getErrorString(int err, char *buf, size_t len);

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -764,7 +764,7 @@ readCEN(jzfile *zip, jint knownTotal)
  * Opens a zip file with the specified mode. Returns the jzfile object
  * or NULL if an error occurred. If a zip error occurred then *pmsg will
  * be set to the error message text if pmsg != 0. Otherwise, *pmsg will be
- * set to NULL. Caller is responsible to free the error message.
+ * set to NULL. Caller doesn't need to free the error message.
  */
 jzfile *
 ZIP_Open_Generic(const char *name, char **pmsg, int mode, jlong lastModified)
@@ -790,7 +790,7 @@ ZIP_Open_Generic(const char *name, char **pmsg, int mode, jlong lastModified)
  * zip files, or NULL if the file is not in the cache.  If the name is longer
  * than PATH_MAX or a zip error occurred then *pmsg will be set to the error
  * message text if pmsg != 0. Otherwise, *pmsg will be set to NULL. Caller
- * is responsible to free the error message.
+ * doesn't need to free the error message.
  */
 jzfile *
 ZIP_Get_From_Cache(const char *name, char **pmsg, jlong lastModified)
@@ -809,7 +809,7 @@ ZIP_Get_From_Cache(const char *name, char **pmsg, jlong lastModified)
 
     if (strlen(name) >= PATH_MAX) {
         if (pmsg) {
-            *pmsg = strdup("zip file name too long");
+            *pmsg = "zip file name too long";
         }
         return NULL;
     }
@@ -834,7 +834,7 @@ ZIP_Get_From_Cache(const char *name, char **pmsg, jlong lastModified)
  * Reads data from the given file descriptor to create a jzfile, puts the
  * jzfile in a cache, and returns that jzfile.  Returns NULL in case of error.
  * If a zip error occurs, then *pmsg will be set to the error message text if
- * pmsg != 0. Otherwise, *pmsg will be set to NULL. Caller is responsible to
+ * pmsg != 0. Otherwise, *pmsg will be set to NULL. Caller doesn't need to
  * free the error message.
  */
 
@@ -863,8 +863,8 @@ ZIP_Put_In_Cache0(const char *name, ZFILE zfd, char **pmsg, jlong lastModified,
     zip->lastModified = lastModified;
 
     if (zfd == -1) {
-        if (pmsg && getLastErrorString(errbuf, sizeof(errbuf)) > 0)
-            *pmsg = strdup(errbuf);
+        if (pmsg)
+            *pmsg = "ZFILE_Open failed";
         freeZip(zip);
         return NULL;
     }
@@ -878,11 +878,11 @@ ZIP_Put_In_Cache0(const char *name, ZFILE zfd, char **pmsg, jlong lastModified,
     if (len <= 0) {
         if (len == 0) { /* zip file is empty */
             if (pmsg) {
-                *pmsg = strdup("zip file is empty");
+                *pmsg = "zip file is empty";
             }
         } else { /* error */
-            if (pmsg && getLastErrorString(errbuf, sizeof(errbuf)) > 0)
-                *pmsg = strdup(errbuf);
+            if (pmsg)
+                *pmsg = "IO_Lseek failed";
         }
         ZFILE_Close(zfd);
         freeZip(zip);
@@ -894,8 +894,7 @@ ZIP_Put_In_Cache0(const char *name, ZFILE zfd, char **pmsg, jlong lastModified,
         /* An error occurred while trying to read the zip file */
         if (pmsg != 0) {
             /* Set the zip error message */
-            if (zip->msg != NULL)
-                *pmsg = strdup(zip->msg);
+            *pmsg = zip->msg;
         }
         freeZip(zip);
         return NULL;
@@ -918,10 +917,6 @@ JNIEXPORT jzfile *
 ZIP_Open(const char *name, char **pmsg)
 {
     jzfile *file = ZIP_Open_Generic(name, pmsg, O_RDONLY, 0);
-    if (file == NULL && pmsg != NULL && *pmsg != NULL) {
-        free(*pmsg);
-        *pmsg = "Zip file open error";
-    }
     return file;
 }
 

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -765,6 +765,7 @@ readCEN(jzfile *zip, jint knownTotal)
  * or NULL if an error occurred. If a zip error occurred then *pmsg will
  * be set to the error message text if pmsg != 0. Otherwise, *pmsg will be
  * set to NULL. Caller doesn't need to free the error message.
+ * The error message, if set, points to a static thread-safe buffer.
  */
 jzfile *
 ZIP_Open_Generic(const char *name, char **pmsg, int mode, jlong lastModified)

--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -529,7 +529,7 @@ addMetaName(jzfile *zip, const char *name, int length)
 static void
 freeMetaNames(jzfile *zip)
 {
-    if (zip->metanames) {
+    if (zip->metanames != NULL) {
         jint i;
         for (i = 0; i < zip->metacount; i++)
             free(zip->metanames[i]);
@@ -804,12 +804,12 @@ ZIP_Get_From_Cache(const char *name, char **pmsg, jlong lastModified)
     }
 
     /* Clear zip error message */
-    if (pmsg != 0) {
+    if (pmsg != NULL) {
         *pmsg = NULL;
     }
 
     if (strlen(name) >= PATH_MAX) {
-        if (pmsg) {
+        if (pmsg != NULL) {
             *pmsg = "zip file name too long";
         }
         return NULL;
@@ -864,7 +864,7 @@ ZIP_Put_In_Cache0(const char *name, ZFILE zfd, char **pmsg, jlong lastModified,
     zip->lastModified = lastModified;
 
     if (zfd == -1) {
-        if (pmsg)
+        if (pmsg != NULL)
             *pmsg = "ZFILE_Open failed";
         freeZip(zip);
         return NULL;
@@ -878,11 +878,11 @@ ZIP_Put_In_Cache0(const char *name, ZFILE zfd, char **pmsg, jlong lastModified,
     len = zip->len = IO_Lseek(zfd, 0, SEEK_END);
     if (len <= 0) {
         if (len == 0) { /* zip file is empty */
-            if (pmsg) {
+            if (pmsg != NULL) {
                 *pmsg = "zip file is empty";
             }
         } else { /* error */
-            if (pmsg)
+            if (pmsg != NULL)
                 *pmsg = "IO_Lseek failed";
         }
         ZFILE_Close(zfd);
@@ -893,7 +893,7 @@ ZIP_Put_In_Cache0(const char *name, ZFILE zfd, char **pmsg, jlong lastModified,
     zip->zfd = zfd;
     if (readCEN(zip, -1) < 0) {
         /* An error occurred while trying to read the zip file */
-        if (pmsg != 0) {
+        if (pmsg != NULL) {
             /* Set the zip error message */
             *pmsg = zip->msg;
         }
@@ -1134,8 +1134,8 @@ ZIP_FreeEntry(jzfile *jz, jzentry *ze)
     if (last != NULL) {
         /* Free the previously cached jzentry */
         free(last->name);
-        if (last->extra)   free(last->extra);
-        if (last->comment) free(last->comment);
+        free(last->extra);
+        free(last->comment);
         free(last);
     }
 }
@@ -1513,7 +1513,7 @@ ZIP_ReadEntry(jzfile *zip, jzentry *entry, unsigned char *buf, char *entryname)
             msg = zip->msg;
             ZIP_Unlock(zip);
             if (n == -1) {
-                if (msg == 0) {
+                if (msg == NULL) {
                     getErrorString(errno, tmpbuf, sizeof(tmpbuf));
                     msg = tmpbuf;
                 }
@@ -1530,7 +1530,7 @@ ZIP_ReadEntry(jzfile *zip, jzentry *entry, unsigned char *buf, char *entryname)
             if ((msg == NULL) || (*msg == 0)) {
                 msg = zip->msg;
             }
-            if (msg == 0) {
+            if (msg == NULL) {
                 getErrorString(errno, tmpbuf, sizeof(tmpbuf));
                 msg = tmpbuf;
             }
@@ -1550,7 +1550,7 @@ ZIP_InflateFully(void *inBuf, jlong inLen, void *outBuf, jlong outLen, char **pm
     z_stream strm;
     memset(&strm, 0, sizeof(z_stream));
 
-    *pmsg = 0; /* Reset error message */
+    *pmsg = NULL; /* Reset error message */
 
     if (inflateInit2(&strm, MAX_WBITS) != Z_OK) {
         *pmsg = strm.msg;

--- a/src/java.base/unix/native/libjava/jni_util_md.c
+++ b/src/java.base/unix/native/libjava/jni_util_md.c
@@ -60,12 +60,13 @@ void buildJniFunctionName(const char *sym, const char *cname,
     }
 }
 
-JNIEXPORT size_t JNICALL
-getLastErrorString(char *buf, size_t len)
+jstring
+getLastErrorString(JNIEnv *env)
 {
-    if (errno == 0 || len < 1) return 0;
-    getErrorString(errno, buf, len);
-    return strlen(buf);
+    char buf[256] = {0};
+    if (errno == 0) return NULL;
+    getErrorString(errno, buf, sizeof(buf));
+    return (*buf) ? JNU_NewStringPlatform(env, buf) : NULL;
 }
 
 JNIEXPORT int JNICALL

--- a/src/java.base/unix/native/libjava/jni_util_md.c
+++ b/src/java.base/unix/native/libjava/jni_util_md.c
@@ -66,7 +66,7 @@ getLastErrorString(JNIEnv *env)
     char buf[256] = {0};
     if (errno == 0) return NULL;
     getErrorString(errno, buf, sizeof(buf));
-    return (*buf) ? JNU_NewStringPlatform(env, buf) : NULL;
+    return (buf[0] != 0) ? JNU_NewStringPlatform(env, buf) : NULL;
 }
 
 JNIEXPORT int JNICALL

--- a/src/java.base/unix/native/libjava/jni_util_md.c
+++ b/src/java.base/unix/native/libjava/jni_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libjava/jni_util_md.c
+++ b/src/java.base/windows/native/libjava/jni_util_md.c
@@ -66,8 +66,9 @@ void buildJniFunctionName(const char *sym, const char *cname,
 jstring
 getLastErrorString(JNIEnv *env) {
 
+#define BUFSIZE 256
     DWORD errval;
-    WCHAR buf[256];
+    WCHAR buf[BUFSIZE];
 
     if ((errval = GetLastError()) != 0) {
         // DOS error
@@ -77,7 +78,7 @@ getLastErrorString(JNIEnv *env) {
                 errval,
                 0,
                 buf,
-                sizeof(buf) / sizeof(WCHAR),
+                BUFSIZE,
                 NULL);
         if (n > 3) {
             // Drop final '.', CR, LF

--- a/src/java.base/windows/native/libjava/jni_util_md.c
+++ b/src/java.base/windows/native/libjava/jni_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
@@ -49,7 +49,7 @@ Java_sun_nio_ch_FileDispatcherImpl_read0(JNIEnv *env, jclass clazz, jobject fdo,
     HANDLE h = (HANDLE)(handleval(env, fdo));
 
     if (h == INVALID_HANDLE_VALUE) {
-        JNU_ThrowIOExceptionWithLastError(env, "Invalid handle");
+        JNU_ThrowIOException(env, "Invalid handle");
         return IOS_THROWN;
     }
     result = ReadFile(h,          /* File handle to read */
@@ -85,7 +85,7 @@ Java_sun_nio_ch_FileDispatcherImpl_readv0(JNIEnv *env, jclass clazz, jobject fdo
     HANDLE h = (HANDLE)(handleval(env, fdo));
 
     if (h == INVALID_HANDLE_VALUE) {
-        JNU_ThrowIOExceptionWithLastError(env, "Invalid handle");
+        JNU_ThrowIOException(env, "Invalid handle");
         return IOS_THROWN;
     }
 
@@ -131,7 +131,7 @@ Java_sun_nio_ch_FileDispatcherImpl_pread0(JNIEnv *env, jclass clazz, jobject fdo
     OVERLAPPED ov;
 
     if (h == INVALID_HANDLE_VALUE) {
-        JNU_ThrowIOExceptionWithLastError(env, "Invalid handle");
+        JNU_ThrowIOException(env, "Invalid handle");
         return IOS_THROWN;
     }
 
@@ -199,9 +199,12 @@ Java_sun_nio_ch_FileDispatcherImpl_write0(JNIEnv *env, jclass clazz, jobject fdo
                            len,              /* number of bytes to write */
                            &written,         /* receives number of bytes written */
                            lpOv);            /* overlapped struct */
+    } else {
+        JNU_ThrowIOException(env, "Invalid handle");
+        return IOS_THROWN;
     }
 
-    if ((h == INVALID_HANDLE_VALUE) || (result == 0)) {
+    if (result == 0) {
         JNU_ThrowIOExceptionWithLastError(env, "Write failed");
         return IOS_THROWN;
     }
@@ -248,9 +251,12 @@ Java_sun_nio_ch_FileDispatcherImpl_writev0(JNIEnv *env, jclass clazz, jobject fd
                 break;
             }
         }
+    } else {
+        JNU_ThrowIOException(env, "Invalid handle");
+        return IOS_THROWN;
     }
 
-    if ((h == INVALID_HANDLE_VALUE) || (result == 0)) {
+    if (result == 0) {
         JNU_ThrowIOExceptionWithLastError(env, "Write failed");
         return IOS_THROWN;
     }
@@ -268,6 +274,10 @@ Java_sun_nio_ch_FileDispatcherImpl_pwrite0(JNIEnv *env, jclass clazz, jobject fd
     LARGE_INTEGER currPos;
     OVERLAPPED ov;
 
+    if (h == INVALID_HANDLE_VALUE) {
+        JNU_ThrowIOException(env, "Invalid handle");
+        return IOS_THROWN;
+    }
     currPos.QuadPart = 0;
     result = SetFilePointerEx(h, currPos, &currPos, FILE_CURRENT);
     if (result == 0) {
@@ -285,7 +295,7 @@ Java_sun_nio_ch_FileDispatcherImpl_pwrite0(JNIEnv *env, jclass clazz, jobject fd
                        &written,         /* receives number of bytes written */
                        &ov);             /* position to write at */
 
-    if ((h == INVALID_HANDLE_VALUE) || (result == 0)) {
+    if (result == 0) {
         JNU_ThrowIOExceptionWithLastError(env, "Write failed");
         return IOS_THROWN;
     }
@@ -341,7 +351,7 @@ Java_sun_nio_ch_FileDispatcherImpl_force0(JNIEnv *env, jobject this,
             }
         }
     } else {
-        JNU_ThrowIOExceptionWithLastError(env, "Force failed");
+        JNU_ThrowIOException(env, "Invalid handle");
         return IOS_THROWN;
     }
     return 0;

--- a/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This patch modifies the `getLastErrorString` method to return a `jstring`. Thanks to that we can avoid unnecessary back and forth conversions between Unicode and other charsets on Windows.

Other changes include:
- the Windows implementation of `getLastErrorString` no longer checks `errno`. I verified all uses of the method and confirmed that `errno` is not used anywhere. 
- While at it, I found and fixed a few calls to `JNU_ThrowIOExceptionWithLastError` that were done in context where `LastError` was not set.
- jdk.hotspot.agent was modified to use `JNU_ThrowByNameWithLastError` and `JNU_ThrowByName` instead of `getLastErrorString`; the code is expected to have identical behavior.
- zip_util was modified to return static messages instead of generated ones. The generated messages were not observed anywhere, because they were replaced by a static message in ZIP_Open, which is the only method used by other native code.
- `getLastErrorString` is no longer exported by libjava.

Tier1-3 tests continue to pass.

No new automated regression test; testing this requires installing a language pack that cannot be displayed in the current code page.
Tested this manually by installing Chinese language pack on English Windows 11, selecting Chinese language, then checking if the message on exception thrown by `InetAddress.getByName("nonexistent.local");` starts with `"不知道这样的主机。"` (or `"\u4e0d\u77e5\u9053\u8fd9\u6837\u7684\u4e3b\u673a\u3002"`). Without the change, the exception message started with a row of question marks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303814](https://bugs.openjdk.org/browse/JDK-8303814): getLastErrorString should avoid charset conversions


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [8ab8d729](https://git.openjdk.org/jdk/pull/12922/files/8ab8d7296f3f32e391684cff6e69ce652351f791)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [ea91b651](https://git.openjdk.org/jdk/pull/12922/files/ea91b651aa7dd19eabe793a1f79afbe457a8c33d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12922/head:pull/12922` \
`$ git checkout pull/12922`

Update a local copy of the PR: \
`$ git checkout pull/12922` \
`$ git pull https://git.openjdk.org/jdk pull/12922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12922`

View PR using the GUI difftool: \
`$ git pr show -t 12922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12922.diff">https://git.openjdk.org/jdk/pull/12922.diff</a>

</details>
