### PR TITLE
8303820: Simplify type metadata

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -323,7 +323,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
      *  and with given constant value
      */
     public Type constType(Object constValue) {
-        return addMetadata(new ConstantValue(constValue));
+        throw new AssertionError();
     }
 
     /**
@@ -772,6 +772,14 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             return true;
         }
 
+        /** Define a constant type, of the same kind as this type
+         *  and with given constant value
+         */
+        @Override
+        public Type constType(Object constValue) {
+            return addMetadata(new ConstantValue(constValue));
+        }
+
         /**
          * The constant value of this type, converted to String
          */
@@ -1026,6 +1034,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         @Override
         public <R,S> R accept(Type.Visitor<R,S> v, S s) {
             return v.visitClassType(this, s);
+        }
+
+        public Type constType(Object constValue) {
+            return addMetadata(new ConstantValue(constValue));
         }
 
         /** The Java source which this type represents.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -438,10 +438,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     }
 
     public Type annotatedType(final List<Attribute.TypeCompound> annos) {
-        return getMetadata(Annotations.class)
-                .map(a -> { a.setAnnotations(annos) ; return this; })
-                .orElseGet(() ->
-                    addMetadata(new Annotations(annos)));
+        return addMetadata(new Annotations(annos));
     }
 
     public boolean isAnnotated() {
@@ -451,7 +448,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     @Override @DefinedBy(Api.LANGUAGE_MODEL)
     public List<Attribute.TypeCompound> getAnnotationMirrors() {
         return getMetadata(TypeMetadata.Annotations.class)
-                .map(Annotations::getAnnotations).orElse(List.nil());
+                .map(Annotations::annotations).orElse(List.nil());
     }
 
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -364,14 +364,17 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     public <M extends TypeMetadata> Optional<M> getMetadata(Class<M> metadataClass) {
         return metadata.stream()
                 .filter(m -> metadataClass.isAssignableFrom(m.getClass()))
-                .map(m -> metadataClass.cast(m))
+                .map(metadataClass::cast)
                 .findFirst();
     }
 
     /**
      * Create a new copy of this type but with the specified type metadata.
+     * If this type is already associated with a type metadata of the same class,
+     * an exception is thrown.
      */
     public Type addMetadata(TypeMetadata md) {
+        Assert.check(getMetadata(md.getClass()).isEmpty());
         return cloneWithMetadata(metadata.append(md));
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeMetadata.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeMetadata.java
@@ -25,9 +25,8 @@
 
 package com.sun.tools.javac.code;
 
-import com.sun.tools.javac.code.Attribute.TypeCompound;
-import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
 
 /**
  * A type metadata is an object that can be stapled on a type. This is typically done using
@@ -56,26 +55,19 @@ public sealed interface TypeMetadata {
      * the existing type (rather than creating a new one), as the type might already have been
      * saved inside other symbols.
      */
-    final class Annotations implements TypeMetadata {
-        private List<Attribute.TypeCompound> annos;
+    record Annotations(ListBuffer<Attribute.TypeCompound> annotationBuffer) implements TypeMetadata {
 
-        public static final List<Attribute.TypeCompound> TO_BE_SET = List.nil();
-
-        public Annotations() {
-            this.annos = TO_BE_SET;
+        Annotations() {
+            this(new ListBuffer<>());
         }
 
-        public Annotations(List<Attribute.TypeCompound> annos) {
-            this.annos = annos;
+        Annotations(List<Attribute.TypeCompound> annotations) {
+            this();
+            annotationBuffer.appendList(annotations);
         }
 
-        public List<Attribute.TypeCompound> getAnnotations() {
-            return annos;
-        }
-
-        public void setAnnotations(List<TypeCompound> annos) {
-            Assert.check(this.annos == TO_BE_SET);
-            this.annos = annos;
+        List<Attribute.TypeCompound> annotations() {
+            return annotationBuffer.toList();
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeMetadata.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeMetadata.java
@@ -41,7 +41,7 @@ import com.sun.tools.javac.util.List;
  * In other cases, type metadata can be mutable and support complex state transitions
  * (see {@link Annotations}).
  * <p>
- * The only invariant the implementation requires is that there is only <em>one</em> metadata
+ * The only invariant the implementation requires is that there must be <em>one</em> metadata
  * of a given kind attached to a type, as this makes accessing and dropping metadata simpler.
  * If clients wish to store multiple metadata values that are logically related, they should
  * define a metadata type that collects such values in e.g. a list.
@@ -53,9 +53,10 @@ public sealed interface TypeMetadata {
      * because type annotations are sometimes set in two steps. That is, a type can be created with
      * an empty set of annotations (e.g. during member enter). At some point later, the type
      * is then updated to contain the correct annotations. At this point we need to augment
-     * the existing type, as the type has already been saved inside other symbols.
+     * the existing type (rather than creating a new one), as the type might already have been
+     * saved inside other symbols.
      */
-    class Annotations implements TypeMetadata {
+    final class Annotations implements TypeMetadata {
         private List<Attribute.TypeCompound> annos;
 
         public static final List<Attribute.TypeCompound> TO_BE_SET = List.nil();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeMetadata.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,181 +25,62 @@
 
 package com.sun.tools.javac.code;
 
+import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.List;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
- * TypeMetadata is essentially an immutable {@code EnumMap<Entry.Kind, <? extends Entry>>}
- *
- * A metadata class represented by a subtype of Entry can express a property on a Type instance.
- * There should be at most one instance of an Entry per Entry.Kind on any given Type instance.
- *
- * Metadata classes of a specific kind are responsible for how they combine themselves.
- *
- * @implNote {@code Entry:combine} need not be commutative.
+ * A type metadata is an object that can be stapled on a type. This is typically done using
+ * {@link Type#addMetadata(TypeMetadata)}. Metadata associated to a type can also be removed,
+ * typically using {@link Type#dropMetadata(Class)}. To drop <em>all</em> metadata from a given type,
+ * the {@link Type#baseType()} method can also be used. This can be useful when comparing two
+ * using reference equality (see also {@link Type#equalsIgnoreMetadata(Type)}).
+ * <p>
+ * There are no constraints on how a type metadata should be defined. Typically, a type
+ * metadata will be defined as a small record, storing additional information (see {@link ConstantValue}).
+ * In other cases, type metadata can be mutable and support complex state transitions
+ * (see {@link Annotations}).
+ * <p>
+ * The only invariant the implementation requires is that there is only <em>one</em> metadata
+ * of a given kind attached to a type, as this makes accessing and dropping metadata simpler.
+ * If clients wish to store multiple metadata values that are logically related, they should
+ * define a metadata type that collects such values in e.g. a list.
  */
-public class TypeMetadata {
-    public static final TypeMetadata EMPTY = new TypeMetadata();
-
-    private final EnumMap<Entry.Kind, Entry> contents;
+public sealed interface TypeMetadata {
 
     /**
-     * Create a new empty TypeMetadata map.
+     * A type metadata object holding type annotations. This metadata needs to be mutable,
+     * because type annotations are sometimes set in two steps. That is, a type can be created with
+     * an empty set of annotations (e.g. during member enter). At some point later, the type
+     * is then updated to contain the correct annotations. At this point we need to augment
+     * the existing type, as the type has already been saved inside other symbols.
      */
-    private TypeMetadata() {
-        contents = new EnumMap<>(Entry.Kind.class);
-    }
-
-    /**
-     * Create a new TypeMetadata map containing the Entry {@code elem}.
-     *
-     * @param elem the sole contents of this map
-     */
-    public TypeMetadata(Entry elem) {
-        this();
-        Assert.checkNonNull(elem);
-        contents.put(elem.kind(), elem);
-    }
-
-    /**
-     * Creates a copy of TypeMetadata {@code other} with a shallow copy the other's metadata contents.
-     *
-     * @param other the TypeMetadata to copy contents from.
-     */
-    public TypeMetadata(TypeMetadata other) {
-        Assert.checkNonNull(other);
-        contents = other.contents.clone();
-    }
-
-    /**
-     * Return a copy of this TypeMetadata with the metadata entry for {@code elem.kind()} combined
-     * with {@code elem}.
-     *
-     * @param elem the new value
-     * @return a new TypeMetadata updated with {@code Entry elem}
-     */
-    public TypeMetadata combine(Entry elem) {
-        Assert.checkNonNull(elem);
-
-        TypeMetadata out = new TypeMetadata(this);
-        Entry.Kind key = elem.kind();
-        if (contents.containsKey(key)) {
-            out.add(key, this.contents.get(key).combine(elem));
-        } else {
-            out.add(key, elem);
-        }
-        return out;
-    }
-
-    /**
-     * Return a copy of this TypeMetadata with the metadata entry for all kinds from {@code other}
-     * combined with the same kind from this.
-     *
-     * @param other the TypeMetadata to combine with this
-     * @return a new TypeMetadata updated with all entries from {@code other}
-     */
-    public TypeMetadata combineAll(TypeMetadata other) {
-        Assert.checkNonNull(other);
-
-        TypeMetadata out = new TypeMetadata();
-        Set<Entry.Kind> keys = new HashSet<>(contents.keySet());
-        keys.addAll(other.contents.keySet());
-
-        for(Entry.Kind key : keys) {
-            if (contents.containsKey(key)) {
-                if (other.contents.containsKey(key)) {
-                    out.add(key, contents.get(key).combine(other.contents.get(key)));
-                } else {
-                    out.add(key, contents.get(key));
-                }
-            } else if (other.contents.containsKey(key)) {
-                out.add(key, other.contents.get(key));
-            }
-        }
-        return out;
-    }
-
-    /**
-     * Return a TypeMetadata with the metadata entry for {@code kind} removed.
-     *
-     * This may be the same instance or a new TypeMetadata.
-     *
-     * @param kind the {@code Kind} to remove metadata for
-     * @return a new TypeMetadata without {@code Kind kind}
-     */
-    public TypeMetadata without(Entry.Kind kind) {
-        if (this == EMPTY || contents.get(kind) == null)
-            return this;
-
-        TypeMetadata out = new TypeMetadata(this);
-        out.contents.remove(kind);
-        return out.contents.isEmpty() ? EMPTY : out;
-    }
-
-    public Entry get(Entry.Kind kind) {
-        return contents.get(kind);
-    }
-
-    private void add(Entry.Kind kind, Entry elem) {
-        contents.put(kind, elem);
-    }
-
-    public interface Entry {
-
-        public enum Kind {
-            ANNOTATIONS
-        }
-
-        /**
-         * Get the kind of metadata this object represents
-         */
-        public Kind kind();
-
-        /**
-         * Combine this type metadata with another metadata of the
-         * same kind.
-         *
-         * @param other The metadata with which to combine this one.
-         * @return The combined metadata.
-         */
-        public Entry combine(Entry other);
-    }
-
-    /**
-     * A type metadata object holding type annotations.
-     */
-    public static class Annotations implements Entry {
+    class Annotations implements TypeMetadata {
         private List<Attribute.TypeCompound> annos;
 
         public static final List<Attribute.TypeCompound> TO_BE_SET = List.nil();
+
+        public Annotations() {
+            this.annos = TO_BE_SET;
+        }
 
         public Annotations(List<Attribute.TypeCompound> annos) {
             this.annos = annos;
         }
 
-        /**
-         * Get the type annotations contained in this metadata.
-         *
-         * @return The annotations.
-         */
         public List<Attribute.TypeCompound> getAnnotations() {
             return annos;
         }
 
-        @Override
-        public Annotations combine(Entry other) {
-            Assert.check(annos == TO_BE_SET);
-            annos = ((Annotations)other).annos;
-            return this;
+        public void setAnnotations(List<TypeCompound> annos) {
+            Assert.check(this.annos == TO_BE_SET);
+            this.annos = annos;
         }
-
-        @Override
-        public Kind kind() { return Kind.ANNOTATIONS; }
-
-        @Override
-        public String toString() { return "ANNOTATIONS [ " + annos + " ]"; }
     }
+
+    /**
+     * A type metadata holding a constant value. This can be used to describe constant types,
+     * such as the type of a string literal, or that of a numeric constant.
+     */
+    record ConstantValue(Object value) implements TypeMetadata { }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -44,7 +44,7 @@ import com.sun.tools.javac.code.Attribute.RetentionPolicy;
 import com.sun.tools.javac.code.Lint.LintCategory;
 import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Type.UndetVar.InferenceBound;
-import com.sun.tools.javac.code.TypeMetadata.Entry.Kind;
+import com.sun.tools.javac.code.TypeMetadata.Annotations;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Check;
 import com.sun.tools.javac.comp.Enter;
@@ -2399,7 +2399,7 @@ public class Types {
         private TypeMapping<Boolean> erasure = new StructuralTypeMapping<Boolean>() {
             private Type combineMetadata(final Type s,
                                          final Type t) {
-                if (t.getMetadata() != TypeMetadata.EMPTY) {
+                if (t.getMetadata().nonEmpty()) {
                     switch (s.getKind()) {
                         case OTHER:
                         case UNION:
@@ -2410,7 +2410,7 @@ public class Types {
                         case VOID:
                         case ERROR:
                             return s;
-                        default: return s.cloneWithMetadata(s.getMetadata().without(Kind.ANNOTATIONS));
+                        default: return s.dropMetadata(Annotations.class);
                     }
                 } else {
                     return s;
@@ -2437,7 +2437,7 @@ public class Types {
                 Type erased = t.tsym.erasure(Types.this);
                 if (recurse) {
                     erased = new ErasedClassType(erased.getEnclosingType(),erased.tsym,
-                            t.getMetadata().without(Kind.ANNOTATIONS));
+                            t.dropMetadata(Annotations.class).getMetadata());
                     return erased;
                 } else {
                     return combineMetadata(erased, t);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -32,7 +32,7 @@ import com.sun.tools.javac.code.Kinds.KindSelector;
 import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Symbol.*;
-import com.sun.tools.javac.code.TypeMetadata.Entry.Kind;
+import com.sun.tools.javac.code.TypeMetadata.Annotations;
 import com.sun.tools.javac.comp.Check.CheckContext;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
@@ -1049,7 +1049,7 @@ public class Annotate {
         typeAnnotation(() -> {
             List<Attribute.TypeCompound> compounds = fromAnnotations(annotations);
             Assert.check(annotations.size() == compounds.size());
-            storeAt.getMetadataOfKind(Kind.ANNOTATIONS).combine(new TypeMetadata.Annotations(compounds));
+            storeAt.getMetadata(Annotations.class).setAnnotations(compounds);
         });
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -1049,7 +1049,10 @@ public class Annotate {
         typeAnnotation(() -> {
             List<Attribute.TypeCompound> compounds = fromAnnotations(annotations);
             Assert.check(annotations.size() == compounds.size());
-            storeAt.getMetadata(Annotations.class).setAnnotations(compounds);
+            // the type already has annotation metadata, but it's empty
+            Annotations metadata = storeAt.getMetadata(Annotations.class).orElseThrow(AssertionError::new);
+            Assert.check(metadata.getAnnotations() == Annotations.TO_BE_SET);
+            storeAt.getMetadata(Annotations.class).get().setAnnotations(compounds);
         });
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -1051,8 +1051,8 @@ public class Annotate {
             Assert.check(annotations.size() == compounds.size());
             // the type already has annotation metadata, but it's empty
             Annotations metadata = storeAt.getMetadata(Annotations.class).orElseThrow(AssertionError::new);
-            Assert.check(metadata.getAnnotations() == Annotations.TO_BE_SET);
-            storeAt.getMetadata(Annotations.class).get().setAnnotations(compounds);
+            Assert.check(metadata.annotationBuffer().isEmpty());
+            metadata.annotationBuffer().appendList(compounds);
         });
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -46,7 +46,6 @@ import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
-import com.sun.tools.javac.code.TypeMetadata.Annotations;
 import com.sun.tools.javac.code.Types.FunctionDescriptorLookupError;
 import com.sun.tools.javac.comp.ArgumentAttr.LocalCacheContext;
 import com.sun.tools.javac.comp.Check.CheckContext;
@@ -5210,7 +5209,7 @@ public class Attr extends JCTree.Visitor {
     public void visitAnnotatedType(JCAnnotatedType tree) {
         attribAnnotationTypes(tree.annotations, env);
         Type underlyingType = attribType(tree.underlyingType, env);
-        Type annotatedType = underlyingType.annotatedType(Annotations.TO_BE_SET);
+        Type annotatedType = underlyingType.preannotatedType();
 
         if (!env.info.isNewClass)
             annotate.annotateTypeSecondStage(tree, tree.annotations, annotatedType);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -221,15 +221,10 @@ public class DeferredAttr extends JCTree.Visitor {
         SpeculativeCache speculativeCache;
 
         DeferredType(JCExpression tree, Env<AttrContext> env) {
-            super(null, TypeMetadata.EMPTY);
+            super(null, List.nil());
             this.tree = tree;
             this.env = attr.copyEnv(env);
             this.speculativeCache = new SpeculativeCache();
-        }
-
-        @Override
-        public DeferredType cloneWithMetadata(TypeMetadata md) {
-            throw new AssertionError("Cannot add metadata to a deferred type");
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2925,18 +2925,13 @@ public class ClassReader {
         private final Name name;
 
         public ProxyType(int index) {
-            super(syms.noSymbol, TypeMetadata.EMPTY);
+            super(syms.noSymbol, List.nil());
             this.name = poolReader.getName(index);
         }
 
         @Override
         public TypeTag getTag() {
             return TypeTag.NONE;
-        }
-
-        @Override
-        public Type cloneWithMetadata(TypeMetadata metadata) {
-            throw new UnsupportedOperationException();
         }
 
         public Type resolve() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/UninitializedType.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/UninitializedType.java
@@ -59,7 +59,7 @@ class UninitializedType extends Type.DelegatedType {
     }
 
     @Override
-    public UninitializedType cloneWithMetadata(final List<TypeMetadata> md) {
+    protected UninitializedType cloneWithMetadata(final List<TypeMetadata> md) {
         return new UninitializedType(tag, qtype, offset, md);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/UninitializedType.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/UninitializedType.java
@@ -53,13 +53,13 @@ class UninitializedType extends Type.DelegatedType {
 
     public final int offset; // PC where allocation took place
     private UninitializedType(TypeTag tag, Type qtype, int offset,
-                              TypeMetadata metadata) {
+                              List<TypeMetadata> metadata) {
         super(tag, qtype, metadata);
         this.offset = offset;
     }
 
     @Override
-    public UninitializedType cloneWithMetadata(final TypeMetadata md) {
+    public UninitializedType cloneWithMetadata(final List<TypeMetadata> md) {
         return new UninitializedType(tag, qtype, offset, md);
     }
 


### PR DESCRIPTION
This patch simplifies the TypeMetadata API. TypeMetadata can be used as a side-channel, to attach extra information to a javac type (type annotations, constant values).

While TypeMetadata provides the right knobs to compare types (see `Type::equalsIgnoreMetadata`), which is used uniformly across the type-system related routines (e.g. subtyping, type equality and type containment), the TypeMetadata API is also rather cumbersome to use.

The only way to add a new metadata to a type is to "combine" the metadata into an existing one, which feels odd, and probably too biased by the type annotations requirements.

This patch simplifies this: now TypeMetadata is a simple marker interface. There can be many implementations - one is `Annotations` (used to store type annotations), another is `ConstantValue` (used to store a type's constant value).

A type is then associated with a `List<TypeMetadata>`, and there are methods to add/drop/get metadata. These methods are used to provide support for annotated and constant types.

The resulting code feels simpler: to add a new metadata, one only has to define a new class/record inside TypeMetadata, and that's pretty much it. Javac will truck the metadata around in the correct way (as it did before).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303820](https://bugs.openjdk.org/browse/JDK-8303820): Simplify type metadata


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12924/head:pull/12924` \
`$ git checkout pull/12924`

Update a local copy of the PR: \
`$ git checkout pull/12924` \
`$ git pull https://git.openjdk.org/jdk pull/12924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12924`

View PR using the GUI difftool: \
`$ git pr show -t 12924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12924.diff">https://git.openjdk.org/jdk/pull/12924.diff</a>

</details>
