### PR TITLE
8302073: Specifying OnError handler prevents WatcherThread to break a deadlock in report_and_die()

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1690,6 +1690,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
       {
         ForkAndExecCheckPoint chechpoint;
         fork_and_exec_res = os::fork_and_exec(cmd);
+        if ( check_timeout() ) break;
       }
       if (fork_and_exec_res < 0) {
         out.print_cr("os::fork_and_exec failed: %s (%s=%d)",

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1688,14 +1688,16 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
 
       int fork_and_exec_res = 0;
       {
+        // suspend timeout detection and run the command
         ForkAndExecCheckPoint chechpoint;
         fork_and_exec_res = os::fork_and_exec(cmd);
-        if ( check_timeout() ) break;
       }
       if (fork_and_exec_res < 0) {
         out.print_cr("os::fork_and_exec failed: %s (%s=%d)",
                      os::strerror(errno), os::errno_name(errno), errno);
       }
+      // check if timeout took place during fork_and_exec()
+      if (check_timeout()) break;
     }
 
     // done with OnError


### PR DESCRIPTION
The patch fixes error reporting to check timeout in the case when a user specifies OnError hander. Before VMError:check_timeout() ignored timeout in this case, and so didn't break malloc() deadlock.

Verification (amd64/20.04LTS): the idea of the test is to crash JVM running with error hander of 3 successive `sleep` commands for 1s, 10s, and 60s with and without specified timeout

```
16:52:17@alex@alex-VirtualBox>( echo "
public class C {
  public static void main(String[] args) throws Throwable {
>     while (true) Thread.sleep(1000);
>   }
> }
> " >> C.java )
16:57:35@alex@alex-VirtualBox>./build/linux-x86_64-server-release/images/jdk/bin/java -XX:OnError='sleep 1;sleep 10;sleep 60' ./C.java &
[2] 179574
17:00:19@alex@alex-VirtualBox>kill -s SIGSEGV 179574
17:00:27@alex@alex-VirtualBox>#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f7b1701ecd5 (sent by kill), pid=179574, tid=179574
#
# JRE version: OpenJDK Runtime Environment (21.0) (build 21-internal-adhoc.alex.jdk)
# Java VM: OpenJDK 64-Bit Server VM (21-internal-adhoc.alex.jdk, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [libpthread.so.0+0x9cd5]  __pthread_clockjoin_ex+0x255
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport %p %s %c %d %P %E" (or dumping to /home/alex/jdk/core.179574)
#
# An error report file with more information is saved as:
# /home/alex/jdk/hs_err_pid179574.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#
#
# -XX:OnError="sleep 1;sleep 10;sleep 60"
#   Executing /bin/sh -c "sleep 1" ...
#   Executing /bin/sh -c "sleep 10" ...
#   Executing /bin/sh -c "sleep 60" ...

[2]+  Aborted                 (core dumped) ./build/linux-x86_64-server-release/images/jdk/bin/java -XX:OnError='sleep 1;sleep 10;sleep 60' ./C.java
17:02:03@alex@alex-VirtualBox>./build/linux-x86_64-server-release/images/jdk/bin/java -XX:ErrorLogTimeout=5 -XX:OnError='sleep 1;sleep 10;sleep 60' ./C.java &
[2] 179602
17:02:32@alex@alex-VirtualBox>kill -s SIGSEGV 179602
17:02:41@alex@alex-VirtualBox>#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f9d71b18cd5 (sent by kill), pid=179602, tid=179602
#
# JRE version: OpenJDK Runtime Environment (21.0) (build 21-internal-adhoc.alex.jdk)
# Java VM: OpenJDK 64-Bit Server VM (21-internal-adhoc.alex.jdk, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [libpthread.so.0+0x9cd5]  __pthread_clockjoin_ex+0x255
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport %p %s %c %d %P %E" (or dumping to /home/alex/jdk/core.179602)
#
# An error report file with more information is saved as:
# /home/alex/jdk/hs_err_pid179602.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#
#
# -XX:OnError="sleep 1;sleep 10;sleep 60"
#   Executing /bin/sh -c "sleep 1" ...
#   Executing /bin/sh -c "sleep 10" ...

------ Timeout during error reporting after 11 s. ------

17:02:54@alex@alex-VirtualBox>
```

Regression (amd64/20.04LTS): `test/hotspot/jtreg/runtime/ErrorHandling` with different combinations of `-vmoption:-XX:ErrorLogTimeout=10` and `-vmoption:-XX:OnError='sleep 10'`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302073](https://bugs.openjdk.org/browse/JDK-8302073): Specifying OnError handler prevents WatcherThread to break a deadlock in report_and_die() ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12925/head:pull/12925` \
`$ git checkout pull/12925`

Update a local copy of the PR: \
`$ git checkout pull/12925` \
`$ git pull https://git.openjdk.org/jdk.git pull/12925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12925`

View PR using the GUI difftool: \
`$ git pr show -t 12925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12925.diff">https://git.openjdk.org/jdk/pull/12925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12925#issuecomment-1460219300)