### PR TITLE
8303644: Add method for counting leading positive bytes in byte arrays

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestCountPositives.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestCountPositives.java
@@ -23,9 +23,11 @@
 
 package compiler.intrinsics.string;
 
+import java.util.Arrays;
+
 /*
  * @test
- * @bug 8999999
+ * @bug 8281146 8303644
  * @summary Validates StringCoding.countPositives intrinsic with a small range of tests.
  * @library /compiler/patches
  *
@@ -98,6 +100,16 @@ public class TestCountPositives {
                             continue;
                         }
                         throw new Exception("Failed test countPositives " + "offset: " + off + " "
+                                + "length: " + len + " " + "return: " + calculated + " expected: " + expected + " negatives: "
+                                + ng);
+                    }
+
+                    // verify also the public API Arrays.countPositives, which
+                    // is using the intrinsic but additionally adjusts the result
+                    // to always be precise
+                    calculated = Arrays.numberOfLeadingPositives(tBa, off, len);
+                    if (calculated != expected) {
+                        throw new Exception("Failed test Arrays.countPositives " + "offset: " + off + " "
                                 + "length: " + len + " " + "return: " + calculated + " expected: " + expected + " negatives: "
                                 + ng);
                     }

--- a/test/micro/org/openjdk/bench/java/util/ArraysLeadingPositives.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysLeadingPositives.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class ArraysLeadingPositives {
+
+    @Param({"1", "15", "64", "8195"})
+    public int size;
+
+    public byte[] positiveByteArray;
+    public byte[] mixedByteArray;
+    @Setup
+    public void setup() {
+        positiveByteArray = new byte[size];
+        Arrays.fill(positiveByteArray, (byte)64);
+        mixedByteArray = positiveByteArray.clone();
+        mixedByteArray[size - 1] = (byte)-17;
+    }
+
+    @Benchmark
+    public int positiveBytes() {
+        return Arrays.numberOfLeadingPositives(positiveByteArray, 0, positiveByteArray.length);
+    }
+
+    @Benchmark
+    public int mixedBytes() {
+        return Arrays.numberOfLeadingPositives(mixedByteArray, 0, mixedByteArray.length);
+    }
+
+    private static int numberOfLeadingPositives(byte[] ba, int off, int len) {
+        int limit = off + len;
+        for (int i = off; i < limit; i++) {
+            if (ba[i] < 0) {
+                return i - off;
+            }
+        }
+        return len;
+    }
+
+    @Benchmark
+    public int positiveBytesBaseline() {
+        return numberOfLeadingPositives(positiveByteArray, 0, positiveByteArray.length);
+    }
+
+    @Benchmark
+    public int mixedBytesBaseline() {
+        return numberOfLeadingPositives(mixedByteArray, 0, mixedByteArray.length);
+    }
+
+}


### PR DESCRIPTION
Internally we've implemented the package private method `java.lang.StringCoding.countPositives` for efficiently counting positive bytes in a byte array, using simd instructions when applicable. This has been developed and deployed to support the needs of built-in charset encoders/decoders, where counting positive bytes is a quick ASCII test. This PR suggest exposing such a utility method publicly - not the least to support similar checks in non-builtin decoders and encoders.

An alternative would be to provide a Vector API-based example and add nothing to the public API, but this is a simple convenience method to add to the public API and would bridge the performance gap between `String` methods, built-in encoders/decoders and third-party encoders/decoders. For the JDK itself having a public API removes the need to export the internal `StringCoding.countPositives` outside of the `java.base` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8303821](https://bugs.openjdk.org/browse/JDK-8303821) to be approved

### Issues
 * [JDK-8303644](https://bugs.openjdk.org/browse/JDK-8303644): Add method for counting leading positive bytes in byte arrays (**Enhancement** - P3)
 * [JDK-8303821](https://bugs.openjdk.org/browse/JDK-8303821): Add method for counting leading positive bytes in byte arrays (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12926/head:pull/12926` \
`$ git checkout pull/12926`

Update a local copy of the PR: \
`$ git checkout pull/12926` \
`$ git pull https://git.openjdk.org/jdk.git pull/12926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12926`

View PR using the GUI difftool: \
`$ git pr show -t 12926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12926.diff">https://git.openjdk.org/jdk/pull/12926.diff</a>

</details>
