### PR TITLE
8303001: Add test for re-entrant upcalls

### DIFF
--- a/test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java
+++ b/test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * @library /test/lib
+ * @library ../
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   --enable-native-access=ALL-UNNAMED
+ *   TestReentrantUpcalls
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import jdk.test.whitebox.WhiteBox;
+
+import static java.lang.invoke.MethodHandles.lookup;
+
+public class TestReentrantUpcalls extends NativeTestHelper {
+    static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    static final MethodHandle MH_m;
+
+    static {
+        System.loadLibrary("ReentrantUpcalls");
+        try {
+            MH_m = lookup().findStatic(TestReentrantUpcalls.class, "m",
+                    MethodType.methodType(void.class, int.class, MemorySegment.class, MethodHandle.class));
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        FunctionDescriptor descriptor = FunctionDescriptor.ofVoid(C_INT, C_POINTER);
+        MethodHandle downcallHandle = downcallHandle("do_recurse", descriptor);
+
+        try (Arena arena = Arena.openConfined()) {
+            MemorySegment stub = LINKER.upcallStub(
+                    MethodHandles.insertArguments(MH_m, 2, downcallHandle), descriptor, arena.scope());
+
+            downcallHandle.invokeExact(0, stub);
+        }
+    }
+
+    static void m(int depth, MemorySegment thisStub, MethodHandle downcallHandle) throws Throwable {
+        if (depth < 100) {
+            downcallHandle.invokeExact(depth + 1, thisStub);
+        } else {
+            WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/true);
+            WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/false); // triggers different code paths
+        }
+    }
+
+}

--- a/test/jdk/java/foreign/stackwalk/libReentrantUpcalls.c
+++ b/test/jdk/java/foreign/stackwalk/libReentrantUpcalls.c
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT void do_recurse(int depth, void (*cb)(int, void*)) {
+    cb(depth, cb);
+}


### PR DESCRIPTION
Add a test that tests re-entrant upcalls, which is a use-case that is uncovered by testing until now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303001](https://bugs.openjdk.org/browse/JDK-8303001): Add test for re-entrant upcalls


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12927/head:pull/12927` \
`$ git checkout pull/12927`

Update a local copy of the PR: \
`$ git checkout pull/12927` \
`$ git pull https://git.openjdk.org/jdk pull/12927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12927`

View PR using the GUI difftool: \
`$ git pr show -t 12927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12927.diff">https://git.openjdk.org/jdk/pull/12927.diff</a>

</details>
