### PR TITLE
8303824: Parallel: Use more strict card table API

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -103,6 +103,11 @@ class PSOldGen : public CHeapObj<mtGC> {
                      (HeapWord*)(_virtual_space->high_boundary()));
   }
 
+  MemRegion committed() const {
+    return MemRegion((HeapWord*)(_virtual_space->low()),
+                     (HeapWord*)(_virtual_space->high()));
+  }
+
   size_t max_gen_size() const { return _max_gen_size; }
   size_t min_gen_size() const { return _min_gen_size; }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1017,11 +1017,11 @@ void PSParallelCompact::post_compact()
     to_space->is_empty();
 
   PSCardTable* ct = heap->card_table();
-  MemRegion old_mr = heap->old_gen()->reserved();
+  MemRegion old_mr = heap->old_gen()->committed();
   if (young_gen_empty) {
-    ct->clear(old_mr);
+    ct->clear_MemRegion(old_mr);
   } else {
-    ct->invalidate(old_mr);
+    ct->dirty_MemRegion(old_mr);
   }
 
   // Delete metaspaces for unloaded class loaders and clean up loader_data graph


### PR DESCRIPTION
Simple refactoring to update only cards of committed heap.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303824](https://bugs.openjdk.org/browse/JDK-8303824): Parallel: Use more strict card table API


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12928/head:pull/12928` \
`$ git checkout pull/12928`

Update a local copy of the PR: \
`$ git checkout pull/12928` \
`$ git pull https://git.openjdk.org/jdk pull/12928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12928`

View PR using the GUI difftool: \
`$ git pr show -t 12928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12928.diff">https://git.openjdk.org/jdk/pull/12928.diff</a>

</details>
