### PR TITLE
8303832: Use enhanced-for cycle instead of Enumeration in JceKeyStore

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -475,9 +475,7 @@ public final class JceKeyStore extends KeyStoreSpi {
     public String engineGetCertificateAlias(Certificate cert) {
         Certificate certElem;
 
-        Enumeration<String> e = entries.keys();
-        while (e.hasMoreElements()) {
-            String alias = e.nextElement();
+        for (String alias : entries.keySet()) {
             Object entry = entries.get(alias);
             if (entry instanceof TrustedCertEntry) {
                 certElem = ((TrustedCertEntry)entry).cert;
@@ -573,10 +571,7 @@ public final class JceKeyStore extends KeyStoreSpi {
 
                 dos.writeInt(entries.size());
 
-                Enumeration<String> e = entries.keys();
-                while (e.hasMoreElements()) {
-
-                    String alias = e.nextElement();
+                for (String alias : entries.keySet()) {
                     Object entry = entries.get(alias);
 
                     if (entry instanceof PrivateKeyEntry) {


### PR DESCRIPTION
java.util.Enumeration is a legacy interface from java 1.0.
There is couple of places with cycles which use it to iterate over collections. We can replace this manual cycle with enchanced-for, which is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303832](https://bugs.openjdk.org/browse/JDK-8303832): Use enhanced-for cycle instead of Enumeration in JceKeyStore


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12930/head:pull/12930` \
`$ git checkout pull/12930`

Update a local copy of the PR: \
`$ git checkout pull/12930` \
`$ git pull https://git.openjdk.org/jdk pull/12930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12930`

View PR using the GUI difftool: \
`$ git pr show -t 12930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12930.diff">https://git.openjdk.org/jdk/pull/12930.diff</a>

</details>
