### PR TITLE
8303833: java.util.LocaleISOData has wrong comments for 'Norwegian Bokmål' and 'Volapük'

### DIFF
--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -145,7 +145,7 @@ class LocaleISOData {
         + "mt" + "mlt"  // Maltese
         + "my" + "mya"  // Burmese
         + "na" + "nau"  // Nauru
-        + "nb" + "nob"  // Norwegian Bokm?l
+        + "nb" + "nob"  // Norwegian Bokm\u00e5l
         + "nd" + "nde"  // North Ndebele
         + "ne" + "nep"  // Nepali
         + "ng" + "ndo"  // Ndonga
@@ -209,7 +209,7 @@ class LocaleISOData {
         + "uz" + "uzb"  // Uzbek
         + "ve" + "ven"  // Venda
         + "vi" + "vie"  // Vietnamese
-        + "vo" + "vol"  // Volap?k
+        + "vo" + "vol"  // Volap\u00fck
         + "wa" + "wln"  // Walloon
         + "wo" + "wol"  // Wolof
         + "xh" + "xho"  // Xhosa


### PR DESCRIPTION
Please review this comment-only PR which fixes incorrect language names  'Norwegian Bokmål' and 'Volapük' in the comments in LocaleISOData:

`+ "nb" + "nob"  // Norwegian Bokm?l`
`+ "vo" + "vol"  // Volap?k`

These encoding issues seem to have been around since Duke imported the file in 2007. Let's fix them now.

For context: 'Norwegian bokmål'  is the most common written form of the Norwegian language:

https://en.wikipedia.org/wiki/Bokm%C3%A5l

'Volapük' is a constructed language: 

https://en.wikipedia.org/wiki/Volap%C3%BCk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303833](https://bugs.openjdk.org/browse/JDK-8303833): java.util.LocaleISOData has wrong comments for 'Norwegian Bokmål' and 'Volapük'


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * @srl295 (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12932/head:pull/12932` \
`$ git checkout pull/12932`

Update a local copy of the PR: \
`$ git checkout pull/12932` \
`$ git pull https://git.openjdk.org/jdk pull/12932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12932`

View PR using the GUI difftool: \
`$ git pr show -t 12932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12932.diff">https://git.openjdk.org/jdk/pull/12932.diff</a>

</details>
