### PR TITLE
8299088: ClassLoader::defineClass2 throws OOME but JNI exception pending thrown by getUTF

### DIFF
--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -185,7 +185,6 @@ Java_java_lang_ClassLoader_defineClass2(JNIEnv *env,
     if (name != NULL) {
         utfName = getUTF(env, name, buf, sizeof(buf));
         if (utfName == NULL) {
-            JNU_ThrowOutOfMemoryError(env, NULL);
             return result;
         }
         fixClassname(utfName);
@@ -196,7 +195,6 @@ Java_java_lang_ClassLoader_defineClass2(JNIEnv *env,
     if (source != NULL) {
         utfSource = getUTF(env, source, sourceBuf, sizeof(sourceBuf));
         if (utfSource == NULL) {
-            JNU_ThrowOutOfMemoryError(env, NULL);
             goto free_utfName;
         }
     } else {
@@ -301,7 +299,6 @@ Java_java_lang_ClassLoader_findBootstrapClass(JNIEnv *env, jclass dummy,
 
     clname = getUTF(env, classname, buf, sizeof(buf));
     if (clname == NULL) {
-        JNU_ThrowOutOfMemoryError(env, NULL);
         return NULL;
     }
     fixClassname(clname);


### PR DESCRIPTION
This PR removes the JNI Exception pending defect groups in ClassLoader.c. 

`getUTF()` throws an exception and subsequently returns `null`; the exception should either be cleared, or control returned to the JVM. `JNU_ThrowOutOfMemoryError(env, NULL);` should not be called again

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299088](https://bugs.openjdk.org/browse/JDK-8299088): ClassLoader::defineClass2 throws OOME but JNI exception pending thrown by getUTF


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12934/head:pull/12934` \
`$ git checkout pull/12934`

Update a local copy of the PR: \
`$ git checkout pull/12934` \
`$ git pull https://git.openjdk.org/jdk pull/12934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12934`

View PR using the GUI difftool: \
`$ git pr show -t 12934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12934.diff">https://git.openjdk.org/jdk/pull/12934.diff</a>

</details>
