### PR TITLE
8303609

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -39,6 +39,8 @@ serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-
 serviceability/sa/ClhsdbPstack.java#process                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#core                      8248912   generic-all
 
+serviceability/sa/TestSysProps.java                           8302055   generic-all
+
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all


### PR DESCRIPTION
Although it takes both ZGC and -Xcomp to cause the test to fail, we have no way to problem list for just that combination, so I'm choosing the problem list with just ZGC since it is the main cause of the failure. I've only seen this issue on windows-x64, but there are clearly failures on linux and macos in mach5, so I'm problem listing for all platforms. 