### PR TITLE
8303105: LoopRangeStrideTest fails IR verification on x86

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
@@ -37,6 +37,7 @@
  *                   compiler.vectorization.runner.LoopRangeStrideTest
  *
  * @requires vm.compiler2.enabled & vm.flagless
+ * @requires (os.arch=="amd64" | os.arch=="x86_64" | os.simpleArch == "aarch64")
  */
 
 package compiler.vectorization.runner;


### PR DESCRIPTION
SLP fails to recognize valid address expression during SWPointer creation for memory operands with 32 bit jvm, this prevents gathering adjacent memory operations. 
Debug trace with -XX:+TraceSuperWord -XX:+TraceNewVectors -XX:CompileCommand=VectorizeDebug,<method>,3  shows following errors .

SWPointer::memory_alignment: SWPointer p invalid, return bottom_align
SWPointer::memory_alignment: SWPointer p invalid, return bottom_align
SWPointer::memory_alignment: SWPointer p invalid, return bottom_align
SWPointer::memory_alignment: SWPointer p invalid, return bottom_align
SWPointer::memory_alignment: SWPointer p invalid, return bottom_align

Problem also exist in JDK17 LTS. As an interim solution to prevent this showing up as a GHA test failure, we can enable the test only for x86_64 and aarch64 targets. Difference in address expression b/w X86 32 and 64 bit jvm will be root caused in follow issue JDK-8303885.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303105](https://bugs.openjdk.org/browse/JDK-8303105): LoopRangeStrideTest fails IR verification on x86


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12938/head:pull/12938` \
`$ git checkout pull/12938`

Update a local copy of the PR: \
`$ git checkout pull/12938` \
`$ git pull https://git.openjdk.org/jdk pull/12938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12938`

View PR using the GUI difftool: \
`$ git pr show -t 12938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12938.diff">https://git.openjdk.org/jdk/pull/12938.diff</a>

</details>
