### PR TITLE
8299047: On Ubuntu 22.04 text cursor in TextArea stops blinking after couple of cycles

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -762,6 +762,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
         if (dropCaret != null) {
             dropCaret.paint(g);
         }
+        Toolkit.getDefaultToolkit().sync();
     }
 
     // --- ComponentUI methods --------------------------------------------

--- a/test/jdk/javax/swing/JTextField/CaretBlinkTest.java
+++ b/test/jdk/javax/swing/JTextField/CaretBlinkTest.java
@@ -74,9 +74,9 @@ public class CaretBlinkTest {
         //Initialize the components
         final String INSTRUCTIONS = """
                 Instructions to Test:
-                1. The test is intended to verify the TextField's graphics state is 
-                synchronized and TextField is updated without delay.
-                2. The test verifies it by Caret Blink happens at 250ms 
+                1. The test is intended to verify the TextField's graphics state
+                is synchronized and TextField is updated without delay.
+                2. The test verifies it by Caret Blink happens at 250ms
                 rate for Linux (Xrender).
                 2. If the Caret Blinks smoothly without stopping the test PASS,
                  if caret blink stops then test FAILS.

--- a/test/jdk/javax/swing/JTextField/CaretBlinkTest.java
+++ b/test/jdk/javax/swing/JTextField/CaretBlinkTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Robot;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @bug 8299047
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test to check if the JTextField graphics performance is Good
+ * for ~250ms especially in Linux using Xrender.
+ * @run main/manual CaretBlinkTest
+ */
+
+public class CaretBlinkTest {
+    static JFrame frame;
+    static JTextField textField;
+    static JButton button;
+    static Robot robot;
+    static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                try {
+                    initialize();
+                } catch (Exception e){
+                    throw  new RuntimeException(e)
+                }
+            }
+        });
+        requestFocus(textField);
+        requestFocus(button);
+        changeEditable();
+        requestFocus(textField);
+        robot.waitForIdle();
+        passFailJFrame.awaitAndCheck();
+    }
+
+    static void initialize() throws InterruptedException, InvocationTargetException {
+        //Initialize the components
+        final String INSTRUCTIONS = """
+                Instructions to Test:
+                1. The test is intended to verify the TextField's graphics state is 
+                synchronized and TextField is updated without delay.
+                2. The test verifies it by Caret Blink happens at 250ms 
+                rate for Linux (Xrender).
+                2. If the Caret Blinks smoothly without stopping the test PASS,
+                 if caret blink stops then test FAILS.
+                """;
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 8, 40);
+        frame = new JFrame("Caret Blink Test");
+        textField = new JTextField("Caret Blink Test");
+        button = new JButton("Button");
+
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(50);
+        frame.setLocationRelativeTo(null);
+        textField.setEditable(false);
+        textField.getCaret().setBlinkRate(250);
+        frame.setLayout(new BorderLayout());
+        frame.add(textField, BorderLayout.NORTH);
+        frame.add(button, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+
+        button.requestFocus();
+    }
+
+    static void requestFocus(Component component) throws InterruptedException,
+            InvocationTargetException {
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            component.requestFocus();
+        });
+    }
+
+    static void changeEditable() throws InterruptedException, InvocationTargetException {
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(()-> {
+            textField.setEditable(!textField.isEditable());
+        });
+    }
+
+}


### PR DESCRIPTION
The issue happens only in xrender and not only specific to cursor blink. On analysis the issue found to common to JTextField and not only to cursor blink. The issue seems to be w.r.t Synchronization of toolkit's graphics state, where buffering of graphics events occurred a delayed painting (As explained in bug [JDK-8068529](https://bugs.openjdk.org/browse/JDK-8068529). This occured only when `xrender` graphics rendering is used (linux). Toolkit synchronization at `BasicTextUI` `paintsafely()` helped solve the issue (As suggested in the referred bug) without causing any regressions.
CI testing results were fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299047](https://bugs.openjdk.org/browse/JDK-8299047): On Ubuntu 22.04 text cursor in TextArea stops blinking after couple of cycles


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12939/head:pull/12939` \
`$ git checkout pull/12939`

Update a local copy of the PR: \
`$ git checkout pull/12939` \
`$ git pull https://git.openjdk.org/jdk pull/12939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12939`

View PR using the GUI difftool: \
`$ git pr show -t 12939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12939.diff">https://git.openjdk.org/jdk/pull/12939.diff</a>

</details>
