### PR TITLE
JDK-8303822: gtestMain should give more helpful output

### DIFF
--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -245,7 +245,7 @@ static void runUnitTestsInner(int argc, char** argv) {
 
   char* java_home = get_java_home_arg(argc, argv);
   if (java_home == NULL) {
-    fprintf(stderr, "ERROR: You must specify a JDK to use for running the unit tests.\n");
+    fprintf(stderr, "ERROR: You must specify a JDK (-jdk <image>, --jdk=<image> or -jdk:<image>) to use for running the unit tests.\n");
     os::exit(1);
   }
 #ifndef _WIN32


### PR DESCRIPTION
When the JDK to test is not provided, gtestMain currently prints something like this :
./hotspot/variant-server/libjvm/gtest/gtestLauncher
ERROR: You must specify a JDK to use for running the unit tests.

The output could be improved, might be helpful for occasional users, e.g.
`ERROR: You must specify a JDK (-jdk <image>, --jdk=<image> or -jdk:<image>) to use for running the unit tests.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303822](https://bugs.openjdk.org/browse/JDK-8303822): gtestMain should give more helpful output


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12940/head:pull/12940` \
`$ git checkout pull/12940`

Update a local copy of the PR: \
`$ git checkout pull/12940` \
`$ git pull https://git.openjdk.org/jdk pull/12940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12940`

View PR using the GUI difftool: \
`$ git pr show -t 12940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12940.diff">https://git.openjdk.org/jdk/pull/12940.diff</a>

</details>
