### PR TITLE
8299375: [PPC64] GetStackTraceSuspendedStressTest tries to deoptimize frame with invalid fp

### DIFF
--- a/src/hotspot/cpu/ppc/continuationFreezeThaw_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuationFreezeThaw_ppc.inline.hpp
@@ -557,6 +557,8 @@ inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bot
 
 inline void ThawBase::patch_pd(frame& f, const frame& caller) {
   patch_callee_link(caller, caller.fp());
+  // Prevent assertion if f gets deoptimized right away before it's fully initialized
+  f.mark_not_fully_initialized();
 }
 
 //

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -352,6 +352,13 @@
 
  private:
 
+#ifdef ASSERT
+  enum special_backlink_values : uint64_t {
+    NOT_FULLY_INITIALIZED = 0xBBAADDF9
+  };
+  bool is_fully_initialized()       const { return (uint64_t)_fp != NOT_FULLY_INITIALIZED; }
+#endif // ASSERT
+
   //  STACK:
   //            ...
   //            [THIS_FRAME]             <-- this._sp (stack pointer for this frame)
@@ -378,6 +385,9 @@
   void set_fp(intptr_t* newfp)  { _fp = newfp; }
   int offset_fp() const         { assert_offset();  return _offset_fp; }
   void set_offset_fp(int value) { assert_on_heap(); _offset_fp = value; }
+
+  // Mark a frame as not fully initialized
+  void mark_not_fully_initialized() const { DEBUG_ONLY(own_abi()->callers_sp = NOT_FULLY_INITIALIZED;)  }
 
   // Accessors for ABIs
   inline abi_minframe* own_abi()     const { return (abi_minframe*) _sp; }

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -386,7 +386,7 @@
   int offset_fp() const         { assert_offset();  return _offset_fp; }
   void set_offset_fp(int value) { assert_on_heap(); _offset_fp = value; }
 
-  // Mark a frame as not fully initialized
+  // Mark a frame as not fully initialized. Must not be used for frames in the valid back chain.
   void mark_not_fully_initialized() const { DEBUG_ONLY(own_abi()->callers_sp = NOT_FULLY_INITIALIZED;)  }
 
   // Accessors for ABIs

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -77,7 +77,9 @@ inline void frame::setup() {
 
   // Continuation frames on the java heap are not aligned.
   // When thawing interpreted frames the sp can be unaligned (see new_stack_frame()).
-  assert(_on_heap || (is_aligned(_sp, alignment_in_bytes) || is_interpreted_frame()) && is_aligned(_fp, alignment_in_bytes),
+  assert(_on_heap ||
+         (is_aligned(_sp, alignment_in_bytes) || is_interpreted_frame()) &&
+         (is_aligned(_fp, alignment_in_bytes) || !is_fully_initialized()),
          "invalid alignment sp:" PTR_FORMAT " unextended_sp:" PTR_FORMAT " fp:" PTR_FORMAT, p2i(_sp), p2i(_unextended_sp), p2i(_fp));
 }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Mark a frame as not fully initialized when copying it from a continuation StackChunk to the stack until the callers_sp (aka back link) is set.

This avoids the assertion given in the bug report when the copied frame is deoptimized before it is fully initialized.
IMHO the deoptimization at that point is a little questionable but it actually only changes the pc of the frame which can be done.
Note that the frame can get extended later (and metadata can get overridden) but [there is code that handles this](https://github.com/openjdk/jdk/blob/34a92466a615415b76c8cb6010ff7e6e1a1d63b4/src/hotspot/share/runtime/continuationFreezeThaw.cpp#L2108-L2110).

Testing: jdk_loom. The fix passed our CI testing. This includes most JCK and JTREG tiers 1-4, also in Xcomp mode, on the standard platforms and also on ppc64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299375](https://bugs.openjdk.org/browse/JDK-8299375): [PPC64] GetStackTraceSuspendedStressTest tries to deoptimize frame with invalid fp


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12941/head:pull/12941` \
`$ git checkout pull/12941`

Update a local copy of the PR: \
`$ git checkout pull/12941` \
`$ git pull https://git.openjdk.org/jdk pull/12941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12941`

View PR using the GUI difftool: \
`$ git pr show -t 12941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12941.diff">https://git.openjdk.org/jdk/pull/12941.diff</a>

</details>
