### PR TITLE
8303883: Confusing parameter name in G1UpdateRemSetTrackingBeforeRebuild::distribute_marked_bytes

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1156,7 +1156,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
       // region. We need to distribute this value across the entire set of regions a
       // humongous object spans.
       if (hr->is_humongous()) {
-        assert(hr->is_starts_humongous() || !_cm->contains_live_object(region_idx),
+        assert(hr->is_starts_humongous() || marked_bytes == 0,
                "Should not have live bytes %zu in continues humongous region %u (%s)",
                marked_bytes, region_idx, hr->get_type_str());
         if (hr->is_starts_humongous()) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -606,7 +606,7 @@ private:
       if (is_clear_concurrent_undo()) {
         // No need to clear bitmaps for empty regions (which includes regions we
         // did not mark through).
-        if (_cm->live_words(r->hrm_index()) == 0) {
+        if (!_cm->contains_live_object(r->hrm_index())) {
           assert(_bitmap->get_next_marked_addr(r->bottom(), r->end()) == r->end(), "Should not have marked bits");
           return r->bottom();
         }
@@ -1109,7 +1109,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
 
       bool selected_for_rebuild;
       if (hr->is_humongous()) {
-        bool const is_live = _cm->live_words(hr->humongous_start_region()->hrm_index()) > 0;
+        bool const is_live = _cm->contains_live_object(hr->humongous_start_region()->hrm_index());
         selected_for_rebuild = tracking_policy->update_humongous_before_rebuild(hr, is_live);
       } else {
         size_t const live_bytes = _cm->live_bytes(hr->hrm_index());
@@ -1121,49 +1121,50 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
       _cm->update_top_at_rebuild_start(hr);
     }
 
-    // Distribute the given words across the humongous object starting with hr and
-    // note end of marking.
-    void distribute_marked_bytes(HeapRegion* hr, size_t marked_words) {
+    // Distribute the given marked bytes across the humongous object starting
+    // with hr and note end of marking for these regions.
+    void distribute_marked_bytes(HeapRegion* hr, size_t marked_bytes) {
       uint const region_idx = hr->hrm_index();
+
       size_t const obj_size_in_words = cast_to_oop(hr->bottom())->size();
       uint const num_regions_in_humongous = (uint)G1CollectedHeap::humongous_obj_size_in_regions(obj_size_in_words);
 
       // "Distributing" zero words means that we only note end of marking for these
       // regions.
-      assert(marked_words == 0 || obj_size_in_words == marked_words,
-             "Marked words should either be 0 or the same as humongous object (" SIZE_FORMAT ") but is " SIZE_FORMAT,
-             obj_size_in_words, marked_words);
+      assert(marked_bytes == 0 || obj_size_in_words * HeapWordSize == marked_bytes,
+             "Marked bytes should either be 0 or the same as humongous object (%zu) but is %zu",
+             obj_size_in_words * HeapWordSize, marked_bytes);
 
       for (uint i = region_idx; i < (region_idx + num_regions_in_humongous); i++) {
         HeapRegion* const r = _g1h->region_at(i);
-        size_t const words_to_add = MIN2(HeapRegion::GrainWords, marked_words);
+        size_t const bytes_to_add = MIN2(HeapRegion::GrainBytes, marked_bytes);
 
-        log_trace(gc, marking)("Adding " SIZE_FORMAT " words to humongous region %u (%s)",
-                               words_to_add, i, r->get_type_str());
-        add_marked_bytes_and_note_end(r, words_to_add * HeapWordSize);
-        marked_words -= words_to_add;
+        log_trace(gc, marking)("Adding %zu bytes to humongous region %u (%s)",
+                               bytes_to_add, i, r->get_type_str());
+        add_marked_bytes_and_note_end(r, bytes_to_add);
+        marked_bytes -= bytes_to_add;
       }
-      assert(marked_words == 0,
-             SIZE_FORMAT " words left after distributing space across %u regions",
-             marked_words, num_regions_in_humongous);
+      assert(marked_bytes == 0,
+             "%zu bytes left after distributing space across %u regions",
+             marked_bytes, num_regions_in_humongous);
     }
 
     void update_marked_bytes(HeapRegion* hr) {
       uint const region_idx = hr->hrm_index();
-      size_t const marked_words = _cm->live_words(region_idx);
+      size_t const marked_bytes = _cm->live_bytes(region_idx);
       // The marking attributes the object's size completely to the humongous starts
       // region. We need to distribute this value across the entire set of regions a
       // humongous object spans.
       if (hr->is_humongous()) {
-        assert(hr->is_starts_humongous() || marked_words == 0,
-               "Should not have marked words " SIZE_FORMAT " in non-starts humongous region %u (%s)",
-               marked_words, region_idx, hr->get_type_str());
+        assert(hr->is_starts_humongous() || !_cm->contains_live_object(region_idx),
+               "Should not have live bytes %zu in continues humongous region %u (%s)",
+               marked_bytes, region_idx, hr->get_type_str());
         if (hr->is_starts_humongous()) {
-          distribute_marked_bytes(hr, marked_words);
+          distribute_marked_bytes(hr, marked_bytes);
         }
       } else {
-        log_trace(gc, marking)("Adding " SIZE_FORMAT " words to region %u (%s)", marked_words, region_idx, hr->get_type_str());
-        add_marked_bytes_and_note_end(hr, _cm->live_bytes(region_idx));
+        log_trace(gc, marking)("Adding %zu bytes to region %u (%s)", marked_bytes, region_idx, hr->get_type_str());
+        add_marked_bytes_and_note_end(hr, marked_bytes);
       }
     }
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -468,11 +468,11 @@ public:
   // To be called when an object is marked the first time, e.g. after a successful
   // mark_in_bitmap call. Updates various statistics data.
   void add_to_liveness(uint worker_id, oop const obj, size_t size);
-  // Live words in the given region as determined by concurrent marking, i.e. the amount of
-  // live words between bottom and TAMS.
-  size_t live_words(uint region) const { return _region_mark_stats[region]._live_words; }
-  // Returns the liveness value in bytes.
-  size_t live_bytes(uint region) const { return live_words(region) * HeapWordSize; }
+  // Did the last marking find a live object between bottom and TAMS?
+  bool contains_live_object(uint region) const { return _region_mark_stats[region]._live_words != 0; }
+  // Live bytes in the given region as determined by concurrent marking, i.e. the amount of
+  // live bytes between bottom and TAMS.
+  size_t live_bytes(uint region) const { return _region_mark_stats[region]._live_words * HeapWordSize; }
 
   // Sets the internal top_at_region_start for the given region to current top of the region.
   inline void update_top_at_rebuild_start(HeapRegion* r);


### PR DESCRIPTION
Hi all,

  please review this change to de-confuse (imo) a parameter in `G1UpdateRemSetTrackingBeforeRebuild::distribute_marked_bytes`.

I also replaced some `SIZE_FORMAT` in the vicinity.

Testing: local jtreg gc test, GHA

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303883](https://bugs.openjdk.org/browse/JDK-8303883): Confusing parameter name in G1UpdateRemSetTrackingBeforeRebuild::distribute_marked_bytes


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [e496ad94](https://git.openjdk.org/jdk/pull/12947/files/e496ad9414fe4b154e38de239c7b8482eba4dde6)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12947/head:pull/12947` \
`$ git checkout pull/12947`

Update a local copy of the PR: \
`$ git checkout pull/12947` \
`$ git pull https://git.openjdk.org/jdk pull/12947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12947`

View PR using the GUI difftool: \
`$ git pr show -t 12947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12947.diff">https://git.openjdk.org/jdk/pull/12947.diff</a>

</details>
