### PR TITLE
8303863: RISC-V: TestArrayStructs.java fails after JDK-8303604

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -305,7 +305,7 @@ public class LinuxRISCV64CallArranger {
                         if (offset + copy < layout.byteSize()) {
                             bindings.dup();
                         }
-                        bindings.bufferLoad(offset, type)
+                        bindings.bufferLoad(offset, type, (int) copy)
                                 .vmStore(storage, type);
                         offset += copy;
                     }
@@ -415,7 +415,7 @@ public class LinuxRISCV64CallArranger {
                         VMStorage storage = locations[locIndex++];
                         Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                         bindings.dup().vmLoad(storage, type)
-                                .bufferStore(offset, type);
+                                .bufferStore(offset, type, (int) copy);
                         offset += copy;
                     }
                 }


### PR DESCRIPTION
[JDK-8303604](https://bugs.openjdk.org/browse/JDK-8303604) fixes an issue with passing structs whose size is not a power of two on SysV and AArch64 platforms. The same issue happens on RISC-V.

Modifications are unnecessary for `STRUCT_REGISTER_F` and `STRUCT_REGISTER_XF`. If there are no available registers, they will fall back to `STRUCT_REGISTER_X`.

Testing:

- [x] TestArrayStructs.java 
- [x] jdk_foreign on Unmatched Board (release build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303863](https://bugs.openjdk.org/browse/JDK-8303863): RISC-V: TestArrayStructs.java fails after JDK-8303604


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12950/head:pull/12950` \
`$ git checkout pull/12950`

Update a local copy of the PR: \
`$ git checkout pull/12950` \
`$ git pull https://git.openjdk.org/jdk pull/12950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12950`

View PR using the GUI difftool: \
`$ git pr show -t 12950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12950.diff">https://git.openjdk.org/jdk/pull/12950.diff</a>

</details>
