### PR TITLE
8303853: Update ISO 3166 country codes table

### DIFF
--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -421,7 +421,7 @@ class LocaleISOData {
         + "SA" + "SAU"  // Saudi Arabia, Kingdom of
         + "SB" + "SLB"  // Solomon Islands
         + "SC" + "SYC"  // Seychelles, Republic of
-        + "SD" + "SDN"  // Sudan, Democratic Republic of the
+        + "SD" + "SDN"  // Sudan, Republic of the
         + "SE" + "SWE"  // Sweden, Kingdom of
         + "SG" + "SGP"  // Singapore, Republic of
         + "SH" + "SHN"  // Saint Helena, Ascension and Tristan da Cunha
@@ -433,7 +433,7 @@ class LocaleISOData {
         + "SN" + "SEN"  // Senegal, Republic of
         + "SO" + "SOM"  // Somalia, Somali Republic
         + "SR" + "SUR"  // Suriname, Republic of
-        + "SS" + "SSD"  // South Sudan
+        + "SS" + "SSD"  // South Sudan, Republic of
         + "ST" + "STP"  // Sao Tome and Principe, Democratic Republic of
         + "SV" + "SLV"  // El Salvador, Republic of
         + "SX" + "SXM"  // Sint Maarten (Dutch part)

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -292,7 +292,7 @@ class LocaleISOData {
         + "EE" + "EST"  // Estonia
         + "EG" + "EGY"  // Egypt, Arab Republic of
         + "EH" + "ESH"  // Western Sahara
-        + "ER" + "ERI"  // Eritrea
+        + "ER" + "ERI"  // Eritrea, State of
         + "ES" + "ESP"  // Spain, Spanish State
         + "ET" + "ETH"  // Ethiopia
         + "FI" + "FIN"  // Finland, Republic of

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -366,7 +366,7 @@ class LocaleISOData {
         + "MC" + "MCO"  // Monaco, Principality of
         + "MD" + "MDA"  // Moldova, Republic of
         + "ME" + "MNE"  // Montenegro
-        + "MF" + "MAF"  // Saint Martin
+        + "MF" + "MAF"  // Saint Martin (French part)
         + "MG" + "MDG"  // Madagascar, Republic of
         + "MH" + "MHL"  // Marshall Islands
         + "MK" + "MKD"  // Macedonia, the former Yugoslav Republic of

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -424,7 +424,7 @@ class LocaleISOData {
         + "SD" + "SDN"  // Sudan, Democratic Republic of the
         + "SE" + "SWE"  // Sweden, Kingdom of
         + "SG" + "SGP"  // Singapore, Republic of
-        + "SH" + "SHN"  // St. Helena
+        + "SH" + "SHN"  // Saint Helena, Ascension and Tristan da Cunha
         + "SI" + "SVN"  // Slovenia
         + "SJ" + "SJM"  // Svalbard & Jan Mayen Islands
         + "SK" + "SVK"  // Slovakia (Slovak Republic)

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -361,7 +361,7 @@ class LocaleISOData {
         + "LT" + "LTU"  // Lithuania
         + "LU" + "LUX"  // Luxembourg, Grand Duchy of
         + "LV" + "LVA"  // Latvia
-        + "LY" + "LBY"  // Libyan Arab Jamahiriya
+        + "LY" + "LBY"  // Libya
         + "MA" + "MAR"  // Morocco, Kingdom of
         + "MC" + "MCO"  // Monaco, Principality of
         + "MD" + "MDA"  // Moldova, Republic of

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -296,7 +296,7 @@ class LocaleISOData {
         + "ES" + "ESP"  // Spain, Spanish State
         + "ET" + "ETH"  // Ethiopia
         + "FI" + "FIN"  // Finland, Republic of
-        + "FJ" + "FJI"  // Fiji, Republic of the Fiji Islands
+        + "FJ" + "FJI"  // Fiji, Republic of
         + "FK" + "FLK"  // Falkland Islands (Malvinas)
         + "FM" + "FSM"  // Micronesia, Federated States of
         + "FO" + "FRO"  // Faeroe Islands
@@ -371,7 +371,7 @@ class LocaleISOData {
         + "MH" + "MHL"  // Marshall Islands
         + "MK" + "MKD"  // Macedonia, the former Yugoslav Republic of
         + "ML" + "MLI"  // Mali, Republic of
-        + "MM" + "MMR"  // Myanmar
+        + "MM" + "MMR"  // Myanmar, Republic of the Union of
         + "MN" + "MNG"  // Mongolia, Mongolian People's Republic
         + "MO" + "MAC"  // Macao, Special Administrative Region of China
         + "MP" + "MNP"  // Northern Mariana Islands
@@ -395,7 +395,7 @@ class LocaleISOData {
         + "NO" + "NOR"  // Norway, Kingdom of
         + "NP" + "NPL"  // Nepal, Kingdom of
         + "NR" + "NRU"  // Nauru, Republic of
-        + "NU" + "NIU"  // Niue, Republic of
+        + "NU" + "NIU"  // Niue
         + "NZ" + "NZL"  // New Zealand
         + "OM" + "OMN"  // Oman, Sultanate of
         + "PA" + "PAN"  // Panama, Republic of

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -365,7 +365,7 @@ class LocaleISOData {
         + "MA" + "MAR"  // Morocco, Kingdom of
         + "MC" + "MCO"  // Monaco, Principality of
         + "MD" + "MDA"  // Moldova, Republic of
-        + "ME" + "MNE"  // Montenegro, Republic of
+        + "ME" + "MNE"  // Montenegro
         + "MF" + "MAF"  // Saint Martin
         + "MG" + "MDG"  // Madagascar, Republic of
         + "MH" + "MHL"  // Marshall Islands

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -325,7 +325,7 @@ class LocaleISOData {
         + "HN" + "HND"  // Honduras, Republic of
         + "HR" + "HRV"  // Hrvatska (Croatia)
         + "HT" + "HTI"  // Haiti, Republic of
-        + "HU" + "HUN"  // Hungary, Hungarian People's Republic
+        + "HU" + "HUN"  // Hungary
         + "ID" + "IDN"  // Indonesia, Republic of
         + "IE" + "IRL"  // Ireland
         + "IL" + "ISR"  // Israel, State of

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -408,7 +408,7 @@ class LocaleISOData {
         + "PM" + "SPM"  // St. Pierre and Miquelon
         + "PN" + "PCN"  // Pitcairn Island
         + "PR" + "PRI"  // Puerto Rico
-        + "PS" + "PSE"  // Palestinian Territory, Occupied
+        + "PS" + "PSE"  // Palestine, State of
         + "PT" + "PRT"  // Portugal, Portuguese Republic
         + "PW" + "PLW"  // Palau
         + "PY" + "PRY"  // Paraguay, Republic of

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -306,7 +306,7 @@ class LocaleISOData {
         + "GD" + "GRD"  // Grenada
         + "GE" + "GEO"  // Georgia
         + "GF" + "GUF"  // French Guiana
-        + "GG" + "GGY"  // Guernsey
+        + "GG" + "GGY"  // Guernsey, Bailiwick of
         + "GH" + "GHA"  // Ghana, Republic of
         + "GI" + "GIB"  // Gibraltar
         + "GL" + "GRL"  // Greenland
@@ -336,7 +336,7 @@ class LocaleISOData {
         + "IR" + "IRN"  // Iran, Islamic Republic of
         + "IS" + "ISL"  // Iceland, Republic of
         + "IT" + "ITA"  // Italy, Italian Republic
-        + "JE" + "JEY"  // Jersey
+        + "JE" + "JEY"  // Jersey, Bailiwick of
         + "JM" + "JAM"  // Jamaica
         + "JO" + "JOR"  // Jordan, Hashemite Kingdom of
         + "JP" + "JPN"  // Japan

--- a/src/java.base/share/classes/java/util/LocaleISOData.java
+++ b/src/java.base/share/classes/java/util/LocaleISOData.java
@@ -253,7 +253,7 @@ class LocaleISOData {
         + "BL" + "BLM"  // Saint Barth\u00e9lemy
         + "BM" + "BMU"  // Bermuda
         + "BN" + "BRN"  // Brunei Darussalam
-        + "BO" + "BOL"  // Bolivia, Republic of
+        + "BO" + "BOL"  // Bolivia, Plurinational State of
         + "BQ" + "BES"  // Bonaire, Sint Eustatius and Saba
         + "BR" + "BRA"  // Brazil, Federative Republic of
         + "BS" + "BHS"  // Bahamas, Commonwealth of the


### PR DESCRIPTION
This PR incorporates all of the missing updates to ensure that `java.util.LocaleISOData.isoCountryTable` is on par with the official [ISO 3166 data](https://www.iso.org/obp/ui/#search/code/).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303853](https://bugs.openjdk.org/browse/JDK-8303853): Update ISO 3166 country codes table


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12954/head:pull/12954` \
`$ git checkout pull/12954`

Update a local copy of the PR: \
`$ git checkout pull/12954` \
`$ git pull https://git.openjdk.org/jdk pull/12954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12954`

View PR using the GUI difftool: \
`$ git pr show -t 12954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12954.diff">https://git.openjdk.org/jdk/pull/12954.diff</a>

</details>
