### PR TITLE
8303908: Add missing check in VTMS_transition_disable_for_all() for suspend mode

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -328,7 +328,8 @@ JvmtiVTMSTransitionDisabler::VTMS_transition_disable_for_all() {
     }
     if (_is_SR) {
       _SR_mode = true;
-      while (_VTMS_transition_disable_for_all_count > 0) {
+      while (_VTMS_transition_disable_for_all_count > 0 ||
+             _VTMS_transition_disable_for_one_count > 0) {
         ml.wait(10);   // Wait while there is any active jvmtiVTMSTransitionDisabler.
       }
     }
@@ -369,7 +370,7 @@ JvmtiVTMSTransitionDisabler::VTMS_transition_enable_for_one() {
   MonitorLocker ml(JvmtiVTMSTransition_lock);
   java_lang_Thread::dec_VTMS_transition_disable_count(vth());
   Atomic::dec(&_VTMS_transition_disable_for_one_count);
-  if (_VTMS_transition_disable_for_one_count == 0 || _is_SR) {
+  if (_VTMS_transition_disable_for_one_count == 0) {
     ml.notify_all();
   }
 #ifdef ASSERT


### PR DESCRIPTION
Please review this small fix. A suspender is a JvmtiVTMSTransitionDisabler monopolist, meaning VTMS_transition_disable_for_all() should not return while there is any active jvmtiVTMSTransitionDisabler. The code though is checking for active "all-disablers" but it's missing the check for active "single disablers".
I attached a simple reproducer to the bug which I used to test the patch. Not sure if it was worth adding a test so the patch contains just the fix.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303908](https://bugs.openjdk.org/browse/JDK-8303908): Add missing check in VTMS_transition_disable_for_all() for suspend mode


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12956/head:pull/12956` \
`$ git checkout pull/12956`

Update a local copy of the PR: \
`$ git checkout pull/12956` \
`$ git pull https://git.openjdk.org/jdk pull/12956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12956`

View PR using the GUI difftool: \
`$ git pr show -t 12956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12956.diff">https://git.openjdk.org/jdk/pull/12956.diff</a>

</details>
