### PR TITLE
8303915: javadoc build failure after JDK-8294959

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -110,12 +110,14 @@ JAVA_WARNINGS_ARE_ERRORS ?= -Werror
 JAVADOC_OPTIONS := -use -keywords -notimestamp \
     -encoding ISO-8859-1 -docencoding UTF-8 -breakiterator \
     -splitIndex --system none -javafx --expand-requires transitive \
+    --enable-preview -source $(JDK_SOURCE_TARGET_VERSION) \
     --override-methods=summary
 
 # The reference options must stay stable to allow for comparisons across the
 # development cycle.
 REFERENCE_OPTIONS := -XDignore.symbol.file=true -use -keywords -notimestamp \
     -encoding ISO-8859-1 -breakiterator -splitIndex --system none \
+    --enable-preview -source $(JDK_SOURCE_TARGET_VERSION) \
     -html5 -javafx --expand-requires transitive
 
 # Should we add DRAFT stamps to the generated javadoc?


### PR DESCRIPTION
Newly added Classfile API is based on pattern matching preview feature.
Unfortunately standard tier1 - 3 tests execution does not involve javadoc generation and so it didn't discover missing preview option.

Please review this patch enabling preview for javadoc generation, until pattern matching is finalized.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303915](https://bugs.openjdk.org/browse/JDK-8303915): javadoc build failure after JDK-8294959


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12957/head:pull/12957` \
`$ git checkout pull/12957`

Update a local copy of the PR: \
`$ git checkout pull/12957` \
`$ git pull https://git.openjdk.org/jdk pull/12957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12957`

View PR using the GUI difftool: \
`$ git pr show -t 12957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12957.diff">https://git.openjdk.org/jdk/pull/12957.diff</a>

</details>
