### PR TITLE
8303922: build-test-lib target is broken

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -39,7 +39,8 @@ $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
-    DISABLED_WARNINGS := deprecation removal, \
+    DISABLED_WARNINGS := deprecation removal preview, \
+    JAVAC_FLAGS := --enable-preview, \
 ))
 
 TARGETS += $(BUILD_WB_JAR)
@@ -51,7 +52,8 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
-    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal, \
+    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal preview, \
+    JAVAC_FLAGS := --enable-preview, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)

--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -36,7 +36,7 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/sun $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
     DISABLED_WARNINGS := deprecation removal, \

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -303,7 +303,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                 case TAG_BitString:
                     out.append(String.format("%s [%d]", tagName(tag), len));
                     do {
-                        var skipped = in.skip(len);
+                        var skipped = (int) in.skip(len);
                         len -= skipped;
                         available -= skipped;
                     } while (len > 0);

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The Make target 'build-test-lib-target' is broken in a few ways:

- make/test/BuildTestLib.gmk references the directory $(TEST_LIB_SOURCE_DIR)/sun which does not seem to exist. This can be fixed by removing the reference.
- Some test-lib sources use preview-features which is not enabled by make/test/BuildTestLib.gmk. This is fixed by adding a JAVAC_FLAGS with --enable-preview and also adding 'preview' to DISABLED_WARNINGS
- ASN1Formatter.annotate has a possible lossy conversion from long to int which can be fixed by adding an explicit cast

This PR fixes the above issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303922](https://bugs.openjdk.org/browse/JDK-8303922): build-test-lib target is broken


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12960/head:pull/12960` \
`$ git checkout pull/12960`

Update a local copy of the PR: \
`$ git checkout pull/12960` \
`$ git pull https://git.openjdk.org/jdk pull/12960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12960`

View PR using the GUI difftool: \
`$ git pr show -t 12960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12960.diff">https://git.openjdk.org/jdk/pull/12960.diff</a>

</details>
