### PR TITLE
8303924: ProblemList serviceability/sa/UniqueVtableTest.java on Linux

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -120,6 +120,7 @@ serviceability/sa/ClhsdbPmap.java#core 8294316,8267433 macosx-x64
 serviceability/sa/ClhsdbPstack.java#core 8294316,8267433 macosx-x64
 serviceability/sa/TestJmapCore.java 8294316,8267433 macosx-x64
 serviceability/sa/TestJmapCoreMetaspace.java 8294316,8267433 macosx-x64
+serviceability/sa/UniqueVtableTest.java 8303921 linux-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 


### PR DESCRIPTION
The test fails intermittently on linux-x64-debug and linux-aarch64-debug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303924](https://bugs.openjdk.org/browse/JDK-8303924): ProblemList serviceability/sa/UniqueVtableTest.java on Linux


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12962/head:pull/12962` \
`$ git checkout pull/12962`

Update a local copy of the PR: \
`$ git checkout pull/12962` \
`$ git pull https://git.openjdk.org/jdk pull/12962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12962`

View PR using the GUI difftool: \
`$ git pr show -t 12962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12962.diff">https://git.openjdk.org/jdk/pull/12962.diff</a>

</details>
