### PR TITLE
8303548: Arguments::get_default_shared_archive_path() should cache the result for future use

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -191,7 +191,6 @@ void FileMapInfo::populate_header(size_t core_region_alignment) {
       header_size += base_archive_name_size;
       base_archive_name_offset = c_header_size;
     }
-    FREE_C_HEAP_ARRAY(const char, default_base_archive_name);
   }
   ResourceMark rm;
   GrowableArray<const char*>* app_cp_array = create_dumptime_app_classpath_array();

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -470,6 +470,7 @@ class Arguments : AllStatic {
   // Return nullptr if the arg has expired.
   static const char* handle_aliases_and_deprecation(const char* arg);
 
+  static char*  _default_shared_archive_path;
   static char*  SharedArchivePath;
   static char*  SharedDynamicArchivePath;
   static size_t _default_SharedBaseAddress; // The default value specified in globals.hpp


### PR DESCRIPTION
The method `Arguments::get_default_shared_archive_path()` generates a string containing a path every time it is called. Since this method is idempotent, the string only needs to be constructed once in the lifetime of the VM. This change caches the result of `Arguments::get_default_shared_archive_path()` and ensures the path string is only generated once.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303548](https://bugs.openjdk.org/browse/JDK-8303548): Arguments::get_default_shared_archive_path() should cache the result for future use


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12963/head:pull/12963` \
`$ git checkout pull/12963`

Update a local copy of the PR: \
`$ git checkout pull/12963` \
`$ git pull https://git.openjdk.org/jdk pull/12963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12963`

View PR using the GUI difftool: \
`$ git pr show -t 12963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12963.diff">https://git.openjdk.org/jdk/pull/12963.diff</a>

</details>
