### PR TITLE
8303930: Fix ConstantUtils.skipOverFieldSignature void case return value

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
@@ -193,7 +193,7 @@ class ConstantUtils {
         int index = start;
         while (index < end) {
             switch (descriptor.charAt(index)) {
-                case JVM_SIGNATURE_VOID: if (!voidOK) { return index; }
+                case JVM_SIGNATURE_VOID: if (!voidOK) { return 0; }
                 case JVM_SIGNATURE_BOOLEAN:
                 case JVM_SIGNATURE_BYTE:
                 case JVM_SIGNATURE_CHAR:


### PR DESCRIPTION
This typo doesn't allow creation of malformed ClassDesc or MethodTypeDesc, but it produces an erroneous exception on certain inputs. Running `java.lang.constant.MethodTypeDesc.ofDescriptor("(IIIII[[[V)I")` in Jshell 19.0.2 throws StringIndexOutOfBoundsException, and throws IllegalArgumentException in the Jshell for this patch.