### PR TITLE
8303934: (fc) Use splice in FileChannel::transferFrom when the source is a pipe (Linux)

### DIFF
--- a/src/java.base/aix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/aix/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,9 +81,9 @@ Java_sun_nio_ch_FileDispatcherImpl_force0(JNIEnv *env, jobject this,
 
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jobject this,
-                                                    jobject srcFDO,
-                                                    jlong position, jlong count,
-                                                    jobject dstFDO, jboolean append)
+                                               jobject srcFDO,
+                                               jlong position, jlong count,
+                                               jobject dstFDO, jboolean append)
 {
     jint srcFD = fdval(env, srcFDO);
     jint dstFD = fdval(env, dstFDO);

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.FileLockInterruptionException;
 import java.nio.channels.NonReadableChannelException;
 import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.Pipe.SourceChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.WritableByteChannel;
@@ -839,6 +840,19 @@ public class FileChannelImpl
         return transferFromDirectlyInternal(srcFD, position, count);
     }
 
+    private long transferFromDirectly(SourceChannelImpl src,
+                                      long position, long count)
+        throws IOException
+    {
+        if (transferFromNotSupported)
+            return IOStatus.UNSUPPORTED;
+        FileDescriptor srcFD = src.getFD();
+        if (srcFD == null)
+            return IOStatus.UNSUPPORTED_CASE;
+
+        return transferFromDirectlyInternal(srcFD, position, count);
+    }
+
     private long transferFromFileChannel(FileChannelImpl src,
                                          long position, long count)
         throws IOException
@@ -945,6 +959,10 @@ public class FileChannelImpl
             if ((n = transferFromDirectly(fci, position, count)) >= 0)
                 return n;
             if ((n = transferFromFileChannel(fci, position, count)) >= 0)
+                return n;
+        } else if (src instanceof SourceChannelImpl sci) {
+            long n;
+            if ((n = transferFromDirectly(sci, position, count)) >= 0)
                 return n;
         }
 

--- a/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@
 
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_read0(JNIEnv *env, jclass clazz, jobject fdo,
-                                      jlong address, jint len)
+                                         jlong address, jint len)
 {
     DWORD read = 0;
     BOOL result = 0;
@@ -73,7 +73,7 @@ Java_sun_nio_ch_FileDispatcherImpl_read0(JNIEnv *env, jclass clazz, jobject fdo,
 
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_readv0(JNIEnv *env, jclass clazz, jobject fdo,
-                                       jlong address, jint len)
+                                          jlong address, jint len)
 {
     DWORD read = 0;
     BOOL result = 0;
@@ -122,7 +122,7 @@ Java_sun_nio_ch_FileDispatcherImpl_readv0(JNIEnv *env, jclass clazz, jobject fdo
 
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_pread0(JNIEnv *env, jclass clazz, jobject fdo,
-                            jlong address, jint len, jlong offset)
+                                          jlong address, jint len, jlong offset)
 {
     DWORD read = 0;
     BOOL result = 0;
@@ -260,7 +260,7 @@ Java_sun_nio_ch_FileDispatcherImpl_writev0(JNIEnv *env, jclass clazz, jobject fd
 
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_pwrite0(JNIEnv *env, jclass clazz, jobject fdo,
-                            jlong address, jint len, jlong offset)
+                                           jlong address, jint len, jlong offset)
 {
     BOOL result = 0;
     DWORD written = 0;
@@ -384,8 +384,8 @@ Java_sun_nio_ch_FileDispatcherImpl_size0(JNIEnv *env, jobject this, jobject fdo)
 
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_lock0(JNIEnv *env, jobject this, jobject fdo,
-                                      jboolean block, jlong pos, jlong size,
-                                      jboolean shared)
+                                         jboolean block, jlong pos, jlong size,
+                                         jboolean shared)
 {
     HANDLE h = (HANDLE)(handleval(env, fdo));
     DWORD lowPos = (DWORD)pos;
@@ -430,7 +430,7 @@ Java_sun_nio_ch_FileDispatcherImpl_lock0(JNIEnv *env, jobject this, jobject fdo,
 
 JNIEXPORT void JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
-                                        jobject fdo, jlong pos, jlong size)
+                                            jobject fdo, jlong pos, jlong size)
 {
     HANDLE h = (HANDLE)(handleval(env, fdo));
     DWORD lowPos = (DWORD)pos;
@@ -600,8 +600,8 @@ Java_sun_nio_ch_FileDispatcherImpl_maxDirectTransferSize0(JNIEnv* env, jclass kl
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jclass klass,
                                                jobject srcFD,
-                                            jlong position, jlong count,
-                                            jobject dstFD, jboolean append)
+                                               jlong position, jlong count,
+                                               jobject dstFD, jboolean append)
 {
     const int PACKET_SIZE = 524288;
 


### PR DESCRIPTION
On Linux, perform `transferFrom()` via the `splice(2)` system call when the source `ReadableByteChannel` is a `Pipe.SourceChannel` (`sun.nio.ch.SourceChannelImpl`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303934](https://bugs.openjdk.org/browse/JDK-8303934): (fc) Use splice in FileChannel::transferFrom when the source is a pipe (Linux)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12965/head:pull/12965` \
`$ git checkout pull/12965`

Update a local copy of the PR: \
`$ git checkout pull/12965` \
`$ git pull https://git.openjdk.org/jdk.git pull/12965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12965`

View PR using the GUI difftool: \
`$ git pr show -t 12965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12965.diff">https://git.openjdk.org/jdk/pull/12965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12965#issuecomment-1463040468)