### PR TITLE
8303937: Corrupted heap dumps due to missing retries for os::write()

### DIFF
--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -55,10 +55,14 @@ char const* FileWriter::write_buf(char* buf, ssize_t size) {
   assert(_fd >= 0, "Must be open");
   assert(size > 0, "Must write at least one byte");
 
-  ssize_t n = os::write(_fd, buf, (uint) size);
+  while (size > 0) {
+    ssize_t n = os::write(_fd, buf, (uint) size);
+    if (n <= 0) {
+      return os::strerror(errno);
+    }
 
-  if (n <= 0) {
-    return os::strerror(errno);
+    buf += n;
+    size -= n;
   }
 
   return nullptr;


### PR DESCRIPTION
Hi all,

Could anyone review this fix for heap dump corruption? See https://bugs.openjdk.org/browse/JDK-8303937 for more details.

Our users reported frequent heap dump corruptions after updating to 11.0.14.1u. We found the root cause is changes from https://bugs.openjdk.org/browse/JDK-8237354.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8303937](https://bugs.openjdk.org/browse/JDK-8303937): Corrupted heap dumps due to missing retries for os::write()


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12966/head:pull/12966` \
`$ git checkout pull/12966`

Update a local copy of the PR: \
`$ git checkout pull/12966` \
`$ git pull https://git.openjdk.org/jdk pull/12966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12966`

View PR using the GUI difftool: \
`$ git pr show -t 12966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12966.diff">https://git.openjdk.org/jdk/pull/12966.diff</a>

</details>
