### PR TITLE
8303955: RISC-V: Factor out the tmp parameter from copy_memory and copy_memory_v

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -897,12 +897,12 @@ class StubGenerator: public StubCodeGenerator {
 
   typedef void (MacroAssembler::*copy_insn)(Register Rd, const Address &adr, Register temp);
 
-  void copy_memory_v(Register s, Register d, Register count, Register tmp, int step) {
+  void copy_memory_v(Register s, Register d, Register count, int step) {
     bool is_backward = step < 0;
     int granularity = uabs(step);
 
     const Register src = x30, dst = x31, vl = x14, cnt = x15, tmp1 = x16, tmp2 = x17;
-    assert_different_registers(s, d, cnt, vl, tmp, tmp1, tmp2);
+    assert_different_registers(s, d, cnt, vl, tmp1, tmp2);
     Assembler::SEW sew = Assembler::elembytes_to_sew(granularity);
     Label loop_forward, loop_backward, done;
 
@@ -929,11 +929,11 @@ class StubGenerator: public StubCodeGenerator {
       __ j(done);
 
       __ bind(loop_backward);
-      __ sub(tmp, cnt, vl);
-      __ slli(tmp, tmp, sew);
-      __ add(tmp1, s, tmp);
+      __ sub(t0, cnt, vl);
+      __ slli(t0, t0, sew);
+      __ add(tmp1, s, t0);
       __ vlex_v(v0, tmp1, sew);
-      __ add(tmp2, d, tmp);
+      __ add(tmp2, d, t0);
       __ vsex_v(v0, tmp2, sew);
       __ sub(cnt, cnt, vl);
       __ bnez(cnt, loop_forward);
@@ -942,10 +942,10 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void copy_memory(DecoratorSet decorators, BasicType type, bool is_aligned,
-                   Register s, Register d, Register count, Register tmp, int step) {
+                   Register s, Register d, Register count, int step) {
     BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
     if (UseRVV && (!is_reference_type(type) || bs_asm->supports_rvv_arraycopy())) {
-      return copy_memory_v(s, d, count, tmp, step);
+      return copy_memory_v(s, d, count, step);
     }
 
     bool is_backwards = step < 0;
@@ -968,22 +968,22 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     if (is_aligned) {
-      __ addi(tmp, cnt, -32);
-      __ bgez(tmp, copy32_loop);
-      __ addi(tmp, cnt, -8);
-      __ bgez(tmp, copy8_loop);
+      __ addi(t0, cnt, -32);
+      __ bgez(t0, copy32_loop);
+      __ addi(t0, cnt, -8);
+      __ bgez(t0, copy8_loop);
       __ j(copy_small);
     } else {
-      __ mv(tmp, 16);
-      __ blt(cnt, tmp, copy_small);
+      __ mv(t0, 16);
+      __ blt(cnt, t0, copy_small);
 
-      __ xorr(tmp, src, dst);
-      __ andi(tmp, tmp, 0b111);
-      __ bnez(tmp, copy_small);
+      __ xorr(t0, src, dst);
+      __ andi(t0, t0, 0b111);
+      __ bnez(t0, copy_small);
 
       __ bind(same_aligned);
-      __ andi(tmp, src, 0b111);
-      __ beqz(tmp, copy_big);
+      __ andi(t0, src, 0b111);
+      __ beqz(t0, copy_big);
       if (is_backwards) {
         __ addi(src, src, step);
         __ addi(dst, dst, step);
@@ -999,8 +999,8 @@ class StubGenerator: public StubCodeGenerator {
       __ j(same_aligned);
 
       __ bind(copy_big);
-      __ mv(tmp, 32);
-      __ blt(cnt, tmp, copy8_loop);
+      __ mv(t0, 32);
+      __ blt(cnt, t0, copy8_loop);
     }
     __ bind(copy32_loop);
     if (is_backwards) {
@@ -1022,14 +1022,14 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, wordSize * 4);
       __ addi(dst, dst, wordSize * 4);
     }
-    __ addi(tmp, cnt, -(32 + wordSize * 4));
+    __ addi(t0, cnt, -(32 + wordSize * 4));
     __ addi(cnt, cnt, -wordSize * 4);
-    __ bgez(tmp, copy32_loop); // cnt >= 32, do next loop
+    __ bgez(t0, copy32_loop); // cnt >= 32, do next loop
 
     __ beqz(cnt, done); // if that's all - done
 
-    __ addi(tmp, cnt, -8); // if not - copy the reminder
-    __ bltz(tmp, copy_small); // cnt < 8, go to copy_small, else fall throught to copy8_loop
+    __ addi(t0, cnt, -8); // if not - copy the reminder
+    __ bltz(t0, copy_small); // cnt < 8, go to copy_small, else fall throught to copy8_loop
 
     __ bind(copy8_loop);
     if (is_backwards) {
@@ -1043,9 +1043,9 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(src, src, wordSize);
       __ addi(dst, dst, wordSize);
     }
-    __ addi(tmp, cnt, -(8 + wordSize));
+    __ addi(t0, cnt, -(8 + wordSize));
     __ addi(cnt, cnt, -wordSize);
-    __ bgez(tmp, copy8_loop); // cnt >= 8, do next loop
+    __ bgez(t0, copy8_loop); // cnt >= 8, do next loop
 
     __ beqz(cnt, done); // if that's all - done
 
@@ -1144,7 +1144,7 @@ class StubGenerator: public StubCodeGenerator {
       // UnsafeCopyMemory page error: continue after ucm
       bool add_entry = !is_oop && (!aligned || sizeof(jlong) == size);
       UnsafeCopyMemoryMark ucmm(this, add_entry, true);
-      copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, t0, size);
+      copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, size);
     }
 
     if (is_oop) {
@@ -1220,7 +1220,7 @@ class StubGenerator: public StubCodeGenerator {
       // UnsafeCopyMemory page error: continue after ucm
       bool add_entry = !is_oop && (!aligned || sizeof(jlong) == size);
       UnsafeCopyMemoryMark ucmm(this, add_entry, true);
-      copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, t0, -size);
+      copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, -size);
     }
 
     if (is_oop) {


### PR DESCRIPTION
The call site of `copy_memory` and `copy_memory_v` always use `t0` as tmp register, so we can factor the tmp parameter out.

Testing:

- [x] tier1 tests on Unmatched board (release build with `-XX:-UseRVV`)
- [x] hotspot_tier1 and jdk_tier1 on QEMU (release build with `-XX:+UseRVV`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303955](https://bugs.openjdk.org/browse/JDK-8303955): RISC-V: Factor out the tmp parameter from copy_memory and copy_memory_v


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12969/head:pull/12969` \
`$ git checkout pull/12969`

Update a local copy of the PR: \
`$ git checkout pull/12969` \
`$ git pull https://git.openjdk.org/jdk pull/12969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12969`

View PR using the GUI difftool: \
`$ git pr show -t 12969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12969.diff">https://git.openjdk.org/jdk/pull/12969.diff</a>

</details>
