### PR TITLE
8303948: HsErrFileUtils.checkHsErrFileContent() fails to check the last pattern.

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -97,7 +97,7 @@ public class HsErrFileUtils {
             if (positivePatterns != null) {
                 Collections.addAll(positivePatternStack, positivePatterns);
             }
-            Pattern currentPositivePattern = positivePatternStack.pollFirst();
+            Pattern currentPositivePattern = positivePatternStack.peekFirst();
 
             while ((line = br.readLine()) != null) {
                 if (verbose) {
@@ -109,7 +109,8 @@ public class HsErrFileUtils {
                             System.out.println(line);
                         }
                         System.out.println("^^^ Matches " + currentPositivePattern + " at line " + lineNo + "^^^");
-                        currentPositivePattern = positivePatternStack.pollFirst();
+                        positivePatternStack.remove(currentPositivePattern);
+                        currentPositivePattern = positivePatternStack.peekFirst();
                         if (currentPositivePattern == null && negativePatterns == null && checkEndMarker == false) {
                             System.out.println("Lazily skipping the rest of the hs-err file...");
                             break; // Shortcut. Nothing to do.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -130,7 +130,7 @@ public class HsErrFileUtils {
                 lastLine = line;
                 lineNo++;
             }
-            // check if current pattern is NULL then pattern matches else throw RuntimeException
+            // If the current pattern is not null then it didn't match
             if (currentPositivePattern != null) {
                 throw new RuntimeException("hs-err file incomplete (first missing pattern: " + currentPositivePattern.pattern() + ")");
             }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -97,7 +97,7 @@ public class HsErrFileUtils {
             if (positivePatterns != null) {
                 Collections.addAll(positivePatternStack, positivePatterns);
             }
-            Pattern currentPositivePattern = positivePatternStack.peekFirst();
+            Pattern currentPositivePattern = positivePatternStack.pollFirst();
 
             while ((line = br.readLine()) != null) {
                 if (verbose) {
@@ -109,8 +109,7 @@ public class HsErrFileUtils {
                             System.out.println(line);
                         }
                         System.out.println("^^^ Matches " + currentPositivePattern + " at line " + lineNo + "^^^");
-                        positivePatternStack.remove(currentPositivePattern);
-                        currentPositivePattern = positivePatternStack.peekFirst();
+                        currentPositivePattern = positivePatternStack.pollFirst();
                         if (currentPositivePattern == null && negativePatterns == null && checkEndMarker == false) {
                             System.out.println("Lazily skipping the rest of the hs-err file...");
                             break; // Shortcut. Nothing to do.
@@ -131,8 +130,8 @@ public class HsErrFileUtils {
                 lastLine = line;
                 lineNo++;
             }
-            // Found all positive pattern?
-            if (!positivePatternStack.isEmpty()) {
+            // check if current pattern is NULL then pattern matches else throw RuntimeException
+            if (currentPositivePattern != null) {
                 throw new RuntimeException("hs-err file incomplete (first missing pattern: " + currentPositivePattern.pattern() + ")");
             }
             if (checkEndMarker && !lastLine.equals("END.")) {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -68,7 +68,7 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
     // Crash address: see VMError::_segfault_address
-    String crashAddress = Platform.isAix() ? "0x0*1400" : "0x0*400";
+    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : "0x0*400";
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);


### PR DESCRIPTION
When last pattern in deque [positivePatternStack] is not matching in HsErrFile, it comes out of the loop and check whether the positivePatternStack is empty or not, which turns to be empty because the pollFirst() removes the pattern. 

This has been noticed in the TestSigInfoInHsErrFile.java where the segfault address for AIX is set as "0x0*1400" instead of "0xffffffffffffffff", which should throw the expected error but the error is neglected due to empty deque and the test is passed. 

JBS issue : [8303948](https://bugs.openjdk.org/browse/JDK-8303948)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303948](https://bugs.openjdk.org/browse/JDK-8303948): HsErrFileUtils.checkHsErrFileContent() fails to check the last pattern.


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [871b2e42](https://git.openjdk.org/jdk/pull/12970/files/871b2e42116c5f2ce2e3b9420c88e82b71752c1d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12970/head:pull/12970` \
`$ git checkout pull/12970`

Update a local copy of the PR: \
`$ git checkout pull/12970` \
`$ git pull https://git.openjdk.org/jdk.git pull/12970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12970`

View PR using the GUI difftool: \
`$ git pr show -t 12970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12970.diff">https://git.openjdk.org/jdk/pull/12970.diff</a>

</details>
