### PR TITLE
8283400: [macos] a11y : Screen magnifier does not reflect JRadioButton value change

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -184,6 +184,11 @@ class CAccessible extends CFRetainedResource implements Accessible {
                     if (thisRole == AccessibleRole.CHECK_BOX) {
                         valueChanged(ptr);
                     }
+
+                    // Do send radio button state changes to native side
+                    if (thisRole == AccessibleRole.RADIO_BUTTON) {
+                        valueChanged(ptr);
+                    }
                 } else if (name.equals(ACCESSIBLE_NAME_PROPERTY)) {
                     //for now trigger only for JTabbedPane.
                     if (e.getSource() instanceof JTabbedPane) {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -189,6 +189,11 @@ class CAccessible extends CFRetainedResource implements Accessible {
                     if (thisRole == AccessibleRole.RADIO_BUTTON) {
                         valueChanged(ptr);
                     }
+
+                    // Do send toggle button state changes to native side
+                    if (thisRole == AccessibleRole.TOGGLE_BUTTON) {
+                        valueChanged(ptr);
+                    }
                 } else if (name.equals(ACCESSIBLE_NAME_PROPERTY)) {
                     //for now trigger only for JTabbedPane.
                     if (e.getSource() instanceof JTabbedPane) {


### PR DESCRIPTION
Screen magnifier doesn't reflect the JRadiobutton checked/unchecked state.
After selecting JRadioButton, the screen magnifier does not show that JRadioButton is selected. When mouse is moved away and moved back on the JRadioButton, magnifier shows the checked state.

Correct behavior should be to show the checked/unchecked state immediately while using magnifier.

Solution:
Added a condition to check if component is JRadioButton and notified the native side whenever state change event occurred.
Verified with the Swingset2 demo.

Steps to reproduce:
This can be verified using swingset2 demo. 
Steps to reproduce are mentioned in JBS.

Note: The same behavior is observed for JTogglebutton also, added the same logic to handle toggle button too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283400](https://bugs.openjdk.org/browse/JDK-8283400): [macos] a11y : Screen magnifier does not reflect JRadioButton value change


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12971/head:pull/12971` \
`$ git checkout pull/12971`

Update a local copy of the PR: \
`$ git checkout pull/12971` \
`$ git pull https://git.openjdk.org/jdk pull/12971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12971`

View PR using the GUI difftool: \
`$ git pr show -t 12971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12971.diff">https://git.openjdk.org/jdk/pull/12971.diff</a>

</details>
