### PR TITLE
JDK-8303949: gcc10 warning Linux ppc64le - note: the layout of aggregates containing vectors with 8-byte alignment has changed in GCC 5

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -189,6 +189,10 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"
 
       DISABLED_WARNINGS="unused-parameter unused"
+      # gcc10/11 on ppc generate lots of abi warnings about layout of aggregates containing vectors
+      if test "x$OPENJDK_TARGET_CPU_ARCH" = "xppc"; then
+        DISABLED_WARNINGS="$DISABLED_WARNINGS psabi"
+      fi
       ;;
 
     clang)


### PR DESCRIPTION
When switching from gcc8 to gcc10 on Linux ppc64le, we get dozens of warnings in hotspot and other sources like this

adaptiveSizePolicy.cpp:262:6: note: the layout of aggregates containing vectors with 8-byte alignment has changed in GCC 5

Probably it would make sense to suppress the warning, -Wno-psabi might be an option.
Some info about this :

https://patches.dpdk.org/project/dpdk/patch/20210623161620.49916-1-drc@linux.vnet.ibm.com/

https://stackoverflow.com/questions/52020305/what-exactly-does-gccs-wpsabi-option-do-what-are-the-implications-of-supressi

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303949](https://bugs.openjdk.org/browse/JDK-8303949): gcc10 warning Linux ppc64le - note: the layout of aggregates containing vectors with 8-byte alignment has changed in GCC 5


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12972/head:pull/12972` \
`$ git checkout pull/12972`

Update a local copy of the PR: \
`$ git checkout pull/12972` \
`$ git pull https://git.openjdk.org/jdk pull/12972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12972`

View PR using the GUI difftool: \
`$ git pr show -t 12972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12972.diff">https://git.openjdk.org/jdk/pull/12972.diff</a>

</details>
