### PR TITLE
8303963: Replace various encodings of UINT/SIZE_MAX in gc code

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -363,7 +363,7 @@ bool G1FullCollector::phase2b_forward_oops() {
 }
 
 uint G1FullCollector::truncate_parallel_cps() {
-  uint lowest_current = (uint)-1;
+  uint lowest_current = UINT_MAX;
   for (uint i = 0; i < workers(); i++) {
     G1FullGCCompactionPoint* cp = compaction_point(i);
     if (cp->has_regions()) {

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -178,7 +178,7 @@ class G1RegionsSmallerThanCommitSizeMapper : public G1RegionToSpaceMapper {
     assert(_region_commit_map.get_next_one_offset(start_idx, region_limit) == region_limit,
            "Should be no committed regions in the range [%u, %u)", start_idx, region_limit);
 
-    size_t const NoPage = ~(size_t)0;
+    size_t const NoPage = SIZE_MAX;
 
     size_t first_committed = NoPage;
     size_t num_committed = 0;

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -60,7 +60,7 @@
 
 class ClassLoaderData;
 
-size_t CollectedHeap::_lab_alignment_reserve = ~(size_t)0;
+size_t CollectedHeap::_lab_alignment_reserve = SIZE_MAX;
 Klass* CollectedHeap::_filler_object_klass = nullptr;
 size_t CollectedHeap::_filler_array_max_size = 0;
 size_t CollectedHeap::_stack_chunk_max_size = 0;

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -314,7 +314,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   }
 
   static size_t lab_alignment_reserve() {
-    assert(_lab_alignment_reserve != ~(size_t)0, "uninitialized");
+    assert(_lab_alignment_reserve != SIZE_MAX, "uninitialized");
     return _lab_alignment_reserve;
   }
 

--- a/src/hotspot/share/gc/shared/gcId.hpp
+++ b/src/hotspot/share/gc/shared/gcId.hpp
@@ -32,7 +32,7 @@ private:
   friend class GCIdMark;
 
   static uint _next_id;
-  static const uint UNDEFINED = (uint)-1;
+  static const uint UNDEFINED = UINT_MAX;
   static uint create();
 
 public:

--- a/src/hotspot/share/gc/shared/workerDataArray.cpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.cpp
@@ -28,7 +28,7 @@
 
 template <>
 size_t WorkerDataArray<size_t>::uninitialized() {
-  return (size_t)-1;
+  return SIZE_MAX;
 }
 
 template <>

--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -303,7 +303,7 @@ void Metachunk::print_on(outputStream* st) const {
             "level " CHKLVL_FORMAT " (" SIZE_FORMAT " words), "
             "used " SIZE_FORMAT " words, committed " SIZE_FORMAT " words.",
             p2i(this), get_state_char(), p2i(base()), level(),
-            (chunklevel::is_valid_level(level()) ? chunklevel::word_size_for_level(level()) : (size_t)-1),
+            (chunklevel::is_valid_level(level()) ? chunklevel::word_size_for_level(level()) : SIZE_MAX),
             used_words(), committed_words());
 }
 

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -118,8 +118,6 @@
 #include "cgroupSubsystem_linux.hpp"
 #endif
 
-#define SIZE_T_MAX_VALUE ((size_t) -1)
-
 #define CHECK_JNI_EXCEPTION_(env, value)                               \
   do {                                                                 \
     JavaThread* THREAD = JavaThread::thread_from_jni_environment(env); \
@@ -347,7 +345,7 @@ WB_ENTRY(jint, WB_StressVirtualSpaceResize(JNIEnv* env, jobject o,
   // sizeof(size_t) depends on whether OS is 32bit or 64bit. sizeof(jlong) is
   // always 8 byte. That's why we should avoid overflow in case of 32bit platform.
   if (sizeof(size_t) < sizeof(jlong)) {
-    jlong size_t_max_value = (jlong) SIZE_T_MAX_VALUE;
+    jlong size_t_max_value = (jlong)SIZE_MAX;
     if (reserved_space_size > size_t_max_value || magnitude > size_t_max_value
         || iterations > size_t_max_value) {
       tty->print_cr("One of variables printed above overflows size_t. Can't proceed.\n");

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1885,7 +1885,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, WhiteBoxAPI, false, DIAGNOSTIC,                             \
           "Enable internal testing APIs")                                   \
                                                                             \
-  product(size_t, ArrayAllocatorMallocLimit, (size_t)-1, EXPERIMENTAL,      \
+  product(size_t, ArrayAllocatorMallocLimit, SIZE_MAX, EXPERIMENTAL,        \
           "Allocation less than this value will be allocated "              \
           "using malloc. Larger allocations will use mmap.")                \
                                                                             \

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1818,7 +1818,7 @@ bool os::release_memory(char* addr, size_t bytes) {
 
 // Prints all mappings
 void os::print_memory_mappings(outputStream* st) {
-  os::print_memory_mappings(nullptr, (size_t)-1, st);
+  os::print_memory_mappings(nullptr, SIZE_MAX, st);
 }
 
 // Pretouching must use a store, not just a load.  On many OSes loads from

--- a/src/hotspot/share/services/gcNotifier.cpp
+++ b/src/hotspot/share/services/gcNotifier.cpp
@@ -122,7 +122,7 @@ static Handle createGcInfo(GCMemoryManager *gcManager, GCStatInfo *gcStatInfo,TR
     if (u.max_size() == 0 && u.used() > 0) {
       // If max size == 0, this pool is a survivor space.
       // Set max size = -1 since the pools will be swapped after GC.
-      MemoryUsage usage(u.init_size(), u.used(), u.committed(), (size_t)-1);
+      MemoryUsage usage(u.init_size(), u.used(), u.committed(), MemoryUsage::undefined_size());
       after_usage = MemoryService::create_MemoryUsage_obj(usage, CHECK_NH);
     } else {
         after_usage = MemoryService::create_MemoryUsage_obj(u, CHECK_NH);

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1913,7 +1913,7 @@ JVM_ENTRY(void, jmm_GetLastGCStat(JNIEnv *env, jobject obj, jmmGCStat *gc_stat))
     if (u.max_size() == 0 && u.used() > 0) {
       // If max size == 0, this pool is a survivor space.
       // Set max size = -1 since the pools will be swapped after GC.
-      MemoryUsage usage(u.init_size(), u.used(), u.committed(), (size_t)-1);
+      MemoryUsage usage(u.init_size(), u.used(), u.committed(), MemoryUsage::undefined_size());
       after_usage = MemoryService::create_MemoryUsage_obj(usage, CHECK);
     } else {
       after_usage = MemoryService::create_MemoryUsage_obj(stat.after_gc_usage_for_pool(i), CHECK);

--- a/src/hotspot/share/services/memoryUsage.hpp
+++ b/src/hotspot/share/services/memoryUsage.hpp
@@ -63,7 +63,7 @@ public:
   size_t committed() const { return _committed; }
   size_t max_size()  const { return _maxSize; }
 
-  static size_t undefined_size() { return (size_t) -1; }
+  static size_t undefined_size() { return SIZE_MAX; }
 
   inline static jlong convert_to_jlong(size_t val) {
     // In the 64-bit vm, a size_t can overflow a jlong (which is signed).


### PR DESCRIPTION
Hi all,

  please review this refactoring that replaces various casts in GC and more-or-less related to get all bits set in an uint/size_t with the available constants from cstdint.
The ones in ZGC files were skipped on request.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303963](https://bugs.openjdk.org/browse/JDK-8303963): Replace various encodings of UINT/SIZE_MAX in gc code


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12973/head:pull/12973` \
`$ git checkout pull/12973`

Update a local copy of the PR: \
`$ git checkout pull/12973` \
`$ git pull https://git.openjdk.org/jdk pull/12973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12973`

View PR using the GUI difftool: \
`$ git pr show -t 12973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12973.diff">https://git.openjdk.org/jdk/pull/12973.diff</a>

</details>
