### PR TITLE
8298469: Obsolete legacy parallel class loading workaround for non-parallel-capable class loaders

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -132,9 +132,6 @@ void PlaceholderEntry::add_seen_thread(JavaThread* thread, PlaceholderTable::cla
   SeenThread* threadEntry = new SeenThread(thread);
   SeenThread* seen = actionToQueue(action);
 
-  assert(action != PlaceholderTable::LOAD_INSTANCE || !EnableWaitForParallelLoad || seen == nullptr,
-         "Only one LOAD_INSTANCE allowed at a time");
-
   if (seen == nullptr) {
     set_threadQ(threadEntry, action);
     return;

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -514,6 +514,7 @@ static bool needs_load_placeholder(Handle class_loader) {
   return class_loader.is_null() || !is_parallelCapable(class_loader);
 }
 
+// Check for other threads loading this class either to throw CCE or wait in the case of the boot loader.
 static InstanceKlass* handle_parallel_loading(JavaThread* current,
                                               Symbol* name,
                                               ClassLoaderData* loader_data,
@@ -643,7 +644,6 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
     bool load_placeholder_added = false;
 
     // Add placeholder entry to record loading instance class
-    // Four cases:
     // case 1. Bootstrap classloader
     //    This classloader supports parallelism at the classloader level
     //    but only allows a single thread to load a class/classloader pair.

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -302,12 +302,6 @@ private:
   static Klass* resolve_array_class_or_null(Symbol* class_name,
                                             Handle class_loader,
                                             Handle protection_domain, TRAPS);
-  static InstanceKlass* handle_parallel_loading(JavaThread* current,
-                                                Symbol* name,
-                                                ClassLoaderData* loader_data,
-                                                Handle lockObject,
-                                                bool* throw_circularity_error);
-
   static void define_instance_class(InstanceKlass* k, Handle class_loader, TRAPS);
   static InstanceKlass* find_or_define_helper(Symbol* class_name,
                                               Handle class_loader,

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -539,7 +539,6 @@ static SpecialFlag const special_jvm_flags[] = {
   { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
-  { "EnableWaitForParallelLoad",    JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::undefined(), JDK_Version::undefined() },
@@ -548,6 +547,7 @@ static SpecialFlag const special_jvm_flags[] = {
 
   // -------------- Obsolete Flags - sorted by expired_in --------------
 
+  { "EnableWaitForParallelLoad",    JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
   { "G1ConcRefinementGreenZone",    JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
   { "G1ConcRefinementYellowZone",   JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
   { "G1ConcRefinementRedZone",      JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -688,10 +688,6 @@ const int ObjectAlignmentInBytes = 8;
           "Allow parallel defineClass requests for class loaders "          \
           "registering as parallel capable")                                \
                                                                             \
-  product(bool, EnableWaitForParallelLoad, false,                           \
-          "(Deprecated) Enable legacy parallel classloading logic for "     \
-          "class loaders not registered as parallel capable")               \
-                                                                            \
   product_pd(bool, DontYieldALot,                                           \
           "Throw away obvious excess yield calls")                          \
                                                                             \

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1340,12 +1340,7 @@ void ObjectMonitor::ExitEpilog(JavaThread* current, ObjectWaiter* Wakee) {
   OM_PERFDATA_OP(Parks, inc());
 }
 
-
-// -----------------------------------------------------------------------------
-// Class Loader deadlock handling.
-//
 // complete_exit exits a lock returning recursion count
-// complete_exit/reenter operate as a wait without waiting
 // complete_exit requires an inflated monitor
 // The _owner field is not always the Thread addr even with an
 // inflated monitor, e.g. the monitor can be inflated by a non-owning
@@ -1368,20 +1363,6 @@ intx ObjectMonitor::complete_exit(JavaThread* current) {
   exit(current);           // exit the monitor
   guarantee(owner_raw() != current, "invariant");
   return save;
-}
-
-// reenter() enters a lock and sets recursion count
-// complete_exit/reenter operate as a wait without waiting
-bool ObjectMonitor::reenter(intx recursions, JavaThread* current) {
-
-  guarantee(owner_raw() != current, "reenter already owner");
-  if (!enter(current)) {
-    return false;
-  }
-  // Entered the monitor.
-  guarantee(_recursions == 0, "reenter recursion");
-  _recursions = recursions;
-  return true;
 }
 
 // Checks that the current THREAD owns this monitor and causes an

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -321,7 +321,6 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
 
   // Use the following at your own risk
   intx      complete_exit(JavaThread* current);
-  bool      reenter(intx recursions, JavaThread* current);
 
  private:
   void      AddWaiter(ObjectWaiter* waiter);

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -154,12 +154,6 @@ class ObjectSynchronizer : AllStatic {
   static bool quick_notify(oopDesc* obj, JavaThread* current, bool All);
   static bool quick_enter(oop obj, JavaThread* current, BasicLock* Lock);
 
-  // used by classloading to free classloader object lock,
-  // wait on an internal lock, and reclaim original lock
-  // with original recursion count
-  static intx complete_exit(Handle obj, JavaThread* current);
-  static void reenter (Handle obj, intx recursions, JavaThread* current);
-
   // Inflate light weight monitor to heavy weight monitor
   static ObjectMonitor* inflate(Thread* current, oop obj, const InflateCause cause);
   // This version is only for internal use

--- a/test/hotspot/jtreg/runtime/ParallelLoad/ParallelSuper/ParallelSuperTest.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/ParallelSuper/ParallelSuperTest.java
@@ -31,7 +31,6 @@
  * @compile -XDignore.symbol.file AsmClasses.java
  * @compile test-classes/ClassInLoader.java test-classes/A.java test-classes/B.java ../share/ThreadPrint.java
  * @run main/othervm ParallelSuperTest
- * @run main/othervm -XX:+EnableWaitForParallelLoad ParallelSuperTest -parallel
  * @run main/othervm ParallelSuperTest -parallel -parallelCapable
  */
 


### PR DESCRIPTION
This change removes the JVM code and option (default off) to synchronize class loading for non-parallel capable class loading.  For more information see: https://bugs.openjdk.org/browse/JDK-8295673
and Release Note for the option in 20: https://bugs.openjdk.org/browse/JDK-8296446

Now Release Note for removal: https://bugs.openjdk.org/browse/JDK-8303967

Tested with tier1-7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8304056](https://bugs.openjdk.org/browse/JDK-8304056) to be approved

### Issues
 * [JDK-8298469](https://bugs.openjdk.org/browse/JDK-8298469): Obsolete legacy parallel class loading workaround for non-parallel-capable class loaders
 * [JDK-8304056](https://bugs.openjdk.org/browse/JDK-8304056): Obsolete legacy parallel class loading workaround for non-parallel-capable class loaders (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12974/head:pull/12974` \
`$ git checkout pull/12974`

Update a local copy of the PR: \
`$ git checkout pull/12974` \
`$ git pull https://git.openjdk.org/jdk pull/12974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12974`

View PR using the GUI difftool: \
`$ git pr show -t 12974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12974.diff">https://git.openjdk.org/jdk/pull/12974.diff</a>

</details>
