### PR TITLE
8303968: Serial: Use more precise liveness info in Young GC reference processing

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -39,12 +39,12 @@
 
 class ContiguousSpace;
 class CSpaceCounters;
-class OldGenScanClosure;
-class YoungGenScanClosure;
 class DefNewTracer;
-class ScanWeakRefClosure;
+class IsAliveClosure;
+class OldGenScanClosure;
 class SerialHeap;
 class STWGCTimer;
+class YoungGenScanClosure;
 
 // DefNewGeneration is a young generation containing eden, from- and
 // to-space.
@@ -59,6 +59,8 @@ class DefNewGeneration: public Generation {
   size_t      _pretenure_size_threshold_words;
 
   // ("Weak") Reference processing support
+
+  static IsAliveClosure _is_alive_closure;
   SpanSubjectToDiscoveryClosure _span_based_discoverer;
   ReferenceProcessor* _ref_processor;
 


### PR DESCRIPTION
Simple refactoring around Young-GC keep-alive-closure.

(I went for the static-local-var approach, as other solutions that I am aware of would expose the is-alive-closure in the header.)

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303968](https://bugs.openjdk.org/browse/JDK-8303968): Serial: Use more precise liveness info in Young GC reference processing


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/12975/head:pull/12975` \
`$ git checkout pull/12975`

Update a local copy of the PR: \
`$ git checkout pull/12975` \
`$ git pull https://git.openjdk.org/jdk.git pull/12975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12975`

View PR using the GUI difftool: \
`$ git pr show -t 12975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12975.diff">https://git.openjdk.org/jdk/pull/12975.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/12975#issuecomment-1463833276)