### PR TITLE
8303969: Limit printed failures within an object during G1 heap verification

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -214,7 +214,8 @@
           range(1, 100)                                                     \
                                                                             \
   develop(size_t, G1MaxVerifyFailures, SIZE_MAX,                            \
-          "The maximum number of verification failures to print.")          \
+          "The maximum number of liveness and remembered set verification " \
+          "failures to print per thread.")                                  \
           range(1, SIZE_MAX)                                                \
                                                                             \
   product(uintx, G1ReservePercent, 10,                                      \

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -619,6 +619,10 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
     assert(_containing_obj != nullptr, "must be");
     assert(!G1CollectedHeap::heap()->is_obj_dead_cond(_containing_obj, _vo), "Precondition");
 
+    if (num_failures() >= G1MaxVerifyFailures) {
+      return;
+    }
+
     T heap_oop = RawAccess<>::oop_load(p);
     if (CompressedOops::is_null(heap_oop)) {
       return;


### PR DESCRIPTION
Hi all,

  please review this change to limit per-object liveness and remembered set error printing by `G1MaxVerifyFailures` too to avoid filling the log/disk when there is a large object that has many failures.

Testing: local compilation, local verification getting less error output on verification failure on humongous objects

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303969](https://bugs.openjdk.org/browse/JDK-8303969): Limit printed failures within an object during G1 heap verification


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12977/head:pull/12977` \
`$ git checkout pull/12977`

Update a local copy of the PR: \
`$ git checkout pull/12977` \
`$ git pull https://git.openjdk.org/jdk pull/12977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12977`

View PR using the GUI difftool: \
`$ git pr show -t 12977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12977.diff">https://git.openjdk.org/jdk/pull/12977.diff</a>

</details>
