### PR TITLE
8304005: ProblemList serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java on linux-x64 in Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -34,6 +34,8 @@ vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 82456
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64
 
+serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-x64
+
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java on linux-x64 in -Xcomp mode

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304005](https://bugs.openjdk.org/browse/JDK-8304005): ProblemList serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java on linux-x64 in Xcomp mode


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12983/head:pull/12983` \
`$ git checkout pull/12983`

Update a local copy of the PR: \
`$ git checkout pull/12983` \
`$ git pull https://git.openjdk.org/jdk pull/12983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12983`

View PR using the GUI difftool: \
`$ git pr show -t 12983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12983.diff">https://git.openjdk.org/jdk/pull/12983.diff</a>

</details>
