### PR TITLE
8304015: G1: Metaspace-induced GCs should not trigger maximal compaction

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1040,6 +1040,7 @@ bool G1CollectedHeap::do_full_collection(bool explicit_gc,
                                          bool clear_all_soft_refs,
                                          bool do_maximal_compaction) {
   assert_at_safepoint_on_vm_thread();
+  assert(!do_maximal_compaction || do_maximal_compaction == clear_all_soft_refs, "Maximal compaction should also clear soft references");
 
   if (GCLocker::check_active_before_gc()) {
     // Full GC was not completed.
@@ -1065,12 +1066,10 @@ void G1CollectedHeap::do_full_collection(bool clear_all_soft_refs) {
   // Currently, there is no facility in the do_full_collection(bool) API to notify
   // the caller that the collection did not succeed (e.g., because it was locked
   // out by the GC locker). So, right now, we'll ignore the return value.
-  // When clear_all_soft_refs is set we want to do a maximal compaction
-  // not leaving any dead wood.
-  bool do_maximal_compaction = clear_all_soft_refs;
-  bool dummy = do_full_collection(true,                /* explicit_gc */
-                                  clear_all_soft_refs,
-                                  do_maximal_compaction);
+
+  do_full_collection(true,                /* explicit_gc */
+                     clear_all_soft_refs,
+                     false /* do_maximal_compaction */);
 }
 
 bool G1CollectedHeap::upgrade_to_full_collection() {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1040,7 +1040,6 @@ bool G1CollectedHeap::do_full_collection(bool explicit_gc,
                                          bool clear_all_soft_refs,
                                          bool do_maximal_compaction) {
   assert_at_safepoint_on_vm_thread();
-  assert(!do_maximal_compaction || do_maximal_compaction == clear_all_soft_refs, "Maximal compaction should also clear soft references");
 
   if (GCLocker::check_active_before_gc()) {
     // Full GC was not completed.
@@ -1067,7 +1066,7 @@ void G1CollectedHeap::do_full_collection(bool clear_all_soft_refs) {
   // the caller that the collection did not succeed (e.g., because it was locked
   // out by the GC locker). So, right now, we'll ignore the return value.
 
-  do_full_collection(true,                /* explicit_gc */
+  do_full_collection(false,                /* explicit_gc */
                      clear_all_soft_refs,
                      false /* do_maximal_compaction */);
 }


### PR DESCRIPTION
Hi all,

Please review this small cleanup to remove triggering maximal compaction on Metaspace-induced full-GCs.

Testing: Tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304015](https://bugs.openjdk.org/browse/JDK-8304015): G1: Metaspace-induced GCs should not trigger maximal compaction


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12987/head:pull/12987` \
`$ git checkout pull/12987`

Update a local copy of the PR: \
`$ git checkout pull/12987` \
`$ git pull https://git.openjdk.org/jdk pull/12987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12987`

View PR using the GUI difftool: \
`$ git pr show -t 12987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12987.diff">https://git.openjdk.org/jdk/pull/12987.diff</a>

</details>
