### PR TITLE
8304017: ProblemList com/sun/jdi/InvokeHangTest.java on windows-x64 in vthread mode

### DIFF
--- a/test/jdk/ProblemList-svc-vthread.txt
+++ b/test/jdk/ProblemList-svc-vthread.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ com/sun/jdi/StepTest.java 8285422 generic-all
 com/sun/jdi/redefine/RedefineTest.java 8285422 generic-all
 com/sun/jdi/redefineMethod/RedefineTest.java 8285422 generic-all
 
-com/sun/jdi/InvokeHangTest.java 8290200 macosx-x64
+com/sun/jdi/InvokeHangTest.java 8290200 macosx-x64,windows-x64
 
 ####
 # JDI SDE Tests

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -665,6 +665,7 @@ java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
 java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64
 
 javax/swing/JColorChooser/Test6827032.java 8224968 windows-x64
+java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8288839 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -664,6 +664,8 @@ java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows
 java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
 java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64
 
+javax/swing/JColorChooser/Test6827032.java 8224968 windows-x64
+
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 


### PR DESCRIPTION
Trivial fixes to ProblemList 3 different tests:
[JDK-8304017](https://bugs.openjdk.org/browse/JDK-8304017) ProblemList com/sun/jdi/InvokeHangTest.java on windows-x64 in vthread mode
[JDK-8304018](https://bugs.openjdk.org/browse/JDK-8304018) ProblemList javax/swing/JColorChooser/Test6827032.java on windows-x64
[JDK-8304019](https://bugs.openjdk.org/browse/JDK-8304019) ProblemList java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java on windows-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8304017](https://bugs.openjdk.org/browse/JDK-8304017): ProblemList com/sun/jdi/InvokeHangTest.java on windows-x64 in vthread mode
 * [JDK-8304018](https://bugs.openjdk.org/browse/JDK-8304018): ProblemList javax/swing/JColorChooser/Test6827032.java on windows-x64
 * [JDK-8304019](https://bugs.openjdk.org/browse/JDK-8304019): ProblemList java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java on windows-x64


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12990/head:pull/12990` \
`$ git checkout pull/12990`

Update a local copy of the PR: \
`$ git checkout pull/12990` \
`$ git pull https://git.openjdk.org/jdk pull/12990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12990`

View PR using the GUI difftool: \
`$ git pr show -t 12990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12990.diff">https://git.openjdk.org/jdk/pull/12990.diff</a>

</details>
