### PR TITLE
make/Init.gmk: fix build build for make-4.4.1

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -60,13 +60,19 @@ ifeq ($(HAS_SPEC),)
   # Extract non-global targets that require a spec file.
   CALLED_SPEC_TARGETS := $(filter-out $(ALL_GLOBAL_TARGETS), $(CALLED_TARGETS))
 
+  # GNU make-4.4 (and later) include not just single-letter form of the
+  # options MAKEFILES but also long for and even some of the arguments.
+  # Skip long form and use only short form:
+  #     MAKEFLAGS=' --debug=basic -- LOG=trace ...'
+  MAKEFLAGS_SINGE_LETTER := $(firstword -$(MAKEFLAGS))
+
   # If we have only global targets, or if we are called with -qp (assuming an
   # external part, e.g. bash completion, is trying to understand our targets),
   # we will skip SPEC location and the sanity checks.
   ifeq ($(CALLED_SPEC_TARGETS), )
     ONLY_GLOBAL_TARGETS := true
   endif
-  ifeq ($(findstring p, $(MAKEFLAGS))$(findstring q, $(MAKEFLAGS)), pq)
+  ifeq ($(findstring p, $(MAKEFLAGS_SINGE_LETTER))$(findstring q, $(MAKEFLAGS_SINGE_LETTER)), pq)
     ONLY_GLOBAL_TARGETS := true
   endif
 


### PR DESCRIPTION
Initially the problem was discovered in `nixpkgs` where update from `make-4.4` to `make-4.4.1` broke the build by turning 'make' into no-op (https://github.com/NixOS/nixpkgs/issues/219513)

    https://hydra.nixos.org/build/211484263/nixlog/4

It happens because `gnumake-4.4.1` strated passing a lot more long options into `MAKEFLAGS`:

    MAKEKEFLAGS=' --debug=basic -- LOG=trace ...'

jdk's make/Init.gmk still assumed `MAKEFLAGS` does not contain long options:

    ifeq ($(findstring p, $(MAKEFLAGS))$(findstring q, $(MAKEFLAGS)), pq)
      ONLY_GLOBAL_TARGETS := true
    endif

This has a high chance of catching `pq` in unrelated parameters. In case of `nixpkgs` it was unused `SHELL=/<long-hash>/bin/bash` variable that happened to contain both `p` and `q`.

The change removes long options using $(firstword) mimicing a similar fix in `glibc` for the same problem:

https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=2d7ed98add14f75041499ac189696c9bd3d757fe

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12992/head:pull/12992` \
`$ git checkout pull/12992`

Update a local copy of the PR: \
`$ git checkout pull/12992` \
`$ git pull https://git.openjdk.org/jdk pull/12992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12992`

View PR using the GUI difftool: \
`$ git pr show -t 12992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12992.diff">https://git.openjdk.org/jdk/pull/12992.diff</a>

</details>
