### PR TITLE
JDK-8303973: Library detection in runtime/ErrorHandling/TestDwarf.java fails on ppc64le RHEL8.5 for libpthread-2.28.so

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,9 +171,9 @@ public class TestDwarf {
      * There are some valid cases where we cannot find source information. Check these.
      */
     private static void checkNoSourceLine(String crashOutputString, String line) {
-        Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+]");
+        Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.-]+)\\+0x.+]");
         Matcher matcher = pattern.matcher(line);
-        Asserts.assertTrue(matcher.find(), "Must find library in \"" + line + "\"");
+        Asserts.assertTrue(matcher.find(), "Must find library name in \"" + line + "\"");
         // Check if there are symbols available for library. If not, then we cannot find any source information for this library.
         // This can happen if this test is run without any JDK debug symbols at all but also for some libraries like libpthread.so
         // which usually has no symbols available.


### PR DESCRIPTION
The test fails with

[dwarf] ##### Find filename and line number for offset 0x000096a8 in library /lib64/glibc-hwcaps/power9/libpthread-2.28.so #####
[dwarf] Failed to load DWARF file for library /lib64/glibc-hwcaps/power9/libpthread-2.28.so or find DWARF sections directly inside it.

and in stderr

java.lang.RuntimeException: Must find library in "C [libpthread-2.28.so+0x96a8] start_thread+0xf8": expected true, was false

Looks like the '-' in the lib-name libpthread-2.28.so is currently not allowed in the pattern of the test. This is similar to [JDK-8293201](https://bugs.openjdk.org/browse/JDK-8293201) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303973](https://bugs.openjdk.org/browse/JDK-8303973): Library detection in runtime/ErrorHandling/TestDwarf.java fails on ppc64le RHEL8.5 for libpthread-2.28.so


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/12998/head:pull/12998` \
`$ git checkout pull/12998`

Update a local copy of the PR: \
`$ git checkout pull/12998` \
`$ git pull https://git.openjdk.org/jdk pull/12998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12998`

View PR using the GUI difftool: \
`$ git pr show -t 12998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/12998.diff">https://git.openjdk.org/jdk/pull/12998.diff</a>

</details>
