### PR TITLE
8304055

### DIFF
--- a/src/hotspot/share/gc/g1/g1AllocRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.hpp
@@ -275,13 +275,6 @@ class OldGCAllocRegion : public G1GCAllocRegion {
 public:
   OldGCAllocRegion(G1EvacStats* stats)
   : G1GCAllocRegion("Old GC Alloc Region", true /* bot_updates */, stats, G1HeapRegionAttr::Old) { }
-
-  // This specialization of release() makes sure that the last card that has
-  // been allocated into has been completely filled by a dummy object.  This
-  // avoids races when remembered set scanning wants to update the BOT of the
-  // last card in the retained old gc alloc region, and allocation threads
-  // allocating into that card at the same time.
-  virtual HeapRegion* release();
 };
 
 #endif // SHARE_GC_G1_G1ALLOCREGION_HPP


### PR DESCRIPTION
Simple removing unnecessary code around BOT update in old-gen allocator.

Test: tier1-6