### PR TITLE
8293324: ciField.hpp has two methods to return field's offset

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -572,7 +572,7 @@ class FieldBuffer: public CompilationResourceObj {
 
   Value at(ciField* field) {
     assert(field->holder()->is_loaded(), "must be a loaded field");
-    int offset = field->offset();
+    int offset = field->offset_in_bytes();
     if (offset < _values.length()) {
       return _values.at(offset);
     } else {
@@ -582,7 +582,7 @@ class FieldBuffer: public CompilationResourceObj {
 
   void at_put(ciField* field, Value value) {
     assert(field->holder()->is_loaded(), "must be a loaded field");
-    int offset = field->offset();
+    int offset = field->offset_in_bytes();
     _values.at_put_grow(offset, value, NULL);
   }
 
@@ -623,7 +623,7 @@ class MemoryBuffer: public CompilationResourceObj {
     Value value = st->value();
     ciField* field = st->field();
     if (field->holder()->is_loaded()) {
-      int offset = field->offset();
+      int offset = field->offset_in_bytes();
       int index = _newobjects.find(object);
       if (index != -1) {
         // newly allocated object with no other stores performed on this field
@@ -691,7 +691,7 @@ class MemoryBuffer: public CompilationResourceObj {
     ciField* field = load->field();
     Value object   = load->obj();
     if (field->holder()->is_loaded() && !field->is_volatile()) {
-      int offset = field->offset();
+      int offset = field->offset_in_bytes();
       Value result = NULL;
       int index = _newobjects.find(object);
       if (index != -1) {
@@ -1752,7 +1752,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     }
   }
 
-  const int offset = !needs_patching ? field->offset() : -1;
+  const int offset = !needs_patching ? field->offset_in_bytes() : -1;
   switch (code) {
     case Bytecodes::_getstatic: {
       // check for compile-time constants, i.e., initialized static final fields

--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -190,7 +190,7 @@ Value ValueMap::find_insert(Value x) {
   LoadField* lf = value->as_LoadField();                                                 \
   bool must_kill = lf != NULL                                                            \
                    && lf->field()->holder() == field->holder()                           \
-                   && (all_offsets || lf->field()->offset() == field->offset());
+                   && (all_offsets || lf->field()->offset_in_bytes() == field->offset_in_bytes());
 
 
 void ValueMap::kill_memory() {

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -881,7 +881,7 @@ void BCEscapeAnalyzer::iterate_one_block(ciBlock *blk, StateInfo &state, Growabl
           if (s.cur_bc() != Bytecodes::_putstatic) {
             ArgumentMap p = state.apop();
             set_method_escape(p);
-            set_modified(p, will_link ? field->offset() : OFFSET_ANY, type2size[field_type]*HeapWordSize);
+            set_modified(p, will_link ? field->offset_in_bytes() : OFFSET_ANY, type2size[field_type]*HeapWordSize);
           }
         }
         break;

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -312,7 +312,7 @@ ciConstant ciField::constant_value() {
   if (_constant_value.basic_type() == T_ILLEGAL) {
     // Static fields are placed in mirror objects.
     ciInstance* mirror = _holder->java_mirror();
-    _constant_value = mirror->field_value_impl(type()->basic_type(), offset());
+    _constant_value = mirror->field_value_impl(type()->basic_type(), offset_in_bytes());
   }
   if (FoldStableValues && is_stable() && _constant_value.is_null_or_zero()) {
     return ciConstant();

--- a/src/hotspot/share/ci/ciField.hpp
+++ b/src/hotspot/share/ci/ciField.hpp
@@ -107,15 +107,10 @@ public:
   // How big is this field in memory?
   int size_in_bytes() { return type2aelembytes(layout_type()); }
 
-  // What is the offset of this field?
-  int offset() const {
+  // What is the offset of this field? (Fields are aligned to the byte level.)
+  int offset_in_bytes() const {
     assert(_offset >= 1, "illegal call to offset()");
     return _offset;
-  }
-
-  // Same question, explicit units.  (Fields are aligned to the byte level.)
-  int offset_in_bytes() const {
-    return offset();
   }
 
   // Is this field shared?

--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -109,7 +109,7 @@ ciConstant ciInstance::field_value(ciField* field) {
   assert(is_loaded(), "invalid access - must be loaded");
   assert(field->holder()->is_loaded(), "invalid access - holder must be loaded");
   assert(field->is_static() || klass()->is_subclass_of(field->holder()), "invalid access - must be subclass");
-  return field_value_impl(field->type()->basic_type(), field->offset());
+  return field_value_impl(field->type()->basic_type(), field->offset_in_bytes());
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -213,7 +213,7 @@ Node* ArrayCopyNode::try_clone_instance(PhaseGVN *phase, bool can_reshape, int c
   for (int i = 0; i < count; i++) {
     ciField* field = ik->nonstatic_field_at(i);
     const TypePtr* adr_type = phase->C->alias_type(field)->adr_type();
-    Node* off = phase->MakeConX(field->offset());
+    Node* off = phase->MakeConX(field->offset_in_bytes());
     Node* next_src = phase->transform(new AddPNode(base_src,base_src,off));
     Node* next_dest = phase->transform(new AddPNode(base_dest,base_dest,off));
     BasicType bt = field->layout_type();

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1703,7 +1703,7 @@ Compile::AliasType* Compile::find_alias_type(const TypePtr* adr_type, bool no_cr
       assert(field == nullptr ||
              original_field == nullptr ||
              (field->holder() == original_field->holder() &&
-              field->offset() == original_field->offset() &&
+              field->offset_in_bytes() == original_field->offset_in_bytes() &&
               field->is_static() == original_field->is_static()), "wrong field?");
       // Set field() and is_rewritable() attributes.
       if (field != nullptr)  alias_type(idx)->set_field(field);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3607,7 +3607,7 @@ Node* GraphKit::set_output_for_allocation(AllocateNode* alloc,
       ciInstanceKlass* ik = oop_type->is_instptr()->instance_klass();
       for (int i = 0, len = ik->nof_nonstatic_fields(); i < len; i++) {
         ciField* field = ik->nonstatic_field_at(i);
-        if (field->offset() >= TrackedInitializationLimit * HeapWordSize)
+        if (field->offset_in_bytes() >= TrackedInitializationLimit * HeapWordSize)
           continue;  // do not bother to track really large numbers of fields
         // Find (or create) the alias category for this field:
         int fieldidx = C->alias_type(field)->index();

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -735,7 +735,7 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       ciField* field = nullptr;
       if (iklass != nullptr) {
         field = iklass->nonstatic_field_at(j);
-        offset = field->offset();
+        offset = field->offset_in_bytes();
         ciType* elem_type = field->type();
         basic_elem_type = field->layout_type();
 


### PR DESCRIPTION
Small refactoring of ciField.hpp method `offset()` removed and  `offset_in_bytes()` used instead.

Test: tier1 linux-x86_64