### PR TITLE
8303910: jdk/classfile/CorpusTest.java failed 1 of 6754 tests

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/TypeKind.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/TypeKind.java
@@ -109,7 +109,7 @@ public enum TypeKind {
             case 9 -> TypeKind.ShortType;
             case 10 -> TypeKind.IntType;
             case 11 -> TypeKind.LongType;
-            default -> throw new IllegalStateException("Bad new array code: " + newarraycode);
+            default -> throw new IllegalArgumentException("Bad new array code: " + newarraycode);
         };
     }
 
@@ -129,7 +129,7 @@ public enum TypeKind {
             case 'J' -> TypeKind.LongType;
             case 'D' -> TypeKind.DoubleType;
             case 'V' -> TypeKind.VoidType;
-            default -> throw new IllegalStateException("Bad type: " + s);
+            default -> throw new IllegalArgumentException("Bad type: " + s);
         };
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/TypeKind.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/TypeKind.java
@@ -50,8 +50,6 @@ public enum TypeKind {
     /** void */
     VoidType("void", "V", -1);
 
-    private static TypeKind[] newarraycodeToTypeTag;
-
     private final String name;
     private final String descriptor;
     private final int newarraycode;
@@ -102,13 +100,17 @@ public enum TypeKind {
      * @param newarraycode the operand of the {@code newarray} instruction
      */
     public static TypeKind fromNewArrayCode(int newarraycode) {
-        if (newarraycodeToTypeTag == null) {
-            newarraycodeToTypeTag = new TypeKind[12];
-            for (TypeKind tag : TypeKind.values()) {
-                if (tag.newarraycode > 0) newarraycodeToTypeTag[tag.newarraycode] = tag;
-            }
-        }
-        return newarraycodeToTypeTag[newarraycode];
+        return switch (newarraycode) {
+            case 4 -> TypeKind.BooleanType;
+            case 5 -> TypeKind.CharType;
+            case 6 -> TypeKind.FloatType;
+            case 7 -> TypeKind.DoubleType;
+            case 8 -> TypeKind.ByteType;
+            case 9 -> TypeKind.ShortType;
+            case 10 -> TypeKind.IntType;
+            case 11 -> TypeKind.LongType;
+            default -> throw new IllegalStateException("Bad new array code: " + newarraycode);
+        };
     }
 
     /**


### PR DESCRIPTION
jdk/classfile/CorpusTest.java rarely fails in 1 of 6754 parametrised parallel junit tests

The root cause seems to be thread-unsafe lazy initialisation of `TypeKind.newarraycodeToTypeTag` in `TypeKind::fromNewArrayCode`. Provided patch replaces that lazy-initialized helper array with switch expression.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303910](https://bugs.openjdk.org/browse/JDK-8303910): jdk/classfile/CorpusTest.java failed 1 of 6754 tests


### Reviewers
 * @liach (no known openjdk.org user name / role)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13004/head:pull/13004` \
`$ git checkout pull/13004`

Update a local copy of the PR: \
`$ git checkout pull/13004` \
`$ git pull https://git.openjdk.org/jdk pull/13004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13004`

View PR using the GUI difftool: \
`$ git pr show -t 13004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13004.diff">https://git.openjdk.org/jdk/pull/13004.diff</a>

</details>
