### PR TITLE
8304059: Use InstanceKlass in dependencies

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1255,8 +1255,8 @@ void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassD
   // can happen
   NoSafepointVerifier nsv;
   for (DepChange::ContextStream str(changes, nsv); str.next(); ) {
-    Klass* d = str.klass();
-    InstanceKlass::cast(d)->mark_dependent_nmethods(deopt_scope, changes);
+    InstanceKlass* d = str.klass();
+    d->mark_dependent_nmethods(deopt_scope, changes);
   }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1166,7 +1166,7 @@ Klass* AbstractClassHierarchyWalker::find_witness(InstanceKlass* context_type, K
       return nullptr; // no implementors
     } else if (nof_impls == 1) { // unique implementor
       assert(context_type != context_type->implementor(), "not unique");
-      context_type = InstanceKlass::cast(context_type->implementor());
+      context_type = context_type->implementor();
     } else { // nof_impls >= 2
       // Avoid this case: *I.m > { A.m, C }; B.m > C
       // Here, I.m has 2 concrete implementations, but m appears unique
@@ -1597,10 +1597,9 @@ bool Dependencies::verify_method_context(InstanceKlass* ctxk, Method* m) {
     return true;  // Must punt the assertion to true.
   }
   Method* lm = ctxk->lookup_method(m->name(), m->signature());
-  if (lm == nullptr && ctxk->is_instance_klass()) {
+  if (lm == nullptr) {
     // It might be an interface method
-    lm = InstanceKlass::cast(ctxk)->lookup_method_in_ordered_interfaces(m->name(),
-                                                                        m->signature());
+    lm = ctxk->lookup_method_in_ordered_interfaces(m->name(), m->signature());
   }
   if (lm == m) {
     // Method m is inherited into ctxk.
@@ -2174,7 +2173,7 @@ Klass* Dependencies::DepStream::spot_check_dependency_at(DepChange& changes) {
 void DepChange::print() {
   int nsup = 0, nint = 0;
   for (ContextStream str(*this); str.next(); ) {
-    Klass* k = str.klass();
+    InstanceKlass* k = str.klass();
     switch (str.change_type()) {
     case Change_new_type:
       tty->print_cr("  dependee = %s", k->external_name());
@@ -2203,7 +2202,7 @@ void DepChange::print() {
 }
 
 void DepChange::ContextStream::start() {
-  Klass* type = (_changes.is_klass_change() ? _changes.as_klass_change()->type() : (Klass*) nullptr);
+  InstanceKlass* type = (_changes.is_klass_change() ? _changes.as_klass_change()->type() : (InstanceKlass*) nullptr);
   _change_type = (type == nullptr ? NO_CHANGE : Start_Klass);
   _klass = type;
   _ti_base = nullptr;
@@ -2214,7 +2213,7 @@ void DepChange::ContextStream::start() {
 bool DepChange::ContextStream::next() {
   switch (_change_type) {
   case Start_Klass:             // initial state; _klass is the new type
-    _ti_base = InstanceKlass::cast(_klass)->transitive_interfaces();
+    _ti_base = _klass->transitive_interfaces();
     _ti_index = 0;
     _change_type = Change_new_type;
     return true;
@@ -2224,7 +2223,7 @@ bool DepChange::ContextStream::next() {
   case Change_new_sub:
     // 6598190: brackets workaround Sun Studio C++ compiler bug 6629277
     {
-      _klass = _klass->super();
+      _klass = _klass->java_super();
       if (_klass != nullptr) {
         return true;
       }
@@ -2254,9 +2253,9 @@ void KlassDepChange::initialize() {
   // Mark all dependee and all its superclasses
   // Mark transitive interfaces
   for (ContextStream str(*this); str.next(); ) {
-    Klass* d = str.klass();
-    assert(!InstanceKlass::cast(d)->is_marked_dependent(), "checking");
-    InstanceKlass::cast(d)->set_is_marked_dependent(true);
+    InstanceKlass* d = str.klass();
+    assert(!d->is_marked_dependent(), "checking");
+    d->set_is_marked_dependent(true);
   }
 }
 
@@ -2264,8 +2263,8 @@ KlassDepChange::~KlassDepChange() {
   // Unmark all dependee and all its superclasses
   // Unmark transitive interfaces
   for (ContextStream str(*this); str.next(); ) {
-    Klass* d = str.klass();
-    InstanceKlass::cast(d)->set_is_marked_dependent(false);
+    InstanceKlass* d = str.klass();
+    d->set_is_marked_dependent(false);
   }
 }
 

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -714,7 +714,7 @@ class DepChange : public StackObj {
 
   // Usage:
   // for (DepChange::ContextStream str(changes); str.next(); ) {
-  //   Klass* k = str.klass();
+  //   InstanceKlass* k = str.klass();
   //   switch (str.change_type()) {
   //     ...
   //   }
@@ -725,8 +725,8 @@ class DepChange : public StackObj {
     friend class DepChange;
 
     // iteration variables:
-    ChangeType  _change_type;
-    Klass*      _klass;
+    ChangeType     _change_type;
+    InstanceKlass* _klass;
     Array<InstanceKlass*>* _ti_base;    // i.e., transitive_interfaces
     int         _ti_index;
     int         _ti_limit;
@@ -747,7 +747,7 @@ class DepChange : public StackObj {
     bool next();
 
     ChangeType change_type()     { return _change_type; }
-    Klass*     klass()           { return _klass; }
+    InstanceKlass* klass()       { return _klass; }
   };
   friend class DepChange::ContextStream;
 };

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -613,12 +613,12 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
           oop call_site = deps.argument_oop(0);
           MethodHandles::add_dependent_nmethod(call_site, nm);
         } else {
-          Klass* klass = deps.context_type();
-          if (klass == nullptr) {
+          InstanceKlass* ik = deps.context_type();
+          if (ik == nullptr) {
             continue;  // ignore things like evol_method
           }
           // record this nmethod as dependent on this klass
-          InstanceKlass::cast(klass)->add_dependent_nmethod(nm);
+          ik->add_dependent_nmethod(nm);
         }
       }
       NOT_PRODUCT(if (nm != nullptr)  note_java_nmethod(nm));
@@ -1496,13 +1496,13 @@ void nmethod::flush_dependencies() {
         oop call_site = deps.argument_oop(0);
         MethodHandles::clean_dependency_context(call_site);
       } else {
-        Klass* klass = deps.context_type();
-        if (klass == nullptr) {
+        InstanceKlass* ik = deps.context_type();
+        if (ik == nullptr) {
           continue;  // ignore things like evol_method
         }
         // During GC liveness of dependee determines class that needs to be updated.
         // The GC may clean dependency contexts concurrently and in parallel.
-        InstanceKlass::cast(klass)->clean_dependency_context();
+        ik->clean_dependency_context();
       }
     }
   }
@@ -2487,9 +2487,9 @@ void nmethod::print_dependencies() {
   tty->print_cr("Dependencies:");
   for (Dependencies::DepStream deps(this); deps.next(); ) {
     deps.print_dependency();
-    Klass* ctxk = deps.context_type();
+    InstanceKlass* ctxk = deps.context_type();
     if (ctxk != nullptr) {
-      if (ctxk->is_instance_klass() && InstanceKlass::cast(ctxk)->is_dependent_nmethod(this)) {
+      if (ctxk->is_dependent_nmethod(this)) {
         tty->print_cr("   [nmethod<=klass]%s", ctxk->external_name());
       }
     }


### PR DESCRIPTION
Please review this small change to eliminate InstanceKlass::cast() calls for things that should be already InstanceKlass.
Tested with tier1-4.