### PR TITLE
8300317: vmTestbase/nsk/stress/strace/strace* tests fail with "ERROR: wrong lengths of stack traces"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
@@ -139,7 +139,7 @@ public class strace015 extends StraceBase {
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
             int k = all.length;
-            if (count - k > 2) {
+            if (count - k > 3) {
                 complain("wrong lengths of stack traces:\n\t"
                         + threads[0].getName() + ": " + count
                         + "\t"


### PR DESCRIPTION
The same bug as https://bugs.openjdk.org/browse/JDK-8295099 vmTestbase/nsk/stress/strace/strace013.java failed with "TestFailure: wrong lengths of stack traces: strace013Thread0: NNN strace013Thread83: MMM"

The test starts failing after changing implementation of Object.wait() method in loom. This method might call Object.wait() and increase stack length of dump.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300317](https://bugs.openjdk.org/browse/JDK-8300317): vmTestbase/nsk/stress/strace/strace* tests fail with "ERROR: wrong lengths of stack traces"


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.org/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13008/head:pull/13008` \
`$ git checkout pull/13008`

Update a local copy of the PR: \
`$ git checkout pull/13008` \
`$ git pull https://git.openjdk.org/jdk pull/13008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13008`

View PR using the GUI difftool: \
`$ git pr show -t 13008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13008.diff">https://git.openjdk.org/jdk/pull/13008.diff</a>

</details>
