### PR TITLE
8304030: Configure call fails on AIX when using --with-gtest option.

### DIFF
--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -61,7 +61,7 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_GTEST],
 
         # Verify that the version is the required one.
         # This is a simplified version of TOOLCHAIN_CHECK_COMPILER_VERSION
-        gtest_version="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"
+        gtest_version="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -e 's/set(GOOGLETEST_VERSION \(.*\))/\1/'`"
         comparable_actual_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$gtest_version"`
         comparable_minimum_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$GTEST_MINIMUM_VERSION"`
         if test $comparable_actual_version -lt $comparable_minimum_version ; then


### PR DESCRIPTION
When calling configure with the --with-gtest option on AIX it fails with the following error:
...
checking for X11/Intrinsic.h... yes
checking for gtest... /sapmnt/sapjvm_work/openjdk/tools/gtest/googletest-1.13.0
/bin/sed: illegal option -- E
Usage: sed [-n] [-u] Script [File ...]
        sed [-n] [-u] [-e Script] ... [-f Script_file] ... [File ...]
configure: error: gtest version is too old, at least version 1.13.0 is required
configure exiting with result code 1

The sed on AIX does not support extended regex with the -E param. But it seems to me, that the extended regex param is not needed for the googletest version detection.

I would suggest to substitute the below line in make/autoconf/lib-tests.m4

gtest_version="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"

by

gtest_version="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -e 's/set(GOOGLETEST_VERSION \(.*\))/\1/'`"
 
That should work on AIX and all other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304030](https://bugs.openjdk.org/browse/JDK-8304030): Configure call fails on AIX when using --with-gtest option.


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13011/head:pull/13011` \
`$ git checkout pull/13011`

Update a local copy of the PR: \
`$ git checkout pull/13011` \
`$ git pull https://git.openjdk.org/jdk pull/13011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13011`

View PR using the GUI difftool: \
`$ git pr show -t 13011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13011.diff">https://git.openjdk.org/jdk/pull/13011.diff</a>

</details>
