### PR TITLE
8257455: javax/swing/Security/6378709/TimerHack.java and javax/swing/JFileChooser/4163841/AcceptAllFileFilterTest.java fails in CI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -195,7 +195,9 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
     }
 
     public int getSize() {
-        return fileCache.size();
+        synchronized(fileCache) {
+            return fileCache.size();
+        }
     }
 
     /**
@@ -206,7 +208,9 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
      * @return {@code true} if an element {@code o} is in file cache
      */
     public boolean contains(Object o) {
-        return fileCache.contains(o);
+        synchronized(fileCache) {
+            return fileCache.contains(o);
+        }
     }
 
     /**
@@ -216,11 +220,15 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
      * @return an index of element {@code o} in file cache
      */
     public int indexOf(Object o) {
-        return fileCache.indexOf(o);
+        synchronized(fileCache) {
+            return fileCache.indexOf(o);
+        }
     }
 
     public Object getElementAt(int index) {
-        return fileCache.get(index);
+        synchronized(fileCache) {
+            return fileCache.get(index);
+        }
     }
 
     /**


### PR DESCRIPTION
The issue is intermittent and was not able to reproduce it. Though through code analysis and bug reported logs, the issue seems to be in COM thread of `FilesLoader` class in `BasicDirectoryModel` file. Looks like there are certain places where the `filecache` variable isn't thread-safe, and this fix address the issue. 
Mach5 test runs are fine, no regressions were found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8257455`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8257455`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13012/head:pull/13012` \
`$ git checkout pull/13012`

Update a local copy of the PR: \
`$ git checkout pull/13012` \
`$ git pull https://git.openjdk.org/jdk.git pull/13012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13012`

View PR using the GUI difftool: \
`$ git pr show -t 13012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13012.diff">https://git.openjdk.org/jdk/pull/13012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13012#issuecomment-1467804945)