### PR TITLE
8300840: Update test runtime/Thread/StopAtExit.java to include Null Pointer Exception as one of the allowed exceptions

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/StopAtExit.java
+++ b/test/hotspot/jtreg/runtime/Thread/StopAtExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,11 @@ public class StopAtExit extends Thread {
             // ignore because we're testing JVM/TI StopThread() which throws it
         } catch (NoClassDefFoundError ncdfe) {
             // ignore because we're testing JVM/TI StopThread() which can cause it
+        } catch (NullPointerException npe) {
+            // NPE is expected
+            // Once the main thread "wakes" the target it next fires stop() at it,
+            // so if the target takes a while to actually return through the await() code,
+            // then the ThreadDeath hits where we don't want it.
         }
     }
 


### PR DESCRIPTION
In the test, NPE is caught with no action.
### Test
mach5 tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8300840`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8300840`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13013/head:pull/13013` \
`$ git checkout pull/13013`

Update a local copy of the PR: \
`$ git checkout pull/13013` \
`$ git pull https://git.openjdk.org/jdk.git pull/13013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13013`

View PR using the GUI difftool: \
`$ git pr show -t 13013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13013.diff">https://git.openjdk.org/jdk/pull/13013.diff</a>

</details>
