### PR TITLE
8270865: Print process ID with -Xlog:os

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -654,6 +654,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   Management::record_vm_init_completed();
 #endif // INCLUDE_MANAGEMENT
 
+  log_info(os)("Initialized VM with process ID %d", os::current_process_id());
+
   // Signal Dispatcher needs to be started before VMInit event is posted
   os::initialize_jdk_signal_support(CHECK_JNI_ERR);
 


### PR DESCRIPTION
Adds logging of the process ID fairly early in the process (right after `HOTSPOT_VM_INIT_END();`) as a quality of life improvement.

Citing the ticket:

> It's useful to add the PID into a log file. For example, we can use it to find the corresponding hs_err_<pid>.log

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270865](https://bugs.openjdk.org/browse/JDK-8270865): Print process ID with -Xlog:os


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13015/head:pull/13015` \
`$ git checkout pull/13015`

Update a local copy of the PR: \
`$ git checkout pull/13015` \
`$ git pull https://git.openjdk.org/jdk pull/13015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13015`

View PR using the GUI difftool: \
`$ git pr show -t 13015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13015.diff">https://git.openjdk.org/jdk/pull/13015.diff</a>

</details>
