### PR TITLE
Class.annotationData shouldn't be volatile

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4145,7 +4145,7 @@ public final class Class<T> implements java.io.Serializable,
 
     // Annotations cache
     @SuppressWarnings("UnusedDeclaration")
-    private transient volatile AnnotationData annotationData;
+    private transient AnnotationData annotationData;
 
     private AnnotationData annotationData() {
         while (true) { // retry loop


### PR DESCRIPTION
If we call `Class.annotationData()` under race we do paired read operations from two volatile fields (`Class.annotationData` and `Class.classRedefinedCount` respectively):
```java
AnnotationData annotationData = this.annotationData;
int classRedefinedCount = this.classRedefinedCount;
```
Here when we read from `this.classRedefinedCount` we do acquiring read i. e. this read "guards" all the preceding reads making the volatile on declaration of `Class.annotationData` unnecessary.

And when we assign a new value to `annotationData` and `classRedefinedCount` in `Atomic.casAnnotationData()`:
```java
if (Atomic.casAnnotationData(this, annotationData, newAnnotationData)) {
    // successfully installed new AnnotationData
    return newAnnotationData;
}
```
we rely on `unsafe.compareAndSetReference()` which according to its JavaDoc has memory semantics of a volatile read and write.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13017/head:pull/13017` \
`$ git checkout pull/13017`

Update a local copy of the PR: \
`$ git checkout pull/13017` \
`$ git pull https://git.openjdk.org/jdk.git pull/13017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13017`

View PR using the GUI difftool: \
`$ git pr show -t 13017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13017.diff">https://git.openjdk.org/jdk/pull/13017.diff</a>

</details>
