### PR TITLE
8304136: Match allocation and free in sspi.cpp

### DIFF
--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,7 +281,13 @@ get_full_name(WCHAR* input)
             continue;
         }
         if (input[i] == L'@') {
-            return _wcsdup(input);
+            size_t newlen = wcslen(input) + 1;
+            WCHAR* result = new WCHAR[newlen];
+            if (!result) {
+                return NULL;
+            }
+            wcscpy_s(result, newlen, input);
+            return result;
         }
     }
 
@@ -539,7 +545,7 @@ gss_export_name(OM_uint32 *minor_status,
     // We only deal with not-so-long names.
     // 04 01 00 ** 06 ** OID len:int32 name
     int mechLen = KRB5_OID.length;
-    char* buffer = new char[10 + mechLen + len];
+    char* buffer = (char*) malloc(10 + mechLen + len);
     if (buffer == NULL) {
         goto err;
     }
@@ -555,7 +561,7 @@ gss_export_name(OM_uint32 *minor_status,
     len = WideCharToMultiByte(CP_UTF8, 0, fullname, len,
                 buffer+10+mechLen, len, NULL, NULL);
     if (len == 0) {
-        delete[] buffer;
+        free(buffer);
         goto err;
     }
     exported_name->length = 10 + mechLen + len;
@@ -580,13 +586,13 @@ gss_display_name(OM_uint32 *minor_status,
 
     SEC_WCHAR* names = input_name->name;
     int len = (int)wcslen(names);
-    char* buffer = new char[4*len+1];
+    char* buffer = (char*) malloc(4*len+1);
     if (buffer == NULL) {
         return GSS_S_FAILURE;
     }
     len = WideCharToMultiByte(CP_UTF8, 0, names, len, buffer, 4*len, NULL, NULL);
     if (len == 0) {
-        delete[] buffer;
+        free(buffer);
         return GSS_S_FAILURE;
     }
     buffer[len] = 0;
@@ -802,6 +808,7 @@ gss_inquire_cred(OM_uint32 *minor_status,
         }
         SEC_WCHAR* names = new SEC_WCHAR[lstrlen(snames.sUserName) + 1];
         if (names == NULL) {
+            FreeContextBuffer(snames.sUserName);
             return GSS_S_FAILURE;
         }
         StringCchCopy(names, lstrlen(snames.sUserName) + 1, snames.sUserName);
@@ -990,7 +997,7 @@ gss_init_sec_context(OM_uint32 *minor_status,
     output_token->length = outSecBuff.cbBuffer;
     if (outSecBuff.cbBuffer) {
         // No idea how user would free the data. Let's duplicate one.
-        output_token->value = new char[outSecBuff.cbBuffer];
+        output_token->value = malloc(outSecBuff.cbBuffer);
         if (!output_token->value) {
             FreeContextBuffer(outSecBuff.pvBuffer);
             goto err;
@@ -1012,12 +1019,12 @@ gss_init_sec_context(OM_uint32 *minor_status,
         return GSS_S_COMPLETE;
     }
 err:
-    if (newCred) {
-        delete newCred;
-    }
     if (firstTime) {
         OM_uint32 dummy;
         gss_delete_sec_context(&dummy, context_handle, GSS_C_NO_BUFFER);
+    }
+    if (newCred) {
+        delete newCred;
     }
     if (output_token->value) {
         gss_release_buffer(NULL, output_token);
@@ -1241,7 +1248,7 @@ gss_get_mic(OM_uint32 *minor_status,
 
     secBuff[1].BufferType = SECBUFFER_TOKEN;
     secBuff[1].cbBuffer = context_handle->SecPkgContextSizes.cbMaxSignature;
-    secBuff[1].pvBuffer = msg_token->value = new char[secBuff[1].cbBuffer];
+    secBuff[1].pvBuffer = msg_token->value = malloc(secBuff[1].cbBuffer);
 
     if (!secBuff[1].pvBuffer) {
         goto err;
@@ -1260,7 +1267,7 @@ err:
     msg_token->length = 0;
     msg_token->value = NULL;
     if (secBuff[1].pvBuffer) {
-        delete[] secBuff[1].pvBuffer;
+        free(secBuff[1].pvBuffer);
     }
     return GSS_S_FAILURE;
 }
@@ -1324,7 +1331,7 @@ gss_wrap(OM_uint32 *minor_status,
 
     SECURITY_STATUS ss;
     SecBufferDesc buffDesc;
-    SecBuffer secBuff[3];
+    SecBuffer secBuff[3] = {0};
 
     buffDesc.ulVersion = SECBUFFER_VERSION;
     buffDesc.cBuffers = 3;
@@ -1332,11 +1339,11 @@ gss_wrap(OM_uint32 *minor_status,
 
     secBuff[0].BufferType = SECBUFFER_TOKEN;
     secBuff[0].cbBuffer = context_handle->SecPkgContextSizes.cbSecurityTrailer;
-    output_message_buffer->value = secBuff[0].pvBuffer = malloc(
+    secBuff[0].pvBuffer = malloc(
             context_handle->SecPkgContextSizes.cbSecurityTrailer
                     + input_message_buffer->length
                     + context_handle->SecPkgContextSizes.cbBlockSize);;
-    if (!output_message_buffer->value) {
+    if (!secBuff[0].pvBuffer) {
         goto err;
     }
 
@@ -1376,8 +1383,10 @@ gss_wrap(OM_uint32 *minor_status,
             secBuff[2].pvBuffer,
             secBuff[2].cbBuffer);
 
+    output_message_buffer->value = secBuff[0].pvBuffer;
     output_message_buffer->length = secBuff[0].cbBuffer + secBuff[1].cbBuffer
             + secBuff[2].cbBuffer;
+
     free(secBuff[1].pvBuffer);
     free(secBuff[2].pvBuffer);
 
@@ -1413,7 +1422,7 @@ gss_unwrap(OM_uint32 *minor_status,
 
     SECURITY_STATUS ss;
     SecBufferDesc buffDesc;
-    SecBuffer secBuff[2];
+    SecBuffer secBuff[2] = {0};
     ULONG ulQop = 0;
 
     buffDesc.cBuffers = 2;
@@ -1445,7 +1454,7 @@ gss_unwrap(OM_uint32 *minor_status,
 
     // Must allocate a new memory block so client can release it correctly
     output_message_buffer->length = secBuff[1].cbBuffer;
-    output_message_buffer->value = new char[secBuff[1].cbBuffer];
+    output_message_buffer->value = malloc(secBuff[1].cbBuffer);
 
     if (!output_message_buffer->value) {
         goto err;
@@ -1595,7 +1604,7 @@ gss_display_status(OM_uint32 *minor_status,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
             msg, 256, 0);
     if (len > 0) {
-        status_string->value = new char[len + 20];
+        status_string->value = malloc(len + 20);
         if (!status_string->value) {
             status_string = GSS_C_NO_BUFFER;
             return GSS_S_FAILURE;
@@ -1604,7 +1613,7 @@ gss_display_status(OM_uint32 *minor_status,
                 (LPSTR)status_string->value, len + 19,
                 "(%lx) %ls", status_value, msg);
     } else {
-        status_string->value = new char[33];
+        status_string->value = malloc(33);
         if (!status_string->value) {
             status_string = GSS_C_NO_BUFFER;
             return GSS_S_FAILURE;
@@ -1662,7 +1671,7 @@ gss_release_buffer(OM_uint32 *minor_status,
         return GSS_S_COMPLETE;
     }
     if (buffer->value) {
-        delete[] buffer->value;
+        free(buffer->value);
         buffer->value = NULL;
     }
     buffer->length = 0;


### PR DESCRIPTION
After this change, `gss_buffer_t` always uses `malloc` and `free`. All others use `new` and `delete`. It also initializes several `SecBuffer` to zeroes so it's safe to check for null when trying to free them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304136](https://bugs.openjdk.org/browse/JDK-8304136): Match allocation and free in sspi.cpp


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13018/head:pull/13018` \
`$ git checkout pull/13018`

Update a local copy of the PR: \
`$ git checkout pull/13018` \
`$ git pull https://git.openjdk.org/jdk.git pull/13018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13018`

View PR using the GUI difftool: \
`$ git pr show -t 13018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13018.diff">https://git.openjdk.org/jdk/pull/13018.diff</a>

</details>
