### PR TITLE
8304148: Remapping a class with Invokedynamic constant loses static bootstrap arguments

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/components/ClassRemapper.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/ClassRemapper.java
@@ -317,7 +317,9 @@ public sealed interface ClassRemapper extends ClassTransform {
                     case InvokeDynamicInstruction idi ->
                         cob.invokeDynamicInstruction(DynamicCallSiteDesc.of(
                                 idi.bootstrapMethod(), idi.name().stringValue(),
-                                mapMethodDesc(idi.typeSymbol())));
+                                mapMethodDesc(idi.typeSymbol()),
+                                idi.bootstrapArgs().stream().map(this::mapConstantValue).toArray(ConstantDesc[]::new)
+                                ));
                     case NewObjectInstruction c ->
                         cob.newObjectInstruction(map(c.className().asSymbol()));
                     case NewReferenceArrayInstruction c ->

--- a/src/java.base/share/classes/jdk/internal/classfile/components/ClassRemapper.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/ClassRemapper.java
@@ -318,8 +318,7 @@ public sealed interface ClassRemapper extends ClassTransform {
                         cob.invokeDynamicInstruction(DynamicCallSiteDesc.of(
                                 idi.bootstrapMethod(), idi.name().stringValue(),
                                 mapMethodDesc(idi.typeSymbol()),
-                                idi.bootstrapArgs().stream().map(this::mapConstantValue).toArray(ConstantDesc[]::new)
-                                ));
+                                idi.bootstrapArgs().stream().map(this::mapConstantValue).toArray(ConstantDesc[]::new)));
                     case NewObjectInstruction c ->
                         cob.newObjectInstruction(map(c.className().asSymbol()));
                     case NewReferenceArrayInstruction c ->

--- a/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
+++ b/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
@@ -211,6 +211,7 @@ class AdvancedTransformationsTest {
                 "INVOKESTATIC, owner: AdvancedTransformationsTest$Bar, method name: fooMethod, method type: (LAdvancedTransformationsTest$Bar;)LAdvancedTransformationsTest$Bar",
                 "method type: ()LAdvancedTransformationsTest$Bar;",
                 "GETFIELD, owner: AdvancedTransformationsTest$Rec, field name: foo, field type: LAdvancedTransformationsTest$Bar;");
+        assertFalse(out.contains("bootstrap method arguments indexes: []"), "bootstrap arguments lost");
     }
 
     private static void assertContains(String actual, String... expected) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304148](https://bugs.openjdk.org/browse/JDK-8304148): Remapping a class with Invokedynamic constant loses static bootstrap arguments


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13021/head:pull/13021` \
`$ git checkout pull/13021`

Update a local copy of the PR: \
`$ git checkout pull/13021` \
`$ git pull https://git.openjdk.org/jdk.git pull/13021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13021`

View PR using the GUI difftool: \
`$ git pr show -t 13021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13021.diff">https://git.openjdk.org/jdk/pull/13021.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13021#issuecomment-1468373873)