### PR TITLE
8304138: [JVMCI] Test FailedSpeculation existence before appending.

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -838,7 +838,7 @@ bool FailedSpeculation::add_failed_speculation(nmethod* nm, FailedSpeculation** 
   assert(failed_speculations_address != nullptr, "must be");
 
   FailedSpeculation** cursor = failed_speculations_address;
-  while (*cursor != NULL) {
+  while (*cursor != nullptr) {
     if ((*cursor)->data_len() == speculation_len && memcmp(speculation, (*cursor)->data(), speculation_len) == 0) {
       return false;
     }
@@ -855,7 +855,6 @@ bool FailedSpeculation::add_failed_speculation(nmethod* nm, FailedSpeculation** 
   guarantee(is_aligned(fs, sizeof(FailedSpeculation*)), "FailedSpeculation objects must be pointer aligned");
   guarantee_failed_speculations_alive(nm, failed_speculations_address);
 
-  cursor = failed_speculations_address;
   do {
     if (*cursor == nullptr) {
       FailedSpeculation* old_fs = Atomic::cmpxchg(cursor, (FailedSpeculation*) nullptr, fs);


### PR DESCRIPTION
Upon uncommon_trap, JVMCI runtime appends a FailedSpeculation entry to the nmethod using an [atomic operation](https://github.com/openjdk/jdk/blob/55aa122462c34d8f4cafa58f4d1f2d900449c83e/src/hotspot/share/oops/methodData.cpp#L852). It becomes a performance bottleneck when there is a large amount of (virtual) threads deoptimizing in the nmethod. In this PR, we test if a FailedSpeculation exists in the list before appending it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304138](https://bugs.openjdk.org/browse/JDK-8304138): [JVMCI] Test FailedSpeculation existence before appending.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to [e8c7eec4](https://git.openjdk.org/jdk/pull/13022/files/e8c7eec468b049e15bf54bac280585389935a37d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13022/head:pull/13022` \
`$ git checkout pull/13022`

Update a local copy of the PR: \
`$ git checkout pull/13022` \
`$ git pull https://git.openjdk.org/jdk pull/13022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13022`

View PR using the GUI difftool: \
`$ git pr show -t 13022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13022.diff">https://git.openjdk.org/jdk/pull/13022.diff</a>

</details>
