### PR TITLE
8304144: G1: Remove unnecessary is_survivor check in G1ClearCardTableTask

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -253,9 +253,7 @@ private:
 
         for (uint i = next; i < max; i++) {
           HeapRegion* r = _g1h->region_at(_regions->at(i));
-          if (!r->is_survivor()) {
-            r->clear_cardtable();
-          }
+          r->clear_cardtable();
         }
       }
     }


### PR DESCRIPTION
Simple removing redundant check.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304144](https://bugs.openjdk.org/browse/JDK-8304144): G1: Remove unnecessary is_survivor check in G1ClearCardTableTask


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13023/head:pull/13023` \
`$ git checkout pull/13023`

Update a local copy of the PR: \
`$ git checkout pull/13023` \
`$ git pull https://git.openjdk.org/jdk.git pull/13023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13023`

View PR using the GUI difftool: \
`$ git pr show -t 13023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13023.diff">https://git.openjdk.org/jdk/pull/13023.diff</a>

</details>
