### PR TITLE
8304161: Add TypeKind.from to derive from TypeDescriptor.OfField

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/TypeKind.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/TypeKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package jdk.internal.classfile;
+
+import java.lang.invoke.TypeDescriptor;
 
 /**
  * Describes the types that can be part of a field or method descriptor.
@@ -131,5 +133,13 @@ public enum TypeKind {
             case 'V' -> TypeKind.VoidType;
             default -> throw new IllegalArgumentException("Bad type: " + s);
         };
+    }
+
+    /**
+     * {@return the type kind associated with the specified field descriptor}
+     * @param descriptor the field descriptor
+     */
+    public static TypeKind from(TypeDescriptor.OfField<?> descriptor) {
+        return fromDescriptor(descriptor.descriptorString());
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/components/CodeLocalsShifter.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/CodeLocalsShifter.java
@@ -57,7 +57,7 @@ public sealed interface CodeLocalsShifter extends CodeTransform {
     static CodeLocalsShifter of(AccessFlags methodFlags, MethodTypeDesc methodDescriptor) {
         int fixed = methodFlags.has(AccessFlag.STATIC) ? 0 : 1;
         for (var param : methodDescriptor.parameterList())
-            fixed += TypeKind.fromDescriptor(param.descriptorString()).slotSize();
+            fixed += TypeKind.from(param).slotSize();
         return new CodeLocalsShifterImpl(fixed);
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/CodeStackTracker.java
@@ -235,13 +235,13 @@ public sealed interface CodeStackTracker extends CodeTransform {
                 case InvokeDynamicInstruction i -> {
                     var type = i.typeSymbol();
                     pop(type.parameterCount());
-                    push(TypeKind.fromDescriptor(type.returnType().descriptorString()));
+                    push(TypeKind.from(type.returnType()));
                 }
                 case InvokeInstruction i -> {
                     var type = i.typeSymbol();
                     pop(type.parameterCount());
                     if (i.opcode() != Opcode.INVOKESTATIC) pop(1);
-                    push(TypeKind.fromDescriptor(type.returnType().descriptorString()));
+                    push(TypeKind.from(type.returnType()));
                 }
                 case LoadInstruction i ->
                     push(i.typeKind());

--- a/src/java.base/share/classes/jdk/internal/classfile/components/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/snippet-files/PackageSnippets.java
@@ -173,7 +173,7 @@ class PackageSnippets {
                                                 if (!mm.flags().has(AccessFlag.STATIC))
                                                     storeStack.push(StoreInstruction.of(TypeKind.ReferenceType, slot++));
                                                 for (var pt : mm.methodTypeSymbol().parameterList()) {
-                                                    var tk = TypeKind.fromDescriptor(pt.descriptorString());
+                                                    var tk = TypeKind.from(pt);
                                                     storeStack.push(StoreInstruction.of(tk, slot));
                                                     slot += tk.slotSize();
                                                 }

--- a/src/java.base/share/classes/jdk/internal/classfile/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/snippet-files/PackageSnippets.java
@@ -267,7 +267,7 @@ class PackageSnippets {
                                                 if (!mm.flags().has(AccessFlag.STATIC))
                                                     storeStack.add(StoreInstruction.of(TypeKind.ReferenceType, slot++));
                                                 for (var pt : mm.methodTypeSymbol().parameterList()) {
-                                                    var tk = TypeKind.fromDescriptor(pt.descriptorString());
+                                                    var tk = TypeKind.from(pt);
                                                     storeStack.addFirst(StoreInstruction.of(tk, slot));
                                                     slot += tk.slotSize();
                                                 }

--- a/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
+++ b/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
@@ -319,7 +319,7 @@ class AdvancedTransformationsTest {
                                                 if (!mm.flags().has(AccessFlag.STATIC))
                                                     storeStack.push(StoreInstruction.of(TypeKind.ReferenceType, slot++));
                                                 for (var pt : mm.methodTypeSymbol().parameterList()) {
-                                                    var tk = TypeKind.fromDescriptor(pt.descriptorString());
+                                                    var tk = TypeKind.from(pt);
                                                     storeStack.push(StoreInstruction.of(tk, slot));
                                                     slot += tk.slotSize();
                                                 }


### PR DESCRIPTION
Such an API allows creating TypeKind from both Class and ClassDesc than having to call descriptorString() explicitly at every use site.

See https://mail.openjdk.org/pipermail/classfile-api-dev/2023-March/000240.html for context.

Upgraded usages of `fromDescriptor` to `from` in applicable use sites in Classfile API and its tests.