### PR TITLE
8301308: Remove version conditionalization for gcc/clang PRAGMA_DIAG_PUSH/POP

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -36,6 +36,9 @@
 
 #define PRAGMA_DISABLE_GCC_WARNING(optstring) _Pragma(STR(GCC diagnostic ignored optstring))
 
+#define PRAGMA_DIAG_PUSH             _Pragma("GCC diagnostic push")
+#define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
+
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED                \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-nonliteral")     \
   PRAGMA_DISABLE_GCC_WARNING("-Wformat-security")
@@ -55,16 +58,6 @@
 #endif
 
 #define PRAGMA_NONNULL_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wnonnull")
-
-#if defined(__clang_major__) && \
-      (__clang_major__ >= 4 || \
-      (__clang_major__ >= 3 && __clang_minor__ >= 1)) || \
-    ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6)) || (__GNUC__ > 4)
-// Tested to work with clang version 3.1 and better.
-#define PRAGMA_DIAG_PUSH             _Pragma("GCC diagnostic push")
-#define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
-
-#endif // clang/gcc version check
 
 #if (__GNUC__ >= 10)
 // TODO: Re-enable warning attribute for Clang once


### PR DESCRIPTION
As of now we at minimum require clang 3.5 and gcc 6 to compile the Java Platform, the version checks for gcc/clang here are for whether clang is either version 4 and above, or has a minor version higher than 3.1, and for gcc either a major version higher than 4 or minor version above 4.6. Now these will always pass, so they can be removed. Also changes the macro definition location to match Visual C++ and look neater

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301308](https://bugs.openjdk.org/browse/JDK-8301308): Remove version conditionalization for gcc/clang PRAGMA_DIAG_PUSH/POP


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13025/head:pull/13025` \
`$ git checkout pull/13025`

Update a local copy of the PR: \
`$ git checkout pull/13025` \
`$ git pull https://git.openjdk.org/jdk pull/13025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13025`

View PR using the GUI difftool: \
`$ git pr show -t 13025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13025.diff">https://git.openjdk.org/jdk/pull/13025.diff</a>

</details>
