### PR TITLE
JDK-8304171: Fix layout of JCov instrumented bundle on Mac OS

### DIFF
--- a/make/Bundles.gmk
+++ b/make/Bundles.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -449,7 +449,7 @@ ifneq ($(filter jcov-bundles, $(MAKECMDGOALS)), )
       BUNDLE_NAME := $(JCOV_BUNDLE_NAME), \
       FILES := $(JCOV_BUNDLE_FILES), \
       BASE_DIRS := $(JCOV_IMAGE_DIR), \
-      SUBDIR := $(JDK_BUNDLE_SUBDIR), \
+      SUBDIR := jdk-$(VERSION_NUMBER), \
   ))
 
   JCOV_TARGETS += $(BUILD_JCOV_BUNDLE)

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -851,7 +851,7 @@ var getJibProfilesProfiles = function (input, common, data) {
     [ "linux-aarch64", "linux-x64", "macosx-x64", "macosx-aarch64", "windows-x64" ]
         .forEach(function (name) {
             var o = artifactData[name]
-            var jdk_subdir = (o.jdk_subdir != null ? o.jdk_subdir : "jdk-" + data.version);
+            var jdk_subdir = "jdk-" + data.version;
             var jdk_suffix = (o.jdk_suffix != null ? o.jdk_suffix : "tar.gz");
             var pf = o.platform
             var jcovName = name + "-jcov";


### PR DESCRIPTION
Now on all platforms the JCov bundle would look the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304171](https://bugs.openjdk.org/browse/JDK-8304171): Fix layout of JCov instrumented bundle on Mac OS


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13027/head:pull/13027` \
`$ git checkout pull/13027`

Update a local copy of the PR: \
`$ git checkout pull/13027` \
`$ git pull https://git.openjdk.org/jdk pull/13027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13027`

View PR using the GUI difftool: \
`$ git pr show -t 13027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13027.diff">https://git.openjdk.org/jdk/pull/13027.diff</a>

</details>
