### PR TITLE
8304174: Remove delays from httpserver tests

### DIFF
--- a/test/jdk/com/sun/net/httpserver/DateFormatterTest.java
+++ b/test/jdk/com/sun/net/httpserver/DateFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/DateFormatterTest.java
+++ b/test/jdk/com/sun/net/httpserver/DateFormatterTest.java
@@ -87,7 +87,7 @@ public class DateFormatterTest {
 
     @AfterTest
     public void cleanUp() {
-        server.stop(1);
+        server.stop(0);
     }
 
     @Test

--- a/test/jdk/com/sun/net/httpserver/HttpServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/HttpServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpServerTest.java
@@ -60,7 +60,7 @@ public class HttpServerTest implements HttpHandler {
         sendHttpStatusCode(HTTP_STATUS_CODE_OK, ex);
 
         System.out.println("Stopping server ...");
-        server.stop(1);
+        server.stop(0);
         serverStopped.countDown();
     }
 

--- a/test/jdk/com/sun/net/httpserver/SelCacheTest.java
+++ b/test/jdk/com/sun/net/httpserver/SelCacheTest.java
@@ -89,9 +89,8 @@ public class SelCacheTest extends Test {
             test(false, "https", root+"/test1", loopback, httpsport, "largefile.txt", 2730088);
             System.out.println("OK");
         } finally {
-            delay();
-            s1.stop(2);
-            s2.stop(2);
+            s1.stop(0);
+            s2.stop(0);
             executor.shutdown();
         }
     }

--- a/test/jdk/com/sun/net/httpserver/SelCacheTest.java
+++ b/test/jdk/com/sun/net/httpserver/SelCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test.java
+++ b/test/jdk/com/sun/net/httpserver/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test.java
+++ b/test/jdk/com/sun/net/httpserver/Test.java
@@ -35,10 +35,4 @@ public class Test {
         logger.setLevel(Level.ALL);
         logger.addHandler(h);
     }
-
-    static void delay () {
-        try {
-            Thread.sleep (1000);
-        } catch (Exception e) {}
-    }
 }

--- a/test/jdk/com/sun/net/httpserver/Test1.java
+++ b/test/jdk/com/sun/net/httpserver/Test1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test1.java
+++ b/test/jdk/com/sun/net/httpserver/Test1.java
@@ -95,11 +95,10 @@ public class Test1 extends Test {
             test (false, "https", root+"/test1", httpsport, "largefile.txt", 2730088);
             System.out.println ("OK");
         } finally {
-            delay();
             if (s1 != null)
-                s1.stop(2);
+                s1.stop(0);
             if (s2 != null)
-                s2.stop(2);
+                s2.stop(0);
             if (executor != null)
                 executor.shutdown ();
         }

--- a/test/jdk/com/sun/net/httpserver/Test10.java
+++ b/test/jdk/com/sun/net/httpserver/Test10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test10.java
+++ b/test/jdk/com/sun/net/httpserver/Test10.java
@@ -57,9 +57,8 @@ public class Test10 extends Test {
             doClient(port);
             System.out.println ("OK");
         } finally {
-            delay();
             if (server != null)
-                server.stop(2);
+                server.stop(0);
             if (exec != null)
                 exec.shutdown();
         }

--- a/test/jdk/com/sun/net/httpserver/Test11.java
+++ b/test/jdk/com/sun/net/httpserver/Test11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test11.java
+++ b/test/jdk/com/sun/net/httpserver/Test11.java
@@ -78,7 +78,7 @@ public class Test11 {
             System.out.println ("OK");
         } finally {
             s.shutdown();
-            server.stop(2);
+            server.stop(0);
         }
     }
 }

--- a/test/jdk/com/sun/net/httpserver/Test12.java
+++ b/test/jdk/com/sun/net/httpserver/Test12.java
@@ -88,11 +88,10 @@ public class Test12 extends Test {
             join (r);
             System.out.println ("OK");
         } finally {
-            delay();
             if (s1 != null)
-                s1.stop(2);
+                s1.stop(0);
             if (s2 != null)
-                s2.stop(2);
+                s2.stop(0);
             if (executor != null)
                 executor.shutdown ();
         }

--- a/test/jdk/com/sun/net/httpserver/Test12.java
+++ b/test/jdk/com/sun/net/httpserver/Test12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test13.java
+++ b/test/jdk/com/sun/net/httpserver/Test13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test13.java
+++ b/test/jdk/com/sun/net/httpserver/Test13.java
@@ -93,11 +93,10 @@ public class Test13 extends Test {
             join (r);
             System.out.println ("OK");
         } finally {
-            delay();
             if (s1 != null)
-                s1.stop(2);
+                s1.stop(0);
             if (s2 != null)
-                s2.stop(2);
+                s2.stop(0);
             if (executor != null)
                 executor.shutdown ();
         }

--- a/test/jdk/com/sun/net/httpserver/Test14.java
+++ b/test/jdk/com/sun/net/httpserver/Test14.java
@@ -114,7 +114,7 @@ public class Test14 extends Test {
             output = output + (char)x;
         }
         error = !output.equals (test_output);
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         if (error ) {
             throw new RuntimeException ("test failed error");

--- a/test/jdk/com/sun/net/httpserver/Test14.java
+++ b/test/jdk/com/sun/net/httpserver/Test14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test2.java
+++ b/test/jdk/com/sun/net/httpserver/Test2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test2.java
+++ b/test/jdk/com/sun/net/httpserver/Test2.java
@@ -79,7 +79,7 @@ public class Test2 extends Test {
         while (is.read()!= -1) {
             c ++;
         }
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         if (error ) {
             throw new RuntimeException ("test failed error");

--- a/test/jdk/com/sun/net/httpserver/Test3.java
+++ b/test/jdk/com/sun/net/httpserver/Test3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test3.java
+++ b/test/jdk/com/sun/net/httpserver/Test3.java
@@ -64,9 +64,8 @@ public class Test3 extends Test {
             doClient(port);
             System.out.println ("OK");
         } finally {
-            delay();
             if (server != null)
-                server.stop(2);
+                server.stop(0);
             if (exec != null)
                 exec.shutdown();
         }

--- a/test/jdk/com/sun/net/httpserver/Test4.java
+++ b/test/jdk/com/sun/net/httpserver/Test4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test4.java
+++ b/test/jdk/com/sun/net/httpserver/Test4.java
@@ -62,9 +62,8 @@ public class Test4 extends Test {
             doClient(port);
             System.out.println ("OK");
         } finally {
-            delay();
             if (server != null)
-                server.stop(2);
+                server.stop(0);
             if (exec != null)
                 exec.shutdown();
         }

--- a/test/jdk/com/sun/net/httpserver/Test5.java
+++ b/test/jdk/com/sun/net/httpserver/Test5.java
@@ -63,9 +63,8 @@ public class Test5 extends Test {
             doClient(port);
             System.out.println ("OK");
         } finally {
-            delay ();
             if (server != null)
-                server.stop(2);
+                server.stop(0);
             if (exec != null)
                 exec.shutdown();
         }

--- a/test/jdk/com/sun/net/httpserver/Test5.java
+++ b/test/jdk/com/sun/net/httpserver/Test5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test6.java
+++ b/test/jdk/com/sun/net/httpserver/Test6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test6.java
+++ b/test/jdk/com/sun/net/httpserver/Test6.java
@@ -81,8 +81,7 @@ public class Test6 extends Test {
         if (error) {
             throw new RuntimeException ("test failed error");
         }
-        delay();
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         System.out.println ("OK");
 

--- a/test/jdk/com/sun/net/httpserver/Test6a.java
+++ b/test/jdk/com/sun/net/httpserver/Test6a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test6a.java
+++ b/test/jdk/com/sun/net/httpserver/Test6a.java
@@ -86,8 +86,7 @@ public class Test6a extends Test {
         if (error) {
             throw new RuntimeException ("test failed error");
         }
-        delay();
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         System.out.println ("OK");
 

--- a/test/jdk/com/sun/net/httpserver/Test7.java
+++ b/test/jdk/com/sun/net/httpserver/Test7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test7.java
+++ b/test/jdk/com/sun/net/httpserver/Test7.java
@@ -80,8 +80,7 @@ public class Test7 extends Test {
         if (error) {
             throw new RuntimeException ("test failed error");
         }
-        delay();
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         System.out.println ("OK");
 

--- a/test/jdk/com/sun/net/httpserver/Test7a.java
+++ b/test/jdk/com/sun/net/httpserver/Test7a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test7a.java
+++ b/test/jdk/com/sun/net/httpserver/Test7a.java
@@ -89,8 +89,7 @@ public class Test7a extends Test {
         if (error) {
             throw new RuntimeException ("test failed error");
         }
-        delay();
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         System.out.println ("OK");
 

--- a/test/jdk/com/sun/net/httpserver/Test8.java
+++ b/test/jdk/com/sun/net/httpserver/Test8.java
@@ -80,8 +80,7 @@ public class Test8 extends Test {
         if (error) {
             throw new RuntimeException ("test failed error");
         }
-        delay();
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         System.out.println ("OK");
 

--- a/test/jdk/com/sun/net/httpserver/Test8.java
+++ b/test/jdk/com/sun/net/httpserver/Test8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test8a.java
+++ b/test/jdk/com/sun/net/httpserver/Test8a.java
@@ -99,8 +99,7 @@ public class Test8a extends Test {
             }
             is.close();
         } finally {
-            delay();
-            if (server != null) server.stop(2);
+            if (server != null) server.stop(0);
             if (executor != null) executor.shutdown();
         }
         if (error) {

--- a/test/jdk/com/sun/net/httpserver/Test8a.java
+++ b/test/jdk/com/sun/net/httpserver/Test8a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test9.java
+++ b/test/jdk/com/sun/net/httpserver/Test9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test9.java
+++ b/test/jdk/com/sun/net/httpserver/Test9.java
@@ -100,11 +100,10 @@ public class Test9 extends Test {
 
             System.out.println ("OK");
         } finally {
-            delay();
             if (s1 != null)
-                s1.stop(2);
+                s1.stop(0);
             if (s2 != null)
-                s2.stop(2);
+                s2.stop(0);
             if (executor != null)
                 executor.shutdown ();
         }

--- a/test/jdk/com/sun/net/httpserver/Test9a.java
+++ b/test/jdk/com/sun/net/httpserver/Test9a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/Test9a.java
+++ b/test/jdk/com/sun/net/httpserver/Test9a.java
@@ -96,9 +96,8 @@ public class Test9a extends Test {
 
             System.out.println ("OK");
         } finally {
-            delay();
             if (server != null)
-                server.stop(2);
+                server.stop(0);
             if (executor != null)
                 executor.shutdown();
         }

--- a/test/jdk/com/sun/net/httpserver/TestLogging.java
+++ b/test/jdk/com/sun/net/httpserver/TestLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/TestLogging.java
+++ b/test/jdk/com/sun/net/httpserver/TestLogging.java
@@ -105,9 +105,8 @@ public class TestLogging extends Test {
             os.close(); is.close(); s.close();
             System.out.println ("OK");
         } finally {
-            delay();
             if (s1 != null)
-                s1.stop(2);
+                s1.stop(0);
             if (executor != null)
                 executor.shutdown();
         }

--- a/test/jdk/com/sun/net/httpserver/bugs/8199849/BasicAuthenticatorCharset.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8199849/BasicAuthenticatorCharset.java
@@ -181,7 +181,7 @@ public class BasicAuthenticatorCharset {
             connectAndAuth("/test3/defaultCharset.html", 200);
         }
 
-        testHttpServer.stop(2);
+        testHttpServer.stop(0);
         executor.shutdown();
 
         // should fail once with UNICODE_PW and unsupporting character set

--- a/test/jdk/com/sun/net/httpserver/bugs/8199849/BasicAuthenticatorCharset.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8199849/BasicAuthenticatorCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/8199849/TestHttpUnicode.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8199849/TestHttpUnicode.java
@@ -94,7 +94,7 @@ public class TestHttpUnicode {
             InputStream is = testConnection.getInputStream();
             while (is.read() != -1) ;
         } finally {
-            testHttpServer.stop(2);
+            testHttpServer.stop(0);
         }
     }
 }

--- a/test/jdk/com/sun/net/httpserver/bugs/8199849/TestHttpUnicode.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/8199849/TestHttpUnicode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6339483.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6339483.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6339483.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6339483.java
@@ -66,7 +66,7 @@ public class B6339483 {
                 c ++;
             }
         } catch (IOException e) {
-            server.stop(2);
+            server.stop(0);
             executor.shutdown();
             System.out.println ("OK");
         }

--- a/test/jdk/com/sun/net/httpserver/bugs/B6341616.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6341616.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6341616.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6341616.java
@@ -75,7 +75,7 @@ public class B6341616 {
                 c ++;
             }
         } catch (IOException e) {
-            server.stop(2);
+            server.stop(0);
             executor.shutdown();
             System.out.println ("OK");
         }

--- a/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
@@ -126,7 +126,7 @@ public class B6361557 {
                 break;
             }
         }
-        server.stop (1);
+        server.stop(0);
         selector.close();
         executor.shutdown ();
 

--- a/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6393710.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6393710.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6393710.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6393710.java
@@ -96,7 +96,7 @@ public class B6393710 {
             ok = false;
         } finally {
             s.close();
-            server.stop(2);
+            server.stop(0);
         }
 
         if (requests != 1) {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6401598.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6401598.java
@@ -130,7 +130,7 @@ public class B6401598 {
                 } catch (Exception e) {
                     throw new AssertionError("Unexpected exception: " + e, e);
                 } finally {
-                        server.stop (1);
+                        server.stop(0);
                         exec.shutdown();
                 }
         }

--- a/test/jdk/com/sun/net/httpserver/bugs/B6401598.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6401598.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
@@ -85,7 +85,7 @@ public class B6431193 {
                       .toURL();
             InputStream is = url.openConnection(Proxy.NO_PROXY).getInputStream();
             read (is);
-            server.stop (1);
+            server.stop(0);
             if (error) {
                 throw new RuntimeException ("error in test");
             }

--- a/test/jdk/com/sun/net/httpserver/bugs/B6433018.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6433018.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6433018.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6433018.java
@@ -77,7 +77,7 @@ public class B6433018 {
             os.write(cmd.getBytes());
             finished.await(30, TimeUnit.SECONDS);
         } finally {
-            server.stop(2);
+            server.stop(0);
         }
 
         if (finished.getCount() != 0)

--- a/test/jdk/com/sun/net/httpserver/bugs/B6526158.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6526158.java
@@ -78,7 +78,7 @@ public class B6526158 {
             }
             is.close();
         } finally {
-            server.stop(2);
+            server.stop(0);
             executor.shutdown();
         }
         if (error) {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6526158.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6526158.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6526913.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6526913.java
@@ -71,7 +71,7 @@ public class B6526913 {
             }
             is.close();
         } finally {
-            server.stop(2);
+            server.stop(0);
             executor.shutdown();
         }
         if (error) {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6526913.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6526913.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6529200.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6529200.java
@@ -72,7 +72,7 @@ public class B6529200 {
                 /* test will timeout otherwise */
             }
         } catch (SocketTimeoutException e) {
-            server.stop (2);
+            server.stop(0);
             executor.shutdown ();
             throw new RuntimeException ("Test failed in test1");
         }
@@ -92,20 +92,20 @@ public class B6529200 {
                 buf[i++] = (byte)c;
             }
         } catch (SocketTimeoutException e) {
-            server.stop (2);
+            server.stop(0);
             executor.shutdown ();
             throw new RuntimeException ("Test failed in test2");
         }
 
         String ss = new String (buf, "ISO-8859-1");
         if (ss.indexOf ("\r\n\r\nhello world") == -1) {
-            server.stop (2);
+            server.stop(0);
             executor.shutdown ();
             throw new RuntimeException ("Test failed in test2: wrong string");
         }
         System.out.println (ss);
         is.close ();
-        server.stop (2);
+        server.stop(0);
         executor.shutdown();
     }
 

--- a/test/jdk/com/sun/net/httpserver/bugs/B6529200.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6529200.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6744329.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6744329.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6744329.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6744329.java
@@ -72,7 +72,7 @@ public class B6744329 {
             e.printStackTrace();
             error = true;
         }
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         if (error) {
             throw new RuntimeException ("Test failed");

--- a/test/jdk/com/sun/net/httpserver/bugs/B6886436.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6886436.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/B6886436.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6886436.java
@@ -74,11 +74,11 @@ public class B6886436 {
             is.close ();
 
         } catch (IOException e) {
-            server.stop(2);
+            server.stop(0);
             executor.shutdown();
             throw new RuntimeException ("Test failed");
         }
-        server.stop(2);
+        server.stop(0);
         executor.shutdown();
         System.out.println ("OK");
     }

--- a/test/jdk/com/sun/net/httpserver/bugs/B8211420.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B8211420.java
@@ -86,7 +86,7 @@ public class B8211420 {
                 throw new RuntimeException("Content-length not present or has wrong value");
             System.out.println("OK");
         } finally {
-            server.stop(2);
+            server.stop(0);
             executor.shutdown();
         }
     }

--- a/test/jdk/com/sun/net/httpserver/bugs/B8211420.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B8211420.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/bugs/HttpExchange/AutoCloseableHttpExchange.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/HttpExchange/AutoCloseableHttpExchange.java
@@ -101,7 +101,7 @@ public class AutoCloseableHttpExchange {
             connectAndCheck("/test");
         }
         latch.await();
-        testHttpServer.stop(2);
+        testHttpServer.stop(0);
         executor.shutdown();
 
         if (exchangeCloseFail.get())

--- a/test/jdk/com/sun/net/httpserver/bugs/HttpExchange/AutoCloseableHttpExchange.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/HttpExchange/AutoCloseableHttpExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/net/SimpleHttpServer.java
+++ b/test/lib/jdk/test/lib/net/SimpleHttpServer.java
@@ -71,7 +71,7 @@ public class SimpleHttpServer {
     }
 
     public void stop() {
-        httpServer.stop(2);
+        httpServer.stop(0);
         executor.shutdown();
     }
 

--- a/test/lib/jdk/test/lib/net/SimpleHttpServer.java
+++ b/test/lib/jdk/test/lib/net/SimpleHttpServer.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This change improves the running time of many httpserver tests; it removes the one second delay introduced by `delay()` calls, and performs immediate httpserver stop by calling `stop(0)`.

For example, `com/sun/net/httpserver/Test1.java` usually takes 20-30 seconds without this change; with this change it completes in 5-8 seconds.

Tiers 1-3 still green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304174](https://bugs.openjdk.org/browse/JDK-8304174): Remove delays from httpserver tests


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13028/head:pull/13028` \
`$ git checkout pull/13028`

Update a local copy of the PR: \
`$ git checkout pull/13028` \
`$ git pull https://git.openjdk.org/jdk pull/13028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13028`

View PR using the GUI difftool: \
`$ git pr show -t 13028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13028.diff">https://git.openjdk.org/jdk/pull/13028.diff</a>

</details>
