### PR TITLE
8304172: ProblemList serviceability/sa/UniqueVtableTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -120,7 +120,7 @@ serviceability/sa/ClhsdbPmap.java#core 8294316,8267433 macosx-x64
 serviceability/sa/ClhsdbPstack.java#core 8294316,8267433 macosx-x64
 serviceability/sa/TestJmapCore.java 8294316,8267433 macosx-x64
 serviceability/sa/TestJmapCoreMetaspace.java 8294316,8267433 macosx-x64
-serviceability/sa/UniqueVtableTest.java 8303921 linux-all
+serviceability/sa/UniqueVtableTest.java 8303921 generic-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,6 +67,8 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
+compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Trivial fixes to ProblemList a couple of tests:

[JDK-8304172](https://bugs.openjdk.org/browse/JDK-8304172) ProblemList serviceability/sa/UniqueVtableTest.java
[JDK-8304175](https://bugs.openjdk.org/browse/JDK-8304175) ProblemList compiler/vectorapi/VectorLogicalOpIdentityTest.java on 2 platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8304172](https://bugs.openjdk.org/browse/JDK-8304172): ProblemList serviceability/sa/UniqueVtableTest.java
 * [JDK-8304175](https://bugs.openjdk.org/browse/JDK-8304175): ProblemList compiler/vectorapi/VectorLogicalOpIdentityTest.java on 2 platforms


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13029/head:pull/13029` \
`$ git checkout pull/13029`

Update a local copy of the PR: \
`$ git checkout pull/13029` \
`$ git pull https://git.openjdk.org/jdk pull/13029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13029`

View PR using the GUI difftool: \
`$ git pr show -t 13029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13029.diff">https://git.openjdk.org/jdk/pull/13029.diff</a>

</details>
