### PR TITLE
8303921: serviceability/sa/UniqueVtableTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -122,7 +122,6 @@ serviceability/sa/ClhsdbPmap.java#core 8294316,8267433 macosx-x64
 serviceability/sa/ClhsdbPstack.java#core 8294316,8267433 macosx-x64
 serviceability/sa/TestJmapCore.java 8294316,8267433 macosx-x64
 serviceability/sa/TestJmapCoreMetaspace.java 8294316,8267433 macosx-x64
-serviceability/sa/UniqueVtableTest.java 8303921 generic-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 

--- a/test/hotspot/jtreg/serviceability/sa/TestIntConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestIntConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import jtreg.SkippedException;
  * @bug 8190307
  * @requires vm.hasSA
  * @library /test/lib
- * @build jdk.test.lib.apps.*
  * @run main/othervm TestIntConstant
  */
 

--- a/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import jtreg.SkippedException;
  * @library /test/lib
  * @requires vm.hasSA
  * @requires vm.flavor == "server" & !vm.emulatedClient & !(vm.opt.TieredStopAtLevel == 1)
- * @build jdk.test.lib.apps.*
  * @run main/othervm TestPrintMdo
  */
 

--- a/test/hotspot/jtreg/serviceability/sa/TestType.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import jtreg.SkippedException;
  * @bug 8190307
  * @requires vm.hasSA
  * @library /test/lib
- * @build jdk.test.lib.apps.*
  * @run main/othervm TestType
  */
 

--- a/test/hotspot/jtreg/serviceability/sa/TestUniverse.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestUniverse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@ import jdk.test.whitebox.gc.GC;
  * @requires vm.hasSA
  * @bug 8190307
  * @library /test/lib
- * @build jdk.test.lib.apps.*
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. TestUniverse

--- a/test/hotspot/jtreg/serviceability/sa/UniqueVtableTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/UniqueVtableTest.java
@@ -155,9 +155,9 @@ public class UniqueVtableTest {
             "UniqueVtableTest",
             Long.toString(lingeredAppPid));
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
-        OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
-        SAOutput.shouldHaveExitValue(0);
-        System.out.println(SAOutput.getOutput());
+        OutputAnalyzer output = ProcessTools.executeProcess(processBuilder);
+        output.shouldHaveExitValue(0);
+        System.out.println(output.getOutput());
     }
 
     private static void runMain() throws Throwable {
@@ -189,8 +189,10 @@ public class UniqueVtableTest {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
         if (args == null || args.length == 0) {
+            // Main test process.
             runMain();
         } else {
+            // Sub-process to attach, arg[0] is the target process pid.
             runTest(Long.parseLong(args[0]));
         }
     }

--- a/test/hotspot/jtreg/serviceability/sa/UniqueVtableTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/UniqueVtableTest.java
@@ -31,7 +31,7 @@
  *          jdk.hotspot.agent/sun.jvm.hotspot.types
  *          jdk.hotspot.agent/sun.jvm.hotspot.types.basic
  *
- * @run main/othervm UniqueVtableTest
+ * @run driver UniqueVtableTest
  */
 
 import java.util.ArrayList;
@@ -46,15 +46,12 @@ import sun.jvm.hotspot.types.Type;
 import sun.jvm.hotspot.types.basic.BasicTypeDataBase;
 
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
 
 
 public class UniqueVtableTest {
-
-    private HotSpotAgent agent;
-
-    public UniqueVtableTest() {
-    }
 
     private static String type2String(Type t) {
         return t + " (extends " + t.getSuperclass() + ")";
@@ -64,20 +61,36 @@ public class UniqueVtableTest {
         System.out.println(o);
     }
 
-    private void attach(long pid) throws Throwable {
-        agent = new HotSpotAgent();
+    private static void runTest(long pid) throws Throwable {
+        HotSpotAgent agent = new HotSpotAgent();
         log("Attaching to process ID " + pid + "...");
         agent.attach((int) pid);
         log("Attached successfully.");
-    }
 
-    private void detach() {
-        if (agent != null) {
-            agent.detach();
+        Throwable reasonToFail = null;
+
+        try {
+            runTest(agent);
+        } catch (Throwable ex) {
+            reasonToFail = ex;
+        } finally {
+            try {
+                agent.detach();
+            } catch (Exception ex) {
+                log("detach error:");
+                ex.printStackTrace(System.out);
+                // do not override original error
+                if (reasonToFail != null) {
+                    reasonToFail = ex;
+                }
+            }
+        }
+        if (reasonToFail != null) {
+            throw reasonToFail;
         }
     }
 
-    private void runTest() throws Throwable {
+    private static void runTest(HotSpotAgent agent) throws Throwable {
         Map<Address, List<Type>> vtableToTypesMap = new HashMap<>();
         Iterator<Type> it = agent.getTypeDataBase().getTypes();
         int dupsFound = 0;
@@ -131,26 +144,31 @@ public class UniqueVtableTest {
         }
     }
 
-    private void run() throws Throwable {
+    private static void createAnotherToAttach(long lingeredAppPid) throws Throwable {
+        // Start a new process to attach to the lingered app
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            "--add-modules=jdk.hotspot.agent",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.types=ALL-UNNAMED",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.types.basic=ALL-UNNAMED",
+            "UniqueVtableTest",
+            Long.toString(lingeredAppPid));
+        SATestUtils.addPrivilegesIfNeeded(processBuilder);
+        OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
+        SAOutput.shouldHaveExitValue(0);
+        System.out.println(SAOutput.getOutput());
+    }
+
+    private static void runMain() throws Throwable {
         Throwable reasonToFail = null;
         LingeredApp app = null;
         try {
             app = LingeredApp.startApp();
-            attach(app.getPid());
-            runTest();
+            createAnotherToAttach(app.getPid());
         } catch (Throwable ex) {
             reasonToFail = ex;
         } finally {
-            try {
-                detach();
-            } catch (Exception ex) {
-                log("detach error:");
-                ex.printStackTrace(System.out);
-                // do not override original error
-                if (reasonToFail != null) {
-                    reasonToFail = ex;
-                }
-            }
             try {
                 LingeredApp.stopApp(app);
             } catch (Exception ex) {
@@ -170,9 +188,11 @@ public class UniqueVtableTest {
     public static void main(String... args) throws Throwable {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
-        UniqueVtableTest test = new UniqueVtableTest();
-
-        test.run();
+        if (args == null || args.length == 0) {
+            runMain();
+        } else {
+            runTest(Long.parseLong(args[0]));
+        }
     }
 
  }


### PR DESCRIPTION
The change:
- updates UniqueVtableTest to follow standard SA way - attach to target from subprocess and use SATestUtils.addPrivilegesIfNeeded for the subprocess;
- updates several tests in the same directory to resolve NoClassDefFoundError failures; It's known JTReg issue that "@build" actions for part of used shared classes may cause intermittent NoClassDefFoundError in other tests which use the same shared library classpath.

Tested: 100 runs on all platforms, no failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303921](https://bugs.openjdk.org/browse/JDK-8303921): serviceability/sa/UniqueVtableTest.java timed out


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13030/head:pull/13030` \
`$ git checkout pull/13030`

Update a local copy of the PR: \
`$ git checkout pull/13030` \
`$ git pull https://git.openjdk.org/jdk pull/13030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13030`

View PR using the GUI difftool: \
`$ git pr show -t 13030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13030.diff">https://git.openjdk.org/jdk/pull/13030.diff</a>

</details>
