### PR TITLE
8225641: Calendar.roll(int field) does not work correctly for WEEK_OF_YEAR

### DIFF
--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1307,7 +1307,13 @@ public class GregorianCalendar extends Calendar {
                             woy = min;
                         }
                     }
-                    set(field, getRolledValue(woy, amount, min, max));
+                    int newWeekOfYear = getRolledValue(woy, amount, min, max);
+                    // Make sure that the (potential) minimum week has the
+                    // current DAY_OF_WEEK
+                    if (newWeekOfYear == 1 && isInvalidWeek1()) {
+                        newWeekOfYear+=1;
+                    }
+                    set(field, newWeekOfYear);
                     return;
                 }
 
@@ -2970,6 +2976,56 @@ public class GregorianCalendar extends Calendar {
     private boolean isCutoverYear(int normalizedYear) {
         int cutoverYear = (calsys == gcal) ? gregorianCutoverYear : gregorianCutoverYearJulian;
         return normalizedYear == cutoverYear;
+    }
+
+    /**
+     * {@return {@code true} if the first week of the current year is minimum
+     * and the {@code DAY_OF_WEEK} does not exist in that week}
+     *
+     * This method is used to check the validity of a {@code WEEK_OF_YEAR} and
+     * {@code DAY_OF_WEEK} combo when WEEK_OF_YEAR is rolled to a value of 1.
+     * This prevents other methods from calling complete() with an invalid combo.
+     */
+    private boolean isInvalidWeek1() {
+        // Calculate the DAY_OF_WEEK for Jan 1 of the current YEAR
+        long jan1Fd =  gcal.getFixedDate(internalGet(YEAR), 1, 1, null);
+        int jan1Dow = BaseCalendar.getDayOfWeekFromFixedDate(jan1Fd);
+        int daysInFirstWeek;
+        if (getFirstDayOfWeek() <= jan1Dow) {
+            // Add wrap around days
+            daysInFirstWeek = (7 - jan1Dow) + getFirstDayOfWeek();
+        } else {
+            daysInFirstWeek = getFirstDayOfWeek() - jan1Dow;
+        }
+        // If the week is minimum, check if the DAY_OF_WEEK does not exist
+        return isMinWeek(daysInFirstWeek) &&
+                dayNotInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, getFirstDayOfWeek() - 1);
+    }
+
+    /**
+     * Determines if the specified day exists in the minimum week.
+     * For example, dayNotInMinWeek(4, 6, 3) returns false since Wednesday
+     * is not between the minimum week given by [Friday, Saturday,
+     * Sunday, Monday, Tuesday].
+     */
+    private boolean dayNotInMinWeek (int day, int startDay, int endDay) {
+        if (endDay >= startDay) {
+            // dayNotInMinWeek(2, 3, 6), check that 2 is
+            // not between 3 4 5 6
+            return !(day >= startDay && day <= endDay);
+        } else {
+            // dayNotInMinWeek(4, 6, 3), check that 4 is
+            // not between 6 7 1 2 3
+            return !(day >= startDay || day <= endDay);
+        }
+    }
+
+    /**
+     * Determines if the specified amount of days can make up
+     * a valid minimum week.
+     */
+    private boolean isMinWeek (int days) {
+        return days >= getMinimalDaysInFirstWeek();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -3003,6 +3003,14 @@ public class GregorianCalendar extends Calendar {
     }
 
     /**
+     * Determines if the specified amount of days can make up
+     * a valid minimum week.
+     */
+    private boolean isMinWeek (int days) {
+        return days >= getMinimalDaysInFirstWeek();
+    }
+
+    /**
      * Determines if the specified day exists in the minimum week.
      * For example, dayNotInMinWeek(4, 6, 3) returns false since Wednesday
      * is not between the minimum week given by [Friday, Saturday,
@@ -3018,14 +3026,6 @@ public class GregorianCalendar extends Calendar {
             // not between 6 7 1 2 3
             return !(day >= startDay || day <= endDay);
         }
-    }
-
-    /**
-     * Determines if the specified amount of days can make up
-     * a valid minimum week.
-     */
-    private boolean isMinWeek (int days) {
-        return days >= getMinimalDaysInFirstWeek();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -2992,27 +2992,38 @@ public class GregorianCalendar extends Calendar {
         // Calculate the DAY_OF_WEEK for Jan 1 of the current YEAR
         long jan1Fd =  gcal.getFixedDate(internalGet(YEAR), 1, 1, null);
         int jan1Dow = BaseCalendar.getDayOfWeekFromFixedDate(jan1Fd);
+        // Calculate how many days are in the first week
         int daysInFirstWeek;
         if (getFirstDayOfWeek() <= jan1Dow) {
             // Add wrap around days
-            daysInFirstWeek = (7 - jan1Dow) + getFirstDayOfWeek();
+            daysInFirstWeek = 7 - jan1Dow + getFirstDayOfWeek();
         } else {
             daysInFirstWeek = getFirstDayOfWeek() - jan1Dow;
         }
+        // Calculate the end day of the first week
+        int endDow = getFirstDayOfWeek() - 1 == 0
+                ? 7 : getFirstDayOfWeek() - 1;
         // If the week is a valid minimum, check if the DAY_OF_WEEK does not exist
         return daysInFirstWeek >= getMinimalDaysInFirstWeek() &&
-                !dayInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, getFirstDayOfWeek() - 1);
+                !dayInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, endDow);
     }
 
     /**
-     * Determines if the specified day exists in the minimum week.
+     * Given the first day and last day of a week, this method determines
+     * if the specified day exists in the minimum week.
+     * This method expects all parameters to be passed in as DAY_OF_WEEK values.
      * For example, dayInMinWeek(4, 6, 3) returns false since Wednesday
      * is not between the minimum week given by [Friday, Saturday,
      * Sunday, Monday, Tuesday].
+     *
+     * @throws IllegalArgumentException if either startDay or endDay are not between
+     * 1 and 7 inclusive (Calendar.SUNDAY to Calendar.SATURDAY)
      */
     private boolean dayInMinWeek (int day, int startDay, int endDay) {
-        endDay = endDay == 0
-                ? 7 : endDay;
+        if (endDay > 7 || endDay < 1 || startDay > 7 || startDay < 1) {
+            throw new IllegalArgumentException("Start day or end day is not " +
+                    "a valid day of the week");
+        }
         if (endDay >= startDay) {
             // dayInMinWeek(6, 3, 5), check that 6 is
             // between 3 4 5

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -3015,15 +3015,8 @@ public class GregorianCalendar extends Calendar {
      * For example, dayInMinWeek(4, 6, 3) returns false since Wednesday
      * is not between the minimum week given by [Friday, Saturday,
      * Sunday, Monday, Tuesday].
-     *
-     * @throws IllegalArgumentException if either startDay or endDay are not between
-     * 1 and 7 inclusive (Calendar.SUNDAY to Calendar.SATURDAY)
      */
     private boolean dayInMinWeek (int day, int startDay, int endDay) {
-        if (endDay > 7 || endDay < 1 || startDay > 7 || startDay < 1) {
-            throw new IllegalArgumentException("Start day or end day is not " +
-                    "a valid day of the week");
-        }
         if (endDay >= startDay) {
             // dayInMinWeek(6, 3, 5), check that 6 is
             // between 3 4 5

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -1312,10 +1312,8 @@ public class GregorianCalendar extends Calendar {
                     // current DAY_OF_WEEK. Only make a check for
                     // rolling up into week 1, as the existing checks
                     // sufficiently handle rolling down into week 1.
-                    if (newWeekOfYear == 1 && (isInvalidWeek1())) {
-                        if (amount > 0) {
-                            newWeekOfYear++;
-                        }
+                    if (newWeekOfYear == 1 && isInvalidWeek1() && amount > 0) {
+                        newWeekOfYear++;
                     }
                     set(field, newWeekOfYear);
                     return;
@@ -3001,34 +2999,28 @@ public class GregorianCalendar extends Calendar {
         } else {
             daysInFirstWeek = getFirstDayOfWeek() - jan1Dow;
         }
-        // If the week is minimum, check if the DAY_OF_WEEK does not exist
-        return isMinWeek(daysInFirstWeek) &&
-                dayNotInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, getFirstDayOfWeek() - 1);
-    }
-
-    /**
-     * Determines if the specified amount of days can make up
-     * a valid minimum week.
-     */
-    private boolean isMinWeek (int days) {
-        return days >= getMinimalDaysInFirstWeek();
+        // If the week is a valid minimum, check if the DAY_OF_WEEK does not exist
+        return daysInFirstWeek >= getMinimalDaysInFirstWeek() &&
+                !dayInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, getFirstDayOfWeek() - 1);
     }
 
     /**
      * Determines if the specified day exists in the minimum week.
-     * For example, dayNotInMinWeek(4, 6, 3) returns false since Wednesday
+     * For example, dayInMinWeek(4, 6, 3) returns false since Wednesday
      * is not between the minimum week given by [Friday, Saturday,
      * Sunday, Monday, Tuesday].
      */
-    private boolean dayNotInMinWeek (int day, int startDay, int endDay) {
+    private boolean dayInMinWeek (int day, int startDay, int endDay) {
+        endDay = endDay == 0
+                ? 7 : endDay;
         if (endDay >= startDay) {
-            // dayNotInMinWeek(2, 3, 6), check that 2 is
-            // not between 3 4 5 6
-            return !(day >= startDay && day <= endDay);
+            // dayInMinWeek(6, 3, 5), check that 6 is
+            // between 3 4 5
+            return (day >= startDay && day <= endDay);
         } else {
-            // dayNotInMinWeek(4, 6, 3), check that 4 is
-            // not between 6 7 1 2 3
-            return !(day >= startDay || day <= endDay);
+            // dayInMinWeek(4, 6, 3), check that 4 is
+            // between 6 7 1 2 3
+            return (day >= startDay || day <= endDay);
         }
     }
 

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -1308,10 +1308,14 @@ public class GregorianCalendar extends Calendar {
                         }
                     }
                     int newWeekOfYear = getRolledValue(woy, amount, min, max);
-                    // Make sure that the (potential) minimum week has the
-                    // current DAY_OF_WEEK
-                    if (newWeekOfYear == 1 && isInvalidWeek1()) {
-                        newWeekOfYear+=1;
+                    // Final check to ensure that the first week has the
+                    // current DAY_OF_WEEK. Only make a check for
+                    // rolling up into week 1, as the existing checks
+                    // sufficiently handle rolling down into week 1.
+                    if (newWeekOfYear == 1 && (isInvalidWeek1())) {
+                        if (amount > 0) {
+                            newWeekOfYear++;
+                        }
                     }
                     set(field, newWeekOfYear);
                     return;
@@ -3000,6 +3004,29 @@ public class GregorianCalendar extends Calendar {
         // If the week is minimum, check if the DAY_OF_WEEK does not exist
         return isMinWeek(daysInFirstWeek) &&
                 dayNotInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, getFirstDayOfWeek() - 1);
+    }
+
+    private int getDaysInLastWeek(int dec31dow) {
+        int daysInLastWeek;
+        if (getFirstDayOfWeek() <= dec31dow) {
+            // Add wrap around days
+            daysInLastWeek = dec31dow - getFirstDayOfWeek() + 1;
+        } else {
+            daysInLastWeek = (7 - getFirstDayOfWeek()) + dec31dow;
+        }
+        return daysInLastWeek;
+    }
+
+    // revisit the logic here
+    private boolean isInvalidWeekMax() {
+        // Calculate the DAY_OF_WEEK for Jan 1 of the current YEAR
+        long dec31Fd =  gcal.getFixedDate(internalGet(YEAR), 12, 31, null);
+        int dec31dow = BaseCalendar.getDayOfWeekFromFixedDate(dec31Fd);
+        int daysInLastWeek = getDaysInLastWeek(dec31dow);
+
+        // If the week is minimum, check if the DAY_OF_WEEK does not exist
+        return isMinWeek(daysInLastWeek) &&
+                dayNotInMinWeek(internalGet(DAY_OF_WEEK), getFirstDayOfWeek() - 1, dec31dow);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -3006,29 +3006,6 @@ public class GregorianCalendar extends Calendar {
                 dayNotInMinWeek(internalGet(DAY_OF_WEEK), jan1Dow, getFirstDayOfWeek() - 1);
     }
 
-    private int getDaysInLastWeek(int dec31dow) {
-        int daysInLastWeek;
-        if (getFirstDayOfWeek() <= dec31dow) {
-            // Add wrap around days
-            daysInLastWeek = dec31dow - getFirstDayOfWeek() + 1;
-        } else {
-            daysInLastWeek = (7 - getFirstDayOfWeek()) + dec31dow;
-        }
-        return daysInLastWeek;
-    }
-
-    // revisit the logic here
-    private boolean isInvalidWeekMax() {
-        // Calculate the DAY_OF_WEEK for Jan 1 of the current YEAR
-        long dec31Fd =  gcal.getFixedDate(internalGet(YEAR), 12, 31, null);
-        int dec31dow = BaseCalendar.getDayOfWeekFromFixedDate(dec31Fd);
-        int daysInLastWeek = getDaysInLastWeek(dec31dow);
-
-        // If the week is minimum, check if the DAY_OF_WEEK does not exist
-        return isMinWeek(daysInLastWeek) &&
-                dayNotInMinWeek(internalGet(DAY_OF_WEEK), getFirstDayOfWeek() - 1, dec31dow);
-    }
-
     /**
      * Determines if the specified amount of days can make up
      * a valid minimum week.

--- a/test/jdk/java/util/Calendar/RollFromLastToFirstWeek.java
+++ b/test/jdk/java/util/Calendar/RollFromLastToFirstWeek.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.params.provider.Arguments;
  * week is incremented to prevent this.
  */
 public class RollFromLastToFirstWeek {
-    static Calendar.Builder GREGORIAN_BUILDER = new Builder()
+    private static final Builder GREGORIAN_BUILDER = new Builder()
             .setCalendarType("gregory");
 
     @ParameterizedTest

--- a/test/jdk/java/util/Calendar/RollFromLastToFirstWeek.java
+++ b/test/jdk/java/util/Calendar/RollFromLastToFirstWeek.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8225641
- * @summary Test the behavior of Calendar.roll(WEEK_OF_YEAR) when the last week
- * is rolled up into a minimal week 1 of the same year
- * @run junit RollToMinWeek
+ * @summary Test the behavior of GregorianCalendar.roll(WEEK_OF_YEAR)
+ * when the last week is rolled into the first week of the same year
+ * @run junit RollFromLastToFirstWeek
  */
 
 
@@ -39,12 +39,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
 
 /**
- * Test to validate the behavior of Calendar.roll(WEEK_OF_YEAR, +1)
- * when rolling into a minimal week 1 from the max week. WEEK_OF_YEAR can
- * not be rolled to a week with a non-existent DAY_OF_WEEK. This only
- * test the implementation of the Gregorian Calendar roll
+ * Test to validate the behavior of GregorianCalendar.roll(WEEK_OF_YEAR, +1)
+ * when rolling from the last week of a year into the first week of the same year.
+ * This only test the implementation of the Gregorian Calendar roll.
+ *
+ * Rolling from the last week of a year into the first week of the same year
+ * could cause a WEEK_OF_YEAR with a non-existent DAY_OF_WEEK combination.
+ * The associated fix ensures that a final check is made, so that the first
+ * week is incremented to prevent this.
  */
-public class RollToMinWeek {
+public class RollFromLastToFirstWeek {
     static Calendar.Builder GREGORIAN_BUILDER = new Builder()
             .setCalendarType("gregory");
 
@@ -96,7 +100,7 @@ public class RollToMinWeek {
         // Test all days at the end of the year that roll into week 1
         for (int dayOfMonth = 25; dayOfMonth <= 31; dayOfMonth++) {
             for (int weekLength = 1; weekLength <= 7; weekLength++) {
-                // Sunday .. Monday -> Saturda
+                // Sunday .. Monday -> Saturday
                 for (int firstDay = SUNDAY; firstDay <= SATURDAY; firstDay++) {
                     calList.add(Arguments.of(buildCalendar(firstDay, weekLength,
                                     dayOfMonth, DECEMBER, 2019), validDates[date]));

--- a/test/jdk/java/util/Calendar/RollToMinWeek.java
+++ b/test/jdk/java/util/Calendar/RollToMinWeek.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8225641
+ * @summary Test the behavior of Calendar.roll(WEEK_OF_YEAR) when the week
+ * is rolled into a minimal week 1
+ * @run junit RollToMinWeek
+ */
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.stream.Stream;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class RollToMinWeek {
+
+    /**
+     * Test to validate the behavior of Calendar.roll(WEEK_OF_YEAR)
+     * when rolling into a minimal week 1. Since other methods
+     * will call complete(), and rolling WEEK_OF_YEAR will cause field mask
+     * to compute the new time using WEEK_OF_YEAR and DAY_OF_WEEK, these values
+     * must represent a valid date. If the DAY_OF_WEEK does not exist in the
+     * minimum first week, WEEK_OF_YEAR should be incremented by 1 to provide a
+     * valid combination.
+     *
+     * For example, (Locale.US) rolling December 29th, 2019 by 1 week will
+     * produce WEEK_OF_YEAR = 1, and DAY_OF_WEEK = 1. However, there is no
+     * Sunday in the first week of 2019, and WEEK_OF_YEAR should be
+     * incremented by 1 to a value of 2.
+     */
+    @ParameterizedTest
+    @MethodSource("calendarProvider")
+    public void testRollToMinWeek1(Calendar calendar, String expectedDate) {
+        String originalDate = longDateString(calendar);
+        calendar.roll(Calendar.WEEK_OF_YEAR, +1);
+        String rolledDate = longDateString(calendar);
+        if (!rolledDate.equals(expectedDate)) {
+            fail(String.format("""
+            {$$$ Failed: Rolled: "%s" by 1 week, expecting: "%s", but got: "%s"},
+            """, originalDate, expectedDate, rolledDate));
+        } else {
+            System.out.printf("""
+            {$$$ Passed: Rolled: "%s" by 1 week and successfully got: "%s"},
+            """, originalDate, rolledDate);
+        }
+    }
+
+    /**
+     * Data provider for testing firstWeek().
+     */
+    private static Stream<Arguments> calendarProvider() {
+        return Stream.of(
+                // Test a variety of rolls that previously produced incorrect results
+                Arguments.of(buildCalendar(27, 11, 2020, Locale.ENGLISH),
+                        "Sunday, 5 January 2020"),
+                Arguments.of(buildCalendar(28, 11, 2020, Locale.ENGLISH),
+                        "Monday, 6 January 2020"),
+                Arguments.of(buildCalendar(29, 11, 2020, Locale.ENGLISH),
+                        "Tuesday, 7 January 2020"),
+                Arguments.of(buildCalendar(29, 11, 2019, Locale.ENGLISH),
+                        "Sunday, 6 January 2019"),
+                Arguments.of(buildCalendar(30, 11, 2019, Locale.ENGLISH),
+                        "Monday, 7 January 2019"),
+                Arguments.of(buildCalendar(30, 11, 2019, Locale.FRANCE),
+                        "Monday, 7 January 2019")
+        );
+    }
+
+    private static Calendar buildCalendar(int day, int month, int year, Locale locale) {
+        Calendar calendar = Calendar.getInstance(locale);
+        calendar.set(Calendar.YEAR, year);
+        calendar.set(Calendar.MONTH, month);
+        calendar.set(Calendar.DAY_OF_MONTH, day);
+        return calendar;
+    }
+
+    private String longDateString(Calendar calendar) {
+        return String.format("%s, %s %s %s",
+                calendar.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.ENGLISH),
+                calendar.get(Calendar.DAY_OF_MONTH),
+                calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.ENGLISH),
+                calendar.get(Calendar.YEAR));
+    }
+}

--- a/test/jdk/java/util/Calendar/RollToMinWeek.java
+++ b/test/jdk/java/util/Calendar/RollToMinWeek.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.params.provider.Arguments;
  * test the implementation of the Gregorian Calendar roll
  */
 public class RollToMinWeek {
+    static Calendar.Builder CAL_BUILDER = new Builder();
+
     @ParameterizedTest
     @MethodSource("rollUpCalProvider")
     public void rollUpTest(Calendar calendar, String[] validDates){
@@ -106,11 +108,11 @@ public class RollToMinWeek {
     private static Calendar buildCalendar(String type, int firstDayOfWeek,
                                  int minimumWeekLength, int dayOfMonth,
                                  int month, int year) {
-        Calendar.Builder calBuilder = new Builder();
-        calBuilder.setCalendarType(type);
-        calBuilder.setWeekDefinition(firstDayOfWeek, minimumWeekLength);
-        calBuilder.setDate(year, month, dayOfMonth);
-        return calBuilder.build();
+        return CAL_BUILDER
+                .setCalendarType(type)
+                .setWeekDefinition(firstDayOfWeek, minimumWeekLength)
+                .setDate(year, month, dayOfMonth)
+                .build();
     }
 
     private static String longDateString(Calendar calendar) {

--- a/test/jdk/java/util/Calendar/RollToMinWeek.java
+++ b/test/jdk/java/util/Calendar/RollToMinWeek.java
@@ -51,27 +51,27 @@ public class RollToMinWeek {
     @MethodSource("rollUpCalProvider")
     public void rollUpTest(Calendar calendar, String[] validDates){
         if (calendar instanceof GregorianCalendar) {
-            testRoll(calendar, validDates, +1);
+            testRoll(calendar, validDates);
         } else {
             fail(String.format("Calendar is not Gregorian: %s", calendar));
         }
     }
 
-    private void testRoll(Calendar calendar, String[] validDates, int amount) {
+    private void testRoll(Calendar calendar, String[] validDates) {
         String originalDate = longDateString(calendar);
-        calendar.roll(Calendar.WEEK_OF_YEAR, amount);
+        calendar.roll(Calendar.WEEK_OF_YEAR, 1);
         String rolledDate = longDateString(calendar);
         if (!Arrays.asList(validDates).contains(rolledDate)) {
             fail(String.format("""
-            {$$$ Failed: Rolled: "%s" by %s week, where the first day of the week
+            {$$$ Failed: Rolled: "%s" by 1 week, where the first day of the week
             is: %s with a minimum week length of: %s and was expecting one of: "%s", but got: "%s"},
-            """, originalDate, amount, calendar.getFirstDayOfWeek(),
+            """, originalDate, calendar.getFirstDayOfWeek(),
                     calendar.getMinimalDaysInFirstWeek(), Arrays.toString(validDates), rolledDate));
         } else {
             System.out.printf("""
-            {$$$ Passed: Rolled: "%s" by %s week where the first day of the week
+            {$$$ Passed: Rolled: "%s" by 1 week where the first day of the week
             is: %s with a minimum week length of: %s and successfully got: "%s"},
-            """, originalDate, amount, calendar.getFirstDayOfWeek(),
+            """, originalDate, calendar.getFirstDayOfWeek(),
                     calendar.getMinimalDaysInFirstWeek(), rolledDate);
         }
     }
@@ -95,9 +95,10 @@ public class RollToMinWeek {
         // Test all days at the end of the year that roll into week 1
         for (int dayOfMonth = 25; dayOfMonth <= 31; dayOfMonth++) {
             for (int weekLength = 1; weekLength <= 7; weekLength++) {
-                for (int firstDay = 1; firstDay <= 7; firstDay++) {
+                // Sunday .. Monday -> Saturda
+                for (int firstDay = SUNDAY; firstDay <= SATURDAY; firstDay++) {
                     calList.add(Arguments.of(buildCalendar("gregory", firstDay, weekLength,
-                                    dayOfMonth, 11, 2019), validDates[date]));
+                                    dayOfMonth, DECEMBER, 2019), validDates[date]));
                 }
             }
             date++;

--- a/test/jdk/java/util/Calendar/RollToMinWeek.java
+++ b/test/jdk/java/util/Calendar/RollToMinWeek.java
@@ -24,86 +24,88 @@
 /*
  * @test
  * @bug 8225641
- * @summary Test the behavior of Calendar.roll(WEEK_OF_YEAR) when the week
- * is rolled into a minimal week 1
+ * @summary Test the behavior of Calendar.roll(WEEK_OF_YEAR) when the last week
+ * is rolled up into a minimal week 1 of the same year
  * @run junit RollToMinWeek
  */
 
-import java.util.Calendar;
-import java.util.Locale;
+
+import java.util.*;
 import java.util.stream.Stream;
+import static java.util.Calendar.*;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
 
+/**
+ * Test to validate the behavior of Calendar.roll(WEEK_OF_YEAR, +1)
+ * when rolling into a minimal week 1 from the max week. WEEK_OF_YEAR can
+ * not be rolled to a week with a non-existent DAY_OF_WEEK. This only
+ * test the implementation of the Gregorian Calendar roll
+ */
 public class RollToMinWeek {
-
-    /**
-     * Test to validate the behavior of Calendar.roll(WEEK_OF_YEAR)
-     * when rolling into a minimal week 1. Since other methods
-     * will call complete(), and rolling WEEK_OF_YEAR will cause field mask
-     * to compute the new time using WEEK_OF_YEAR and DAY_OF_WEEK, these values
-     * must represent a valid date. If the DAY_OF_WEEK does not exist in the
-     * minimum first week, WEEK_OF_YEAR should be incremented by 1 to provide a
-     * valid combination.
-     *
-     * For example, (Locale.US) rolling December 29th, 2019 by 1 week will
-     * produce WEEK_OF_YEAR = 1, and DAY_OF_WEEK = 1. However, there is no
-     * Sunday in the first week of 2019, and WEEK_OF_YEAR should be
-     * incremented by 1 to a value of 2.
-     */
     @ParameterizedTest
-    @MethodSource("calendarProvider")
-    public void testRollToMinWeek1(Calendar calendar, String expectedDate) {
-        String originalDate = longDateString(calendar);
-        calendar.roll(Calendar.WEEK_OF_YEAR, +1);
-        String rolledDate = longDateString(calendar);
-        if (!rolledDate.equals(expectedDate)) {
-            fail(String.format("""
-            {$$$ Failed: Rolled: "%s" by 1 week, expecting: "%s", but got: "%s"},
-            """, originalDate, expectedDate, rolledDate));
+    @MethodSource("rollUpCalProvider")
+    public void rollUpTest(Calendar calendar, String[] validDates){
+        if (calendar instanceof GregorianCalendar) {
+            testRoll(calendar, validDates, +1);
         } else {
-            System.out.printf("""
-            {$$$ Passed: Rolled: "%s" by 1 week and successfully got: "%s"},
-            """, originalDate, rolledDate);
+            fail(String.format("Calendar is not Gregorian: %s", calendar));
         }
     }
 
-    /**
-     * Data provider for testing firstWeek().
-     */
-    private static Stream<Arguments> calendarProvider() {
-        return Stream.of(
-                // Test a variety of rolls that previously produced incorrect results
-                Arguments.of(buildCalendar(27, 11, 2020, Locale.ENGLISH),
-                        "Sunday, 5 January 2020"),
-                Arguments.of(buildCalendar(28, 11, 2020, Locale.ENGLISH),
-                        "Monday, 6 January 2020"),
-                Arguments.of(buildCalendar(29, 11, 2020, Locale.ENGLISH),
-                        "Tuesday, 7 January 2020"),
-                Arguments.of(buildCalendar(29, 11, 2019, Locale.ENGLISH),
-                        "Sunday, 6 January 2019"),
-                Arguments.of(buildCalendar(30, 11, 2019, Locale.ENGLISH),
-                        "Monday, 7 January 2019"),
-                Arguments.of(buildCalendar(30, 11, 2019, Locale.FRANCE),
-                        "Monday, 7 January 2019")
-        );
+    private void testRoll(Calendar calendar, String[] validDates, int amount) {
+        String originalDate = longDateString(calendar);
+        calendar.roll(Calendar.WEEK_OF_YEAR, amount);
+        String rolledDate = longDateString(calendar);
+        if (!Arrays.asList(validDates).contains(rolledDate)) {
+            fail(String.format("""
+            {$$$ Failed: Rolled: "%s" by %s week, where the first day of the week
+            is: %s with a minimum week length of: %s and was expecting one of: "%s", but got: "%s"},
+            """, originalDate, amount, calendar.getFirstDayOfWeek(),
+                    calendar.getMinimalDaysInFirstWeek(), Arrays.toString(validDates), rolledDate));
+        } else {
+            System.out.printf("""
+            {$$$ Passed: Rolled: "%s" by %s week where the first day of the week
+            is: %s with a minimum week length of: %s and successfully got: "%s"},
+            """, originalDate, amount, calendar.getFirstDayOfWeek(),
+                    calendar.getMinimalDaysInFirstWeek(), rolledDate);
+        }
     }
 
-    private static Calendar buildCalendar(int day, int month, int year, Locale locale) {
-        Calendar calendar = Calendar.getInstance(locale);
-        calendar.set(Calendar.YEAR, year);
-        calendar.set(Calendar.MONTH, month);
-        calendar.set(Calendar.DAY_OF_MONTH, day);
-        return calendar;
+    // This implicitly tests the Iso8601 calendar as
+    // MinWeek = 4 and FirstDayOfWeek = Monday is included in the provider
+    private static Stream<Arguments> rollUpCalProvider() {
+        ArrayList<Arguments> calList = new ArrayList<Arguments>();
+        for (int weekLength = 1; weekLength <= 7; weekLength++) {
+            for (int firstDay = 1; firstDay <= 7; firstDay++) {
+                // Week 1, Week 2 are all potential dates to roll into
+                String[] validDates = {"Sunday, 6 January 2019", "Sunday, 13 January 2019"};
+                calList.add(Arguments.of(buildCalendar("gregory", firstDay, weekLength,
+                                29, 11, 2019), validDates)
+                        // Roll from week Max to week 1 with non-existent day of week
+                );
+            }
+        }
+        return calList.stream();
     }
 
-    private String longDateString(Calendar calendar) {
+    private static Calendar buildCalendar(String type, int firstDayOfWeek,
+                                 int minimumWeekLength, int dayOfMonth,
+                                 int month, int year) {
+        Calendar.Builder calBuilder = new Builder();
+        calBuilder.setCalendarType(type);
+        calBuilder.setWeekDefinition(firstDayOfWeek, minimumWeekLength);
+        calBuilder.setDate(year, month, dayOfMonth);
+        return calBuilder.build();
+    }
+
+    private static String longDateString(Calendar calendar) {
         return String.format("%s, %s %s %s",
                 calendar.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.ENGLISH),
                 calendar.get(Calendar.DAY_OF_MONTH),
                 calendar.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.ENGLISH),
-                calendar.get(Calendar.YEAR));
+                calendar.get(YEAR));
     }
 }

--- a/test/jdk/java/util/Calendar/RollToMinWeek.java
+++ b/test/jdk/java/util/Calendar/RollToMinWeek.java
@@ -45,7 +45,8 @@ import org.junit.jupiter.params.provider.Arguments;
  * test the implementation of the Gregorian Calendar roll
  */
 public class RollToMinWeek {
-    static Calendar.Builder CAL_BUILDER = new Builder();
+    static Calendar.Builder GREGORIAN_BUILDER = new Builder()
+            .setCalendarType("gregory");
 
     @ParameterizedTest
     @MethodSource("rollUpCalProvider")
@@ -97,7 +98,7 @@ public class RollToMinWeek {
             for (int weekLength = 1; weekLength <= 7; weekLength++) {
                 // Sunday .. Monday -> Saturda
                 for (int firstDay = SUNDAY; firstDay <= SATURDAY; firstDay++) {
-                    calList.add(Arguments.of(buildCalendar("gregory", firstDay, weekLength,
+                    calList.add(Arguments.of(buildCalendar(firstDay, weekLength,
                                     dayOfMonth, DECEMBER, 2019), validDates[date]));
                 }
             }
@@ -106,11 +107,10 @@ public class RollToMinWeek {
         return calList.stream();
     }
 
-    private static Calendar buildCalendar(String type, int firstDayOfWeek,
-                                 int minimumWeekLength, int dayOfMonth,
-                                 int month, int year) {
-        return CAL_BUILDER
-                .setCalendarType(type)
+    private static Calendar buildCalendar(int firstDayOfWeek,
+                                          int minimumWeekLength, int dayOfMonth,
+                                          int month, int year) {
+        return GREGORIAN_BUILDER
                 .setWeekDefinition(firstDayOfWeek, minimumWeekLength)
                 .setDate(year, month, dayOfMonth)
                 .build();

--- a/test/jdk/java/util/Calendar/RollToMinWeek.java
+++ b/test/jdk/java/util/Calendar/RollToMinWeek.java
@@ -78,15 +78,27 @@ public class RollToMinWeek {
     // MinWeek = 4 and FirstDayOfWeek = Monday is included in the provider
     private static Stream<Arguments> rollUpCalProvider() {
         ArrayList<Arguments> calList = new ArrayList<Arguments>();
-        for (int weekLength = 1; weekLength <= 7; weekLength++) {
-            for (int firstDay = 1; firstDay <= 7; firstDay++) {
-                // Week 1, Week 2 are all potential dates to roll into
-                String[] validDates = {"Sunday, 6 January 2019", "Sunday, 13 January 2019"};
-                calList.add(Arguments.of(buildCalendar("gregory", firstDay, weekLength,
-                                29, 11, 2019), validDates)
-                        // Roll from week Max to week 1 with non-existent day of week
-                );
+        // Week 1, Week 2 are all potential dates to roll into
+        // Depends on first day of week / min days in week
+        String[][] validDates = {
+                {"Wednesday, 2 January 2019", "Wednesday, 9 January 2019"},
+                {"Thursday, 3 January 2019" , "Thursday, 10 January 2019"},
+                {"Friday, 4 January 2019"   , "Friday, 11 January 2019"},
+                {"Saturday, 5 January 2019" , "Saturday, 12 January 2019"},
+                {"Sunday, 6 January 2019"   , "Sunday, 13 January 2019"},
+                {"Monday, 7 January 2019"   , "Monday, 14 January 2019"},
+                {"Tuesday, 1 January 2019"  , "Tuesday, 8 January 2019"}
+        };
+        int date = 0;
+        // Test all days at the end of the year that roll into week 1
+        for (int dayOfMonth = 25; dayOfMonth <= 31; dayOfMonth++) {
+            for (int weekLength = 1; weekLength <= 7; weekLength++) {
+                for (int firstDay = 1; firstDay <= 7; firstDay++) {
+                    calList.add(Arguments.of(buildCalendar("gregory", firstDay, weekLength,
+                                    dayOfMonth, 11, 2019), validDates[date]));
+                }
             }
+            date++;
         }
         return calList.stream();
     }


### PR DESCRIPTION
This PR fixes the bug which occurred when `Calendar.roll(WEEK_OF_YEAR)` rolled into a minimal first week with an invalid `WEEK_OF_YEAR` and `DAY_OF_WEEK` combo.

For example, Rolling _Monday, 30 December 2019_ by 1 week produced _Monday, 31 December 2018_, which is incorrect. This is because `WEEK_OF_YEAR` is rolled from 52 to 1, and the original `DAY_OF_WEEK` is 1. However, there is no Monday in week 1 of 2019. This is exposed when a future method calls `Calendar.complete()`, which eventually calculates a `fixedDate` with the invalid `WEEK_OF_YEAR` and `DAY_OF_WEEK` combo.

To prevent this, a check is added for rolls into week 1, which determines if the first week is minimal. If it is indeed minimal, then it is checked if  `DAY_OF_WEEK` exists in that week, if not, `WEEK_OF_YEAR` must be incremented by one.

After the fix, Rolling _Monday, 30 December 2019_ by 1 week produces _Monday, 7 January 2019_

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225641](https://bugs.openjdk.org/browse/JDK-8225641): Calendar.roll(int field) does not work correctly for WEEK_OF_YEAR


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13031/head:pull/13031` \
`$ git checkout pull/13031`

Update a local copy of the PR: \
`$ git checkout pull/13031` \
`$ git pull https://git.openjdk.org/jdk.git pull/13031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13031`

View PR using the GUI difftool: \
`$ git pr show -t 13031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13031.diff">https://git.openjdk.org/jdk/pull/13031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13031#issuecomment-1468922376)