### PR TITLE
8304180: Constant Descriptors for MethodHandles::classData and classDataAt

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -262,6 +262,22 @@ public final class ConstantDescs {
     /** {@link ClassDesc} representing the primitive type {@code void} */
     public static final ClassDesc CD_void = ClassDesc.ofDescriptor("V");
 
+    /**
+     * {@link MethodHandleDesc} representing {@link MethodHandles#classData(Lookup, String, Class)} MethodHandles.classData}
+     * @since 21
+     */
+    public static final DirectMethodHandleDesc BSM_CLASS_DATA
+            = ofConstantBootstrap(CD_MethodHandles, "classData",
+            CD_Object);
+
+    /**
+     * {@link MethodHandleDesc} representing {@link MethodHandles#classDataAt(Lookup, String, Class, int)} MethodHandles.classDataAt}
+     * @since 21
+     */
+    public static final DirectMethodHandleDesc BSM_CLASS_DATA_AT
+            = ofConstantBootstrap(CD_MethodHandles, "classDataAt",
+            CD_Object, CD_int);
+
     /** Nominal descriptor representing the constant {@code null} */
     public static final ConstantDesc NULL
             = DynamicConstantDesc.ofNamed(ConstantDescs.BSM_NULL_CONSTANT,


### PR DESCRIPTION
Add Constant Descriptors for DirectMethodHandleDesc of MethodHandles::classData and classDataAt in ConstantDescs. This facilitates easier access of class data via condy in Classfile API-generated bytecode. Most other constant bootstrap methods provided in the JDK, notably from `ConstantBootstraps`, already have constant descriptors in ConstantDescs.

Context: https://mail.openjdk.org/pipermail/classfile-api-dev/2023-March/000235.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8304181](https://bugs.openjdk.org/browse/JDK-8304181) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8304180](https://bugs.openjdk.org/browse/JDK-8304180): Constant Descriptors for MethodHandles::classData and classDataAt
 * [JDK-8304181](https://bugs.openjdk.org/browse/JDK-8304181): Constant Descriptors for MethodHandles::classData and classDataAt (**CSR**)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13033/head:pull/13033` \
`$ git checkout pull/13033`

Update a local copy of the PR: \
`$ git checkout pull/13033` \
`$ git pull https://git.openjdk.org/jdk.git pull/13033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13033`

View PR using the GUI difftool: \
`$ git pr show -t 13033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13033.diff">https://git.openjdk.org/jdk/pull/13033.diff</a>

</details>
