### PR TITLE
8304225: Remove javax/script/Test7.java from ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -734,7 +734,6 @@ sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aa
 
 javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-all
 
-javax/script/Test7.java                                         8239361 generic-all
 
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java   8303498 linux-s390x
 


### PR DESCRIPTION
Can I please get a review of this change which removes `javax/script/Test7.java` from the ProblemList?

As noted in https://bugs.openjdk.org/browse/JDK-8304225, this test no longer fails and passes just like the other tests in `javax/script` directory with:

```
----------System.out:(4/60)----------

Test7

Warning: No js engine found; test vacuously passes.
```

With this proposed change, relevant tier testing has been run to verify that the original reported issue which caused this test to be problem listed https://bugs.openjdk.org/browse/JDK-8239361 is no longer seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304225](https://bugs.openjdk.org/browse/JDK-8304225): Remove javax/script/Test7.java from ProblemList


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13035/head:pull/13035` \
`$ git checkout pull/13035`

Update a local copy of the PR: \
`$ git checkout pull/13035` \
`$ git pull https://git.openjdk.org/jdk pull/13035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13035`

View PR using the GUI difftool: \
`$ git pr show -t 13035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13035.diff">https://git.openjdk.org/jdk/pull/13035.diff</a>

</details>
