### PR TITLE
8304149: Avoid walking the CodeCache in DeoptimizationScope::deoptimize_marked

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1383,17 +1383,6 @@ void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, Method
   }
 }
 
-void CodeCache::make_marked_nmethods_deoptimized() {
-  RelaxedCompiledMethodIterator iter(RelaxedCompiledMethodIterator::only_not_unloading);
-  while(iter.next()) {
-    CompiledMethod* nm = iter.method();
-    if (nm->is_marked_for_deoptimization() && !nm->has_been_deoptimized() && nm->can_be_deoptimized()) {
-      nm->make_not_entrant();
-      nm->make_deoptimized();
-    }
-  }
-}
-
 // Marks compiled methods dependent on dependee.
 void CodeCache::mark_dependents_on(DeoptimizationScope* deopt_scope, InstanceKlass* dependee) {
   assert_lock_strong(Compile_lock);

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -307,7 +307,6 @@ class CodeCache : AllStatic {
  public:
   static void mark_all_nmethods_for_deoptimization(DeoptimizationScope* deopt_scope);
   static void mark_for_deoptimization(DeoptimizationScope* deopt_scope, Method* dependee);
-  static void make_marked_nmethods_deoptimized();
 
   // Marks dependents during classloading
   static void mark_dependents_on(DeoptimizationScope* deopt_scope, InstanceKlass* dependee);

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -55,6 +55,7 @@ CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType ty
                                bool caller_must_gc_arguments, bool compiled)
   : CodeBlob(name, type, layout, frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments, compiled),
     _deoptimization_status(not_marked),
+    _next_deoptimization_link(nullptr),
     _deoptimization_generation(0),
     _method(method),
     _gc_data(nullptr)
@@ -68,6 +69,7 @@ CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType ty
   : CodeBlob(name, type, CodeBlobLayout((address) this, size, header_size, cb), cb,
              frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments, compiled),
     _deoptimization_status(not_marked),
+    _next_deoptimization_link(nullptr),
     _deoptimization_generation(0),
     _method(method),
     _gc_data(nullptr)

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -141,6 +141,7 @@ public:
 class CompiledMethod : public CodeBlob {
   friend class VMStructs;
   friend class DeoptimizationScope;
+  friend class DeoptimizationScopeIterator;
   void init_defaults();
 protected:
   enum DeoptimizationStatus : u1 {
@@ -151,6 +152,9 @@ protected:
   };
 
   volatile DeoptimizationStatus _deoptimization_status; // Used for stack deoptimization
+  // Used to link deoptimization marked methods.
+  // Invariant: all methods in the list have the same deoptimization generation.
+  CompiledMethod*               _next_deoptimization_link;
   // Used to track in which deoptimize handshake this method will be deoptimized.
   uint64_t                      _deoptimization_generation;
 

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -37,6 +37,7 @@ class ObjectValue;
 class AutoBoxObjectValue;
 class ScopeValue;
 class compiledVFrame;
+class CompiledMethod;
 
 template<class E> class GrowableArray;
 
@@ -48,10 +49,14 @@ class DeoptimizationScope {
   static uint64_t _active_deopt_gen;
   // Indicate an in-progress deopt handshake.
   static bool     _committing_in_progress;
+  // List of methods in the deopt scope with active gen
+  static CompiledMethod* _root_deoptimization_link;
 
   // The required gen we need to execute/wait for
   uint64_t _required_gen;
   DEBUG_ONLY(bool _deopted;)
+
+  void verify_marked_nmethods_deoptimized(uint64_t committed_gen);
 
  public:
   DeoptimizationScope();
@@ -173,11 +178,6 @@ class Deoptimization : AllStatic {
   // Can reconstruct virtualized unsafe large accesses to byte arrays.
   static const int _support_large_access_byte_array_virtualization = 1;
 #endif
-
-  // Make all nmethods that are marked_for_deoptimization not_entrant and deoptimize any live
-  // activations using those nmethods. Scan of the code cache is done to
-  // find all marked nmethods and they are made not_entrant.
-  static void deoptimize_all_marked();
 
  public:
   // Deoptimizes a frame lazily. Deopt happens on return to the frame.


### PR DESCRIPTION
Change DeoptimizationScope to keep track of the marked CompiledMethods in a list to avoid having to walk the CodeCache to find them again when deoptimizing.

This adds a linked list to DeoptimizationScope which tracks the marked CompiledMethods for the active deoptimization generation. Then when deoptimize_marked is called the committing caller claims the list and uses it to deoptimize the linked (and marked) CompileMethods instead of iterating over the CodeCache to find them again.

Testing: Oracle platforms tier 1-7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304149](https://bugs.openjdk.org/browse/JDK-8304149): Avoid walking the CodeCache in DeoptimizationScope::deoptimize_marked (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13036/head:pull/13036` \
`$ git checkout pull/13036`

Update a local copy of the PR: \
`$ git checkout pull/13036` \
`$ git pull https://git.openjdk.org/jdk.git pull/13036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13036`

View PR using the GUI difftool: \
`$ git pr show -t 13036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13036.diff">https://git.openjdk.org/jdk/pull/13036.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13036#issuecomment-1469545286)