### PR TITLE
8304049: C2 can not merge trivial Ifs due to CastII

### DIFF
--- a/src/hotspot/share/opto/locknode.hpp
+++ b/src/hotspot/share/opto/locknode.hpp
@@ -95,6 +95,7 @@ public:
   virtual int Opcode() const;
   virtual const Type* Value(PhaseGVN* phase) const { return TypeInt::CC; }
   const Type *sub(const Type *t1, const Type *t2) const { return TypeInt::CC;}
+  virtual bool is_arithmetic_cmp() const { return false; }
 
   void create_rtm_lock_counter(JVMState* state);
   RTMLockingCounters*       rtm_counters() const { return _rtm_counters; }
@@ -120,7 +121,7 @@ public:
   virtual int Opcode() const;
   virtual const Type* Value(PhaseGVN* phase) const { return TypeInt::CC; }
   const Type *sub(const Type *t1, const Type *t2) const { return TypeInt::CC;}
-
+  virtual bool is_arithmetic_cmp() const { return false; }
 };
 
 #endif // SHARE_OPTO_LOCKNODE_HPP

--- a/src/hotspot/share/opto/mathexactnode.hpp
+++ b/src/hotspot/share/opto/mathexactnode.hpp
@@ -40,6 +40,7 @@ public:
 
   virtual uint ideal_reg() const { return Op_RegFlags; }
   virtual const Type* sub(const Type* t1, const Type* t2) const;
+  virtual bool is_arithmetic_cmp() const { return false; }
 };
 
 class OverflowINode : public OverflowNode {

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -141,6 +141,7 @@ public:
   const Type *add_id() const { return TypeInt::ZERO; }
   const Type *bottom_type() const { return TypeInt::CC; }
   virtual uint ideal_reg() const { return Op_RegFlags; }
+  virtual bool is_arithmetic_cmp() const { return true; }
 
   static CmpNode *make(Node *in1, Node *in2, BasicType bt, bool unsigned_comp = false);
 };

--- a/src/hotspot/share/opto/subtypenode.hpp
+++ b/src/hotspot/share/opto/subtypenode.hpp
@@ -49,6 +49,7 @@ public:
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::CC; }
   bool depends_only_on_test() const { return false; };
+  virtual bool is_arithmetic_cmp() const { return false; }
 
 #ifdef ASSERT
 private:

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1438,6 +1438,7 @@ class VectorTestNode : public CmpNode {
   virtual const Type* Value(PhaseGVN* phase) const { return TypeInt::CC; }
   virtual const Type* sub(const Type*, const Type*) const { return TypeInt::CC; }
   BoolTest::mask get_predicate() const { return _predicate; }
+  virtual bool is_arithmetic_cmp() const { return false; }
 
   virtual bool cmp( const Node &n ) const {
     return Node::cmp(n) && _predicate == ((VectorTestNode&)n)._predicate;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestBackToBackIfs.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestBackToBackIfs.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +30,7 @@ import java.util.Random;
 
 /*
  * @test
- * @bug 8278228
+ * @bug 8278228 8304049
  * @summary C2: Improve identical back-to-back if elimination
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestBackToBackIfs
@@ -57,9 +58,30 @@ public class TestBackToBackIfs {
         }
     }
 
+    @Test
+    @IR(counts = { IRNode.IF, "1" })
+    public static void test1(int a, int b) {
+        if (b != 0) {
+            int_field = 0x42;
+        } else {
+            int_field = 42;
+        }
+        if (b != 0) {
+            int_field = 0x42;
+        } else {
+            int_field = 42;
+        }
+    }
+
     @Run(test = "test")
     public static void test_runner() {
         test(42, 0x42);
         test(0x42, 0x42);
+    }
+
+    @Run(test = "test1")
+    @Warmup(1) // So C2 can't rely on profile data
+    public static void test_runner1() {
+        test1(0, 1);
     }
 }


### PR DESCRIPTION
Hi can I have a review for this patch? C2 can not apply Split If for the attached trivial case. PhiNode::Ideal removes itself by unique_input but introduces a new CastII, therefore we have two Cmp, which is not identical for split_if.

```java
  public static void test5(int a, int b){
 
    if( b!=0) {
      int_field = 35;
    } else {
      int_field =222;
    }

    if( b!=0) {
      int_field = 35;
    } else {
      int_field =222;
    }
  }
```


Test: tier1, application/ctw/modules