### PR TITLE
8304245: Speed up CharacterData.of by avoiding bit shifting in the latin1 fast-path test

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/CharacterData.java
+++ b/src/java.base/share/classes/java/lang/CharacterData.java
@@ -69,7 +69,7 @@ abstract class CharacterData {
     // Should revisit after optimization of table initialization.
 
     static final CharacterData of(int ch) {
-        if (ch >>> 8 == 0) {     // fast-path
+        if (ch >= 0 && ch <= 0xFF) {     // fast-path
             return CharacterDataLatin1.instance;
         } else {
             return switch (ch >>> 16) {  //plane 00-16

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -48,7 +48,7 @@ final class StringLatin1 {
     }
 
     public static boolean canEncode(int cp) {
-        return cp >>> 8 == 0;
+        return cp >= 0 && cp <= 0xFF;
     }
 
     public static int length(byte[] value) {


### PR DESCRIPTION
By avoiding a bit shift operation for the latin1 fast-path test, we can speed up the `java.lang.CharacterData.of` method by ~25% for latin1 code points.

The latin1 test is currently implemented as `ch >>> 8 == 0`.  We can replace this with `ch >= 0 && ch <= 0xFF` for a noticable performance gain (especially for Latin1 code points):

This method is called frequently by various property-determining methods in `java.lang.Character` like `isLowerCase`, `isDigit` etc, so one should expect improvements for all these methods.

Performance is tested using the `Characters.isDigit` benchmark using the digits '0' (decimal 48, in CharacterDataLatin1) and '\u0660' (decimal 1632, in CharacterData00):

Baseline:

```
Benchmark           (codePoint)  Mode  Cnt  Score   Error  Units
Characters.isDigit           48  avgt   15  0.870 ± 0.011  ns/op
Characters.isDigit         1632  avgt   15  2.168 ± 0.017  ns/op
```
PR:

```
Benchmark           (codePoint)  Mode  Cnt  Score   Error  Units
Characters.isDigit           48  avgt   15  0.654 ± 0.007  ns/op
Characters.isDigit         1632  avgt   15  2.032 ± 0.019  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304245](https://bugs.openjdk.org/browse/JDK-8304245): Speed up CharacterData.of by avoiding bit shifting in the latin1 fast-path test


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [0174440e](https://git.openjdk.org/jdk/pull/13040/files/0174440e3b2468db08c1742969b59af8bddc436d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13040/head:pull/13040` \
`$ git checkout pull/13040`

Update a local copy of the PR: \
`$ git checkout pull/13040` \
`$ git pull https://git.openjdk.org/jdk.git pull/13040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13040`

View PR using the GUI difftool: \
`$ git pr show -t 13040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13040.diff">https://git.openjdk.org/jdk/pull/13040.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13040#issuecomment-1469859167)