### PR TITLE
JDK-8304063: tools/jpackage/share/AppLauncherEnvTest.java fails when checking LD_LIBRARY_PATH

### DIFF
--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,8 +83,14 @@ public class AppLauncherEnvTest {
         final String expectedEnvVarValue = Optional.ofNullable(System.getenv(
                 envVarName)).orElse("") + File.pathSeparator + appDir;
 
-        TKit.assertEquals(expectedEnvVarValue, actualEnvVarValue, String.format(
-                "Check value of %s env variable", envVarName));
+        String msg = String.format("Check value of %s env variable", envVarName);
+        if (TKit.isLinux()) {
+            if (! actualEnvVarValue.endsWith(expectedEnvVarValue)) {
+                TKit.assertTrue(false, msg);
+            }
+        } else {
+            TKit.assertEquals(expectedEnvVarValue, actualEnvVarValue, msg);
+        }
 
         final String javaLibraryPath = getValue.apply(2, "java.library.path");
         TKit.assertTrue(

--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Executor;
@@ -83,14 +84,10 @@ public class AppLauncherEnvTest {
         final String expectedEnvVarValue = Optional.ofNullable(System.getenv(
                 envVarName)).orElse("") + File.pathSeparator + appDir;
 
-        String msg = String.format("Check value of %s env variable", envVarName);
-        if (TKit.isLinux()) {
-            if (! actualEnvVarValue.endsWith(expectedEnvVarValue)) {
-                TKit.assertTrue(false, msg);
-            }
-        } else {
-            TKit.assertEquals(expectedEnvVarValue, actualEnvVarValue, msg);
-        }
+        TKit.assertTextStream(expectedEnvVarValue)
+            .predicate(TKit.isLinux() ? String::endsWith : String::equals)
+            .label(String.format("value of %s env variable", envVarName))
+            .apply(Stream.of(actualEnvVarValue));
 
         final String javaLibraryPath = getValue.apply(2, "java.library.path");
         TKit.assertTrue(


### PR DESCRIPTION
The test fails on Alpine Linux 3.17, when checking the environment variable LD_LIBRARY_PATH; looks like the actual env variable is much longer than the test expects. It turned out that at least on Linux (probably also on other OS like AIX)  the actual env variable has the expected string at it's end, but might contain more path entries ( LD_LIBRARY_PATH can be adjusted by jvm - https://github.com/openjdk/jdk/blob/master/src/java.base/unix/native/libjli/java_md.c  ).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304063](https://bugs.openjdk.org/browse/JDK-8304063): tools/jpackage/share/AppLauncherEnvTest.java fails when checking LD_LIBRARY_PATH


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13041/head:pull/13041` \
`$ git checkout pull/13041`

Update a local copy of the PR: \
`$ git checkout pull/13041` \
`$ git pull https://git.openjdk.org/jdk pull/13041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13041`

View PR using the GUI difftool: \
`$ git pr show -t 13041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13041.diff">https://git.openjdk.org/jdk/pull/13041.diff</a>

</details>
