### PR TITLE
8304264: Debug messages always show up for NativeGSS

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSLibStub.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSLibStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,9 @@ class GSSLibStub {
         return s;
     }
     private GSSLibStub(Oid mech) throws GSSException {
-        SunNativeProvider.debug("Created GSSLibStub for mech " + mech);
+        if (SunNativeProvider.DEBUG) {
+            SunNativeProvider.debug("Created GSSLibStub for mech " + mech);
+        }
         this.mech = mech;
         this.pMech = getMechPtr(mech.getDER());
     }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSNameElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSNameElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,12 +73,16 @@ public class GSSNameElement implements GSSNameSpi {
                         supportedNTs = stub.inquireNamesForMech();
                     } catch (GSSException ge2) {
                         // Should never happen
-                        SunNativeProvider.debug("Name type list unavailable: " +
-                            ge2.getMajorString());
+                        if (SunNativeProvider.DEBUG) {
+                            SunNativeProvider.debug("Name type list unavailable: " +
+                                    ge2.getMajorString());
+                        }
                     }
                 } else {
-                    SunNativeProvider.debug("Name type list unavailable: " +
-                        ge.getMajorString());
+                    if (SunNativeProvider.DEBUG) {
+                        SunNativeProvider.debug("Name type list unavailable: " +
+                                ge.getMajorString());
+                    }
                 }
             }
             if (supportedNTs != null) {
@@ -86,8 +90,10 @@ public class GSSNameElement implements GSSNameSpi {
                     if (supportedNTs[i].equals(nameType)) return nameType;
                 }
                 // Special handling the specified name type
-                SunNativeProvider.debug("Override " + nameType +
-                    " with mechanism default(null)");
+                if (SunNativeProvider.DEBUG) {
+                    SunNativeProvider.debug("Override " + nameType +
+                            " with mechanism default(null)");
+                }
                 return null; // Use mechanism specific default
             }
         }
@@ -185,8 +191,10 @@ public class GSSNameElement implements GSSNameSpi {
             }
         }
 
-        SunNativeProvider.debug("Imported " + printableName + " w/ type " +
-                                printableType);
+        if (SunNativeProvider.DEBUG) {
+            SunNativeProvider.debug("Imported " + printableName + " w/ type " +
+                    printableType);
+        }
     }
 
     private void setPrintables() throws GSSException {
@@ -211,7 +219,9 @@ public class GSSNameElement implements GSSNameSpi {
         mName = stub.canonicalizeName(pName);
         Object[] printables2 = stub.displayName(mName);
         stub.releaseName(mName);
-        SunNativeProvider.debug("Got kerberized name: " + printables2[0]);
+        if (SunNativeProvider.DEBUG) {
+            SunNativeProvider.debug("Got kerberized name: " + printables2[0]);
+        }
         return (String) printables2[0];
     }
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/Krb5Util.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/Krb5Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,10 @@ class Krb5Util {
         @SuppressWarnings("removal")
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
-            SunNativeProvider.debug("Checking ServicePermission(" +
-                                    target + ", " + action + ")");
+            if (SunNativeProvider.DEBUG) {
+                SunNativeProvider.debug("Checking ServicePermission(" +
+                        target + ", " + action + ")");
+            }
             ServicePermission perm =
                 new ServicePermission(target, action);
             sm.checkPermission(perm);

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,8 +148,10 @@ class NativeGSSContext implements GSSContextSpi {
             String tgsStr = Krb5Util.getTGSName(targetName);
             String krbPrincPair = "\"" + targetStr + "\" \"" +
                     tgsStr + '\"';
-            SunNativeProvider.debug("Checking DelegationPermission (" +
-                                    krbPrincPair + ")");
+            if (SunNativeProvider.DEBUG) {
+                SunNativeProvider.debug("Checking DelegationPermission (" +
+                        krbPrincPair + ")");
+            }
             DelegationPermission perm =
                 new DelegationPermission(krbPrincPair);
             sm.checkPermission(perm);
@@ -163,8 +165,10 @@ class NativeGSSContext implements GSSContextSpi {
             byte[] result;
             if (mechTokenLen != -1) {
                 // Need to add back the GSS header for a complete GSS token
-                SunNativeProvider.debug("Precomputed mechToken length: " +
-                                         mechTokenLen);
+                if (SunNativeProvider.DEBUG) {
+                    SunNativeProvider.debug("Precomputed mechToken length: " +
+                            mechTokenLen);
+                }
                 GSSHeader gssHeader = new GSSHeader
                     (ObjectIdentifier.of(cStub.getMech().toString()),
                      mechTokenLen);
@@ -182,8 +186,10 @@ class NativeGSSContext implements GSSContextSpi {
                 DerValue dv = new DerValue(is);
                 result = dv.toByteArray();
             }
-            SunNativeProvider.debug("Complete Token length: " +
-                                    result.length);
+            if (SunNativeProvider.DEBUG) {
+                SunNativeProvider.debug("Complete Token length: " +
+                        result.length);
+            }
             return result;
         } catch (IOException ioe) {
             throw new GSSExceptionImpl(GSSException.FAILURE, ioe);
@@ -273,8 +279,10 @@ class NativeGSSContext implements GSSContextSpi {
             // Ignore the specified input stream on the first call
             if (pContext != 0) {
                 inToken = retrieveToken(is, mechTokenLen);
-                SunNativeProvider.debug("initSecContext=> inToken len=" +
-                    inToken.length);
+                if (SunNativeProvider.DEBUG) {
+                    SunNativeProvider.debug("initSecContext=> inToken len=" +
+                            inToken.length);
+                }
             }
 
             if (!getCredDelegState()) skipDelegPermCheck = true;
@@ -286,8 +294,10 @@ class NativeGSSContext implements GSSContextSpi {
             long pCred = (cred == null? 0 : cred.pCred);
             outToken = cStub.initContext(pCred, targetName.pName,
                                          cb, inToken, this);
-            SunNativeProvider.debug("initSecContext=> outToken len=" +
-                (outToken == null ? 0 : outToken.length));
+            if (SunNativeProvider.DEBUG) {
+                SunNativeProvider.debug("initSecContext=> outToken len=" +
+                        (outToken == null ? 0 : outToken.length));
+            }
 
             // Only inspect the token when the permission check
             // has not been performed
@@ -321,13 +331,17 @@ class NativeGSSContext implements GSSContextSpi {
         byte[] outToken = null;
         if ((!isEstablished) && (!isInitiator)) {
             byte[] inToken = retrieveToken(is, mechTokenLen);
-            SunNativeProvider.debug("acceptSecContext=> inToken len=" +
-                                    inToken.length);
+            if (SunNativeProvider.DEBUG) {
+                SunNativeProvider.debug("acceptSecContext=> inToken len=" +
+                        inToken.length);
+            }
             long pCred = (cred == null? 0 : cred.pCred);
             outToken = cStub.acceptContext(pCred, cb, inToken, this);
             disposeDelegatedCred = delegatedCred;
-            SunNativeProvider.debug("acceptSecContext=> outToken len=" +
-                                    (outToken == null? 0 : outToken.length));
+            if (SunNativeProvider.DEBUG) {
+                SunNativeProvider.debug("acceptSecContext=> outToken len=" +
+                        (outToken == null ? 0 : outToken.length));
+            }
 
             if (targetName == null) {
                 targetName = new GSSNameElement

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,8 @@ public final class SunNativeProvider extends Provider {
     private static final String INFO = "Sun Native GSS provider";
     private static final String MF_CLASS =
         "sun.security.jgss.wrapper.NativeGSSFactory";
-    private static final boolean DEBUG =
+
+    static final boolean DEBUG =
         GetBooleanAction.privilegedGetProperty("sun.security.nativegss.debug");
 
     static void debug(String message) {


### PR DESCRIPTION
Only call `debug()` when `DEBUG` is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304264](https://bugs.openjdk.org/browse/JDK-8304264): Debug messages always show up for NativeGSS


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13043/head:pull/13043` \
`$ git checkout pull/13043`

Update a local copy of the PR: \
`$ git checkout pull/13043` \
`$ git pull https://git.openjdk.org/jdk pull/13043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13043`

View PR using the GUI difftool: \
`$ git pr show -t 13043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13043.diff">https://git.openjdk.org/jdk/pull/13043.diff</a>

</details>
