### PR TITLE
8304146: Refactor VisibleMemberTable (LocalMemberTable)

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -1001,7 +1001,7 @@ public class VisibleMemberTable {
             }
 
             var setter = lmt.getPropertyMethods(utils.elementUtils.getName(pUtils.getSetName(propertyMethod))).stream()
-                    // TODO: number of parameters a setter take is not tested (JDK-8304170)
+                    // TODO: the number and the types of parameters a setter takes is not tested (JDK-8304170)
                     .filter(m -> m.getParameters().size() == 1 && pUtils.isValidSetterMethod(m))
                     .findAny()
                     .orElse(null);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -900,19 +900,19 @@ public class VisibleMemberTable {
             return orderedMembers.get(kind);
         }
 
-        List<Element> getMembers(Name simplename, Kind kind) {
-            return namedMembers.get(kind).getOrDefault(simplename, List.of());
+        List<Element> getMembers(Name simpleName, Kind kind) {
+            return namedMembers.get(kind).getOrDefault(simpleName, List.of());
         }
 
-        <T extends Element> List<T> getMembers(Name simplename, Kind kind, Class<T> clazz) {
-            return getMembers(simplename, kind)
+        <T extends Element> List<T> getMembers(Name simpleName, Kind kind, Class<T> clazz) {
+            return getMembers(simpleName, kind)
                     .stream()
                     .map(clazz::cast)
                     .toList();
         }
 
-        List<ExecutableElement> getPropertyMethods(Name simplename) {
-            return getMembers(simplename, Kind.METHODS).stream()
+        List<ExecutableElement> getPropertyMethods(Name simpleName) {
+            return getMembers(simpleName, Kind.METHODS).stream()
                     .filter(m -> (utils.isPublic(m) || utils.isProtected(m)))
                     .map(m -> (ExecutableElement) m)
                     .toList();
@@ -979,7 +979,7 @@ public class VisibleMemberTable {
             List<VariableElement> flist = lmt.getMembers(utils.elementUtils.getName(baseName), Kind.FIELDS, VariableElement.class);
             VariableElement field = flist.isEmpty() ? null : flist.get(0);
 
-            // TODO: this code does not seem to be covered by tests well
+            // TODO: this code does not seem to be covered by tests well (JDK-8304170)
             ExecutableElement getter = null;
             var g = lmt.getPropertyMethods(utils.elementUtils.getName(pUtils.getGetName(propertyMethod))).stream()
                     .filter(m -> m.getParameters().isEmpty()) // Getters have zero params, no overloads!
@@ -1001,7 +1001,7 @@ public class VisibleMemberTable {
             }
 
             var setter = lmt.getPropertyMethods(utils.elementUtils.getName(pUtils.getSetName(propertyMethod))).stream()
-                    // TODO: number of parameters a setter take is not tested
+                    // TODO: number of parameters a setter take is not tested (JDK-8304170)
                     .filter(m -> m.getParameters().size() == 1 && pUtils.isValidSetterMethod(m))
                     .findAny()
                     .orElse(null);


### PR DESCRIPTION
Please review a change to clean up and simplify LocalMemberTable; a container to cache, classify, and provide efficient lookup for the return value of `TypeElement.getEnclosedElements()`.

While the change primarily targets internals of LocalMemberTable, it also affects its clients: in particular, code that handles JavaFX documentation. That code does not seem to be tested well (I filed a bug for that: JDK-8304170). To make sure I haven't broken anything, aside from usual testing, I also cloned [OpenJFX](https://github.com/openjdk/jfx) and built its documentation with javadoc before and after the change. Documentation bundles were identical.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304146](https://bugs.openjdk.org/browse/JDK-8304146): Refactor VisibleMemberTable (LocalMemberTable)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [6013787a](https://git.openjdk.org/jdk/pull/13044/files/6013787aec7b612f698be5aaea3205a7ca0f23a6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13044/head:pull/13044` \
`$ git checkout pull/13044`

Update a local copy of the PR: \
`$ git checkout pull/13044` \
`$ git pull https://git.openjdk.org/jdk pull/13044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13044`

View PR using the GUI difftool: \
`$ git pr show -t 13044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13044.diff">https://git.openjdk.org/jdk/pull/13044.diff</a>

</details>
