### PR TITLE
JDK-8304054: Linux: NullPointerException from FontConfiguration.getVersion in case no fonts are installed

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,6 +106,7 @@ public abstract class FontConfiguration {
             initFontConfig();
             inited = true;
         }
+
         return true;
     }
 
@@ -153,6 +154,7 @@ public abstract class FontConfiguration {
      */
     public boolean fontFilesArePresent() {
         init();
+
         short fontNameID = compFontNameIDs[0][0][0];
         short fileNameID = getComponentFileID(fontNameID);
         final String fileName = mapFileName(getComponentFileName(fileNameID));
@@ -1249,10 +1251,16 @@ public abstract class FontConfiguration {
      * search path.
      */
     public String getExtraFontPath() {
+        if (head == null) {
+            throw new RuntimeException("Fontconfig head is null, check your fonts or fonts configuration");
+        }
         return getString(head[INDEX_appendedfontpath]);
     }
 
     public String getVersion() {
+        if (head == null) {
+            throw new RuntimeException("Fontconfig head is null, check your fonts or fonts configuration");
+        }
         return getString(head[INDEX_version]);
     }
 

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -1244,7 +1244,8 @@ public abstract class FontConfiguration {
         return filenamesMap.get(platformName);
     }
 
-    private static final String fontconfigErrorMessage = "Fontconfig head is null, check your fonts or fonts configuration";
+    private static final String fontconfigErrorMessage =
+            "Fontconfig head is null, check your fonts or fonts configuration";
 
     /**
      * Returns a configuration specific path to be appended to the font

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -1246,20 +1246,22 @@ public abstract class FontConfiguration {
         return filenamesMap.get(platformName);
     }
 
+    private static final String fontconfigErrorMessage = "Fontconfig head is null, check your fonts or fonts configuration";
+
     /**
      * Returns a configuration specific path to be appended to the font
      * search path.
      */
     public String getExtraFontPath() {
         if (head == null) {
-            throw new RuntimeException("Fontconfig head is null, check your fonts or fonts configuration");
+            throw new RuntimeException(fontconfigErrorMessage);
         }
         return getString(head[INDEX_appendedfontpath]);
     }
 
     public String getVersion() {
         if (head == null) {
-            throw new RuntimeException("Fontconfig head is null, check your fonts or fonts configuration");
+            throw new RuntimeException(fontconfigErrorMessage);
         }
         return getString(head[INDEX_version]);
     }

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -106,7 +106,6 @@ public abstract class FontConfiguration {
             initFontConfig();
             inited = true;
         }
-
         return true;
     }
 
@@ -154,7 +153,6 @@ public abstract class FontConfiguration {
      */
     public boolean fontFilesArePresent() {
         init();
-
         short fontNameID = compFontNameIDs[0][0][0];
         short fileNameID = getComponentFileID(fontNameID);
         final String fileName = mapFileName(getComponentFileName(fileNameID));


### PR DESCRIPTION
On Linux Alpine we were running in the jtreg awt tests into a lot of NPEs like this :

java.lang.InternalError: java.lang.reflect.InvocationTargetException
at java.desktop/sun.font.FontManagerFactory$1.run(FontManagerFactory.java:87)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
at java.desktop/sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:75)
at java.desktop/java.awt.Font.getFont2D(Font.java:526)
at java.desktop/java.awt.Font$FontAccessImpl.getFont2D(Font.java:265)
at java.desktop/sun.font.FontUtilities.getFont2D(FontUtilities.java:148)
at java.desktop/sun.font.GlyphLayout$SDCache.<init>(GlyphLayout.java:254)
at java.desktop/sun.font.GlyphLayout$SDCache.get(GlyphLayout.java:328)
at java.desktop/sun.font.GlyphLayout.layout(GlyphLayout.java:375)
at java.desktop/java.awt.Font.layoutGlyphVector(Font.java:2858)
at FontLayoutStressTest.doLayout(FontLayoutStressTest.java:51)
at FontLayoutStressTest.main(FontLayoutStressTest.java:57)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.reflect.InvocationTargetException
at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
at java.desktop/sun.font.FontManagerFactory$1.run(FontManagerFactory.java:85)
... 17 more
Caused by: java.lang.NullPointerException: Cannot load from short array because "sun.awt.FontConfiguration.head" is null
at java.desktop/sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
at java.desktop/sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:224)
at java.desktop/sun.awt.FontConfiguration.init(FontConfiguration.java:106)
at java.desktop/sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:706)
at java.desktop/sun.font.SunFontManager$2.run(SunFontManager.java:358)
at java.desktop/sun.font.SunFontManager$2.run(SunFontManager.java:315)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
at java.desktop/sun.font.SunFontManager.<init>(SunFontManager.java:315)
at java.desktop/sun.awt.FcFontManager.<init>(FcFontManager.java:35)
at java.desktop/sun.awt.X11FontManager.<init>(X11FontManager.java:56)
... 23 more

Seems this was caused because no fonts were installed on the machine.
Probably 'head' in FontConfiguration.getVersion() should be checked for null and a specific exception like "Check your fonts or fonts configuration"
should be throw.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304054](https://bugs.openjdk.org/browse/JDK-8304054): Linux: NullPointerException from FontConfiguration.getVersion in case no fonts are installed


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [e9e7b54b](https://git.openjdk.org/jdk/pull/13045/files/e9e7b54b1d8bac212c01b0c1c5eefc403978466f)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13045/head:pull/13045` \
`$ git checkout pull/13045`

Update a local copy of the PR: \
`$ git checkout pull/13045` \
`$ git pull https://git.openjdk.org/jdk.git pull/13045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13045`

View PR using the GUI difftool: \
`$ git pr show -t 13045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13045.diff">https://git.openjdk.org/jdk/pull/13045.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13045#issuecomment-1470325856)