### PR TITLE
8304267: JDK-8303415 missed change in Zero Interpreter

### DIFF
--- a/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.cpp
@@ -56,6 +56,7 @@ void ZeroInterpreterGenerator::generate_all() {
     method_entry(java_lang_math_tan   );
     method_entry(java_lang_math_abs   );
     method_entry(java_lang_math_sqrt  );
+    method_entry(java_lang_math_sqrt_strict);
     method_entry(java_lang_math_log   );
     method_entry(java_lang_math_log10 );
     method_entry(java_lang_math_pow );
@@ -98,6 +99,7 @@ address ZeroInterpreterGenerator::generate_method_entry(
   case Interpreter::java_lang_math_log     : // fall thru
   case Interpreter::java_lang_math_log10   : // fall thru
   case Interpreter::java_lang_math_sqrt    : // fall thru
+  case Interpreter::java_lang_math_sqrt_strict: // fall thru
   case Interpreter::java_lang_math_pow     : // fall thru
   case Interpreter::java_lang_math_exp     : // fall thru
   case Interpreter::java_lang_math_fmaD    : // fall thru


### PR DESCRIPTION
Added missing lines to Zero Interpreter.

Tested with building debug JDK with Zero JVM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304267](https://bugs.openjdk.org/browse/JDK-8304267): JDK-8303415 missed change in Zero Interpreter


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13046/head:pull/13046` \
`$ git checkout pull/13046`

Update a local copy of the PR: \
`$ git checkout pull/13046` \
`$ git pull https://git.openjdk.org/jdk pull/13046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13046`

View PR using the GUI difftool: \
`$ git pr show -t 13046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13046.diff">https://git.openjdk.org/jdk/pull/13046.diff</a>

</details>
