### PR TITLE
8304283: Modernize the switch statements in jdk.internal.foreign

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -197,7 +197,7 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT_UNALIGNED;
  *
  * --------------------
  */
-public interface Binding {
+public sealed interface Binding {
 
     /**
      * A binding context is used as an helper to carry out evaluation of certain bindings; for instance,
@@ -291,21 +291,6 @@ public interface Binding {
             }
         };
     }
-
-    enum Tag {
-        VM_STORE,
-        VM_LOAD,
-        BUFFER_STORE,
-        BUFFER_LOAD,
-        COPY_BUFFER,
-        ALLOC_BUFFER,
-        BOX_ADDRESS,
-        UNBOX_ADDRESS,
-        DUP,
-        CAST
-    }
-
-    Tag tag();
 
     void verify(Deque<Class<?>> stack);
 
@@ -503,7 +488,7 @@ public interface Binding {
         }
     }
 
-    interface Move extends Binding {
+    sealed interface Move extends Binding {
         VMStorage storage();
         Class<?> type();
     }
@@ -514,10 +499,6 @@ public interface Binding {
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
     record VMStore(VMStorage storage, Class<?> type) implements Move {
-        @Override
-        public Tag tag() {
-            return Tag.VM_STORE;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -539,10 +520,6 @@ public interface Binding {
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
     record VMLoad(VMStorage storage, Class<?> type) implements Move {
-        @Override
-        public Tag tag() {
-            return Tag.VM_LOAD;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -556,7 +533,7 @@ public interface Binding {
         }
     }
 
-    interface Dereference extends Binding {
+    sealed interface Dereference extends Binding {
         long offset();
         Class<?> type();
     }
@@ -568,10 +545,6 @@ public interface Binding {
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
     record BufferStore(long offset, Class<?> type, int byteWidth) implements Dereference {
-        @Override
-        public Tag tag() {
-            return Tag.BUFFER_STORE;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -629,10 +602,6 @@ public interface Binding {
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
     record BufferLoad(long offset, Class<?> type, int byteWidth) implements Dereference {
-        @Override
-        public Tag tag() {
-            return Tag.BUFFER_LOAD;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -694,11 +663,6 @@ public interface Binding {
         }
 
         @Override
-        public Tag tag() {
-            return Tag.COPY_BUFFER;
-        }
-
-        @Override
         public void verify(Deque<Class<?>> stack) {
             Class<?> actualType = stack.pop();
             SharedUtils.checkType(actualType, MemorySegment.class);
@@ -724,11 +688,6 @@ public interface Binding {
         }
 
         @Override
-        public Tag tag() {
-            return Tag.ALLOC_BUFFER;
-        }
-
-        @Override
         public void verify(Deque<Class<?>> stack) {
             stack.push(MemorySegment.class);
         }
@@ -747,11 +706,6 @@ public interface Binding {
      */
     record UnboxAddress() implements Binding {
         static final UnboxAddress INSTANCE = new UnboxAddress();
-
-        @Override
-        public Tag tag() {
-            return Tag.UNBOX_ADDRESS;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -773,11 +727,6 @@ public interface Binding {
      * (either the context scope, or the global scope), and pushes that onto the operand stack.
      */
     record BoxAddress(long size, boolean needsScope) implements Binding {
-
-        @Override
-        public Tag tag() {
-            return Tag.BOX_ADDRESS;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -802,11 +751,6 @@ public interface Binding {
      */
     record Dup() implements Binding {
         static final Dup INSTANCE = new Dup();
-
-        @Override
-        public Tag tag() {
-            return Tag.DUP;
-        }
 
         @Override
         public void verify(Deque<Class<?>> stack) {
@@ -859,11 +803,6 @@ public interface Binding {
 
         public Class<?> toType() {
             return toType;
-        }
-
-        @Override
-        public Tag tag() {
-            return Tag.CAST;
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -467,17 +467,17 @@ public class BindingSpecializer {
 
     private void doBindings(List<Binding> bindings) {
         for (Binding binding : bindings) {
-            switch (binding.tag()) {
-                case VM_STORE -> emitVMStore((Binding.VMStore) binding);
-                case VM_LOAD -> emitVMLoad((Binding.VMLoad) binding);
-                case BUFFER_STORE -> emitBufferStore((Binding.BufferStore) binding);
-                case BUFFER_LOAD -> emitBufferLoad((Binding.BufferLoad) binding);
-                case COPY_BUFFER -> emitCopyBuffer((Binding.Copy) binding);
-                case ALLOC_BUFFER -> emitAllocBuffer((Binding.Allocate) binding);
-                case BOX_ADDRESS -> emitBoxAddress((Binding.BoxAddress) binding);
-                case UNBOX_ADDRESS -> emitUnboxAddress();
-                case DUP -> emitDupBinding();
-                case CAST -> emitCast((Binding.Cast) binding);
+            switch (binding) {
+                case Binding.VMStore vmStore -> emitVMStore(vmStore);
+                case Binding.VMLoad vmLoad -> emitVMLoad(vmLoad);
+                case Binding.BufferStore bufferStore -> emitBufferStore(bufferStore);
+                case Binding.BufferLoad bufferLoad -> emitBufferLoad(bufferLoad);
+                case Binding.Copy copy -> emitCopyBuffer(copy);
+                case Binding.Allocate allocate -> emitAllocBuffer(allocate);
+                case Binding.BoxAddress boxAddress -> emitBoxAddress(boxAddress);
+                case Binding.UnboxAddress unused -> emitUnboxAddress();
+                case Binding.Dup unused -> emitDupBinding();
+                case Binding.Cast cast -> emitCast(cast);
             }
         }
     }
@@ -638,15 +638,15 @@ public class BindingSpecializer {
                 Class<?> chunkStoreType;
                 long mask;
                 switch (chunkSize) {
-                    case 4 -> {
+                    case Integer.BYTES -> {
                         chunkStoreType = int.class;
                         mask = 0xFFFF_FFFFL;
                     }
-                    case 2 -> {
+                    case Short.BYTES -> {
                         chunkStoreType = short.class;
                         mask = 0xFFFFL;
                     }
-                    case 1 -> {
+                    case Byte.BYTES -> {
                         chunkStoreType = byte.class;
                         mask = 0xFFL;
                     }
@@ -802,17 +802,17 @@ public class BindingSpecializer {
                 Class<?> toULongHolder;
                 String toULongDescriptor;
                 switch (chunkSize) {
-                    case 4 -> {
+                    case Integer.BYTES -> {
                         chunkType = int.class;
                         toULongHolder = Integer.class;
                         toULongDescriptor = INTEGER_TO_UNSIGNED_LONG_DESC;
                     }
-                    case 2 -> {
+                    case Short.BYTES -> {
                         chunkType = short.class;
                         toULongHolder = Short.class;
                         toULongDescriptor = SHORT_TO_UNSIGNED_LONG_DESC;
                     }
-                    case 1 -> {
+                    case Byte.BYTES -> {
                         chunkType = byte.class;
                         toULongHolder = Byte.class;
                         toULongDescriptor = BYTE_TO_UNSIGNED_LONG_DESC;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -25,6 +25,16 @@
 package jdk.internal.foreign.abi;
 
 import jdk.internal.foreign.Utils;
+import jdk.internal.foreign.abi.Binding.Allocate;
+import jdk.internal.foreign.abi.Binding.BoxAddress;
+import jdk.internal.foreign.abi.Binding.BufferLoad;
+import jdk.internal.foreign.abi.Binding.BufferStore;
+import jdk.internal.foreign.abi.Binding.Cast;
+import jdk.internal.foreign.abi.Binding.Copy;
+import jdk.internal.foreign.abi.Binding.Dup;
+import jdk.internal.foreign.abi.Binding.UnboxAddress;
+import jdk.internal.foreign.abi.Binding.VMLoad;
+import jdk.internal.foreign.abi.Binding.VMStore;
 import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.FunctionDescriptor;
@@ -125,11 +135,11 @@ public class CallingSequenceBuilder {
     }
 
     private MethodType computeCallerTypeForUpcall() {
-        return computeTypeHelper(Binding.VMLoad.class, Binding.VMStore.class);
+        return computeTypeHelper(VMLoad.class, VMStore.class);
     }
 
     private MethodType computeCalleeTypeForDowncall() {
-        return computeTypeHelper(Binding.VMStore.class, Binding.VMLoad.class);
+        return computeTypeHelper(VMStore.class, VMLoad.class);
     }
 
     private MethodType computeTypeHelper(Class<? extends Binding.Move> inputVMClass,
@@ -156,10 +166,10 @@ public class CallingSequenceBuilder {
         long size = 0;
         for (List<Binding> bindings : inputBindings) {
             for (Binding b : bindings) {
-                if (b instanceof Binding.Copy copy) {
+                if (b instanceof Copy copy) {
                     size = Utils.alignUp(size, copy.alignment());
                     size += copy.size();
-                } else if (b instanceof Binding.Allocate allocate) {
+                } else if (b instanceof Allocate allocate) {
                     size = Utils.alignUp(size, allocate.alignment());
                     size += allocate.size();
                 }
@@ -205,16 +215,17 @@ public class CallingSequenceBuilder {
 
     static boolean isUnbox(Binding binding) {
         return switch (binding) {
-            case Binding.VMStore unused -> true;
-            case Binding.VMLoad unused -> false;
-            case Binding.BufferStore unused -> false;
-            case Binding.BufferLoad unused -> true;
-            case Binding.Copy unused -> true;
-            case Binding.Allocate unused -> false;
-            case Binding.BoxAddress unused -> false;
-            case Binding.UnboxAddress unused -> true;
-            case Binding.Dup unused -> true;
-            case Binding.Cast unused-> true;
+            case VMStore      unused -> true;
+            case BufferLoad   unused -> true;
+            case Copy         unused -> true;
+            case UnboxAddress unused -> true;
+            case Dup          unused -> true;
+            case Cast         unused -> true;
+
+            case VMLoad       unused -> false;
+            case BufferStore  unused -> false;
+            case Allocate     unused -> false;
+            case BoxAddress   unused -> false;
         };
     }
 
@@ -237,16 +248,17 @@ public class CallingSequenceBuilder {
 
     static boolean isBox(Binding binding) {
         return switch (binding) {
-            case Binding.VMStore unused -> false;
-            case Binding.VMLoad unused -> true;
-            case Binding.BufferStore unused -> true;
-            case Binding.BufferLoad unused -> false;
-            case Binding.Copy unused -> true;
-            case Binding.Allocate unused -> true;
-            case Binding.BoxAddress unused -> true;
-            case Binding.UnboxAddress unused -> false;
-            case Binding.Dup unused -> true;
-            case Binding.Cast unused-> true;
+            case VMLoad       unused -> true;
+            case BufferStore  unused -> true;
+            case Copy         unused -> true;
+            case Allocate     unused -> true;
+            case BoxAddress   unused -> true;
+            case Dup          unused -> true;
+            case Cast         unused -> true;
+
+            case VMStore      unused -> false;
+            case BufferLoad   unused -> false;
+            case UnboxAddress unused -> false;
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
@@ -46,13 +46,12 @@ public class AArch64Architecture implements Architecture {
 
     @Override
     public int typeSize(int cls) {
-        switch (cls) {
-            case StorageType.INTEGER: return INTEGER_REG_SIZE;
-            case StorageType.VECTOR: return VECTOR_REG_SIZE;
+        return switch (cls) {
+            case StorageType.INTEGER -> INTEGER_REG_SIZE;
+            case StorageType.VECTOR -> VECTOR_REG_SIZE;
             // STACK is deliberately omitted
-        }
-
-        throw new IllegalArgumentException("Invalid Storage Class: " + cls);
+            default -> throw new IllegalArgumentException("Invalid Storage Class: " + cls);
+        };
     }
 
     public interface StorageType {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
@@ -48,13 +48,11 @@ public class RISCV64Architecture implements Architecture {
 
     @Override
     public int typeSize(int cls) {
-        switch (cls) {
-            case StorageType.INTEGER: return INTEGER_REG_SIZE;
-            case StorageType.FLOAT: return FLOAT_REG_SIZE;
-            // STACK is deliberately omitted
-        }
-
-        throw new IllegalArgumentException("Invalid Storage Class: " + cls);
+        return switch (cls) {
+            case StorageType.INTEGER -> INTEGER_REG_SIZE;
+            case StorageType.FLOAT -> FLOAT_REG_SIZE;
+            default -> throw new IllegalArgumentException("Invalid Storage Class: " + cls);
+        };
     }
 
     public interface StorageType {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
@@ -50,7 +50,7 @@ public class RISCV64Architecture implements Architecture {
     public int typeSize(int cls) {
         return switch (cls) {
             case StorageType.INTEGER -> INTEGER_REG_SIZE;
-            case StorageType.FLOAT -> FLOAT_REG_SIZE;
+            case StorageType.FLOAT   -> FLOAT_REG_SIZE;
             // STACK is deliberately omitted
             default -> throw new IllegalArgumentException("Invalid Storage Class: " + cls);
         };

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
@@ -51,6 +51,7 @@ public class RISCV64Architecture implements Architecture {
         return switch (cls) {
             case StorageType.INTEGER -> INTEGER_REG_SIZE;
             case StorageType.FLOAT -> FLOAT_REG_SIZE;
+            // STACK is deliberately omitted
             default -> throw new IllegalArgumentException("Invalid Storage Class: " + cls);
         };
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/RISCV64Architecture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Institute of Software, Chinese Academy of Sciences.
  * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
@@ -87,7 +87,7 @@ public enum TypeClass {
                 case ValueLayout valueLayout -> {
                     return switch (classifyValueType(valueLayout)) {
                         case INTEGER -> FieldCounter.SINGLE_INTEGER;
-                        case FLOAT -> FieldCounter.SINGLE_FLOAT;
+                        case FLOAT   -> FieldCounter.SINGLE_FLOAT;
                         case POINTER -> FieldCounter.SINGLE_POINTER;
                         default -> throw new IllegalStateException("Should not reach here.");
                     };

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
@@ -109,7 +109,7 @@ public enum TypeClass {
                     }
                     return flatten(sequenceLayout.elementLayout()).mul(elementCount);
                 }
-                case null, default -> throw new IllegalStateException("Cannot get here: " + layout);
+                default -> throw new IllegalStateException("Cannot get here: " + layout);
             }
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Institute of Software, Chinese Academy of Sciences.
  * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
@@ -55,14 +55,13 @@ public class X86_64Architecture implements Architecture {
 
     @Override
     public int typeSize(int cls) {
-        switch (cls) {
-            case StorageType.INTEGER: return INTEGER_REG_SIZE;
-            case StorageType.VECTOR: return VECTOR_REG_SIZE;
-            case StorageType.X87: return X87_REG_SIZE;
+        return switch (cls) {
+            case StorageType.INTEGER -> INTEGER_REG_SIZE;
+            case StorageType.VECTOR -> VECTOR_REG_SIZE;
+            case StorageType.X87 -> X87_REG_SIZE;
             // STACK is deliberately omitted
-        }
-
-        throw new IllegalArgumentException("Invalid Storage Class: " +cls);
+            default -> throw new IllegalArgumentException("Invalid Storage Class: " +cls);
+        };
     }
 
     // must keep in sync with StorageType in VM code

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
@@ -57,8 +57,8 @@ public class X86_64Architecture implements Architecture {
     public int typeSize(int cls) {
         return switch (cls) {
             case StorageType.INTEGER -> INTEGER_REG_SIZE;
-            case StorageType.VECTOR -> VECTOR_REG_SIZE;
-            case StorageType.X87 -> X87_REG_SIZE;
+            case StorageType.VECTOR  -> VECTOR_REG_SIZE;
+            case StorageType.X87     -> X87_REG_SIZE;
             // STACK is deliberately omitted
             default -> throw new IllegalArgumentException("Invalid Storage Class: " +cls);
         };

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -86,9 +86,9 @@ public class CallArranger {
         class CallingSequenceBuilderHelper {
             final CallingSequenceBuilder csb = new CallingSequenceBuilder(CWindows, forUpcall, options);
             final BindingCalculator argCalc =
-                forUpcall ? new BoxBindingCalculator(true) : new UnboxBindingCalculator(true);
+                    forUpcall ? new BoxBindingCalculator(true) : new UnboxBindingCalculator(true);
             final BindingCalculator retCalc =
-                forUpcall ? new UnboxBindingCalculator(false) : new BoxBindingCalculator(false);
+                    forUpcall ? new UnboxBindingCalculator(false) : new BoxBindingCalculator(false);
 
             void addArgumentBindings(Class<?> carrier, MemoryLayout layout, boolean isVararg) {
                 csb.addArgumentBindings(carrier, layout, argCalc.getBindings(carrier, layout, isVararg));
@@ -171,7 +171,7 @@ public class CallArranger {
             return (forArguments
                     ? CWindows.inputStorage
                     : CWindows.outputStorage)
-                 [type][nRegs++];
+                    [type][nRegs++];
         }
 
         public VMStorage extraVarargsStorage() {
@@ -196,39 +196,34 @@ public class CallArranger {
             TypeClass argumentClass = TypeClass.typeClassFor(layout, isVararg);
             Binding.Builder bindings = Binding.builder();
             switch (argumentClass) {
-                case STRUCT_REGISTER: {
+                case STRUCT_REGISTER -> {
                     assert carrier == MemorySegment.class;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize(), false);
                     bindings.bufferLoad(0, type)
                             .vmStore(storage, type);
-                    break;
                 }
-                case STRUCT_REFERENCE: {
+                case STRUCT_REFERENCE -> {
                     assert carrier == MemorySegment.class;
                     bindings.copy(layout)
                             .unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmStore(storage, long.class);
-                    break;
                 }
-                case POINTER: {
+                case POINTER -> {
                     bindings.unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmStore(storage, long.class);
-                    break;
                 }
-                case INTEGER: {
+                case INTEGER -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmStore(storage, carrier);
-                    break;
                 }
-                case FLOAT: {
+                case FLOAT -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.VECTOR);
                     bindings.vmStore(storage, carrier);
-                    break;
                 }
-                case VARARG_FLOAT: {
+                case VARARG_FLOAT -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.VECTOR);
                     if (!INSTANCE.isStackType(storage.type())) { // need extra for register arg
                         VMStorage extraStorage = storageCalculator.extraVarargsStorage();
@@ -237,10 +232,8 @@ public class CallArranger {
                     }
 
                     bindings.vmStore(storage, carrier);
-                    break;
                 }
-                default:
-                    throw new UnsupportedOperationException("Unhandled class " + argumentClass);
+                default -> throw new UnsupportedOperationException("Unhandled class " + argumentClass);
             }
             return bindings.build();
         }
@@ -258,7 +251,7 @@ public class CallArranger {
             TypeClass argumentClass = TypeClass.typeClassFor(layout, isVararg);
             Binding.Builder bindings = Binding.builder();
             switch (argumentClass) {
-                case STRUCT_REGISTER: {
+                case STRUCT_REGISTER -> {
                     assert carrier == MemorySegment.class;
                     bindings.allocate(layout)
                             .dup();
@@ -266,33 +259,27 @@ public class CallArranger {
                     Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize(), false);
                     bindings.vmLoad(storage, type)
                             .bufferStore(0, type);
-                    break;
                 }
-                case STRUCT_REFERENCE: {
+                case STRUCT_REFERENCE -> {
                     assert carrier == MemorySegment.class;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddress(layout);
-                    break;
                 }
-                case POINTER: {
+                case POINTER -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeSize(layout));
-                    break;
                 }
-                case INTEGER: {
+                case INTEGER -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, carrier);
-                    break;
                 }
-                case FLOAT: {
+                case FLOAT -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.VECTOR);
                     bindings.vmLoad(storage, carrier);
-                    break;
                 }
-                default:
-                    throw new UnsupportedOperationException("Unhandled class " + argumentClass);
+                default -> throw new UnsupportedOperationException("Unhandled class " + argumentClass);
             }
             return bindings.build();
         }


### PR DESCRIPTION
This PR proposes changing old-type switch statements to newer forms of switch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304283](https://bugs.openjdk.org/browse/JDK-8304283): Modernize the switch statements in jdk.internal.foreign


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [779d1ee2](https://git.openjdk.org/jdk/pull/13047/files/779d1ee25d97430a405a2f88fb8564d266f598aa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13047/head:pull/13047` \
`$ git checkout pull/13047`

Update a local copy of the PR: \
`$ git checkout pull/13047` \
`$ git pull https://git.openjdk.org/jdk pull/13047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13047`

View PR using the GUI difftool: \
`$ git pr show -t 13047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13047.diff">https://git.openjdk.org/jdk/pull/13047.diff</a>

</details>
