### PR TITLE
8291598: Matcher.appendReplacement should not create new StringBuilder instances

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -1053,25 +1053,24 @@ public final class Matcher implements MatchResult {
                     int refNum = -1;
                     if (nextChar == '{') {
                         cursor++;
-                        StringBuilder gsb = new StringBuilder();
+                        int begin = cursor;
                         while (cursor < replacement.length()) {
                             nextChar = replacement.charAt(cursor);
                             if (ASCII.isLower(nextChar) ||
                                     ASCII.isUpper(nextChar) ||
                                     ASCII.isDigit(nextChar)) {
-                                gsb.append(nextChar);
                                 cursor++;
                             } else {
                                 break;
                             }
                         }
-                        if (gsb.length() == 0)
+                        if (begin == cursor)
                             throw new IllegalArgumentException(
                                     "named capturing group has 0 length name");
                         if (nextChar != '}')
                             throw new IllegalArgumentException(
                                     "named capturing group is missing trailing '}'");
-                        String gname = gsb.toString();
+                        String gname = replacement.substring(begin, cursor);
                         if (ASCII.isDigit(gname.charAt(0)))
                             throw new IllegalArgumentException(
                                     "capturing group name {" + gname +

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -25,6 +25,7 @@
 
 package java.util.regex;
 
+import java.io.IOException;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
@@ -917,12 +918,16 @@ public final class Matcher implements MatchResult {
      */
     public Matcher appendReplacement(StringBuffer sb, String replacement) {
         checkMatch();
-        StringBuilder result = new StringBuilder();
-        appendExpandedReplacement(replacement, result);
-        // Append the intervening text
-        sb.append(text, lastAppendPosition, first);
-        // Append the match substitution
-        sb.append(result);
+        int curLen = sb.length();
+        try {
+            // Append the intervening text
+            sb.append(text, lastAppendPosition, first);
+            // Append the match substitution
+            appendExpandedReplacement(sb, replacement);
+        } catch (IllegalArgumentException e) {
+            sb.setLength(curLen);
+            throw e;
+        }
         lastAppendPosition = last;
         modCount++;
         return this;
@@ -1004,14 +1009,17 @@ public final class Matcher implements MatchResult {
      * @since 9
      */
     public Matcher appendReplacement(StringBuilder sb, String replacement) {
-        // If no match, return error
         checkMatch();
-        StringBuilder result = new StringBuilder();
-        appendExpandedReplacement(replacement, result);
-        // Append the intervening text
-        sb.append(text, lastAppendPosition, first);
-        // Append the match substitution
-        sb.append(result);
+        int curLen = sb.length();
+        try {
+            // Append the intervening text
+            sb.append(text, lastAppendPosition, first);
+            // Append the match substitution
+            appendExpandedReplacement(sb, replacement);
+        } catch (IllegalArgumentException e) {
+            sb.setLength(curLen);
+            throw e;
+        }
         lastAppendPosition = last;
         modCount++;
         return this;
@@ -1021,93 +1029,95 @@ public final class Matcher implements MatchResult {
      * Processes replacement string to replace group references with
      * groups.
      */
-    private StringBuilder appendExpandedReplacement(
-        String replacement, StringBuilder result) {
-        int cursor = 0;
-        while (cursor < replacement.length()) {
-            char nextChar = replacement.charAt(cursor);
-            if (nextChar == '\\') {
-                cursor++;
-                if (cursor == replacement.length())
-                    throw new IllegalArgumentException(
-                        "character to be escaped is missing");
-                nextChar = replacement.charAt(cursor);
-                result.append(nextChar);
-                cursor++;
-            } else if (nextChar == '$') {
-                // Skip past $
-                cursor++;
-                // Throw IAE if this "$" is the last character in replacement
-                if (cursor == replacement.length())
-                   throw new IllegalArgumentException(
-                        "Illegal group reference: group index is missing");
-                nextChar = replacement.charAt(cursor);
-                int refNum = -1;
-                if (nextChar == '{') {
+    private void appendExpandedReplacement(Appendable app, String replacement) {
+        try {
+            int cursor = 0;
+            while (cursor < replacement.length()) {
+                char nextChar = replacement.charAt(cursor);
+                if (nextChar == '\\') {
                     cursor++;
-                    StringBuilder gsb = new StringBuilder();
-                    while (cursor < replacement.length()) {
-                        nextChar = replacement.charAt(cursor);
-                        if (ASCII.isLower(nextChar) ||
-                            ASCII.isUpper(nextChar) ||
-                            ASCII.isDigit(nextChar)) {
-                            gsb.append(nextChar);
-                            cursor++;
-                        } else {
-                            break;
+                    if (cursor == replacement.length())
+                        throw new IllegalArgumentException(
+                                "character to be escaped is missing");
+                    nextChar = replacement.charAt(cursor);
+                    app.append(nextChar);
+                    cursor++;
+                } else if (nextChar == '$') {
+                    // Skip past $
+                    cursor++;
+                    // Throw IAE if this "$" is the last character in replacement
+                    if (cursor == replacement.length())
+                        throw new IllegalArgumentException(
+                                "Illegal group reference: group index is missing");
+                    nextChar = replacement.charAt(cursor);
+                    int refNum = -1;
+                    if (nextChar == '{') {
+                        cursor++;
+                        StringBuilder gsb = new StringBuilder();
+                        while (cursor < replacement.length()) {
+                            nextChar = replacement.charAt(cursor);
+                            if (ASCII.isLower(nextChar) ||
+                                    ASCII.isUpper(nextChar) ||
+                                    ASCII.isDigit(nextChar)) {
+                                gsb.append(nextChar);
+                                cursor++;
+                            } else {
+                                break;
+                            }
+                        }
+                        if (gsb.length() == 0)
+                            throw new IllegalArgumentException(
+                                    "named capturing group has 0 length name");
+                        if (nextChar != '}')
+                            throw new IllegalArgumentException(
+                                    "named capturing group is missing trailing '}'");
+                        String gname = gsb.toString();
+                        if (ASCII.isDigit(gname.charAt(0)))
+                            throw new IllegalArgumentException(
+                                    "capturing group name {" + gname +
+                                            "} starts with digit character");
+                        if (!namedGroups().containsKey(gname))
+                            throw new IllegalArgumentException(
+                                    "No group with name {" + gname + "}");
+                        refNum = namedGroups().get(gname);
+                        cursor++;
+                    } else {
+                        // The first number is always a group
+                        refNum = nextChar - '0';
+                        if ((refNum < 0) || (refNum > 9))
+                            throw new IllegalArgumentException(
+                                    "Illegal group reference");
+                        cursor++;
+                        // Capture the largest legal group string
+                        boolean done = false;
+                        while (!done) {
+                            if (cursor >= replacement.length()) {
+                                break;
+                            }
+                            int nextDigit = replacement.charAt(cursor) - '0';
+                            if ((nextDigit < 0) || (nextDigit > 9)) { // not a number
+                                break;
+                            }
+                            int newRefNum = (refNum * 10) + nextDigit;
+                            if (groupCount() < newRefNum) {
+                                done = true;
+                            } else {
+                                refNum = newRefNum;
+                                cursor++;
+                            }
                         }
                     }
-                    if (gsb.length() == 0)
-                        throw new IllegalArgumentException(
-                            "named capturing group has 0 length name");
-                    if (nextChar != '}')
-                        throw new IllegalArgumentException(
-                            "named capturing group is missing trailing '}'");
-                    String gname = gsb.toString();
-                    if (ASCII.isDigit(gname.charAt(0)))
-                        throw new IllegalArgumentException(
-                            "capturing group name {" + gname +
-                            "} starts with digit character");
-                    if (!namedGroups().containsKey(gname))
-                        throw new IllegalArgumentException(
-                            "No group with name {" + gname + "}");
-                    refNum = namedGroups().get(gname);
-                    cursor++;
+                    // Append group
+                    if (start(refNum) != -1 && end(refNum) != -1)
+                        app.append(text, start(refNum), end(refNum));
                 } else {
-                    // The first number is always a group
-                    refNum = nextChar - '0';
-                    if ((refNum < 0) || (refNum > 9))
-                        throw new IllegalArgumentException(
-                            "Illegal group reference");
+                    app.append(nextChar);
                     cursor++;
-                    // Capture the largest legal group string
-                    boolean done = false;
-                    while (!done) {
-                        if (cursor >= replacement.length()) {
-                            break;
-                        }
-                        int nextDigit = replacement.charAt(cursor) - '0';
-                        if ((nextDigit < 0) || (nextDigit > 9)) { // not a number
-                            break;
-                        }
-                        int newRefNum = (refNum * 10) + nextDigit;
-                        if (groupCount() < newRefNum) {
-                            done = true;
-                        } else {
-                            refNum = newRefNum;
-                            cursor++;
-                        }
-                    }
                 }
-                // Append group
-                if (start(refNum) != -1 && end(refNum) != -1)
-                    result.append(text, start(refNum), end(refNum));
-            } else {
-                result.append(nextChar);
-                cursor++;
             }
+        } catch (IOException e) {  // cannot happen on String[Buffer|Builder]
+            throw new AssertionError(e.getMessage());
         }
-        return result;
     }
 
     /**


### PR DESCRIPTION
Remove instantiation of `StringBuilder`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291598](https://bugs.openjdk.org/browse/JDK-8291598): Matcher.appendReplacement should not create new StringBuilder instances


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13048/head:pull/13048` \
`$ git checkout pull/13048`

Update a local copy of the PR: \
`$ git checkout pull/13048` \
`$ git pull https://git.openjdk.org/jdk.git pull/13048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13048`

View PR using the GUI difftool: \
`$ git pr show -t 13048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13048.diff">https://git.openjdk.org/jdk/pull/13048.diff</a>

</details>
