### PR TITLE
8304230: LShift ideal transform assertion

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -882,14 +882,14 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Check for "(x >> C1) << C2"
   if (add1_op == Op_RShiftI || add1_op == Op_URShiftI) {
+    int add1Con = 0;
+    const_shift_count(phase, add1, &add1Con);
+
     // Special case C1 == C2, which just masks off low bits
-    if (add1->in(2) == in(2)) {
+    if (add1Con > 0 && con == add1Con) {
       // Convert to "(x & -(1 << C2))"
       return new AndINode(add1->in(1), phase->intcon(-(1 << con)));
     } else {
-      int add1Con = 0;
-      const_shift_count(phase, add1, &add1Con);
-
       // Wait until the right shift has been sharpened to the correct count
       if (add1Con > 0 && add1Con < BitsPerJavaInteger) {
         // As loop parsing can produce LShiftI nodes, we should wait until the graph is fully formed
@@ -1058,14 +1058,14 @@ Node *LShiftLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Check for "(x >> C1) << C2"
   if (add1_op == Op_RShiftL || add1_op == Op_URShiftL) {
+    int add1Con = 0;
+    const_shift_count(phase, add1, &add1Con);
+
     // Special case C1 == C2, which just masks off low bits
-    if (add1->in(2) == in(2)) {
+    if (add1Con > 0 && con == add1Con) {
       // Convert to "(x & -(1 << C2))"
       return new AndLNode(add1->in(1), phase->longcon(-(CONST64(1) << con)));
     } else {
-      int add1Con = 0;
-      const_shift_count(phase, add1, &add1Con);
-
       // Wait until the right shift has been sharpened to the correct count
       if (add1Con > 0 && add1Con < BitsPerJavaLong) {
         // As loop parsing can produce LShiftI nodes, we should wait until the graph is fully formed


### PR DESCRIPTION
Hi,
This PR aims to address the assertion on arm32 where the special-case `add1->in(2) == in(2)` check fails, and it falls through to the regular cases. I'm not quite sure how this issue can manifest as AFAIK the GVN should allow the usage of `==` to check against constants that are equal. I've changed the check from node equality to constant equality to hopefully resolve this. I unfortunately cannot reproduce the behavior on x86, nor do I have access to arm32 hardware, so I would greatly appreciate reviews and help testing this change (cc @bulasevich). Thank you all in advance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304230](https://bugs.openjdk.org/browse/JDK-8304230): LShift ideal transform assertion


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13049/head:pull/13049` \
`$ git checkout pull/13049`

Update a local copy of the PR: \
`$ git checkout pull/13049` \
`$ git pull https://git.openjdk.org/jdk.git pull/13049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13049`

View PR using the GUI difftool: \
`$ git pr show -t 13049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13049.diff">https://git.openjdk.org/jdk/pull/13049.diff</a>

</details>
