### PR TITLE
8304287: Problemlist java/net/SocketOption/OptionsTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -537,6 +537,8 @@ java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
+java/net/SocketOption/OptionsTest.java                          8304286 windows-all
+
 ############################################################################
 
 # jdk_nio

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -106,7 +106,7 @@ public class OptionsTest {
             Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
             while (nifs.hasMoreElements()) {
                 NetworkInterface ni = nifs.nextElement();
-                if (ni.supportsMulticast() && !ni.getInterfaceAddresses().isEmpty()) {
+                if (ni.supportsMulticast()) {
                     return ni;
                 }
             }


### PR DESCRIPTION
java/net/SocketOption/OptionsTest.java was broken on Linux by the changes in [JDK-8302659](https://bugs.openjdk.org/browse/JDK-8302659) which were necessary to make the test pass on Windows.

This PR reverts the test to its original state and problemlists it on Windows.

The original test change can be found here:
https://github.com/openjdk/jdk/pull/12593/files#diff-f09fe4a52959400e9bb12ae26f0e4acf8718f5cc07d4e46be2e0933b4903ca5c

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304287](https://bugs.openjdk.org/browse/JDK-8304287): Problemlist java/net/SocketOption/OptionsTest.java


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13050/head:pull/13050` \
`$ git checkout pull/13050`

Update a local copy of the PR: \
`$ git checkout pull/13050` \
`$ git pull https://git.openjdk.org/jdk pull/13050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13050`

View PR using the GUI difftool: \
`$ git pr show -t 13050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13050.diff">https://git.openjdk.org/jdk/pull/13050.diff</a>

</details>
