### PR TITLE
8304288: Add foreign linker tag set descriptions

### DIFF
--- a/src/hotspot/share/logging/logTagSetDescriptions.cpp
+++ b/src/hotspot/share/logging/logTagSetDescriptions.cpp
@@ -31,7 +31,11 @@
 // -Xlog:help (or "VM.log list")
 #define LOG_TAG_SET_DESCRIPTION_LIST \
   LOG_TAG_SET_DESCRIPTION(LOG_TAGS(logging), \
-                          "Logging for the log framework itself")
+                          "Logging for the log framework itself") \
+  NOT_PRODUCT(LOG_TAG_SET_DESCRIPTION(LOG_TAGS(foreign, downcall), \
+                          "Generation of foreign linker downcall stubs")) \
+  NOT_PRODUCT(LOG_TAG_SET_DESCRIPTION(LOG_TAGS(foreign, upcall), \
+                          "Generation of foreign linker upcall stubs"))
 
 #define LOG_TAG_SET_DESCRIPTION(tags, descr) \
   { &LogTagSetMapping<tags>::tagset(), descr },


### PR DESCRIPTION
Add foreign linker tag set descriptions for `foreign+downcall`, `foreign+upcall`, which are printed in the `-Xlog:help` message.

Sample output:

```
Described tag sets:
 logging: Logging for the log framework itself
 foreign+downcall: Generation of foreign linker downcall stubs
 foreign+upcall: Generation of foreign linker upcall stubs
```

I've kept the descriptions succinct. I think the main usefulness comes from knowing that the particular combination of tags can be used, without having to grep through the source code (both by being listed in the help message, and in the source code in `logging/logTagSetDescriptions.cpp`)

Testing: manual testing + build on Windows with MSVC, and on Linux (WSL) with GCC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304288](https://bugs.openjdk.org/browse/JDK-8304288): Add foreign linker tag set descriptions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13051/head:pull/13051` \
`$ git checkout pull/13051`

Update a local copy of the PR: \
`$ git checkout pull/13051` \
`$ git pull https://git.openjdk.org/jdk.git pull/13051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13051`

View PR using the GUI difftool: \
`$ git pr show -t 13051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13051.diff">https://git.openjdk.org/jdk/pull/13051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13051#issuecomment-1470878520)