### PR TITLE
8304293: RISC-V: JDK-8276799 missed atomic intrinsic support for C1

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -35,6 +35,12 @@ const char* VM_Version::_vm_mode = "";
 uint32_t VM_Version::_initial_vector_length = 0;
 
 void VM_Version::initialize() {
+  _supports_cx8 = true;
+  _supports_atomic_getset4 = true;
+  _supports_atomic_getadd4 = true;
+  _supports_atomic_getset8 = true;
+  _supports_atomic_getadd8 = true;
+
   get_os_cpu_info();
 
   // check if satp.mode is supported, currently supports up to SV48(RV64)


### PR DESCRIPTION
The following intrinsics in C1 are controlled by supports_atomic_xxx, but they are not set properly on RISC-V:
- _getAndAddInt
- _getAndAddLong
- _getAndSetInt
- _getAndSetLong
- _getAndSetReference

RISC-V provides a set of atomic instructions [1], these intrinsics could be enabled by default.

Here is the HIR output of C1:

before:

```
B18 (V) [189, 196] -> B20 pred: B8 B17 
empty stack
inlining depth 0
__bci__use__tid____instr____________________________________
  0    0    a251   <instance 0x00000040a802fb98 klass=jdk/internal/misc/Unsafe>
  3    0    a252   null   
  4    0    l254   274954985816L
  7    0    l255   1L
. 8    0    l256   a251.invokespecial(a252, l254, l255)
                   jdk/internal/misc/Unsafe.getAndAddLong(Ljava/lang/Object;JJ)J
. 193  0    l258   a42._24 := l256 (J) tid
. 196  0     259   goto B20
```

after:

```
B18 (V) [189, 196] -> B20 pred: B8 B17 
empty stack
inlining depth 0
__bci__use__tid____instr____________________________________
  0    0    a251   <instance 0x00000040a802fb98 klass=jdk/internal/misc/Unsafe>
  3    0    a252   null   
  4    0    l254   274954985816L
  7    0    l255   1L
. 8    0    l256   UnsafeGetAndSet (add)(a252, l254, value l255)
. 193  0    l258   a42._24 := l256 (J) tid
. 196  0     259   goto B20
```

1. https://github.com/riscv/riscv-isa-manual/blob/8b9047d8d20ef548f7996efee1550760d7bc1279/src/a.tex#L416-L422

Testing:

- [x] `hotspot_tier1` & `jdk_tier1` on Unmatched board (release build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304293](https://bugs.openjdk.org/browse/JDK-8304293): RISC-V: JDK-8276799 missed atomic intrinsic support for C1


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13053/head:pull/13053` \
`$ git checkout pull/13053`

Update a local copy of the PR: \
`$ git checkout pull/13053` \
`$ git pull https://git.openjdk.org/jdk pull/13053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13053`

View PR using the GUI difftool: \
`$ git pr show -t 13053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13053.diff">https://git.openjdk.org/jdk/pull/13053.diff</a>

</details>
