### PR TITLE
8304320: java.base does not export jdk.internal.org.objectweb.asm to module jdk.jshell

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -203,6 +203,7 @@ module java.base {
         jdk.jshell;
     exports jdk.internal.org.objectweb.asm to
         jdk.jfr,
+        jdk.jshell,
         jdk.jlink;
     exports jdk.internal.org.objectweb.asm.tree to
         jdk.jfr,


### PR DESCRIPTION
jdk/test/jdk/tools/jimage/VerifyJimage.java is failing because the module java.base is not exporting jdk.internal.org.objectweb.asm to module jdk.jshell. 

Reported Issue : [JDK-8304320](https://bugs.openjdk.org/browse/JDK-8304320)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304320](https://bugs.openjdk.org/browse/JDK-8304320): java.base does not export jdk.internal.org.objectweb.asm to module jdk.jshell


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13057/head:pull/13057` \
`$ git checkout pull/13057`

Update a local copy of the PR: \
`$ git checkout pull/13057` \
`$ git pull https://git.openjdk.org/jdk pull/13057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13057`

View PR using the GUI difftool: \
`$ git pr show -t 13057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13057.diff">https://git.openjdk.org/jdk/pull/13057.diff</a>

</details>
