### PR TITLE
8304314: StackWalkTest.java fails after CODETOOLS-7903373

### DIFF
--- a/test/jdk/java/lang/StackWalker/StackWalkTest.java
+++ b/test/jdk/java/lang/StackWalker/StackWalkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class StackWalkTest {
             "java.lang.reflect.Method",
             "com.sun.javatest.regtest.MainWrapper$MainThread",
             "com.sun.javatest.regtest.agent.MainWrapper$MainThread",
+            "com.sun.javatest.regtest.agent.MainWrapper$MainTask",
             "java.lang.Thread"
     ));
     static final List<Class<?>> streamPipelines = Arrays.asList(


### PR DESCRIPTION
The test depends on the jtreg stack and should be updated.
The fix is backported from loom repo where jtreg with CODETOOLS-7903373 is used.
Tested with current promoted jtreg (without CODETOOLS-7903373) by running test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304314](https://bugs.openjdk.org/browse/JDK-8304314): StackWalkTest.java fails after CODETOOLS-7903373


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13058/head:pull/13058` \
`$ git checkout pull/13058`

Update a local copy of the PR: \
`$ git checkout pull/13058` \
`$ git pull https://git.openjdk.org/jdk pull/13058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13058`

View PR using the GUI difftool: \
`$ git pr show -t 13058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13058.diff">https://git.openjdk.org/jdk/pull/13058.diff</a>

</details>
