### PR TITLE
JDK-8303742: CompletableFuture.orTimeout leaks if the future completes exceptionally

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -2937,7 +2937,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         final Future<?> f;
         Canceller(Future<?> f) { this.f = f; }
         public void accept(Object ignore, Throwable ex) {
-            if (ex == null && f != null && !f.isDone())
+            if (f != null && !f.isDone())
                 f.cancel(false);
         }
     }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8303742
+ * @summary CompletableFuture.orTimeout can leak memory if completed exceptionally
+ * @run junit/othervm -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
+ */
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class CompletableFutureOrTimeoutExceptionallyTest {
+    /**
+     * Test that orTimeout task is cancelled if the CompletableFuture is completed Exceptionally
+     */
+    @Test
+    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() throws Exception {
+        var startTime = System.currentTimeMillis();
+        var testRunTime = Duration.ofSeconds(10).toMillis();
+        while((System.currentTimeMillis() - startTime) < testRunTime) {
+            new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
+        }
+    }
+}

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -42,7 +42,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() throws Exception {
         var startTime = System.currentTimeMillis();
         var testRunTime = Duration.ofSeconds(10).toMillis();
-        while((System.currentTimeMillis() - startTime) < testRunTime) {
+        while ((System.currentTimeMillis() - startTime) < testRunTime) {
             new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
         }
     }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -39,11 +39,11 @@ class CompletableFutureOrTimeoutExceptionallyTest {
      * Test that orTimeout task is cancelled if the CompletableFuture is completed Exceptionally
      */
     @Test
-    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() throws Exception {
-        var startTime = System.currentTimeMillis();
-        var testRunTime = Duration.ofSeconds(10).toMillis();
-        while ((System.currentTimeMillis() - startTime) < testRunTime) {
+    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
+        var count = 0L;
+        while(count < 2_000_000) {
             new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
+            ++count;
         }
     }
 }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -41,7 +41,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     @Test
     void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
         var count = 0L;
-        while(count < 2_000_000) {
+        while (count < 2_000_000) {
             new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
             ++count;
         }
@@ -53,7 +53,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     @Test
     void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
         var count = 0L;
-        while(count < 2_000_000) {
+        while (count < 2_000_000) {
             new CompletableFuture<>().completeOnTimeout(null, 12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
             ++count;
         }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,18 @@ class CompletableFutureOrTimeoutExceptionallyTest {
         var count = 0L;
         while(count < 2_000_000) {
             new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
+            ++count;
+        }
+    }
+
+    /**
+     * Test that the completeOnTimeout task is cancelled if the CompletableFuture is completed Exceptionally
+     */
+    @Test
+    void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
+        var count = 0L;
+        while(count < 2_000_000) {
+            new CompletableFuture<>().completeOnTimeout(null, 12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
             ++count;
         }
     }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -41,9 +41,10 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     @Test
     void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
         var count = 0L;
-        while (count < 2_000_000) {
-            new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
-            ++count;
+        while (count++ < 2_000_000) {
+            new CompletableFuture<>()
+            .orTimeout(12, TimeUnit.HOURS)
+            .completeExceptionally(new RuntimeException("This is fine"));
         }
     }
 
@@ -53,9 +54,10 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     @Test
     void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
         var count = 0L;
-        while (count < 2_000_000) {
-            new CompletableFuture<>().completeOnTimeout(null, 12, TimeUnit.HOURS).completeExceptionally(new RuntimeException("This is fine"));
-            ++count;
+        while (count++ < 2_000_000) {
+            new CompletableFuture<>()
+            .completeOnTimeout(null, 12, TimeUnit.HOURS)
+            .completeExceptionally(new RuntimeException("This is fine"));
         }
     }
 }


### PR DESCRIPTION
Addresses the situation where exceptional completion of `orTimeout`:ed CompletableFutures wouldn't cancel the timeout task which could lead to memory leaks if done frequently enough with long enough timeout durations.

Fix discussed with @DougLea

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303742](https://bugs.openjdk.org/browse/JDK-8303742): CompletableFuture.orTimeout leaks if the future completes exceptionally


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [e2c1c366](https://git.openjdk.org/jdk/pull/13059/files/e2c1c366834701458d89ba60611f68215e5dc883)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13059/head:pull/13059` \
`$ git checkout pull/13059`

Update a local copy of the PR: \
`$ git checkout pull/13059` \
`$ git pull https://git.openjdk.org/jdk pull/13059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13059`

View PR using the GUI difftool: \
`$ git pr show -t 13059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13059.diff">https://git.openjdk.org/jdk/pull/13059.diff</a>

</details>
