### PR TITLE
JDK-8303069: Memory leak in CompilerOracle::parse_from_line

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -309,6 +309,8 @@ static void register_command(TypedMethodOptionMatcher* matcher,
 
   if (option == CompileCommand::Blackhole && !UnlockExperimentalVMOptions) {
     warning("Blackhole compile option is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions");
+    // Delete matcher as we don't keep it
+    delete matcher;
     return;
   }
 


### PR DESCRIPTION
A memory leak has been detected using *lsan* when running the `compiler/blackhole/BlackholeExperimentalUnlockTest.java` test.

This happens when parsing the *blackhole* *CompileCommand*. There is a check for the `-XX:+UnlockExperimentalVMOptions` flag being enabled when *blackhole* is used. If this flag is not set, a warning gets printed and the *CompileCommand* is not taken.

Unfortunately this happens in `register_commands` where commands are supposed to be added to a list. In this case we bail out and the option is neither added nor deleted.

https://github.com/openjdk/jdk/blob/f629152021d4ce0288119c47d5a111b87dce1de6/src/hotspot/share/compiler/compilerOracle.cpp#L310-L313

So, this changes deletes the `matcher` object before returning. This is done in `register_commands` (the callee) mainly because a couple of other similar checks are also done in this function.

The other option would have been to move the check to the caller (the only one for this case) before `register_command`:
https://github.com/openjdk/jdk/blob/f629152021d4ce0288119c47d5a111b87dce1de6/src/hotspot/share/compiler/compilerOracle.cpp#L915-L917
but it seemed less appropriate (no other similar checks).

Letting it handle like other experimental flags (code below) is not an option either since in this case we have to do with a `CompileCommand`.
https://github.com/openjdk/jdk/blob/f629152021d4ce0288119c47d5a111b87dce1de6/src/hotspot/share/runtime/flags/jvmFlag.cpp#L112-L118

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303069](https://bugs.openjdk.org/browse/JDK-8303069): Memory leak in CompilerOracle::parse_from_line


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Justin King](https://openjdk.org/census#jcking) (@jcking - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13060/head:pull/13060` \
`$ git checkout pull/13060`

Update a local copy of the PR: \
`$ git checkout pull/13060` \
`$ git pull https://git.openjdk.org/jdk pull/13060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13060`

View PR using the GUI difftool: \
`$ git pr show -t 13060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13060.diff">https://git.openjdk.org/jdk/pull/13060.diff</a>

</details>
