### PR TITLE
8304286: java/net/SocketOption/OptionsTest.java failing after JDK-8302659

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -537,8 +537,6 @@ java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
-java/net/SocketOption/OptionsTest.java                          8304286 windows-all
-
 ############################################################################
 
 # jdk_nio

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -107,7 +107,12 @@ public class OptionsTest {
             while (nifs.hasMoreElements()) {
                 NetworkInterface ni = nifs.nextElement();
                 if (ni.supportsMulticast()) {
-                    return ni;
+                    try (MulticastSocket ms = new MulticastSocket()) {
+                        ms.setNetworkInterface(ni);
+                        return ni;
+                    } catch (SocketException ex) {
+                        // continue
+                    }
                 }
             }
         } catch (Exception e) {

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8036979 8072384 8044773 8225214 8233296 8234083
  * @library /test/lib
+ * @build jdk.test.lib.Platform jdk.test.lib.NetworkConfiguration
  * @requires !vm.graal.enabled
  * @run main/othervm -Xcheck:jni OptionsTest
  * @run main/othervm -Xcheck:jni -Djava.net.preferIPv4Stack=true OptionsTest
@@ -35,6 +36,8 @@
 import java.lang.reflect.Method;
 import java.net.*;
 import java.util.*;
+
+import jdk.test.lib.NetworkConfiguration;
 import jdk.test.lib.net.IPSupport;
 
 public class OptionsTest {
@@ -103,13 +106,8 @@ public class OptionsTest {
 
     static NetworkInterface getNetworkInterface() {
         try {
-            Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
-            while (nifs.hasMoreElements()) {
-                NetworkInterface ni = nifs.nextElement();
-                if (ni.supportsMulticast() && !ni.getInterfaceAddresses().isEmpty()) {
-                    return ni;
-                }
-            }
+            NetworkConfiguration nc = NetworkConfiguration.probe();
+            return nc.multicastInterfaces(true).findAny().orElse(null);
         } catch (Exception e) {
         }
         return null;

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -106,13 +106,8 @@ public class OptionsTest {
             Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
             while (nifs.hasMoreElements()) {
                 NetworkInterface ni = nifs.nextElement();
-                if (ni.supportsMulticast()) {
-                    try (MulticastSocket ms = new MulticastSocket()) {
-                        ms.setNetworkInterface(ni);
-                        return ni;
-                    } catch (SocketException ex) {
-                        // continue
-                    }
+                if (ni.supportsMulticast() && !ni.getInterfaceAddresses().isEmpty()) {
+                    return ni;
                 }
             }
         } catch (Exception e) {

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8036979 8072384 8044773 8225214 8233296 8234083
  * @library /test/lib
- * @build jdk.test.lib.Platform jdk.test.lib.NetworkConfiguration
  * @requires !vm.graal.enabled
  * @run main/othervm -Xcheck:jni OptionsTest
  * @run main/othervm -Xcheck:jni -Djava.net.preferIPv4Stack=true OptionsTest

--- a/test/jdk/java/net/SocketOption/options.policy
+++ b/test/jdk/java/net/SocketOption/options.policy
@@ -22,7 +22,15 @@
 //
 
 grant {
-    permission java.net.SocketPermission "*:*", "connect, accept, listen, resolve";
+    permission java.net.SocketPermission "localhost:*", "connect, accept, listen, resolve";
     permission java.util.PropertyPermission "java.net.preferIPv4Stack", "read";
     permission java.util.PropertyPermission "java.net.preferIPv6Addresses", "read";
+};
+// for JTwork/classes/test/lib/jdk/test/lib/Platform.class
+grant codeBase "file:${test.classes}/../../../../test/lib/-" {
+    permission java.util.PropertyPermission "*", "read";
+};
+// for JTwork/classes/test/lib/jdk/test/lib/NetworkConfiguration.class
+grant codeBase "file:${test.classes}/../../../../test/lib/-" {
+    permission java.net.SocketPermission "*:*", "connect";
 };

--- a/test/jdk/java/net/SocketOption/options.policy
+++ b/test/jdk/java/net/SocketOption/options.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,6 @@
 //
 
 grant {
-    permission java.net.SocketPermission "localhost:*", "connect, accept, listen, resolve";
-    permission java.util.PropertyPermission "java.net.preferIPv4Stack", "read";
-    permission java.util.PropertyPermission "java.net.preferIPv6Addresses", "read";
-};
-// for JTwork/classes/test/lib/jdk/test/lib/Platform.class
-grant codeBase "file:${test.classes}/../../../../test/lib/-" {
+    permission java.net.SocketPermission "*:*", "connect, accept, listen, resolve";
     permission java.util.PropertyPermission "*", "read";
-};
-// for JTwork/classes/test/lib/jdk/test/lib/NetworkConfiguration.class
-grant codeBase "file:${test.classes}/../../../../test/lib/-" {
-    permission java.net.SocketPermission "*:*", "connect";
 };

--- a/test/jdk/java/net/SocketOption/options.policy
+++ b/test/jdk/java/net/SocketOption/options.policy
@@ -22,7 +22,7 @@
 //
 
 grant {
-    permission java.net.SocketPermission "localhost:*", "connect, accept, listen, resolve";
+    permission java.net.SocketPermission "*:*", "connect, accept, listen, resolve";
     permission java.util.PropertyPermission "java.net.preferIPv4Stack", "read";
     permission java.util.PropertyPermission "java.net.preferIPv6Addresses", "read";
 };

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -393,10 +393,7 @@ public class NetworkConfiguration {
             List<Inet6Address> ip6Addresses = new LinkedList<>();
             ip4Interfaces.put(nif, ip4Addresses);
             ip6Interfaces.put(nif, ip6Addresses);
-            @SuppressWarnings("removal")
-            List<InetAddress> addrList = AccessController.doPrivileged(
-                    (PrivilegedAction<List<InetAddress>>) () -> list(nif.getInetAddresses()));
-            for (InetAddress addr : addrList) {
+            for (InetAddress addr : list(nif.getInetAddresses())) {
                 if (addr instanceof Inet4Address) {
                     ip4Addresses.add((Inet4Address) addr);
                 } else if (addr instanceof Inet6Address) {

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -393,7 +393,10 @@ public class NetworkConfiguration {
             List<Inet6Address> ip6Addresses = new LinkedList<>();
             ip4Interfaces.put(nif, ip4Addresses);
             ip6Interfaces.put(nif, ip6Addresses);
-            for (InetAddress addr : list(nif.getInetAddresses())) {
+            @SuppressWarnings("removal")
+            List<InetAddress> addrList = AccessController.doPrivileged(
+                    (PrivilegedAction<List<InetAddress>>) () -> list(nif.getInetAddresses()));
+            for (InetAddress addr : addrList) {
                 if (addr instanceof Inet4Address) {
                     ip4Addresses.add((Inet4Address) addr);
                 } else if (addr instanceof Inet6Address) {


### PR DESCRIPTION
Please review this change that fixes and reenables OptionsTest on Windows.

The test is checking that the values retrieved from getOption match the values set by an earlier call to setOption. The `IP_MULTICAST_IF` option was tested with the first network interface for which `supportsMulticast` returned true. JDK-8302659 changed the network interface iteration order and the test started failing.

The proposed change is to verify if the interface is actually usable for multicasting before using it in set/get test. Test passed on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304286](https://bugs.openjdk.org/browse/JDK-8304286): java/net/SocketOption/OptionsTest.java failing after JDK-8302659


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13061/head:pull/13061` \
`$ git checkout pull/13061`

Update a local copy of the PR: \
`$ git checkout pull/13061` \
`$ git pull https://git.openjdk.org/jdk.git pull/13061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13061`

View PR using the GUI difftool: \
`$ git pr show -t 13061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13061.diff">https://git.openjdk.org/jdk/pull/13061.diff</a>

</details>
