### PR TITLE
8304242: CPUInfoTest fails because "serialize" CPU feature is not known

### DIFF
--- a/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+++ b/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
+++ b/test/lib-test/jdk/test/whitebox/CPUInfoTest.java
@@ -65,7 +65,7 @@ public class CPUInfoTest {
                     "avx512_vbmi2", "avx512_vbmi",      "rdtscp",            "rdpid",
                     "hv",           "fsrm",             "avx512_bitalg",     "gfni",
                     "f16c",         "pku",              "ospke",             "cet_ibt",
-                    "cet_ss",       "avx512_ifma"
+                    "cet_ss",       "avx512_ifma",      "serialize"
                     );
             // @formatter:on
             // Checkstyle: resume


### PR DESCRIPTION
This test fails on modern x86_64 hardware with "serialize" feature (eg. Intel Gen 12 and higher).
Support for this feature was added by JDK-8264543 but the test wasn't updated.

I have updated the test to recognize "serialize" as a supported CPU feature.
Tested on 13th Gen Intel(R) Core(TM) i7-13700K by running this new version of the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304242](https://bugs.openjdk.org/browse/JDK-8304242): CPUInfoTest fails because "serialize" CPU feature is not known


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13062/head:pull/13062` \
`$ git checkout pull/13062`

Update a local copy of the PR: \
`$ git checkout pull/13062` \
`$ git pull https://git.openjdk.org/jdk pull/13062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13062`

View PR using the GUI difftool: \
`$ git pr show -t 13062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13062.diff">https://git.openjdk.org/jdk/pull/13062.diff</a>

</details>
