### PR TITLE
8304353: Add lib-test tier1 testing in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
+          - 'lib-test/tier1'
 
         include:
           - test-name: 'jdk/tier1 part 1'
@@ -97,6 +98,9 @@ jobs:
           - test-name: 'hs/tier1 serviceability'
             test-suite: 'test/hotspot/jtreg/:tier1_serviceability'
             debug-suffix: -debug
+
+          - test-name: 'lib-test/tier1'
+            test-suite: 'test/lib-test/:tier1'
 
     steps:
       - name: 'Checkout the JDK source'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
 
           - test-name: 'lib-test/tier1'
             test-suite: 'test/lib-test/:tier1'
+            debug-suffix: -debug
 
     steps:
       - name: 'Checkout the JDK source'


### PR DESCRIPTION
Tier1 testing in GitHub should include lib-test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304353](https://bugs.openjdk.org/browse/JDK-8304353): Add lib-test tier1 testing in GHA


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13063/head:pull/13063` \
`$ git checkout pull/13063`

Update a local copy of the PR: \
`$ git checkout pull/13063` \
`$ git pull https://git.openjdk.org/jdk.git pull/13063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13063`

View PR using the GUI difftool: \
`$ git pr show -t 13063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13063.diff">https://git.openjdk.org/jdk/pull/13063.diff</a>

</details>
