### PR TITLE
8304364: [AIX] Build erroneously determines build disk is non-local when using GNU-utils df on AIX

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -477,7 +477,11 @@ AC_DEFUN([BASIC_CHECK_DIR_ON_LOCAL_DISK],
     # df on AIX does not understand -l. On modern AIXes it understands "-T local" which
     # is the same. On older AIXes we just continue to live with a "not local build" warning.
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      DF_LOCAL_ONLY_OPTION='-T local'
+      if "$DF -T local > /dev/null 2>&1"; then
+        DF_LOCAL_ONLY_OPTION='-T local'
+      else # AIX may use GNU-utils instead
+        DF_LOCAL_ONLY_OPTION='-l'
+      fi
     elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl1"; then
       # In WSL1, we can only build on a drvfs file system (that is, a mounted real Windows drive)
       DF_LOCAL_ONLY_OPTION='-t drvfs'

--- a/src/java.desktop/share/native/libharfbuzz/hb.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb.hh
@@ -115,11 +115,11 @@
 
 /* Ignored currently, but should be fixed at some point. */
 #ifndef HB_NO_PRAGMA_GCC_DIAGNOSTIC_IGNORED
-#pragma GCC diagnostic ignored "-Wconversion"                   // TODO fix
-#pragma GCC diagnostic ignored "-Wshadow"                       // TODO fix
-#pragma GCC diagnostic ignored "-Wunused-parameter"             // TODO fix
+#pragma GCC diagnostic ignored "-Wconversion"			// TODO fix
+#pragma GCC diagnostic ignored "-Wshadow"			// TODO fix
+#pragma GCC diagnostic ignored "-Wunused-parameter"		// TODO fix
 #if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-result"                // TODO fix
+#pragma GCC diagnostic ignored "-Wunused-result"		// TODO fix
 #endif
 #endif
 
@@ -246,7 +246,15 @@ extern "C" void  hb_free_impl(void *ptr);
  * Compiler attributes
  */
 
-#if (defined(__GNUC__) || defined(__clang__)) && defined(__OPTIMIZE__)
+// gcc 10 has __has_builtin but not earlier versions. Sanction any gcc >= 5
+// clang defines it so no need.
+#ifdef __has_builtin
+#define hb_has_builtin __has_builtin
+#else
+#define hb_has_builtin(x) ((defined(__GNUC__) && __GNUC__ >= 5))
+#endif
+
+#if defined(__OPTIMIZE__) && hb_has_builtin(__builtin_expect)
 #define likely(expr) (__builtin_expect (!!(expr), 1))
 #define unlikely(expr) (__builtin_expect (!!(expr), 0))
 #else
@@ -265,7 +273,7 @@ extern "C" void  hb_free_impl(void *ptr);
 #define HB_PRINTF_FUNC(format_idx, arg_idx)
 #endif
 #if defined(__GNUC__) && (__GNUC__ >= 4) || (__clang__)
-#define HB_UNUSED       __attribute__((unused))
+#define HB_UNUSED	__attribute__((unused))
 #elif defined(_MSC_VER) /* https://github.com/harfbuzz/harfbuzz/issues/635 */
 #define HB_UNUSED __pragma(warning(suppress: 4100 4101))
 #else
@@ -501,6 +509,12 @@ static_assert ((sizeof (hb_mask_t) == 4), "");
 static_assert ((sizeof (hb_var_int_t) == 4), "");
 
 
+/* Pie time. */
+// https://github.com/harfbuzz/harfbuzz/issues/4166
+#define HB_PI 3.14159265358979f
+#define HB_2_PI (2.f * HB_PI)
+
+
 /* Headers we include for everyone.  Keep topologically sorted by dependency.
  * They express dependency amongst themselves, but no other file should include
  * them directly.*/
@@ -508,13 +522,13 @@ static_assert ((sizeof (hb_var_int_t) == 4), "");
 #include "hb-meta.hh"
 #include "hb-mutex.hh"
 #include "hb-number.hh"
-#include "hb-atomic.hh" // Requires: hb-meta
-#include "hb-null.hh"   // Requires: hb-meta
-#include "hb-algs.hh"   // Requires: hb-meta hb-null hb-number
-#include "hb-iter.hh"   // Requires: hb-algs hb-meta
-#include "hb-debug.hh"  // Requires: hb-algs hb-atomic
-#include "hb-array.hh"  // Requires: hb-algs hb-iter hb-null
-#include "hb-vector.hh" // Requires: hb-array hb-null
-#include "hb-object.hh" // Requires: hb-atomic hb-mutex hb-vector
+#include "hb-atomic.hh"	// Requires: hb-meta
+#include "hb-null.hh"	// Requires: hb-meta
+#include "hb-algs.hh"	// Requires: hb-meta hb-null hb-number
+#include "hb-iter.hh"	// Requires: hb-algs hb-meta
+#include "hb-debug.hh"	// Requires: hb-algs hb-atomic
+#include "hb-array.hh"	// Requires: hb-algs hb-iter hb-null
+#include "hb-vector.hh"	// Requires: hb-array hb-null
+#include "hb-object.hh"	// Requires: hb-atomic hb-mutex hb-vector
 
 #endif /* HB_HH */


### PR DESCRIPTION
The GNU-utils df command supports a flag `-l` which displays information about local disks only. The AIX df equivalent is `-T local`. However, my build systems uses GNU-utils on AIX. In this case, the build system erroneously uses `df -T local`, and incorrectly determines that the disk is non-local from the error text.

This change corrects that issue by testing if the enabled version of df returns cleanly with the `-T local` flag when AIX is the detected OS. If it does, `-T local` is used, and if not, it defaults to `-l`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304364](https://bugs.openjdk.org/browse/JDK-8304364): [AIX] Build erroneously determines build disk is non-local when using GNU-utils df on AIX


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [4fa6d1b4](https://git.openjdk.org/jdk/pull/13065/files/4fa6d1b41ef6eb055eaff4945f336a999465014e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13065/head:pull/13065` \
`$ git checkout pull/13065`

Update a local copy of the PR: \
`$ git checkout pull/13065` \
`$ git pull https://git.openjdk.org/jdk pull/13065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13065`

View PR using the GUI difftool: \
`$ git pr show -t 13065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13065.diff">https://git.openjdk.org/jdk/pull/13065.diff</a>

</details>
