### PR TITLE
8304364: [AIX] Build erroneously determines build disk is non-local when using GNU-utils df on AIX

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -477,7 +477,11 @@ AC_DEFUN([BASIC_CHECK_DIR_ON_LOCAL_DISK],
     # df on AIX does not understand -l. On modern AIXes it understands "-T local" which
     # is the same. On older AIXes we just continue to live with a "not local build" warning.
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      DF_LOCAL_ONLY_OPTION='-T local'
+      if "$DF -T local > /dev/null 2>&1"; then
+        DF_LOCAL_ONLY_OPTION='-T local'
+      else # AIX may use GNU-utils instead
+        DF_LOCAL_ONLY_OPTION='-l'
+      fi
     elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl1"; then
       # In WSL1, we can only build on a drvfs file system (that is, a mounted real Windows drive)
       DF_LOCAL_ONLY_OPTION='-t drvfs'


### PR DESCRIPTION
The GNU-utils df command supports a flag `-l` which displays information about local disks only. The AIX df equivalent is `-T local`. However, my build systems uses GNU-utils on AIX. In this case, the build system uses `df -T local`, and incorrectly determines that the disk is non-local from the error code.

This change corrects that issue by testing if the enabled version of df returns cleanly with the `-T local` flag when AIX is the detected OS. If it does, `-T local` is used, and if not, it defaults to `-l`.

@erikj79 Thanks for your review on #13065. I pushed to the wrong branch by mistake, and it seems I must now re-create the PR to fix the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304364](https://bugs.openjdk.org/browse/JDK-8304364): [AIX] Build erroneously determines build disk is non-local when using GNU-utils df on AIX


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13066/head:pull/13066` \
`$ git checkout pull/13066`

Update a local copy of the PR: \
`$ git checkout pull/13066` \
`$ git pull https://git.openjdk.org/jdk pull/13066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13066`

View PR using the GUI difftool: \
`$ git pr show -t 13066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13066.diff">https://git.openjdk.org/jdk/pull/13066.diff</a>

</details>
