### PR TITLE
8304367: jlink --include-locales=* attempts to parse non .class resource files with classfile reader

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -157,7 +157,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 resource = predicate.test(path) ? resource: null;
                 if (resource != null &&
                     resource.type().equals(ResourcePoolEntry.Type.CLASS_OR_RESOURCE) &&
-                    resource.path().endsWith(".class")) {
+                    path.endsWith(".class")) {
                     byte[] bytes = resource.contentBytes();
                     ClassReader cr = newClassReader(path, bytes);
                     if (Arrays.stream(cr.getInterfaces())

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,7 +156,8 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 String path = resource.path();
                 resource = predicate.test(path) ? resource: null;
                 if (resource != null &&
-                    resource.type().equals(ResourcePoolEntry.Type.CLASS_OR_RESOURCE)) {
+                    resource.type().equals(ResourcePoolEntry.Type.CLASS_OR_RESOURCE) &&
+                    resource.path().endsWith(".class")) {
                     byte[] bytes = resource.contentBytes();
                     ClassReader cr = newClassReader(path, bytes);
                     if (Arrays.stream(cr.getInterfaces())


### PR DESCRIPTION
This is a blocker for [JDK-8294972](https://bugs.openjdk.org/browse/JDK-8294972). The fix is to weed out non-class files for calling `ClassReader` by checking the file extension. Regression tests are not provided as it is not possible to detect the fix from the artifact jimage, but manually confirmed it would effectively weed out `LineBreakIteratorData_th`, `WordBreakIteratorData_th`, and `thai_dict` files by running `IncludeLocalesPluginTest.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304367](https://bugs.openjdk.org/browse/JDK-8304367): jlink --include-locales=* attempts to parse non .class resource files with classfile reader


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [d7ad21cb](https://git.openjdk.org/jdk/pull/13067/files/d7ad21cb335237a97480d8f8fc414d29eddc69e0)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13067/head:pull/13067` \
`$ git checkout pull/13067`

Update a local copy of the PR: \
`$ git checkout pull/13067` \
`$ git pull https://git.openjdk.org/jdk pull/13067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13067`

View PR using the GUI difftool: \
`$ git pr show -t 13067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13067.diff">https://git.openjdk.org/jdk/pull/13067.diff</a>

</details>
