### PR TITLE
8290200: com/sun/jdi/InvokeHangTest.java fails with "Debuggee appears to be hung"

### DIFF
--- a/test/jdk/ProblemList-svc-vthread.txt
+++ b/test/jdk/ProblemList-svc-vthread.txt
@@ -54,8 +54,6 @@ com/sun/jdi/StepTest.java 8285422 generic-all
 com/sun/jdi/redefine/RedefineTest.java 8285422 generic-all
 com/sun/jdi/redefineMethod/RedefineTest.java 8285422 generic-all
 
-com/sun/jdi/InvokeHangTest.java 8290200 macosx-x64,windows-x64
-
 ####
 # JDI SDE Tests
 # Use custom classpath

--- a/test/jdk/com/sun/jdi/InvokeHangTest.java
+++ b/test/jdk/com/sun/jdi/InvokeHangTest.java
@@ -69,7 +69,7 @@ class InvokeHangTarg implements Runnable {
 
     // This is called from the debugger via invokeMethod
     public double invokeee() {
-        System.out.println("Debuggee: invokeee in thread "+Thread.currentThread().toString());
+        System.out.println("Debuggee: invokeee in thread " + Thread.currentThread().toString());
         Thread.yield();
         return longMethod(2);
     }
@@ -197,7 +197,7 @@ public class InvokeHangTest extends TestScaffold {
         ThreadReference thread = event.thread();
         try {
             StackFrame sf = thread.frame(0);
-            System.out.println("  Debugger: Breakpoint hit at "+sf.location());
+            System.out.println("  Debugger: Breakpoint hit at " + sf.location());
             doInvoke(thread, sf.thisObject(), "invokeee");
         } catch (IncompatibleThreadStateException itsex) {
             itsex.printStackTrace();

--- a/test/jdk/com/sun/jdi/InvokeHangTest.java
+++ b/test/jdk/com/sun/jdi/InvokeHangTest.java
@@ -59,6 +59,12 @@ class InvokeHangTarg implements Runnable {
 
         t1.start();
         t2.start();
+        try {
+            t1.join();
+            t2.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     // This is called from the debugger via invokeMethod
@@ -145,9 +151,9 @@ public class InvokeHangTest extends TestScaffold {
         List methods = ref.referenceType().methodsByName(methodName);
         Method method = (Method) methods.get(0);
         try {
-            System.err.println("  Debugger: Invoking in thread" + thread);
+            System.out.println("  Debugger: Invoking in thread " + thread);
             ref.invokeMethod(thread, method, new ArrayList(), ref.INVOKE_NONVIRTUAL);
-            System.err.println("  Debugger: Invoke done");
+            System.out.println("  Debugger: Invoke done");
         } catch (Exception ex) {
             ex.printStackTrace();
             failure("failure: Exception");
@@ -191,7 +197,7 @@ public class InvokeHangTest extends TestScaffold {
         ThreadReference thread = event.thread();
         try {
             StackFrame sf = thread.frame(0);
-            System.err.println("  Debugger: Breakpoint hit at "+sf.location());
+            System.out.println("  Debugger: Breakpoint hit at "+sf.location());
             doInvoke(thread, sf.thisObject(), "invokeee");
         } catch (IncompatibleThreadStateException itsex) {
             itsex.printStackTrace();
@@ -214,7 +220,7 @@ public class InvokeHangTest extends TestScaffold {
         targetClass = bpe.location().declaringType();
         mainThread = bpe.thread();
         EventRequestManager erm = vm().eventRequestManager();
-        final Thread mainThread = Thread.currentThread();
+        final Thread mainTestThread = Thread.currentThread();
 
         /*
          * Set event requests
@@ -246,7 +252,7 @@ public class InvokeHangTest extends TestScaffold {
                                 vmDisconnected = true;
                                 // This awakens the main thread which is
                                 // waiting for a VMDisconnect.
-                                mainThread.interrupt();
+                                mainTestThread.interrupt();
                                 break;
                             }
                             myBkpts = bkpts;

--- a/test/jdk/com/sun/jdi/InvokeHangTest.java
+++ b/test/jdk/com/sun/jdi/InvokeHangTest.java
@@ -62,7 +62,7 @@ class InvokeHangTarg implements Runnable {
 
         try {
             // The join ensures that the test completes before we exit main(). If we are using
-            // virtual threads, they are always daemon threads, and therefor the JVM will exit
+            // virtual threads, they are always daemon threads, and therefore the JVM will exit
             // while they are still running (and the test has not yet completed). The join
             // isn't really needed for platform threads, since by default they are not
             // daemon threads, but it doesn't hurt any either.

--- a/test/jdk/com/sun/jdi/InvokeHangTest.java
+++ b/test/jdk/com/sun/jdi/InvokeHangTest.java
@@ -65,7 +65,7 @@ class InvokeHangTarg implements Runnable {
             // virtual threads, they are always daemon threads, and therefor the JVM will exit
             // while they are still running (and the test has not yet completed). The join
             // isn't really needed for platform threads, since by default they are not
-            // deamon threads, but it doesn't hurt any either.
+            // daemon threads, but it doesn't hurt any either.
             t1.join();
             t2.join();
         } catch (InterruptedException e) {

--- a/test/jdk/com/sun/jdi/InvokeHangTest.java
+++ b/test/jdk/com/sun/jdi/InvokeHangTest.java
@@ -59,7 +59,13 @@ class InvokeHangTarg implements Runnable {
 
         t1.start();
         t2.start();
+
         try {
+            // The join ensures that the test completes before we exit main(). If we are using
+            // virtual threads, they are always daemon threads, and therefor the JVM will exit
+            // while they are still running (and the test has not yet completed). The join
+            // isn't really needed for platform threads, since by default they are not
+            // deamon threads, but it doesn't hurt any either.
             t1.join();
             t2.join();
         } catch (InterruptedException e) {


### PR DESCRIPTION
The debuggee main method creates two threads and then starts them:

```
    public static void main(String[] args) {
        System.out.println("Howdy!");
        Thread t1 = TestScaffold.newThread(new InvokeHangTarg(), name1);
        Thread t2 = TestScaffold.newThread(new InvokeHangTarg(), name2);

        t1.start();
        t2.start();
    }
```

These threads will hit breakpoints which the debugger handles and issues an invoke on the breakpoint thread. The threads run until they generate 100 breakpoints. There is an issue when these two threads are virtual threads. Virtual threads are daemon threads. That means the JVM can exit while they are still running. The above main() method is not waiting for these two threads to exit, so main() exits immediately and the JVM starts the shutdown process. It first must wait for all non-daemon threads to exit, but there are none, so the JVM exits right away before the two threads are completed.  The end result of this early exit is that sometimes the invoke done by the debugger never completes because the JVM has already issued a VMDeath event and the debuggee has been disconnected.

When these two threads are platform threads, the JVM has to wait until they complete before it exits, so they will always complete. The fix for virtual threads is to do a join with t1 and t2. This forces the main() method to block until they have completed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290200](https://bugs.openjdk.org/browse/JDK-8290200): com/sun/jdi/InvokeHangTest.java fails with "Debuggee appears to be hung"


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [4d28b92e](https://git.openjdk.org/jdk/pull/13068/files/4d28b92e413f21000cf3bc392b8907527d496722)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [4d28b92e](https://git.openjdk.org/jdk/pull/13068/files/4d28b92e413f21000cf3bc392b8907527d496722)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [4d28b92e](https://git.openjdk.org/jdk/pull/13068/files/4d28b92e413f21000cf3bc392b8907527d496722)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [58ca27b8](https://git.openjdk.org/jdk/pull/13068/files/58ca27b8e590cac9311f1998ad560c2032e41194)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13068/head:pull/13068` \
`$ git checkout pull/13068`

Update a local copy of the PR: \
`$ git checkout pull/13068` \
`$ git pull https://git.openjdk.org/jdk pull/13068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13068`

View PR using the GUI difftool: \
`$ git pr show -t 13068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13068.diff">https://git.openjdk.org/jdk/pull/13068.diff</a>

</details>
