### PR TITLE
8304376: Rename t1/t2 classes in com/sun/jdi/CLETest.java to avoid class duplication error in IDE

### DIFF
--- a/test/jdk/com/sun/jdi/CLETest.java
+++ b/test/jdk/com/sun/jdi/CLETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,11 @@ import com.sun.jdi.event.*;
 import com.sun.jdi.request.*;
 import java.util.*;
 
-class t1 {
+class cle1 {
     public static void foo() {
     }
 }
-class t2 {
+class cle2 {
     public static void foo() {
     }
 }
@@ -72,10 +72,10 @@ class CLEDebugee {
     // verify that the generated MethodEntry events during class loading are not improperly
     // co-located as described the the CR.
     public static void test1() {
-        t1.foo();  // BREAKPOINT_1
+        cle1.foo();  // BREAKPOINT_1
     }
     public static void test2() {
-        t2.foo();  // BREAKPOINT_2
+        cle2.foo();  // BREAKPOINT_2
     }
 
     // Tests that MethodEntry, Step, and Breakpoint events that occur at the same

--- a/test/jdk/com/sun/jdi/CLETest.java
+++ b/test/jdk/com/sun/jdi/CLETest.java
@@ -35,11 +35,11 @@ import com.sun.jdi.event.*;
 import com.sun.jdi.request.*;
 import java.util.*;
 
-class cle1 {
+class CLEClass1 {
     public static void foo() {
     }
 }
-class cle2 {
+class CLEClass2 {
     public static void foo() {
     }
 }
@@ -72,10 +72,10 @@ class CLEDebugee {
     // verify that the generated MethodEntry events during class loading are not improperly
     // co-located as described the the CR.
     public static void test1() {
-        cle1.foo();  // BREAKPOINT_1
+        CLEClass1.foo();  // BREAKPOINT_1
     }
     public static void test2() {
-        cle2.foo();  // BREAKPOINT_2
+        CLEClass2.foo();  // BREAKPOINT_2
     }
 
     // Tests that MethodEntry, Step, and Breakpoint events that occur at the same


### PR DESCRIPTION
The com/sun/jdi tests are located in the on package, and classes with same name cause 'class duplication error' when this directory is opened as source code in IDE.

The simplest fix to avoid this is just to rename class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304376](https://bugs.openjdk.org/browse/JDK-8304376): Rename t1/t2 classes in com/sun/jdi/CLETest.java to avoid class duplication error in IDE


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13069/head:pull/13069` \
`$ git checkout pull/13069`

Update a local copy of the PR: \
`$ git checkout pull/13069` \
`$ git pull https://git.openjdk.org/jdk.git pull/13069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13069`

View PR using the GUI difftool: \
`$ git pr show -t 13069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13069.diff">https://git.openjdk.org/jdk/pull/13069.diff</a>

</details>
