### PR TITLE
8304387: Fix positions of shared static stubs / trampolines

### DIFF
--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -70,7 +70,6 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
   assert(requests->number_of_entries() >= 1, "at least one");
   const int total_requested_size = MacroAssembler::max_trampoline_stub_size() * requests->number_of_entries();
   if (cb->stubs()->maybe_expand_to_ensure_remaining(total_requested_size) && cb->blob() == NULL) {
-    ciEnv::current()->record_failure("CodeCache is full");
     return false;
   }
 

--- a/src/hotspot/cpu/arm/codeBuffer_arm.hpp
+++ b/src/hotspot/cpu/arm/codeBuffer_arm.hpp
@@ -28,9 +28,7 @@
 private:
   void pd_initialize() {}
   bool pd_finalize_stubs() {
-    if (_finalize_stubs) {
-      Unimplemented();
-    }
+    Unimplemented();
     return true;
   }
 

--- a/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
+++ b/src/hotspot/cpu/ppc/codeBuffer_ppc.hpp
@@ -29,9 +29,7 @@
 private:
   void pd_initialize() {}
   bool pd_finalize_stubs() {
-    if (_finalize_stubs) {
-      Unimplemented();
-    }
+    Unimplemented();
     return true;
   }
 

--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -72,7 +72,6 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
   assert(requests->number_of_entries() >= 1, "at least one");
   const int total_requested_size = MacroAssembler::max_trampoline_stub_size() * requests->number_of_entries();
   if (cb->stubs()->maybe_expand_to_ensure_remaining(total_requested_size) && cb->blob() == NULL) {
-    ciEnv::current()->record_failure("CodeCache is full");
     return false;
   }
 

--- a/src/hotspot/cpu/s390/codeBuffer_s390.hpp
+++ b/src/hotspot/cpu/s390/codeBuffer_s390.hpp
@@ -29,9 +29,7 @@
  private:
   void pd_initialize() {}
   bool pd_finalize_stubs() {
-    if (_finalize_stubs) {
-      Unimplemented();
-    }
+    Unimplemented();
     return true;
   }
 

--- a/src/hotspot/cpu/zero/codeBuffer_zero.hpp
+++ b/src/hotspot/cpu/zero/codeBuffer_zero.hpp
@@ -29,9 +29,7 @@
  private:
   void pd_initialize() {}
   bool pd_finalize_stubs() {
-    if (_finalize_stubs) {
-      Unimplemented();
-    }
+    Unimplemented();
     return true;
   }
  public:

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1010,7 +1010,8 @@ void CodeBuffer::log_section_sizes(const char* name) {
 }
 
 bool CodeBuffer::finalize_stubs() {
-  if (!pd_finalize_stubs()) {
+  if (_finalize_stubs && !pd_finalize_stubs()) {
+    // stub allocation failure
     return false;
   }
   _finalize_stubs = false;

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1009,11 +1009,12 @@ void CodeBuffer::log_section_sizes(const char* name) {
   }
 }
 
-void CodeBuffer::finalize_stubs() {
+bool CodeBuffer::finalize_stubs() {
   if (!pd_finalize_stubs()) {
-    return;
+    return false;
   }
   _finalize_stubs = false;
+  return true;
 }
 
 void CodeBuffer::shared_stub_to_interp_for(ciMethod* callee, csize_t call_offset) {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -715,7 +715,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   void log_section_sizes(const char* name);
 
   // Make a set of stubs final. It can create/optimize stubs.
-  void finalize_stubs();
+  bool finalize_stubs();
 
   // Request for a shared stub to the interpreter
   void shared_stub_to_interp_for(ciMethod* callee, csize_t call_offset);

--- a/src/hotspot/share/asm/codeBuffer.inline.hpp
+++ b/src/hotspot/share/asm/codeBuffer.inline.hpp
@@ -50,7 +50,6 @@ bool emit_shared_stubs_to_interp(CodeBuffer* cb, SharedStubToInterpRequests* sha
   for (int i = 0; i < shared_stub_to_interp_requests->length();) {
     address stub = __ start_a_stub(CompiledStaticCall::to_interp_stub_size());
     if (stub == NULL) {
-      ciEnv::current()->record_failure("CodeCache is full");
       return false;
     }
 

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -286,6 +286,11 @@ void Compilation::emit_code_epilog(LIR_Assembler* assembler) {
 
   CodeOffsets* code_offsets = assembler->offsets();
 
+  if (!code()->finalize_stubs()) {
+    bailout("CodeCache is full");
+    return;
+  }
+
   // generate code or slow cases
   assembler->emit_slow_case_stubs();
   CHECK_BAILOUT();

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1112,10 +1112,6 @@ void ciEnv::register_method(ciMethod* target,
     }
 #endif
 
-    if (!failing()) {
-      code_buffer->finalize_stubs();
-    }
-
     if (failing()) {
       // While not a true deoptimization, it is a preemptive decompile.
       MethodData* mdo = method()->method_data();

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1746,6 +1746,11 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
   }
 #endif
 
+  if (!cb->finalize_stubs()) {
+    C->record_failure("CodeCache is full");
+    return;
+  }
+
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->emit_stubs(*cb);
   if (C->failing())  return;


### PR DESCRIPTION
This RFE fixes the positions of shared static stubs / trampolines. They should be like:

```
[Verified Entry Point]
    ...
    ...
    ...
[Stub Code]
    <static stubs and trampolines>
[Exception Handler]
    ...
    ...
[Deopt Handler Code]
    ...
    ...
```

Currently after we have the shared static stubs/trampolines in JDK-8280481 and JDK-8280152 :

```
[Verified Entry Point]
    ...
    ...
    ...
[Stub Code]
    <static stubs and trampolines>
[Exception Handler]
    ...
    ...
[Deopt Handler Code]
    ...
    ...
    <shared static stubs and trampolines> // they are presented in the Deopt range, though do not have correctness issues.
```

For example on x86:

```
[Verified Entry Point]
  ...
[Stub Code]
  0x00007fac68ef4908:   nopl   0x0(%rax,%rax,1)             ;   {no_reloc}
  0x00007fac68ef490d:   mov    $0x0,%rbx                    ;   {static_stub}
  0x00007fac68ef4917:   jmpq   0x00007fac68ef4917           ;   {runtime_call}
  0x00007fac68ef491c:   nop
  0x00007fac68ef491d:   mov    $0x0,%rbx                    ;   {static_stub}
  0x00007fac68ef4927:   jmpq   0x00007fac68ef4927           ;   {runtime_call}
[Exception Handler]
  0x00007fac68ef492c:   callq  0x00007fac703da280           ;   {runtime_call handle_exception_from_callee Runtime1 stub}
  0x00007fac68ef4931:   mov    $0x7fac885d8067,%rdi         ;   {external_word}
  0x00007fac68ef493b:   and    $0xfffffffffffffff0,%rsp
  0x00007fac68ef493f:   callq  0x00007fac881e9900           ;   {runtime_call MacroAssembler::debug64(char*, long, long*)}
  0x00007fac68ef4944:   hlt
[Deopt Handler Code]
  0x00007fac68ef4945:   mov    $0x7fac68ef4945,%r10         ;   {section_word}
  0x00007fac68ef494f:   push   %r10
  0x00007fac68ef4951:   jmpq   0x00007fac70326520           ;   {runtime_call DeoptimizationBlob}
  0x00007fac68ef4956:   mov    $0x0,%rbx                    ;   {static_stub}       //  <----------  here
  0x00007fac68ef4960:   jmpq   0x00007fac68ef4960           ;   {runtime_call}
  0x00007fac68ef4965:   mov    $0x0,%rbx                    ;   {static_stub}       //  <----------  here
  0x00007fac68ef496f:   jmpq   0x00007fac68ef496f           ;   {runtime_call}
  0x00007fac68ef4974:   mov    $0x0,%rbx                    ;   {static_stub}       //  <----------  here
  0x00007fac68ef497e:   jmpq   0x00007fac68ef497e           ;   {runtime_call}
  0x00007fac68ef4983:   hlt
  0x00007fac68ef4984:   hlt
  0x00007fac68ef4985:   hlt
  0x00007fac68ef4986:   hlt
  0x00007fac68ef4987:   hlt
--------------------------------------------------------------------------------
[/Disassembly]

```

It can be simply reproduced and dumped by `-XX:+PrintAssembly`.

Though the correctness doesn't get affected in the current case, we may need to move them to a better place, back into the `[Stub Code]`, which might be more reasonable and unified. Also for the performance's sake, `ciEnv::register_method()`, where `code_buffer->finalize_stubs()` locates currently, has two locks `Compile_lock` and `MethodCompileQueue_lock`. So I think it may be better to move `code_buffer->finalize_stubs()` out to C1 and C2 code generation phases, separately, before the exception handler code is emitted so they are inside the `[Stub Code]` range.

BTW, this is the "direct cause" of [JDK-8302384](https://bugs.openjdk.org/browse/JDK-8302384) because shared trampolines and their data are generated at the end of compiled code, which is different from the original condition. Though for that issue, the root cause is still from the Binutils, for even if trampolines are generated at the end of code, we should not fail as well when disassembling. But that is another issue, please see [JDK-8302384](https://bugs.openjdk.org/browse/JDK-8302384) for more details.

Tested x86, AArch64, and RISC-V hotspot tier1\~4 with fastdebug build, no new errors found.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304387](https://bugs.openjdk.org/browse/JDK-8304387): Fix positions of shared static stubs / trampolines


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to [c3262f74](https://git.openjdk.org/jdk/pull/13071/files/c3262f74b2a7a518856efdb00d1f323106c0f138)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13071/head:pull/13071` \
`$ git checkout pull/13071`

Update a local copy of the PR: \
`$ git checkout pull/13071` \
`$ git pull https://git.openjdk.org/jdk.git pull/13071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13071`

View PR using the GUI difftool: \
`$ git pr show -t 13071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13071.diff">https://git.openjdk.org/jdk/pull/13071.diff</a>

</details>
