### PR TITLE
JDK-8304334: java/awt/color/ICC_ColorSpace/ToFromCIEXYZRoundTrip.java times out on slow platforms

### DIFF
--- a/test/jdk/java/awt/color/ICC_ColorSpace/ToFromCIEXYZRoundTrip.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/ToFromCIEXYZRoundTrip.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 /**
  * @test
  * @bug 8288633
+ * @run main/othervm/timeout=1000 ToFromCIEXYZRoundTrip
  * @summary Verifies precision of ICC_ColorSpace.toCIEXYZ/fromCIEXYZ
  */
 public final class ToFromCIEXYZRoundTrip {


### PR DESCRIPTION
The ToFromCIEXYZRoundTrip test times out on slow platforms , especially when (fast)debug binaries are used.
This was observed on Alpine Linux and AIX in our automated tests.  Setting an increased timeout for the test helps to reduce test errors because of timeouts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304334](https://bugs.openjdk.org/browse/JDK-8304334): java/awt/color/ICC_ColorSpace/ToFromCIEXYZRoundTrip.java times out on slow platforms


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13073/head:pull/13073` \
`$ git checkout pull/13073`

Update a local copy of the PR: \
`$ git checkout pull/13073` \
`$ git pull https://git.openjdk.org/jdk.git pull/13073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13073`

View PR using the GUI difftool: \
`$ git pr show -t 13073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13073.diff">https://git.openjdk.org/jdk/pull/13073.diff</a>

</details>
