### PR TITLE
8304411: Remove unused CardTable::clear

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -363,13 +363,6 @@ void CardTable::clear_MemRegion(MemRegion mr) {
   memset(cur, clean_card, pointer_delta(last, cur, sizeof(CardValue)));
 }
 
-void CardTable::clear(MemRegion mr) {
-  for (int i = 0; i < _cur_covered_regions; i++) {
-    MemRegion mri = mr.intersection(_covered[i]);
-    if (!mri.is_empty()) clear_MemRegion(mri);
-  }
-}
-
 uintx CardTable::ct_max_alignment_constraint() {
   // Calculate maximum alignment using GCCardSizeInBytes as card_size hasn't been set yet
   return GCCardSizeInBytes * os::vm_page_size();

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -156,7 +156,6 @@ public:
   }
 
   virtual void invalidate(MemRegion mr);
-  void clear(MemRegion mr);
 
   // Provide read-only access to the card table array.
   const CardValue* byte_for_const(const void* p) const {


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304411](https://bugs.openjdk.org/browse/JDK-8304411): Remove unused CardTable::clear


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13075/head:pull/13075` \
`$ git checkout pull/13075`

Update a local copy of the PR: \
`$ git checkout pull/13075` \
`$ git pull https://git.openjdk.org/jdk pull/13075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13075`

View PR using the GUI difftool: \
`$ git pr show -t 13075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13075.diff">https://git.openjdk.org/jdk/pull/13075.diff</a>

</details>
