### PR TITLE
JDK-8304421: Introduce malloc size feedback

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -155,6 +155,13 @@ Chunk* Chunk::allocate(size_t length, AllocFailType alloc_failmode) {
          "chunk payload length misaligned: " SIZE_FORMAT, length);
   const size_t overhead = aligned_overhead_size();
   size_t bytes = length + overhead;
+  if (bytes < length) {
+    // Overflow.
+    if (alloc_failmode == AllocFailStrategy::EXIT_OOM) {
+      vm_exit_out_of_memory(length, OOM_MALLOC_ERROR, "Chunk::allocate");
+    }
+    return nullptr;
+  }
   size_t actual_bytes;
   void* p = os::malloc(bytes, mtChunk, CALLER_PC, &actual_bytes);
   if (p == nullptr) {

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -113,7 +113,7 @@ class ChunkPool {
   static ChunkPool* get_pool_for_chunk(Chunk* c) {
     ChunkPool* pool;
     const ChunkPoolSize pool_size = c->pool_size();
-    const size_t pool_index = static_cast<size_t>(pool_size);
+    const size_t pool_index = static_cast<size_t>(pool_size) - 1;  // Underflow is fine.
     if (pool_index < ARRAY_SIZE(_pools)) {
       pool = &_pools[pool_index];
       assert(pool_size == Chunk::pool_size(pool->_size), "unexpected chunk pool");
@@ -129,7 +129,7 @@ class ChunkPool {
 
 };
 
-// Must be in the same order as ChunkPoolSize.
+// Must be in the same order as ChunkPoolSize. The index is ChunkPoolSize minus 1.
 ChunkPool ChunkPool::_pools[] = { Chunk::tiny_size, Chunk::small_size, Chunk::medium_size, Chunk::large_size };
 
 //--------------------------------------------------------------------------------------

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -55,7 +55,7 @@ class ChunkPool {
   static ChunkPool _pools[4];
 
  public:
-  constexpr ChunkPool(size_t size) : _first(nullptr), _size(size) {}
+  ChunkPool(size_t size) : _first(nullptr), _size(size) {}
 
   // Allocate a chunk from the pool; returns null if pool is empty.
   Chunk* allocate() {
@@ -141,8 +141,7 @@ class ChunkPoolCleaner : public PeriodicTask {
 
  public:
    ChunkPoolCleaner() : PeriodicTask(cleaning_interval) {}
-
-   void task() override {
+   void task() {
      ChunkPool::clean();
    }
 };
@@ -232,13 +231,13 @@ Chunk::Chunk(size_t length, ChunkPoolSize pool_size)
 }
 
 void Chunk::chop() {
-  Chunk* c = this;
-  while (c != nullptr) {
-    Chunk* next = c->next();
+  Chunk *k = this;
+  while( k ) {
+    Chunk *tmp = k->next();
     // clear out this chunk (to detect allocation bugs)
-    if (ZapResourceArea) memset(c->bottom(), badResourceValue, c->length());
-    c->release();
-    c = next;
+    if (ZapResourceArea) memset(k->bottom(), badResourceValue, k->length());
+    k->release();
+    k = tmp;
   }
 }
 

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -36,11 +36,11 @@
 #include "utilities/ostream.hpp"
 
 // Pre-defined default chunk sizes must be arena-aligned, see Chunk::operator new()
-STATIC_ASSERT(is_aligned(Chunk::tiny_size, ARENA_AMALLOC_ALIGNMENT));
-STATIC_ASSERT(is_aligned(Chunk::init_size, ARENA_AMALLOC_ALIGNMENT));
-STATIC_ASSERT(is_aligned(Chunk::medium_size, ARENA_AMALLOC_ALIGNMENT));
-STATIC_ASSERT(is_aligned(Chunk::size, ARENA_AMALLOC_ALIGNMENT));
-STATIC_ASSERT(is_aligned(Chunk::non_pool_size, ARENA_AMALLOC_ALIGNMENT));
+STATIC_ASSERT(is_aligned((int)Chunk::tiny_size, ARENA_AMALLOC_ALIGNMENT));
+STATIC_ASSERT(is_aligned((int)Chunk::init_size, ARENA_AMALLOC_ALIGNMENT));
+STATIC_ASSERT(is_aligned((int)Chunk::medium_size, ARENA_AMALLOC_ALIGNMENT));
+STATIC_ASSERT(is_aligned((int)Chunk::size, ARENA_AMALLOC_ALIGNMENT));
+STATIC_ASSERT(is_aligned((int)Chunk::non_pool_size, ARENA_AMALLOC_ALIGNMENT));
 
 //--------------------------------------------------------------------------------------
 // ChunkPool implementation

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -40,12 +40,12 @@
 #define ARENA_ALIGN(x) (align_up((size_t) (x), ARENA_AMALLOC_ALIGNMENT))
 
 enum class ChunkPoolSize : uintptr_t {
-  TINY = 0,
-  SMALL = 1,
-  MEDIUM = 2,
-  LARGE = 3,
+  NONE = 0,
 
-  NONE = 7,
+  TINY = 1,
+  SMALL = 2,
+  MEDIUM = 3,
+  LARGE = 4,
 };
 
 constexpr uintptr_t chunk_pool_size_bits = uintptr_t{8} - 1;

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -37,7 +37,7 @@
 
 // The byte alignment to be used by Arena::Amalloc.
 #define ARENA_AMALLOC_ALIGNMENT ((size_t) BytesPerLong)
-#define ARENA_ALIGN(x) (align_up((size_t) (x), ARENA_AMALLOC_ALIGNMENT))
+#define ARENA_ALIGN(x) (align_up((x), ARENA_AMALLOC_ALIGNMENT))
 
 enum class ChunkPoolSize : uintptr_t {
   NONE = 0,

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -103,7 +103,7 @@ class Chunk final {
   static constexpr size_t small_size = 1*K - slack;       // Size of first chunk (normal aka small)
   static constexpr size_t init_size = small_size;
   static constexpr size_t medium_size = 10*K - slack;     // Size of medium-sized chunk
-  static constexpr size_t large_size = 32*K - slack;    // Large size of an Arena chunk (following the first)
+  static constexpr size_t large_size = 32*K - slack;      // Large size of an Arena chunk (following the first)
   static constexpr size_t size = large_size;
   static constexpr size_t non_pool_size = init_size + 32; // An initial size which is not one of above
 

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -36,7 +36,7 @@
 #include <new>
 
 // The byte alignment to be used by Arena::Amalloc.
-#define ARENA_AMALLOC_ALIGNMENT ((size_t) BytesPerLong)
+#define ARENA_AMALLOC_ALIGNMENT BytesPerLong
 #define ARENA_ALIGN(x) (align_up((x), ARENA_AMALLOC_ALIGNMENT))
 
 enum class ChunkPoolSize : uintptr_t {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -860,14 +860,22 @@ class os: AllStatic {
   // Return: number of stack frames captured.
   static int get_native_stack(address* stack, int size, int toSkip = 0);
 
-  // General allocation (must be MT-safe)
-  static void* malloc  (size_t size, MEMFLAGS flags, const NativeCallStack& stack);
-  static void* malloc  (size_t size, MEMFLAGS flags);
-  static void* realloc (void *memblock, size_t size, MEMFLAGS flag, const NativeCallStack& stack);
-  static void* realloc (void *memblock, size_t size, MEMFLAGS flag);
+  // Memory allocation. If `actual_size` is not nullptr, the actual usable size of the underlying
+  // memory allocation is returned. This will be at least as large as `size`. This should only be
+  // specified in cases where extra usable memory is useful, for example in an arena allocator, as
+  // it may require more overhead to fetch the usable size. You *should* call os::free_sized instead
+  // of os::free if `actual_size` was specified. The size passed to os::free_sized *must* be the
+  // same as was returned in `actual_size`.
+  static void* malloc(size_t size, MEMFLAGS flags, const NativeCallStack& stack, size_t* actual_size = nullptr);
+  static void* malloc(size_t size, MEMFLAGS flags, size_t* actual_size = nullptr);
+
+  // Memory reallocation.
+  static void* realloc(void *memblock, size_t size, MEMFLAGS flag, const NativeCallStack& stack);
+  static void* realloc(void *memblock, size_t size, MEMFLAGS flag);
 
   // handles null pointers
-  static void  free    (void *memblock);
+  static void  free(void *memblock);
+  static void  free_sized(void *memblock, size_t size);
   static char* strdup(const char *, MEMFLAGS flags = mtInternal);  // Like strdup
   // Like strdup, but exit VM when strdup() returns null
   static char* strdup_check_oom(const char*, MEMFLAGS flags = mtInternal);


### PR DESCRIPTION
Memory allocated by `malloc()` is frequently larger than the size actually requested. Some `malloc()` implementations allow querying this information. This can be useful as an optimization for some use cases, such as an arena allocator, as it allows using the entire memory block.

This change updates `os::malloc()` by appending an additional argument that can request the actual usable size. On platforms that support it, the actual usable size of the allocation returned by `malloc()` will be filled in. Callers should then use `os::free_sized`, as with NMT enabled it can assert that the size is correct. This also is a precursor to eventually supporting `free_sized` from C23, which is an optimization usabled by some `malloc()` implementations to make `free()` quicker.

This change also upgrades Chunk to use this facility.

**Observations**

NMT could use this same facility to keep track of the actual allocated size, instead of the requested size it has today, making it more accurate. Doing so is out of scope for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304421](https://bugs.openjdk.org/browse/JDK-8304421): Introduce malloc size feedback (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13081/head:pull/13081` \
`$ git checkout pull/13081`

Update a local copy of the PR: \
`$ git checkout pull/13081` \
`$ git pull https://git.openjdk.org/jdk.git pull/13081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13081`

View PR using the GUI difftool: \
`$ git pr show -t 13081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13081.diff">https://git.openjdk.org/jdk/pull/13081.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13081#issuecomment-1474169249)