### PR TITLE
8304425: ClassHierarchyResolver from Reflection

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,6 +189,8 @@ public final class ClassHierarchyImpl {
 
         @Override
         public ClassHierarchyInfo getClassInfo(ClassDesc cd) {
+            if (!cd.isClassOrInterface())
+                return null;
             return cache.computeIfAbsent(cd, desc -> {
                 var cl = resolve(desc);
                 if (cl == null) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,9 +114,26 @@ public class Util {
         return count;
     }
 
-    public static String toClassString(String desc) {
-        //TODO: this doesn't look right L ... ;
-        return desc.replace('/', '.');
+    /**
+     * Convert a descriptor of classes or interfaces or arrays, or an internal
+     * name of a class or interface, into a fully qualified binary name, that can
+     * be resolved by {@link Class#forName(String) Class::forName}. Primitive type
+     * descriptors should never be passed into this method.
+     *
+     * @param descOrInternalName a descriptor or internal name
+     * @return the fully qualified binary name
+     */
+    public static String toBinaryName(String descOrInternalName) {
+        if (descOrInternalName.startsWith("L")) {
+            // descriptors of classes or interfaces
+            if (descOrInternalName.length() <= 2 || !descOrInternalName.endsWith(";")) {
+                throw new IllegalArgumentException(descOrInternalName);
+            }
+            return descOrInternalName.substring(1, descOrInternalName.length() - 1).replace('/', '.');
+        } else {
+            // arrays, classes or interfaces' internal names
+            return descOrInternalName.replace('/', '.');
+        }
     }
 
     public static Iterator<String> parameterTypes(String s) {

--- a/test/jdk/jdk/classfile/UtilTest.java
+++ b/test/jdk/jdk/classfile/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  */
 import jdk.internal.classfile.impl.Util;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -37,6 +39,25 @@ import static org.junit.jupiter.api.Assertions.*;
  * UtilTest
  */
 class UtilTest {
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Long.class,
+            Object.class,
+            Util.class,
+            Test.class,
+            int[][].class,
+            Object[].class,
+    })
+    void testDescToBinaryName(Class<?> type) throws ReflectiveOperationException {
+        if (!type.isArray()) {
+            // Test internal name
+            var internal = type.getName().replace('.', '/');
+            assertEquals(type, Class.forName(Util.toBinaryName(internal)));
+        }
+        // Test descriptor
+        assertEquals(type, Class.forName(Util.toBinaryName(type.descriptorString())));
+    }
+
     @Test
     void testFindParams() {
         assertEquals(Util.findParams("(IIII)V").cardinality(), 4);


### PR DESCRIPTION
Add API to explore Class Hierarchy with a `ClassLoader` or a `Lookup` with proper privileges, with tests.

This addition is useful in case classes at runtime are not loaded from the system class loader, such as Proxy. This is also useful to APIs that generate bytecode with a `Lookup` object, such as a custom single-abstract-method class implementations from a method handle.

See https://mail.openjdk.org/pipermail/classfile-api-dev/2023-March/000249.html as well.

Current questions, which I wish to discuss with @asotona:
1. Should the resolver fail fast on `IllegalAccessException` from the lookup? This usually indicates the hierarchy resolver is set up improperly, and proceeding may simply yield verification errors in class loading that are hard to track. For bytecode-generating APIs, throwing access errors for the Lookup eagerly is also more preferable than later silent generation failure.
2. Whether the default resolver should be reading from jrt alone, reflection alone, or jrt then reflection. I personally believe reflection alone is more reliable, for classes may redefined with instrumentation or jfr, which may not be reflected in the system resources.
3. In addition, I don't think chaining system class loader reflection after system resource retrieval is really meaningful: is there any case where reflection always works while the system resource retrieval always fails?

