### PR TITLE
8177352: Calendar.getDisplayName(s) in non-lenient mode inconsistent, does not match spec

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -2077,6 +2077,14 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * which a {@link DateFormatSymbols} has names in the given
      * {@code locale}.
      *
+     * @implSpec This method will return {@code null} over throwing an
+     * {@code IllegalArgumentException} when both of the following conditions are true:
+     * <ol>
+     *     <li>There is no string representation of
+     *     the {@code Calendar} {@code field}.</li>
+     *     <li>The calendar is in non-lenient mode and
+     *     any calendar fields have invalid values.</li>
+     * </ol>
      * @param field
      *        the calendar field for which the string representation
      *        is returned
@@ -2170,6 +2178,11 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * all strings returned by {@link DateFormatSymbols#getShortMonths()}
      * and {@link DateFormatSymbols#getMonths()}.
      *
+     * @implSpec Unlike {@link #getDisplayName(int, int, Locale)}, this
+     * method will not throw an {@code IllegalArgumentException} if the
+     * {@code Calendar} is non-lenient and any of the calendar fields have
+     * invalid values. Instead, this method will return one of the two
+     * possible return values specified.
      * @param field
      *        the calendar field for which the display names are returned
      * @param style
@@ -2184,9 +2197,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      *        field values, or {@code null} if no display names
      *        are defined for {@code field}
      * @throws    IllegalArgumentException
-     *        if {@code field} or {@code style} is invalid,
-     *        or if this {@code Calendar} is non-lenient and any
-     *        of the calendar fields have invalid values
+     *        if {@code field} or {@code style} is invalid
      * @throws    NullPointerException
      *        if {@code locale} is null
      * @since 1.6

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -2077,7 +2077,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * which a {@link DateFormatSymbols} has names in the given
      * {@code locale}.
      *
-     * @implSpec This method will return {@code null} over throwing an
+     * <p>This method will return {@code null} over throwing an
      * {@code IllegalArgumentException} when both of the following conditions are true:
      * <ol>
      *     <li>There is no string representation of
@@ -2085,6 +2085,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      *     <li>The calendar is in non-lenient mode and
      *     any calendar fields have invalid values.</li>
      * </ol>
+     *
      * @param field
      *        the calendar field for which the string representation
      *        is returned
@@ -2178,11 +2179,12 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * all strings returned by {@link DateFormatSymbols#getShortMonths()}
      * and {@link DateFormatSymbols#getMonths()}.
      *
-     * @implSpec Unlike {@link #getDisplayName(int, int, Locale)}, this
+     * <p>Unlike {@link #getDisplayName(int, int, Locale)}, this
      * method will not throw an {@code IllegalArgumentException} if the
      * {@code Calendar} is non-lenient and any of the calendar fields have
      * invalid values. Instead, this method will return one of the two
      * possible return values specified.
+     *
      * @param field
      *        the calendar field for which the display names are returned
      * @param style

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -2077,14 +2077,11 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * which a {@link DateFormatSymbols} has names in the given
      * {@code locale}.
      *
-     * <p>This method will return {@code null} over throwing an
-     * {@code IllegalArgumentException} when both of the following conditions are true:
-     * <ol>
-     *     <li>There is no string representation of
-     *     the {@code Calendar} {@code field}.</li>
-     *     <li>The calendar is in non-lenient mode and
-     *     any calendar fields have invalid values.</li>
-     * </ol>
+     * <p>If there is no string representation of the {@code Calendar} {@code field}
+     * and the calendar is in non-lenient mode and any calendar fields have invalid values,
+     * {@code null} is returned. If there is a string representation of the {@code Calendar}
+     * {@code field} and the calendar is in non-lenient mode and any calendar fields
+     * have invalid values, {@code IllegalArgumentException} will be thrown.
      *
      * @param field
      *        the calendar field for which the string representation
@@ -2182,8 +2179,8 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * <p>Unlike {@link #getDisplayName(int, int, Locale)}, this
      * method will not throw an {@code IllegalArgumentException} if the
      * {@code Calendar} is non-lenient and any of the calendar fields have
-     * invalid values. Instead, this method will return one of the two
-     * possible return values specified.
+     * invalid values. Instead, this method will return either {@code null} or
+     * a {@code Map}.
      *
      * @param field
      *        the calendar field for which the display names are returned


### PR DESCRIPTION
This PR updates the javadoc of `java.util.Calendar.getDisplayName()` and `java.util.Calendar.getDisplayNames()` to better reflect the actual behavior when the calendar is non-lenient.

This involves updating the spec of both methods to clarify behavior, as well as removing false behavior from the **throws** tag in `java.util.Calendar.getDisplayNames()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8304371](https://bugs.openjdk.org/browse/JDK-8304371) to be approved

### Issues
 * [JDK-8177352](https://bugs.openjdk.org/browse/JDK-8177352): Calendar.getDisplayName(s) in non-lenient mode inconsistent, does not match spec
 * [JDK-8304371](https://bugs.openjdk.org/browse/JDK-8304371): Calendar.getDisplayName(s) in non-lenient mode inconsistent, does not match spec (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13083/head:pull/13083` \
`$ git checkout pull/13083`

Update a local copy of the PR: \
`$ git checkout pull/13083` \
`$ git pull https://git.openjdk.org/jdk.git pull/13083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13083`

View PR using the GUI difftool: \
`$ git pr show -t 13083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13083.diff">https://git.openjdk.org/jdk/pull/13083.diff</a>

</details>
