### PR TITLE
8182621: JSSE should reject empty TLS plaintexts

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,10 @@ final class SSLEngineInputRecord extends InputRecord implements SSLRecord {
         // parse handshake messages
         //
         if (contentType == ContentType.HANDSHAKE.id) {
+            if (!fragment.hasRemaining()) {
+                throw new SSLProtocolException("Handshake packets may not be zero-length");
+            }
+
             ByteBuffer handshakeFrag = fragment;
             if ((handshakeBuffer != null) &&
                     (handshakeBuffer.remaining() != 0)) {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -284,6 +284,10 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         //
         if (contentType == ContentType.HANDSHAKE.id) {
             ByteBuffer handshakeFrag = fragment;
+            if (!handshakeFrag.hasRemaining()) {
+                throw new SSLProtocolException("Handshake fragments cannot be zero length.");
+            }
+
             if ((handshakeBuffer != null) &&
                     (handshakeBuffer.remaining() != 0)) {
                 ByteBuffer bb = ByteBuffer.wrap(new byte[

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineEmptyFragments.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineEmptyFragments.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8182621
+ * @summary Verify the SSLEngine rejects empty Handshake, Alert, and ChangeCipherSpec messages.
+ * @library /javax/net/ssl/templates
+ * @run main SSLEngineEmptyFragments
+ */
+import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.*;
+
+public class SSLEngineEmptyFragments extends SSLContextTemplate {
+    private static final byte HANDSHAKE_TYPE = 22;
+    private static final byte ALERT_TYPE = 21;
+    private static final byte CHANGE_CIPHERSPEC_TYPE = 20;
+    private static final String TLSv12 = "TLSv1.2";
+    private static final String TLSv13 = "TLSv1.3";
+
+    private SSLEngine serverEngine;
+    private SSLEngine clientEngine;
+    private ByteBuffer clientIn;
+    private ByteBuffer serverIn;
+    private ByteBuffer clientToServer;
+    private ByteBuffer serverToClient;
+    private ByteBuffer clientOut;
+    private ByteBuffer serverOut;
+
+    private final String protocol;
+
+    public SSLEngineEmptyFragments(String protocol) {
+        this.protocol = protocol;
+    }
+
+    private void initialize() throws Exception {
+        initialize(null);
+    }
+
+    private void initialize(String [] protocols) throws Exception {
+        serverEngine = createServerSSLContext().createSSLEngine();
+        clientEngine = createClientSSLContext().createSSLEngine();
+
+        serverEngine.setUseClientMode(false);
+        clientEngine.setUseClientMode(true);
+
+        if (protocols != null) {
+            clientEngine.setEnabledProtocols(protocols);
+            serverEngine.setEnabledProtocols(protocols);
+        }
+
+        // do one legitimate handshake packet, then send a zero-length alert.
+        SSLSession session = clientEngine.getSession();
+        int appBufferMax = session.getApplicationBufferSize();
+        int netBufferMax = session.getPacketBufferSize();
+
+        // We'll make the input buffers a bit bigger than the max needed
+        // size, so that unwrap()s following a successful data transfer
+        // won't generate BUFFER_OVERFLOWS.
+        //
+        // We'll use a mix of direct and indirect ByteBuffers for
+        // tutorial purposes only.  In reality, only use direct
+        // ByteBuffers when they give a clear performance enhancement.
+        clientIn = ByteBuffer.allocate(appBufferMax + 50);
+        serverIn = ByteBuffer.allocate(appBufferMax + 50);
+
+        clientToServer = ByteBuffer.allocateDirect(netBufferMax);
+        serverToClient = ByteBuffer.allocateDirect(netBufferMax);
+
+        clientOut = ByteBuffer.wrap("Hi Server, I'm Client".getBytes());
+        serverOut = ByteBuffer.wrap("Hello Client, I'm Server".getBytes());
+    }
+
+    private void testAlertPacketNotHandshaking() throws Exception {
+        log("**** Empty alert packet/not handshaking");
+        initialize();
+
+        ByteBuffer alert = ByteBuffer.allocate(5);
+        alert.put(new byte[]{ALERT_TYPE, 3, 3, 0, 0});
+        alert.flip();
+
+        try {
+            unwrap(serverEngine, alert, serverIn);
+            throw new RuntimeException("Expected exception was not thrown.");
+        } catch (SSLHandshakeException exc) {
+            log("Got the exception I wanted.");
+        }
+    }
+
+    private void testAlertPacketMidHandshake() throws Exception {
+        log("**** Empty alert packet during handshake.");
+        initialize(new String[]{protocol});
+
+        wrap(clientEngine, clientOut, clientToServer);
+        runDelegatedTasks(clientEngine);
+        clientToServer.flip();
+
+        unwrap(serverEngine, clientToServer, serverIn);
+        runDelegatedTasks(serverEngine);
+
+        while(serverEngine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+            wrap(serverEngine, serverOut, serverToClient);
+            runDelegatedTasks(serverEngine);
+            serverToClient.flip();
+        }
+
+        ByteBuffer alert = ByteBuffer.allocate(5);
+        alert.put(new byte[]{ALERT_TYPE, 3, 3, 0, 0});
+        alert.flip();
+
+        try {
+            unwrap(serverEngine, alert, serverIn);
+            log("Server unwrap was successful when it should have failed.");
+            throw new RuntimeException("Expected exception was not thrown.");
+        } catch (SSLHandshakeException exc) {
+            log("Got the exception I wanted.");
+        }
+    }
+
+    private void testHandshakePacket() throws NoSuchAlgorithmException, SSLException {
+        log("**** Empty handshake package.");
+        SSLContext ctx = SSLContext.getDefault();
+        SSLEngine engine = ctx.createSSLEngine();
+        engine.setUseClientMode(false);
+
+        try {
+            ByteBuffer bb = ByteBuffer.allocate(5);
+            bb.put(new byte[]{HANDSHAKE_TYPE, 3, 3, 0, 0});
+            bb.flip();
+            ByteBuffer out = ByteBuffer.allocate(engine.getSession().getPacketBufferSize());
+            engine.unwrap(bb, out);
+            throw new RuntimeException("SSLEngine did not throw an exception for a zero-length fragment.");
+        } catch (SSLProtocolException exc) {
+            log("Received expected exception");
+        }
+    }
+
+    private void testEmptyChangeCipherSpec() throws Exception {
+        initialize(new String[]{protocol});
+
+        boolean foundCipherSpecMsg = false;
+        do {
+            log("Client wrap");
+            wrap(clientEngine, clientOut, clientToServer);
+            runDelegatedTasks(clientEngine);
+
+            if(clientToServer.get(0) == CHANGE_CIPHERSPEC_TYPE) {
+                foundCipherSpecMsg = true;
+                break;
+            }
+
+            log("server wrap");
+            wrap(serverEngine, serverOut, serverToClient);
+            runDelegatedTasks(serverEngine);
+
+            clientToServer.flip();
+            serverToClient.flip();
+
+            log("client unwrap");
+            unwrap(clientEngine, serverToClient, clientIn);
+            runDelegatedTasks(clientEngine);
+
+            log("server unwrap");
+            unwrap(serverEngine, clientToServer, serverIn);
+            runDelegatedTasks(serverEngine);
+
+            clientToServer.compact();
+            serverToClient.compact();
+        } while(clientEngine.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.FINISHED
+            && serverEngine.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.FINISHED);
+
+        if (!foundCipherSpecMsg) {
+            // performed TLS handshaking but didn't catch change-cipherspec message.
+            throw new RuntimeException("Did not intercept ChangeCipherSpec message.");
+        }
+
+        ByteBuffer changeCipher = ByteBuffer.allocate(5);
+        changeCipher.put(new byte[]{CHANGE_CIPHERSPEC_TYPE, 3, 3, 0, 0});
+        changeCipher.flip();
+        try {
+            unwrap(serverEngine, changeCipher, serverIn);
+            throw new RuntimeException("Didn't get the expected SSL exception");
+        } catch (SSLProtocolException exc) {
+            log("Received expected exception.");
+        }
+    }
+
+    private SSLEngineResult wrap(SSLEngine engine, ByteBuffer src, ByteBuffer dst) throws SSLException {
+        SSLEngineResult result = engine.wrap(src, dst);
+        logEngineStatus(engine, result);
+        return result;
+    }
+
+    private SSLEngineResult unwrap(SSLEngine engine, ByteBuffer src, ByteBuffer dst) throws SSLException {
+        SSLEngineResult result = engine.unwrap(src, dst);
+        logEngineStatus(engine, result);
+        return result;
+    }
+
+    protected void runDelegatedTasks(SSLEngine engine) throws Exception {
+        if (engine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+            Runnable runnable;
+            while ((runnable = engine.getDelegatedTask()) != null) {
+                log("    running delegated task...");
+                runnable.run();
+            }
+            SSLEngineResult.HandshakeStatus hsStatus = engine.getHandshakeStatus();
+            if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                throw new Exception(
+                        "handshake shouldn't need additional tasks");
+            }
+            logEngineStatus(engine);
+        }
+    }
+
+    private void logEngineStatus(SSLEngine engine) {
+        log("\tCurrent HS State: " + engine.getHandshakeStatus());
+        log("\tisInboundDone() : " + engine.isInboundDone());
+        log("\tisOutboundDone(): " + engine.isOutboundDone());
+    }
+
+    private void logEngineStatus(
+            SSLEngine engine, SSLEngineResult result) {
+        log("\tResult Status    : " + result.getStatus());
+        log("\tResult HS Status : " + result.getHandshakeStatus());
+        log("\tEngine HS Status : " + engine.getHandshakeStatus());
+        log("\tisInboundDone()  : " + engine.isInboundDone());
+        log("\tisOutboundDone() : " + engine.isOutboundDone());
+        log("\tMore Result      : " + result);
+    }
+
+    private void log(String message) {
+        System.err.println(message);
+    }
+
+    public static void main(String [] args) throws Exception {
+        SSLEngineEmptyFragments tests = new SSLEngineEmptyFragments(TLSv12);
+        tests.testHandshakePacket();
+        tests.testAlertPacketNotHandshaking();
+        tests.testAlertPacketMidHandshake();
+        tests.testEmptyChangeCipherSpec();
+
+        tests = new SSLEngineEmptyFragments(TLSv13);
+        tests.testHandshakePacket();
+        tests.testAlertPacketNotHandshaking();
+    }
+}

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketEmptyFragments.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketEmptyFragments.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8182621
+ * @summary Verify JSSE rejects empty Handshake, Alert, and ChangeCipherSpec messages.
+ * @library /javax/net/ssl/templates
+ * @run main SSLSocketEmptyFragments
+ */
+
+import javax.net.ssl.*;
+import java.io.*;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.concurrent.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class SSLSocketEmptyFragments extends SSLContextTemplate {
+    private static final boolean DEBUG = Boolean.getBoolean("test.debug");
+    private static final byte HANDSHAKE_TYPE = 22;
+    private static final byte ALERT_TYPE = 21;
+    private static final byte CHANGE_CIPHERSPEC_TYPE = 20;
+
+    private static final byte[] INVALID_ALERT = {ALERT_TYPE, 3, 3, 0, 0};
+
+    private static final byte[] INVALID_HANDSHAKE = {HANDSHAKE_TYPE, 3, 3, 0, 0};
+    private static final int SERVER_WAIT_SEC = 5;
+    private static final String TLSv13 = "TLSv1.3";
+    private static final String TLSv12 = "TLSv1.2";
+
+    private final String protocol;
+
+    public SSLSocketEmptyFragments(String protocol) {
+        this.protocol = protocol;
+    }
+
+    /**
+     * Creates a socket connection between an SSLSocket (server-side) and
+     * a plain Socket on the client. Then runs the given executor to execute
+     * the test.
+     *
+     * @param consumer runs the test-specific code. The SSLSocket argument is the
+     *                 server-side of the connection. The Socket is the client-side.
+     */
+    private void executeSingleThreadedTest(BiConsumer<SSLSocket, Socket> consumer)
+            throws Exception {
+        SSLContext ctx = createServerSSLContext();
+        SSLServerSocketFactory factory = ctx.getServerSocketFactory();
+
+        try(ExecutorService executors = Executors.newFixedThreadPool(1);
+            SSLServerSocket serverSocket = (SSLServerSocket) factory.createServerSocket()) {
+            serverSocket.bind(null);
+            int port = serverSocket.getLocalPort();
+            InetAddress address = serverSocket.getInetAddress();
+
+            Future<SSLSocket> serverThread = executors.submit(
+                    () -> (SSLSocket)serverSocket.accept());
+
+            try (Socket client = new Socket(address, port);
+                SSLSocket sslSocket = serverThread.get(SERVER_WAIT_SEC, TimeUnit.SECONDS)) {
+                consumer.accept(sslSocket, client);
+            }
+        }
+    }
+
+    private static void testEmptyHandshakeRecord(SSLSocket server, Socket client) {
+        log("Sending bad handshake packet to server...");
+
+        try {
+            OutputStream os = client.getOutputStream();
+            os.write(INVALID_HANDSHAKE);
+            os.flush();
+            log("Reading data from client.");
+            // try to read some data to start the SSL handshake
+            server.getInputStream().read();
+            throw new RuntimeException(
+                    "Reading bad packet did not throw expected exception.");
+        } catch (SSLProtocolException exc) {
+            log("Caught expected SSLProtocolException.");
+        } catch (IOException exc) {
+            throw new RuntimeException("Unexpected IOException thrown by socket operations", exc);
+        }
+    }
+
+
+    private static void testEmptyAlertNotHandshaking(SSLSocket server, Socket client) {
+        log("Sending empty alert packet before handshaking starts.");
+
+        try {
+            OutputStream os = client.getOutputStream();
+            os.write(INVALID_ALERT);
+            os.flush();
+            log("Reading data from client.");
+            // try to read some data to start the SSL handshake
+            server.getInputStream().read();
+            throw new RuntimeException(
+                    "Reading bad packet did not throw expected exception.");
+        } catch (SSLHandshakeException exc) {
+            log("Caught expected SSLHandshakeException.");
+            if (!server.isClosed()) {
+                throw new RuntimeException("Server socket was not closed after exception.");
+            }
+
+        } catch (IOException exc) {
+            throw new RuntimeException("Unexpected IOException thrown by socket operations.", exc);
+        }
+    }
+
+    /**
+     * Runs a test where the server -- in a separate thread -- accepts a connection
+     * and attempts to read from the remote side. Tests are successful if the
+     * server thread returns true.
+     *
+     * @param clientConsumer Client-side test code that injects bad packets into the TLS handshake.
+     * @param expectedException The exception that should be thrown by the server
+     */
+    private void executeMultiThreadedTest(Consumer<Socket> clientConsumer,
+                              final Class<?> expectedException) throws Exception {
+        SSLContext serverContext = createServerSSLContext();
+        SSLServerSocketFactory factory = serverContext.getServerSocketFactory();
+
+        try(ExecutorService threadPool = Executors.newFixedThreadPool(1);
+            SSLServerSocket serverSocket = (SSLServerSocket) factory.createServerSocket()) {
+            serverSocket.bind(null);
+            int port = serverSocket.getLocalPort();
+            InetAddress address = serverSocket.getInetAddress();
+
+            Future<Boolean> serverThread = threadPool.submit(() -> {
+                try (SSLSocket socket = (SSLSocket) serverSocket.accept()) {
+                    log("Server reading data from client.");
+                    socket.getInputStream().read();
+                    log("The expected exception was not thrown.");
+                    return false;
+
+                } catch (Exception exc) {
+                    if (expectedException.isAssignableFrom(exc.getClass())) {
+                        log("Server thread received expected SSLProtocolException");
+                        return true;
+                    } else {
+                        log("Server thread threw an unexpected exception: " + exc);
+                        throw exc;
+                    }
+                }
+            });
+
+            try(Socket socket = new Socket(address, port)) {
+                clientConsumer.accept(socket);
+                log("waiting for server to exit.");
+
+                // wait for the server to exit, which should be quick if the test passes.
+                if (!serverThread.get(SERVER_WAIT_SEC, TimeUnit.SECONDS)) {
+                    throw new RuntimeException(
+                            "The server side of the connection did not throw the expected exception");
+                }
+            }
+        }
+    }
+
+    /**
+     * Performs the client side of the TLS handshake, sending and receiving
+     * packets over the given socket.
+     * @param socket Connected socket to the server side.
+     * @throws IOException
+     */
+    private void testEmptyAlertDuringHandshake(Socket socket) {
+        log("**** Testing empty alert during handshake");
+
+        try {
+            SSLEngine engine = createClientSSLContext().createSSLEngine();
+            engine.setUseClientMode(true);
+            SSLSession session = engine.getSession();
+
+            int appBufferMax = session.getApplicationBufferSize();
+            int netBufferMax = session.getPacketBufferSize();
+
+            ByteBuffer clientIn = ByteBuffer.allocate(appBufferMax + 50);
+            ByteBuffer clientToServer = ByteBuffer.allocate(appBufferMax + 50);
+            ByteBuffer serverToClient = ByteBuffer.allocate(netBufferMax + 50);
+            ByteBuffer clientOut = ByteBuffer.wrap("Hi Server, I'm Client".getBytes());
+
+            wrap(engine, clientOut, clientToServer);
+            runDelegatedTasks(engine);
+            clientToServer.flip();
+
+            OutputStream socketOut = socket.getOutputStream();
+            byte [] outbound = new byte[netBufferMax];
+            clientToServer.get(outbound, 0, clientToServer.limit());
+            socketOut.write(outbound, 0, clientToServer.limit());
+            socketOut.flush();
+
+            processServerResponse(engine, clientIn, socket.getInputStream());
+
+            log("Sending invalid alert packet!");
+            socketOut.write(new byte[]{ALERT_TYPE, 3, 3, 0, 0});
+            socketOut.flush();
+
+        } catch (Exception exc){
+            throw new RuntimeException("An error occurred running the test.", exc);
+        }
+    }
+
+    /**
+     * Performs TLS handshake until the client (this method) needs to send the
+     * ChangeCipherSpec message. Then we send a packet with a zero-length fragment.
+     */
+    private void testEmptyChangeCipherSpecMessage(Socket socket) {
+        log("**** Testing invalid ChangeCipherSpec message");
+
+        try {
+            socket.setSoTimeout(500);
+            SSLEngine engine = createClientSSLContext().createSSLEngine();
+            engine.setUseClientMode(true);
+            SSLSession session = engine.getSession();
+            int appBufferMax = session.getApplicationBufferSize();
+
+            ByteBuffer clientIn = ByteBuffer.allocate(appBufferMax + 50);
+            ByteBuffer clientToServer = ByteBuffer.allocate(appBufferMax + 50);
+
+            ByteBuffer clientOut = ByteBuffer.wrap("Hi Server, I'm Client".getBytes());
+
+            OutputStream outputStream = socket.getOutputStream();
+
+            boolean foundCipherSpecMsg = false;
+
+            byte[] outbound = new byte[8192];
+            do {
+                wrap(engine, clientOut, clientToServer);
+                runDelegatedTasks(engine);
+                clientToServer.flip();
+
+                if(clientToServer.get(0) == CHANGE_CIPHERSPEC_TYPE) {
+                    foundCipherSpecMsg = true;
+                    break;
+                }
+                clientToServer.get(outbound, 0, clientToServer.limit());
+                debug("Writing " + clientToServer.limit() + " bytes to the server.");
+                outputStream.write(outbound, 0, clientToServer.limit());
+                outputStream.flush();
+
+                processServerResponse(engine, clientIn, socket.getInputStream());
+
+                clientToServer.clear();
+
+            } while(engine.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.FINISHED);
+
+            if (!foundCipherSpecMsg) {
+                throw new RuntimeException("Didn't intercept the ChangeCipherSpec message.");
+            } else {
+                log("Sending invalid ChangeCipherSpec message");
+                outputStream.write(new byte[]{CHANGE_CIPHERSPEC_TYPE, 3, 3, 0, 0});
+                outputStream.flush();
+            }
+
+        } catch (Exception exc) {
+            throw new RuntimeException("An error occurred running the test.", exc);
+        }
+    }
+
+    /**
+     * Processes TLS handshake messages received from the server.
+     */
+    private static void processServerResponse(SSLEngine engine, ByteBuffer clientIn,
+                                      InputStream inputStream) throws IOException {
+        byte [] inbound = new byte[8192];
+        ByteBuffer serverToClient = ByteBuffer.allocate(
+                engine.getSession().getApplicationBufferSize() + 50);
+
+        while(engine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+            log("reading data from server.");
+            int len = inputStream.read(inbound);
+            if (len == -1) {
+                throw new IOException("Could not read from server.");
+            }
+
+            dumpBytes(inbound, len);
+
+            serverToClient.put(inbound, 0, len);
+            serverToClient.flip();
+
+            // unwrap packets in a loop because we sometimes get multiple
+            // TLS messages in one read() operation.
+            do {
+                unwrap(engine, serverToClient, clientIn);
+                runDelegatedTasks(engine);
+                log("Status after running tasks: " + engine.getHandshakeStatus());
+            } while (serverToClient.hasRemaining());
+            serverToClient.compact();
+        }
+    }
+
+    private static SSLEngineResult wrap(SSLEngine engine, ByteBuffer src, ByteBuffer dst) throws SSLException {
+        log("Wrapping...");
+        SSLEngineResult result = engine.wrap(src, dst);
+        logEngineStatus(engine, result);
+        return result;
+    }
+
+    private static SSLEngineResult unwrap(SSLEngine engine, ByteBuffer src, ByteBuffer dst) throws SSLException {
+        log("Unwrapping");
+        SSLEngineResult result = engine.unwrap(src, dst);
+        logEngineStatus(engine, result);
+        return result;
+    }
+
+    protected static void runDelegatedTasks(SSLEngine engine) {
+        if (engine.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+            Runnable runnable;
+            while ((runnable = engine.getDelegatedTask()) != null) {
+                log("    running delegated task...");
+                runnable.run();
+            }
+            SSLEngineResult.HandshakeStatus hsStatus = engine.getHandshakeStatus();
+            if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                throw new RuntimeException(
+                        "handshake shouldn't need additional tasks");
+            }
+        }
+    }
+
+
+    @Override
+    protected ContextParameters getClientContextParameters() {
+        return getContextParameters();
+    }
+
+    @Override
+    protected ContextParameters getServerContextParameters() {
+        return getContextParameters();
+    }
+
+    private ContextParameters getContextParameters() {
+        return new ContextParameters(protocol, "PKIX", "NewSunX509");
+    }
+    
+    private static void log(String message) {
+        System.out.println(message);
+        System.out.flush();
+    }
+
+    private static void dumpBytes(byte[] buffer, int length) {
+        int totalLength = Math.min(buffer.length, length);
+        StringBuffer sb = new StringBuffer();
+        int counter = 0;
+        for (int idx = 0; idx < totalLength ; ++idx) {
+            sb.append(String.format("%02x ", buffer[idx]));
+            if (++counter == 16) {
+                sb.append("\n");
+                counter = 0;
+            }
+        }
+        debug(sb.toString());
+    }
+
+    private static void debug(String message) {
+        if (DEBUG) {
+            log(message);
+        }
+    }
+
+    private static FileWriter fw;
+
+    private static void logEngineStatus(
+            SSLEngine engine, SSLEngineResult result) {
+        debug("\tResult Status    : " + result.getStatus());
+        debug("\tResult HS Status : " + result.getHandshakeStatus());
+        debug("\tEngine HS Status : " + engine.getHandshakeStatus());
+        debug("\tisInboundDone()  : " + engine.isInboundDone());
+        debug("\tisOutboundDone() : " + engine.isOutboundDone());
+        debug("\tMore Result      : " + result);
+    }
+
+
+    public static void main(String [] args) throws Exception {
+        SSLSocketEmptyFragments tests = new SSLSocketEmptyFragments(TLSv12);
+
+        tests.executeSingleThreadedTest(
+                SSLSocketEmptyFragments::testEmptyHandshakeRecord);
+        tests.executeSingleThreadedTest(
+                SSLSocketEmptyFragments::testEmptyAlertNotHandshaking);
+        tests.executeMultiThreadedTest(tests::testEmptyAlertDuringHandshake, SSLHandshakeException.class);
+        tests.executeMultiThreadedTest(tests::testEmptyChangeCipherSpecMessage, SSLProtocolException.class);
+
+        tests = new SSLSocketEmptyFragments(TLSv13);
+        tests.executeSingleThreadedTest(
+                SSLSocketEmptyFragments::testEmptyHandshakeRecord);
+        tests.executeSingleThreadedTest(
+                SSLSocketEmptyFragments::testEmptyAlertNotHandshaking);
+    }
+}


### PR DESCRIPTION
Added code similar to the suggested patches for empty Handshake messages. I also implemented tests to verify empty Handshake, Alert, and ChangeCipherSpec messages result in expected behavior: for SSLEngineImpl, exceptions are thrown, for SSLSockets the connection is closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8182621`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8182621`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13084/head:pull/13084` \
`$ git checkout pull/13084`

Update a local copy of the PR: \
`$ git checkout pull/13084` \
`$ git pull https://git.openjdk.org/jdk.git pull/13084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13084`

View PR using the GUI difftool: \
`$ git pr show -t 13084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13084.diff">https://git.openjdk.org/jdk/pull/13084.diff</a>

</details>
