### PR TITLE
8304437: ProblemList com/sun/jdi/ThreadMemoryLeadTest.java with ZGC

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -28,3 +28,5 @@
 #############################################################################
 
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8298066 windows-x64
+
+com/sun/jdi/ThreadMemoryLeakTest.java 8304436 generic-all


### PR DESCRIPTION
This new test is failing with ZGC, I believe on every run. Needs to be problem listed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304437](https://bugs.openjdk.org/browse/JDK-8304437): ProblemList com/sun/jdi/ThreadMemoryLeadTest.java with ZGC


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13087/head:pull/13087` \
`$ git checkout pull/13087`

Update a local copy of the PR: \
`$ git checkout pull/13087` \
`$ git pull https://git.openjdk.org/jdk pull/13087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13087`

View PR using the GUI difftool: \
`$ git pr show -t 13087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13087.diff">https://git.openjdk.org/jdk/pull/13087.diff</a>

</details>
