### PR TITLE
8304442: Defer VirtualMemoryTracker work until reporting

### DIFF
--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -144,7 +144,7 @@ class MemTracker : AllStatic {
     if (!enabled()) return;
     if (addr != nullptr) {
       ThreadCritical tc;
-      VirtualMemoryTracker::add_reserved_region((address)addr, size, stack, flag);
+      VirtualMemoryTracker::add_reserved_region(addr, size, stack, flag);
     }
   }
 
@@ -154,8 +154,8 @@ class MemTracker : AllStatic {
     if (!enabled()) return;
     if (addr != nullptr) {
       ThreadCritical tc;
-      VirtualMemoryTracker::add_reserved_region((address)addr, size, stack, flag);
-      VirtualMemoryTracker::add_committed_region((address)addr, size, stack);
+      VirtualMemoryTracker::add_reserved_region(addr, size, stack, flag);
+      VirtualMemoryTracker::add_committed_region(addr, size, stack);
     }
   }
 
@@ -165,7 +165,7 @@ class MemTracker : AllStatic {
     if (!enabled()) return;
     if (addr != nullptr) {
       ThreadCritical tc;
-      VirtualMemoryTracker::add_committed_region((address)addr, size, stack);
+      VirtualMemoryTracker::add_committed_region(addr, size, stack);
     }
   }
 

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -34,7 +34,7 @@
 
 size_t VirtualMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(VirtualMemorySnapshot, size_t)];
 
-GrowableArray<VirtualMemoryTracker::MemoryEvent> VirtualMemoryTracker::work_queue{256, mtNMT};
+GrowableArray<VirtualMemoryTracker::MemoryEvent> VirtualMemoryTracker::work_queue{0, mtNMT};
 
 void VirtualMemorySummary::initialize() {
   assert(sizeof(_snapshot) >= sizeof(VirtualMemorySnapshot), "Sanity Check");
@@ -327,6 +327,7 @@ bool VirtualMemoryTracker::initialize(NMT_TrackingLevel level) {
     VirtualMemorySummary::initialize();
     _reserved_regions = new (std::nothrow, mtNMT)
       SortedLinkedList<ReservedMemoryRegion, compare_reserved_region_base>();
+    work_queue.reserve(256);
     return (_reserved_regions != nullptr);
   }
   return true;

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -438,6 +438,11 @@ public:
       } else if(evt.tag == Tag::SplitReserved) {
         split_reserved_region_impl((address)evt.addr, evt.size, evt.split.split);
       }
+#ifdef ASSERT
+      else {
+        ShouldNotReachHere();
+      }
+#endif
     }
     // Try not to keep too much unused memory around.
     if (length > 1024) {

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -40,7 +40,7 @@ public:
 
     MemTracker::record_thread_stack(stack_end, stack_size);
 
-    VirtualMemoryTracker::add_reserved_region(stack_end, stack_size, CALLER_PC, mtThreadStack);
+    VirtualMemoryTracker::add_reserved_region_impl(stack_end, stack_size, CALLER_PC, mtThreadStack);
 
     // snapshot current stack usage
     VirtualMemoryTracker::snapshot_thread_stacks();
@@ -106,7 +106,7 @@ public:
 
     address frame = (address)0x1235;
     NativeCallStack stack(&frame, 1);
-    VirtualMemoryTracker::add_reserved_region((address)base, size, stack, mtThreadStack);
+    VirtualMemoryTracker::add_reserved_region_impl((address)base, size, stack, mtThreadStack);
 
     // trigger the test
     VirtualMemoryTracker::snapshot_thread_stacks();
@@ -136,7 +136,7 @@ public:
 
     // Cleanup
     os::free_memory(base, size, page_sz);
-    VirtualMemoryTracker::remove_released_region((address)base, size);
+    VirtualMemoryTracker::remove_released_region_impl((address)base, size);
 
     rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion((address)base, size));
     ASSERT_TRUE(rmr == NULL);

--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -102,6 +102,8 @@ public:
     NativeCallStack stack(&frame1, 1);
     NativeCallStack stack2(&frame2, 1);
 
+    VirtualMemoryTracker::commit_events();
+
     // Fetch the added RMR for the space
     ReservedMemoryRegion* rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion(addr, size));
 
@@ -176,6 +178,7 @@ public:
     NativeCallStack stack(&frame1, 1);
     NativeCallStack stack2(&frame2, 1);
 
+    VirtualMemoryTracker::commit_events();
     // Add the reserved memory
     VirtualMemoryTracker::add_reserved_region_impl(addr, size, stack, mtTest);
 
@@ -252,7 +255,6 @@ public:
   }
 
   static void test_add_committed_region_overlapping() {
-
     size_t size  = 0x01000000;
     ReservedSpace rs(size);
     address addr = (address)rs.base();
@@ -262,6 +264,8 @@ public:
 
     NativeCallStack stack(&frame1, 1);
     NativeCallStack stack2(&frame2, 1);
+
+    VirtualMemoryTracker::commit_events();
 
     // Fetch the added RMR for the space
     ReservedMemoryRegion* rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion(addr, size));
@@ -434,6 +438,7 @@ public:
     NativeCallStack stack(&frame1, 1);
     NativeCallStack stack2(&frame2, 1);
 
+    VirtualMemoryTracker::commit_events();
     // Fetch the added RMR for the space
     ReservedMemoryRegion* rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion(addr, size));
 

--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -177,7 +177,7 @@ public:
     NativeCallStack stack2(&frame2, 1);
 
     // Add the reserved memory
-    VirtualMemoryTracker::add_reserved_region(addr, size, stack, mtTest);
+    VirtualMemoryTracker::add_reserved_region_impl(addr, size, stack, mtTest);
 
     // Fetch the added RMR for the space
     ReservedMemoryRegion* rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion(addr, size));


### PR DESCRIPTION
Hi,

The virtual memory tracker of NMT used to do a lot of heavy linked list calculations when memory was reserved, committed, uncommited or split up. However, the results of these calculations are actually only used when creating a native memory report. Let's not slow down the JVM unnecessarily, we can do this work at time of report instead.

In order to achieve this I've replaced the public API with a work queue:ing solution. We append each work item to a `GrowableArray` and introduce the `commit_events` method to do the actual work, which we call internally when needed.

I measured the gains in efficiency through the use of Valgrind's Cachegrind tool. I ran a `linux-x64` build with the following source code:

```java
public class Test {
    public static void main(String[] args) {
    }
}
```

These are the total cycles executed by `os::commit` and `os::reserve` as estimated by Valgrind over the entire run of the program. 

```
os::commit
old         | new         | new / old
935238      | 578979      | 0.62
os::reserve
old         | new         | new / old
53628       | 21825       | 0.41
```

There should also be some memory savings as a `MemoryEvent` is smaller (64 bytes) than a `ReservedRegion` (96 bytes). That is, until a `commit_events()` occur.