### PR TITLE
[PATCH] Remove unnecessary condition in Files.getAttribute

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1984,7 +1984,7 @@ public final class Files {
         if (pos == -1) {
             name = attribute;
         } else {
-            name = (pos == attribute.length()) ? "" : attribute.substring(pos+1);
+            name = attribute.substring(pos + 1);
         }
         return map.get(name);
     }


### PR DESCRIPTION
`int pos = attribute.indexOf(':');`
Value of `pos` variable is limited to `[-1 .. attribute.length()-1]`. So, comparing with `attribute.length()` is redundant - it's always false.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13094/head:pull/13094` \
`$ git checkout pull/13094`

Update a local copy of the PR: \
`$ git checkout pull/13094` \
`$ git pull https://git.openjdk.org/jdk.git pull/13094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13094`

View PR using the GUI difftool: \
`$ git pr show -t 13094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13094.diff">https://git.openjdk.org/jdk/pull/13094.diff</a>

</details>
