### PR TITLE
8297539: Consolidate the uses of the int<->float union conversion trick

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020 Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +27,7 @@
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.hpp"
 #include "compiler/disassembler.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "immediate_aarch64.hpp"
 #include "memory/resourceArea.hpp"
 
@@ -499,12 +500,9 @@ unsigned Assembler::pack(double value) {
 // Packed operands for  Floating-point Move (immediate)
 
 static float unpack(unsigned value) {
-  union {
-    unsigned ival;
-    float val;
-  };
+  unsigned ival;
   ival = fp_immediate_for_encoding(value, 0);
-  return val;
+  return PrimitiveConversions::cast<float>(ival);
 }
 
 address Assembler::locate_next_instruction(address inst) {

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 #include "precompiled.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "immediate_aarch64.hpp"
 
@@ -431,11 +432,7 @@ uint32_t encoding_for_fp_immediate(float immediate)
   // return the imm8 result [s:r:f]
   //
 
-  union {
-    float fpval;
-    uint32_t val;
-  };
-  fpval = immediate;
+  uint32_t val = PrimitiveConversions::cast<uint32_t>(immediate);
   uint32_t s, r, f, res;
   // sign bit is 31
   s = (val >> 31) & 0x1;

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -279,19 +279,16 @@ class VFP {
   class float_num : public fpnum {
    public:
     float_num(float v) {
-      _num.val = v;
+      _num_bits = PrimitiveConversions::cast<unsigned int>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num.bits << 9) >> (19+9); }
-    virtual bool f_lo_is_null() const { return (_num.bits & ((1 << 19) - 1)) == 0; }
-    virtual int e() const { return ((_num.bits << 1) >> (23+1)) - 127; }
-    virtual unsigned int s() const { return _num.bits >> 31; }
+    virtual unsigned int f_hi4() const { return (_num_bits << 9) >> (19+9); }
+    virtual bool f_lo_is_null() const { return (_num_bits & ((1 << 19) - 1)) == 0; }
+    virtual int e() const { return ((_num_bits << 1) >> (23+1)) - 127; }
+    virtual unsigned int s() const { return _num_bits >> 31; }
 
    private:
-    union {
-      float val;
-      unsigned int bits;
-    } _num;
+    unsigned int _num_bits;
   };
 
   class double_num : public fpnum {

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -673,15 +673,11 @@ void MacroAssembler::mov_metadata(Register rd, Metadata* o, int metadata_index) 
 
 void MacroAssembler::mov_float(FloatRegister fd, jfloat c, AsmCondition cond) {
   Label skip_constant;
-  union {
-    jfloat f;
-    jint i;
-  } accessor;
-  accessor.f = c;
+  jint accessor_i = PrimitiveConversions::cast<jint>(c);
 
   flds(fd, Address(PC), cond);
   b(skip_constant);
-  emit_int32(accessor.i);
+  emit_int32(accessor_i);
   bind(skip_constant);
 }
 

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -37,6 +37,7 @@
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "oops/accessDecorators.hpp"
 #include "oops/klass.inline.hpp"
 #include "prims/methodHandles.hpp"


### PR DESCRIPTION
All instances of using `union` for converting `int` <-> `float` are replaced with `PrimitiveConversions::cast<To>(From)`.
The instances that there are other fields than `int` and `float` are not changed nor the instances with other types.

### Test
mach5 tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297539](https://bugs.openjdk.org/browse/JDK-8297539): Consolidate the uses of the int&lt;-&gt;float union conversion trick


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/13097/head:pull/13097` \
`$ git checkout pull/13097`

Update a local copy of the PR: \
`$ git checkout pull/13097` \
`$ git pull https://git.openjdk.org/jdk pull/13097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13097`

View PR using the GUI difftool: \
`$ git pr show -t 13097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13097.diff">https://git.openjdk.org/jdk/pull/13097.diff</a>

</details>
