### PR TITLE
8304502: Classfile API class hierarchy makes assumptions when class is not resolved

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
@@ -165,11 +165,15 @@ public final class ClassHierarchyImpl {
     }
 
     public static final class StaticClassHierarchyResolver implements ClassHierarchyResolver {
+
+        private static final ClassHierarchyInfo CHI_Object =
+                new ClassHierarchyInfo(ConstantDescs.CD_Object, false, null);
+
         private final Map<ClassDesc, ClassHierarchyInfo> map;
 
         public StaticClassHierarchyResolver(Collection<ClassDesc> interfaceNames, Map<ClassDesc, ClassDesc> classToSuperClass) {
             map = HashMap.newHashMap(interfaceNames.size() + classToSuperClass.size() + 1);
-            map.put(ConstantDescs.CD_Object, new ClassHierarchyInfo(ConstantDescs.CD_Object, false, null));
+            map.put(ConstantDescs.CD_Object, CHI_Object);
             for (var e : classToSuperClass.entrySet())
                 map.put(e.getKey(), new ClassHierarchyInfo(e.getKey(), false, e.getValue()));
             for (var i : interfaceNames)

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
@@ -168,7 +168,7 @@ public final class ClassHierarchyImpl {
         private final Map<ClassDesc, ClassHierarchyInfo> map;
 
         public StaticClassHierarchyResolver(Collection<ClassDesc> interfaceNames, Map<ClassDesc, ClassDesc> classToSuperClass) {
-            map = new HashMap<>(interfaceNames.size() + classToSuperClass.size() + 1);
+            map = HashMap.newHashMap(interfaceNames.size() + classToSuperClass.size() + 1);
             map.put(ConstantDescs.CD_Object, new ClassHierarchyInfo(ConstantDescs.CD_Object, false, null));
             for (var e : classToSuperClass.entrySet())
                 map.put(e.getKey(), new ClassHierarchyInfo(e.getKey(), false, e.getValue()));

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
@@ -45,9 +45,6 @@ public final class ClassHierarchyImpl {
 
     private final ClassHierarchyResolver resolver;
 
-    //defer initialization of logging until needed
-    private static System.Logger logger;
-
     /**
      * Public constructor of <code>ClassHierarchyImpl</code> accepting instances of <code>ClassHierarchyInfoResolver</code> to resolve individual class streams.
      * @param classHierarchyResolver <code>ClassHierarchyInfoResolver</code> instance
@@ -59,12 +56,7 @@ public final class ClassHierarchyImpl {
     private ClassHierarchyResolver.ClassHierarchyInfo resolve(ClassDesc classDesc) {
         var res = resolver.getClassInfo(classDesc);
         if (res != null) return res;
-        //maybe throw an exception here to avoid construction of potentially invalid stack maps
-        if (logger == null)
-            logger = System.getLogger("jdk.internal.classfile");
-        if (logger.isLoggable(System.Logger.Level.DEBUG))
-            logger.log(System.Logger.Level.DEBUG, "Could not resolve class " + classDesc.displayName());
-        return new ClassHierarchyResolver.ClassHierarchyInfo(classDesc, false, null);
+        throw new IllegalArgumentException("Could not resolve class " + classDesc.displayName());
     }
 
     /**
@@ -176,7 +168,8 @@ public final class ClassHierarchyImpl {
         private final Map<ClassDesc, ClassHierarchyInfo> map;
 
         public StaticClassHierarchyResolver(Collection<ClassDesc> interfaceNames, Map<ClassDesc, ClassDesc> classToSuperClass) {
-            map = new HashMap<>(interfaceNames.size() + classToSuperClass.size());
+            map = new HashMap<>(interfaceNames.size() + classToSuperClass.size() + 1);
+            map.put(ConstantDescs.CD_Object, new ClassHierarchyInfo(ConstantDescs.CD_Object, false, null));
             for (var e : classToSuperClass.entrySet())
                 map.put(e.getKey(), new ClassHierarchyInfo(e.getKey(), false, e.getValue()));
             for (var i : interfaceNames)

--- a/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
+++ b/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
@@ -116,7 +116,7 @@ class AdvancedTransformationsTest {
             var clm = Classfile.parse(in.readAllBytes());
             var remapped = Classfile.parse(ClassRemapper.of(map).remapClass(clm));
             assertEmpty(remapped.verify(
-                    ClassHierarchyResolver.of(Set.of(), Map.of(
+                    ClassHierarchyResolver.of(Set.of(ClassDesc.of("remapped.List")), Map.of(
                             ClassDesc.of("remapped.RemappedBytecode"), ConstantDescs.CD_Object,
                             ClassDesc.ofDescriptor(RawBytecodeHelper.class.descriptorString()), ClassDesc.of("remapped.RemappedBytecode")))
                                           .orElse(ClassHierarchyResolver.DEFAULT_CLASS_HIERARCHY_RESOLVER)

--- a/test/jdk/jdk/classfile/ClassHierarchyInfoTest.java
+++ b/test/jdk/jdk/classfile/ClassHierarchyInfoTest.java
@@ -50,7 +50,7 @@ class ClassHierarchyInfoTest {
 
     @Test
     public void testProduceInvalidStackMaps() throws Exception {
-        assertThrows(VerifyError.class, () -> transformAndVerify(className -> null));
+        assertThrows(IllegalArgumentException.class, () -> transformAndVerify(className -> null));
     }
 
     @Test
@@ -60,6 +60,7 @@ class ClassHierarchyInfoTest {
                        ConstantDescs.CD_Collection),
                 Map.of(ClassDesc.of("java.util.HashMap$TreeNode"), ClassDesc.of("java.util.HashMap$Node"),
                         ClassDesc.of("java.util.HashMap$Node"), ConstantDescs.CD_Object,
+                        ClassDesc.of("java.util.HashMap$EntrySet"), ClassDesc.of("java.util.AbstractSet"),
                         ClassDesc.of("java.util.HashMap$Values"), ConstantDescs.CD_Object)));
     }
 

--- a/test/jdk/jdk/classfile/VerifierSelfTest.java
+++ b/test/jdk/jdk/classfile/VerifierSelfTest.java
@@ -35,6 +35,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import jdk.internal.classfile.ClassHierarchyResolver;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.CodeModel;
 import jdk.internal.classfile.MethodModel;
@@ -62,7 +63,8 @@ class VerifierSelfTest {
     @Test
     void testFailedDump() throws IOException {
         Path path = FileSystems.getFileSystem(URI.create("jrt:/")).getPath("modules/java.base/java/util/HashMap.class");
-        var classModel = Classfile.parse(path, Classfile.Option.classHierarchyResolver(className -> null));
+        var classModel = Classfile.parse(path, Classfile.Option.classHierarchyResolver(
+                className -> new ClassHierarchyResolver.ClassHierarchyInfo(className, false, null)));
         byte[] brokenClassBytes = classModel.transform(
                 (clb, cle) -> {
                     if (cle instanceof MethodModel mm) {


### PR DESCRIPTION
Classfile API class hierarchy makes assumptions when class is not resolved and that may lead to silent generation of invalid stack maps. Only debug-level log information of case is actually provided.

Proposed patch throws IllegalArgumentException when the class is not resolved instead.

Thanks for review.

Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304502](https://bugs.openjdk.org/browse/JDK-8304502): Classfile API class hierarchy makes assumptions when class is not resolved


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13099/head:pull/13099` \
`$ git checkout pull/13099`

Update a local copy of the PR: \
`$ git checkout pull/13099` \
`$ git pull https://git.openjdk.org/jdk.git pull/13099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13099`

View PR using the GUI difftool: \
`$ git pr show -t 13099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13099.diff">https://git.openjdk.org/jdk/pull/13099.diff</a>

</details>
