### PR TITLE
8304498: JShell does not switch to raw mode when there is no /bin/test

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
@@ -93,7 +93,8 @@ public class OSUtils {
             stty = IS_OSX ? "/bin/stty" : "stty";
             sttyfopt = IS_OSX ? "-f" : "-F";
             infocmp = "infocmp";
-            test = "/bin/test";
+            test = isTestCommandValid("/usr/bin/test") ? "/usr/bin/test"
+                                                       : "/bin/test";
         }
         TTY_COMMAND = tty;
         STTY_COMMAND = stty;
@@ -102,4 +103,13 @@ public class OSUtils {
         TEST_COMMAND = test;
     }
 
+    private static boolean isTestCommandValid(String command) {
+        try {
+            Process p = new ProcessBuilder(command, "-z", "").inheritIO().start();
+            return p.waitFor() == 0;
+        } catch (Throwable unused) {
+            //ignore
+        }
+        return false;
+    }
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
@@ -9,6 +9,8 @@
 package jdk.internal.org.jline.utils;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class OSUtils {
 
@@ -104,12 +106,6 @@ public class OSUtils {
     }
 
     private static boolean isTestCommandValid(String command) {
-        try {
-            Process p = new ProcessBuilder(command, "-z", "").inheritIO().start();
-            return p.waitFor() == 0;
-        } catch (Throwable unused) {
-            //ignore
-        }
-        return false;
+        return Files.isExecutable(Paths.get(command));
     }
 }

--- a/test/jdk/jdk/internal/jline/OSUtilsTest.java
+++ b/test/jdk/jdk/internal/jline/OSUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8304498
+ * @summary Verify the OSUtils class is initialized properly
+ * @modules jdk.internal.le/jdk.internal.org.jline.utils
+ */
+
+import jdk.internal.org.jline.utils.OSUtils;
+
+public class OSUtilsTest {
+    public static void main(String... args) throws Exception {
+        new OSUtilsTest().run();
+    }
+
+    void run() throws Exception {
+        runTestTest();
+    }
+
+    void runTestTest() throws Exception {
+        if (OSUtils.IS_WINDOWS) {
+            return ; //skip on Windows
+        }
+
+        Process p = new ProcessBuilder(OSUtils.TEST_COMMAND, "-z", "").inheritIO().start();
+        if (p.waitFor() != 0) {
+            throw new AssertionError("Unexpected result!");
+        }
+    }
+}


### PR DESCRIPTION
If JShell is run on a system that does not have `/bin/test` (which is, apparently, possible for some systems, which only have `/usr/bin/test`), it won't switch the terminal into the raw mode, and the input will not work properly.

The proposed fix herein is to detect whether `test` existing in `/usr/bin/test`, and if yes, use that location. Use the existing `/bin/test` otherwise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304498](https://bugs.openjdk.org/browse/JDK-8304498): JShell does not switch to raw mode when there is no /bin/test


### Reviewers
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13100/head:pull/13100` \
`$ git checkout pull/13100`

Update a local copy of the PR: \
`$ git checkout pull/13100` \
`$ git pull https://git.openjdk.org/jdk.git pull/13100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13100`

View PR using the GUI difftool: \
`$ git pr show -t 13100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13100.diff">https://git.openjdk.org/jdk/pull/13100.diff</a>

</details>
