### PR TITLE
8304503: Modernize debugging jvm args in demo netbeans projects

### DIFF
--- a/src/demo/share/nbproject/jfc/FileChooserDemo/build.properties
+++ b/src/demo/share/nbproject/jfc/FileChooserDemo/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/FileChooserDemo
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/FileChooserDemo/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/FileChooserDemo/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     

--- a/src/demo/share/nbproject/jfc/Font2DTest/build.properties
+++ b/src/demo/share/nbproject/jfc/Font2DTest/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/Font2DTest
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/Font2DTest/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/Font2DTest/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     

--- a/src/demo/share/nbproject/jfc/Metalworks/build.properties
+++ b/src/demo/share/nbproject/jfc/Metalworks/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/Metalworks
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/Metalworks/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/Metalworks/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     

--- a/src/demo/share/nbproject/jfc/Notepad/build.properties
+++ b/src/demo/share/nbproject/jfc/Notepad/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/Notepad
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/Notepad/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/Notepad/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     

--- a/src/demo/share/nbproject/jfc/SampleTree/build.properties
+++ b/src/demo/share/nbproject/jfc/SampleTree/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/SampleTree
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/SampleTree/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/SampleTree/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     

--- a/src/demo/share/nbproject/jfc/TableExample/build.properties
+++ b/src/demo/share/nbproject/jfc/TableExample/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/TableExample
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/TableExample/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/TableExample/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     

--- a/src/demo/share/nbproject/jfc/TransparentRuler/build.properties
+++ b/src/demo/share/nbproject/jfc/TransparentRuler/build.properties
@@ -1,6 +1,6 @@
 main.dir=${basedir}/../../../jfc/TransparentRuler
 
-src.dir=${main.dir}/src
+src.dir=${main.dir}/
 
 build.dir=build
 classes.dir=${build.dir}/classes

--- a/src/demo/share/nbproject/jfc/TransparentRuler/nbproject/netbeans-targets.xml
+++ b/src/demo/share/nbproject/jfc/TransparentRuler/nbproject/netbeans-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -41,10 +41,7 @@
         </nbjpdastart>
         <java classname="${main.class}" failonerror="true" fork="true">
             <classpath path="${run.cp}"/>
-            <jvmarg value="-Xdebug"/>
-            <jvmarg value="-Xnoagent"/>
-            <jvmarg value="-Djava.compiler=none"/>
-            <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
+            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
         </java>
     </target>
     


### PR DESCRIPTION
Please review this PR which suggests to modernize the JVM arguments used to enable debugging in the netbeans project files for demos. 

The netbeans projects found in src/demo/share/nbproject currently use the following outdated combination of jvm arguments to set up debugging:

```xml
<jvmarg value="-Xdebug"/>
<jvmarg value="-Xnoagent"/>
<jvmarg value="-Djava.compiler=none"/>
<jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"/>
```

They should instead just do:

```xml
<jvmarg value="-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=${jpda.address}"/>
```

Additionally, the source dir set up in build.properties for these projects do not seem to align with the source layout.

`src.dir=${main.dir}/src` should instead be just `src.dir=${main.dir}/`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304503](https://bugs.openjdk.org/browse/JDK-8304503): Modernize debugging jvm args in demo netbeans projects (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13101/head:pull/13101` \
`$ git checkout pull/13101`

Update a local copy of the PR: \
`$ git checkout pull/13101` \
`$ git pull https://git.openjdk.org/jdk.git pull/13101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13101`

View PR using the GUI difftool: \
`$ git pr show -t 13101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13101.diff">https://git.openjdk.org/jdk/pull/13101.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13101#issuecomment-1476222745)