### PR TITLE
JDK-8304537: Ant-based langtools build fails after JDK-8015831 Add lint check for calling overridable methods from a constructor

### DIFF
--- a/make/langtools/build.properties
+++ b/make/langtools/build.properties
@@ -24,7 +24,7 @@
 #
 
 #javac configuration for "normal build" (these will be passed to the bootstrap compiler):
-javac.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-exports,-this-escape -Werror -g:source,lines,vars
+javac.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-exports -Werror -g:source,lines,vars
 
 #version used to compile build tools
 javac.build.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-options -Werror -g:source,lines,vars

--- a/make/langtools/build.properties
+++ b/make/langtools/build.properties
@@ -24,7 +24,7 @@
 #
 
 #javac configuration for "normal build" (these will be passed to the bootstrap compiler):
-javac.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-exports -Werror -g:source,lines,vars
+javac.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-exports,-this-escape -Werror -g:source,lines,vars
 
 #version used to compile build tools
 javac.build.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-options -Werror -g:source,lines,vars

--- a/make/modules/jdk.compiler/Java.gmk
+++ b/make/modules/jdk.compiler/Java.gmk
@@ -23,8 +23,6 @@
 # questions.
 #
 
-DISABLED_WARNINGS_java += this-escape
-
 DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:-com.sun.tools.*,-jdk.internal.*,sun.tools.serialver.resources.*'
 JAVAC_FLAGS += -XDstringConcat=inline

--- a/make/modules/jdk.jdeps/Java.gmk
+++ b/make/modules/jdk.jdeps/Java.gmk
@@ -25,8 +25,6 @@
 
 COPY += .txt
 
-DISABLED_WARNINGS_java += this-escape
-
 CLEAN_FILES += $(wildcard \
     $(TOPDIR)/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/*.properties \
     $(TOPDIR)/src/jdk.jdeps/share/classes/com/sun/tools/javap/resources/*.properties)

--- a/make/modules/jdk.jshell/Java.gmk
+++ b/make/modules/jdk.jshell/Java.gmk
@@ -23,6 +23,4 @@
 # questions.
 #
 
-DISABLED_WARNINGS_java += this-escape
-
 COPY += .jsh .properties

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Dependencies.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Dependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@ public class Dependencies {
     /**
      * Thrown when a class file cannot be found.
      */
+    @SuppressWarnings("this-escape")
     public static class ClassFileNotFoundException extends Exception {
         private static final long serialVersionUID = 3632265927794475048L;
 
@@ -86,6 +87,7 @@ public class Dependencies {
     /**
      * Thrown when an exception is found processing a class file.
      */
+    @SuppressWarnings("this-escape")
     public static class ClassFileError extends Error {
         private static final long serialVersionUID = 4111110813961313203L;
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiInitiator.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiInitiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ public class JdiInitiator {
      * @param customConnectorArgs custom arguments passed to the connector.
      * These are JDI com.sun.jdi.connect.Connector arguments.
      */
+    @SuppressWarnings("this-escape")
     public JdiInitiator(int port, List<String> remoteVMOptions, String remoteAgent,
             boolean isLaunch, String host, int timeout,
             Map<String, String> customConnectorArgs) {

--- a/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,6 +428,7 @@ public interface ExecutionControl extends AutoCloseable {
 
         private final String causeExceptionClass;
 
+        @SuppressWarnings("this-escape")
         public UserException(String message, String causeExceptionClass, StackTraceElement[] stackElements) {
             super(message);
             this.causeExceptionClass = causeExceptionClass;
@@ -467,6 +468,7 @@ public interface ExecutionControl extends AutoCloseable {
          * @param id An internal identifier of the specific method
          * @param stackElements the stack trace
          */
+        @SuppressWarnings("this-escape")
         public ResolutionException(int id, StackTraceElement[] stackElements) {
             super("resolution exception: " + id);
             this.id = id;


### PR DESCRIPTION
`this-escape` lint is disabled for jdk.compiler, so it should be disabled for the ant-based langtools-only build as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304537](https://bugs.openjdk.org/browse/JDK-8304537): Ant-based langtools build fails after JDK-8015831 Add lint check for calling overridable methods from a constructor


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13102/head:pull/13102` \
`$ git checkout pull/13102`

Update a local copy of the PR: \
`$ git checkout pull/13102` \
`$ git pull https://git.openjdk.org/jdk.git pull/13102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13102`

View PR using the GUI difftool: \
`$ git pr show -t 13102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13102.diff">https://git.openjdk.org/jdk/pull/13102.diff</a>

</details>
