### PR TITLE
8304541: Modules THROW_MSG_ should return nullptr instead of JNI_FALSE

### DIFF
--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -761,7 +761,7 @@ jobject Modules::get_module(jclass clazz, TRAPS) {
 
   if (clazz == nullptr) {
     THROW_MSG_(vmSymbols::java_lang_NullPointerException(),
-               "class is null", JNI_FALSE);
+               "class is null", nullptr);
   }
   oop mirror = JNIHandles::resolve_non_null(clazz);
   if (mirror == nullptr) {
@@ -770,7 +770,7 @@ jobject Modules::get_module(jclass clazz, TRAPS) {
   }
   if (!java_lang_Class::is_instance(mirror)) {
     THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-               "Invalid class", JNI_FALSE);
+               "Invalid class", nullptr);
   }
 
   oop module = java_lang_Class::module(mirror);


### PR DESCRIPTION
Cleanup in NPE code to return a proper nullptr instead of JNI_FALSE. JNI_FALSE expands to 0, which technically works as a null pointer here, but this becomes pretty confusing and strange when reading through the code