### PR TITLE
8304543: Modernize debugging jvm args in test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004.java

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004.java
@@ -122,8 +122,7 @@ public class value004 {
                 }
                 flg = true;
                 ovl = argHandler.getLaunchExecPath() + " "
-                     + "-Xdebug -Xnoagent -Djava.compiler=NONE "
-                     + "-Xrunjdwp:transport=" + c.transport().name() + ",suspend=y,"
+                     +"-agentlib:jdwp=transport=" + c.transport().name() +",server=n,suspend=y,"
                      + "address=" + address + " nsk.jdi.Argument.value.value004a";
                 if (argval.isValid(ovl)) {
                     argval.setValue(ovl);


### PR DESCRIPTION
Please review this PR which replaces the use of outdated JVM flags for setting up debugging in the test value004.java

This is part of an ongoing effort to remove use of the outdated flag '-Djava.compiler" such that the option itself can eventually be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304543](https://bugs.openjdk.org/browse/JDK-8304543): Modernize debugging jvm args in test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13107/head:pull/13107` \
`$ git checkout pull/13107`

Update a local copy of the PR: \
`$ git checkout pull/13107` \
`$ git pull https://git.openjdk.org/jdk.git pull/13107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13107`

View PR using the GUI difftool: \
`$ git pr show -t 13107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13107.diff">https://git.openjdk.org/jdk/pull/13107.diff</a>

</details>
