### PR TITLE
JDK-8304546: CompileTask::_directive leaked if CompileBroker::invoke_compiler_on_method not called

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2274,6 +2274,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       }
     }
 
+    task->clear_directive();
     DirectivesStack::release(directive);
 
     if (!ci_env.failing() && !task->is_success()) {

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -66,6 +66,10 @@ void CompileTask::free(CompileTask* task) {
   MutexLocker locker(CompileTaskAlloc_lock);
   if (!task->is_free()) {
     assert(!task->lock()->is_locked(), "Should not be locked when freed");
+    if (task->_directive != nullptr) {
+      DirectivesStack::release(task->_directive);
+      task->clear_directive();
+    }
     if ((task->_method_holder != nullptr && JNIHandles::is_weak_global_handle(task->_method_holder)) ||
         (task->_hot_method_holder != nullptr && JNIHandles::is_weak_global_handle(task->_hot_method_holder))) {
       JNIHandles::destroy_weak_global(task->_method_holder);

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -128,6 +128,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
   bool         is_blocking() const               { return _is_blocking; }
   bool         is_success() const                { return _is_success; }
   DirectiveSet* directive() const                { return _directive; }
+  void          clear_directive()                { _directive = nullptr; }
   CodeSection::csize_t nm_content_size() { return _nm_content_size; }
   void         set_nm_content_size(CodeSection::csize_t size) { _nm_content_size = size; }
   CodeSection::csize_t nm_insts_size() { return _nm_insts_size; }


### PR DESCRIPTION
Ensure `CompileTask::_directive` is not leaked when `CompileBroker::invoke_compiler_on_method` is not called. This can happen for stale tasks or when compilation is disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304546](https://bugs.openjdk.org/browse/JDK-8304546): CompileTask::_directive leaked if CompileBroker::invoke_compiler_on_method not called


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13108/head:pull/13108` \
`$ git checkout pull/13108`

Update a local copy of the PR: \
`$ git checkout pull/13108` \
`$ git pull https://git.openjdk.org/jdk.git pull/13108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13108`

View PR using the GUI difftool: \
`$ git pr show -t 13108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13108.diff">https://git.openjdk.org/jdk/pull/13108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13108#issuecomment-1476923358)