### PR TITLE
8304547: Remove checking of -Djava.compiler in src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,12 +170,6 @@ public class SunCommandLineLauncher extends AbstractLauncher {
         if (quote.length() > 1) {
             throw new IllegalConnectorArgumentsException("Invalid length",
                                                          ARG_QUOTE);
-        }
-
-        if ((options.indexOf("-Djava.compiler=") != -1) &&
-            (options.toLowerCase().indexOf("-djava.compiler=none") == -1)) {
-            throw new IllegalConnectorArgumentsException("Cannot debug with a JIT compiler",
-                                                         ARG_OPTIONS);
         }
 
         /*


### PR DESCRIPTION
Please review this PR which removes the following outdated guard/check from SunCommandLineLauncher:

```
if ((options.indexOf("-Djava.compiler=") != -1) &&
    (options.toLowerCase().indexOf("-djava.compiler=none") == -1)) {
    throw new IllegalConnectorArgumentsException("Cannot debug with a JIT compiler",
                                                 ARG_OPTIONS);
}

```

Efforts are underway to remove the `java.compiler` system property entirely, besides that this test no longer makes sense since debugging with a JIT has been supported for a while.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304547](https://bugs.openjdk.org/browse/JDK-8304547): Remove checking of -Djava.compiler in src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13109/head:pull/13109` \
`$ git checkout pull/13109`

Update a local copy of the PR: \
`$ git checkout pull/13109` \
`$ git pull https://git.openjdk.org/jdk.git pull/13109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13109`

View PR using the GUI difftool: \
`$ git pr show -t 13109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13109.diff">https://git.openjdk.org/jdk/pull/13109.diff</a>

</details>
