### PR TITLE
6245410: javax.swing.text.html.CSS.Attribute: BACKGROUND_POSITION is not w3c spec compliant

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -210,7 +210,7 @@ public class CSS implements Serializable {
          * CSS attribute "background-position".
          */
         public static final Attribute BACKGROUND_POSITION =
-            new Attribute("background-position", null, false);
+            new Attribute("background-position", "0% 0%", false);
 
         /**
          * CSS attribute "background-repeat".

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeComplianceTest.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeComplianceTest.java
@@ -29,7 +29,7 @@
 
 import javax.swing.text.html.CSS.Attribute;
 
-public class CSSAttributeComplianceTest{
+public class CSSAttributeComplianceTest {
 
     public static void main(String[] argv) {
         String val = Attribute.BACKGROUND_POSITION.getDefaultValue();

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeComplianceTest.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeComplianceTest.java
@@ -30,9 +30,9 @@
 import javax.swing.text.html.CSS.Attribute;
 
 public class CSSAttributeComplianceTest{
- 
+
     public static void main(String[] argv) {
-        String val = Attribute.BACKGROUND_POSITION.getDefaultValue();	    
+        String val = Attribute.BACKGROUND_POSITION.getDefaultValue();
         if (!"0% 0%".equals(val)) {
             System.out.println("Attribute.BACKGROUND_POSITION value : " + val);
             throw new RuntimeException("Expected from w3c.background-position: " +

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeComplianceTest.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeComplianceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6245410
+ * @summary  Verifies CSS.Attribute: BACKGROUND_POSITION is w3c spec compliant
+ * @run main CSSAttributeComplianceTest
+ */
+
+import javax.swing.text.html.CSS.Attribute;
+
+public class CSSAttributeComplianceTest{
+ 
+    public static void main(String[] argv) {
+        String val = Attribute.BACKGROUND_POSITION.getDefaultValue();	    
+        if (!"0% 0%".equals(val)) {
+            System.out.println("Attribute.BACKGROUND_POSITION value : " + val);
+            throw new RuntimeException("Expected from w3c.background-position: " +
+                                       " Initial: 0% 0%");
+        }
+    }
+}


### PR DESCRIPTION
[CSS spec for background-position](https://www.w3.org/TR/CSS22/colors.html#propdef-background-position)
mention the initial value should be "0% 0%" but JDK has the value as "null".
Rectified the spec violation. 
No regression is seen in client tests..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6245410](https://bugs.openjdk.org/browse/JDK-6245410): javax.swing.text.html.CSS.Attribute: BACKGROUND_POSITION is not w3c spec compliant


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [38c0f1a4](https://git.openjdk.org/jdk/pull/13114/files/38c0f1a470c9e78fe75d8af56ed1f48ad1f39ab9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13114/head:pull/13114` \
`$ git checkout pull/13114`

Update a local copy of the PR: \
`$ git checkout pull/13114` \
`$ git pull https://git.openjdk.org/jdk.git pull/13114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13114`

View PR using the GUI difftool: \
`$ git pr show -t 13114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13114.diff">https://git.openjdk.org/jdk/pull/13114.diff</a>

</details>
