### PR TITLE
8304591: UnixPath.stringValue shouldn't be volatile

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ import java.util.Objects;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 
-import static sun.nio.fs.UnixConstants.*;
-import static sun.nio.fs.UnixNativeDispatcher.*;
+import static sun.nio.fs.UnixNativeDispatcher.open;
+import static sun.nio.fs.UnixNativeDispatcher.realpath;
 
 /**
  * Linux/Mac implementation of java.nio.file.Path
@@ -57,8 +57,8 @@ class UnixPath implements Path {
     // internal representation
     private final byte[] path;
 
-    // String representation (created lazily)
-    private volatile String stringValue;
+    // String representation (created lazily, no need to be volatile)
+    private String stringValue;
 
     // cached hashcode (created lazily, no need to be volatile)
     private int hash;
@@ -761,8 +761,9 @@ class UnixPath implements Path {
     @Override
     public String toString() {
         // OK if two or more threads create a String
+        String stringValue = this.stringValue;
         if (stringValue == null) {
-            stringValue = fs.normalizeJavaPath(Util.toString(path));     // platform encoding
+            this.stringValue = stringValue = fs.normalizeJavaPath(Util.toString(path));     // platform encoding
         }
         return stringValue;
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -42,6 +42,8 @@ import java.util.Objects;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 
+import static sun.nio.fs.UnixConstants.O_NOFOLLOW;
+import static sun.nio.fs.UnixConstants.O_RDONLY;
 import static sun.nio.fs.UnixNativeDispatcher.open;
 import static sun.nio.fs.UnixNativeDispatcher.realpath;
 


### PR DESCRIPTION
`UnixPath.stringValue` can be computed by multiple threads safely as the actual value is the same, so the race is benign in this case.