### PR TITLE
JDK-8304557: java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java times out

### DIFF
--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8303742
  * @summary CompletableFuture.orTimeout can leak memory if completed exceptionally
- * @run junit/othervm -Xmx128m --add-opens java.base/java.util.concurrent=ALL-UNNAMED CompletableFutureOrTimeoutExceptionallyTest
+ * @modules java.base/java.util.concurrent:open
+ * @run junit/othervm -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
  */
 
 import java.time.Duration;
@@ -41,11 +42,13 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     static final BlockingQueue<Runnable> delayerQueue;
     static {
         try {
-            var delayerClass = Class.forName("java.util.concurrent.CompletableFuture$Delayer", true, CompletableFuture.class.getClassLoader());
+            var delayerClass = Class.forName("java.util.concurrent.CompletableFuture$Delayer",
+                                             true,
+                                             CompletableFuture.class.getClassLoader());
             var delayerField = delayerClass.getDeclaredField("delayer");
             delayerField.setAccessible(true);
             delayerQueue = ((ScheduledThreadPoolExecutor)delayerField.get(null)).getQueue();
-        } catch(Throwable t) {
+        } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }
     }
@@ -59,7 +62,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
         var future = new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS);
         assertTrue(delayerQueue.peek() != null);
         future.completeExceptionally(new RuntimeException("This is fine"));
-        while(delayerQueue.peek() != null) {
+        while (delayerQueue.peek() != null) {
             Thread.sleep(100);
         };
     }
@@ -73,7 +76,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
         var future = new CompletableFuture<>().completeOnTimeout(null, 12, TimeUnit.HOURS);
         assertTrue(delayerQueue.peek() != null);
         future.completeExceptionally(new RuntimeException("This is fine"));
-        while(delayerQueue.peek() != null) {
+        while (delayerQueue.peek() != null) {
             Thread.sleep(100);
         };
     }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -25,39 +25,56 @@
  * @test
  * @bug 8303742
  * @summary CompletableFuture.orTimeout can leak memory if completed exceptionally
- * @run junit/othervm/timeout=1000 -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
+ * @run junit/othervm -Xmx128m --add-opens java.base/java.util.concurrent=ALL-UNNAMED CompletableFutureOrTimeoutExceptionallyTest
  */
 
 import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CompletableFutureOrTimeoutExceptionallyTest {
+    static final BlockingQueue<Runnable> delayerQueue;
+    static {
+        try {
+            var delayerClass = Class.forName("java.util.concurrent.CompletableFuture$Delayer", true, CompletableFuture.class.getClassLoader());
+            var delayerField = delayerClass.getDeclaredField("delayer");
+            delayerField.setAccessible(true);
+            delayerQueue = ((ScheduledThreadPoolExecutor)delayerField.get(null)).getQueue();
+        } catch(Throwable t) {
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+
     /**
      * Test that orTimeout task is cancelled if the CompletableFuture is completed Exceptionally
      */
     @Test
-    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
-        var count = 0L;
-        while (count++ < 1_000_000) {
-            new CompletableFuture<>()
-            .orTimeout(12, TimeUnit.HOURS)
-            .completeExceptionally(new RuntimeException("This is fine"));
-        }
+    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() throws InterruptedException {
+        assertTrue(delayerQueue.peek() == null);
+        var future = new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS);
+        assertTrue(delayerQueue.peek() != null);
+        future.completeExceptionally(new RuntimeException("This is fine"));
+        while(delayerQueue.peek() != null) {
+            Thread.sleep(100);
+        };
     }
 
     /**
      * Test that the completeOnTimeout task is cancelled if the CompletableFuture is completed Exceptionally
      */
     @Test
-    void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
-        var count = 0L;
-        while (count++ < 1_000_000) {
-            new CompletableFuture<>()
-            .completeOnTimeout(null, 12, TimeUnit.HOURS)
-            .completeExceptionally(new RuntimeException("This is fine"));
-        }
+    void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() throws InterruptedException {
+        assertTrue(delayerQueue.peek() == null);
+        var future = new CompletableFuture<>().completeOnTimeout(null, 12, TimeUnit.HOURS);
+        assertTrue(delayerQueue.peek() != null);
+        future.completeExceptionally(new RuntimeException("This is fine"));
+        while(delayerQueue.peek() != null) {
+            Thread.sleep(100);
+        };
     }
 }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8303742
  * @summary CompletableFuture.orTimeout can leak memory if completed exceptionally
- * @run junit/othervm -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
+ * @run junit/othervm/timeout=1000 -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
  */
 
 import java.time.Duration;
@@ -41,7 +41,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     @Test
     void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
         var count = 0L;
-        while (count++ < 2_000_000) {
+        while (count++ < 1_000_000) {
             new CompletableFuture<>()
             .orTimeout(12, TimeUnit.HOURS)
             .completeExceptionally(new RuntimeException("This is fine"));
@@ -54,7 +54,7 @@ class CompletableFutureOrTimeoutExceptionallyTest {
     @Test
     void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
         var count = 0L;
-        while (count++ < 2_000_000) {
+        while (count++ < 1_000_000) {
             new CompletableFuture<>()
             .completeOnTimeout(null, 12, TimeUnit.HOURS)
             .completeExceptionally(new RuntimeException("This is fine"));


### PR DESCRIPTION
Improves the stability of the memory leak test for CompletableFuture timeout cancellation by both reducing the count by 50% (which should still be above threshold to trigger given the ample margin set initially) as well as extending the default timeout of the test run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304557](https://bugs.openjdk.org/browse/JDK-8304557): java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java times out


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13116/head:pull/13116` \
`$ git checkout pull/13116`

Update a local copy of the PR: \
`$ git checkout pull/13116` \
`$ git pull https://git.openjdk.org/jdk.git pull/13116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13116`

View PR using the GUI difftool: \
`$ git pr show -t 13116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13116.diff">https://git.openjdk.org/jdk/pull/13116.diff</a>

</details>
