### PR TITLE
8304657: G1: Rename set_state_empty to set_state_untracked

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -47,10 +47,10 @@ void G1RemSetTrackingPolicy::update_at_allocate(HeapRegion* r) {
     r->rem_set()->set_state_complete();
   } else if (r->is_archive()) {
     // Archive regions never move ever. So never build remembered sets for them.
-    r->rem_set()->set_state_empty();
+    r->rem_set()->set_state_untracked();
   } else if (r->is_old()) {
     // By default, do not create remembered set for new old regions.
-    r->rem_set()->set_state_empty();
+    r->rem_set()->set_state_untracked();
   } else {
     guarantee(false, "Unhandled region %u with heap region type %s", r->hrm_index(), r->get_type_str());
   }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -79,7 +79,7 @@ void HeapRegionRemSet::clear_locked(bool only_cardset) {
   }
   clear_fcc();
   _card_set.clear();
-  set_state_empty();
+  set_state_untracked();
   assert(occupied() == 0, "Should be clear.");
 }
 

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -109,7 +109,7 @@ public:
   bool is_updating() { return _state == Updating; }
   bool is_complete() { return _state == Complete; }
 
-  inline void set_state_empty();
+  inline void set_state_untracked();
   inline void set_state_updating();
   inline void set_state_complete();
 

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
@@ -33,7 +33,7 @@
 #include "runtime/atomic.hpp"
 #include "utilities/bitMap.inline.hpp"
 
-void HeapRegionRemSet::set_state_empty() {
+void HeapRegionRemSet::set_state_untracked() {
   guarantee(SafepointSynchronize::is_at_safepoint() || !is_tracked(),
             "Should only set to Untracked during safepoint but is %s.", get_state_str());
   if (_state == Untracked) {


### PR DESCRIPTION
Trivial renaming.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304657](https://bugs.openjdk.org/browse/JDK-8304657): G1: Rename set_state_empty to set_state_untracked


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13118/head:pull/13118` \
`$ git checkout pull/13118`

Update a local copy of the PR: \
`$ git checkout pull/13118` \
`$ git pull https://git.openjdk.org/jdk.git pull/13118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13118`

View PR using the GUI difftool: \
`$ git pr show -t 13118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13118.diff">https://git.openjdk.org/jdk/pull/13118.diff</a>

</details>
