### PR TITLE
JDK-8303123: Add line break opportunity to single type parameters

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -202,8 +202,9 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
             if (list != null && !list.isEmpty()) {
                 Content typeParameters = ((AbstractExecutableMemberWriter) this)
                         .getTypeParameters((ExecutableElement)member);
-                    code.add(typeParameters);
-                //Code to avoid ugly wrapping in member summary table.
+                code.add(typeParameters);
+                // Add explicit line break between method type parameters and
+                // return type in member summary table to avoid random wrapping.
                 if (typeParameters.charCount() > 10) {
                     code.add(new HtmlTree(TagName.BR));
                 } else {
@@ -212,7 +213,8 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
             }
             code.add(
                     writer.getLink(new HtmlLinkInfo(configuration,
-                            HtmlLinkInfo.Kind.LINK_TYPE_PARAMS, type)));
+                            HtmlLinkInfo.Kind.LINK_TYPE_PARAMS, type)
+                            .addLineBreakOpportunitiesInTypeParameters(true)));
         }
         target.add(code);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -327,6 +327,9 @@ public class HtmlLinkFactory {
             return links;
         }
         if (!vars.isEmpty()) {
+            if (linkInfo.addLineBreakOpportunitiesInTypeParameters()) {
+                links.add(new HtmlTree(TagName.WBR));
+            }
             links.add("<");
             boolean many = false;
             for (TypeMirror t : vars) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkInfo.java
@@ -122,8 +122,11 @@ public class HtmlLinkInfo {
     // True iff the preview flags should be skipped for this link.
     private boolean skipPreview;
 
-    // True if type parameters should be separated by line breaks.
+    // True if type parameters should be separated by hard line breaks.
     private boolean addLineBreaksInTypeParameters = false;
+
+    // True if additional <wbr> tags should be added to type parameters
+    private boolean addLineBreakOpportunitiesInTypeParameters = false;
 
     // True if annotations on type parameters should be shown.
     private boolean showTypeParameterAnnotations = false;
@@ -309,6 +312,23 @@ public class HtmlLinkInfo {
      */
     public boolean addLineBreaksInTypeParameters() {
         return addLineBreaksInTypeParameters;
+    }
+
+    /**
+     * Sets the addLineBreakOpportunitiesInTypeParameters flag for this link.
+     * @param addLineBreakOpportunities the new value
+     * @return this object
+     */
+    public HtmlLinkInfo addLineBreakOpportunitiesInTypeParameters(boolean addLineBreakOpportunities) {
+        this.addLineBreakOpportunitiesInTypeParameters = addLineBreakOpportunities;
+        return this;
+    }
+
+    /**
+     * {@return true if line break opportunities should be added to type parameters}
+     */
+    public boolean addLineBreakOpportunitiesInTypeParameters() {
+        return addLineBreakOpportunitiesInTypeParameters;
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -369,16 +369,16 @@ public class TestJavaFX extends JavadocTester {
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code>final java.util.List&lt;java.util.Set&lt;? \
-                    super java.lang.Object&gt;&gt;</code></div>
+                    ab2 method-summary-table-tab4"><code>final java.util.List<wbr>&lt;java.util.Set&\
+                    lt;? super java.lang.Object&gt;&gt;</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#deltaProperty()" class="member-n\
                     ame-link">deltaProperty</a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
-                    b2 method-summary-table-tab4"><code>final java.util.List&lt;java.lang.String&gt;\
-                    </code></div>
+                    b2 method-summary-table-tab4"><code>final java.util.List<wbr>&lt;java.lang.Strin\
+                    g&gt;</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code><a href="#gammaProperty()" class="member-na\
                     me-link">gammaProperty</a>()</code></div>

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -272,7 +272,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     ></span></div>""",
                 """
                     <div class="col-first even-row-color"><code><a href="../ParamTest.html" title="class\
-                     in pkg2">ParamTest</a>&lt;<a href="../Foo.html" title="class in pkg2">Foo</a>&g\
+                     in pkg2">ParamTest</a><wbr>&lt;<a href="../Foo.html" title="class in pkg2">Foo</a>&g\
                     t;</code></div>"""
         );
 
@@ -283,7 +283,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     pan></div>""",
                 """
                     <div class="col-first even-row-color"><code><a href="../ParamTest.html" title="class\
-                     in pkg2">ParamTest</a>&lt;<a href="../Foo.html" title="class in pkg2">Foo</a>&\
+                     in pkg2">ParamTest</a><wbr>&lt;<a href="../Foo.html" title="class in pkg2">Foo</a>&\
                     gt;</code></div>"""
         );
 
@@ -331,9 +331,9 @@ public class TestNewLanguageFeatures extends JavadocTester {
                      declared as <a href="../ParamTest.html" title="class in pkg2">ParamTest</a></s\
                     pan></div>""",
                 """
-                    <div class="col-first even-row-color"><code><a href="../ParamTest.html" title="class\
-                     in pkg2">ParamTest</a>&lt;<a href="../Foo.html" title="class in pkg2">Foo</a>&\
-                    gt;</code></div>""",
+                    <div class="col-first even-row-color"><code><a href="../ParamTest.html" title="\
+                    class in pkg2">ParamTest</a><wbr>&lt;<a href="../Foo.html" title="class in pkg2\
+                    ">Foo</a>&gt;</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > with type parameters of type <a href="../ParamTest.html" title="class in pkg2\
@@ -342,8 +342,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="col-first even-row-color"><code>&lt;T extends <a href="../ParamTest.html\
                     " title="class in pkg2">ParamTest</a>&lt;<a href="../Foo3.html" title="class in\
                      pkg2">Foo3</a>&gt;&gt;<br><a href="../ParamTest.html" title="class in pkg2">Pa\
-                    ramTest</a>&lt;<a href="../Foo3.html" title="class in pkg2">Foo3</a>&gt;</code>\
-                    </div>"""
+                    ramTest</a><wbr>&lt;<a href="../Foo3.html" title="class in pkg2">Foo3</a>&gt;</\
+                    code></div>"""
         );
 
         checkOutput("pkg2/class-use/Foo3.html", true,
@@ -372,8 +372,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="col-first even-row-color"><code>&lt;T extends <a href="../ParamTest.html\
                     " title="class in pkg2">ParamTest</a>&lt;<a href="../Foo3.html" title="class in\
                      pkg2">Foo3</a>&gt;&gt;<br><a href="../ParamTest.html" title="class in pkg2">Pa\
-                    ramTest</a>&lt;<a href="../Foo3.html" title="class in pkg2">Foo3</a>&gt;</code>\
-                    </div>"""
+                    ramTest</a><wbr>&lt;<a href="../Foo3.html" title="class in pkg2">Foo3</a>&gt;</\
+                    code></div>"""
         );
 
         // ClassUseTest3: <T extends ParamTest2<List<? extends Foo4>>>
@@ -400,8 +400,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="col-first even-row-color"><code>&lt;T extends <a href="../ParamTest2.htm\
                     l" title="class in pkg2">ParamTest2</a>&lt;java.util.List&lt;? extends <a href=\
                     "../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;&gt;<br><a href="../ParamT\
-                    est2.html" title="class in pkg2">ParamTest2</a>&lt;java.util.List&lt;? extends\
-                     <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;</code></div>"""
+                    est2.html" title="class in pkg2">ParamTest2</a><wbr>&lt;java.util.List&lt;? ext\
+                    ends <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;</code></div>"""
         );
 
         checkOutput("pkg2/class-use/Foo4.html", true,
@@ -431,8 +431,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="col-first even-row-color"><code>&lt;T extends <a href="../ParamTest2\
                     .html" title="class in pkg2">ParamTest2</a>&lt;java.util.List&lt;? extends <a hr\
                     ef="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;&gt;<br><a href="../Para\
-                    mTest2.html" title="class in pkg2">ParamTest2</a>&lt;java.util.List&lt;? extends\
-                     <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;</code></div>"""
+                    mTest2.html" title="class in pkg2">ParamTest2</a><wbr>&lt;java.util.List&lt;? ex\
+                    tends <a href="../Foo4.html" title="class in pkg2">Foo4</a>&gt;&gt;</code></div>"""
         );
 
         // Type parameters in constructor and method args

--- a/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
+++ b/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,8 +89,8 @@ public class TestProperty extends JavadocTester {
                 // no tab classes should be used in the property table
                 """
                     <div class="col-first even-row-color"><code>final <a href="ObjectProperty.html" \
-                    title="class in pkg">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in \
-                    pkg">MyObj</a>[]&gt;</code></div>
+                    title="class in pkg">ObjectProperty</a><wbr>&lt;<a href="MyObj.html" title="clas\
+                    s in pkg">MyObj</a>[]&gt;</code></div>
                     <div class="col-second even-row-color"><code><a href="#badProperty" class="membe\
                     r-name-link">bad</a></code></div>
                     <div class="col-last even-row-color">""",
@@ -99,8 +99,8 @@ public class TestProperty extends JavadocTester {
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code>final <a href="ObjectProperty.html" title="\
-                    class in pkg">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in pkg">My\
-                    Obj</a>[]&gt;</code></div>
+                    class in pkg">ObjectProperty</a><wbr>&lt;<a href="MyObj.html" title="class in pk\
+                    g">MyObj</a>[]&gt;</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#badProperty()" class="member-nam\
                     e-link">badProperty</a>()</code></div>"""


### PR DESCRIPTION
Please review a simple change to add a `<wbr>` (line break opportunity) tag before type parameters in some type links. This is only used in the first column of member summary tables as this is the only place where we have type names with full type parameters and no natural line break opportunities in a very limited horizontal space. Attached below is a screenshot of the method summary table of `java.net.http.HttpResponse.BodySubscribers` with this fix applied (see JBS issue for a screenshot of the previous rendering).

<img width="1175" alt="return-type-line-breaks" src="https://user-images.githubusercontent.com/15975/226632264-73700740-dc25-429f-acce-d26e24be26cd.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303123](https://bugs.openjdk.org/browse/JDK-8303123): Add line break opportunity to single type parameters


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13119/head:pull/13119` \
`$ git checkout pull/13119`

Update a local copy of the PR: \
`$ git checkout pull/13119` \
`$ git pull https://git.openjdk.org/jdk.git pull/13119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13119`

View PR using the GUI difftool: \
`$ git pr show -t 13119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13119.diff">https://git.openjdk.org/jdk/pull/13119.diff</a>

</details>
