### PR TITLE
8304680: Problemlist compiler/sharedstubs/SharedStubToInterpTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,6 +69,8 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
 
+compiler/sharedstubs/SharedStubToInterpTest.java 8304681 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
[JDK-8304387](https://bugs.openjdk.org/browse/JDK-8304387) moved the positions of static stubs which lets `compiler/sharedstubs/SharedStubToInterpTest.java` fail in tier2 on different architectures as the test still expects the old layout. The test should be fixed accordingly.

To reduce noise in the CI, I propose to problemlist the test for now.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304680](https://bugs.openjdk.org/browse/JDK-8304680): Problemlist compiler/sharedstubs/SharedStubToInterpTest.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13122/head:pull/13122` \
`$ git checkout pull/13122`

Update a local copy of the PR: \
`$ git checkout pull/13122` \
`$ git pull https://git.openjdk.org/jdk.git pull/13122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13122`

View PR using the GUI difftool: \
`$ git pr show -t 13122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13122.diff">https://git.openjdk.org/jdk/pull/13122.diff</a>

</details>
