### PR TITLE
JDK-8304684: Memory leak in DirectivesParser::set_option_flag

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -602,7 +602,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
 
 #define copy_string_members_definition(name, type, dvalue, cc_flag)          \
   if (src->name##Option != nullptr && src->_modified[name##Index]) {         \
-    set->name##option = os::strdup_check_oom(src->name##Option, mtCompiler); \
+    set->name##Option = os::strdup_check_oom(src->name##Option, mtCompiler); \
   } else {                                                                   \
     set->name##Option = src->name##Option;                                   \
   }

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -279,11 +279,15 @@ void DirectiveSet::init_control_intrinsic() {
 }
 
 DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d) {
-#define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   _ideal_phase_name_mask = 0;
+#define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
+  compilerdirectives_common_string_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
+  compilerdirectives_c2_string_flags(init_defaults_definition)
   compilerdirectives_c1_flags(init_defaults_definition)
+  compilerdirectives_c1_string_flags(init_defaults_definition)
+#undef init_defaults_definition
   memset(_modified, 0, sizeof(_modified));
   _intrinsic_control_words.fill_in(/*default value*/TriBool());
 }
@@ -296,6 +300,12 @@ DirectiveSet::~DirectiveSet() {
     delete tmp;
     tmp = next;
   }
+
+#define free_string_flags(name, type, dvalue, cc_flag) if (_modified[name##Index]) os::free(const_cast<char*>(name##Option));
+  compilerdirectives_common_string_flags(free_string_flags)
+  compilerdirectives_c2_string_flags(free_string_flags)
+  compilerdirectives_c1_string_flags(free_string_flags)
+#undef free_string_flags
 }
 
 // A smart pointer of DirectiveSet. It uses Copy-on-Write strategy to avoid cloning.
@@ -397,8 +407,16 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
     // inline and dontinline (including exclude) are implemented in the directiveset accessors
 #define init_default_cc(name, type, dvalue, cc_flag) { type v; if (!_modified[name##Index] && CompileCommand::cc_flag != CompileCommand::Unknown && CompilerOracle::has_option_value(method, CompileCommand::cc_flag, v) && v != this->name##Option) { set.cloned()->name##Option = v; } }
     compilerdirectives_common_flags(init_default_cc)
+    compilerdirectives_common_string_flags(init_default_cc)
     compilerdirectives_c2_flags(init_default_cc)
+    compilerdirectives_c2_string_flags(init_default_cc)
     compilerdirectives_c1_flags(init_default_cc)
+    compilerdirectives_c1_string_flags(init_default_cc)
+#undef init_default_cc
+
+#define init_string_default_cc(name, type, dvalue, cc_flag) {}
+
+#undef init_string_default_cc
 
     // Parse PrintIdealPhaseName and create an efficient lookup mask
 #ifndef PRODUCT
@@ -580,6 +598,18 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
     compilerdirectives_common_flags(copy_members_definition)
     compilerdirectives_c2_flags(copy_members_definition)
     compilerdirectives_c1_flags(copy_members_definition)
+  #undef copy_members_definition
+
+#define copy_string_members_definition(name, type, dvalue, cc_flag)          \
+  if (src->name##Option != nullptr && _modified[name##Index]) {              \
+    set->name##option = os::strdup_check_oom(src->name##Option, mtCompiler); \
+  } else {                                                                   \
+    set->name##Option = src->name##Option;                                   \
+  }
+  compilerdirectives_common_string_flags(copy_string_members_definition)
+  compilerdirectives_c2_string_flags(copy_string_members_definition)
+  compilerdirectives_c1_string_flags(copy_string_members_definition)
+#undef copy_string_members_definition
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
   set->_ideal_phase_name_mask = src->_ideal_phase_name_mask;

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -601,7 +601,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
   #undef copy_members_definition
 
 #define copy_string_members_definition(name, type, dvalue, cc_flag)          \
-  if (src->name##Option != nullptr && _modified[name##Index]) {              \
+  if (src->name##Option != nullptr && src->_modified[name##Index]) {         \
     set->name##option = os::strdup_check_oom(src->name##Option, mtCompiler); \
   } else {                                                                   \
     set->name##Option = src->name##Option;                                   \

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -282,11 +282,8 @@ DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _di
   _ideal_phase_name_mask = 0;
 #define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
-  compilerdirectives_common_string_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
-  compilerdirectives_c2_string_flags(init_defaults_definition)
   compilerdirectives_c1_flags(init_defaults_definition)
-  compilerdirectives_c1_string_flags(init_defaults_definition)
 #undef init_defaults_definition
   memset(_modified, 0, sizeof(_modified));
   _intrinsic_control_words.fill_in(/*default value*/TriBool());
@@ -407,16 +404,9 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
     // inline and dontinline (including exclude) are implemented in the directiveset accessors
 #define init_default_cc(name, type, dvalue, cc_flag) { type v; if (!_modified[name##Index] && CompileCommand::cc_flag != CompileCommand::Unknown && CompilerOracle::has_option_value(method, CompileCommand::cc_flag, v) && v != this->name##Option) { set.cloned()->name##Option = v; } }
     compilerdirectives_common_flags(init_default_cc)
-    compilerdirectives_common_string_flags(init_default_cc)
     compilerdirectives_c2_flags(init_default_cc)
-    compilerdirectives_c2_string_flags(init_default_cc)
     compilerdirectives_c1_flags(init_default_cc)
-    compilerdirectives_c1_string_flags(init_default_cc)
 #undef init_default_cc
-
-#define init_string_default_cc(name, type, dvalue, cc_flag) {}
-
-#undef init_string_default_cc
 
     // Parse PrintIdealPhaseName and create an efficient lookup mask
 #ifndef PRODUCT
@@ -595,13 +585,13 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
   }
 
   #define copy_members_definition(name, type, dvalue, cc_flag) set->name##Option = src->name##Option;
-    compilerdirectives_common_flags(copy_members_definition)
-    compilerdirectives_c2_flags(copy_members_definition)
-    compilerdirectives_c1_flags(copy_members_definition)
+    compilerdirectives_common_other_flags(copy_members_definition)
+    compilerdirectives_c2_other_flags(copy_members_definition)
+    compilerdirectives_c1_other_flags(copy_members_definition)
   #undef copy_members_definition
 
 #define copy_string_members_definition(name, type, dvalue, cc_flag)          \
-  if (src->name##Option != nullptr && src->_modified[name##Index]) {         \
+  if (src->_modified[name##Index]) {                                         \
     set->name##Option = os::strdup_check_oom(src->name##Option, mtCompiler); \
   } else {                                                                   \
     set->name##Option = src->name##Option;                                   \

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -35,7 +35,7 @@
 #include "utilities/tribool.hpp"
 
   //      Directives flag name,    type, default value, compile command name
-  #define compilerdirectives_common_flags(cflags) \
+  #define compilerdirectives_common_other_flags(cflags) \
     cflags(Enable,                  bool, false, Unknown) \
     cflags(Exclude,                 bool, false, Unknown) \
     cflags(BreakAtExecute,          bool, false, BreakAtExecute) \
@@ -53,18 +53,25 @@
     cflags(RepeatCompilation,       intx, RepeatCompilation, RepeatCompilation)
 #define compilerdirectives_common_string_flags(cflags)                           \
   cflags(DisableIntrinsic,        ccstrlist, DisableIntrinsic, DisableIntrinsic) \
-  cflags(ControlIntrinsic,        ccstrlist, ControlIntrinsic, ControlIntrinsic) \
+  cflags(ControlIntrinsic,        ccstrlist, ControlIntrinsic, ControlIntrinsic)
+#define compilerdirectives_common_flags(cflags) \
+  compilerdirectives_common_other_flags(cflags) \
+  compilerdirectives_common_string_flags(cflags)
 
 #ifdef COMPILER1
-  #define compilerdirectives_c1_flags(cflags)
+  #define compilerdirectives_c1_other_flags(cflags)
   #define compilerdirectives_c1_string_flags(cflags)
 #else
-  #define compilerdirectives_c1_flags(cflags)
+  #define compilerdirectives_c1_other_flags(cflags)
   #define compilerdirectives_c1_string_flags(cflags)
 #endif
 
+#define compilerdirectives_c1_flags(cflags) \
+  compilerdirectives_c1_other_flags(cflags) \
+  compilerdirectives_c1_string_flags(cflags)
+
 #ifdef COMPILER2
-  #define compilerdirectives_c2_flags(cflags) \
+  #define compilerdirectives_c2_other_flags(cflags) \
     cflags(BlockLayoutByFrequency,  bool, BlockLayoutByFrequency,  BlockLayoutByFrequency) \
     cflags(PrintOptoAssembly,       bool, PrintOptoAssembly, PrintOptoAssembly) \
     cflags(PrintIntrinsics,         bool, PrintIntrinsics, PrintIntrinsics) \
@@ -82,9 +89,13 @@ NOT_PRODUCT(cflags(IGVPrintLevel,       intx, PrintIdealGraphLevel, IGVPrintLeve
 #define compilerdirectives_c2_string_flags(cflags) \
 NOT_PRODUCT(cflags(PrintIdealPhase,     ccstrlist, "", PrintIdealPhase))
 #else
-  #define compilerdirectives_c2_flags(cflags)
+  #define compilerdirectives_c2_other_flags(cflags)
   #define compilerdirectives_c2_string_flags(cflags)
 #endif
+
+#define compilerdirectives_c2_flags(cflags) \
+  compilerdirectives_c2_other_flags(cflags) \
+  compilerdirectives_c2_string_flags(cflags)
 
 class AbstractCompiler;
 class CompilerDirectives;
@@ -140,11 +151,8 @@ public:
   typedef enum {
 #define enum_of_flags(name, type, dvalue, cc_flag) name##Index,
     compilerdirectives_common_flags(enum_of_flags)
-    compilerdirectives_common_string_flags(enum_of_flags)
     compilerdirectives_c2_flags(enum_of_flags)
-    compilerdirectives_c2_string_flags(enum_of_flags)
     compilerdirectives_c1_flags(enum_of_flags)
-    compilerdirectives_c1_string_flags(enum_of_flags)
 #undef enum_of_flags
     number_of_flags
   } flags;
@@ -154,18 +162,15 @@ public:
  public:
 #define flag_store_definition(name, type, dvalue, cc_flag) type name##Option;
   compilerdirectives_common_flags(flag_store_definition)
-  compilerdirectives_common_string_flags(flag_store_definition)
   compilerdirectives_c2_flags(flag_store_definition)
-  compilerdirectives_c2_string_flags(flag_store_definition)
   compilerdirectives_c1_flags(flag_store_definition)
-  compilerdirectives_c1_string_flags(flag_store_definition)
 #undef flag_store_definition
 
 // Casting to get the same function signature for all setters. Used from parser.
 #define set_function_definition(name, type, dvalue, cc_flag) void set_##name(void* value) { type val = *(type*)value; name##Option = val; _modified[name##Index] = true; }
-  compilerdirectives_common_flags(set_function_definition)
-  compilerdirectives_c2_flags(set_function_definition)
-  compilerdirectives_c1_flags(set_function_definition)
+  compilerdirectives_common_other_flags(set_function_definition)
+  compilerdirectives_c2_other_flags(set_function_definition)
+  compilerdirectives_c1_other_flags(set_function_definition)
 #undef set_function_definition
 
 // Casting to get the same function signature for all setters. Used from parser.
@@ -201,11 +206,8 @@ void print(outputStream* st) {
     st->print("  ");
 #define print_function_definition(name, type, dvalue, cc_flag) print_##type(st, #name, this->name##Option, true);
     compilerdirectives_common_flags(print_function_definition)
-    compilerdirectives_common_string_flags(print_function_definition)
     compilerdirectives_c2_flags(print_function_definition)
-    compilerdirectives_c2_string_flags(print_function_definition)
     compilerdirectives_c1_flags(print_function_definition)
-    compilerdirectives_c1_string_flags(print_function_definition)
 #undef print_function_definition
     st->cr();
   }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -50,14 +50,17 @@
     cflags(DumpReplay,              bool, false, DumpReplay) \
     cflags(DumpInline,              bool, false, DumpInline) \
     cflags(CompilerDirectivesIgnoreCompileCommands, bool, CompilerDirectivesIgnoreCompileCommands, Unknown) \
-    cflags(DisableIntrinsic,        ccstrlist, DisableIntrinsic, DisableIntrinsic) \
-    cflags(ControlIntrinsic,        ccstrlist, ControlIntrinsic, ControlIntrinsic) \
     cflags(RepeatCompilation,       intx, RepeatCompilation, RepeatCompilation)
+#define compilerdirectives_common_string_flags(cflags)                           \
+  cflags(DisableIntrinsic,        ccstrlist, DisableIntrinsic, DisableIntrinsic) \
+  cflags(ControlIntrinsic,        ccstrlist, ControlIntrinsic, ControlIntrinsic) \
 
 #ifdef COMPILER1
   #define compilerdirectives_c1_flags(cflags)
+  #define compilerdirectives_c1_string_flags(cflags)
 #else
   #define compilerdirectives_c1_flags(cflags)
+  #define compilerdirectives_c1_string_flags(cflags)
 #endif
 
 #ifdef COMPILER2
@@ -69,7 +72,6 @@ NOT_PRODUCT(cflags(TraceOptoPipelining, bool, TraceOptoPipelining, TraceOptoPipe
 NOT_PRODUCT(cflags(TraceOptoOutput,     bool, TraceOptoOutput, TraceOptoOutput)) \
 NOT_PRODUCT(cflags(TraceEscapeAnalysis, bool, false, TraceEscapeAnalysis)) \
 NOT_PRODUCT(cflags(PrintIdeal,          bool, PrintIdeal, PrintIdeal)) \
-NOT_PRODUCT(cflags(PrintIdealPhase,     ccstrlist, "", PrintIdealPhase)) \
     cflags(TraceSpilling,           bool, TraceSpilling, TraceSpilling) \
     cflags(Vectorize,               bool, false, Vectorize) \
     cflags(CloneMapDebug,           bool, false, CloneMapDebug) \
@@ -77,8 +79,11 @@ NOT_PRODUCT(cflags(IGVPrintLevel,       intx, PrintIdealGraphLevel, IGVPrintLeve
     cflags(VectorizeDebug,          uintx, 0, VectorizeDebug) \
     cflags(IncrementalInlineForceCleanup, bool, IncrementalInlineForceCleanup, IncrementalInlineForceCleanup) \
     cflags(MaxNodeLimit,            intx, MaxNodeLimit, MaxNodeLimit)
+#define compilerdirectives_c2_string_flags(cflags) \
+NOT_PRODUCT(cflags(PrintIdealPhase,     ccstrlist, "", PrintIdealPhase))
 #else
   #define compilerdirectives_c2_flags(cflags)
+  #define compilerdirectives_c2_string_flags(cflags)
 #endif
 
 class AbstractCompiler;
@@ -135,8 +140,12 @@ public:
   typedef enum {
 #define enum_of_flags(name, type, dvalue, cc_flag) name##Index,
     compilerdirectives_common_flags(enum_of_flags)
+    compilerdirectives_common_string_flags(enum_of_flags)
     compilerdirectives_c2_flags(enum_of_flags)
+    compilerdirectives_c2_string_flags(enum_of_flags)
     compilerdirectives_c1_flags(enum_of_flags)
+    compilerdirectives_c1_string_flags(enum_of_flags)
+#undef enum_of_flags
     number_of_flags
   } flags;
 
@@ -145,14 +154,37 @@ public:
  public:
 #define flag_store_definition(name, type, dvalue, cc_flag) type name##Option;
   compilerdirectives_common_flags(flag_store_definition)
+  compilerdirectives_common_string_flags(flag_store_definition)
   compilerdirectives_c2_flags(flag_store_definition)
+  compilerdirectives_c2_string_flags(flag_store_definition)
   compilerdirectives_c1_flags(flag_store_definition)
+  compilerdirectives_c1_string_flags(flag_store_definition)
+#undef flag_store_definition
 
 // Casting to get the same function signature for all setters. Used from parser.
 #define set_function_definition(name, type, dvalue, cc_flag) void set_##name(void* value) { type val = *(type*)value; name##Option = val; _modified[name##Index] = true; }
   compilerdirectives_common_flags(set_function_definition)
   compilerdirectives_c2_flags(set_function_definition)
   compilerdirectives_c1_flags(set_function_definition)
+#undef set_function_definition
+
+// Casting to get the same function signature for all setters. Used from parser.
+//
+// IMPORTANT: Takes ownership, will use os::free. Ensure the memory was dynamically allocated on the
+//            C heap.
+#define set_string_function_definition(name, type, dvalue, cc_flag) \
+void set_##name(void* value) {                                      \
+  if (_modified[name##Index]) {                                     \
+    os::free(const_cast<char*>(name##Option));                      \
+  }                                                                 \
+  type val = *(type*)value;                                         \
+  name##Option = val;                                               \
+  _modified[name##Index] = true;                                    \
+}
+  compilerdirectives_common_string_flags(set_string_function_definition)
+  compilerdirectives_c2_string_flags(set_string_function_definition)
+  compilerdirectives_c1_string_flags(set_string_function_definition)
+#undef set_string_function_definition
 
   void set_ideal_phase_mask(uint64_t mask) { _ideal_phase_name_mask = mask; };
   uint64_t ideal_phase_mask() { return _ideal_phase_name_mask; };
@@ -169,8 +201,12 @@ void print(outputStream* st) {
     st->print("  ");
 #define print_function_definition(name, type, dvalue, cc_flag) print_##type(st, #name, this->name##Option, true);
     compilerdirectives_common_flags(print_function_definition)
+    compilerdirectives_common_string_flags(print_function_definition)
     compilerdirectives_c2_flags(print_function_definition)
+    compilerdirectives_c2_string_flags(print_function_definition)
     compilerdirectives_c1_flags(print_function_definition)
+    compilerdirectives_c1_string_flags(print_function_definition)
+#undef print_function_definition
     st->cr();
   }
 };

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -315,35 +315,43 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
         error(VALUE_ERROR, "Cannot use string value for a %s flag", flag_type_names[option_key->flag_type]);
         return false;
       } else {
-        char* s = NEW_C_HEAP_ARRAY(char, v->str.length+1,  mtCompiler);
+        char* s = NEW_C_HEAP_ARRAY(char, v->str.length + 1, mtCompiler);
         strncpy(s, v->str.start, v->str.length + 1);
         s[v->str.length] = '\0';
-        (set->*test)((void *)&s);  // Takes ownership.
+
+        bool valid = true;
 
         if (strncmp(option_key->name, "ControlIntrinsic", 16) == 0) {
           ControlIntrinsicValidator validator(s, false/*disabled_all*/);
 
-          if (!validator.is_valid()) {
+          valid = validator.is_valid();
+          if (!valid) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in ControlIntrinsic: %s", validator.what());
-            return false;
           }
         } else if (strncmp(option_key->name, "DisableIntrinsic", 16) == 0) {
           ControlIntrinsicValidator validator(s, true/*disabled_all*/);
 
-          if (!validator.is_valid()) {
+          valid = validator.is_valid();
+          if (!valid) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
-            return false;
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
           uint64_t mask = 0;
           PhaseNameValidator validator(s, mask);
 
-          if (!validator.is_valid()) {
+          valid = validator.is_valid();
+          if (valid) {
+            set->set_ideal_phase_mask(mask);
+          } else {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
-            return false;
           }
-          set->set_ideal_phase_mask(mask);
         }
+
+        if (!valid) {
+          FREE_C_HEAP_ARRAY(char, s);
+          return false;
+        }
+        (set->*test)((void *)&s);  // Takes ownership.
       }
       break;
 

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -325,6 +325,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
 
           if (!validator.is_valid()) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in ControlIntrinsic: %s", validator.what());
+            FREE_C_HEAP_ARRAY(char, s);
             return false;
           }
         } else if (strncmp(option_key->name, "DisableIntrinsic", 16) == 0) {
@@ -332,6 +333,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
 
           if (!validator.is_valid()) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
+            FREE_C_HEAP_ARRAY(char, s);
             return false;
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
@@ -340,10 +342,12 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
 
           if (!validator.is_valid()) {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
+            FREE_C_HEAP_ARRAY(char, s);
             return false;
           }
           set->set_ideal_phase_mask(mask);
         }
+        FREE_C_HEAP_ARRAY(char, s);
       }
       break;
 

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -318,39 +318,31 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
         char* s = NEW_C_HEAP_ARRAY(char, v->str.length+1,  mtCompiler);
         strncpy(s, v->str.start, v->str.length + 1);
         s[v->str.length] = '\0';
-        (set->*test)((void *)&s);
-
-        bool valid = true;
+        (set->*test)((void *)&s);  // Takes ownership.
 
         if (strncmp(option_key->name, "ControlIntrinsic", 16) == 0) {
           ControlIntrinsicValidator validator(s, false/*disabled_all*/);
 
-          valid = validator.is_valid();
-          if (!valid) {
+          if (!validator.is_valid()) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in ControlIntrinsic: %s", validator.what());
+            return false;
           }
         } else if (strncmp(option_key->name, "DisableIntrinsic", 16) == 0) {
           ControlIntrinsicValidator validator(s, true/*disabled_all*/);
 
-          valid = validator.is_valid();
-          if (!valid) {
+          if (!validator.is_valid()) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
+            return false;
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
           uint64_t mask = 0;
           PhaseNameValidator validator(s, mask);
 
-          valid = validator.is_valid();
-          if (!valid) {
+          if (!validator.is_valid()) {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
-          } else {
-            set->set_ideal_phase_mask(mask);
+            return false;
           }
-        }
-
-        FREE_C_HEAP_ARRAY(char, s);
-        if (!valid) {
-          return false;
+          set->set_ideal_phase_mask(mask);
         }
       }
       break;

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -320,34 +320,38 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
         s[v->str.length] = '\0';
         (set->*test)((void *)&s);
 
+        bool valid = true;
+
         if (strncmp(option_key->name, "ControlIntrinsic", 16) == 0) {
           ControlIntrinsicValidator validator(s, false/*disabled_all*/);
 
-          if (!validator.is_valid()) {
+          valid = validator.is_valid();
+          if (!valid) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in ControlIntrinsic: %s", validator.what());
-            FREE_C_HEAP_ARRAY(char, s);
-            return false;
           }
         } else if (strncmp(option_key->name, "DisableIntrinsic", 16) == 0) {
           ControlIntrinsicValidator validator(s, true/*disabled_all*/);
 
-          if (!validator.is_valid()) {
+          valid = validator.is_valid();
+          if (!valid) {
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
-            FREE_C_HEAP_ARRAY(char, s);
-            return false;
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
           uint64_t mask = 0;
           PhaseNameValidator validator(s, mask);
 
-          if (!validator.is_valid()) {
+          valid = validator.is_valid();
+          if (!valid) {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
-            FREE_C_HEAP_ARRAY(char, s);
-            return false;
+          } else {
+            set->set_ideal_phase_mask(mask);
           }
-          set->set_ideal_phase_mask(mask);
         }
+
         FREE_C_HEAP_ARRAY(char, s);
+        if (!valid) {
+          return false;
+        }
       }
       break;
 


### PR DESCRIPTION
Update `DirectivesSet` to take ownership of string options in some cases, to not leak memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304684](https://bugs.openjdk.org/browse/JDK-8304684): Memory leak in DirectivesParser::set_option_flag


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [a832d587](https://git.openjdk.org/jdk/pull/13125/files/a832d587837a341bb80ca04f9019dc96ee6266a0)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13125/head:pull/13125` \
`$ git checkout pull/13125`

Update a local copy of the PR: \
`$ git checkout pull/13125` \
`$ git pull https://git.openjdk.org/jdk.git pull/13125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13125`

View PR using the GUI difftool: \
`$ git pr show -t 13125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13125.diff">https://git.openjdk.org/jdk/pull/13125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13125#issuecomment-1478265032)