### PR TITLE
8304436: com/sun/jdi/ThreadMemoryLeakTest.java fails with "OutOfMemoryError: Java heap space" with ZGC

### DIFF
--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -30,8 +30,8 @@
  * @requires (vm.compMode == "Xmixed")
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g ThreadMemoryLeakTest.java
- * @comment run with -Xmx6m so any leak will quickly produce OOME
- * @run main/othervm -Xmx6m ThreadMemoryLeakTest
+ * @comment run with -Xmx7m so any leak will quickly produce OOME
+ * @run main/othervm -Xmx7m ThreadMemoryLeakTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;
@@ -95,30 +95,26 @@ public class ThreadMemoryLeakTest extends TestScaffold {
 
     /********** event handlers **********/
 
-    static int threadStartCount;
-    static int threadDeathCount;
-    private static List<ThreadReference> threads =
-        Collections.synchronizedList(new ArrayList<ThreadReference>());
+    static LongAdder threadStartCount = new LongAdder();
+    static LongAdder threadDeathCount = new LongAdder();
 
     public void threadStarted(ThreadStartEvent event) {
-        threadStartCount++;
-        if ((threadStartCount % 1000) == 0) {
+        threadStartCount.increment();
+        if ((threadStartCount.sum() % 1000) == 0) {
             println("Got ThreadStartEvent #" + threadStartCount +
-                               " threads:" + threads.size());
+                    " threads:" + (threadStartCount.sum() - threadDeathCount.sum()));
         }
         ThreadStartEvent tse = (ThreadStartEvent)event;
-        threads.add(tse.thread());
     }
 
     public void threadDied(ThreadDeathEvent event) {
-        threadDeathCount++;
-        if ((threadDeathCount % 1000) == 0) {
+        threadDeathCount.increment();
+        if ((threadDeathCount.sum() % 1000) == 0) {
             println("Got ThreadDeathEvent #" + threadDeathCount +
-                               " threads:" + threads.size());
+                    " threads:" + (threadStartCount.sum() - threadDeathCount.sum()));
         }
         ThreadDeathEvent tde = (ThreadDeathEvent)event;
         ThreadReference thread = tde.thread();
-        threads.remove(thread);
     }
 
     public void vmDied(VMDeathEvent event) {


### PR DESCRIPTION
There are two GC related issues with this test that are being addressed. The test was limiting the heap size to 6m so if there is still a leak, it will be detected quickly. This proved to be too small of a size when using ZGC. For the most part changing the size to 7m fixed this issue. However, I was still seeing frequent issues with ZGC on macOS. This is explained by [JDK-8304449](https://bugs.openjdk.org/browse/JDK-8304449), which noticed (rarely) OOME on macos even when not using ZGC. From JDK-8304449:

"macOS has a thread behavior that is not seen on linux and windows that is causing more memory usage, which sometimes leads to this unexpected OOME. The debuggee side of the test constantly creates threads that do little more than a short sleep. It has a counter of "live" threads, and won't let that go over 500. On the debugger side it is just tracking ThreadStartEvents and ThreadDeathEvents. It keep tracks of threads (ThreadReferences) for which a ThreadStartEvent had been received but a ThreadDeathEvent has not. On linux and windows the count of outstanding threads is generally in the 200-400 range, sometimes briefly going over 500. However, on macOS it is closer to 2400. This means a lot more ThreadReferences being tracked, which means more memory usage, so sometimes you see an OOME on macOS as a result. "

The `threads` collection mainly existed just so its size could be used to log the number of outstanding ThreadDeathEvents. I got rid of the `threads` collection and instead am just tracking the number of ThreadStartEvents and ThreadDeathEvents, and computing the difference to get the number of outstanding ThreadDeathEvents.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8304436 is used in problem lists: [test/jdk/ProblemList-zgc.txt]

### Issues
 * [JDK-8304436](https://bugs.openjdk.org/browse/JDK-8304436): com/sun/jdi/ThreadMemoryLeakTest.java fails with "OutOfMemoryError: Java heap space" with ZGC
 * [JDK-8304449](https://bugs.openjdk.org/browse/JDK-8304449): com/sun/jdi/ThreadMemoryLeakTest.java times out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13128/head:pull/13128` \
`$ git checkout pull/13128`

Update a local copy of the PR: \
`$ git checkout pull/13128` \
`$ git pull https://git.openjdk.org/jdk.git pull/13128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13128`

View PR using the GUI difftool: \
`$ git pr show -t 13128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13128.diff">https://git.openjdk.org/jdk/pull/13128.diff</a>

</details>
