### PR TITLE
8272613: CharsetDecoder.decode(ByteBuffer) throws IllegalArgumentException

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
+++ b/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.nio.BufferUnderflowException;
 import java.lang.ref.WeakReference;
 import java.nio.charset.CoderMalfunctionError;                  // javadoc
 import java.util.Arrays;
+import jdk.internal.util.ArraysSupport;
 
 
 /**
@@ -795,7 +796,8 @@ public abstract class Charset$Coder$ {
     public final $Otype$Buffer $code$($Itype$Buffer in)
         throws CharacterCodingException
     {
-        int n = (int)(in.remaining() * average$ItypesPerOtype$());
+        int n = Math.min((int)(in.remaining() * average$ItypesPerOtype$()),
+                    ArraysSupport.SOFT_MAX_ARRAY_LENGTH);
         $Otype$Buffer out = $Otype$Buffer.allocate(n);
 
         if ((n == 0) && (in.remaining() == 0))
@@ -810,7 +812,8 @@ public abstract class Charset$Coder$ {
             if (cr.isUnderflow())
                 break;
             if (cr.isOverflow()) {
-                n = 2*n + 1;    // Ensure progress; n might be 0!
+                // Ensure progress; n might be 0!
+                n = ArraysSupport.newLength(n, Math.min(n + 1, 1_024), n + 1);
                 $Otype$Buffer o = $Otype$Buffer.allocate(n);
                 out.flip();
                 o.put(out);

--- a/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
+++ b/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
@@ -792,6 +792,10 @@ public abstract class Charset$Coder$ {
      *          position cannot be mapped to an equivalent $otype$ sequence and
      *          the current unmappable-character action is {@link
      *          CodingErrorAction#REPORT}
+     *
+     * @throws  OutOfMemoryError
+     *          If the output $otype$ buffer for the requested size of the input
+     *          $itype$ buffer cannot be allocated
      */
     public final $Otype$Buffer $code$($Itype$Buffer in)
         throws CharacterCodingException

--- a/test/jdk/java/nio/charset/CharsetDecoder/DecodeOverflow.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/DecodeOverflow.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8272613
+ * @summary Make sure IAE is not thrown on decoder overflow. The test should
+ *          either not throw any Throwable, or an OOME with real Java heap
+ *          space error (not "exceeds VM limit").
+ * @run junit/othervm DecodeOverflow
+ */
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class DecodeOverflow {
+    private static Stream<Arguments> sizes() {
+        return Stream.of(
+            // SOFT_MAX_ARRAY_LENGTH: copied from ArraysSupport. No overflow; no OOME.
+            Arguments.of(Integer.MAX_VALUE - 8),
+
+            // overflow case: OOME w/ "Java heap space" is thrown
+            Arguments.of(Integer.MAX_VALUE - 1000000)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sizes")
+    public void testDecodeOverflow(int size) throws CharacterCodingException {
+        try {
+            StandardCharsets.UTF_8
+                .newDecoder()
+                .decode(ByteBuffer.wrap(new byte[size], 0, size));
+            System.out.println("Decoded without error");
+        } catch (OutOfMemoryError oome) {
+            if (oome.getMessage().equals("Java heap space")) {
+                System.out.println("OOME for \"Java heap space\" is thrown correctly");
+            } else {
+                throw oome;
+            }
+        }
+    }
+}

--- a/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
@@ -27,6 +27,7 @@
  * @summary Make sure IAE is not thrown on `int` overflow, turning negative
  *          size. The test should either not throw any Throwable, or an OOME
  *          with real Java heap space error (not "exceeds VM limit").
+ * @requires sun.arch.data.model == "64"
  * @run junit/othervm XcodeOverflow
  */
 

--- a/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
@@ -36,7 +36,6 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
@@ -47,7 +46,7 @@ public class XcodeOverflow {
             // SOFT_MAX_ARRAY_LENGTH: copied from ArraysSupport. No overflow; no OOME.
             Arguments.of(Integer.MAX_VALUE - 8),
 
-            // overflow case: OOME w/ "Java heap space" is thrown
+            // overflow case: OOME w/ "Java heap space" is thrown on decoding
             Arguments.of(Integer.MAX_VALUE - 1000000)
         );
     }


### PR DESCRIPTION
Addressing an integer overflow on decoding a large byte buffer. Now that the code only throws OOME if necessary, describing the fact with the `@throws` tag. A CSR for that is also drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8304842](https://bugs.openjdk.org/browse/JDK-8304842) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8272613](https://bugs.openjdk.org/browse/JDK-8272613): CharsetDecoder.decode(ByteBuffer) throws IllegalArgumentException
 * [JDK-8304842](https://bugs.openjdk.org/browse/JDK-8304842): CharsetDecoder.decode(ByteBuffer) throws IllegalArgumentException (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13131/head:pull/13131` \
`$ git checkout pull/13131`

Update a local copy of the PR: \
`$ git checkout pull/13131` \
`$ git pull https://git.openjdk.org/jdk.git pull/13131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13131`

View PR using the GUI difftool: \
`$ git pr show -t 13131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13131.diff">https://git.openjdk.org/jdk/pull/13131.diff</a>

</details>
