### PR TITLE
8304681: compiler/sharedstubs/SharedStubToInterpTest.java fails after JDK-8304387

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,8 +69,6 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
 
-compiler/sharedstubs/SharedStubToInterpTest.java 8304681 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -88,7 +88,8 @@ public class SharedStubToInterpTest {
         List<String> addrs = Pattern.compile("\\(static_stub\\) addr=(\\w+) .*\\[static_call=")
             .matcher(output.getStdout())
             .results()
-            .map(m -> m.group(1)).toList();
+            .map(m -> m.group(1))
+            .toList();
         if (addrs.stream().distinct().count() >= addrs.size()) {
             throw new RuntimeException("No static stubs reused: distinct " + addrs.stream().distinct().count() + ", in total " + addrs.size());
         }

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -29,6 +29,7 @@
  * @library /test/lib
  *
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires vm.debug
  *
  * @run driver compiler.sharedstubs.SharedStubToInterpTest
  */
@@ -36,8 +37,8 @@
 package compiler.sharedstubs;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Pattern;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -50,6 +51,7 @@ public class SharedStubToInterpTest {
         command.add(compiler);
         command.add("-XX:+UnlockDiagnosticVMOptions");
         command.add("-Xbatch");
+        command.add("-XX:+PrintRelocations");
         command.add("-XX:CompileCommand=compileonly," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "test");
         command.add("-XX:CompileCommand=print," + testClassName + "::" + "test");
@@ -82,48 +84,13 @@ public class SharedStubToInterpTest {
         }
     }
 
-    private static String skipTo(Iterator<String> iter, String substring) {
-        while (iter.hasNext()) {
-            String nextLine = iter.next();
-            if (nextLine.contains(substring)) {
-                return nextLine;
-            }
-        }
-        return null;
-    }
-
     private static void checkOutput(OutputAnalyzer output) {
-        Iterator<String> iter = output.asLines().listIterator();
-
-        String match = skipTo(iter, "Compiled method");
-        while (match != null && !match.contains("Test::test")) {
-            match = skipTo(iter, "Compiled method");
-        }
-        if (match == null) {
-            throw new RuntimeException("Missing compiler output for the method 'test'");
-        }
-
-        while (iter.hasNext()) {
-            String nextLine = iter.next();
-            if (nextLine.contains("{static_stub}")) {
-                // Static stubs must be created at the end of the Stub section.
-                throw new RuntimeException("Found {static_stub} before Deopt Handler Code");
-            } else if (nextLine.contains("{runtime_call DeoptimizationBlob}")) {
-                // Shared static stubs are put after Deopt Handler Code.
-                break;
-            }
-        }
-
-        int foundStaticStubs = 0;
-        while (iter.hasNext()) {
-            if (iter.next().contains("{static_stub}")) {
-                foundStaticStubs += 1;
-            }
-        }
-
-        final int expectedStaticStubs = 2;
-        if (foundStaticStubs != expectedStaticStubs) {
-            throw new RuntimeException("Found static stubs: " + foundStaticStubs + "; Expected static stubs: " + expectedStaticStubs);
+        List<String> addrs = Pattern.compile("\\(static_stub\\) addr=(\\w+) .*\\[static_call=")
+            .matcher(output.getStdout())
+            .results()
+            .map(m -> m.group(1)).toList();
+        if (addrs.stream().distinct().count() >= addrs.size()) {
+            throw new RuntimeException("No static stubs reused: distinct " + addrs.stream().distinct().count() + ", in total " + addrs.size());
         }
     }
 

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -85,7 +85,8 @@ public class SharedTrampolineTest {
         List<String> addrs = Pattern.compile("\\(trampoline_stub\\) addr=(\\w+) .*\\[trampoline owner")
             .matcher(output.getStdout())
             .results()
-            .map(m -> m.group(1)).toList();
+            .map(m -> m.group(1))
+            .toList();
         if (addrs.stream().distinct().count() >= addrs.size()) {
             throw new RuntimeException("No runtime trampoline stubs reused: distinct " + addrs.stream().distinct().count() + ", in total " + addrs.size());
         }

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -81,24 +81,13 @@ public class SharedTrampolineTest {
         }
     }
 
-    private static String skipTo(Iterator<String> iter, String substring) {
-        while (iter.hasNext()) {
-            String nextLine = iter.next();
-            if (nextLine.contains(substring)) {
-                return nextLine;
-            }
-        }
-        return null;
-    }
-
     private static void checkOutput(OutputAnalyzer output) {
         List<String> addrs = Pattern.compile("\\(trampoline_stub\\) addr=(\\w+) .*\\[trampoline owner")
             .matcher(output.getStdout())
             .results()
-            .map(m -> m.group(1))
-            .collect(Collectors.toList());
+            .map(m -> m.group(1)).toList();
         if (addrs.stream().distinct().count() >= addrs.size()) {
-            throw new RuntimeException("No stubs reused");
+            throw new RuntimeException("No runtime trampoline stubs reused: distinct " + addrs.stream().distinct().count() + ", in total " + addrs.size());
         }
     }
 


### PR DESCRIPTION
Please review this test fix for [JDK-8304387](https://bugs.openjdk.org/browse/JDK-8304387) after RFR.

Instead of specifying shared stubs' locations in this test, we could check if two or more relocations combined with each of them in this test, same as the other test `SharedTrampolineTest.java`. The counting logic is aligned with `SharedTrampolineTest.java`. Printing relocation stuff requires debug version vm, so this test is changed to debug only. Also some minor cleanups for the tests.

Apologies for the tier2 failure. I mainly focused on if there were new hs_errs when working on JDK-8304387. :-(

I am now confirming if the comment "Static stubs must be created at the end of the Stub section" could be removed, which needs a little extra time - though I think we can relax such limitations in `SharedStubToInterpTest.java`.
\-\- Update on March 27th: comfirmed; please see the JBS issue for the discussion.

Tested x86_64, AArch64 and RISC-V for tests under `compiler/sharedstubs` folder, and now all passed (release, fastdebug).

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304681](https://bugs.openjdk.org/browse/JDK-8304681): compiler/sharedstubs/SharedStubToInterpTest.java fails after JDK-8304387


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer) ⚠️ Review applies to [3f343c2b](https://git.openjdk.org/jdk/pull/13135/files/3f343c2b1f4bb51ef28850aead9a042507fb451d)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [3f343c2b](https://git.openjdk.org/jdk/pull/13135/files/3f343c2b1f4bb51ef28850aead9a042507fb451d)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13135/head:pull/13135` \
`$ git checkout pull/13135`

Update a local copy of the PR: \
`$ git checkout pull/13135` \
`$ git pull https://git.openjdk.org/jdk.git pull/13135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13135`

View PR using the GUI difftool: \
`$ git pr show -t 13135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13135.diff">https://git.openjdk.org/jdk/pull/13135.diff</a>

</details>
