### PR TITLE
8297539: Use PrimitiveConversions::cast for local uses of the int<->float union conversion trick

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020 Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +27,7 @@
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.hpp"
 #include "compiler/disassembler.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "immediate_aarch64.hpp"
 #include "memory/resourceArea.hpp"
 
@@ -499,12 +500,9 @@ unsigned Assembler::pack(double value) {
 // Packed operands for  Floating-point Move (immediate)
 
 static float unpack(unsigned value) {
-  union {
-    unsigned ival;
-    float val;
-  };
+  unsigned ival;
   ival = fp_immediate_for_encoding(value, 0);
-  return val;
+  return PrimitiveConversions::cast<float>(ival);
 }
 
 address Assembler::locate_next_instruction(address inst) {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -27,9 +27,9 @@
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.hpp"
 #include "compiler/disassembler.hpp"
-#include "metaprogramming/primitiveConversions.hpp"
 #include "immediate_aarch64.hpp"
 #include "memory/resourceArea.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 
 #ifndef PRODUCT
 const uintptr_t Assembler::asm_bp = 0x0000ffffac221240;

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -500,8 +500,7 @@ unsigned Assembler::pack(double value) {
 // Packed operands for  Floating-point Move (immediate)
 
 static float unpack(unsigned value) {
-  unsigned ival;
-  ival = fp_immediate_for_encoding(value, 0);
+  unsigned ival = fp_immediate_for_encoding(value, 0);
   return PrimitiveConversions::cast<float>(ival);
 }
 

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -27,9 +27,9 @@
 #include <stdint.h>
 
 #include "precompiled.hpp"
+#include "immediate_aarch64.hpp"
 #include "metaprogramming/primitiveConversions.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "immediate_aarch64.hpp"
 
 // there are at most 2^13 possible logical immediate encodings
 // however, some combinations of immr and imms are invalid

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,6 +27,7 @@
 #include <stdint.h>
 
 #include "precompiled.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "immediate_aarch64.hpp"
 
@@ -431,11 +433,7 @@ uint32_t encoding_for_fp_immediate(float immediate)
   // return the imm8 result [s:r:f]
   //
 
-  union {
-    float fpval;
-    uint32_t val;
-  };
-  fpval = immediate;
+  uint32_t val = PrimitiveConversions::cast<uint32_t>(immediate);
   uint32_t s, r, f, res;
   // sign bit is 31
   s = (val >> 31) & 0x1;

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -279,31 +279,31 @@ class VFP {
   class float_num : public fpnum {
    public:
     float_num(float v) {
-      _num_bits = PrimitiveConversions::cast<unsigned int>(v);
+      _bits = PrimitiveConversions::cast<unsigned int>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num_bits << 9) >> (19+9); }
-    virtual bool f_lo_is_null() const { return (_num_bits & ((1 << 19) - 1)) == 0; }
-    virtual int e() const { return ((_num_bits << 1) >> (23+1)) - 127; }
-    virtual unsigned int s() const { return _num_bits >> 31; }
+    override unsigned int f_hi4() const { return (_bits << 9) >> (19+9); }
+    override bool f_lo_is_null() const { return (_bits & ((1 << 19) - 1)) == 0; }
+    override int e() const { return ((_bits << 1) >> (23+1)) - 127; }
+    override unsigned int s() const { return _bits >> 31; }
 
    private:
-    unsigned int _num_bits;
+    unsigned int _bits;
   };
 
   class double_num : public fpnum {
    public:
     double_num(double v) {
-      _num_bits = PrimitiveConversions::cast<uint64_t>(v);
+      _bits = PrimitiveConversions::cast<uint64_t>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num_bits << 12) >> (48+12); }
-    virtual bool f_lo_is_null() const { return (_num_bits & ((1LL << 48) - 1)) == 0; }
-    virtual int e() const { return ((_num_bits << 1) >> (52+1)) - 1023; }
-    virtual unsigned int s() const { return _num_bits >> 63; }
+    override unsigned int f_hi4() const { return (_bits << 12) >> (48+12); }
+    override bool f_lo_is_null() const { return (_bits & ((1LL << 48) - 1)) == 0; }
+    override int e() const { return ((_bits << 1) >> (52+1)) - 1023; }
+    override unsigned int s() const { return _bits >> 63; }
 
    private:
-    uint64_t _num_bits;
+    uint64_t _bits;
   };
 };
 #endif

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -282,10 +282,10 @@ class VFP {
       _bits = PrimitiveConversions::cast<unsigned int>(v);
     }
 
-    override unsigned int f_hi4() const { return (_bits << 9) >> (19+9); }
-    override bool f_lo_is_null() const { return (_bits & ((1 << 19) - 1)) == 0; }
-    override int e() const { return ((_bits << 1) >> (23+1)) - 127; }
-    override unsigned int s() const { return _bits >> 31; }
+    unsigned int f_hi4() const override { return (_bits << 9) >> (19+9); }
+    bool f_lo_is_null() const override { return (_bits & ((1 << 19) - 1)) == 0; }
+    int e() const override { return ((_bits << 1) >> (23+1)) - 127; }
+    unsigned int s() const override { return _bits >> 31; }
 
    private:
     unsigned int _bits;
@@ -297,10 +297,10 @@ class VFP {
       _bits = PrimitiveConversions::cast<uint64_t>(v);
     }
 
-    override unsigned int f_hi4() const { return (_bits << 12) >> (48+12); }
-    override bool f_lo_is_null() const { return (_bits & ((1LL << 48) - 1)) == 0; }
-    override int e() const { return ((_bits << 1) >> (52+1)) - 1023; }
-    override unsigned int s() const { return _bits >> 63; }
+    unsigned int f_hi4() const override { return (_bits << 12) >> (48+12); }
+    bool f_lo_is_null() const override { return (_bits & ((1LL << 48) - 1)) == 0; }
+    int e() const override { return ((_bits << 1) >> (52+1)) - 1023; }
+    unsigned int s() const override { return _bits >> 63; }
 
    private:
     uint64_t _bits;

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -294,19 +294,16 @@ class VFP {
   class double_num : public fpnum {
    public:
     double_num(double v) {
-      _num.val = v;
+      _num_bits = PrimitiveConversions::cast<unsigned long long>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num.bits << 12) >> (48+12); }
-    virtual bool f_lo_is_null() const { return (_num.bits & ((1LL << 48) - 1)) == 0; }
-    virtual int e() const { return ((_num.bits << 1) >> (52+1)) - 1023; }
-    virtual unsigned int s() const { return _num.bits >> 63; }
+    virtual unsigned int f_hi4() const { return (_num_bits << 12) >> (48+12); }
+    virtual bool f_lo_is_null() const { return (_num_bits & ((1LL << 48) - 1)) == 0; }
+    virtual int e() const { return ((_num_bits << 1) >> (52+1)) - 1023; }
+    virtual unsigned int s() const { return _num_bits >> 63; }
 
    private:
-    union {
-      double val;
-      unsigned long long bits;
-    } _num;
+    unsigned long long _num_bits;
   };
 };
 #endif

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -279,19 +279,16 @@ class VFP {
   class float_num : public fpnum {
    public:
     float_num(float v) {
-      _num.val = v;
+      _num_bits = PrimitiveConversions::cast<unsigned int>(v);
     }
 
-    virtual unsigned int f_hi4() const { return (_num.bits << 9) >> (19+9); }
-    virtual bool f_lo_is_null() const { return (_num.bits & ((1 << 19) - 1)) == 0; }
-    virtual int e() const { return ((_num.bits << 1) >> (23+1)) - 127; }
-    virtual unsigned int s() const { return _num.bits >> 31; }
+    virtual unsigned int f_hi4() const { return (_num_bits << 9) >> (19+9); }
+    virtual bool f_lo_is_null() const { return (_num_bits & ((1 << 19) - 1)) == 0; }
+    virtual int e() const { return ((_num_bits << 1) >> (23+1)) - 127; }
+    virtual unsigned int s() const { return _num_bits >> 31; }
 
    private:
-    union {
-      float val;
-      unsigned int bits;
-    } _num;
+    unsigned int _num_bits;
   };
 
   class double_num : public fpnum {

--- a/src/hotspot/cpu/arm/assembler_arm.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm.hpp
@@ -294,7 +294,7 @@ class VFP {
   class double_num : public fpnum {
    public:
     double_num(double v) {
-      _num_bits = PrimitiveConversions::cast<unsigned long long>(v);
+      _num_bits = PrimitiveConversions::cast<uint64_t>(v);
     }
 
     virtual unsigned int f_hi4() const { return (_num_bits << 12) >> (48+12); }
@@ -303,7 +303,7 @@ class VFP {
     virtual unsigned int s() const { return _num_bits >> 63; }
 
    private:
-    unsigned long long _num_bits;
+    uint64_t _num_bits;
   };
 };
 #endif

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -674,11 +674,11 @@ void MacroAssembler::mov_metadata(Register rd, Metadata* o, int metadata_index) 
 
 void MacroAssembler::mov_float(FloatRegister fd, jfloat c, AsmCondition cond) {
   Label skip_constant;
-  jint accessor_i = PrimitiveConversions::cast<jint>(c);
+  jint float_bits = PrimitiveConversions::cast<jint>(c);
 
   flds(fd, Address(PC), cond);
   b(skip_constant);
-  emit_int32(accessor_i);
+  emit_int32(float_bits);
   bind(skip_constant);
 }
 

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -37,6 +37,7 @@
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "oops/accessDecorators.hpp"
 #include "oops/klass.inline.hpp"
 #include "prims/methodHandles.hpp"
@@ -673,15 +674,11 @@ void MacroAssembler::mov_metadata(Register rd, Metadata* o, int metadata_index) 
 
 void MacroAssembler::mov_float(FloatRegister fd, jfloat c, AsmCondition cond) {
   Label skip_constant;
-  union {
-    jfloat f;
-    jint i;
-  } accessor;
-  accessor.f = c;
+  jint accessor_i = PrimitiveConversions::cast<jint>(c);
 
   flds(fd, Address(PC), cond);
   b(skip_constant);
-  emit_int32(accessor.i);
+  emit_int32(accessor_i);
   bind(skip_constant);
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -46,6 +46,7 @@
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "metaprogramming/primitiveConversions.hpp"
 #include "oops/compiledICHolder.inline.hpp"
 #include "oops/klass.hpp"
 #include "oops/method.inline.hpp"
@@ -237,12 +238,11 @@ JRT_LEAF(jfloat, SharedRuntime::frem(jfloat  x, jfloat  y))
 #ifdef _WIN64
   // 64-bit Windows on amd64 returns the wrong values for
   // infinity operands.
-  union { jfloat f; juint i; } xbits, ybits;
-  xbits.f = x;
-  ybits.f = y;
+  juint xbits_i = PrimitiveConversions::cast<juint>(x);
+  juint xbits_i = PrimitiveConversions::cast<juint>(x);
   // x Mod Infinity == x unless x is infinity
-  if (((xbits.i & float_sign_mask) != float_infinity) &&
-       ((ybits.i & float_sign_mask) == float_infinity) ) {
+  if (((xbits_i & float_sign_mask) != float_infinity) &&
+       ((ybits_i & float_sign_mask) == float_infinity) ) {
     return x;
   }
   return ((jfloat)fmod_winx64((double)x, (double)y));

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -254,12 +254,11 @@ JRT_END
 
 JRT_LEAF(jdouble, SharedRuntime::drem(jdouble x, jdouble y))
 #ifdef _WIN64
-  union { jdouble d; julong l; } xbits, ybits;
-  xbits.d = x;
-  ybits.d = y;
+  julong xbits_l = PrimitiveConversions::cast<julong>(x);
+  julong ybits_l = PrimitiveConversions::cast<julong>(y);
   // x Mod Infinity == x unless x is infinity
-  if (((xbits.l & double_sign_mask) != double_infinity) &&
-       ((ybits.l & double_sign_mask) == double_infinity) ) {
+  if (((xbits_l & double_sign_mask) != double_infinity) &&
+       ((ybits_l & double_sign_mask) == double_infinity) ) {
     return x;
   }
   return ((jdouble)fmod_winx64((double)x, (double)y));

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -238,11 +238,11 @@ JRT_LEAF(jfloat, SharedRuntime::frem(jfloat  x, jfloat  y))
 #ifdef _WIN64
   // 64-bit Windows on amd64 returns the wrong values for
   // infinity operands.
-  juint xbits_i = PrimitiveConversions::cast<juint>(x);
-  juint ybits_i = PrimitiveConversions::cast<juint>(y);
+  juint xbits = PrimitiveConversions::cast<juint>(x);
+  juint ybits = PrimitiveConversions::cast<juint>(y);
   // x Mod Infinity == x unless x is infinity
-  if (((xbits_i & float_sign_mask) != float_infinity) &&
-       ((ybits_i & float_sign_mask) == float_infinity) ) {
+  if (((xbits & float_sign_mask) != float_infinity) &&
+       ((ybits & float_sign_mask) == float_infinity) ) {
     return x;
   }
   return ((jfloat)fmod_winx64((double)x, (double)y));
@@ -254,11 +254,11 @@ JRT_END
 
 JRT_LEAF(jdouble, SharedRuntime::drem(jdouble x, jdouble y))
 #ifdef _WIN64
-  julong xbits_l = PrimitiveConversions::cast<julong>(x);
-  julong ybits_l = PrimitiveConversions::cast<julong>(y);
+  julong xbits = PrimitiveConversions::cast<julong>(x);
+  julong ybits = PrimitiveConversions::cast<julong>(y);
   // x Mod Infinity == x unless x is infinity
-  if (((xbits_l & double_sign_mask) != double_infinity) &&
-       ((ybits_l & double_sign_mask) == double_infinity) ) {
+  if (((xbits & double_sign_mask) != double_infinity) &&
+       ((ybits & double_sign_mask) == double_infinity) ) {
     return x;
   }
   return ((jdouble)fmod_winx64((double)x, (double)y));

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -239,7 +239,7 @@ JRT_LEAF(jfloat, SharedRuntime::frem(jfloat  x, jfloat  y))
   // 64-bit Windows on amd64 returns the wrong values for
   // infinity operands.
   juint xbits_i = PrimitiveConversions::cast<juint>(x);
-  juint xbits_i = PrimitiveConversions::cast<juint>(x);
+  juint ybits_i = PrimitiveConversions::cast<juint>(y);
   // x Mod Infinity == x unless x is infinity
   if (((xbits_i & float_sign_mask) != float_infinity) &&
        ((ybits_i & float_sign_mask) == float_infinity) ) {


### PR DESCRIPTION
**Only** the instances of using `union` for converting `int` to `float` are replaced with call to `PrimitiveConversions::cast<To>(From)` method. Some few cases with conversion of `long` <->`double` are also replaced with `PrimitiveConversions::cast<To>(From)`. The other instances where the union contains other types of fields than `int` and `float` are left unchanged.

### Test
local hotspot:tier1
mach5 tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297539](https://bugs.openjdk.org/browse/JDK-8297539): Use PrimitiveConversions::cast for local uses of the int&lt;-&gt;float union conversion trick


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [88e9a239](https://git.openjdk.org/jdk/pull/13136/files/88e9a23952a62ed7a6a3d14218e166169e9da266)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13136/head:pull/13136` \
`$ git checkout pull/13136`

Update a local copy of the PR: \
`$ git checkout pull/13136` \
`$ git pull https://git.openjdk.org/jdk.git pull/13136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13136`

View PR using the GUI difftool: \
`$ git pr show -t 13136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13136.diff">https://git.openjdk.org/jdk/pull/13136.diff</a>

</details>
