### PR TITLE
8304134 jib bootstrapper fails to quote filename when checking download filetype

### DIFF
--- a/bin/jib.sh
+++ b/bin/jib.sh
@@ -130,7 +130,7 @@ install_jib() {
     fi
     # Want to check the filetype using file, to see if we got served a HTML error page.
     # This is sensitive to the filename containing a specific string, but good enough.
-    file ${installed_jib_script}.gz | grep "gzip compressed data" > /dev/null
+    file "${installed_jib_script}.gz" | grep "gzip compressed data" > /dev/null
     if [ $? -ne 0 ]; then 
         echo "Warning: ${installed_jib_script}.gz is not a gzip file."
         echo "If you are behind a proxy you may need to configure exceptions using no_proxy."


### PR DESCRIPTION
Add quoting not to fail on paths with spaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304134](https://bugs.openjdk.org/browse/JDK-8304134): jib bootstrapper fails to quote filename when checking download filetype


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13138/head:pull/13138` \
`$ git checkout pull/13138`

Update a local copy of the PR: \
`$ git checkout pull/13138` \
`$ git pull https://git.openjdk.org/jdk.git pull/13138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13138`

View PR using the GUI difftool: \
`$ git pr show -t 13138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13138.diff">https://git.openjdk.org/jdk/pull/13138.diff</a>

</details>
