### PR TITLE
8304717: Declaration aliasing between boolean and jboolean is wrong

### DIFF
--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -814,7 +814,7 @@ jclass FindBootStrapClass(JNIEnv *env, const char *classname)
 }
 
 void
-InitLauncher(boolean javaw)
+InitLauncher(jboolean javaw)
 {
     INITCOMMONCONTROLSEX icx;
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -2637,7 +2637,7 @@ JNIEXPORT jint JNICALL Java_sun_awt_windows_WPrinterJob_getGDIAdvance
  */
 JNIEXPORT void JNICALL Java_sun_awt_windows_WPrinterJob_textOut
 (JNIEnv *env, jobject self, jlong printDC, jstring text, jint strLen,
-     boolean glyphCodes, jfloat x, jfloat y, jfloatArray positions)
+     jboolean glyphCodes, jfloat x, jfloat y, jfloatArray positions)
 {
 
     long posX = ROUND_TO_LONG(x);

--- a/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
+++ b/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
@@ -659,7 +659,7 @@ Java_java_util_prefs_MacOSXPreferencesFile_removeNode
 
 
 // child must end with '/'
-JNIEXPORT Boolean JNICALL
+JNIEXPORT jboolean JNICALL
 Java_java_util_prefs_MacOSXPreferencesFile_addChildToNode
 (JNIEnv *env, jobject klass, jobject jpath, jobject jchild,
  jobject jname, jlong juser, jlong jhost)
@@ -682,7 +682,7 @@ Java_java_util_prefs_MacOSXPreferencesFile_addChildToNode
     CFDictionaryRef node;
     CFStringRef topKey;
     CFMutableDictionaryRef topValue;
-    Boolean beforeAdd = false;
+    jboolean beforeAdd = JNI_FALSE;
 
     if (!path  ||  !child  ||  !name) goto badparams;
 
@@ -697,7 +697,7 @@ Java_java_util_prefs_MacOSXPreferencesFile_addChildToNode
     if (!beforeAdd)
         beforeAdd = CFDictionaryContainsKey(parent, child);
     else
-        beforeAdd = false;
+        beforeAdd = JNI_FALSE;
     CFPreferencesSetValue(topKey, topValue, name, user, host);
 
     CFRelease(parent);

--- a/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
+++ b/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
@@ -695,7 +695,7 @@ Java_java_util_prefs_MacOSXPreferencesFile_addChildToNode
     beforeAdd = CFDictionaryContainsKey(parent, child);
     CFDictionaryAddValue(parent, child, node);
     if (!beforeAdd)
-        beforeAdd = CFDictionaryContainsKey(parent, child);
+        beforeAdd = CFDictionaryContainsKey(parent, child) ? JNI_TRUE : JNI_FALSE;
     else
         beforeAdd = JNI_FALSE;
     CFPreferencesSetValue(topKey, topValue, name, user, host);

--- a/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
+++ b/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
@@ -692,7 +692,7 @@ Java_java_util_prefs_MacOSXPreferencesFile_addChildToNode
     // copyMutableNode creates the node if necessary
     parent = copyMutableNode(path, name, user, host, &topKey, &topValue);
     throwIfNull(parent, "copyMutableNode failed");
-    beforeAdd = CFDictionaryContainsKey(parent, child);
+    beforeAdd = CFDictionaryContainsKey(parent, child) ? JNI_TRUE : JNI_FALSE;
     CFDictionaryAddValue(parent, child, node);
     if (!beforeAdd)
         beforeAdd = CFDictionaryContainsKey(parent, child) ? JNI_TRUE : JNI_FALSE;


### PR DESCRIPTION
A couple of spots wrongly refer to boolean and jboolean as the same thing. While this does still compile thanks to a happy accident and implicit conversions, they are not the same at all, and should be fixed before a future compiler error happens if their declarations are touched

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304717](https://bugs.openjdk.org/browse/JDK-8304717): Declaration aliasing between boolean and jboolean is wrong


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13139/head:pull/13139` \
`$ git checkout pull/13139`

Update a local copy of the PR: \
`$ git checkout pull/13139` \
`$ git pull https://git.openjdk.org/jdk.git pull/13139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13139`

View PR using the GUI difftool: \
`$ git pr show -t 13139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13139.diff">https://git.openjdk.org/jdk/pull/13139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13139#issuecomment-1479650861)