### PR TITLE
8304718: GetIntArrayElements should not be passed JNI_FALSE

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -759,7 +759,7 @@ Java_sun_lwawt_macosx_LWCToolkit_initIDs
     CHECK_NULL(getButtonDownMasksID);
     jintArray obj = (jintArray)(*env)->CallStaticObjectMethod(env, inputEventClazz, getButtonDownMasksID);
     CHECK_EXCEPTION();
-    jint * tmp = (*env)->GetIntArrayElements(env, obj, JNI_FALSE);
+    jint * tmp = (*env)->GetIntArrayElements(env, obj, NULL);
     CHECK_NULL(tmp);
 
     gButtonDownMasks = (jint*)SAFE_SIZE_ARRAY_ALLOC(malloc, sizeof(jint), gNumberOfButtons);

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_Robot.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_Robot.c
@@ -243,7 +243,7 @@ Java_sun_awt_X11_XRobotPeer_setup (JNIEnv * env, jclass cls, jint numberOfButton
     DTRACE_PRINTLN("RobotPeer: setup()");
 
     num_buttons = numberOfButtons;
-    tmp = (*env)->GetIntArrayElements(env, buttonDownMasks, JNI_FALSE);
+    tmp = (*env)->GetIntArrayElements(env, buttonDownMasks, NULL);
     CHECK_NULL(tmp);
 
     masks = (jint *)SAFE_SIZE_ARRAY_ALLOC(malloc, sizeof(jint), num_buttons);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -6584,7 +6584,7 @@ Java_java_awt_Component_initIDs(JNIEnv *env, jclass cls)
                                                           "java/awt/event/InputEvent",
                                                           "getButtonDownMasks", "()[I").l;
     CHECK_NULL(obj);
-    jint * tmp = env->GetIntArrayElements(obj, JNI_FALSE);
+    jint * tmp = env->GetIntArrayElements(obj, nullptr);
     CHECK_NULL(tmp);
     jsize len = env->GetArrayLength(obj);
     AwtComponent::masks = SAFE_SIZE_NEW_ARRAY(jint, len);


### PR DESCRIPTION
AWT passes JNI_FALSE to the JVM to avoid a copy, which is not correct since JNI has absolutely no control over whether a copy is made or not. The parameter in question is a pointer to a jboolean that the JVM sets to indicate whether it made a copy or not, which should be passed nullptr because we don't bother about the copy status of the jint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304718](https://bugs.openjdk.org/browse/JDK-8304718): GetIntArrayElements should not be passed JNI_FALSE


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13140/head:pull/13140` \
`$ git checkout pull/13140`

Update a local copy of the PR: \
`$ git checkout pull/13140` \
`$ git pull https://git.openjdk.org/jdk.git pull/13140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13140`

View PR using the GUI difftool: \
`$ git pr show -t 13140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13140.diff">https://git.openjdk.org/jdk/pull/13140.diff</a>

</details>
