### PR TITLE
8304069: ClassFileParser has ad-hoc hashtables

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -774,10 +774,6 @@ class NameSigHash: public ResourceObj {
 
   static const int HASH_ROW_SIZE = 256;
 
-  NameSigHash() :
-    _name(nullptr),
-    _sig(nullptr) {}
-
   NameSigHash(Symbol* name, Symbol* sig) :
     _name(name),
     _sig(sig) {}
@@ -1592,8 +1588,8 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     // Set containing name-signature pairs
     NameSigHashtable* names_and_sigs = new NameSigHashtable();
     for (int i = 0; i < _temp_field_info->length(); i++) {
-      NameSigHash name_and_sig = NameSigHash(_temp_field_info->adr_at(i)->name(_cp),
-                                 _temp_field_info->adr_at(i)->signature(_cp));
+      NameSigHash name_and_sig(_temp_field_info->adr_at(i)->name(_cp),
+                               _temp_field_info->adr_at(i)->signature(_cp));
       // If no duplicates, add name/signature in hashtable names_and_sigs.
       if(!names_and_sigs->put(name_and_sig, 0)) {
         classfile_parse_error("Duplicate field name \"%s\" with signature \"%s\" in class file %s",
@@ -2832,7 +2828,7 @@ void ClassFileParser::parse_methods(const ClassFileStream* const cfs,
       NameSigHashtable* names_and_sigs = new NameSigHashtable();
       for (int i = 0; i < length; i++) {
         const Method* const m = _methods->at(i);
-        NameSigHash name_and_sig = NameSigHash(m->name(), m->signature());
+        NameSigHash name_and_sig(m->name(), m->signature());
         // If no duplicates, add name/signature in hashtable names_and_sigs.
         if(!names_and_sigs->put(name_and_sig, 0)) {
           classfile_parse_error("Duplicate method name \"%s\" with signature \"%s\" in class file %s",

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -783,7 +783,7 @@ class NameSigHash: public ResourceObj {
     _sig(sig) {}
 
   static unsigned int hash(NameSigHash const& namesig) {
-    return namesig._name->identity_hash() ^ (namesig._sig == nullptr ? 0 : namesig._sig->identity_hash());
+    return namesig._name->identity_hash() ^ namesig._sig->identity_hash();
   }
 
   static bool equals(NameSigHash const& e0, NameSigHash const& e1) {
@@ -862,15 +862,15 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
     // Check if there's any duplicates in interfaces
     ResourceMark rm(THREAD);
     // Set containing interface names
-    NameSigHashtable* interface_names = new NameSigHashtable();
-    NameSigHash interface_name;
+    ResourceHashtable<Symbol*, int>* interface_names = new ResourceHashtable<Symbol*, int>();
+    Symbol* interface_name;
     for (index = 0; index < itfs_len; index++) {
       const InstanceKlass* const k = _local_interfaces->at(index);
-      interface_name = NameSigHash(k->name(), nullptr);
+      interface_name = k->name();
       // If no duplicates, add (name, nullptr) in hashtable interface_names.
       if (!interface_names->put(interface_name, 0)) {
         classfile_parse_error("Duplicate interface name \"%s\" in class file %s",
-                               interface_name._name->as_C_string(), THREAD);
+                               interface_name->as_C_string(), THREAD);
       }
     }
   }
@@ -1595,7 +1595,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     NameSigHash name_and_sig;
     for (int i = 0; i < _temp_field_info->length(); i++) {
       name_and_sig = NameSigHash(_temp_field_info->adr_at(i)->name(_cp),
-                                  _temp_field_info->adr_at(i)->signature(_cp));
+                                 _temp_field_info->adr_at(i)->signature(_cp));
       // If no duplicates, add name/signature in hashtable names_and_sigs.
       if(!names_and_sigs->put(name_and_sig, 0)) {
         classfile_parse_error("Duplicate field name \"%s\" with signature \"%s\" in class file %s",

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -771,52 +771,22 @@ class NameSigHash: public ResourceObj {
  public:
   const Symbol*       _name;       // name
   const Symbol*       _sig;        // signature
-  NameSigHash*  _next;             // Next entry in hash table
-};
 
-static const int HASH_ROW_SIZE = 256;
+  static const int HASH_ROW_SIZE = 256;
 
-static unsigned int hash(const Symbol* name, const Symbol* sig) {
-  unsigned int raw_hash = 0;
-  raw_hash += ((unsigned int)(uintptr_t)name) >> (LogHeapWordSize + 2);
-  raw_hash += ((unsigned int)(uintptr_t)sig) >> LogHeapWordSize;
+  static unsigned int hash(NameSigHash* const& namesig) {
+    unsigned int raw_hash = 0;
+    raw_hash += ((unsigned int)(uintptr_t)namesig->_name) >> (LogHeapWordSize + 2);
+    raw_hash += ((unsigned int)(uintptr_t)namesig->_sig) >> LogHeapWordSize;
 
-  return (raw_hash + (unsigned int)(uintptr_t)name) % HASH_ROW_SIZE;
-}
-
-
-static void initialize_hashtable(NameSigHash** table) {
-  memset((void*)table, 0, sizeof(NameSigHash*) * HASH_ROW_SIZE);
-}
-// Return false if the name/sig combination is found in table.
-// Return true if no duplicate is found. And name/sig is added as a new entry in table.
-// The old format checker uses heap sort to find duplicates.
-// NOTE: caller should guarantee that GC doesn't happen during the life cycle
-// of table since we don't expect Symbol*'s to move.
-static bool put_after_lookup(const Symbol* name, const Symbol* sig, NameSigHash** table) {
-  assert(name != nullptr, "name in constant pool is null");
-
-  // First lookup for duplicates
-  int index = hash(name, sig);
-  NameSigHash* entry = table[index];
-  while (entry != nullptr) {
-    if (entry->_name == name && entry->_sig == sig) {
-      return false;
-    }
-    entry = entry->_next;
+    return (raw_hash + (unsigned int)(uintptr_t)namesig->_name) % HASH_ROW_SIZE;
   }
 
-  // No duplicate is found, allocate a new entry and fill it.
-  entry = new NameSigHash();
-  entry->_name = name;
-  entry->_sig = sig;
-
-  // Insert into hash table
-  entry->_next = table[index];
-  table[index] = entry;
-
-  return true;
-}
+  static bool equals(NameSigHash* const& e0, NameSigHash* const& e1) {
+    return (e0->_name == e1->_name) &&
+          (e0->_sig  == e1->_sig);
+  }
+};
 
 // Side-effects: populates the _local_interfaces field
 void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
@@ -882,27 +852,35 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
 
     // Check if there's any duplicates in interfaces
     ResourceMark rm(THREAD);
-    NameSigHash** interface_names = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD,
-                                                                 NameSigHash*,
-                                                                 HASH_ROW_SIZE);
-    initialize_hashtable(interface_names);
-    bool dup = false;
-    const Symbol* name = nullptr;
+    // Set containing interface names
+    ResourceHashtable<NameSigHash*,
+                      int,
+                      NameSigHash::HASH_ROW_SIZE,
+                      AnyObj::RESOURCE_AREA,
+                      mtInternal,
+                      &NameSigHash::hash,
+                      &NameSigHash::equals>* interface_names = new ResourceHashtable<NameSigHash*,
+                                                                                     int,
+                                                                                     NameSigHash::HASH_ROW_SIZE,
+                                                                                     AnyObj::RESOURCE_AREA,
+                                                                                     mtInternal,
+                                                                                     &NameSigHash::hash,
+                                                                                     &NameSigHash::equals>();
+    bool dup = true;
+    NameSigHash* interface_name = nullptr;
     {
       debug_only(NoSafepointVerifier nsv;)
-      for (index = 0; index < itfs_len; index++) {
+      for (index = 0; (index < itfs_len) && dup; index++) {
         const InstanceKlass* const k = _local_interfaces->at(index);
-        name = k->name();
+        interface_name = new NameSigHash();
+        interface_name->_name = k->name();
         // If no duplicates, add (name, nullptr) in hashtable interface_names.
-        if (!put_after_lookup(name, nullptr, interface_names)) {
-          dup = true;
-          break;
-        }
+        interface_names->put_if_absent(interface_name, &dup);
       }
     }
-    if (dup) {
+    if (!dup) {
       classfile_parse_error("Duplicate interface name \"%s\" in class file %s",
-                             name->as_C_string(), THREAD);
+                             interface_name->_name->as_C_string(), THREAD);
     }
   }
 }
@@ -1621,27 +1599,35 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
   if (_need_verify && length > 1) {
     // Check duplicated fields
     ResourceMark rm(THREAD);
-    NameSigHash** names_and_sigs = NEW_RESOURCE_ARRAY_IN_THREAD(
-      THREAD, NameSigHash*, HASH_ROW_SIZE);
-    initialize_hashtable(names_and_sigs);
-    bool dup = false;
-    const Symbol* name = nullptr;
-    const Symbol* sig = nullptr;
+    // Set containing name-signature pairs
+    ResourceHashtable<NameSigHash*,
+                      int,
+                      NameSigHash::HASH_ROW_SIZE,
+                      AnyObj::RESOURCE_AREA,
+                      mtInternal,
+                      &NameSigHash::hash,
+                      &NameSigHash::equals>* names_and_sigs = new ResourceHashtable<NameSigHash*,
+                                                                                    int,
+                                                                                    NameSigHash::HASH_ROW_SIZE,
+                                                                                    AnyObj::RESOURCE_AREA,
+                                                                                    mtInternal,
+                                                                                    &NameSigHash::hash,
+                                                                                    &NameSigHash::equals>();
+    bool dup = true;
+    NameSigHash* name_and_sig = nullptr;
     {
       debug_only(NoSafepointVerifier nsv;)
-      for (int i = 0; i < _temp_field_info->length(); i++) {
-        name = _temp_field_info->adr_at(i)->name(_cp);
-        sig = _temp_field_info->adr_at(i)->signature(_cp);
+      for (int i = 0; (i < _temp_field_info->length()) && dup; i++) {
+        name_and_sig = new NameSigHash();
+        name_and_sig->_name = _temp_field_info->adr_at(i)->name(_cp);
+        name_and_sig->_sig = _temp_field_info->adr_at(i)->signature(_cp);
         // If no duplicates, add name/signature in hashtable names_and_sigs.
-        if (!put_after_lookup(name, sig, names_and_sigs)) {
-          dup = true;
-          break;
-        }
+        names_and_sigs->put_if_absent(name_and_sig, &dup);
       }
     }
-    if (dup) {
+    if (!dup) {
       classfile_parse_error("Duplicate field name \"%s\" with signature \"%s\" in class file %s",
-                             name->as_C_string(), sig->as_klass_external_name(), THREAD);
+                             name_and_sig->_name->as_C_string(), name_and_sig->_sig->as_klass_external_name(), THREAD);
     }
   }
 }
@@ -2871,28 +2857,36 @@ void ClassFileParser::parse_methods(const ClassFileStream* const cfs,
     if (_need_verify && length > 1) {
       // Check duplicated methods
       ResourceMark rm(THREAD);
-      NameSigHash** names_and_sigs = NEW_RESOURCE_ARRAY_IN_THREAD(
-        THREAD, NameSigHash*, HASH_ROW_SIZE);
-      initialize_hashtable(names_and_sigs);
-      bool dup = false;
-      const Symbol* name = nullptr;
-      const Symbol* sig = nullptr;
+      // Set containing name-signature pairs
+      ResourceHashtable<NameSigHash*,
+                        int,
+                        NameSigHash::HASH_ROW_SIZE,
+                        AnyObj::RESOURCE_AREA,
+                        mtInternal,
+                        &NameSigHash::hash,
+                        &NameSigHash::equals>* names_and_sigs = new ResourceHashtable<NameSigHash*,
+                                                                                      int,
+                                                                                      NameSigHash::HASH_ROW_SIZE,
+                                                                                      AnyObj::RESOURCE_AREA,
+                                                                                      mtInternal,
+                                                                                      &NameSigHash::hash,
+                                                                                      &NameSigHash::equals>();
+      bool dup = true;
+      NameSigHash* name_and_sig = nullptr;
       {
         debug_only(NoSafepointVerifier nsv;)
-        for (int i = 0; i < length; i++) {
+        for (int i = 0; (i < length) && dup; i++) {
+          name_and_sig = new NameSigHash();
           const Method* const m = _methods->at(i);
-          name = m->name();
-          sig = m->signature();
+          name_and_sig->_name = m->name();
+          name_and_sig->_sig = m->signature();
           // If no duplicates, add name/signature in hashtable names_and_sigs.
-          if (!put_after_lookup(name, sig, names_and_sigs)) {
-            dup = true;
-            break;
-          }
+          names_and_sigs->put_if_absent(name_and_sig, &dup);
         }
       }
-      if (dup) {
+      if (!dup) {
         classfile_parse_error("Duplicate method name \"%s\" with signature \"%s\" in class file %s",
-                               name->as_C_string(), sig->as_klass_external_name(), THREAD);
+                               name_and_sig->_name->as_C_string(), name_and_sig->_sig->as_klass_external_name(), THREAD);
       }
     }
   }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -863,10 +863,9 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
     ResourceMark rm(THREAD);
     // Set containing interface names
     ResourceHashtable<Symbol*, int>* interface_names = new ResourceHashtable<Symbol*, int>();
-    Symbol* interface_name;
     for (index = 0; index < itfs_len; index++) {
       const InstanceKlass* const k = _local_interfaces->at(index);
-      interface_name = k->name();
+      Symbol* interface_name = k->name();
       // If no duplicates, add (name, nullptr) in hashtable interface_names.
       if (!interface_names->put(interface_name, 0)) {
         classfile_parse_error("Duplicate interface name \"%s\" in class file %s",
@@ -1592,9 +1591,8 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     ResourceMark rm(THREAD);
     // Set containing name-signature pairs
     NameSigHashtable* names_and_sigs = new NameSigHashtable();
-    NameSigHash name_and_sig;
     for (int i = 0; i < _temp_field_info->length(); i++) {
-      name_and_sig = NameSigHash(_temp_field_info->adr_at(i)->name(_cp),
+      NameSigHash name_and_sig = NameSigHash(_temp_field_info->adr_at(i)->name(_cp),
                                  _temp_field_info->adr_at(i)->signature(_cp));
       // If no duplicates, add name/signature in hashtable names_and_sigs.
       if(!names_and_sigs->put(name_and_sig, 0)) {
@@ -2832,10 +2830,9 @@ void ClassFileParser::parse_methods(const ClassFileStream* const cfs,
       ResourceMark rm(THREAD);
       // Set containing name-signature pairs
       NameSigHashtable* names_and_sigs = new NameSigHashtable();
-      NameSigHash name_and_sig;
       for (int i = 0; i < length; i++) {
         const Method* const m = _methods->at(i);
-        name_and_sig = NameSigHash(m->name(), m->signature());
+        NameSigHash name_and_sig = NameSigHash(m->name(), m->signature());
         // If no duplicates, add name/signature in hashtable names_and_sigs.
         if(!names_and_sigs->put(name_and_sig, 0)) {
           classfile_parse_error("Duplicate method name \"%s\" with signature \"%s\" in class file %s",

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -788,6 +788,11 @@ class NameSigHash: public ResourceObj {
   }
 };
 
+using NameSigHashtable = ResourceHashtable<NameSigHash*, int,
+                                           NameSigHash::HASH_ROW_SIZE,
+                                           AnyObj::RESOURCE_AREA, mtInternal,
+                                           &NameSigHash::hash, &NameSigHash::equals>;
+
 // Side-effects: populates the _local_interfaces field
 void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
                                        const int itfs_len,
@@ -853,19 +858,7 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
     // Check if there's any duplicates in interfaces
     ResourceMark rm(THREAD);
     // Set containing interface names
-    ResourceHashtable<NameSigHash*,
-                      int,
-                      NameSigHash::HASH_ROW_SIZE,
-                      AnyObj::RESOURCE_AREA,
-                      mtInternal,
-                      &NameSigHash::hash,
-                      &NameSigHash::equals>* interface_names = new ResourceHashtable<NameSigHash*,
-                                                                                     int,
-                                                                                     NameSigHash::HASH_ROW_SIZE,
-                                                                                     AnyObj::RESOURCE_AREA,
-                                                                                     mtInternal,
-                                                                                     &NameSigHash::hash,
-                                                                                     &NameSigHash::equals>();
+    NameSigHashtable* interface_names = new NameSigHashtable();
     bool dup = true;
     NameSigHash* interface_name = nullptr;
     {
@@ -1600,19 +1593,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     // Check duplicated fields
     ResourceMark rm(THREAD);
     // Set containing name-signature pairs
-    ResourceHashtable<NameSigHash*,
-                      int,
-                      NameSigHash::HASH_ROW_SIZE,
-                      AnyObj::RESOURCE_AREA,
-                      mtInternal,
-                      &NameSigHash::hash,
-                      &NameSigHash::equals>* names_and_sigs = new ResourceHashtable<NameSigHash*,
-                                                                                    int,
-                                                                                    NameSigHash::HASH_ROW_SIZE,
-                                                                                    AnyObj::RESOURCE_AREA,
-                                                                                    mtInternal,
-                                                                                    &NameSigHash::hash,
-                                                                                    &NameSigHash::equals>();
+    NameSigHashtable* names_and_sigs = new NameSigHashtable();
     bool dup = true;
     NameSigHash* name_and_sig = nullptr;
     {
@@ -2858,19 +2839,7 @@ void ClassFileParser::parse_methods(const ClassFileStream* const cfs,
       // Check duplicated methods
       ResourceMark rm(THREAD);
       // Set containing name-signature pairs
-      ResourceHashtable<NameSigHash*,
-                        int,
-                        NameSigHash::HASH_ROW_SIZE,
-                        AnyObj::RESOURCE_AREA,
-                        mtInternal,
-                        &NameSigHash::hash,
-                        &NameSigHash::equals>* names_and_sigs = new ResourceHashtable<NameSigHash*,
-                                                                                      int,
-                                                                                      NameSigHash::HASH_ROW_SIZE,
-                                                                                      AnyObj::RESOURCE_AREA,
-                                                                                      mtInternal,
-                                                                                      &NameSigHash::hash,
-                                                                                      &NameSigHash::equals>();
+      NameSigHashtable* names_and_sigs = new NameSigHashtable();
       bool dup = true;
       NameSigHash* name_and_sig = nullptr;
       {


### PR DESCRIPTION
The ClassFileParser has ad-hoc hash tables for checking for duplicate names for fields, methods and interfaces. ResourceHashtable will now be used instead. Verified with tier1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304069](https://bugs.openjdk.org/browse/JDK-8304069): ClassFileParser has ad-hoc hashtables


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13141/head:pull/13141` \
`$ git checkout pull/13141`

Update a local copy of the PR: \
`$ git checkout pull/13141` \
`$ git pull https://git.openjdk.org/jdk.git pull/13141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13141`

View PR using the GUI difftool: \
`$ git pr show -t 13141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13141.diff">https://git.openjdk.org/jdk/pull/13141.diff</a>

</details>
