### PR TITLE
8219083: java/net/MulticastSocket/SetGetNetworkInterfaceTest.java failed in same binary run on windows x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -533,8 +533,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-a
 
 java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all
-
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
 ############################################################################


### PR DESCRIPTION
This PR removes the test from the problemlist.

The test failed in JDK13 because of an issue with `TwoStackPlainDatagramSocket`'s implementation of `setNetworkInterface`, see JBS for details.

`TwoStackPlainDatagramSocket` was completely removed in JDK 18, and the current implementation appears to be immune to the original problem. The test passed on all Windows versions available in Mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8219083](https://bugs.openjdk.org/browse/JDK-8219083): java/net/MulticastSocket/SetGetNetworkInterfaceTest.java failed in same binary run on windows x64


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13142/head:pull/13142` \
`$ git checkout pull/13142`

Update a local copy of the PR: \
`$ git checkout pull/13142` \
`$ git pull https://git.openjdk.org/jdk.git pull/13142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13142`

View PR using the GUI difftool: \
`$ git pr show -t 13142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13142.diff">https://git.openjdk.org/jdk/pull/13142.diff</a>

</details>
