### PR TITLE
8304725: AsyncGetCallTrace can cause SIGBUS on M1

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2136,7 +2136,9 @@ PcDesc* PcDescContainer::find_pc_desc_internal(address pc, bool approximate, con
 
   if (match_desc(upper, pc_offset, approximate)) {
     assert(upper == linear_search(search, pc_offset, approximate), "search ok");
-    _pc_desc_cache.add_pc_desc(upper);
+    if (!Thread::current_in_asgct()) {
+      _pc_desc_cache.add_pc_desc(upper);
+    }
     return upper;
   } else {
     assert(nullptr == linear_search(search, pc_offset, approximate), "search ok");

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2137,6 +2137,8 @@ PcDesc* PcDescContainer::find_pc_desc_internal(address pc, bool approximate, con
   if (match_desc(upper, pc_offset, approximate)) {
     assert(upper == linear_search(search, pc_offset, approximate), "search ok");
     if (!Thread::current_in_asgct()) {
+      // we don't want to modify the cache if we're in ASGCT
+      // which is typically called in a signal handler
       _pc_desc_cache.add_pc_desc(upper);
     }
     return upper;

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -33,6 +33,7 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.inline.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "runtime/vframeArray.hpp"
 
@@ -605,6 +606,9 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_GC_active; // -2
     return;
   }
+
+  // Decoding an nmethod can write to a PcDescCache (see PcDescCache::add_pc_desc)
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
 
   switch (thread->thread_state()) {
   case _thread_new:

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -33,7 +33,6 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.inline.hpp"
-#include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "runtime/vframeArray.hpp"
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -607,8 +607,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  // Decoding an nmethod can write to a PcDescCache (see PcDescCache::add_pc_desc)
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, raw_thread);)
+  ThreadInAsgct tia(thread);
 
   switch (thread->thread_state()) {
   case _thread_new:

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -606,6 +606,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
+  // signify to other code in the VM that we're in ASGCT
   ThreadInAsgct tia(thread);
 
   switch (thread->thread_state()) {

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -608,7 +608,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   }
 
   // Decoding an nmethod can write to a PcDescCache (see PcDescCache::add_pc_desc)
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, raw_thread);)
 
   switch (thread->thread_state()) {
   case _thread_new:

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -638,7 +638,7 @@ protected:
   bool in_asgct() const { return _in_asgct; }
   void set_in_asgct(bool value) { _in_asgct = value; }
   static bool current_in_asgct() {
-    Thread *cur = Thread::current();
+    Thread *cur = Thread::current_or_null();
     return cur != nullptr && cur->in_asgct();
   }
 };
@@ -648,7 +648,7 @@ class ThreadInAsgct {
   Thread* _thread;
  public:
   ThreadInAsgct(Thread* thread) : _thread(thread) {
-    assert(thread != NULL, "invariant");
+    assert(thread != nullptr, "invariant");
     assert(!thread->in_asgct(), "invariant");
     thread->set_in_asgct(true);
   }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -632,6 +632,31 @@ protected:
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64
+
+ private:
+  bool _in_asgct = false;
+ public:
+  bool in_asgct() const { return _in_asgct; }
+  void set_in_asgct(bool value) { _in_asgct = value; }
+  static bool current_in_asgct() {
+    Thread *cur = Thread::current();
+    return cur != nullptr && cur->in_asgct();
+  }
+};
+
+class ThreadInAsgct {
+ private:
+  Thread* _thread;
+ public:
+  ThreadInAsgct(Thread* thread) : _thread(thread) {
+    assert(thread != NULL, "invariant");
+    assert(!thread->in_asgct(), "invariant");
+    thread->set_in_asgct(true);
+  }
+  ~ThreadInAsgct() {
+    assert(_thread->in_asgct(), "invariant");
+    _thread->set_in_asgct(false);
+  }
 };
 
 // Inline implementation of Thread::current()

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -638,7 +638,7 @@ protected:
   bool in_asgct() const { return _in_asgct; }
   void set_in_asgct(bool value) { _in_asgct = value; }
   static bool current_in_asgct() {
-    Thread *cur = Thread::current_or_null();
+    Thread *cur = Thread::current_or_null_safe();
     return cur != nullptr && cur->in_asgct();
   }
 };

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -622,7 +622,8 @@ protected:
 #if defined(__APPLE__) && defined(AARCH64)
  private:
   DEBUG_ONLY(bool _wx_init);
-  WXMode _wx_state;
+  // this might also be modified in signal handlers (e.g. ASGCT)
+  volatile WXMode _wx_state;
  public:
   void init_wx();
   WXMode enable_wx(WXMode new_state);

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -622,8 +622,7 @@ protected:
 #if defined(__APPLE__) && defined(AARCH64)
  private:
   DEBUG_ONLY(bool _wx_init);
-  // this might also be modified in signal handlers (e.g. ASGCT)
-  volatile WXMode _wx_state;
+  WXMode _wx_state;
  public:
   void init_wx();
   WXMode enable_wx(WXMode new_state);


### PR DESCRIPTION
Fixes the issue by disabling PCDesc cache modifications when in ASGCT.

Tested on my M1 mac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304725](https://bugs.openjdk.org/browse/JDK-8304725): AsyncGetCallTrace can cause SIGBUS on M1


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [6f1108ed](https://git.openjdk.org/jdk/pull/13144/files/6f1108ed4a4ffea3f8f784140834b0df3f21daa5)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [468d71e3](https://git.openjdk.org/jdk/pull/13144/files/468d71e370e9ba6334022b46ceae0680b7686d64)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [6f1108ed](https://git.openjdk.org/jdk/pull/13144/files/6f1108ed4a4ffea3f8f784140834b0df3f21daa5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13144/head:pull/13144` \
`$ git checkout pull/13144`

Update a local copy of the PR: \
`$ git checkout pull/13144` \
`$ git pull https://git.openjdk.org/jdk.git pull/13144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13144`

View PR using the GUI difftool: \
`$ git pr show -t 13144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13144.diff">https://git.openjdk.org/jdk/pull/13144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13144#issuecomment-1479878306)