### PR TITLE
8304711

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -994,6 +994,11 @@ void G1ConcurrentMark::add_root_region(HeapRegion* r) {
   root_regions()->add(r->top_at_mark_start(), r->top());
 }
 
+void G1ConcurrentMark::root_region_scan_abort_and_wait() {
+  root_regions()->abort();
+  root_regions()->wait_until_scan_finished();
+}
+
 void G1ConcurrentMark::concurrent_cycle_start() {
   _gc_timer_cm->register_gc_start();
 
@@ -2000,8 +2005,7 @@ bool G1ConcurrentMark::concurrent_cycle_abort() {
   // be moving objects / updating references. So let's wait until
   // they are done. By telling them to abort, they should complete
   // early.
-  root_regions()->abort();
-  root_regions()->wait_until_scan_finished();
+  root_region_scan_abort_and_wait();
 
   // We haven't started a concurrent cycle no need to do anything; we might have
   // aborted the marking because of shutting down though. In this case the marking

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -219,14 +219,14 @@ private:
 // Typically they contain the areas from TAMS to top of the regions.
 // We could scan and mark through these objects during the concurrent start pause,
 // but for pause time reasons we move this work to the concurrent phase.
-// We need to complete this procedure before the next GC because it might determine
-// that some of these "root objects" are dead, potentially dropping some required
-// references.
+// We need to complete this procedure before we can evacuate a particular region
+// because evacuation might determine that some of these "root objects" are dead,
+// potentially dropping some required references.
 // Root MemRegions comprise of the contents of survivor regions at the end
 // of the GC, and any objects copied into the old gen during GC.
 class G1CMRootMemRegions {
   // The set of root MemRegions.
-  MemRegion*   _root_regions;
+  MemRegion* _root_regions;
   size_t const _max_regions;
 
   volatile size_t _num_root_regions; // Actual number of root regions.
@@ -480,6 +480,8 @@ public:
   void clear_statistics(HeapRegion* r);
   // Notification for eagerly reclaimed regions to clean up.
   void humongous_object_eagerly_reclaimed(HeapRegion* r);
+  // Notification for old gen regions to clean up.
+  void old_region_reclaimed(HeapRegion* r);
   // Manipulation of the global mark stack.
   // The push and pop operations are used by tasks for transfers
   // between task-local queues and the global mark stack.
@@ -557,6 +559,7 @@ public:
   void scan_root_regions();
   bool wait_until_root_region_scan_finished();
   void add_root_region(HeapRegion* r);
+  void root_region_scan_abort_and_wait();
 
 private:
   G1CMRootMemRegions* root_regions() { return &_root_regions; }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -142,8 +142,7 @@ void G1ConcurrentMarkThread::stop_service() {
   if (in_progress()) {
     // We are not allowed to abort the marking threads during root region scan.
     // Needs to be done separately.
-    _cm->root_regions()->abort();
-    _cm->root_regions()->wait_until_scan_finished();
+    _cm->root_region_scan_abort_and_wait();
 
     _cm->abort_marking_threads();
   }


### PR DESCRIPTION
Hi all,

  merge root region scan and abort calls into a single method as they are used together twice; this also helps with (JDK-8300770)[https://bugs.openjdk.org/browse/JDK-8300770] later.

Testing: gha

Thanks,
  Thomas