### PR TITLE
8304694: Runtime exception thrown when break stmt is missing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -450,6 +450,7 @@ public class TransPatterns extends TreeTranslator {
                     return l;
                 });
                 newCases.add(c.head);
+                appendBreakIfNeeded(tree, cases, c.head);
             }
             cases = processCases(tree, newCases.toList());
             ListBuffer<JCStatement> statements = new ListBuffer<>();
@@ -594,7 +595,6 @@ public class TransPatterns extends TreeTranslator {
                 previousCompletesNormally =
                         c.caseKind == CaseTree.CaseKind.STATEMENT &&
                         c.completesNormally;
-                appendBreakIfNeeded(tree, c);
             }
 
             if (tree.hasTag(Tag.SWITCH)) {
@@ -639,9 +639,11 @@ public class TransPatterns extends TreeTranslator {
             }.scan(c.stats);
         }
 
-    private void appendBreakIfNeeded(JCTree switchTree, JCCase c) {
-        if (c.caseKind == CaseTree.CaseKind.RULE) {
-            JCBreak brk = make.at(TreeInfo.endPos(c.stats.last())).Break(null);
+    void appendBreakIfNeeded(JCTree switchTree, List<JCCase> cases, JCCase c) {
+        if (c.caseKind == CaseTree.CaseKind.RULE || (cases.last() == c && c.completesNormally)) {
+            JCTree pos = c.stats.nonEmpty() ? c.stats.last()
+                                            : c;
+            JCBreak brk = make.at(TreeInfo.endPos(pos)).Break(null);
             brk.target = switchTree;
             c.stats = c.stats.append(brk);
         }
@@ -744,7 +746,6 @@ public class TransPatterns extends TreeTranslator {
                         } else {
                             newLabel = List.of(make.PatternCaseLabel(binding, newGuard));
                         }
-                        appendBreakIfNeeded(currentSwitch, accummulated);
                         nestedCases.add(make.Case(CaseKind.STATEMENT, newLabel, accummulated.stats, null));
                         lastGuard = newGuard;
                     }

--- a/test/langtools/tools/javac/patterns/DeconstructionDesugaring.java
+++ b/test/langtools/tools/javac/patterns/DeconstructionDesugaring.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8291769 8301858
+ * @bug 8291769 8301858 8304694
  * @summary Verify more complex switches work properly
  * @compile --enable-preview -source ${jdk.version} DeconstructionDesugaring.java
  * @run main/othervm --enable-preview DeconstructionDesugaring
@@ -45,6 +45,8 @@ public class DeconstructionDesugaring {
         assertEquals(runCheckExpressionWithUnconditional1(new R5(null)), 3);
         assertEquals(runCheckExpressionWithUnconditionalAndParams(new R1(42)), 1);
         assertEquals(runCheckExpressionWithUnconditionalAndParams(new R1(new Object())), 2);
+        assertEquals(runFallThrough(new R6(1, 1)), 0);
+        assertEquals(runFallThrough(new R6(0, 0)), 1);
     }
 
     private void test(ToIntFunction<Object> task) {
@@ -113,6 +115,15 @@ public class DeconstructionDesugaring {
                 return meth_O(o);
         }
     }
+
+    public static int runFallThrough(R6 r) {
+        switch (r) {
+            case R6(var v1, var v2) when v1 != 0: return 0;
+            case R6(var v1, var v2):
+        }
+        return 1;
+    }
+
     public static int meth_I(Integer i) { return 1; }
     public static int meth_O(Object o) { return 2;}
 
@@ -134,4 +145,5 @@ public class DeconstructionDesugaring {
 
     record R4(Super o) {}
     record R5(R4 o) {}
+    record R6(int i1, int i2) {}
 }


### PR DESCRIPTION
For code like this:
```
    public static int runFallThrough(R6 r) {
        switch (r) {
            case R6(var v1, var v2) when v1 != 0: return 0;
            case R6(var v1, var v2):
        }
        return 1;
    }
```

The execution falls through from the last case not outside the switch, but inside the fallback default case (that throws).

The current code is injecting breaks, but only for rule cases, and this situation where the last case needs a break is not handled. To simplify the code, it is now proposed to inject breaks at the beginning of the processing (rather than during processing/at the end) to all necessary cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304694](https://bugs.openjdk.org/browse/JDK-8304694): Runtime exception thrown when break stmt is missing


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13146/head:pull/13146` \
`$ git checkout pull/13146`

Update a local copy of the PR: \
`$ git checkout pull/13146` \
`$ git pull https://git.openjdk.org/jdk.git pull/13146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13146`

View PR using the GUI difftool: \
`$ git pr show -t 13146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13146.diff">https://git.openjdk.org/jdk/pull/13146.diff</a>

</details>
