### PR TITLE
8304712: Only pass total number of regions into G1Policy::calc_min_old_cset_length

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
@@ -291,7 +291,7 @@ public:
 void G1CollectionSetChooser::prune(G1CollectionSetCandidates* candidates) {
   G1Policy* p = G1CollectedHeap::heap()->policy();
 
-  uint min_old_cset_length = p->calc_min_old_cset_length(candidates);
+  uint min_old_cset_length = p->calc_min_old_cset_length(candidates->num_regions());
   uint num_candidates = candidates->num_regions();
 
   if (min_old_cset_length < num_candidates) {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1380,10 +1380,6 @@ size_t G1Policy::allowed_waste_in_collection_set() const {
   return G1HeapWastePercent * _g1h->capacity() / 100;
 }
 
-static size_t divide_and_round_up(size_t dividend, size_t divisor) {
-  return (dividend + divisor - 1) / divisor;
-}
-
 uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
   // The min old CSet region bound is based on the maximum desired
   // number of mixed GCs after a cycle. I.e., even if some old regions
@@ -1396,7 +1392,7 @@ uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
   // that the result is the same during all mixed GCs that follow a cycle.
   const size_t gc_num = MAX2((size_t)G1MixedGCCountTarget, (size_t)1);
   // Round up to be conservative.
-  return (uint)divide_and_round_up(num_marked_regions, gc_num);
+  return (uint)ceil((double)num_marked_regions / gc_num);
 }
 
 uint G1Policy::calc_max_old_cset_length() const {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1381,7 +1381,7 @@ size_t G1Policy::allowed_waste_in_collection_set() const {
 }
 
 static uint divide_and_round_up(size_t dividend, size_t divisor) {
-  return (uint)(dividend + divisor - 1) / divisor;
+  return (uint)((dividend + divisor - 1) / divisor);
 }
 
 uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
@@ -1394,7 +1394,7 @@ uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
   // The calculation is based on the number of marked regions we added
   // to the CSet candidates in the first place, not how many remain, so
   // that the result is the same during all mixed GCs that follow a cycle.
-  const size_t gc_num = MAX2(G1MixedGCCountTarget, (size_t)1);
+  const size_t gc_num = MAX2((size_t)G1MixedGCCountTarget, (size_t)1);
   // Round up to be conservative.
   return divide_and_round_up(num_marked_regions, gc_num);
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1380,8 +1380,8 @@ size_t G1Policy::allowed_waste_in_collection_set() const {
   return G1HeapWastePercent * _g1h->capacity() / 100;
 }
 
-static uint divide_and_round_up(size_t dividend, size_t divisor) {
-  return (uint)((dividend + divisor - 1) / divisor);
+static size_t divide_and_round_up(size_t dividend, size_t divisor) {
+  return (dividend + divisor - 1) / divisor;
 }
 
 uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
@@ -1396,7 +1396,7 @@ uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
   // that the result is the same during all mixed GCs that follow a cycle.
   const size_t gc_num = MAX2((size_t)G1MixedGCCountTarget, (size_t)1);
   // Round up to be conservative.
-  return divide_and_round_up(num_marked_regions, gc_num);
+  return (uint)divide_and_round_up(num_marked_regions, gc_num);
 }
 
 uint G1Policy::calc_max_old_cset_length() const {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -487,7 +487,7 @@ uint G1Policy::calculate_desired_eden_length_before_mixed(double base_time_ms,
                                                           uint max_eden_length) const {
   G1CollectionSetCandidates* candidates = _collection_set->candidates();
 
-  uint min_old_regions_end = MIN2(candidates->cur_idx() + calc_min_old_cset_length(candidates),
+  uint min_old_regions_end = MIN2(candidates->cur_idx() + calc_min_old_cset_length(candidates->num_regions()),
                                   candidates->num_regions());
   double predicted_region_evac_time_ms = base_time_ms;
   for (uint i = candidates->cur_idx(); i < min_old_regions_end; i++) {
@@ -1380,7 +1380,11 @@ size_t G1Policy::allowed_waste_in_collection_set() const {
   return G1HeapWastePercent * _g1h->capacity() / 100;
 }
 
-uint G1Policy::calc_min_old_cset_length(G1CollectionSetCandidates* candidates) const {
+static uint divide_and_round_up(size_t dividend, size_t divisor) {
+  return (uint)(dividend + divisor - 1) / divisor;
+}
+
+uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
   // The min old CSet region bound is based on the maximum desired
   // number of mixed GCs after a cycle. I.e., even if some old regions
   // look expensive, we should add them to the CSet anyway to make
@@ -1390,15 +1394,9 @@ uint G1Policy::calc_min_old_cset_length(G1CollectionSetCandidates* candidates) c
   // The calculation is based on the number of marked regions we added
   // to the CSet candidates in the first place, not how many remain, so
   // that the result is the same during all mixed GCs that follow a cycle.
-
-  const size_t region_num = candidates->num_regions();
-  const size_t gc_num = (size_t) MAX2(G1MixedGCCountTarget, (uintx) 1);
-  size_t result = region_num / gc_num;
-  // emulate ceiling
-  if (result * gc_num < region_num) {
-    result += 1;
-  }
-  return (uint) result;
+  const size_t gc_num = MAX2(G1MixedGCCountTarget, (size_t)1);
+  // Round up to be conservative.
+  return divide_and_round_up(num_marked_regions, gc_num);
 }
 
 uint G1Policy::calc_max_old_cset_length() const {
@@ -1433,7 +1431,7 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
 
   double optional_threshold_ms = time_remaining_ms * optional_prediction_fraction();
 
-  const uint min_old_cset_length = calc_min_old_cset_length(candidates);
+  const uint min_old_cset_length = calc_min_old_cset_length(candidates->num_regions());
   const uint max_old_cset_length = MAX2(min_old_cset_length, calc_max_old_cset_length());
   const uint max_optional_regions = max_old_cset_length - min_old_cset_length;
   bool check_time_remaining = use_adaptive_young_list_length();

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1380,7 +1380,7 @@ size_t G1Policy::allowed_waste_in_collection_set() const {
   return G1HeapWastePercent * _g1h->capacity() / 100;
 }
 
-uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
+uint G1Policy::calc_min_old_cset_length(uint num_candidate_regions) const {
   // The min old CSet region bound is based on the maximum desired
   // number of mixed GCs after a cycle. I.e., even if some old regions
   // look expensive, we should add them to the CSet anyway to make
@@ -1392,7 +1392,7 @@ uint G1Policy::calc_min_old_cset_length(uint num_marked_regions) const {
   // that the result is the same during all mixed GCs that follow a cycle.
   const size_t gc_num = MAX2((size_t)G1MixedGCCountTarget, (size_t)1);
   // Round up to be conservative.
-  return (uint)ceil((double)num_marked_regions / gc_num);
+  return (uint)ceil((double)num_candidate_regions / gc_num);
 }
 
 uint G1Policy::calc_max_old_cset_length() const {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -257,8 +257,9 @@ public:
   size_t pending_cards_at_gc_start() const { return _pending_cards_at_gc_start; }
 
   // Calculate the minimum number of old regions we'll add to the CSet
-  // during a mixed GC.
-  uint calc_min_old_cset_length(G1CollectionSetCandidates* candidates) const;
+  // during a single mixed GC given the initial number of regions selected during
+  // marking.
+  uint calc_min_old_cset_length(uint num_marked_regions) const;
 
   // Calculate the maximum number of old regions we'll add to the CSet
   // during a mixed GC.

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -259,7 +259,7 @@ public:
   // Calculate the minimum number of old regions we'll add to the CSet
   // during a single mixed GC given the initial number of regions selected during
   // marking.
-  uint calc_min_old_cset_length(uint num_marked_regions) const;
+  uint calc_min_old_cset_length(uint num_candidate_regions) const;
 
   // Calculate the maximum number of old regions we'll add to the CSet
   // during a mixed GC.


### PR DESCRIPTION
Hi all,

  please review this change that refactors `G1Policy::calc_min_old_cset_length` to take only required parameters and also just use `ceil()` for the calculation. It just does not matter to be clever here imo.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304712](https://bugs.openjdk.org/browse/JDK-8304712): Only pass total number of regions into G1Policy::calc_min_old_cset_length


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [13c093c6](https://git.openjdk.org/jdk/pull/13147/files/13c093c6a1683af189bd1d2a1a3be179a850308d)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [13c093c6](https://git.openjdk.org/jdk/pull/13147/files/13c093c6a1683af189bd1d2a1a3be179a850308d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13147/head:pull/13147` \
`$ git checkout pull/13147`

Update a local copy of the PR: \
`$ git checkout pull/13147` \
`$ git pull https://git.openjdk.org/jdk.git pull/13147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13147`

View PR using the GUI difftool: \
`$ git pr show -t 13147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13147.diff">https://git.openjdk.org/jdk/pull/13147.diff</a>

</details>
