### PR TITLE
8304947: Unnecessary Vector usage in java.awt.MenuBar.shortcuts

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Vector;
@@ -488,14 +489,14 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
     }
 
     synchronized Enumeration<MenuShortcut> shortcuts() {
-        Vector<MenuShortcut> shortcuts = new Vector<>();
+        ArrayList<MenuShortcut> shortcuts = new ArrayList<>();
         int nitems = getItemCount();
         for (int i = 0 ; i < nitems ; i++) {
             MenuItem mi = getItem(i);
-            if (mi instanceof Menu) {
-                Enumeration<MenuShortcut> e = ((Menu)mi).shortcuts();
+            if (mi instanceof Menu menu) {
+                Enumeration<MenuShortcut> e = menu.shortcuts();
                 while (e.hasMoreElements()) {
-                    shortcuts.addElement(e.nextElement());
+                    shortcuts.add(e.nextElement());
                 }
             } else {
                 MenuShortcut ms = mi.getShortcut();
@@ -504,7 +505,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
                 }
             }
         }
-        return shortcuts.elements();
+        return Collections.enumeration(shortcuts);
     }
 
     void deleteShortcut(MenuShortcut s) {

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Vector;
@@ -339,15 +341,15 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
      * @since       1.1
      */
     public synchronized Enumeration<MenuShortcut> shortcuts() {
-        Vector<MenuShortcut> shortcuts = new Vector<>();
+        ArrayList<MenuShortcut> shortcuts = new ArrayList<>();
         int nmenus = getMenuCount();
         for (int i = 0 ; i < nmenus ; i++) {
             Enumeration<MenuShortcut> e = getMenu(i).shortcuts();
             while (e.hasMoreElements()) {
-                shortcuts.addElement(e.nextElement());
+                shortcuts.add(e.nextElement());
             }
         }
-        return shortcuts.elements();
+        return Collections.enumeration(shortcuts);
     }
 
     /**


### PR DESCRIPTION
Method `'java.awt.MenuBar#shortcuts` creates a 'Vector<MenuShortcut>', fills it and then returns its 'Enumeration elements()' as return value.
Instead of usage of legacy synchronized Vector here we can use ArrayList instead. Wrap it in Collections.enumeration to adapt to 'Enumeration' result type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304947](https://bugs.openjdk.org/browse/JDK-8304947): Unnecessary Vector usage in java.awt.MenuBar.shortcuts


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13149/head:pull/13149` \
`$ git checkout pull/13149`

Update a local copy of the PR: \
`$ git checkout pull/13149` \
`$ git pull https://git.openjdk.org/jdk.git pull/13149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13149`

View PR using the GUI difftool: \
`$ git pr show -t 13149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13149.diff">https://git.openjdk.org/jdk/pull/13149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13149#issuecomment-1487511229)