### PR TITLE
4130823: Not painting focus when the radio button has only icon

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonUI.java
@@ -110,8 +110,7 @@ public class WindowsRadioButtonUI extends BasicRadioButtonUI
 
 
     protected void paintFocus(Graphics g, Rectangle textRect, Dimension d){
-        g.setColor(getFocusColor());
-        BasicGraphicsUtils.drawDashedRect(g, textRect.x, textRect.y, textRect.width, textRect.height);
+        //do nothing
     }
 
     // ********************************

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 /*
  * @test
  * @key headful
- * @bug 8216358 8279586
+ * @bug 8216358 8279586 4130823
  * @summary [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"
  * @library ../../regtesthelpers/
  * @build Util
@@ -90,15 +90,26 @@ public class ImageCheckboxTest {
         checkbox.paint(imageFocus.createGraphics());
 
         if (Util.compareBufferedImages(imageFocus, imageNoFocus)) {
-            File folder = new File(laf.getName());
-            if (!folder.exists()) {
-                folder.mkdir();
+            // In windows L&F, checkbox and radiobutton does not have focus rect
+            if (laf.getName().contains("Windows")) {
+                success = true;
+            } else {
+                File folder = new File(laf.getName());
+                if (!folder.exists()) {
+                    folder.mkdir();
+                }
+                ImageIO.write(imageFocus, "png", new File(folder, "/imageFocus.png"));
+                ImageIO.write(imageNoFocus, "png", new File(folder, "/imageNoFocus.png"));
+                System.err.println(laf.getName() + ": Changing of focus is not visualized");
+                success = false;
+	    }
+        } else {
+            // In windows L&F, focus should not be visualized
+            if (laf.getName().contains("Windows")) {
+                System.err.println(laf.getName() + ": Changing of focus is visualized");
+                success = false;
             }
-            ImageIO.write(imageFocus, "png", new File(folder, "/imageFocus.png"));
-            ImageIO.write(imageNoFocus, "png", new File(folder, "/imageNoFocus.png"));
-            System.err.println(laf.getName() + ": Changing of focus is not visualized");
-            success = false;
-        }
+	}
 
         checkbox.setFocusPainted(false);
         checkbox.paint(imageFocusNotPainted.createGraphics());

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -102,14 +102,14 @@ public class ImageCheckboxTest {
                 ImageIO.write(imageNoFocus, "png", new File(folder, "/imageNoFocus.png"));
                 System.err.println(laf.getName() + ": Changing of focus is not visualized");
                 success = false;
-	    }
+            }
         } else {
             // In windows L&F, focus should not be visualized
             if (laf.getName().contains("Windows")) {
                 System.err.println(laf.getName() + ": Changing of focus is visualized");
                 success = false;
             }
-	}
+        }
 
         checkbox.setFocusPainted(false);
         checkbox.paint(imageFocusNotPainted.createGraphics());


### PR DESCRIPTION
Although the issue here is asking about not painting focus when it has icon, however it seems Windows does not draw focus rect for radiobutton at all so instead of closing this as "Not an issue" it is made to not draw the focusrect even when there is text

This is what can be seen in windows system setting

![systemsetting-nofocusrect](https://user-images.githubusercontent.com/43534309/227118784-97d6231d-beb4-4fc9-b760-c47e95817592.png)

and notepad

![notepad-nofocus](https://user-images.githubusercontent.com/43534309/227118824-9d02329f-396d-43b3-aa68-927009a1bd57.png)

We have currently

![beforefix-dashrect](https://user-images.githubusercontent.com/43534309/227119231-19feb2fd-203b-48a2-9e59-62ab63b51ccc.png)


and after fix

![afterfix-nodashrect](https://user-images.githubusercontent.com/43534309/227119263-09be94e2-c6cc-4d7b-9449-a860aabca572.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4130823](https://bugs.openjdk.org/browse/JDK-4130823): Not painting focus when the radio button has only icon


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [4fbd354f](https://git.openjdk.org/jdk/pull/13153/files/4fbd354f7360141df160993b64489448df620ab2)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [4fbd354f](https://git.openjdk.org/jdk/pull/13153/files/4fbd354f7360141df160993b64489448df620ab2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13153/head:pull/13153` \
`$ git checkout pull/13153`

Update a local copy of the PR: \
`$ git checkout pull/13153` \
`$ git pull https://git.openjdk.org/jdk.git pull/13153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13153`

View PR using the GUI difftool: \
`$ git pr show -t 13153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13153.diff">https://git.openjdk.org/jdk/pull/13153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13153#issuecomment-1480661216)