### PR TITLE
8304802

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -113,7 +113,7 @@
           "of the optimal occupancy to start marking.")                     \
           range(1, max_intx)                                                \
                                                                             \
-  product(uintx, G1ConfidencePercent, 50,                                   \
+  product(uint, G1ConfidencePercent, 50,                                    \
           "Confidence level for MMU/pause predictions")                     \
           range(0, 100)                                                     \
                                                                             \
@@ -319,11 +319,6 @@
           "The percentage of free card set memory that G1 should keep as "  \
           "percentage of the currently used memory.")                       \
           range(0.0, 1.0)                                                   \
-                                                                            \
-  product(bool, G1UsePreventiveGC, false, DIAGNOSTIC,                       \
-          "Allows collections to be triggered proactively based on the      \
-           number of free regions and the expected survival rates in each   \
-           section of the heap.")                                           \
                                                                             \
   product(uint, G1RestoreRetainedRegionChunksPerWorker, 16, DIAGNOSTIC,     \
           "The number of chunks assigned per worker thread for "            \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -558,8 +558,9 @@ static SpecialFlag const special_jvm_flags[] = {
   { "G1UseAdaptiveConcRefinement",  JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
   { "G1ConcRefinementServiceIntervalMillis", JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
 
-  { "G1ConcRSLogCacheSize",    JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
-  { "G1ConcRSHotCardLimit",   JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
+  { "G1UsePreventiveGC",            JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::jdk(22) },
+  { "G1ConcRSLogCacheSize",         JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
+  { "G1ConcRSHotCardLimit",         JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
 
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },


### PR DESCRIPTION
Hi all,

  please review this change that puts the `G1UsePreventiveGC` into the argument obsoletion table so that the appropriate warning is printed when starting the VM with that option. Functionality has already been removed, and CSR request approved with [JDK-8297639](https://bugs.openjdk.org/browse/JDK-8297639).

Testing: local compilation, manual testing that the obsoletion warning is printed on the command line.

Thanks,
  Thomas