### PR TITLE
7026262: HttpServer: improve handling of finished HTTP exchanges

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package sun.net.httpserver;
 
 import java.io.*;
 import java.net.*;
+import java.util.Objects;
+
 import com.sun.net.httpserver.*;
 import com.sun.net.httpserver.spi.*;
 
@@ -77,6 +79,10 @@ class ChunkedOutputStream extends FilterOutputStream
     }
 
     public void write (byte[]b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return;
+        }
         if (closed) {
             throw new StreamClosedException ();
         }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ExchangeImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ExchangeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,9 +282,7 @@ class ExchangeImpl {
         sentHeaders = true;
         logger.log(Level.TRACE, "Sent headers: noContentToSend=" + noContentToSend);
         if (noContentToSend) {
-            WriteFinishedEvent e = new WriteFinishedEvent (this);
-            server.addEvent (e);
-            closed = true;
+            close();
         }
         server.logReply (rCode, req.requestLine(), null);
     }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/FixedLengthOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/FixedLengthOutputStream.java
@@ -27,6 +27,8 @@ package sun.net.httpserver;
 
 import java.io.*;
 import java.net.*;
+import java.util.Objects;
+
 import com.sun.net.httpserver.*;
 import com.sun.net.httpserver.spi.*;
 
@@ -42,7 +44,6 @@ class FixedLengthOutputStream extends FilterOutputStream
 {
     private long remaining;
     private boolean closed = false;
-    private final boolean zerolength;
     ExchangeImpl t;
 
     FixedLengthOutputStream (ExchangeImpl t, OutputStream src, long len) {
@@ -52,7 +53,6 @@ class FixedLengthOutputStream extends FilterOutputStream
         }
         this.t = t;
         this.remaining = len;
-        zerolength = (len == 0);
     }
 
     public void write (int b) throws IOException {
@@ -67,6 +67,10 @@ class FixedLengthOutputStream extends FilterOutputStream
     }
 
     public void write (byte[]b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return;
+        }
         if (closed) {
             throw new IOException ("stream closed");
         }
@@ -83,10 +87,6 @@ class FixedLengthOutputStream extends FilterOutputStream
             return;
         }
         closed = true;
-        if (zerolength) {
-            // WriteFinishedEvent was sent already; nothing to do
-            return;
-        }
         if (remaining > 0) {
             t.close();
             throw new IOException ("insufficient bytes written to stream");

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -878,7 +878,6 @@ class ServerImpl {
             sendReply (
                 code, true, "<h1>"+code+Code.msg(code)+"</h1>"+message
             );
-            closeConnection(connection);
         }
 
         void sendReply (

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -713,7 +713,14 @@ class ServerImpl {
                     return;
                 }
                 String uriStr = requestLine.substring (start, space);
-                URI uri = new URI (uriStr);
+                URI uri;
+                try {
+                    uri = new URI (uriStr);
+                } catch (URISyntaxException e3) {
+                    reject(Code.HTTP_BAD_REQUEST,
+                            requestLine, "URISyntaxException thrown");
+                    return;
+                }
                 start = space+1;
                 String version = requestLine.substring (start);
                 Headers headers = req.headers();
@@ -749,7 +756,13 @@ class ServerImpl {
                 } else {
                     headerValue = headers.getFirst("Content-Length");
                     if (headerValue != null) {
-                        clen = Long.parseLong(headerValue);
+                        try {
+                            clen = Long.parseLong(headerValue);
+                        } catch (NumberFormatException e2) {
+                            reject(Code.HTTP_BAD_REQUEST,
+                                    requestLine, "NumberFormatException thrown");
+                            return;
+                        }
                         if (clen < 0) {
                             reject(Code.HTTP_BAD_REQUEST, requestLine,
                                     "Illegal Content-Length value");
@@ -834,20 +847,11 @@ class ServerImpl {
                     uc.doFilter (new HttpExchangeImpl (tx));
                 }
 
-            } catch (IOException e1) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (1)", e1);
-                closeConnection(connection);
-            } catch (NumberFormatException e2) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (2)", e2);
-                reject (Code.HTTP_BAD_REQUEST,
-                        requestLine, "NumberFormatException thrown");
-            } catch (URISyntaxException e3) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (3)", e3);
-                reject (Code.HTTP_BAD_REQUEST,
-                        requestLine, "URISyntaxException thrown");
-            } catch (Exception e4) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (4)", e4);
-                closeConnection(connection);
+            } catch (Exception e) {
+                logger.log (Level.TRACE, "ServerImpl.Exchange", e);
+                if (tx == null || !tx.writefinished) {
+                    closeConnection(connection);
+                }
             } catch (Throwable t) {
                 logger.log(Level.TRACE, "ServerImpl.Exchange (5)", t);
                 throw t;
@@ -872,7 +876,7 @@ class ServerImpl {
             rejected = true;
             logReply (code, requestStr, message);
             sendReply (
-                code, false, "<h1>"+code+Code.msg(code)+"</h1>"+message
+                code, true, "<h1>"+code+Code.msg(code)+"</h1>"+message
             );
             closeConnection(connection);
         }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/UndefLengthOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/UndefLengthOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package sun.net.httpserver;
 
 import java.io.*;
 import java.net.*;
+import java.util.Objects;
+
 import com.sun.net.httpserver.*;
 import com.sun.net.httpserver.spi.*;
 
@@ -55,6 +57,10 @@ class UndefLengthOutputStream extends FilterOutputStream
     }
 
     public void write (byte[]b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return;
+        }
         if (closed) {
             throw new IOException ("stream closed");
         }

--- a/test/jdk/com/sun/net/httpserver/bugs/ExceptionKeepAlive.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/ExceptionKeepAlive.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8219083
+ * @summary Exceptions thrown from HttpHandler.handle should not close connection
+ *          if response is completed
+ * @library /test/lib
+ * @run junit ExceptionKeepAlive
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExceptionKeepAlive
+{
+
+    public static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
+
+    @Test
+    void test() throws IOException, InterruptedException {
+        HttpServer httpServer = startHttpServer();
+        int port = httpServer.getAddress().getPort();
+        try {
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .path("/firstCall")
+                .toURLUnchecked();
+            HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            int responseCode = uc.getResponseCode();
+            assertEquals(200, responseCode, "First request should succeed");
+
+            URL url2 = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/secondCall")
+                    .toURLUnchecked();
+            HttpURLConnection uc2 = (HttpURLConnection)url2.openConnection(Proxy.NO_PROXY);
+            responseCode = uc2.getResponseCode();
+            assertEquals(200, responseCode, "Second request should reuse connection");
+        } finally {
+            httpServer.stop(0);
+        }
+    }
+
+    /**
+     * Http Server
+     */
+    HttpServer startHttpServer() throws IOException {
+        Handler outHandler = new StreamHandler(System.out,
+                                 new SimpleFormatter());
+        outHandler.setLevel(Level.FINEST);
+        LOGGER.setLevel(Level.FINEST);
+        LOGGER.addHandler(outHandler);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+        httpServer.createContext("/", new MyHandler());
+        httpServer.start();
+        return httpServer;
+    }
+
+    class MyHandler implements HttpHandler {
+
+        volatile int port1;
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            String path = t.getRequestURI().getPath();
+            if (path.equals("/firstCall")) {
+                port1 = t.getRemoteAddress().getPort();
+                System.out.println("First connection on client port = " + port1);
+
+                // close request to enable reuse
+                t.getRequestBody().close();
+                // send response
+                t.sendResponseHeaders(200, -1);
+                // response is completed now; throw exception
+                throw new NumberFormatException();
+                // the connection should still be reusable
+            } else if (path.equals("/secondCall")) {
+                int port2 = t.getRemoteAddress().getPort();
+                System.out.println("Second connection on client port = " + port2);
+
+                if (port1 == port2) {
+                    t.sendResponseHeaders(200, -1);
+                } else {
+                    t.sendResponseHeaders(500, -1);
+                }
+            }
+            t.close();
+        }
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/bugs/ExceptionKeepAlive.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/ExceptionKeepAlive.java
@@ -110,8 +110,6 @@ public class ExceptionKeepAlive
                 port1 = t.getRemoteAddress().getPort();
                 System.out.println("First connection on client port = " + port1);
 
-                // close request to enable reuse
-                t.getRequestBody().close();
                 // send response
                 t.sendResponseHeaders(200, -1);
                 // response is completed now; throw exception

--- a/test/jdk/com/sun/net/httpserver/bugs/ZeroLengthOutputStream.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/ZeroLengthOutputStream.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8219083
+ * @summary HttpExchange.getResponseBody write and close should not throw
+ *          even when response length is zero
+ * @library /test/lib
+ * @run junit ZeroLengthOutputStream
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ZeroLengthOutputStream
+{
+
+    public static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
+    public volatile boolean closed;
+    public CountDownLatch cdl = new CountDownLatch(1);
+
+    @Test
+    void test() throws IOException, InterruptedException {
+        HttpServer httpServer = startHttpServer();
+        int port = httpServer.getAddress().getPort();
+        try {
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .path("/flis/")
+                .toURLUnchecked();
+            HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            uc.getResponseCode();
+            cdl.await();
+            assertTrue(closed, "OutputStream close did not complete");
+        } finally {
+            httpServer.stop(0);
+        }
+    }
+
+    /**
+     * Http Server
+     */
+    HttpServer startHttpServer() throws IOException {
+        Handler outHandler = new StreamHandler(System.out,
+                                 new SimpleFormatter());
+        outHandler.setLevel(Level.FINEST);
+        LOGGER.setLevel(Level.FINEST);
+        LOGGER.addHandler(outHandler);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+        httpServer.createContext("/flis/", new MyHandler());
+        httpServer.start();
+        return httpServer;
+    }
+
+    class MyHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            try {
+                OutputStream os = t.getResponseBody();
+                t.sendResponseHeaders(200, -1);
+                os.write(new byte[0]);
+                os.close();
+                System.out.println("Output stream closed");
+                closed = true;
+            } finally {
+                cdl.countDown();
+            }
+        }
+    }
+}

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,7 +169,7 @@ class SimpleHttpTransactionHandler implements HttpHandler
         try {
             String path = trans.getRequestURI().getPath();
             if (path.equals("/firstCall")) {
-                port1 = trans.getLocalAddress().getPort();
+                port1 = trans.getRemoteAddress().getPort();
                 System.out.println("First connection on client port = " + port1);
 
                 byte[] responseBody = new byte[RESPONSE_DATA_LENGTH];
@@ -180,7 +180,7 @@ class SimpleHttpTransactionHandler implements HttpHandler
                     pw.print(responseBody);
                 }
             } else if (path.equals("/secondCall")) {
-                int port2 = trans.getLocalAddress().getPort();
+                int port2 = trans.getRemoteAddress().getPort();
                 System.out.println("Second connection on client port = " + port2);
 
                 if (port1 != port2)


### PR DESCRIPTION
This patch fixes the following issues with HttpHandler exception handling:
- The connection is no longer closed if an exception is thrown after the response is completed. As soon as the response is completed, the connection is added back to the pool, ready for reuse. Closing the connection would race with the subsequent handler.
- The stream returned by `getResponseBody` is now usable even if the response has zero-length body. Writing any data to the stream will still fail, but zero-length writes and closing the stream will now succeed.
- `ServerImpl.Exchange.reject` now sends a `Connection: close` header in addition to closing the connection

The test `B8293562` had to be adjusted to avoid `Connection: close`.
Additionally, while I was looking for a good test to copy from, I found and fixed a bug in test `B5045306`.

The new tests are passing with this patch, failing without it. Tier 1-3 clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7026262](https://bugs.openjdk.org/browse/JDK-7026262): HttpServer: improve handling of finished HTTP exchanges


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13157/head:pull/13157` \
`$ git checkout pull/13157`

Update a local copy of the PR: \
`$ git checkout pull/13157` \
`$ git pull https://git.openjdk.org/jdk.git pull/13157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13157`

View PR using the GUI difftool: \
`$ git pr show -t 13157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13157.diff">https://git.openjdk.org/jdk/pull/13157.diff</a>

</details>
