### PR TITLE
JDK-8304820: Statically allocate ObjectSynchronizer mutexes

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -249,10 +249,8 @@ static constexpr size_t inflation_lock_count() {
   return 256;
 }
 
-// Static storage for an array of PlatformMutex. Each entry is aligned to `alignas(PlatformMutex)`
-// by property of the storage itself being aligned to that requirement and each entry storage being
-// `sizeof(PlatformMutex)` aligned up to `alignof(PlatformMutex)`.
-alignas(PlatformMutex) static uint8_t _inflation_locks[inflation_lock_count()][align_up(sizeof(PlatformMutex), alignof(PlatformMutex))];
+// Static storage for an array of PlatformMutex.
+alignas(PlatformMutex) static uint8_t _inflation_locks[inflation_lock_count()][sizeof(PlatformMutex)];
 
 static inline PlatformMutex* inflation_lock(size_t index) {
   return reinterpret_cast<PlatformMutex*>(_inflation_locks[index]);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -740,7 +740,7 @@ static markWord read_stable_mark(oop obj) {
 
         // Index into the lock array based on the current object address.
         static_assert(is_power_of_2(ARRAY_SIZE(gInflationLocks)), "must be");
-        size_t ix = (cast_from_oop<intptr_t>(obj) >> 5) & (ARRAY_SIZE(gInflationLocks)-1);
+        size_t ix = (cast_from_oop<intptr_t>(obj) >> 5) & (ARRAY_SIZE(gInflationLocks) - 1);
         int YieldThenBlock = 0;
         assert(ix < ARRAY_SIZE(gInflationLocks), "invariant");
         gInflationLocks[ix].lock();

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -245,11 +245,22 @@ int dtrace_waited_probe(ObjectMonitor* monitor, Handle obj, JavaThread* thr) {
   return 0;
 }
 
-static PlatformMutex gInflationLocks[256];
+static constexpr size_t inflation_lock_count() {
+  return 256;
+}
+
+// Static storage for an array of PlatformMutex. Each entry is aligned to `alignas(PlatformMutex)`
+// by property of the storage itself being aligned to that requirement and each entry storage being
+// `sizeof(PlatformMutex)` aligned up to `alignof(PlatformMutex)`.
+alignas(PlatformMutex) static uint8_t _inflation_locks[inflation_lock_count()][align_up(sizeof(PlatformMutex), alignof(PlatformMutex))];
+
+static inline PlatformMutex* inflation_lock(size_t index) {
+  return reinterpret_cast<PlatformMutex*>(_inflation_locks[index]);
+}
 
 void ObjectSynchronizer::initialize() {
-  for (size_t i = 0; i < ARRAY_SIZE(gInflationLocks); i++) {
-    ::new(static_cast<void*>(&gInflationLocks[i])) PlatformMutex();
+  for (size_t i = 0; i < inflation_lock_count(); i++) {
+    ::new(static_cast<void*>(inflation_lock(i))) PlatformMutex();
   }
   // Start the ceiling with the estimate for one thread.
   set_in_use_list_ceiling(AvgMonitorsPerThreadEstimate);
@@ -739,11 +750,11 @@ static markWord read_stable_mark(oop obj) {
         // then for each thread on the list, set the flag and unpark() the thread.
 
         // Index into the lock array based on the current object address.
-        static_assert(is_power_of_2(ARRAY_SIZE(gInflationLocks)), "must be");
-        size_t ix = (cast_from_oop<intptr_t>(obj) >> 5) & (ARRAY_SIZE(gInflationLocks) - 1);
+        static_assert(is_power_of_2(inflation_lock_count()), "must be");
+        size_t ix = (cast_from_oop<intptr_t>(obj) >> 5) & (inflation_lock_count() - 1);
         int YieldThenBlock = 0;
-        assert(ix < ARRAY_SIZE(gInflationLocks), "invariant");
-        gInflationLocks[ix].lock();
+        assert(ix < inflation_lock_count(), "invariant");
+        inflation_lock(ix)->lock();
         while (obj->mark_acquire() == markWord::INFLATING()) {
           // Beware: naked_yield() is advisory and has almost no effect on some platforms
           // so we periodically call current->_ParkEvent->park(1).
@@ -754,7 +765,7 @@ static markWord read_stable_mark(oop obj) {
             os::naked_yield();
           }
         }
-        gInflationLocks[ix].unlock();
+        inflation_lock(ix)->unlock();
       }
     } else {
       SpinPause();       // SMP-polite spinning


### PR DESCRIPTION
Similar to https://git.openjdk.org/jdk/pull/13143, statically allocate mutexes which live for the lifetime of the process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304820](https://bugs.openjdk.org/browse/JDK-8304820): Statically allocate ObjectSynchronizer mutexes


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d6afef79](https://git.openjdk.org/jdk/pull/13160/files/d6afef796107a09a9cbc077f751e6860b8ddb071)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13160/head:pull/13160` \
`$ git checkout pull/13160`

Update a local copy of the PR: \
`$ git checkout pull/13160` \
`$ git pull https://git.openjdk.org/jdk.git pull/13160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13160`

View PR using the GUI difftool: \
`$ git pr show -t 13160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13160.diff">https://git.openjdk.org/jdk/pull/13160.diff</a>

</details>
