### PR TITLE
JDK-8304815: Use NMT for more precise hs_err location printing

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1202,6 +1202,11 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
   }
 #endif
 
+  // Still nothing? If NMT is enabled, we can ask what it thinks...
+  if (MemTracker::print_containing_region(addr, st)) {
+    return;
+  }
+
   // Try an OS specific find
   if (os::find(addr, st)) {
     return;

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -139,6 +139,13 @@ public:
   inline void mark_block_as_dead();
   inline void revive();
 
+
+  bool is_dead() const { return _canary == _header_canary_dead_mark; }
+  bool is_life() const { return _canary == _header_canary_life_mark; }
+
+  // Used for debugging purposes only. Check header if it could constitute a valid (life or dead) header.
+  inline bool looks_valid() const;
+
   // If block is broken, fill in a short descriptive text in out,
   // an option pointer to the corruption in p_corruption, and return false.
   // Return true if block is fine.

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -96,11 +96,11 @@ class MallocHeader {
   const uint8_t _unused;
   uint16_t _canary;
 
-  static const uint16_t _header_canary_life_mark = 0xE99E;
+  static const uint16_t _header_canary_live_mark = 0xE99E;
   static const uint16_t _header_canary_dead_mark = 0xD99D;
-  static const uint16_t _footer_canary_life_mark = 0xE88E;
+  static const uint16_t _footer_canary_live_mark = 0xE88E;
   static const uint16_t _footer_canary_dead_mark = 0xD88D;
-  NOT_LP64(static const uint32_t _header_alt_canary_life_mark = 0xE99EE99E;)
+  NOT_LP64(static const uint32_t _header_alt_canary_live_mark = 0xE99EE99E;)
   NOT_LP64(static const uint32_t _header_alt_canary_dead_mark = 0xD88DD88D;)
 
   // We discount sizes larger than these
@@ -141,9 +141,9 @@ public:
 
 
   bool is_dead() const { return _canary == _header_canary_dead_mark; }
-  bool is_live() const { return _canary == _header_canary_life_mark; }
+  bool is_live() const { return _canary == _header_canary_live_mark; }
 
-  // Used for debugging purposes only. Check header if it could constitute a valid (life or dead) header.
+  // Used for debugging purposes only. Check header if it could constitute a valid (live or dead) header.
   inline bool looks_valid() const;
 
   // If block is broken, fill in a short descriptive text in out,

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -141,7 +141,7 @@ public:
 
 
   bool is_dead() const { return _canary == _header_canary_dead_mark; }
-  bool is_life() const { return _canary == _header_canary_life_mark; }
+  bool is_live() const { return _canary == _header_canary_life_mark; }
 
   // Used for debugging purposes only. Check header if it could constitute a valid (life or dead) header.
   inline bool looks_valid() const;

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -116,6 +116,16 @@ inline const MallocHeader* MallocHeader::resolve_checked(const void* memblock) {
   return MallocHeader::resolve_checked_impl<const void*, const MallocHeader*>(memblock);
 }
 
+
+// Used for debugging purposes only. Check header if it could constitute a valid (life or dead) header.
+inline bool MallocHeader::looks_valid() const {
+  // Note: we define these restrictions lose enough to also catch moderately corrupted blocks.
+  // E.g. we don't check footer canary.
+  return ( (_canary == _header_canary_life_mark NOT_LP64(&& _alt_canary == _header_alt_canary_life_mark)) ||
+           (_canary == _header_canary_dead_mark NOT_LP64(&& _alt_canary == _header_alt_canary_dead_mark)) ) &&
+           _size > 0 && _size < max_reasonable_malloc_size;
+}
+
 inline bool MallocHeader::check_block_integrity(char* msg, size_t msglen, address* p_corruption) const {
   // Note: if you modify the error messages here, make sure you
   // adapt the associated gtests too.

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -119,7 +119,7 @@ inline const MallocHeader* MallocHeader::resolve_checked(const void* memblock) {
 
 // Used for debugging purposes only. Check header if it could constitute a valid (life or dead) header.
 inline bool MallocHeader::looks_valid() const {
-  // Note: we define these restrictions lose enough to also catch moderately corrupted blocks.
+  // Note: we define these restrictions loose enough to also catch moderately corrupted blocks.
   // E.g. we don't check footer canary.
   return ( (_canary == _header_canary_life_mark NOT_LP64(&& _alt_canary == _header_alt_canary_life_mark)) ||
            (_canary == _header_canary_dead_mark NOT_LP64(&& _alt_canary == _header_alt_canary_dead_mark)) ) &&

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -36,22 +36,22 @@
 
 inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker)
   : _size(size), _mst_marker(mst_marker), _flags(flags),
-    _unused(0), _canary(_header_canary_life_mark)
+    _unused(0), _canary(_header_canary_live_mark)
 {
   assert(size < max_reasonable_malloc_size, "Too large allocation size?");
   // On 32-bit we have some bits more, use them for a second canary
   // guarding the start of the header.
-  NOT_LP64(_alt_canary = _header_alt_canary_life_mark;)
-  set_footer(_footer_canary_life_mark); // set after initializing _size
+  NOT_LP64(_alt_canary = _header_alt_canary_live_mark;)
+  set_footer(_footer_canary_live_mark); // set after initializing _size
 }
 
 inline void MallocHeader::revive() {
   assert(_canary == _header_canary_dead_mark, "must be dead");
   assert(get_footer() == _footer_canary_dead_mark, "must be dead");
   NOT_LP64(assert(_alt_canary == _header_alt_canary_dead_mark, "must be dead"));
-  _canary = _header_canary_life_mark;
-  NOT_LP64(_alt_canary = _header_alt_canary_life_mark);
-  set_footer(_footer_canary_life_mark);
+  _canary = _header_canary_live_mark;
+  NOT_LP64(_alt_canary = _header_alt_canary_live_mark);
+  set_footer(_footer_canary_live_mark);
 }
 
 // The effects of this method must be reversible with MallocHeader::revive()
@@ -117,11 +117,11 @@ inline const MallocHeader* MallocHeader::resolve_checked(const void* memblock) {
 }
 
 
-// Used for debugging purposes only. Check header if it could constitute a valid (life or dead) header.
+// Used for debugging purposes only. Check header if it could constitute a valid (live or dead) header.
 inline bool MallocHeader::looks_valid() const {
   // Note: we define these restrictions loose enough to also catch moderately corrupted blocks.
   // E.g. we don't check footer canary.
-  return ( (_canary == _header_canary_life_mark NOT_LP64(&& _alt_canary == _header_alt_canary_life_mark)) ||
+  return ( (_canary == _header_canary_live_mark NOT_LP64(&& _alt_canary == _header_alt_canary_live_mark)) ||
            (_canary == _header_canary_dead_mark NOT_LP64(&& _alt_canary == _header_alt_canary_dead_mark)) ) &&
            _size > 0 && _size < max_reasonable_malloc_size;
 }
@@ -131,7 +131,7 @@ inline bool MallocHeader::check_block_integrity(char* msg, size_t msglen, addres
   // adapt the associated gtests too.
 
   // Check header canary
-  if (_canary != _header_canary_life_mark) {
+  if (_canary != _header_canary_live_mark) {
     *p_corruption = (address)this;
     jio_snprintf(msg, msglen, "header canary broken");
     return false;
@@ -139,7 +139,7 @@ inline bool MallocHeader::check_block_integrity(char* msg, size_t msglen, addres
 
 #ifndef _LP64
   // On 32-bit we have a second canary, check that one too.
-  if (_alt_canary != _header_alt_canary_life_mark) {
+  if (_alt_canary != _header_alt_canary_live_mark) {
     *p_corruption = (address)this;
     jio_snprintf(msg, msglen, "header canary broken");
     return false;
@@ -154,7 +154,7 @@ inline bool MallocHeader::check_block_integrity(char* msg, size_t msglen, addres
   }
 
   // Check footer canary
-  if (get_footer() != _footer_canary_life_mark) {
+  if (get_footer() != _footer_canary_live_mark) {
     *p_corruption = footer_address();
     jio_snprintf(msg, msglen, "footer canary broken at " PTR_FORMAT " (buffer overflow?)",
                  p2i(footer_address()));

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -204,10 +204,10 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
 
   // Carefully feel your way upwards and try to find a malloc header. Then check if
   // we are within the block.
-  // We give preference to found life blocks; but if no life block had been found,
+  // We give preference to found live blocks; but if no live block had been found,
   // but the pointer points into remnants of a dead block, print that instead.
   const MallocHeader* likely_dead_block = nullptr;
-  const MallocHeader* likely_life_block = nullptr;
+  const MallocHeader* likely_live_block = nullptr;
   {
     const MallocHeader* candidate = (const MallocHeader*)(align_down(addr, 16));
     const MallocHeader* const end = candidate - 0x1001; // stop searching after 4k
@@ -232,11 +232,11 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
       const address end_payload_plus_fudge = end_payload + fudge;
       if (addr >= start_block && addr < end_payload_plus_fudge) {
         // We found a block the pointer is pointing into, or almost into.
-        // If its a life block, we have our info. If its a dead block, we still
-        // may be within the borders of a larger life block we have not found yet -
+        // If its a live block, we have our info. If its a dead block, we still
+        // may be within the borders of a larger live block we have not found yet -
         // continue search.
         if (candidate->is_live()) {
-          likely_life_block = candidate;
+          likely_live_block = candidate;
           break;
         } else {
           likely_dead_block = candidate;
@@ -247,7 +247,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
   }
 
   // If we've found a reasonable candidate. Print the info.
-  const MallocHeader* block = likely_life_block != nullptr ? likely_life_block : likely_dead_block;
+  const MallocHeader* block = likely_live_block != nullptr ? likely_live_block : likely_dead_block;
   if (block != nullptr) {
     const char* where = nullptr;
     const address start_block = (address)block;

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -230,7 +230,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
         }
         st->print_cr(PTR_FORMAT " %s %s malloced block starting at " PTR_FORMAT ", size " SIZE_FORMAT ", tag %s",
                   p2i(p), where,
-                  (candidate->is_dead() ? "dead" : "life"),
+                  (candidate->is_dead() ? "dead" : "live"),
                   p2i(candidate + 1), // lets print the payload start, not the header
                   candidate->size(), NMTUtil::flag_to_enum_name(candidate->flags()));
         if (MemTracker::tracking_level() == NMT_detail) {

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -243,9 +243,9 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
         return true;
         break;
       } else {
-        // We continue search even if we found a header but were outside of it if the header was dead since
-        // its area may be reused by another, larger block further down.
-        if (candidate->is_life()) {
+        // Break if we found a live header but the pointer had not been nearby. If this was a dead header, it may be
+        // a remnant from an older freed block, so continue searching.
+        if (candidate->is_live()) {
           return false;
         }
       }

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,7 +231,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
       const address end_payload = start_payload + candidate->size();
       const address end_payload_plus_fudge = end_payload + fudge;
       if (addr >= start_block && addr < end_payload_plus_fudge) {
-        // We found a life block the pointer is pointing into or very nearby.
+        // We found a block the pointer is pointing into, or almost into.
         // If its a life block, we have our info. If its a dead block, we still
         // may be within the borders of a larger life block we have not found yet -
         // continue search.

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -308,8 +308,8 @@ class MallocTracker : AllStatic {
   // under category f would hit either the global limit or the limit for category f.
   static inline bool check_exceeds_limit(size_t s, MEMFLAGS f);
 
-  // Given a pointer, if it seems to point to the start of a valid malloced block,
-  // print the block. Note that since there is very low risk of memory looking
+  // Given a pointer, look for the containing malloc block.
+  // Print the block. Note that since there is very low risk of memory looking
   // accidentally like a valid malloc block header (canaries and all) this is not
   // totally failproof. Only use this during debugging or when you can afford
   // signals popping up, e.g. when writing an hs_err file.

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -132,6 +132,14 @@ void MemTracker::final_report(outputStream* output) {
   }
 }
 
+// Given an unknown pointer, check if it points into a known region; print region if found
+// and return true; false if not found.
+bool MemTracker::print_containing_region(const void* p, outputStream* out) {
+  return enabled() &&
+      (MallocTracker::print_pointer_information(p, out) ||
+       VirtualMemoryTracker::print_containing_region(p, out));
+}
+
 void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
  assert(output != nullptr, "No output stream");
   MemBaseline baseline;

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -234,6 +234,10 @@ class MemTracker : AllStatic {
   // under category f would hit either the global limit or the limit for category f.
   static inline bool check_exceeds_limit(size_t s, MEMFLAGS f);
 
+  // Given an unknown pointer, check if it points into a known region; print region if found
+  // and return true; false if not found.
+  static bool print_containing_region(const void* p, outputStream* out);
+
  private:
   static void report(bool summary_only, outputStream* output, size_t scale);
 

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -679,8 +679,8 @@ public:
 
   bool do_allocation_site(const ReservedMemoryRegion* rgn) {
     if (rgn->contain_address(_p)) {
-      _st->print_cr(PTR_FORMAT " in mmap'd memory region [" PTR_FORMAT " - " PTR_FORMAT "] by %s",
-        p2i(_p), p2i(rgn->base()), p2i(rgn->base() + rgn->size()), rgn->flag_name());
+      _st->print_cr(PTR_FORMAT " in mmap'd memory region [" PTR_FORMAT " - " PTR_FORMAT "], tag %s",
+        p2i(_p), p2i(rgn->base()), p2i(rgn->base() + rgn->size()), NMTUtil::flag_to_enum_name(rgn->flag()));
       if (MemTracker::tracking_level() == NMT_detail) {
         rgn->call_stack()->print_on(_st);
         _st->cr();

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -393,15 +393,8 @@ extern "C" JNIEXPORT void pp(void* p) {
     // catch the signal and disable the pp() command for further use.
     // In order to avoid that, switch off SIGSEGV handling with "handle SIGSEGV nostop" before
     // invoking pp()
-    if (MemTracker::enabled()) {
-      // Does it point into a known mmapped region?
-      if (VirtualMemoryTracker::print_containing_region(p, tty)) {
-        return;
-      }
-      // Does it look like the start of a malloced block?
-      if (MallocTracker::print_pointer_information(p, tty)) {
-        return;
-      }
+    if (MemTracker::print_containing_region(p, tty)) {
+      return;
     }
     tty->print_cr(PTR_FORMAT, p2i(p));
   }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -33,6 +33,7 @@
 #include "gc/shared/gcLogPrecious.hpp"
 #include "jvm.h"
 #include "logging/logConfiguration.hpp"
+#include "memory/allocation.hpp"
 #include "memory/metaspace.hpp"
 #include "memory/metaspaceUtils.hpp"
 #include "memory/resourceArea.inline.hpp"
@@ -1886,6 +1887,10 @@ void VMError::controlled_crash(int how) {
         ThreadsListHandle tlh2;
         fatal("Force crash with a nested ThreadsListHandle.");
       }
+    }
+    case 18: {
+      char* c = NEW_C_HEAP_ARRAY(char, 100, mtTest);
+      fatal("test " PTR_FORMAT, p2i(c));
     }
     default:
       // If another number is given, give a generic crash.

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1888,10 +1888,6 @@ void VMError::controlled_crash(int how) {
         fatal("Force crash with a nested ThreadsListHandle.");
       }
     }
-    case 18: {
-      char* c = NEW_C_HEAP_ARRAY(char, 100, mtTest);
-      fatal("test " PTR_FORMAT, p2i(c));
-    }
     default:
       // If another number is given, give a generic crash.
       fatal("Crashing with number %d", how);

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/os.hpp"
+#include "services/memTracker.hpp"
+#include "unittest.hpp"
+
+//#define LOG_PLEASE
+#include "testutils.hpp"
+
+using ::testing::HasSubstr;
+
+static void test_pointer(const void* p, bool expected_return_code, const char* expected_message) {
+  stringStream ss;
+  const bool b = MemTracker::print_containing_region(p, &ss);
+  LOG_HERE("MemTracker::print_containing_region(" PTR_FORMAT ") yielded: %d \"%s\"", p2i(p), b, ss.base());
+  EXPECT_EQ(b, expected_return_code);
+  if (b) {
+    EXPECT_THAT(ss.base(), HasSubstr(expected_message));
+  }
+}
+
+static void test_for_c_heap(size_t sz, ssize_t offset) {
+  char* c = NEW_C_HEAP_ARRAY(char, sz, mtTest);
+  LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), offset);
+  memset(c, 0, sz);
+  if (MemTracker::enabled()) {
+    const char* expected_string = "into life malloced block";
+    if (offset < 0) {
+      expected_string = "into header of life malloced block";
+    } else if ((size_t)offset >= sz) {
+      expected_string = "just outside of life malloced block";
+    }
+    test_pointer(c + offset, true, expected_string);
+  } else {
+    // NMT disabled: we should see nothing.
+    test_pointer(c + offset, false, "");
+  }
+  FREE_C_HEAP_ARRAY(char, c);
+}
+
+TEST_VM(NMT, barrierrr) {
+  for (size_t i = 0; i < os::vm_page_size(); i ++) {
+    test_for_c_heap(os::vm_page_size(), i);
+  }
+
+}
+TEST_VM(NMT, location_printing_cheap_1) { test_for_c_heap(2 * K, 0); }              // start of payload
+TEST_VM(NMT, location_printing_cheap_2) { test_for_c_heap(2 * K, -7); }             // into header
+TEST_VM(NMT, location_printing_cheap_3) { test_for_c_heap(2 * K, K + 1); }          // into payload
+TEST_VM(NMT, location_printing_cheap_4) { test_for_c_heap(2 * K + 1, 2 * K + 2); }  // just outside payload
+TEST_VM(NMT, location_printing_cheap_5) { test_for_c_heap(4, 4); }                  // just outside a very small block
+
+static void test_for_mmap(size_t sz, ssize_t offset) {
+  char* addr = os::reserve_memory(sz, false, mtTest);
+  if (MemTracker::enabled()) {
+    test_pointer(addr + offset, true, "in mmap'd memory region");
+  } else {
+    // NMT disabled: we should see nothing.
+    test_pointer(addr + offset, false, "");
+  }
+  os::release_memory(addr, os::vm_page_size());
+}
+
+TEST_VM(NMT, location_printing_mmap_1) { test_for_mmap(os::vm_page_size(), 0);  }
+TEST_VM(NMT, location_printing_mmap_2) { test_for_mmap(os::vm_page_size(), os::vm_page_size() - 1);  }

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -30,7 +30,7 @@
 #include "unittest.hpp"
 
 // Uncomment to get test output
-#define LOG_PLEASE
+//#define LOG_PLEASE
 #include "testutils.hpp"
 
 using ::testing::HasSubstr;

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -62,12 +62,6 @@ static void test_for_c_heap(size_t sz, ssize_t offset) {
   FREE_C_HEAP_ARRAY(char, c);
 }
 
-TEST_VM(NMT, barrierrr) {
-  for (size_t i = 0; i < os::vm_page_size(); i ++) {
-    test_for_c_heap(os::vm_page_size(), i);
-  }
-
-}
 TEST_VM(NMT, location_printing_cheap_1) { test_for_c_heap(2 * K, 0); }              // start of payload
 TEST_VM(NMT, location_printing_cheap_2) { test_for_c_heap(2 * K, -7); }             // into header
 TEST_VM(NMT, location_printing_cheap_3) { test_for_c_heap(2 * K, K + 1); }          // into payload

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -98,6 +98,7 @@ TEST_VM(NMT, location_printing_cheap_live_5) { test_for_live_c_heap_block(2 * K 
 TEST_VM(NMT, location_printing_cheap_live_6) { test_for_live_c_heap_block(4, 0); }                  // into a very small block
 TEST_VM(NMT, location_printing_cheap_live_7) { test_for_live_c_heap_block(4, 4); }                  // just outside a very small block
 
+#ifdef LINUX
 TEST_VM(NMT, location_printing_cheap_dead_1) { test_for_dead_c_heap_block(2 * K, 0); }              // start of payload
 TEST_VM(NMT, location_printing_cheap_dead_2) { test_for_dead_c_heap_block(2 * K, -7); }             // into header
 TEST_VM(NMT, location_printing_cheap_dead_3) { test_for_dead_c_heap_block(2 * K, K + 1); }          // into payload
@@ -105,6 +106,7 @@ TEST_VM(NMT, location_printing_cheap_dead_4) { test_for_dead_c_heap_block(2 * K,
 TEST_VM(NMT, location_printing_cheap_dead_5) { test_for_dead_c_heap_block(2 * K + 1, 2 * K + 2); }  // just outside payload
 TEST_VM(NMT, location_printing_cheap_dead_6) { test_for_dead_c_heap_block(4, 0); }                  // into a very small block
 TEST_VM(NMT, location_printing_cheap_dead_7) { test_for_dead_c_heap_block(4, 4); }                  // just outside a very small block
+#endif
 
 static void test_for_mmap(size_t sz, ssize_t offset) {
   char* addr = os::reserve_memory(sz, false, mtTest);

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -27,8 +27,6 @@
 #include "runtime/os.hpp"
 #include "services/memTracker.hpp"
 #include "unittest.hpp"
-
-//#define LOG_PLEASE
 #include "testutils.hpp"
 
 using ::testing::HasSubstr;
@@ -65,8 +63,10 @@ static void test_for_c_heap(size_t sz, ssize_t offset) {
 TEST_VM(NMT, location_printing_cheap_1) { test_for_c_heap(2 * K, 0); }              // start of payload
 TEST_VM(NMT, location_printing_cheap_2) { test_for_c_heap(2 * K, -7); }             // into header
 TEST_VM(NMT, location_printing_cheap_3) { test_for_c_heap(2 * K, K + 1); }          // into payload
-TEST_VM(NMT, location_printing_cheap_4) { test_for_c_heap(2 * K + 1, 2 * K + 2); }  // just outside payload
-TEST_VM(NMT, location_printing_cheap_5) { test_for_c_heap(4, 4); }                  // just outside a very small block
+TEST_VM(NMT, location_printing_cheap_4) { test_for_c_heap(2 * K, K + 2); }          // into payload (check for even/odd errors)
+TEST_VM(NMT, location_printing_cheap_5) { test_for_c_heap(2 * K + 1, 2 * K + 2); }  // just outside payload
+TEST_VM(NMT, location_printing_cheap_6) { test_for_c_heap(4, 0); }                  // into a very small block
+TEST_VM(NMT, location_printing_cheap_7) { test_for_c_heap(4, 4); }                  // just outside a very small block
 
 static void test_for_mmap(size_t sz, ssize_t offset) {
   char* addr = os::reserve_memory(sz, false, mtTest);

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -48,11 +48,11 @@ static void test_for_c_heap(size_t sz, ssize_t offset) {
   LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), offset);
   memset(c, 0, sz);
   if (MemTracker::enabled()) {
-    const char* expected_string = "into life malloced block";
+    const char* expected_string = "into live malloced block";
     if (offset < 0) {
-      expected_string = "into header of life malloced block";
+      expected_string = "into header of live malloced block";
     } else if ((size_t)offset >= sz) {
-      expected_string = "just outside of life malloced block";
+      expected_string = "just outside of live malloced block";
     }
     test_pointer(c + offset, true, expected_string);
   } else {

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -25,8 +25,12 @@
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
+#include "services/mallocHeader.inline.hpp"
 #include "services/memTracker.hpp"
 #include "unittest.hpp"
+
+// Uncomment to get test output
+#define LOG_PLEASE
 #include "testutils.hpp"
 
 using ::testing::HasSubstr;
@@ -41,7 +45,7 @@ static void test_pointer(const void* p, bool expected_return_code, const char* e
   }
 }
 
-static void test_for_c_heap(size_t sz, ssize_t offset) {
+static void test_for_live_c_heap_block(size_t sz, ssize_t offset) {
   char* c = NEW_C_HEAP_ARRAY(char, sz, mtTest);
   LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), offset);
   memset(c, 0, sz);
@@ -60,13 +64,47 @@ static void test_for_c_heap(size_t sz, ssize_t offset) {
   FREE_C_HEAP_ARRAY(char, c);
 }
 
-TEST_VM(NMT, location_printing_cheap_1) { test_for_c_heap(2 * K, 0); }              // start of payload
-TEST_VM(NMT, location_printing_cheap_2) { test_for_c_heap(2 * K, -7); }             // into header
-TEST_VM(NMT, location_printing_cheap_3) { test_for_c_heap(2 * K, K + 1); }          // into payload
-TEST_VM(NMT, location_printing_cheap_4) { test_for_c_heap(2 * K, K + 2); }          // into payload (check for even/odd errors)
-TEST_VM(NMT, location_printing_cheap_5) { test_for_c_heap(2 * K + 1, 2 * K + 2); }  // just outside payload
-TEST_VM(NMT, location_printing_cheap_6) { test_for_c_heap(4, 0); }                  // into a very small block
-TEST_VM(NMT, location_printing_cheap_7) { test_for_c_heap(4, 4); }                  // just outside a very small block
+static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
+  if (!MemTracker::enabled()) {
+    return;
+  }
+  char* c = NEW_C_HEAP_ARRAY(char, sz, mtTest);
+  LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), offset);
+  memset(c, 0, sz);
+  // We cannot just free the allocation to try dead block printing, since the memory
+  // may be immediately reused by concurrent code. Instead, we mark the block as dead
+  // manually, and revert that before freeing it.
+  MallocHeader* const hdr = MallocHeader::resolve_checked(c);
+  hdr->mark_block_as_dead();
+
+  const char* expected_string = "into dead malloced block";
+  if (offset < 0) {
+    expected_string = "into header of dead malloced block";
+  } else if ((size_t)offset >= sz) {
+    expected_string = "just outside of dead malloced block";
+  }
+
+  test_pointer(c + offset, true, expected_string);
+
+  hdr->revive();
+  FREE_C_HEAP_ARRAY(char, c);
+}
+
+TEST_VM(NMT, location_printing_cheap_live_1) { test_for_live_c_heap_block(2 * K, 0); }              // start of payload
+TEST_VM(NMT, location_printing_cheap_live_2) { test_for_live_c_heap_block(2 * K, -7); }             // into header
+TEST_VM(NMT, location_printing_cheap_live_3) { test_for_live_c_heap_block(2 * K, K + 1); }          // into payload
+TEST_VM(NMT, location_printing_cheap_live_4) { test_for_live_c_heap_block(2 * K, K + 2); }          // into payload (check for even/odd errors)
+TEST_VM(NMT, location_printing_cheap_live_5) { test_for_live_c_heap_block(2 * K + 1, 2 * K + 2); }  // just outside payload
+TEST_VM(NMT, location_printing_cheap_live_6) { test_for_live_c_heap_block(4, 0); }                  // into a very small block
+TEST_VM(NMT, location_printing_cheap_live_7) { test_for_live_c_heap_block(4, 4); }                  // just outside a very small block
+
+TEST_VM(NMT, location_printing_cheap_dead_1) { test_for_dead_c_heap_block(2 * K, 0); }              // start of payload
+TEST_VM(NMT, location_printing_cheap_dead_2) { test_for_dead_c_heap_block(2 * K, -7); }             // into header
+TEST_VM(NMT, location_printing_cheap_dead_3) { test_for_dead_c_heap_block(2 * K, K + 1); }          // into payload
+TEST_VM(NMT, location_printing_cheap_dead_4) { test_for_dead_c_heap_block(2 * K, K + 2); }          // into payload (check for even/odd errors)
+TEST_VM(NMT, location_printing_cheap_dead_5) { test_for_dead_c_heap_block(2 * K + 1, 2 * K + 2); }  // just outside payload
+TEST_VM(NMT, location_printing_cheap_dead_6) { test_for_dead_c_heap_block(4, 0); }                  // into a very small block
+TEST_VM(NMT, location_printing_cheap_dead_7) { test_for_dead_c_heap_block(4, 4); }                  // just outside a very small block
 
 static void test_for_mmap(size_t sz, ssize_t offset) {
   char* addr = os::reserve_memory(sz, false, mtTest);

--- a/test/hotspot/gtest/nmt/test_nmt_totals.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_totals.cpp
@@ -30,8 +30,8 @@
 #include "unittest.hpp"
 
 // convenience log. switch on if debugging tests. Don't use tty, plain stdio only.
-#define LOG(...) { printf(__VA_ARGS__); printf("\n"); fflush(stdout); }
-//#define LOG(...)
+//#define LOG(...) { printf(__VA_ARGS__); printf("\n"); fflush(stdout); }
+#define LOG(...)
 
 static size_t get_total_malloc_invocs() {
   return MallocMemorySummary::as_snapshot()->total_count();

--- a/test/hotspot/gtest/testutils.hpp
+++ b/test/hotspot/gtest/testutils.hpp
@@ -62,6 +62,10 @@ public:
 
 #define ASSERT_ALIGN(p, n) ASSERT_TRUE(is_aligned(p, n))
 
+#ifdef LOG_PLEASE
 #define LOG_HERE(s, ...) { printf(s, __VA_ARGS__); printf("\n"); fflush(stdout); }
+#else
+#define LOG_HERE(s, ...)
+#endif
 
 #endif // TESTUTILS_HPP


### PR DESCRIPTION
(This is a byproduct of work on the arm port for https://github.com/openjdk/jdk/pull/10907. I needed better debugging information in the hs-err file and in gdb.)

Back in 2022 @zhengyu123 had the very nice idea of using NMT mapping info for smartening up pp in gdb: [JDK-8280289](https://bugs.openjdk.org/browse/JDK-8280289).

The same idea can be applied to hs_err file location printing. NMT has information about all its mappings and can tell us where it thinks a given unknown pointer points into.

This could be even more useful if the "find malloc block" part of that functionality would be smarter. As it is now, it only works if the pointer in question points to the start of a user-allocated area. Would be nice if the code could (carefully) search for the next valid-looking malloc header instead.

--------------

This patch does this: we introduce a new API, MemTracker::print_containing_region(void*), that tries to make sense of a given unknown pointer.

It will search its mmap regions and print those if found. For malloc'ed pointers, it will carefully sniff out the immediate surroundings of the block, trying to find what looks like a valid malloc header. It uses SafeFetch to not trip over unmapped or protected pages. Note that, of course, we may get false recognition positives if it finds something that looks like a valid header. But even that could be useful (e.g. a remnant dead header may indicate we access memory after free).

Looks like this (its arm, so 32-bit pointers):

```
Register to memory mapping:

->  r0  = 0x728a6ae0 into life malloced block starting at 0x728a6ae0, size 104, tag mtSynchronizer
->  r1  = 0x75b02010 into life malloced block starting at 0x75b02010, size 184, tag mtObjectMonitor
->  r2  = 0x728a6ae0 into life malloced block starting at 0x728a6ae0, size 104, tag mtSynchronizer
    r3  = 0x0 is nullptr
->  r4  = 0x728a6ae0 into life malloced block starting at 0x728a6ae0, size 104, tag mtSynchronizer
    r5  = 0xb6d3bbc8: <offset 0x018f6bc8> in /shared/projects/openjdk/jdk-jdk/output-fastdebug-arm/images/jdk/lib/server/libjvm.so at 0xb5445000
    r6  = 0xffffffff is an unknown value
    r7  = 0x0 is nullptr
    r8  = 0x0000000a is an unknown value
    r9  = 0x728a4308 is a thread
    r10 = 0x0000000b is an unknown value
->  fp  = 0x753fe8cc in mmap'd memory region [0x75380000 - 0x75400000] by Thread Stack
    r12 = 0x0 is nullptr
->  sp  = 0x753fe8b0 in mmap'd memory region [0x75380000 - 0x75400000] by Thread Stack
    lr  = 0xb69bc1d0: <offset 0x015771d0> in /shared/projects/openjdk/jdk-jdk/output-fastdebug-arm/images/jdk/lib/server/libjvm.so at 0xb5445000
    pc  = 0xb69c8670: <offset 0x01583670> in /shared/projects/openjdk/jdk-jdk/output-fastdebug-arm/images/jdk/lib/server/libjvm.so at 0xb5445000
```


The small caveat here is that NMT reporting needs ThreadCritical, and thus using it for location printing may block error reporting if it crashed inside a ThreadCritical section. We face the same issue today when printing the NMT report as part of the hs-err file. 

I think the usefulness of these printouts justify this risk. However I opened https://bugs.openjdk.org/browse/JDK-8304824 to investigate a better locking strategy for NMT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304815](https://bugs.openjdk.org/browse/JDK-8304815): Use NMT for more precise hs_err location printing


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - Committer) ⚠️ Review applies to [e5a4a9f1](https://git.openjdk.org/jdk/pull/13162/files/e5a4a9f19136c9b60dbfa51eae47b07db8c624f8)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [d19d06ca](https://git.openjdk.org/jdk/pull/13162/files/d19d06ca1bc04e094ee2c2e314dbbc8d1d58c4d2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13162/head:pull/13162` \
`$ git checkout pull/13162`

Update a local copy of the PR: \
`$ git checkout pull/13162` \
`$ git pull https://git.openjdk.org/jdk.git pull/13162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13162`

View PR using the GUI difftool: \
`$ git pr show -t 13162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13162.diff">https://git.openjdk.org/jdk/pull/13162.diff</a>

</details>
