### PR TITLE
8304837: Classfile API throws IOOBE for MethodParameters attribute without parameter names

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,7 +360,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 int p = payloadStart + 1;
                 int pEnd = p + (cnt * 4);
                 for (int i = 0; p < pEnd; p += 4, i++) {
-                    Utf8Entry name = classReader.readUtf8Entry(p);
+                    Utf8Entry name = classReader.readUtf8EntryOrNull(p);
                     int accessFlags = classReader.readU2(p + 2);
                     elements[i] = MethodParameterInfo.of(Optional.ofNullable(name), accessFlags);
                 }

--- a/test/jdk/jdk/classfile/BoundAttributeTest.java
+++ b/test/jdk/jdk/classfile/BoundAttributeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.classfile.Attributes;
+import jdk.internal.classfile.ClassModel;
+import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.CodeBuilder;
+import jdk.internal.classfile.attribute.MethodParameterInfo;
+import jdk.internal.classfile.attribute.MethodParametersAttribute;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @summary Testing BoundAttributes
+ * @run junit BoundAttributeTest
+ */
+class BoundAttributeTest {
+
+    @Test
+    void testReadMethodParametersAttributeWithoutParameterName() {
+        // build a simple method: void method(int)
+        MethodTypeDesc methodTypeDesc = MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_int);
+        byte[] raw = Classfile.build(ClassDesc.of("TestClass"), builder -> {
+            builder.withMethod("method", methodTypeDesc, 0, mb -> {
+                mb.withCode(CodeBuilder::return_);
+                // add a MethodParameters attribute without name for the parameter
+                mb.with(MethodParametersAttribute.of(MethodParameterInfo.ofParameter(Optional.empty(), 0)));
+            });
+        });
+        ClassModel model = Classfile.parse(raw);
+        MethodParametersAttribute methodParametersAttribute = model.methods().get(0)
+                .findAttribute(Attributes.METHOD_PARAMETERS)
+                .orElseThrow(() -> new AssertionFailedError("Attribute not present"));
+        // MethodParametersAttribute#parameters() materializes the parameters
+        List<MethodParameterInfo> parameters = assertDoesNotThrow(methodParametersAttribute::parameters);
+        assertTrue(parameters.get(0).name().isEmpty());
+    }
+}

--- a/test/jdk/jdk/classfile/BoundAttributeTest.java
+++ b/test/jdk/jdk/classfile/BoundAttributeTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
+ * @issue 8304837
  * @summary Testing BoundAttributes
  * @run junit BoundAttributeTest
  */

--- a/test/jdk/jdk/classfile/BoundAttributeTest.java
+++ b/test/jdk/jdk/classfile/BoundAttributeTest.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * @test
+ * @bug 8304837
+ * @summary Testing BoundAttributes
+ * @run junit BoundAttributeTest
+ */
 import jdk.internal.classfile.Attributes;
 import jdk.internal.classfile.ClassModel;
 import jdk.internal.classfile.Classfile;
@@ -41,12 +47,6 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/*
- * @test
- * @issue 8304837
- * @summary Testing BoundAttributes
- * @run junit BoundAttributeTest
- */
 class BoundAttributeTest {
 
     @Test


### PR DESCRIPTION
After merging master into https://github.com/openjdk/jdk/pull/9862, we encountered test failures (e.g., https://github.com/SirYwell/jdk/actions/runs/4500940829/jobs/7923018438#step:9:2541). The Classfile API tries to read from constant pool index 0 if a MethodParameters attribute has an entry without name.

The fix is simply using `readUtf8EntryOrNull` instead of `readUtf8Entry`. The related code already correctly handles nullability.

I didn't find an appropriate test class so I added a new one. Let me know if there's a better place or if the test can be improved somehow.

As I don't have a JBS account, someone needs to create a bug report there for me. Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304837](https://bugs.openjdk.org/browse/JDK-8304837): Classfile API throws IOOBE for MethodParameters attribute without parameter names


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - Committer)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13167/head:pull/13167` \
`$ git checkout pull/13167`

Update a local copy of the PR: \
`$ git checkout pull/13167` \
`$ git pull https://git.openjdk.org/jdk.git pull/13167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13167`

View PR using the GUI difftool: \
`$ git pr show -t 13167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13167.diff">https://git.openjdk.org/jdk/pull/13167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13167#issuecomment-1481838703)