### PR TITLE
8304833: (fc) Remove dead code in sun.nio.ch.FileChannelImpl::implCloseChannel

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -25,6 +25,7 @@
 
 package sun.nio.ch;
 
+import java.io.Closeable;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -79,7 +80,7 @@ public class FileChannelImpl
     private final boolean readable;
 
     // Required to prevent finalization of creating stream (immutable)
-    private final Object parent;
+    private final Closeable parent;
 
     // The path of the referenced file
     // (null if the parent stream is created with a file descriptor)
@@ -121,7 +122,7 @@ public class FileChannelImpl
     }
 
     private FileChannelImpl(FileDescriptor fd, String path, boolean readable,
-                            boolean writable, boolean direct, Object parent)
+                            boolean writable, boolean direct, Closeable parent)
     {
         this.fd = fd;
         this.path = path;
@@ -149,7 +150,7 @@ public class FileChannelImpl
     // and RandomAccessFile::getChannel
     public static FileChannel open(FileDescriptor fd, String path,
                                    boolean readable, boolean writable,
-                                   boolean direct, Object parent)
+                                   boolean direct, Closeable parent)
     {
         return new FileChannelImpl(fd, path, readable, writable, direct, parent);
     }
@@ -199,7 +200,7 @@ public class FileChannelImpl
             // superclass AbstractInterruptibleChannel, but the isOpen logic in
             // that method will prevent this method from being reinvoked.
             //
-            ((java.io.Closeable)parent).close();
+            parent.close();
         } else { // parent == null hence closer != null
             //
             // Perform the cleaning action so it is not redone when

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,25 +193,24 @@ public class FileChannelImpl
         threads.signalAndWait();
 
         if (parent != null) {
-
+            //
             // Close the fd via the parent stream's close method.  The parent
             // will reinvoke our close method, which is defined in the
             // superclass AbstractInterruptibleChannel, but the isOpen logic in
             // that method will prevent this method from being reinvoked.
             //
             ((java.io.Closeable)parent).close();
-        } else if (closer != null) {
+        } else { // parent == null hence closer != null
+            //
             // Perform the cleaning action so it is not redone when
             // this channel becomes phantom reachable.
+            //
             try {
                 closer.clean();
             } catch (UncheckedIOException uioe) {
                 throw uioe.getCause();
             }
-        } else {
-            fdAccess.close(fd);
         }
-
     }
 
     public int read(ByteBuffer dst) throws IOException {


### PR DESCRIPTION
Remove `fdAccess.close(fd)` branch in `implCloseChannel` as it is unreachable because exactly one of `parent` and `closer` can be non-`null`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304833](https://bugs.openjdk.org/browse/JDK-8304833): (fc) Remove dead code in sun.nio.ch.FileChannelImpl::implCloseChannel


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13168/head:pull/13168` \
`$ git checkout pull/13168`

Update a local copy of the PR: \
`$ git checkout pull/13168` \
`$ git pull https://git.openjdk.org/jdk.git pull/13168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13168`

View PR using the GUI difftool: \
`$ git pr show -t 13168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13168.diff">https://git.openjdk.org/jdk/pull/13168.diff</a>

</details>
