### PR TITLE
8304844 JFR: Missing disk parameter in ActiveRecording event

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,9 @@ public final class ActiveRecordingEvent extends AbstractJDKEvent {
     @Label("Destination")
     public String destination;
 
+    @Label("To Disk")
+    public boolean disk;
+
     @Label("Max Age")
     @Timespan(Timespan.MILLISECONDS)
     public long maxAge;
@@ -77,7 +80,7 @@ public final class ActiveRecordingEvent extends AbstractJDKEvent {
     }
 
     public static void commit(long timestamp, long duration, long id, String name,
-                              String destination, long maxAge, long flushInterval,
+                              String destination, boolean disk, long maxAge, long flushInterval,
                               long maxSize, long recordingStart, long recordingDuration) {
         // Generated
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -474,6 +474,7 @@ public final class PlatformRecorder {
                         r.getId(),
                         r.getName(),
                         path == null ? null : path.getRealPathText(),
+                        r.isToDisk(),
                         age == null ? Long.MAX_VALUE : age.toMillis(),
                         flush == null ? Long.MAX_VALUE : flush.toMillis(),
                         size == null ? Long.MAX_VALUE : size,

--- a/test/jdk/jdk/jfr/event/runtime/TestActiveRecordingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveRecordingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,8 @@ public final class TestActiveRecordingEvent {
         assertTrue(tsAfterStop >= tsRecordingStart);
 
         assertEquals(recording.getId(), ev.getValue("id"));
+
+        assertEquals(recording.isToDisk(), ev.getValue("disk"));
 
         ValueDescriptor maxAgeField = evType.getField("maxAge");
         assertEquals(maxAgeField.getAnnotation(Timespan.class).value(), Timespan.MILLISECONDS);


### PR DESCRIPTION
Could I have a review of a change that adds the disk parameter to the ActiveRecording event.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304844](https://bugs.openjdk.org/browse/JDK-8304844): JFR: Missing disk parameter in ActiveRecording event


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13171/head:pull/13171` \
`$ git checkout pull/13171`

Update a local copy of the PR: \
`$ git checkout pull/13171` \
`$ git pull https://git.openjdk.org/jdk.git pull/13171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13171`

View PR using the GUI difftool: \
`$ git pr show -t 13171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13171.diff">https://git.openjdk.org/jdk/pull/13171.diff</a>

</details>
