### PR TITLE
8068824: Exception thrown in JTableHeader after clicking on popupmenu opened with right-click on header

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -700,7 +700,8 @@ public class BasicTableHeaderUI extends TableHeaderUI {
         if (draggedColumn != null) {
             int draggedColumnIndex = viewIndexForColumn(draggedColumn);
             if (draggedColumnIndex != -1) {
-                Rectangle draggedCellRect = header.getHeaderRect(draggedColumnIndex);
+                Rectangle draggedCellRect =
+                                header.getHeaderRect(draggedColumnIndex);
 
                 // Draw a gray well in place of the moving column.
                 g.setColor(header.getParent().getBackground());
@@ -716,7 +717,6 @@ public class BasicTableHeaderUI extends TableHeaderUI {
 
                 paintCell(g, draggedCellRect, draggedColumnIndex);
             }
-
         }
 
         // Remove all components in the rendererPane.
@@ -724,7 +724,6 @@ public class BasicTableHeaderUI extends TableHeaderUI {
     }
 
     private Component getHeaderRenderer(int columnIndex) {
-
         TableColumn aColumn = header.getColumnModel().getColumn(columnIndex);
         TableCellRenderer renderer = aColumn.getHeaderRenderer();
         if (renderer == null) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
@@ -699,21 +699,24 @@ public class BasicTableHeaderUI extends TableHeaderUI {
         // Paint the dragged column if we are dragging.
         if (draggedColumn != null) {
             int draggedColumnIndex = viewIndexForColumn(draggedColumn);
-            Rectangle draggedCellRect = header.getHeaderRect(draggedColumnIndex);
+            if (draggedColumnIndex != -1) {
+                Rectangle draggedCellRect = header.getHeaderRect(draggedColumnIndex);
 
-            // Draw a gray well in place of the moving column.
-            g.setColor(header.getParent().getBackground());
-            g.fillRect(draggedCellRect.x, draggedCellRect.y,
-                               draggedCellRect.width, draggedCellRect.height);
+                // Draw a gray well in place of the moving column.
+                g.setColor(header.getParent().getBackground());
+                g.fillRect(draggedCellRect.x, draggedCellRect.y,
+                        draggedCellRect.width, draggedCellRect.height);
 
-            draggedCellRect.x += header.getDraggedDistance();
+                draggedCellRect.x += header.getDraggedDistance();
 
-            // Fill the background.
-            g.setColor(header.getBackground());
-            g.fillRect(draggedCellRect.x, draggedCellRect.y,
-                       draggedCellRect.width, draggedCellRect.height);
+                // Fill the background.
+                g.setColor(header.getBackground());
+                g.fillRect(draggedCellRect.x, draggedCellRect.y,
+                        draggedCellRect.width, draggedCellRect.height);
 
-            paintCell(g, draggedCellRect, draggedColumnIndex);
+                paintCell(g, draggedCellRect, draggedColumnIndex);
+            }
+
         }
 
         // Remove all components in the rendererPane.
@@ -721,6 +724,7 @@ public class BasicTableHeaderUI extends TableHeaderUI {
     }
 
     private Component getHeaderRenderer(int columnIndex) {
+
         TableColumn aColumn = header.getColumnModel().getColumn(columnIndex);
         TableCellRenderer renderer = aColumn.getHeaderRenderer();
         if (renderer == null) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -2121,6 +2121,9 @@ public class BasicTableUI extends TableUI
     private void paintDraggedArea(Graphics g, int rMin, int rMax, TableColumn draggedColumn, int distance) {
         int draggedColumnIndex = viewIndexForColumn(draggedColumn);
 
+        if (draggedColumnIndex == -1) {
+            return;
+        }
         Rectangle minCell = table.getCellRect(rMin, draggedColumnIndex, true);
         Rectangle maxCell = table.getCellRect(rMax, draggedColumnIndex, true);
 

--- a/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
+++ b/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
@@ -56,7 +56,7 @@ public class JTableHeaderExceptionTest {
                 Object rowData[][] =
                         {{"Row1-Column1", "Row1-Column2", "Row1-Column3"},
                         {"Row2-Column1", "Row2-Column2", "Row2-Column3"}};
-                Object columnNames[] = 
+                Object columnNames[] =
                     {"Test", "Click me with right mouse click!", "Test"};
 
                 DragTestTable.DragTestTableModel model =
@@ -136,7 +136,7 @@ class DragTestTable extends JTable {
             return rowData[row][col];
         }
         public boolean isCellEditable(int row, int column) {
-            return true; 
+            return true;
         }
         public void setValueAt(Object value, int row, int col) {
             rowData[row][col] = value;

--- a/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
+++ b/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
@@ -26,7 +26,7 @@
  * @bug 8068824
  * @key headful
  * @summary JTable header rendering problem (after setting preferred size)
- * @run JTableHeaderExceptionTest
+ * @run main JTableHeaderExceptionTest
 */
 import java.awt.BorderLayout;
 import java.awt.MouseInfo;
@@ -53,11 +53,14 @@ public class JTableHeaderExceptionTest {
                 frame = new JFrame();
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-                Object rowData[][] = {{"Row1-Column1", "Row1-Column2", "Row1-Column3"},
+                Object rowData[][] =
+                        {{"Row1-Column1", "Row1-Column2", "Row1-Column3"},
                         {"Row2-Column1", "Row2-Column2", "Row2-Column3"}};
-                Object columnNames[] = {"Test", "Click me with right mouse click!", "Test"};
+                Object columnNames[] = 
+                    {"Test", "Click me with right mouse click!", "Test"};
 
-                DragTestTable.DragTestTableModel model = new DragTestTable.DragTestTableModel(rowData, columnNames);
+                DragTestTable.DragTestTableModel model =
+                    new DragTestTable.DragTestTableModel(rowData, columnNames);
 
                 DragTestTable dragTable = new DragTestTable(model);
                 table = dragTable;
@@ -120,11 +123,21 @@ class DragTestTable extends JTable {
             this.columnNames = columnNames;
         }
 
-        public String getColumnName(int column) { return columnNames[column].toString(); }
-        public int getRowCount() { return rowData.length; }
-        public int getColumnCount() { return columnNames.length; }
-        public Object getValueAt(int row, int col) { return rowData[row][col]; }
-        public boolean isCellEditable(int row, int column) { return true; }
+        public String getColumnName(int column) {
+            return columnNames[column].toString();
+        }
+        public int getRowCount() {
+            return rowData.length;
+        }
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+        public boolean isCellEditable(int row, int column) {
+            return true; 
+        }
         public void setValueAt(Object value, int row, int col) {
             rowData[row][col] = value;
             fireTableCellUpdated(row, col);

--- a/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
+++ b/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8068824
+ * @key headful
+ * @summary JTable header rendering problem (after setting preferred size)
+ * @run JTableHeaderExceptionTest
+*/
+import java.awt.BorderLayout;
+import java.awt.MouseInfo;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+
+public class JTableHeaderExceptionTest {
+    static JFrame frame;
+    static JTable table;
+    static Point tableLoc;
+
+    public static void main(String args[]) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+                Object rowData[][] = {{"Row1-Column1", "Row1-Column2", "Row1-Column3"},
+                        {"Row2-Column1", "Row2-Column2", "Row2-Column3"}};
+                Object columnNames[] = {"Test", "Click me with right mouse click!", "Test"};
+
+                DragTestTable.DragTestTableModel model = new DragTestTable.DragTestTableModel(rowData, columnNames);
+
+                DragTestTable dragTable = new DragTestTable(model);
+                table = dragTable;
+
+                JScrollPane scrollPane = new JScrollPane(table);
+                frame.add(scrollPane, BorderLayout.CENTER);
+                frame.setSize(600, 150);
+                frame.setVisible(true);
+            });
+            Robot robot = new Robot();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                tableLoc = table.getTableHeader().getLocationOnScreen();
+            });
+            robot.mouseMove(tableLoc.x + 5, tableLoc.y + 5);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(1000);
+            Point p = MouseInfo.getPointerInfo().getLocation();
+            robot.mouseMove(p.x + 5, p.y + 5);
+            robot.delay(1000);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(frame::dispose);
+        }
+    }
+}
+
+class DragTestTable extends JTable {
+
+    Point loc;
+    public DragTestTable(DragTestTableModel model){
+
+        super(model);
+
+        JPopupMenu menu = new JPopupMenu();
+        menu.add(new AbstractAction("Bug Test") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                //loc = menu.getLocationOnScreen();
+                ((DragTestTableModel)getModel()).fireTableStructureChanged();
+            }
+        });
+
+
+
+        getTableHeader().setComponentPopupMenu(menu);
+    }
+
+    public static class DragTestTableModel extends AbstractTableModel {
+        private Object rowData[][];
+        private Object columnNames[];
+
+        public DragTestTableModel(Object rowData[][], Object columnNames[]){
+            super();
+            this.rowData = rowData;
+            this.columnNames = columnNames;
+        }
+
+        public String getColumnName(int column) { return columnNames[column].toString(); }
+        public int getRowCount() { return rowData.length; }
+        public int getColumnCount() { return columnNames.length; }
+        public Object getValueAt(int row, int col) { return rowData[row][col]; }
+        public boolean isCellEditable(int row, int column) { return true; }
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+        public void fireTableStructureChanged(){
+            super.fireTableStructureChanged();
+        }
+
+    }
+}
+
+

--- a/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
+++ b/test/jdk/javax/swing/JTableHeader/JTableHeaderExceptionTest.java
@@ -34,7 +34,12 @@ import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 
 public class JTableHeaderExceptionTest {
@@ -88,7 +93,7 @@ public class JTableHeaderExceptionTest {
 class DragTestTable extends JTable {
 
     Point loc;
-    public DragTestTable(DragTestTableModel model){
+    public DragTestTable(DragTestTableModel model) {
 
         super(model);
 
@@ -96,7 +101,6 @@ class DragTestTable extends JTable {
         menu.add(new AbstractAction("Bug Test") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                //loc = menu.getLocationOnScreen();
                 ((DragTestTableModel)getModel()).fireTableStructureChanged();
             }
         });
@@ -110,7 +114,7 @@ class DragTestTable extends JTable {
         private Object rowData[][];
         private Object columnNames[];
 
-        public DragTestTableModel(Object rowData[][], Object columnNames[]){
+        public DragTestTableModel(Object rowData[][], Object columnNames[]) {
             super();
             this.rowData = rowData;
             this.columnNames = columnNames;


### PR DESCRIPTION
The issue is observed on mouse right click on the table header to open a pupup menu and then, do a mouse left click on the menu entry in which case we get AIOOBE
This is because the columnIndex for popup menu is returned by `viewIndexForColumn `as -1 seen here https://github.com/openjdk/jdk/blob/941a7ac7dab243c6033a78880fd31faa803e62ab/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java#L745-L753
which is then passed to DefaultTableColumnModel.getColumn(columnIndex) causing it to throw AIOOBE as per the [DefaultTableColumnModel.getColumn spec](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java#L293)

So, inline with check done for `viewIndexForColumn `
https://github.com/openjdk/jdk/blob/941a7ac7dab243c6033a78880fd31faa803e62ab/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java#L310-L312
a similar check is added when `viewIndexForColumn `is called

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8068824](https://bugs.openjdk.org/browse/JDK-8068824): Exception thrown in JTableHeader after clicking on popupmenu opened with right-click on header


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [130baf1a](https://git.openjdk.org/jdk/pull/13172/files/130baf1a3b4a4a0b029aba78fb379ea91dc7d872)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13172/head:pull/13172` \
`$ git checkout pull/13172`

Update a local copy of the PR: \
`$ git checkout pull/13172` \
`$ git pull https://git.openjdk.org/jdk.git pull/13172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13172`

View PR using the GUI difftool: \
`$ git pr show -t 13172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13172.diff">https://git.openjdk.org/jdk/pull/13172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13172#issuecomment-1482596710)