### PR TITLE
JDK-8304867: Explicitly disable dtrace for ppc builds

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -247,9 +247,9 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_CDS],
 AC_DEFUN_ONCE([JVM_FEATURES_CHECK_DTRACE],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(dtrace, [
-    AC_MSG_CHECKING([for dtrace tool])
+    AC_MSG_CHECKING([for dtrace tool and platform support])
     if test "x$OPENJDK_TARGET_CPU_ARCH" = "xppc"; then
-      AC_MSG_RESULT([no])
+      AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU_ARCH])
       AVAILABLE=false
     elif test "x$DTRACE" != "x" && test -x "$DTRACE"; then
       AC_MSG_RESULT([$DTRACE])

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,10 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_DTRACE],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(dtrace, [
     AC_MSG_CHECKING([for dtrace tool])
-    if test "x$DTRACE" != "x" && test -x "$DTRACE"; then
+    if test "x$OPENJDK_TARGET_CPU_ARCH" = "xppc"; then
+      AC_MSG_RESULT([no])
+      AVAILABLE=false
+    elif test "x$DTRACE" != "x" && test -x "$DTRACE"; then
       AC_MSG_RESULT([$DTRACE])
     else
       AC_MSG_RESULT([no])


### PR DESCRIPTION
Currently the support for the JVM feature 'dtrace' is not implemented in the HS codebase on ppc, so we should disable it in the jvm-features make detection as well. Otherwise we could run into building with dtrace feature support if e.g. the 'dtrace' tool and related header(s) are available on the build machine.

Probably the same is true for the s390x platform, see
https://github.com/openjdk/jdk/blob/0deb648985b018653ccdaf193dc13b3cf21c088a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp#L226
but I only looked a bit more into ppc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304867](https://bugs.openjdk.org/browse/JDK-8304867): Explicitly disable dtrace for ppc builds


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13173/head:pull/13173` \
`$ git checkout pull/13173`

Update a local copy of the PR: \
`$ git checkout pull/13173` \
`$ git pull https://git.openjdk.org/jdk.git pull/13173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13173`

View PR using the GUI difftool: \
`$ git pr show -t 13173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13173.diff">https://git.openjdk.org/jdk/pull/13173.diff</a>

</details>
