### PR TITLE
8304880: [PPC64] VerifyOops code in C1 doesn't work with ZGC

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -819,10 +819,6 @@ int LIR_Assembler::load(Register base, int offset, LIR_Opr to_reg, BasicType typ
           } else {
             __ ld(to_reg->as_register(), offset, base);
           }
-          if (VerifyOops) {
-            BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-            bs->check_oop(_masm, to_reg->as_register(), FILE_AND_LINE); // kills R0
-          }
           break;
         }
       case T_FLOAT:  __ lfs(to_reg->as_float_reg(), offset, base); break;
@@ -852,10 +848,6 @@ int LIR_Assembler::load(Register base, Register disp, LIR_Opr to_reg, BasicType 
           __ decode_heap_oop(to_reg->as_register());
         } else {
           __ ldx(to_reg->as_register(), base, disp);
-        }
-        if (VerifyOops) {
-          BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-          bs->check_oop(_masm, to_reg->as_register(), FILE_AND_LINE); // kills R0
         }
         break;
       }


### PR DESCRIPTION
I suggest to remove this code for the following reasons:
- It doesn't work with ZGC (oop needs to go through load barrier, see JBS issue).
- It generates too much code. Loading oops is quite common and the oop verification code is quite lengthy.
- Other platforms don't have it, either.