### PR TITLE
8304445: Remaining uses of NULL in ciInstanceKlass.cpp

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -731,7 +731,7 @@ void ciInstanceKlass::dump_replay_instanceKlass(outputStream* out, InstanceKlass
 }
 
 GrowableArray<ciInstanceKlass*>* ciInstanceKlass::transitive_interfaces() const{
-  if (_transitive_interfaces == NULL) {
+  if (_transitive_interfaces == nullptr) {
     const_cast<ciInstanceKlass*>(this)->compute_transitive_interfaces();
   }
   return _transitive_interfaces;
@@ -745,7 +745,7 @@ void ciInstanceKlass::compute_transitive_interfaces() {
           Arena* arena = CURRENT_ENV->arena();
           int transitive_interfaces_len = orig_length + (is_interface() ? 1 : 0);
           GrowableArray<ciInstanceKlass*>* transitive_interfaces = new(arena)GrowableArray<ciInstanceKlass*>(arena, transitive_interfaces_len,
-                                                                                                             0, NULL);
+                                                                                                             0, nullptr);
           for (int i = 0; i < orig_length; i++) {
             transitive_interfaces->append(CURRENT_ENV->get_instance_klass(interfaces->at(i)));
           }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304445](https://bugs.openjdk.org/browse/JDK-8304445): Remaining uses of NULL in ciInstanceKlass.cpp


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13178/head:pull/13178` \
`$ git checkout pull/13178`

Update a local copy of the PR: \
`$ git checkout pull/13178` \
`$ git pull https://git.openjdk.org/jdk.git pull/13178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13178`

View PR using the GUI difftool: \
`$ git pr show -t 13178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13178.diff">https://git.openjdk.org/jdk/pull/13178.diff</a>

</details>
