### PR TITLE
8304893: Link Time Optimization with gcc can be faster

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -70,7 +70,8 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       fi
     fi
 
-    BASIC_LDFLAGS_JVM_ONLY="-Wl,-O1"
+    # Moved optimization flags to JvmFeatures.gmk, was -Wl,-O1
+    BASIC_LDFLAGS_JVM_ONLY=""
 
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     BASIC_LDFLAGS_JVM_ONLY="-mno-omit-leaf-frame-pointer -mstack-alignment=16 \

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -70,7 +70,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       fi
     fi
 
-    # Moved optimization flags to JvmFeatures.gmk, was -Wl,-O1
     BASIC_LDFLAGS_JVM_ONLY=""
 
   elif test "x$TOOLCHAIN_TYPE" = xclang; then

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -170,7 +170,7 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   JVM_OPTIMIZATION := HIGHEST_JVM
   ifeq ($(call isCompiler, gcc), true)
     JVM_CFLAGS_FEATURES += -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing -fno-fat-lto-objects
-    JVM_LDFLAGS_FEATURES += -O3 -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing
+    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing
   endif
 else
   ifeq ($(call isCompiler, gcc), true)

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -169,8 +169,12 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   # later on if desired
   JVM_OPTIMIZATION := HIGHEST_JVM
   ifeq ($(call isCompiler, gcc), true)
-    JVM_CFLAGS_FEATURES += -flto -fuse-linker-plugin
-    JVM_LDFLAGS_FEATURES += -flto -fuse-linker-plugin -fno-strict-aliasing
+    JVM_CFLAGS_FEATURES += -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing -fno-fat-lto-objects
+    JVM_LDFLAGS_FEATURES += -O3 -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing
+  endif
+else
+  ifeq ($(call isCompiler, gcc), true)
+    JVM_LDFLAGS_FEATURES += -O1
   endif
 endif
 

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -169,8 +169,8 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   # later on if desired
   JVM_OPTIMIZATION := HIGHEST_JVM
   ifeq ($(call isCompiler, gcc), true)
-    JVM_CFLAGS_FEATURES += -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing -fno-fat-lto-objects
-    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing
+    JVM_CFLAGS_FEATURES += -flto=auto -fuse-linker-plugin -fno-strict-aliasing -fno-fat-lto-objects
+    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto -fuse-linker-plugin -fno-strict-aliasing
   endif
 else
   ifeq ($(call isCompiler, gcc), true)


### PR DESCRIPTION
A previous argument against link time optimization support that we have for gcc is that it was extremely slow. After some checks it turns out we are passing rather inefficient flags to gcc in optimized builds. Changing these flags to run the linker optimizations in parallel and passing additional flags to the compiler have the ability to speed this process up significantly. Also fixes some incorrect flags passed to ld for linking as well, since strict-aliasing is required for both linker and compiler, and the same optimization level should be specified instead of letting the default -O1 be passed to the linker

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304893](https://bugs.openjdk.org/browse/JDK-8304893): Link Time Optimization with gcc can be faster


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [1fe1ba77](https://git.openjdk.org/jdk/pull/13180/files/1fe1ba77cc28a755ed96909935f457a03be8d6a0)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [1fe1ba77](https://git.openjdk.org/jdk/pull/13180/files/1fe1ba77cc28a755ed96909935f457a03be8d6a0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13180/head:pull/13180` \
`$ git checkout pull/13180`

Update a local copy of the PR: \
`$ git checkout pull/13180` \
`$ git pull https://git.openjdk.org/jdk.git pull/13180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13180`

View PR using the GUI difftool: \
`$ git pr show -t 13180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13180.diff">https://git.openjdk.org/jdk/pull/13180.diff</a>

</details>
