### PR TITLE
8304918: Remove unused decl field from AnnotatedType implementations

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
@@ -46,14 +46,11 @@ public final class AnnotatedTypeFactory {
      * @param actualTypeAnnos the type annotations this AnnotatedType has
      * @param allOnSameTarget all type annotation on the same TypeAnnotationTarget
      *                          as the AnnotatedType being built
-     * @param decl the declaration having the type use this AnnotatedType
-     *                          corresponds to
      */
     public static AnnotatedType buildAnnotatedType(Type type,
             LocationInfo currentLoc,
             TypeAnnotation[] actualTypeAnnos,
-            TypeAnnotation[] allOnSameTarget,
-            AnnotatedElement decl) {
+            TypeAnnotation[] allOnSameTarget) {
         if (type == null) {
             return EMPTY_ANNOTATED_TYPE;
         }
@@ -61,32 +58,27 @@ public final class AnnotatedTypeFactory {
             return new AnnotatedArrayTypeImpl(type,
                     currentLoc,
                     actualTypeAnnos,
-                    allOnSameTarget,
-                    decl);
+                    allOnSameTarget);
         if (type instanceof Class) {
             return new AnnotatedTypeBaseImpl(type,
                     currentLoc,
                     actualTypeAnnos,
-                    allOnSameTarget,
-                    decl);
+                    allOnSameTarget);
         } else if (type instanceof TypeVariable<?> typeVariable) {
             return new AnnotatedTypeVariableImpl(typeVariable,
                     currentLoc,
                     actualTypeAnnos,
-                    allOnSameTarget,
-                    decl);
+                    allOnSameTarget);
         } else if (type instanceof ParameterizedType paramType) {
             return new AnnotatedParameterizedTypeImpl(paramType,
                     currentLoc,
                     actualTypeAnnos,
-                    allOnSameTarget,
-                    decl);
+                    allOnSameTarget);
         } else if (type instanceof WildcardType wildType) {
             return new AnnotatedWildcardTypeImpl(wildType,
                     currentLoc,
                     actualTypeAnnos,
-                    allOnSameTarget,
-                    decl);
+                    allOnSameTarget);
         }
         throw new AssertionError("Unknown instance of Type: " + type + "\nThis should not happen.");
     }
@@ -123,7 +115,7 @@ public final class AnnotatedTypeFactory {
 
     static final TypeAnnotation[] EMPTY_TYPE_ANNOTATION_ARRAY = new TypeAnnotation[0];
     static final AnnotatedType EMPTY_ANNOTATED_TYPE = new AnnotatedTypeBaseImpl(null, LocationInfo.BASE_LOCATION,
-            EMPTY_TYPE_ANNOTATION_ARRAY, EMPTY_TYPE_ANNOTATION_ARRAY, null);
+            EMPTY_TYPE_ANNOTATION_ARRAY, EMPTY_TYPE_ANNOTATION_ARRAY);
     static final AnnotatedType[] EMPTY_ANNOTATED_TYPE_ARRAY = new AnnotatedType[0];
 
     /*
@@ -134,16 +126,13 @@ public final class AnnotatedTypeFactory {
 
     private static class AnnotatedTypeBaseImpl implements AnnotatedType {
         private final Type type;
-        private final AnnotatedElement decl;
         private final LocationInfo location;
         private final TypeAnnotation[] allOnSameTargetTypeAnnotations;
         private final Map<Class <? extends Annotation>, Annotation> annotations;
 
         AnnotatedTypeBaseImpl(Type type, LocationInfo location,
-                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations,
-                AnnotatedElement decl) {
+                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations) {
             this.type = type;
-            this.decl = decl;
             this.location = location;
             this.allOnSameTargetTypeAnnotations = allOnSameTargetTypeAnnotations;
             this.annotations = TypeAnnotationParser.mapTypeAnnotations(location.filter(actualTypeAnnotations));
@@ -202,7 +191,7 @@ public final class AnnotatedTypeFactory {
             LocationInfo outerLoc = getLocation().popLocation((byte)1);
             if (outerLoc == null) {
               return buildAnnotatedType(owner, LocationInfo.BASE_LOCATION,
-                      EMPTY_TYPE_ANNOTATION_ARRAY, EMPTY_TYPE_ANNOTATION_ARRAY, getDecl());
+                      EMPTY_TYPE_ANNOTATION_ARRAY, EMPTY_TYPE_ANNOTATION_ARRAY);
             }
             TypeAnnotation[]all = getTypeAnnotations();
             List<TypeAnnotation> l = new ArrayList<>(all.length);
@@ -211,7 +200,7 @@ public final class AnnotatedTypeFactory {
                 if (t.getLocationInfo().isSameLocationInfo(outerLoc))
                     l.add(t);
 
-            return buildAnnotatedType(owner, outerLoc, l.toArray(EMPTY_TYPE_ANNOTATION_ARRAY), all, getDecl());
+            return buildAnnotatedType(owner, outerLoc, l.toArray(EMPTY_TYPE_ANNOTATION_ARRAY), all);
 
         }
 
@@ -285,16 +274,12 @@ public final class AnnotatedTypeFactory {
         final TypeAnnotation[] getTypeAnnotations() {
             return allOnSameTargetTypeAnnotations;
         }
-        final AnnotatedElement getDecl() {
-            return decl;
-        }
     }
 
     private static final class AnnotatedArrayTypeImpl extends AnnotatedTypeBaseImpl implements AnnotatedArrayType {
         AnnotatedArrayTypeImpl(Type type, LocationInfo location,
-                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations,
-                AnnotatedElement decl) {
-            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations, decl);
+                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations) {
+            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations);
         }
 
         @Override
@@ -303,8 +288,7 @@ public final class AnnotatedTypeFactory {
             return AnnotatedTypeFactory.buildAnnotatedType(t,
                     nestingForType(t, getLocation().pushArray()),
                     getTypeAnnotations(),
-                    getTypeAnnotations(),
-                    getDecl());
+                    getTypeAnnotations());
         }
 
         @Override
@@ -367,9 +351,8 @@ public final class AnnotatedTypeFactory {
 
     private static final class AnnotatedTypeVariableImpl extends AnnotatedTypeBaseImpl implements AnnotatedTypeVariable {
         AnnotatedTypeVariableImpl(TypeVariable<?> type, LocationInfo location,
-                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations,
-                AnnotatedElement decl) {
-            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations, decl);
+                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations) {
+            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations);
         }
 
         @Override
@@ -406,9 +389,8 @@ public final class AnnotatedTypeFactory {
     private static final class AnnotatedParameterizedTypeImpl extends AnnotatedTypeBaseImpl
             implements AnnotatedParameterizedType {
         AnnotatedParameterizedTypeImpl(ParameterizedType type, LocationInfo location,
-                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations,
-                AnnotatedElement decl) {
-            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations, decl);
+                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations) {
+            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations);
         }
 
         @Override
@@ -426,8 +408,7 @@ public final class AnnotatedTypeFactory {
                 res[i] = buildAnnotatedType(arguments[i],
                         newLoc,
                         l.toArray(EMPTY_TYPE_ANNOTATION_ARRAY),
-                        getTypeAnnotations(),
-                        getDecl());
+                        getTypeAnnotations());
             }
             return res;
         }
@@ -441,7 +422,7 @@ public final class AnnotatedTypeFactory {
             LocationInfo outerLoc = getLocation().popLocation((byte)1);
             if (outerLoc == null) {
               return buildAnnotatedType(owner, LocationInfo.BASE_LOCATION,
-                      EMPTY_TYPE_ANNOTATION_ARRAY, EMPTY_TYPE_ANNOTATION_ARRAY, getDecl());
+                      EMPTY_TYPE_ANNOTATION_ARRAY, EMPTY_TYPE_ANNOTATION_ARRAY);
             }
             TypeAnnotation[]all = getTypeAnnotations();
             List<TypeAnnotation> l = new ArrayList<>(all.length);
@@ -450,7 +431,7 @@ public final class AnnotatedTypeFactory {
                 if (t.getLocationInfo().isSameLocationInfo(outerLoc))
                     l.add(t);
 
-            return buildAnnotatedType(owner, outerLoc, l.toArray(EMPTY_TYPE_ANNOTATION_ARRAY), all, getDecl());
+            return buildAnnotatedType(owner, outerLoc, l.toArray(EMPTY_TYPE_ANNOTATION_ARRAY), all);
         }
 
         private ParameterizedType getParameterizedType() {
@@ -494,9 +475,8 @@ public final class AnnotatedTypeFactory {
     private static final class AnnotatedWildcardTypeImpl extends AnnotatedTypeBaseImpl implements AnnotatedWildcardType {
         private final boolean hasUpperBounds;
         AnnotatedWildcardTypeImpl(WildcardType type, LocationInfo location,
-                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations,
-                AnnotatedElement decl) {
-            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations, decl);
+                TypeAnnotation[] actualTypeAnnotations, TypeAnnotation[] allOnSameTargetTypeAnnotations) {
+            super(type, location, actualTypeAnnotations, allOnSameTargetTypeAnnotations);
             hasUpperBounds = (type.getLowerBounds().length == 0);
         }
 
@@ -506,8 +486,7 @@ public final class AnnotatedTypeFactory {
                 return new AnnotatedType[] { buildAnnotatedType(Object.class,
                         LocationInfo.BASE_LOCATION,
                         EMPTY_TYPE_ANNOTATION_ARRAY,
-                        EMPTY_TYPE_ANNOTATION_ARRAY,
-                        null)
+                        EMPTY_TYPE_ANNOTATION_ARRAY)
                 };
             }
             return getAnnotatedBounds(getWildcardType().getUpperBounds());
@@ -538,8 +517,7 @@ public final class AnnotatedTypeFactory {
                 res[i] = buildAnnotatedType(bounds[i],
                         newLoc,
                         l.toArray(EMPTY_TYPE_ANNOTATION_ARRAY),
-                        getTypeAnnotations(),
-                        getDecl());
+                        getTypeAnnotations());
             }
             return res;
         }

--- a/src/java.base/share/classes/sun/reflect/annotation/TypeAnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/TypeAnnotationParser.java
@@ -78,8 +78,7 @@ public final class TypeAnnotationParser {
         return AnnotatedTypeFactory.buildAnnotatedType(type,
                 AnnotatedTypeFactory.nestingForType(type, LocationInfo.BASE_LOCATION),
                 typeAnnotations,
-                typeAnnotations,
-                decl);
+                typeAnnotations);
     }
 
     /**
@@ -156,8 +155,7 @@ public final class TypeAnnotationParser {
             result[i] = AnnotatedTypeFactory.buildAnnotatedType(types[i],
                     AnnotatedTypeFactory.nestingForType(types[i], LocationInfo.BASE_LOCATION),
                     typeAnnotations,
-                    typeAnnotations,
-                    decl);
+                    typeAnnotations);
 
         }
         return result;
@@ -303,8 +301,7 @@ public final class TypeAnnotationParser {
                 res[i] = AnnotatedTypeFactory.buildAnnotatedType(bounds[i],
                         AnnotatedTypeFactory.nestingForType(bounds[i], loc),
                         typeAnnotations,
-                        typeAnnotations,
-                        decl);
+                        typeAnnotations);
             }
             return res;
         }


### PR DESCRIPTION
In `AnnotatedTypeBaseImpl`, a `decl` field is declared, referring to the declaration that the AnnotatedType is from. However, this field is not used anywhere except passing to constructors of other implementations; it's not used in debug messages (unlike in `TypeAnnotation`), not involved in equality checks. Since these implementations are not serializable, we can safely remove the decl field from the implementations. All 1048 java/lang tests pass on my machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304918](https://bugs.openjdk.org/browse/JDK-8304918): Remove unused decl field from AnnotatedType implementations


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13183/head:pull/13183` \
`$ git checkout pull/13183`

Update a local copy of the PR: \
`$ git checkout pull/13183` \
`$ git pull https://git.openjdk.org/jdk.git pull/13183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13183`

View PR using the GUI difftool: \
`$ git pr show -t 13183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13183.diff">https://git.openjdk.org/jdk/pull/13183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13183#issuecomment-1483736379)