### PR TITLE
8304932: MethodTypeDescImpl can be mutated by argument passed to MethodTypeDesc.of

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 package java.lang.constant;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -36,6 +34,7 @@ import static java.util.Objects.requireNonNull;
 class ConstantUtils {
     /** an empty constant descriptor */
     public static final ConstantDesc[] EMPTY_CONSTANTDESC = new ConstantDesc[0];
+    public static final ClassDesc[] EMPTY_CLASSDESC = new ClassDesc[0];
     static final Constable[] EMPTY_CONSTABLE = new Constable[0];
     static final int MAX_ARRAY_TYPE_DESC_DIMENSIONS = 255;
 
@@ -124,41 +123,6 @@ class ConstantUtils {
 
     static String dropFirstAndLastChar(String s) {
         return s.substring(1, s.length() - 1);
-    }
-
-    /**
-     * Parses a method descriptor string, and return a list of field descriptor
-     * strings, return type first, then parameter types
-     *
-     * @param descriptor the descriptor string
-     * @return the list of types
-     * @throws IllegalArgumentException if the descriptor string is not valid
-     */
-    static List<String> parseMethodDescriptor(String descriptor) {
-        int cur = 0, end = descriptor.length();
-        ArrayList<String> ptypes = new ArrayList<>();
-        ptypes.add(null); //placeholder for return type
-
-        if (cur >= end || descriptor.charAt(cur) != '(')
-            throw new IllegalArgumentException("Bad method descriptor: " + descriptor);
-
-        ++cur;  // skip '('
-        while (cur < end && descriptor.charAt(cur) != ')') {
-            int len = skipOverFieldSignature(descriptor, cur, end, false);
-            if (len == 0)
-                throw new IllegalArgumentException("Bad method descriptor: " + descriptor);
-            ptypes.add(descriptor.substring(cur, cur + len));
-            cur += len;
-        }
-        if (cur >= end)
-            throw new IllegalArgumentException("Bad method descriptor: " + descriptor);
-        ++cur;  // skip ')'
-
-        int rLen = skipOverFieldSignature(descriptor, cur, end, true);
-        if (rLen == 0 || cur + rLen != end)
-            throw new IllegalArgumentException("Bad method descriptor: " + descriptor);
-        ptypes.set(0, descriptor.substring(cur, cur + rLen));
-        return ptypes;
     }
 
     private static final char JVM_SIGNATURE_ARRAY = '[';

--- a/src/java.base/share/classes/java/lang/constant/MethodTypeDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodTypeDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public sealed interface MethodTypeDesc
      * {@link ClassDesc} for {@code void}
      */
     static MethodTypeDesc of(ClassDesc returnDesc, ClassDesc... paramDescs) {
-        return new MethodTypeDescImpl(returnDesc, paramDescs);
+        return new MethodTypeDescImpl(returnDesc, List.of(paramDescs));
     }
 
     /**

--- a/test/jdk/java/lang/constant/MethodTypeDescTest.java
+++ b/test/jdk/java/lang/constant/MethodTypeDescTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 import java.lang.invoke.MethodType;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -31,15 +32,14 @@ import java.util.stream.Stream;
 
 import org.testng.annotations.Test;
 
-import static java.lang.constant.ConstantDescs.CD_int;
-import static java.lang.constant.ConstantDescs.CD_void;
+import static java.lang.constant.ConstantDescs.*;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 /**
  * @test
+ * @bug 8304932
  * @compile MethodTypeDescTest.java
  * @run testng MethodTypeDescTest
  * @summary unit tests for java.lang.constant.MethodTypeDesc
@@ -104,12 +104,9 @@ public class MethodTypeDescTest extends SymbolicDescTest {
         }
 
         // try with null parameter
-        try {
+        expectThrows(NullPointerException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.changeReturnType(null);
-            fail("should fail with NPE");
-        } catch (NullPointerException ex) {
-            // good
-        }
+        });
 
         // changeParamType
         for (int i=0; i<paramTypes.length; i++) {
@@ -133,6 +130,15 @@ public class MethodTypeDescTest extends SymbolicDescTest {
             MethodTypeDesc newDesc = mtDesc.dropParameterTypes(i, i + 1);
             assertEquals(newDesc, MethodTypeDesc.of(returnType, ps));
             testMethodTypeDesc(newDesc, mt.dropParameterTypes(i, i+1));
+
+            // drop multiple params
+            for (int j = i; j < paramTypes.length; j++) {
+                var t = new ArrayList<>(Arrays.asList(paramTypes));
+                t.subList(i, j).clear();
+                MethodTypeDesc multiDrop = mtDesc.dropParameterTypes(i, j);
+                assertEquals(multiDrop, MethodTypeDesc.of(returnType, t.toArray(ClassDesc[]::new)));
+                testMethodTypeDesc(multiDrop, mt.dropParameterTypes(i, j));
+            }
         }
 
         badDropParametersTypes(CD_void, paramDescs);
@@ -148,6 +154,21 @@ public class MethodTypeDescTest extends SymbolicDescTest {
                 assertEquals(newDesc, MethodTypeDesc.of(returnType, ps));
                 testMethodTypeDesc(newDesc, mt.insertParameterTypes(i, (Class<?>)p.resolveConstantDesc(LOOKUP)));
             }
+
+            // add multiple params
+            ClassDesc[] addition = {CD_int, CD_String};
+            var a = new ArrayList<>(Arrays.asList(paramTypes));
+            a.addAll(i, Arrays.asList(addition));
+
+            MethodTypeDesc newDesc = mtDesc.insertParameterTypes(i, addition);
+            assertEquals(newDesc, MethodTypeDesc.of(returnType, a.toArray(ClassDesc[]::new)));
+            testMethodTypeDesc(newDesc, mt.insertParameterTypes(i, Arrays.stream(addition).map(d -> {
+                try {
+                    return (Class<?>) d.resolveConstantDesc(LOOKUP);
+                } catch (ReflectiveOperationException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }).toArray(Class[]::new)));
         }
 
         badInsertParametersTypes(CD_void, paramDescs);
@@ -158,47 +179,32 @@ public class MethodTypeDescTest extends SymbolicDescTest {
                 IntStream.rangeClosed(0, paramDescTypes.length - 1)
                         .mapToObj(i -> ClassDesc.ofDescriptor(paramDescTypes[i])).toArray(ClassDesc[]::new);
         MethodTypeDesc mtDesc = MethodTypeDesc.of(returnType, paramTypes);
-        try {
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.insertParameterTypes(-1, paramTypes);
-            fail("pos < 0 should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.insertParameterTypes(paramTypes.length + 1, paramTypes);
-            fail("pos > current arguments length should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(IllegalArgumentException.class, () -> {
             ClassDesc[] newParamTypes = new ClassDesc[1];
             newParamTypes[0] = CD_void;
             MethodTypeDesc newDesc = MethodTypeDesc.of(returnType, CD_int);
             newDesc = newDesc.insertParameterTypes(0, newParamTypes);
-            fail("shouldn't allow parameters with class descriptor CD_void");
-        } catch (IllegalArgumentException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(NullPointerException.class, () -> {
             MethodTypeDesc newDesc = MethodTypeDesc.of(returnType, CD_int);
             newDesc = newDesc.insertParameterTypes(0, null);
-            fail("should fail with NPE");
-        } catch (NullPointerException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(NullPointerException.class, () -> {
             ClassDesc[] newParamTypes = new ClassDesc[1];
             newParamTypes[0] = null;
             MethodTypeDesc newDesc = MethodTypeDesc.of(returnType, CD_int);
             newDesc = newDesc.insertParameterTypes(0, newParamTypes);
-            fail("should fail with NPE");
-        } catch (NullPointerException ex) {
-            // good
-        }
+        });
     }
 
     private void badDropParametersTypes(ClassDesc returnType, String... paramDescTypes) {
@@ -206,40 +212,26 @@ public class MethodTypeDescTest extends SymbolicDescTest {
                 IntStream.rangeClosed(0, paramDescTypes.length - 1)
                         .mapToObj(i -> ClassDesc.ofDescriptor(paramDescTypes[i])).toArray(ClassDesc[]::new);
         MethodTypeDesc mtDesc = MethodTypeDesc.of(returnType, paramTypes);
-        try {
+
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.dropParameterTypes(-1, 0);
-            fail("start index < 0 should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.dropParameterTypes(paramTypes.length, 0);
-            fail("start index = arguments.length should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.dropParameterTypes(paramTypes.length + 1, 0);
-            fail("start index > arguments.length should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.dropParameterTypes(0, paramTypes.length + 1);
-            fail("end index > arguments.length should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(IndexOutOfBoundsException.class, () -> {
             MethodTypeDesc newDesc = mtDesc.dropParameterTypes(1, 0);
-            fail("start index > end index should have failed");
-        } catch (IndexOutOfBoundsException ex) {
-            // good
-        }
+        });
     }
 
     public void testMethodTypeDesc() throws ReflectiveOperationException {
@@ -260,49 +252,41 @@ public class MethodTypeDescTest extends SymbolicDescTest {
                                               "(Ljava.lang.String;)V", "(java/lang/String)V");
 
         for (String d : badDescriptors) {
-            try {
+            expectThrows(IllegalArgumentException.class, () -> {
                 MethodTypeDesc r = MethodTypeDesc.ofDescriptor(d);
-                fail(d);
-            }
-            catch (IllegalArgumentException e) {
-                // good
-            }
+            });
         }
 
         // try with null argument
-        try {
+        expectThrows(NullPointerException.class, () -> {
             MethodTypeDesc r = MethodTypeDesc.ofDescriptor(null);
-            fail("should fail with NPE");
-        } catch (NullPointerException ex) {
-            // good
-        }
+        });
 
         // try with void arguments, this will stress another code path in particular
         // ConstantMethodTypeDesc::init
-        try {
+        expectThrows(IllegalArgumentException.class, () -> {
             MethodTypeDesc r = MethodTypeDesc.of(CD_int, CD_void);
-            fail("can't reach here");
-        }
-        catch (IllegalArgumentException e) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(NullPointerException.class, () -> {
             MethodTypeDesc r = MethodTypeDesc.of(CD_int, null);
-            fail("ClassDesc array should not be null");
-        }
-        catch (NullPointerException e) {
-            // good
-        }
+        });
 
-        try {
+        expectThrows(NullPointerException.class, () -> {
             ClassDesc[] paramDescs = new ClassDesc[1];
             paramDescs[0] = null;
             MethodTypeDesc r = MethodTypeDesc.of(CD_int, paramDescs);
-            fail("ClassDesc should not be null");
-        }
-        catch (NullPointerException e) {
-            // good
-        }
+        });
+    }
+
+    public void testImmutability() {
+        ClassDesc[] args = {CD_Object, CD_int};
+        var mtd = MethodTypeDesc.of(CD_void, args);
+
+        args[1] = CD_void;
+        assertEquals(mtd, MethodTypeDesc.of(CD_void, CD_Object, CD_int));
+
+        mtd.parameterArray()[1] = CD_void;
+        assertEquals(mtd, MethodTypeDesc.of(CD_void, CD_Object, CD_int));
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/constant/MethodTypeDescConstruct.java
+++ b/test/micro/org/openjdk/bench/java/lang/constant/MethodTypeDescConstruct.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.constant;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.constant.ConstantDescs.*;
+
+/**
+ * Performance of different MethodTypeDesc factory methods
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 6, time = 1)
+@Fork(1)
+@State(Scope.Benchmark)
+public class MethodTypeDescConstruct {
+    public enum Kind {
+        GENERIC(CD_Object, CD_Object, CD_Object),
+        VOID(CD_void),
+        NO_PARAM(CD_Class.arrayType()),
+        ARBITRARY(CD_int, CD_String, CD_String.arrayType(), CD_double.arrayType());
+
+        final String desc;
+        final ClassDesc ret;
+        final ClassDesc[] args;
+
+        Kind(ClassDesc ret, ClassDesc... args) {
+            this.desc = MethodTypeDesc.of(ret, args).descriptorString();
+            this.ret = ret;
+            this.args = args;
+        }
+    }
+
+    @Param
+    public Kind kind;
+
+    @Benchmark
+    public MethodTypeDesc ofDescriptorBench() {
+        return MethodTypeDesc.ofDescriptor(kind.desc);
+    }
+
+    @Benchmark
+    public MethodTypeDesc ofBench() {
+        return MethodTypeDesc.of(kind.ret, kind.args);
+    }
+}


### PR DESCRIPTION
Fixed the bug where if a caller keeps a reference to the array passed into `MethodTypeDesc.of`, the caller may mutate the Desc via the array and can create invalid MethodTypeDesc.

Unfortunately, since the input array now needs to be copied, the `of` factory suffers from a performance drop. But otherwise, this patch has minor performance gains on `ofDescriptor` factory, even compared to Adam's patch that optimized `ofDescriptor` in #12945.

This patch moves the parameters to an immutable list, to avoid allocations on `parameterList` as well.

Benchmark of Oracle JDK 20: https://gist.github.com/683c6219e183cbc2b336224fc2c0d50a
Benchmark of this patch: https://gist.github.com/22be9371a2370fb4a7b44f1684750ec4
Benchmark of [asotona's patch](https://github.com/openjdk/jdk/pull/12945/files#diff-ac8e413d3e13532a2b0d34a90253c6ddd7a4f04082f792b9d076e9b5a33f2078): https://gist.github.com/eb98579c3b51cafae481049a95a78f80

[sotona vs this](https://jmh.morethan.io/?gists=eb98579c3b51cafae481049a95a78f80,22be9371a2370fb4a7b44f1684750ec4); [20 vs this](https://jmh.morethan.io/?gists=683c6219e183cbc2b336224fc2c0d50a,22be9371a2370fb4a7b44f1684750ec4); [20 vs sotona](https://jmh.morethan.io/?gists=683c6219e183cbc2b336224fc2c0d50a,eb98579c3b51cafae481049a95a78f80), for reference