### PR TITLE
8304937: BufferedFieldBuilder.Model missing writeTo(DirectClassBuilder)

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,16 @@ public final class BufferedFieldBuilder
         @Override
         public Utf8Entry fieldType() {
             return desc;
+        }
+
+        @Override
+        public void writeTo(DirectClassBuilder builder) {
+            builder.withField(name, desc, new Consumer<FieldBuilder>() {
+                @Override
+                public void accept(FieldBuilder fieldBuilder) {
+                    elements.forEach(fieldBuilder);
+                }
+            });
         }
 
         @Override

--- a/test/jdk/jdk/classfile/ClassBuildingTest.java
+++ b/test/jdk/jdk/classfile/ClassBuildingTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8304937
+ * @compile -parameters ClassBuildingTest.java
+ * @summary Ensure that class transform chaining works.
+ * @run junit ClassBuildingTest
+ */
+
+import jdk.internal.classfile.ClassModel;
+import jdk.internal.classfile.ClassTransform;
+import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.MethodTransform;
+import jdk.internal.classfile.attribute.MethodParametersAttribute;
+import jdk.internal.classfile.attribute.SignatureAttribute;
+import jdk.internal.classfile.components.ClassRemapper;
+import org.junit.jupiter.api.Test;
+
+import java.lang.constant.ClassDesc;
+import java.lang.invoke.MethodHandles;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+
+public class ClassBuildingTest {
+    @Test
+    public void test() throws Throwable {
+        ClassModel cm;
+        try (var in = ClassBuildingTest.class.getResourceAsStream("/Outer$1Local.class")) {
+            cm = Classfile.parse(Objects.requireNonNull(in).readAllBytes());
+        }
+
+        ClassTransform transform = ClassRemapper.of(Map.of(ClassDesc.of("Outer"), ClassDesc.of("Router")));
+        transform = transform.andThen(ClassTransform.transformingMethods(MethodTransform.dropping(me
+                -> me instanceof MethodParametersAttribute)));
+        transform = transform.andThen(ClassTransform.transformingMethods(MethodTransform.dropping(me
+                -> me instanceof SignatureAttribute)));
+
+        MethodHandles.lookup().defineClass(cm.transform(transform));
+    }
+}
+
+class Outer {
+    void method(int p) {
+        class Local<V> {
+            Local(V value, int q, Comparator<Integer> p2) {
+                System.out.println(p + q);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please review this simple patch to Classfile API that fixes a missing override that otherwise affects usage of chained class transforms. A test is included, that it fails on the missing method without this patch.

Please review a few other patches fixing bugs affecting normal usage of the Classfile API as well:
#13167 #13021 #12996

I am trying to write a test for my in-progress patch to unify parameter mapping in core reflection in anticipation of #9862, however this bug prevents me from dropping method Signature and MethodParameters attributes with chained class transforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304937](https://bugs.openjdk.org/browse/JDK-8304937): BufferedFieldBuilder.Model missing writeTo(DirectClassBuilder)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13187/head:pull/13187` \
`$ git checkout pull/13187`

Update a local copy of the PR: \
`$ git checkout pull/13187` \
`$ git pull https://git.openjdk.org/jdk.git pull/13187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13187`

View PR using the GUI difftool: \
`$ git pr show -t 13187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13187.diff">https://git.openjdk.org/jdk/pull/13187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13187#issuecomment-1484218014)