### PR TITLE
8304927: Update java/net/httpclient/BasicAuthTest.java to check basic auth over HTTP/2

### DIFF
--- a/test/jdk/java/net/httpclient/BasicAuthTest.java
+++ b/test/jdk/java/net/httpclient/BasicAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,61 +24,70 @@
 /**
  * @test
  * @bug 8087112
- * @modules java.net.http
- *          jdk.httpserver
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
  * @run main/othervm BasicAuthTest
  * @summary Basic Authentication Test
  */
 
 import com.sun.net.httpserver.BasicAuthenticator;
-import com.sun.net.httpserver.HttpContext;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
+import jdk.test.lib.net.SimpleSSLContext;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import javax.net.ssl.SSLContext;
+
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
-public class BasicAuthTest {
+public class BasicAuthTest implements HttpServerAdapters {
 
     static volatile boolean ok;
     static final String RESPONSE = "Hello world";
     static final String POST_BODY = "This is the POST body 123909090909090";
 
     public static void main(String[] args) throws Exception {
-        InetSocketAddress addr = new InetSocketAddress(InetAddress.getLoopbackAddress(),0);
-        HttpServer server = HttpServer.create(addr, 10);
+        test(Version.HTTP_1_1, false);
+        test(Version.HTTP_2, false);
+        test(Version.HTTP_1_1, true);
+        test(Version.HTTP_2, true);
+    }
+
+    public static void test(Version version, boolean secure) throws Exception {
+
         ExecutorService e = Executors.newCachedThreadPool();
         Handler h = new Handler();
-        HttpContext serverContext = server.createContext("/test", h);
-        int port = server.getAddress().getPort();
-        System.out.println("Server port = " + port);
-
-        ClientAuth ca = new ClientAuth();
+        SSLContext sslContext = secure ? new SimpleSSLContext().get() : null;
+        HttpTestServer server = HttpTestServer.create(version, sslContext, e);
+        HttpTestContext serverContext = server.addHandler(h,"/test/");
         ServerAuth sa = new ServerAuth("foo realm");
         serverContext.setAuthenticator(sa);
-        server.setExecutor(e);
         server.start();
-        HttpClient client = HttpClient.newBuilder()
-                                      .authenticator(ca)
-                                      .build();
+        System.out.println("Server auth = " + server.serverAuthority());
+
+        ClientAuth ca = new ClientAuth();
+        var clientBuilder = HttpClient.newBuilder();
+        if (sslContext != null) clientBuilder.sslContext(sslContext);
+        HttpClient client = clientBuilder.authenticator(ca).build();
 
         try {
-            URI uri = new URI("http://localhost:" + Integer.toString(port) + "/test/foo");
-            HttpRequest req = HttpRequest.newBuilder(uri).GET().build();
+            String scheme = sslContext == null ? "http" : "https";
+            URI uri = new URI(scheme + "://" + server.serverAuthority() + "/test/foo/"+version);
+            var builder = HttpRequest.newBuilder(uri);
+            HttpRequest req = builder.copy().GET().build();
 
+            System.out.println("\n\nSending request: " + req);
             HttpResponse resp = client.send(req, BodyHandlers.ofString());
             ok = resp.statusCode() == 200 && resp.body().equals(RESPONSE);
 
@@ -87,6 +96,7 @@ public class BasicAuthTest {
 
             // repeat same request, should succeed but no additional authenticator calls
 
+            System.out.println("\n\nRepeat request: " + req);
             resp = client.send(req, BodyHandlers.ofString());
             ok = resp.statusCode() == 200 && resp.body().equals(RESPONSE);
 
@@ -95,16 +105,18 @@ public class BasicAuthTest {
 
             // try a POST
 
-            req = HttpRequest.newBuilder(uri)
-                             .POST(BodyPublishers.ofString(POST_BODY))
+            req = builder.copy().POST(BodyPublishers.ofString(POST_BODY))
                              .build();
+            System.out.println("\n\nSending POST request: " + req);
             resp = client.send(req, BodyHandlers.ofString());
             ok = resp.statusCode() == 200;
 
             if (!ok || ca.count != 1)
                 throw new RuntimeException("Test failed");
+
+
         } finally {
-            server.stop(0);
+            server.stop();
             e.shutdownNow();
         }
         System.out.println("OK");
@@ -136,20 +148,20 @@ public class BasicAuthTest {
         }
     }
 
-   static class Handler implements HttpHandler {
+   static class Handler implements HttpTestHandler {
         static volatile boolean ok;
 
         @Override
-        public void handle(HttpExchange he) throws IOException {
+        public void handle(HttpTestExchange he) throws IOException {
             String method = he.getRequestMethod();
             InputStream is = he.getRequestBody();
             if (method.equalsIgnoreCase("POST")) {
                 String requestBody = new String(is.readAllBytes(), US_ASCII);
                 if (!requestBody.equals(POST_BODY)) {
-                    he.sendResponseHeaders(500, -1);
+                    he.sendResponseHeaders(500, 0);
                     ok = false;
                 } else {
-                    he.sendResponseHeaders(200, -1);
+                    he.sendResponseHeaders(200, 0);
                     ok = true;
                 }
             } else { // GET

--- a/test/jdk/java/net/httpclient/BasicAuthTest.java
+++ b/test/jdk/java/net/httpclient/BasicAuthTest.java
@@ -91,8 +91,9 @@ public class BasicAuthTest implements HttpServerAdapters {
             HttpResponse resp = client.send(req, BodyHandlers.ofString());
             ok = resp.statusCode() == 200 && resp.body().equals(RESPONSE);
 
-            if (!ok || ca.count != 1)
-                throw new RuntimeException("Test failed");
+            var count = ca.count;
+            if (!ok || count != 1)
+                throw new RuntimeException("Test failed: ca.count=" + count);
 
             // repeat same request, should succeed but no additional authenticator calls
 
@@ -100,8 +101,9 @@ public class BasicAuthTest implements HttpServerAdapters {
             resp = client.send(req, BodyHandlers.ofString());
             ok = resp.statusCode() == 200 && resp.body().equals(RESPONSE);
 
-            if (!ok || ca.count != 1)
-                throw new RuntimeException("Test failed");
+            count = ca.count;
+            if (!ok || count != 1)
+                throw new RuntimeException("Test failed: ca.count=" + count);
 
             // try a POST
 
@@ -111,8 +113,9 @@ public class BasicAuthTest implements HttpServerAdapters {
             resp = client.send(req, BodyHandlers.ofString());
             ok = resp.statusCode() == 200;
 
-            if (!ok || ca.count != 1)
-                throw new RuntimeException("Test failed");
+            count = ca.count;
+            if (!ok || count != 1)
+                throw new RuntimeException("Test failed: ca.count=" + count);
 
 
         } finally {

--- a/test/jdk/java/net/httpclient/DigestEchoServer.java
+++ b/test/jdk/java/net/httpclient/DigestEchoServer.java
@@ -67,6 +67,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters.AbstractHttpAuthFilter.HttpAuthMode;
 import sun.net.www.HeaderParser;
 import java.net.http.HttpClient.Version;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
@@ -88,8 +90,14 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
     public static final boolean TUNNEL_REQUIRES_HOST =
             Boolean.parseBoolean(System.getProperty("test.requiresHost", "false"));
     public enum HttpAuthType {
-        SERVER, PROXY, SERVER307, PROXY305
+        SERVER, PROXY, SERVER307, PROXY305;
         /* add PROXY_AND_SERVER and SERVER_PROXY_NONE */
+        public HttpAuthMode authMode() {
+            return switch (this) {
+                case SERVER, SERVER307 -> HttpAuthMode.SERVER;
+                case PROXY, PROXY305 -> HttpAuthMode.PROXY;
+            };
+        }
     };
     public enum HttpAuthSchemeType { NONE, BASICSERVER, BASIC, DIGEST };
     public static final HttpAuthType DEFAULT_HTTP_AUTH_TYPE = HttpAuthType.SERVER;
@@ -480,19 +488,21 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
         return server;
     }
 
+    static BasicAuthenticator toBasicAuthenticator(HttpTestAuthenticator auth) {
+        final String realm = auth.getRealm();
+        return new BasicAuthenticator(realm) {
+            @Override
+            public boolean checkCredentials(String username, String pwd) {
+                return auth.getUserName().equals(username)
+                        && new String(auth.getPassword(username)).equals(pwd);
+            }
+        };
+    }
 
     static void setContextAuthenticator(HttpTestContext ctxt,
                                         HttpTestAuthenticator auth) {
-        final String realm = auth.getRealm();
-        com.sun.net.httpserver.Authenticator authenticator =
-            new BasicAuthenticator(realm) {
-                @Override
-                public boolean checkCredentials(String username, String pwd) {
-                    return auth.getUserName().equals(username)
-                           && new String(auth.getPassword(username)).equals(pwd);
-                }
-        };
-        ctxt.setAuthenticator(authenticator);
+
+        ctxt.setAuthenticator(toBasicAuthenticator(auth));
     }
 
     public static DigestEchoServer createServer(Version version,
@@ -659,7 +669,7 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
                                  HttpAuthType authType) {
         switch(schemeType) {
             case DIGEST:
-                // DIGEST authentication is handled by the handler.
+                // DIGEST authentication is handled by the filter.
                 ctxt.addFilter(new HttpDigestFilter(key, auth, authType));
                 break;
             case BASIC:
@@ -705,85 +715,6 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
         return new Http3xxHandler(key, proxyURL, type, code300);
     }
 
-    // Abstract HTTP filter class.
-    private abstract static class AbstractHttpFilter extends HttpTestFilter {
-
-        final HttpAuthType authType;
-        final String type;
-        public AbstractHttpFilter(HttpAuthType authType, String type) {
-            this.authType = authType;
-            this.type = type;
-        }
-
-        String getLocation() {
-            return "Location";
-        }
-        String getAuthenticate() {
-            return authType == HttpAuthType.PROXY
-                    ? "Proxy-Authenticate" : "WWW-Authenticate";
-        }
-        String getAuthorization() {
-            return authType == HttpAuthType.PROXY
-                    ? "Proxy-Authorization" : "Authorization";
-        }
-        int getUnauthorizedCode() {
-            return authType == HttpAuthType.PROXY
-                    ? HttpURLConnection.HTTP_PROXY_AUTH
-                    : HttpURLConnection.HTTP_UNAUTHORIZED;
-        }
-        String getKeepAlive() {
-            return "keep-alive";
-        }
-        String getConnection() {
-            return authType == HttpAuthType.PROXY
-                    ? "Proxy-Connection" : "Connection";
-        }
-        protected abstract boolean isAuthentified(HttpTestExchange he) throws IOException;
-        protected abstract void requestAuthentication(HttpTestExchange he) throws IOException;
-        protected void accept(HttpTestExchange he, HttpChain chain) throws IOException {
-            chain.doFilter(he);
-        }
-
-        @Override
-        public String description() {
-            return "Filter for " + type;
-        }
-        @Override
-        public void doFilter(HttpTestExchange he, HttpChain chain) throws IOException {
-            try {
-                System.out.println(type + ": Got " + he.getRequestMethod()
-                    + ": " + he.getRequestURI()
-                    + "\n" + DigestEchoServer.toString(he.getRequestHeaders()));
-
-                // Assert only a single value for Expect. Not directly related
-                // to digest authentication, but verifies good client behaviour.
-                List<String> expectValues = he.getRequestHeaders().get("Expect");
-                if (expectValues != null && expectValues.size() > 1) {
-                    throw new IOException("Expect:  " + expectValues);
-                }
-
-                if (!isAuthentified(he)) {
-                    try {
-                        requestAuthentication(he);
-                        he.sendResponseHeaders(getUnauthorizedCode(), -1);
-                        System.out.println(type
-                            + ": Sent back " + getUnauthorizedCode());
-                    } finally {
-                        he.close();
-                    }
-                } else {
-                    accept(he, chain);
-                }
-            } catch (RuntimeException | Error | IOException t) {
-               System.err.println(type
-                    + ": Unexpected exception while handling request: " + t);
-               t.printStackTrace(System.err);
-               he.close();
-               throw t;
-            }
-        }
-
-    }
 
     // WARNING: This is not a full fledged implementation of DIGEST.
     // It does contain bugs and inaccuracy.
@@ -918,16 +849,16 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
 
     }
 
-    private static class HttpNoAuthFilter extends AbstractHttpFilter {
+    private static class HttpNoAuthFilter extends AbstractHttpAuthFilter {
 
         static String type(String key, HttpAuthType authType) {
-            String type = authType == HttpAuthType.SERVER
+            String type = authType.authMode() == HttpAuthMode.SERVER
                     ? "NoAuth Server Filter" : "NoAuth Proxy Filter";
             return "["+type+"]:"+key;
         }
 
         public HttpNoAuthFilter(String key, HttpAuthType authType) {
-            super(authType, type(key, authType));
+            super(authType.authMode(), type(key, authType));
         }
 
         @Override
@@ -948,73 +879,22 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
     }
 
     // An HTTP Filter that performs Basic authentication
-    private static class HttpBasicFilter extends AbstractHttpFilter {
+    private static class HttpBasicFilter extends HttpBasicAuthFilter {
 
         static String type(String key, HttpAuthType authType) {
-            String type = authType == HttpAuthType.SERVER
+            String type = authType.authMode() == HttpAuthMode.SERVER
                     ? "Basic Server Filter" : "Basic Proxy Filter";
             return "["+type+"]:"+key;
         }
 
-        private final HttpTestAuthenticator auth;
         public HttpBasicFilter(String key, HttpTestAuthenticator auth,
                                HttpAuthType authType) {
-            super(authType, type(key, authType));
-            this.auth = auth;
-        }
-
-        @Override
-        protected void requestAuthentication(HttpTestExchange he)
-            throws IOException
-        {
-            String headerName = getAuthenticate();
-            String headerValue = "Basic realm=\"" + auth.getRealm() + "\"";
-            he.getResponseHeaders().addHeader(headerName, headerValue);
-            System.out.println(type + ": Requesting Basic Authentication, "
-                               + headerName + " : "+ headerValue);
-        }
-
-        @Override
-        protected boolean isAuthentified(HttpTestExchange he) {
-            if (he.getRequestHeaders().containsKey(getAuthorization())) {
-                List<String> authorization =
-                    he.getRequestHeaders().get(getAuthorization());
-                for (String a : authorization) {
-                    System.out.println(type + ": processing " + a);
-                    int sp = a.indexOf(' ');
-                    if (sp < 0) return false;
-                    String scheme = a.substring(0, sp);
-                    if (!"Basic".equalsIgnoreCase(scheme)) {
-                        System.out.println(type + ": Unsupported scheme '"
-                                           + scheme +"'");
-                        return false;
-                    }
-                    if (a.length() <= sp+1) {
-                        System.out.println(type + ": value too short for '"
-                                            + scheme +"'");
-                        return false;
-                    }
-                    a = a.substring(sp+1);
-                    return validate(a);
-                }
-                return false;
-            }
-            return false;
-        }
-
-        boolean validate(String a) {
-            byte[] b = Base64.getDecoder().decode(a);
-            String userpass = new String (b);
-            int colon = userpass.indexOf (':');
-            String uname = userpass.substring (0, colon);
-            String pass = userpass.substring (colon+1);
-            return auth.getUserName().equals(uname) &&
-                   new String(auth.getPassword(uname)).equals(pass);
+            super(toBasicAuthenticator(auth), authType.authMode(), type(key, authType));
         }
 
         @Override
         public String description() {
-            return "Filter for BASIC authentication: " + type;
+            return "Filter for BASIC authentication: " + type();
         }
 
     }
@@ -1023,10 +903,10 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
     // An HTTP Filter that performs Digest authentication
     // WARNING: This is not a full fledged implementation of DIGEST.
     // It does contain bugs and inaccuracy.
-    private static class HttpDigestFilter extends AbstractHttpFilter {
+    private static class HttpDigestFilter extends AbstractHttpAuthFilter {
 
         static String type(String key, HttpAuthType authType) {
-            String type = authType == HttpAuthType.SERVER
+            String type = authType.authMode() == HttpAuthMode.SERVER
                     ? "Digest Server Filter" : "Digest Proxy Filter";
             return "["+type+"]:"+key;
         }
@@ -1038,12 +918,14 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
         private final HttpTestAuthenticator auth;
         private final byte[] nonce;
         private final String ns;
+        private final String type;
         public HttpDigestFilter(String key, HttpTestAuthenticator auth, HttpAuthType authType) {
-            super(authType, type(key, authType));
+            super(authType.authMode(), type(key, authType));
             this.auth = auth;
             nonce = new byte[16];
             new Random(Instant.now().toEpochMilli()).nextBytes(nonce);
             ns = new BigInteger(1, nonce).toString(16);
+            this.type = type();
         }
 
         @Override

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -22,6 +22,8 @@
  */
 package jdk.httpclient.test.lib.common;
 
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.BasicAuthenticator;
 import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpContext;
@@ -48,6 +50,7 @@ import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpHeaders;
+import java.util.Base64;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -58,6 +61,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.net.ssl.SSLContext;
@@ -506,6 +510,175 @@ public interface HttpServerAdapters {
         }
     }
 
+    static String toString(HttpTestRequestHeaders headers) {
+        return headers.entrySet().stream()
+                .map((e) -> e.getKey() + ": " + e.getValue())
+                .collect(Collectors.joining("\n"));
+    }
+
+    abstract static class AbstractHttpAuthFilter extends HttpTestFilter {
+
+        public static final int HTTP_PROXY_AUTH = 407;
+        public static final int HTTP_UNAUTHORIZED = 401;
+        public enum HttpAuthMode {PROXY, SERVER}
+        final HttpAuthMode authType;
+        final String type;
+
+        public AbstractHttpAuthFilter(HttpAuthMode authType, String type) {
+            this.authType = authType;
+            this.type = type;
+        }
+
+        public final String type() {
+            return type;
+        }
+
+        protected String getLocation() {
+            return "Location";
+        }
+        protected String getKeepAlive() {
+            return "keep-alive";
+        }
+        protected String getConnection() {
+            return authType == HttpAuthMode.PROXY ? "Proxy-Connection" : "Connection";
+        }
+
+        protected String getAuthenticate() {
+            return authType == HttpAuthMode.PROXY
+                    ? "Proxy-Authenticate" : "WWW-Authenticate";
+        }
+        protected String getAuthorization() {
+            return authType == HttpAuthMode.PROXY
+                    ? "Proxy-Authorization" : "Authorization";
+        }
+        protected int getUnauthorizedCode() {
+            return authType == HttpAuthMode.PROXY
+                    ? HTTP_PROXY_AUTH
+                    : HTTP_UNAUTHORIZED;
+        }
+        protected abstract boolean isAuthentified(HttpTestExchange he) throws IOException;
+        protected abstract void requestAuthentication(HttpTestExchange he) throws IOException;
+        protected void accept(HttpTestExchange he, HttpChain chain) throws IOException {
+            chain.doFilter(he);
+        }
+
+        @Override
+        public void doFilter(HttpTestExchange he, HttpChain chain) throws IOException {
+            try {
+                System.out.println(type + ": Got " + he.getRequestMethod()
+                        + ": " + he.getRequestURI()
+                        + "\n" + HttpServerAdapters.toString(he.getRequestHeaders()));
+
+                // Assert only a single value for Expect. Not directly related
+                // to digest authentication, but verifies good client behaviour.
+                List<String> expectValues = he.getRequestHeaders().get("Expect");
+                if (expectValues != null && expectValues.size() > 1) {
+                    throw new IOException("Expect:  " + expectValues);
+                }
+
+                if (!isAuthentified(he)) {
+                    try {
+                        requestAuthentication(he);
+                        he.sendResponseHeaders(getUnauthorizedCode(), -1);
+                        System.out.println(type
+                                + ": Sent back " + getUnauthorizedCode());
+                    } finally {
+                        he.close();
+                    }
+                } else {
+                    accept(he, chain);
+                }
+            } catch (RuntimeException | Error | IOException t) {
+                System.err.println(type
+                        + ": Unexpected exception while handling request: " + t);
+                t.printStackTrace(System.err);
+                he.close();
+                throw t;
+            }
+        }
+
+    }
+
+    public static class HttpBasicAuthFilter extends AbstractHttpAuthFilter {
+
+            static String type(HttpAuthMode authType) {
+                String type = authType == HttpAuthMode.SERVER
+                        ? "BasicAuth Server Filter" : "BasicAuth Proxy Filter";
+                return "["+type+"]";
+            }
+
+            final BasicAuthenticator auth;
+            public HttpBasicAuthFilter(BasicAuthenticator auth) {
+                this(auth, HttpAuthMode.SERVER);
+            }
+
+            public HttpBasicAuthFilter(BasicAuthenticator auth, HttpAuthMode authType) {
+                this(auth, authType, type(authType));
+            }
+
+            public HttpBasicAuthFilter(BasicAuthenticator auth, HttpAuthMode authType, String typeDesc) {
+                super(authType, typeDesc);
+                this.auth = auth;
+            }
+
+            protected String getAuthValue() {
+                return "Basic realm=\"" + auth.getRealm() + "\"";
+            }
+
+            @Override
+            protected void requestAuthentication(HttpTestExchange he)
+                    throws IOException
+            {
+                String headerName = getAuthenticate();
+                String headerValue = getAuthValue();
+                he.getResponseHeaders().addHeader(headerName, headerValue);
+                System.out.println(type + ": Requesting Basic Authentication, "
+                        + headerName + " : "+ headerValue);
+            }
+
+            @Override
+            protected boolean isAuthentified(HttpTestExchange he) {
+                if (he.getRequestHeaders().containsKey(getAuthorization())) {
+                    List<String> authorization =
+                            he.getRequestHeaders().get(getAuthorization());
+                    for (String a : authorization) {
+                        System.out.println(type + ": processing " + a);
+                        int sp = a.indexOf(' ');
+                        if (sp < 0) return false;
+                        String scheme = a.substring(0, sp);
+                        if (!"Basic".equalsIgnoreCase(scheme)) {
+                            System.out.println(type + ": Unsupported scheme '"
+                                    + scheme +"'");
+                            return false;
+                        }
+                        if (a.length() <= sp+1) {
+                            System.out.println(type + ": value too short for '"
+                                    + scheme +"'");
+                            return false;
+                        }
+                        a = a.substring(sp+1);
+                        return validate(a);
+                    }
+                    return false;
+                }
+                return false;
+            }
+
+            boolean validate(String a) {
+                byte[] b = Base64.getDecoder().decode(a);
+                String userpass = new String (b);
+                int colon = userpass.indexOf (':');
+                String uname = userpass.substring (0, colon);
+                String pass = userpass.substring (colon+1);
+                return auth.checkCredentials(uname, pass);
+            }
+
+        @Override
+        public String description() {
+            return "HttpBasicAuthFilter";
+        }
+    }
+
     /**
      * A version agnostic adapter class for HTTP Server Context.
      */
@@ -514,7 +687,7 @@ public interface HttpServerAdapters {
         public abstract void addFilter(HttpTestFilter filter);
         public abstract Version getVersion();
 
-        // will throw UOE if the server is HTTP/2
+        // will throw UOE if the server is HTTP/2 or Authenticator is not a BasicAuthenticator
         public abstract void setAuthenticator(com.sun.net.httpserver.Authenticator authenticator);
     }
 
@@ -752,8 +925,13 @@ public interface HttpServerAdapters {
                 HttpChain.of(filters, handler).doFilter(exchange);
             }
             @Override
-            public void setAuthenticator(com.sun.net.httpserver.Authenticator authenticator) {
-                throw new UnsupportedOperationException("Can't set HTTP/1.1 authenticator on HTTP/2 context");
+            public void setAuthenticator(final Authenticator authenticator) {
+                if (authenticator instanceof BasicAuthenticator basicAuth) {
+                    addFilter(new HttpBasicAuthFilter(basicAuth));
+                } else {
+                    throw new UnsupportedOperationException(
+                            "only BasicAuthenticator is supported on HTTP/2 context");
+                }
             }
             @Override public Version getVersion() { return Version.HTTP_2; }
         }


### PR DESCRIPTION
The BasicAuthTest only tests basic authentication with clear HTTP/1.1. 
This changes upgrades it to also test against TLS,  as well as HTTP/2.
The bulk of the fix is to move the implementation of a HttpBasicAuthFilter from DigestEchoServer.java to HttpServerAdapters. This makes it possible to enable basic auth in the HTTP/2 test server.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304927](https://bugs.openjdk.org/browse/JDK-8304927): Update java/net/httpclient/BasicAuthTest.java to check basic auth over HTTP/2


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [446b1b48](https://git.openjdk.org/jdk/pull/13189/files/446b1b481e09754d03ae81fa9177ceb4d3d87f04)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13189/head:pull/13189` \
`$ git checkout pull/13189`

Update a local copy of the PR: \
`$ git checkout pull/13189` \
`$ git pull https://git.openjdk.org/jdk.git pull/13189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13189`

View PR using the GUI difftool: \
`$ git pr show -t 13189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13189.diff">https://git.openjdk.org/jdk/pull/13189.diff</a>

</details>
