### PR TITLE
8304442: Allocate VirtualMemoryTracker into Arena

### DIFF
--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -35,9 +35,8 @@
 #include "memory/arena.hpp"
 #include "utilities/ostream.hpp"
 
-/*
- * Virtual memory counter
- */
+
+// Virtual memory counter
 class VirtualMemory {
  private:
   size_t     _reserved;


### PR DESCRIPTION
Hi,

This is a suggestion to allocate the VirtualMemoryTracker memory inside of an Arena instead of on the heap. This reduces the number of NativeCallStacks allocated as VMT doesn't go through os::malloc for each linked list node. It also hopefully increases memory locality, as the nodes are in the best case allocated very close to each other.

This PR sees a performance improvement in os::commit_memory and reserve_memory of about 10-25%, at no cost to reporting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304442](https://bugs.openjdk.org/browse/JDK-8304442): Allocate VirtualMemoryTracker into Arena


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13190/head:pull/13190` \
`$ git checkout pull/13190`

Update a local copy of the PR: \
`$ git checkout pull/13190` \
`$ git pull https://git.openjdk.org/jdk.git pull/13190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13190`

View PR using the GUI difftool: \
`$ git pr show -t 13190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13190.diff">https://git.openjdk.org/jdk/pull/13190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13190#issuecomment-1484981886)