### PR TITLE
8057586: Explicit GC ignored if GCLocker is active

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2108,14 +2108,11 @@ bool G1CollectedHeap::try_collect_fullgc(GCCause::Cause cause,
       return op.gc_succeeded();
     }
 
-    uint full_gc_count = 0;
     {
       MutexLocker ml(Heap_lock);
-      full_gc_count = total_full_collections();
-    }
-
-    if (counters_before.total_full_collections() != full_gc_count) {
-      return true;
+      if (counters_before.total_full_collections() != total_full_collections()) {
+        return true;
+      }
     }
 
     if (GCLocker::is_active_and_needs_gc()) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2093,6 +2093,38 @@ bool G1CollectedHeap::try_collect_concurrently(GCCause::Cause cause,
   }
 }
 
+bool G1CollectedHeap::try_collect_fullgc(GCCause::Cause cause,
+                                         const G1GCCounters& counters_before) {
+  assert_heap_not_locked();
+
+  while(true) {
+    VM_G1CollectFull op(counters_before.total_collections(),
+                        counters_before.total_full_collections(),
+                        cause);
+    VMThread::execute(&op);
+
+    // Request is trivially finished.
+    if (op.gc_succeeded() || cause == GCCause::_g1_periodic_collection) {
+      return op.gc_succeeded();
+    }
+
+    uint full_gc_count = 0;
+    {
+      MutexLocker ml(Heap_lock);
+      full_gc_count = total_full_collections();
+    }
+
+    if (counters_before.total_full_collections() != full_gc_count) {
+      return true;
+    }
+
+    if (GCLocker::is_active_and_needs_gc()) {
+      // If GCLocker is active, wait until clear before retrying.
+      GCLocker::stall_until_clear();
+    }
+  }
+}
+
 bool G1CollectedHeap::try_collect(GCCause::Cause cause,
                                   const G1GCCounters& counters_before) {
   if (should_do_concurrent_full_gc(cause)) {
@@ -2116,11 +2148,7 @@ bool G1CollectedHeap::try_collect(GCCause::Cause cause,
     return op.gc_succeeded();
   } else {
     // Schedule a Full GC.
-    VM_G1CollectFull op(counters_before.total_collections(),
-                        counters_before.total_full_collections(),
-                        cause);
-    VMThread::execute(&op);
-    return op.gc_succeeded();
+    return try_collect_fullgc(cause, counters_before);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2104,7 +2104,7 @@ bool G1CollectedHeap::try_collect_fullgc(GCCause::Cause cause,
     VMThread::execute(&op);
 
     // Request is trivially finished.
-    if (op.gc_succeeded() || cause == GCCause::_g1_periodic_collection) {
+    if (!GCCause::is_explicit_gc(cause) || op.gc_succeeded()) {
       return op.gc_succeeded();
     }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2104,7 +2104,7 @@ bool G1CollectedHeap::try_collect_fullgc(GCCause::Cause cause,
     VMThread::execute(&op);
 
     // Request is trivially finished.
-    if (!GCCause::is_explicit_gc(cause) || op.gc_succeeded()) {
+    if (!GCCause::is_explicit_full_gc(cause) || op.gc_succeeded()) {
       return op.gc_succeeded();
     }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -284,6 +284,9 @@ private:
                                 uint gc_counter,
                                 uint old_marking_started_before);
 
+  bool try_collect_fullgc(GCCause::Cause cause,
+                          const G1GCCounters& counters_before);
+
   // indicates whether we are in young or mixed GC mode
   G1CollectorState _collector_state;
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -553,7 +553,9 @@ void ParallelScavengeHeap::collect(GCCause::Cause cause) {
     VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
     VMThread::execute(&op);
 
-    if (!GCCause::is_explicit_gc(cause) || op.full_gc_succeeded()) {
+    if (!GCCause::is_explicit_gc(cause) ||
+        !VM_ParallelGCSystemGC::is_cause_full(cause) ||
+        op.full_gc_succeeded()) {
       return;
     }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -553,7 +553,7 @@ void ParallelScavengeHeap::collect(GCCause::Cause cause) {
     VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
     VMThread::execute(&op);
 
-    if (!VM_ParallelGCSystemGC::is_cause_full(cause) || op.full_gc_succeeded()) {
+    if (!VM_ParallelGCSystemGC::is_cause_full(cause) || op.gc_succeeded()) {
       return;
     }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -553,7 +553,7 @@ void ParallelScavengeHeap::collect(GCCause::Cause cause) {
     VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
     VMThread::execute(&op);
 
-    if (!VM_ParallelGCSystemGC::is_cause_full(cause) || op.full_gc_succeeded()) {
+    if (!GCCause::is_explicit_gc(cause) || op.full_gc_succeeded()) {
       return;
     }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -553,9 +553,7 @@ void ParallelScavengeHeap::collect(GCCause::Cause cause) {
     VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
     VMThread::execute(&op);
 
-    if (!GCCause::is_explicit_gc(cause) ||
-        !VM_ParallelGCSystemGC::is_cause_full(cause) ||
-        op.full_gc_succeeded()) {
+    if (!GCCause::is_explicit_full_gc(cause) || op.full_gc_succeeded()) {
       return;
     }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -549,8 +549,26 @@ void ParallelScavengeHeap::collect(GCCause::Cause cause) {
     return;
   }
 
-  VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
-  VMThread::execute(&op);
+  while (true) {
+    VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
+    VMThread::execute(&op);
+
+    if (!VM_ParallelGCSystemGC::is_cause_full(cause) || op.full_gc_succeeded()) {
+      return;
+    }
+
+    {
+      MutexLocker ml(Heap_lock);
+      if (full_gc_count != total_full_collections()) {
+        return;
+      }
+    }
+
+    if (GCLocker::is_active_and_needs_gc()) {
+      // If GCLocker is active, wait until clear before retrying.
+      GCLocker::stall_until_clear();
+    }
+  }
 }
 
 void ParallelScavengeHeap::object_iterate(ObjectClosure* cl) {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -553,7 +553,7 @@ void ParallelScavengeHeap::collect(GCCause::Cause cause) {
     VM_ParallelGCSystemGC op(gc_count, full_gc_count, cause);
     VMThread::execute(&op);
 
-    if (!VM_ParallelGCSystemGC::is_cause_full(cause) || op.gc_succeeded()) {
+    if (!VM_ParallelGCSystemGC::is_cause_full(cause) || op.full_gc_succeeded()) {
       return;
     }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -211,7 +211,7 @@ class ParallelScavengeHeap : public CollectedHeap {
   // will then attempt a full gc.  The second collects the entire heap; if
   // maximum_compaction is true, it will compact everything and clear all soft
   // references.
-  inline void invoke_scavenge();
+  inline bool invoke_scavenge();
 
   // Perform a full collection
   void do_full_collection(bool clear_all_soft_refs) override;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ inline bool ParallelScavengeHeap::should_alloc_in_eden(const size_t size) const 
   return size < eden_size / 2;
 }
 
-inline void ParallelScavengeHeap::invoke_scavenge() {
-  PSScavenge::invoke();
+inline bool ParallelScavengeHeap::invoke_scavenge() {
+  return PSScavenge::invoke();
 }
 
 inline bool ParallelScavengeHeap::is_in_young(const void* p) const {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1678,7 +1678,7 @@ void PSParallelCompact::summary_phase(bool maximum_compaction)
 // may be true because this method can be called without intervening
 // activity.  For example when the heap space is tight and full measure
 // are being taken to free space.
-void PSParallelCompact::invoke(bool maximum_heap_compaction) {
+bool PSParallelCompact::invoke(bool maximum_heap_compaction) {
   assert(SafepointSynchronize::is_at_safepoint(), "should be at safepoint");
   assert(Thread::current() == (Thread*)VMThread::vm_thread(),
          "should be in vm thread");
@@ -1695,8 +1695,8 @@ void PSParallelCompact::invoke(bool maximum_heap_compaction) {
   const bool clear_all_soft_refs =
     heap->soft_ref_policy()->should_clear_all_soft_refs();
 
-  PSParallelCompact::invoke_no_policy(clear_all_soft_refs ||
-                                      maximum_heap_compaction);
+  return PSParallelCompact::invoke_no_policy(clear_all_soft_refs ||
+                                             maximum_heap_compaction);
 }
 
 // This method contains no policy. You should probably

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -1141,7 +1141,7 @@ class PSParallelCompact : AllStatic {
 
   PSParallelCompact();
 
-  static void invoke(bool maximum_heap_compaction);
+  static bool invoke(bool maximum_heap_compaction);
   static bool invoke_no_policy(bool maximum_heap_compaction);
 
   static void post_initialize();

--- a/src/hotspot/share/gc/parallel/psVMOperations.cpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.cpp
@@ -49,7 +49,7 @@ void VM_ParallelGCFailedAllocation::doit() {
   }
 }
 
-static bool is_cause_full(GCCause::Cause cause) {
+bool VM_ParallelGCSystemGC::is_cause_full(GCCause::Cause cause) {
   return (cause != GCCause::_gc_locker) && (cause != GCCause::_wb_young_gc)
          DEBUG_ONLY(&& (cause != GCCause::_scavenge_alot));
 }
@@ -58,7 +58,8 @@ static bool is_cause_full(GCCause::Cause cause) {
 VM_ParallelGCSystemGC::VM_ParallelGCSystemGC(uint gc_count,
                                              uint full_gc_count,
                                              GCCause::Cause gc_cause) :
-  VM_GC_Operation(gc_count, gc_cause, full_gc_count, is_cause_full(gc_cause))
+  VM_GC_Operation(gc_count, gc_cause, full_gc_count, is_cause_full(gc_cause)),
+  _full_gc_succeeded(false)
 {
 }
 
@@ -70,8 +71,8 @@ void VM_ParallelGCSystemGC::doit() {
   GCCauseSetter gccs(heap, _gc_cause);
   if (!_full) {
     // If (and only if) the scavenge fails, this will invoke a full gc.
-    heap->invoke_scavenge();
+    _full_gc_succeeded = heap->invoke_scavenge();
   } else {
-    heap->do_full_collection(false);
+    _full_gc_succeeded = PSParallelCompact::invoke(false);
   }
 }

--- a/src/hotspot/share/gc/parallel/psVMOperations.cpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.cpp
@@ -59,7 +59,7 @@ VM_ParallelGCSystemGC::VM_ParallelGCSystemGC(uint gc_count,
                                              uint full_gc_count,
                                              GCCause::Cause gc_cause) :
   VM_GC_Operation(gc_count, gc_cause, full_gc_count, is_cause_full(gc_cause)),
-  _gc_succeeded(false)
+  _full_gc_succeeded(false)
 {
 }
 
@@ -71,8 +71,8 @@ void VM_ParallelGCSystemGC::doit() {
   GCCauseSetter gccs(heap, _gc_cause);
   if (!_full) {
     // If (and only if) the scavenge fails, this will invoke a full gc.
-    _gc_succeeded = heap->invoke_scavenge();
+    _full_gc_succeeded = heap->invoke_scavenge();
   } else {
-    _gc_succeeded = PSParallelCompact::invoke(false);
+    _full_gc_succeeded = PSParallelCompact::invoke(false);
   }
 }

--- a/src/hotspot/share/gc/parallel/psVMOperations.cpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.cpp
@@ -59,7 +59,7 @@ VM_ParallelGCSystemGC::VM_ParallelGCSystemGC(uint gc_count,
                                              uint full_gc_count,
                                              GCCause::Cause gc_cause) :
   VM_GC_Operation(gc_count, gc_cause, full_gc_count, is_cause_full(gc_cause)),
-  _full_gc_succeeded(false)
+  _gc_succeeded(false)
 {
 }
 
@@ -71,8 +71,8 @@ void VM_ParallelGCSystemGC::doit() {
   GCCauseSetter gccs(heap, _gc_cause);
   if (!_full) {
     // If (and only if) the scavenge fails, this will invoke a full gc.
-    _full_gc_succeeded = heap->invoke_scavenge();
+    _gc_succeeded = heap->invoke_scavenge();
   } else {
-    _full_gc_succeeded = PSParallelCompact::invoke(false);
+    _gc_succeeded = PSParallelCompact::invoke(false);
   }
 }

--- a/src/hotspot/share/gc/parallel/psVMOperations.cpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.cpp
@@ -49,7 +49,7 @@ void VM_ParallelGCFailedAllocation::doit() {
   }
 }
 
-bool VM_ParallelGCSystemGC::is_cause_full(GCCause::Cause cause) {
+static bool is_cause_full(GCCause::Cause cause) {
   return (cause != GCCause::_gc_locker) && (cause != GCCause::_wb_young_gc)
          DEBUG_ONLY(&& (cause != GCCause::_scavenge_alot));
 }

--- a/src/hotspot/share/gc/parallel/psVMOperations.hpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.hpp
@@ -46,7 +46,6 @@ class VM_ParallelGCSystemGC: public VM_GC_Operation {
   virtual VMOp_Type type() const { return VMOp_ParallelGCSystemGC; }
   virtual void doit();
   bool full_gc_succeeded() const { return _full_gc_succeeded; }
-  static bool is_cause_full(GCCause::Cause cause);
 };
 
 #endif // SHARE_GC_PARALLEL_PSVMOPERATIONS_HPP

--- a/src/hotspot/share/gc/parallel/psVMOperations.hpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,13 @@ class VM_ParallelGCFailedAllocation : public VM_CollectForAllocation {
 };
 
 class VM_ParallelGCSystemGC: public VM_GC_Operation {
+  bool _full_gc_succeeded;
  public:
   VM_ParallelGCSystemGC(uint gc_count, uint full_gc_count, GCCause::Cause gc_cause);
   virtual VMOp_Type type() const { return VMOp_ParallelGCSystemGC; }
   virtual void doit();
+  bool full_gc_succeeded() const { return _full_gc_succeeded; }
+  static bool is_cause_full(GCCause::Cause cause);
 };
 
 #endif // SHARE_GC_PARALLEL_PSVMOPERATIONS_HPP

--- a/src/hotspot/share/gc/parallel/psVMOperations.hpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.hpp
@@ -40,12 +40,12 @@ class VM_ParallelGCFailedAllocation : public VM_CollectForAllocation {
 };
 
 class VM_ParallelGCSystemGC: public VM_GC_Operation {
-  bool _gc_succeeded;
+  bool _full_gc_succeeded;
  public:
   VM_ParallelGCSystemGC(uint gc_count, uint full_gc_count, GCCause::Cause gc_cause);
   virtual VMOp_Type type() const { return VMOp_ParallelGCSystemGC; }
   virtual void doit();
-  bool gc_succeeded() const { return _gc_succeeded; }
+  bool full_gc_succeeded() const { return _full_gc_succeeded; }
   static bool is_cause_full(GCCause::Cause cause);
 };
 

--- a/src/hotspot/share/gc/parallel/psVMOperations.hpp
+++ b/src/hotspot/share/gc/parallel/psVMOperations.hpp
@@ -40,12 +40,12 @@ class VM_ParallelGCFailedAllocation : public VM_CollectForAllocation {
 };
 
 class VM_ParallelGCSystemGC: public VM_GC_Operation {
-  bool _full_gc_succeeded;
+  bool _gc_succeeded;
  public:
   VM_ParallelGCSystemGC(uint gc_count, uint full_gc_count, GCCause::Cause gc_cause);
   virtual VMOp_Type type() const { return VMOp_ParallelGCSystemGC; }
   virtual void doit();
-  bool full_gc_succeeded() const { return _full_gc_succeeded; }
+  bool gc_succeeded() const { return _gc_succeeded; }
   static bool is_cause_full(GCCause::Cause cause);
 };
 

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -95,10 +95,9 @@ class GCCause : public AllStatic {
             cause == GCCause::_dcmd_gc_run);
   }
 
-  inline static bool is_explicit_gc(GCCause::Cause cause) {
+  inline static bool is_explicit_full_gc(GCCause::Cause cause) {
     return (is_user_requested_gc(cause) ||
             is_serviceability_requested_gc(cause) ||
-            cause == GCCause::_wb_young_gc ||
             cause == GCCause::_wb_full_gc);
   }
 

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -95,6 +95,12 @@ class GCCause : public AllStatic {
             cause == GCCause::_dcmd_gc_run);
   }
 
+  inline static bool is_explicit_gc(GCCause::Cause cause) {
+    return (cause == GCCause::_java_lang_system_gc ||
+            cause == GCCause::_dcmd_gc_run ||
+            cause == GCCause::_wb_full_gc);
+  }
+
   inline static bool is_serviceability_requested_gc(GCCause::Cause
                                                              cause) {
     return (cause == GCCause::_jvmti_force_gc ||

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -96,8 +96,9 @@ class GCCause : public AllStatic {
   }
 
   inline static bool is_explicit_gc(GCCause::Cause cause) {
-    return (cause == GCCause::_java_lang_system_gc ||
-            cause == GCCause::_dcmd_gc_run ||
+    return (is_user_requested_gc(cause) ||
+            is_serviceability_requested_gc(cause) ||
+            cause == GCCause::_wb_young_gc ||
             cause == GCCause::_wb_full_gc);
   }
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -796,9 +796,28 @@ void GenCollectedHeap::collect(GCCause::Cause cause) {
                                       ? YoungGen
                                       : OldGen;
 
-  VM_GenCollectFull op(gc_count_before, full_gc_count_before,
-                       cause, max_generation);
-  VMThread::execute(&op);
+  while (true) {
+    VM_GenCollectFull op(gc_count_before, full_gc_count_before,
+                        cause, max_generation);
+    VMThread::execute(&op);
+
+    if (should_run_young_gc) {
+      return;
+    }
+
+    {
+      MutexLocker ml(Heap_lock);
+      // Read the GC count while holding the Heap_lock
+      if (full_gc_count_before != total_full_collections()) {
+        return;
+      }
+    }
+
+    if (GCLocker::is_active_and_needs_gc()) {
+      // If GCLocker is active, wait until clear before retrying.
+      GCLocker::stall_until_clear();
+    }
+  }
 }
 
 void GenCollectedHeap::do_full_collection(bool clear_all_soft_refs) {

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -801,7 +801,7 @@ void GenCollectedHeap::collect(GCCause::Cause cause) {
                         cause, max_generation);
     VMThread::execute(&op);
 
-    if (should_run_young_gc) {
+    if (!GCCause::is_explicit_gc(cause)) {
       return;
     }
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -801,7 +801,7 @@ void GenCollectedHeap::collect(GCCause::Cause cause) {
                         cause, max_generation);
     VMThread::execute(&op);
 
-    if (!GCCause::is_explicit_gc(cause) || should_run_young_gc) {
+    if (!GCCause::is_explicit_full_gc(cause)) {
       return;
     }
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -801,7 +801,7 @@ void GenCollectedHeap::collect(GCCause::Cause cause) {
                         cause, max_generation);
     VMThread::execute(&op);
 
-    if (!GCCause::is_explicit_gc(cause)) {
+    if (!GCCause::is_explicit_gc(cause) || should_run_young_gc) {
       return;
     }
 

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -44,6 +44,17 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseParallelGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 Parallel
  */
 
+/*
+ * @test Serial Full GC execution when JNICritical is active
+ * @bug 8057586
+ * @requires vm.gc.Serial
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseSerialGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 Serial
+ */
+
 import jdk.test.lib.Asserts;
 import jdk.test.whitebox.WhiteBox;
 

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -206,6 +206,9 @@ public class TestJNICriticalStressTest {
 
         largeMap = populateMap(LARGE_MAP_SIZE);
 
+        // Start threads to allocate memory, this will trigger both GCLocker initiated
+        // garbage collections (GCs) and regular GCs. Thus increasing the likelihood of
+        // having different types of GCs happening concurrently with the System.gc call.
         println("Starting " + allocThreadNum + " allocating threads");
         for (int i = 0; i < allocThreadNum; i += 1) {
             new Thread(new AllocatingWorker()).start();

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test G1 Full GC execution when JNICritical is active
+ * @summary Check that Full GC calls are not ignored if concurrent with an active GCLocker.
+ * @bug 8057586
+ * @requires vm.gc.G1
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 G1
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.Deflater;
+
+/**
+ * Test verifies that Full GC calls are not ignored if concurrent with an active GCLocker.
+ *
+ * The test checks that at least a full gc is executed in the duration of a WhiteBox.fullGC() call;
+ * either by the calling thread or a concurrent thread.
+ */
+public class TestJNICriticalStressTest {
+    private static final WhiteBox wb = WhiteBox.getWhiteBox();
+
+    static private final int LARGE_MAP_SIZE = 64 * 1024;
+
+    static private final int MAP_ARRAY_LENGTH = 4;
+    static private final int MAP_SIZE = 1024;
+
+    static private final int BYTE_ARRAY_LENGTH = 16 * 1024;
+
+    static private final long SYSTEM_GC_PERIOD_MS = 5 * 1000;
+    static private long fullGcCounts = 0;
+
+    static private void println(String str) { System.out.println(str); }
+    static private void println()           { System.out.println();    }
+    static private void exit(int code)      { System.exit(code);       }
+
+    static Map<Integer,String> populateMap(int size) {
+        Map<Integer,String> map = new HashMap<Integer,String>();
+        for (int i = 0; i < size; i += 1) {
+            Integer keyInt = new Integer(i);
+            String valStr = "value is [" + i + "]";
+            map.put(keyInt,valStr);
+        }
+        return map;
+    }
+
+    static private class AllocatingWorker implements Runnable {
+        private final Object[] array = new Object[MAP_ARRAY_LENGTH];
+        private int arrayIndex = 0;
+        
+        private void doStep() {
+            Map<Integer,String> map = populateMap(MAP_SIZE);
+            array[arrayIndex] = map;
+            arrayIndex = (arrayIndex + 1) % MAP_ARRAY_LENGTH;
+        }
+
+        public void run() {
+            while (true) {
+                doStep();
+            }
+        }
+    }
+
+    static private class JNICriticalWorker implements Runnable {
+        private int count;
+
+        private void doStep() {
+            byte[] inputArray = new byte[BYTE_ARRAY_LENGTH];
+            for (int i = 0; i < inputArray.length; i += 1) {
+                inputArray[i] = (byte) (count + i);
+            }
+
+            Deflater deflater = new Deflater();
+            deflater.setInput(inputArray);
+            deflater.finish();
+
+            byte[] outputArray = new byte[2 * inputArray.length];
+            deflater.deflate(outputArray);
+
+            count += 1;
+        }
+
+        public void run() {
+            while (true) {
+                doStep();
+            }
+        }
+    }
+
+    static private class SystemGCWorker implements Runnable {
+        public void run() {
+            while (true) {
+                try {
+                    Thread.sleep(SYSTEM_GC_PERIOD_MS);
+                } catch (InterruptedException e) {
+                }
+                System.out.println("SYSTEM_GC BEFORE");
+                wb.fullGC();
+                fullGcCounts += 1;
+                System.out.println("SYSTEM_GC AFTER");
+            }
+        }
+    }
+
+    static public Map<Integer,String> largeMap;
+
+    public static void main(String... args) throws Exception {
+        if (args.length < 4) {
+            println("usage: JNICriticalStressTest3 <duration sec> <alloc threads> <jni critical threads>");
+            exit(-1);
+        }
+
+        long durationSec = Long.parseLong(args[0]);
+        int allocThreadNum = Integer.parseInt(args[1]);
+        int jniCriticalThreadNum = Integer.parseInt(args[2]);
+
+        StringBuilder OldGCName = new StringBuilder();
+        switch (args[3]) {
+            case "G1":
+                OldGCName.append("G1 Old Generation");
+                break;
+            case "Parallel":
+                OldGCName.append("PS MarkSweep");
+                break;
+            case "Serial":
+                OldGCName.append("MarkSweepCompact");
+                break;
+            default:
+                throw new RuntimeException("Unsupported GC selected");
+        }
+
+        List<GarbageCollectorMXBean> collectors = ManagementFactory.getGarbageCollectorMXBeans();
+
+        GarbageCollectorMXBean collector = null;
+
+        for (int i = 0; i < collectors.size(); i++) {
+            println(collectors.get(i).getName());
+            if (collectors.get(i).getName().contains(OldGCName.toString())) {
+                collector = collectors.get(i);
+                break;
+            }
+        }
+
+        if (collector == null) {
+            throw new RuntimeException(OldGCName.toString() + " not found");
+        }
+
+        println("Running for " + durationSec + " secs");
+
+        largeMap = populateMap(LARGE_MAP_SIZE);
+
+        println("Starting " + allocThreadNum + " allocating threads");
+        for (int i = 0; i < allocThreadNum; i += 1) {
+            new Thread(new AllocatingWorker()).start();
+        }
+
+        println("Starting " + jniCriticalThreadNum + " jni critical threads");
+        for (int i = 0; i < jniCriticalThreadNum; i += 1) {
+            new Thread(new JNICriticalWorker()).start();
+        }
+
+        long gcCountBefore = collector.getCollectionCount();
+
+        new Thread(new SystemGCWorker()).start();
+
+        long durationMS = (long) (1000 * durationSec);
+        long start = System.currentTimeMillis();
+        long now = start;
+        long soFar = now - start;
+        while (soFar < durationMS) {
+            try {
+                Thread.sleep(durationMS - soFar);
+            } catch (Exception e) {
+            }
+            now = System.currentTimeMillis();
+            soFar = now - start;
+        }
+
+        long gcCountAfter = collector.getCollectionCount();
+        Asserts.assertLessThanOrEqual(gcCountBefore + fullGcCounts, gcCountAfter, "Triggered more Full GCs than expected");
+   }
+}

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 G1
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 4 G1
  */
 
  /*
@@ -41,7 +41,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseParallelGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 Parallel
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseParallelGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 4 Parallel
  */
 
 /*
@@ -52,7 +52,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseSerialGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 Serial
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseSerialGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 4 Serial
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -219,18 +219,11 @@ public class TestJNICriticalStressTest {
         new Thread(new SystemGCWorker()).start();
 
         long durationMS = (long) (1000 * durationSec);
-        long start = System.currentTimeMillis();
-        long now = start;
-        long soFar = now - start;
-        while (soFar < durationMS) {
-            try {
-                Thread.sleep(durationMS - soFar);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-                return;
-            }
-            now = System.currentTimeMillis();
-            soFar = now - start;
+        try {
+            Thread.sleep(durationMS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            exit(-1);
         }
    }
 }

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -101,7 +101,7 @@ public class TestJNICriticalStressTest {
     static private class AllocatingWorker implements Runnable {
         private final Object[] array = new Object[MAP_ARRAY_LENGTH];
         private int arrayIndex = 0;
-        
+
         private void doStep() {
             Map<Integer,String> map = populateMap(MAP_SIZE);
             array[arrayIndex] = map;

--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -33,6 +33,17 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 G1
  */
 
+ /*
+ * @test Parallel Full GC execution when JNICritical is active
+ * @bug 8057586
+ * @requires vm.gc.Parallel
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseParallelGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 1 Parallel
+ */
+
 import jdk.test.lib.Asserts;
 import jdk.test.whitebox.WhiteBox;
 


### PR DESCRIPTION
Hi All,

Please review this change to guarantee that at least a Full GC is executed between the invocation and return of an explicit Full GC call, even if the call is concurrent with an active `GCLocker`.  We specify explicit GCs as GCs triggered by the end user in some form (jcmd, System.GC, or WhiteBox testing).

The change should also handle the issues reported in JDK-8299276.

Split into 3 commits, one commit for changes to each GC in [G1, Parallel, Serial]. 

Testing: Tier 1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8057586](https://bugs.openjdk.org/browse/JDK-8057586): Explicit GC ignored if GCLocker is active


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [bd418d01](https://git.openjdk.org/jdk/pull/13191/files/bd418d01d066ca7e376e4793b6bd67de1679672e)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13191/head:pull/13191` \
`$ git checkout pull/13191`

Update a local copy of the PR: \
`$ git checkout pull/13191` \
`$ git pull https://git.openjdk.org/jdk.git pull/13191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13191`

View PR using the GUI difftool: \
`$ git pr show -t 13191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13191.diff">https://git.openjdk.org/jdk/pull/13191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13191#issuecomment-1485236758)