### PR TITLE
8304962: sun/net/www/http/KeepAliveCache/B5045306.java: java.lang.RuntimeException: Failed: Initial Keep Alive Connection is not being reused

### DIFF
--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -202,6 +202,7 @@ class SimpleHttpTransactionHandler implements HttpHandler
                 OutputStream os = trans.getResponseBody();
                 os.write(responseBody);
                 // now close the socket
+                // closing the stream here would throw; close the exchange instead
                 trans.close();
             }
         } catch (Exception e) {


### PR DESCRIPTION
This PR fixes intermittent test failures.

The test was broken by 95ca94436d12974d98b1b999f9cc8408d64cbe3c, which changed the `/firstCall` handler to return chunked response (second parameter to `sendResponseHeaders` was `0`). The test verifies the behavior of KeepAliveStreamCleaner, which only works on responses containing `Content-Length` header, and sometimes fails on chunked streams.

~~Additionally I removed the unnecessary byte-to-character-to-byte conversion introduced in the same commit.~~
Fixed the test server output. The PrintWriter printed the result of `toString()` call on a byte array instead of sending the byte array contents.

No failures after 50 test runs. Without the change the test failed 3 times in 10.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304962](https://bugs.openjdk.org/browse/JDK-8304962): sun/net/www/http/KeepAliveCache/B5045306.java: java.lang.RuntimeException: Failed: Initial Keep Alive Connection is not being reused


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13194/head:pull/13194` \
`$ git checkout pull/13194`

Update a local copy of the PR: \
`$ git checkout pull/13194` \
`$ git pull https://git.openjdk.org/jdk.git pull/13194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13194`

View PR using the GUI difftool: \
`$ git pr show -t 13194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13194.diff">https://git.openjdk.org/jdk/pull/13194.diff</a>

</details>
