### PR TITLE
8304931: vm/concepts/methods/methods001/methods00101m1/methods00101m1 failures with already pending exception

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -866,6 +866,7 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
       if (!interface_names->put(interface_name, 0)) {
         classfile_parse_error("Duplicate interface name \"%s\" in class file %s",
                                interface_name->as_C_string(), THREAD);
+        return;
       }
     }
   }
@@ -1594,6 +1595,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
       if(!names_and_sigs->put(name_and_sig, 0)) {
         classfile_parse_error("Duplicate field name \"%s\" with signature \"%s\" in class file %s",
                                name_and_sig._name->as_C_string(), name_and_sig._sig->as_klass_external_name(), THREAD);
+        return;
       }
     }
   }
@@ -2833,6 +2835,7 @@ void ClassFileParser::parse_methods(const ClassFileStream* const cfs,
         if(!names_and_sigs->put(name_and_sig, 0)) {
           classfile_parse_error("Duplicate method name \"%s\" with signature \"%s\" in class file %s",
                                  name_and_sig._name->as_C_string(), name_and_sig._sig->as_klass_external_name(), THREAD);
+          return;
         }
       }
     }


### PR DESCRIPTION
The change in [JDK-8304069](https://bugs.openjdk.org/browse/JDK-8304069) resulted in an assertion failure in the case of multiple duplicate fields, methods, or interfaces. This would create unwanted pending exceptions leading to a failure later.

The method will now return following a class file parse error to avoid adding more pending errors. Verified with tiers 1-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304931](https://bugs.openjdk.org/browse/JDK-8304931): vm/concepts/methods/methods001/methods00101m1/methods00101m1 failures with already pending exception


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13195/head:pull/13195` \
`$ git checkout pull/13195`

Update a local copy of the PR: \
`$ git checkout pull/13195` \
`$ git pull https://git.openjdk.org/jdk.git pull/13195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13195`

View PR using the GUI difftool: \
`$ git pr show -t 13195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13195.diff">https://git.openjdk.org/jdk/pull/13195.diff</a>

</details>
