### PR TITLE
4670339: (ch) Channels.newChannel(OutputStream) should flush stream on every write

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,8 +341,11 @@ public final class Channels {
      * Constructs a channel that writes bytes to the given stream.
      *
      * <p> The resulting channel will not be buffered; it will simply redirect
-     * its I/O operations to the given stream.  Closing the channel will in
-     * turn cause the stream to be closed.  </p>
+     * its I/O operations to the given stream.  Upon returning from the
+     * channel's {@linkplain WritableByteChannel#write write} method, the
+     * state of the stream will be as if its {@linkplain OutputStream#flush
+     * flush} method had been invoked.  Closing the channel will in turn cause
+     * the stream to be closed. </p>
      *
      * @param  out
      *         The stream to which bytes are to be written
@@ -395,6 +398,7 @@ public final class Channels {
                     }
                     totalWritten += bytesToWrite;
                 }
+                out.flush();
                 return totalWritten;
             }
         }

--- a/test/jdk/java/nio/channels/Channels/Basic.java
+++ b/test/jdk/java/nio/channels/Channels/Basic.java
@@ -303,7 +303,7 @@ public class Basic {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream(size);
         try (BufferedOutputStream bos = new BufferedOutputStream(baos, size);
-             WritableByteChannel wbc = Channels.newChannel(bos);) {
+             WritableByteChannel wbc = Channels.newChannel(bos, true);) {
             int max = size + 1 + RND.nextInt(size);
             byte[] expected = new byte[max];
             RND.nextBytes(expected);


### PR DESCRIPTION
Call `flush()` on the `OutputStream` before returning from `WritableByteChannelImpl::write`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 21 to be approved (needs to be created)

### Issue
 * [JDK-4670339](https://bugs.openjdk.org/browse/JDK-4670339): (ch) Channels.newChannel(OutputStream) should flush stream on every write


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13198/head:pull/13198` \
`$ git checkout pull/13198`

Update a local copy of the PR: \
`$ git checkout pull/13198` \
`$ git pull https://git.openjdk.org/jdk.git pull/13198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13198`

View PR using the GUI difftool: \
`$ git pr show -t 13198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13198.diff">https://git.openjdk.org/jdk/pull/13198.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13198#issuecomment-1486005048)