### PR TITLE
JDK-8305004: add @spec tags to langtools modules

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
@@ -123,6 +123,7 @@ import java.io.IOException;
  * annotation if the environment is configured so that that class or
  * interface is accessible.
  *
+ * @spec https://www.rfc-editor.org/info/rfc3986 RFC 3986: RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
  * @apiNote Some of the effect of overwriting a file can be
  * achieved by using a <i>decorator</i>-style pattern.  Instead of
  * modifying a class directly, the class is designed so that either

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -103,6 +103,7 @@ import static javax.tools.JavaFileObject.Kind;
  * <p>Unless explicitly allowed, all methods in this interface might
  * throw a NullPointerException if given a {@code null} argument.
  *
+ * @spec https://www.rfc-editor.org/info/rfc3986 RFC 3986: RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
  * @see JavaFileObject
  * @see FileObject
  * @since 1.6

--- a/src/jdk.compiler/share/classes/com/sun/source/doctree/package-info.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/doctree/package-info.java
@@ -27,10 +27,9 @@
  * Provides interfaces to represent documentation comments as abstract syntax
  * trees (AST).
  *
+ * @spec javadoc/doc-comment-spec.html Documentation Comment Specification for the Standard Doclet
  * @author Jonathan Gibbons
  * @since 1.8
  *
- * @see <a href="{@docRoot}/../specs/javadoc/doc-comment-spec.html">
- *      Documentation Comment Specification for the Standard Doclet</a>
  */
 package com.sun.source.doctree;

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
@@ -249,6 +249,7 @@ public abstract class DocTrees extends Trees {
      *
      * @param tree the tree containing the entity
      * @return a string containing the characters
+     * @spec https://www.w3.org/TR/html52 HTML Standard
      */
     public abstract String getCharacters(EntityTree tree);
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
@@ -63,8 +63,8 @@ import jdk.javadoc.internal.doclets.formats.html.HtmlDoclet;
  *      of {@code <dt>} and {@code <dd>} elements.
  * </dl>
  *
- * @see <a href="{@docRoot}/../specs/javadoc/doc-comment-spec.html">
- *      Documentation Comment Specification for the Standard Doclet</a>
+ @spec javadoc/doc-comment-spec.html Documentation Comment Specification for the Standard Doclet
+ @spec https://www.w3.org/TR/html52 HTML Standard
  */
 public class StandardDoclet implements Doclet {
 

--- a/src/jdk.javadoc/share/classes/module-info.java
+++ b/src/jdk.javadoc/share/classes/module-info.java
@@ -42,6 +42,7 @@
  * or the {@linkplain java.util.ServiceLoader service loader} with the name
  * {@code "javadoc"}.
  *
+ * @spec javadoc/doc-comment-spec.html Documentation Comment Specification for the Standard Doclet
  * @toolGuide javadoc
  *
  * @provides java.util.spi.ToolProvider
@@ -51,8 +52,6 @@
  * @provides javax.tools.DocumentationTool
  * @provides javax.tools.Tool
  *
- * @see <a href="{@docRoot}/../specs/javadoc/doc-comment-spec.html">
- *      Documentation Comment Specification for the Standard Doclet</a>
  *
  * @moduleGraph
  * @since 9


### PR DESCRIPTION
Please review a simple doc-only PR to add `@spec` tags to 3 "langtools" modules, for eventual use in an "External Specifications" page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305004](https://bugs.openjdk.org/browse/JDK-8305004): add @spec tags to langtools modules


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13201/head:pull/13201` \
`$ git checkout pull/13201`

Update a local copy of the PR: \
`$ git checkout pull/13201` \
`$ git pull https://git.openjdk.org/jdk.git pull/13201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13201`

View PR using the GUI difftool: \
`$ git pr show -t 13201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13201.diff">https://git.openjdk.org/jdk/pull/13201.diff</a>

</details>
