### PR TITLE
8304989: unnecessary dash in @param gives double-dash in docs

### DIFF
--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,9 +129,9 @@ public abstract class Enum<E extends Enum<E>>
      * It is for use by code emitted by the compiler in response to
      * enum class declarations.
      *
-     * @param name - The name of this enum constant, which is the identifier
+     * @param name The name of this enum constant, which is the identifier
      *               used to declare it.
-     * @param ordinal - The ordinal of this enumeration constant (its position
+     * @param ordinal The ordinal of this enumeration constant (its position
      *         in the enum declaration, where the initial constant is assigned
      *         an ordinal of zero).
      */

--- a/src/java.base/share/classes/java/net/CookieHandler.java
+++ b/src/java.base/share/classes/java/net/CookieHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public abstract class CookieHandler {
      *
      * @param uri a {@code URI} representing the intended use for the
      *            cookies
-     * @param requestHeaders - a Map from request header
+     * @param requestHeaders a Map from request header
      *            field names to lists of field values representing
      *            the current request headers
      * @return an immutable map from state management headers, with

--- a/src/java.base/share/classes/java/net/ResponseCache.java
+++ b/src/java.base/share/classes/java/net/ResponseCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ public abstract class ResponseCache {
      *            network resource
      * @param rqstMethod a {@code String} representing the request
      *            method
-     * @param rqstHeaders - a Map from request header
+     * @param rqstHeaders a Map from request header
      *            field names to lists of field values representing
      *            the current request headers
      * @return a {@code CacheResponse} instance if available
@@ -157,7 +157,7 @@ public abstract class ResponseCache {
      *
      * @param uri a {@code URI} used to reference the requested
      *            network resource
-     * @param conn - a URLConnection instance that is used to fetch
+     * @param conn a URLConnection instance that is used to fetch
      *            the response to be cached
      * @return a {@code CacheRequest} for recording the
      *            response to be cached. Null return indicates that


### PR DESCRIPTION
Can I please get a review of this trivial doc-only change that addresses https://bugs.openjdk.org/browse/JDK-8304989?

I ran `make docs-image` with this change and the generated javadocs look fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304989](https://bugs.openjdk.org/browse/JDK-8304989): unnecessary dash in @param gives double-dash in docs


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13204/head:pull/13204` \
`$ git checkout pull/13204`

Update a local copy of the PR: \
`$ git checkout pull/13204` \
`$ git pull https://git.openjdk.org/jdk.git pull/13204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13204`

View PR using the GUI difftool: \
`$ git pr show -t 13204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13204.diff">https://git.openjdk.org/jdk/pull/13204.diff</a>

</details>
