### PR TITLE
JDK-8305090: Some NMT tests broken when running under ASan

### DIFF
--- a/make/data/asan/asan_default_options.c
+++ b/make/data/asan/asan_default_options.c
@@ -67,6 +67,13 @@ ATTRIBUTE_DEFAULT_VISIBILITY ATTRIBUTE_USED const char* CDECL __asan_default_opt
 #endif
     "print_suppressions=0,"
     "handle_segv=0,"
+    "allocator_may_return_null=1,"
+#if defined(__linux__) || defined(__FreeBSD__)
+    // Linux and FreeBSD have MADV_DONTDUMP and MADV_NOCORE respectively. In these cases we can
+    // enable coredump with ASan without creating a 16TiB+ core file.
+    "use_madv_dontdump=1,"
+    "disable_coredump=0,"
+#endif
     // See https://github.com/google/sanitizers/issues/1322. Hopefully this is resolved
     // at some point and we can remove this option.
     "intercept_tls_get_addr=0";

--- a/make/data/lsan/lsan_default_options.c
+++ b/make/data/lsan/lsan_default_options.c
@@ -52,6 +52,13 @@ ATTRIBUTE_DEFAULT_VISIBILITY ATTRIBUTE_USED const char* __lsan_default_options()
   return
     "print_suppressions=0,"
     "leak_check_at_exit=0,"
+    "allocator_may_return_null=1,"
+#if defined(__linux__) || defined(__FreeBSD__)
+    // Linux and FreeBSD have MADV_DONTDUMP and MADV_NOCORE respectively. In these cases we can
+    // enable coredump with ASan without creating a 16TiB+ core file.
+    "use_madv_dontdump=1,"
+    "disable_coredump=0,"
+#endif
     // See https://github.com/google/sanitizers/issues/1322. Hopefully this is resolved
     // at some point and we can remove this option.
     "intercept_tls_get_addr=0";

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -35,8 +35,15 @@
 // come, just use this one.
 #define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT corruption"
 
+#ifdef ADDRESS_SANITIZER
+#define ASAN_NOT_ENABLED() false
+#else
+#define ASAN_NOT_ENABLED() true
+#endif
+
 #define DEFINE_TEST(test_function, expected_assertion_message)                            \
-  TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \
+  TEST_VM_FATAL_ERROR_MSG_IF(ASAN_NOT_ENABLED(), NMT, test_function,                      \
+                             ".*" expected_assertion_message ".*") {                      \
     if (MemTracker::tracking_level() > NMT_off) {                                         \
       tty->print_cr("NMT overwrite death test, please ignore subsequent error dump.");    \
       test_function ();                                                                   \

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -85,7 +85,7 @@ public:
     p2 = os_realloc(os_malloc(10), 20);  // realloc, growing
     p3 = os_realloc(os_malloc(20), 10);  // realloc, shrinking
     p4 = os_realloc(NULL, 10);           // realloc with NULL pointer
-    os_realloc(os_realloc(os_malloc(20), 0), 30);  // realloc to size 0 and back up again
+    os::free(os_realloc(os_realloc(os_malloc(20), 0), 30));  // realloc to size 0 and back up again
     os::free(os_malloc(20));             // malloc, free
     os::free(os_realloc(os_malloc(20), 30));  // malloc, realloc, free
     os::free(NULL);                      // free(null)

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -142,7 +142,7 @@ extern void gtest_exit_from_child_vm(int num);
     TEST_VM_ASSERT_MSG is only available in debug builds
 #endif
 
-#define TEST_VM_FATAL_ERROR_MSG(category, name, msg)                \
+#define TEST_VM_FATAL_ERROR_MSG_IF(condition, category, name, msg)  \
   static void test_  ## category ## _ ## name ## _();               \
                                                                     \
   static void child_ ## category ## _ ## name ## _() {              \
@@ -152,11 +152,17 @@ extern void gtest_exit_from_child_vm(int num);
   }                                                                 \
                                                                     \
   TEST(category, CONCAT(name, _vm_assert)) {                        \
+    if (!(condition)) {                                             \
+      GTEST_SKIP() << "Skipping because " #condition;               \
+    }                                                               \
     ASSERT_EXIT(child_ ## category ## _ ## name ## _(),             \
                 ::testing::ExitedWithCode(1),                       \
                 msg);                                               \
   }                                                                 \
                                                                     \
   void test_ ## category ## _ ## name ## _()
+
+#define TEST_VM_FATAL_ERROR_MSG(category, name, msg)                \
+  TEST_VM_FATAL_ERROR_MSG_IF(true, category, name, msg)
 
 #endif // UNITTEST_HPP


### PR DESCRIPTION
This change fixes or skips some NMT tests when running under ASan, as well as fixing a leak.

- `allocator_may_return_null=1` is added as the default is `0`, meaning ASan will never return `nullptr` and will instead crash. NMT tests check that large allocations return `nullptr` so those do not work under ASan currently.
- We skip tests that intentionally access memory outside the allocated range or do things that ASan will catch, causing the tests to fail.
- Fix a memory leak in `test_nmtpreinit.cpp`.
- Enable coredumps to work on some platforms with ASan, some other tests rely on this working.

All of this is related to ASan and NMT, so I opted to do it in a single change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8305090](https://bugs.openjdk.org/browse/JDK-8305090): Some NMT tests broken when running under ASan


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13208/head:pull/13208` \
`$ git checkout pull/13208`

Update a local copy of the PR: \
`$ git checkout pull/13208` \
`$ git pull https://git.openjdk.org/jdk.git pull/13208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13208`

View PR using the GUI difftool: \
`$ git pr show -t 13208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13208.diff">https://git.openjdk.org/jdk/pull/13208.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13208#issuecomment-1487090945)