### PR TITLE
8305086: G1 Redirty Cards phase printed twice

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -510,12 +510,12 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set(bool evacuation_failed
 #if COMPILER2_OR_JVMCI
   debug_phase(_gc_par_phases[UpdateDerivedPointers], 1);
 #endif
-  debug_phase(_gc_par_phases[RedirtyCards], 1);
   debug_phase(_gc_par_phases[EagerlyReclaimHumongousObjects], 1);
 
   if (G1CollectedHeap::heap()->should_sample_collection_set_candidates()) {
     debug_phase(_gc_par_phases[SampleCollectionSetCandidates], 1);
   }
+  debug_phase(_gc_par_phases[RedirtyCards], 1);
   if (UseTLAB && ResizeTLAB) {
     debug_phase(_gc_par_phases[ResizeThreadLABs], 1);
   }

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -501,7 +501,6 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set(bool evacuation_failed
     debug_phase(_gc_par_phases[RemoveSelfForwards], 2);
   }
 
-  trace_phase(_gc_par_phases[RedirtyCards]);
   debug_time("Post Evacuate Cleanup 2", _cur_post_evacuate_cleanup_2_time_ms);
   if (evacuation_failed) {
     debug_phase(_gc_par_phases[RecalculateUsed], 1);
@@ -511,12 +510,12 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set(bool evacuation_failed
 #if COMPILER2_OR_JVMCI
   debug_phase(_gc_par_phases[UpdateDerivedPointers], 1);
 #endif
+  debug_phase(_gc_par_phases[RedirtyCards], 1);
   debug_phase(_gc_par_phases[EagerlyReclaimHumongousObjects], 1);
 
   if (G1CollectedHeap::heap()->should_sample_collection_set_candidates()) {
     debug_phase(_gc_par_phases[SampleCollectionSetCandidates], 1);
   }
-  debug_phase(_gc_par_phases[RedirtyCards], 1);
   if (UseTLAB && ResizeTLAB) {
     debug_phase(_gc_par_phases[ResizeThreadLABs], 1);
   }


### PR DESCRIPTION
Hi all,

  please review this change that removes one the printout of the `Redirty Logged Cards` phase with `gc+phases=trace`; there is already one later in the code with `gc+phases=debug`.

Testing: gha, local checking that there is still one printout

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305086](https://bugs.openjdk.org/browse/JDK-8305086): G1 Redirty Cards phase printed twice


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13209/head:pull/13209` \
`$ git checkout pull/13209`

Update a local copy of the PR: \
`$ git checkout pull/13209` \
`$ git pull https://git.openjdk.org/jdk.git pull/13209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13209`

View PR using the GUI difftool: \
`$ git pr show -t 13209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13209.diff">https://git.openjdk.org/jdk/pull/13209.diff</a>

</details>
