### PR TITLE
JDK-8305094: typo (missing *) in doc comment

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
@@ -63,8 +63,8 @@ import jdk.javadoc.internal.doclets.formats.html.HtmlDoclet;
  *      of {@code <dt>} and {@code <dd>} elements.
  * </dl>
  *
- @spec javadoc/doc-comment-spec.html Documentation Comment Specification for the Standard Doclet
- @spec https://www.w3.org/TR/html52 HTML Standard
+ * @spec javadoc/doc-comment-spec.html Documentation Comment Specification for the Standard Doclet
+ * @spec https://www.w3.org/TR/html52 HTML Standard
  */
 public class StandardDoclet implements Doclet {
 


### PR DESCRIPTION
Please review a trivial patch to fix a typo in a recent update

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305094](https://bugs.openjdk.org/browse/JDK-8305094): typo (missing *) in doc comment


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13210/head:pull/13210` \
`$ git checkout pull/13210`

Update a local copy of the PR: \
`$ git checkout pull/13210` \
`$ git pull https://git.openjdk.org/jdk.git pull/13210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13210`

View PR using the GUI difftool: \
`$ git pr show -t 13210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13210.diff">https://git.openjdk.org/jdk/pull/13210.diff</a>

</details>
