### PR TITLE
JDK-8305098 [Backout] JDK-8303912 Clean up JavadocTokenizer

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -79,7 +79,8 @@ public class JavadocTokenizer extends JavaTokenizer {
 
     @Override
     protected Comment processComment(int pos, int endPos, CommentStyle style) {
-        return new JavadocComment(style, this, pos, endPos);
+        char[] buf = getRawCharacters(pos, endPos);
+        return new JavadocComment(style, fac, buf, pos);
     }
 
     /**
@@ -87,6 +88,13 @@ public class JavadocTokenizer extends JavaTokenizer {
      * of a Javadoc comment.
      */
     protected static class JavadocComment extends BasicComment {
+        /**
+         * Pattern used to detect a well formed @deprecated tag in a Javadoc
+         * comment.
+         */
+        private static final Pattern DEPRECATED_PATTERN =
+            Pattern.compile("(?sm).*^\\s*@deprecated( |$).*");
+
         /**
          * The relevant portion of the comment that is of interest to Javadoc.
          * Produced by invoking scanDocComment.
@@ -104,35 +112,45 @@ public class JavadocTokenizer extends JavaTokenizer {
          */
         OffsetMap offsetMap = new OffsetMap();
 
-        JavadocComment(CommentStyle cs, UnicodeReader reader, int pos, int endPos) {
-            super(cs, reader, pos, endPos);
+        JavadocComment(CommentStyle cs, ScannerFactory sf, char[] array, int offset) {
+            super( cs, sf, array, offset);
             this.sb = new StringBuilder();
         }
 
         /**
-         * Add current character or code point from line to the extraction buffer.
+         * Add a character to the extraction buffer.
          *
-         * @param line line reader
+         * @param ch  character to add.
          */
-        protected void putLine(UnicodeReader line) {
-            while (line.isAvailable()) {
-                offsetMap.add(sb.length(), line.position());
+        protected void put(char ch) {
+            offsetMap.add(sb.length(), offsetPosition());
+            sb.append(ch);
+        }
 
-                if (line.isSurrogate()) {
-                    sb.appendCodePoint(line.getCodepoint());
-                } else {
-                    sb.append(line.get());
-                }
+        /**
+         * Add a code point to the extraction buffer.
+         *
+         * @param codePoint  code point to add.
+         */
+        protected void putCodePoint(int codePoint) {
+            offsetMap.add(sb.length(), offsetPosition());
+            sb.appendCodePoint(codePoint);
+        }
 
-                line.next();
+        /**
+         * Add current character or code point to the extraction buffer.
+         */
+        protected void put() {
+            if (isSurrogate()) {
+                putCodePoint(getCodepoint());
+            } else {
+                put(get());
             }
-            offsetMap.add(sb.length(), line.position());
-            sb.append('\n');
         }
 
         @Override
         public String getText() {
-            if (!scanned) {
+            if (!scanned && cs == CommentStyle.JAVADOC) {
                 scanDocComment();
             }
             return docComment;
@@ -153,10 +171,104 @@ public class JavadocTokenizer extends JavaTokenizer {
 
         @Override
         protected void scanDocComment() {
-            try {
-                super.scanDocComment();
+             try {
+                 boolean firstLine = true;
+
+                 // Skip over /*
+                 accept("/*");
+
+                 // Consume any number of stars
+                 skip('*');
+
+                 // Is the comment in the form /**/, /***/, /****/, etc. ?
+                 if (is('/')) {
+                     docComment = "";
+                     return;
+                 }
+
+                 // Skip line terminator on the first line of the comment.
+                 if (isOneOf('\n', '\r')) {
+                     accept('\r');
+                     accept('\n');
+                     firstLine = false;
+                 }
+
+             outerLoop:
+                 // The outerLoop processes the doc comment, looping once
+                 // for each line.  For each line, it first strips off
+                 // whitespace, then it consumes any stars, then it
+                 // puts the rest of the line into the extraction buffer.
+                 while (isAvailable()) {
+                     int begin_pos = position();
+                     // Consume  whitespace from the beginning of each line.
+                     skipWhitespace();
+                     // Are there stars here?  If so, consume them all
+                     // and check for the end of comment.
+                     if (is('*')) {
+                         // skip all of the stars
+                         skip('*');
+
+                         // check for the closing slash.
+                         if (accept('/')) {
+                             // We're done with the Javadoc comment
+                             break outerLoop;
+                         }
+                     } else if (!firstLine) {
+                         // The current line does not begin with a '*' so we will
+                         // treat it as comment
+                         reset(begin_pos);
+                     }
+
+                 textLoop:
+                     // The textLoop processes the rest of the characters
+                     // on the line, adding them to the extraction buffer.
+                     while (isAvailable()) {
+                         if (accept("*/")) {
+                             // This is the end of the comment, return
+                             // the contents of the extraction buffer.
+                             break outerLoop;
+                         } else if (isOneOf('\n', '\r')) {
+                             // We've seen a newline.  Add it to our
+                             // buffer and break out of this loop,
+                             // starting fresh on a new line.
+                             put('\n');
+                             accept('\r');
+                             accept('\n');
+                             break textLoop;
+                         } else if (is('\f')){
+                             next();
+                             break textLoop; // treat as end of line
+
+                         } else {
+                             // Add the character to our buffer.
+                             put();
+                             next();
+                         }
+                     } // end textLoop
+                     firstLine = false;
+                 } // end outerLoop
+
+                 // If extraction buffer is not empty.
+                 if (sb.length() > 0) {
+                     // Remove trailing asterisks.
+                     int i = sb.length() - 1;
+                     while (i > -1 && sb.charAt(i) == '*') {
+                         i--;
+                     }
+                     sb.setLength(i + 1) ;
+
+                     // Store the text of the doc comment
+                    docComment = sb.toString();
+                 } else {
+                    docComment = "";
+                }
             } finally {
-                docComment = sb.toString();
+                scanned = true;
+
+                // Check if comment contains @deprecated comment.
+                if (docComment != null && DEPRECATED_PATTERN.matcher(docComment).matches()) {
+                    deprecatedFlag = true;
+                }
             }
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -273,9 +273,9 @@ public class Tokens {
     public interface Comment {
 
         enum CommentStyle {
-            LINE,       // Starting with //
-            BLOCK,      // starting with /*
-            JAVADOC,    // starting with /**
+            LINE,
+            BLOCK,
+            JAVADOC,
         }
 
         String getText();


### PR DESCRIPTION
This reverts commit 1fc218c58b58887c3b217603ed222ba0b561a9f1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305098](https://bugs.openjdk.org/browse/JDK-8305098): [Backout] JDK-8303912 Clean up JavadocTokenizer


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13212/head:pull/13212` \
`$ git checkout pull/13212`

Update a local copy of the PR: \
`$ git checkout pull/13212` \
`$ git pull https://git.openjdk.org/jdk.git pull/13212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13212`

View PR using the GUI difftool: \
`$ git pr show -t 13212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13212.diff">https://git.openjdk.org/jdk/pull/13212.diff</a>

</details>
