### PR TITLE
8304993: bad sentence break in DateFormat

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -1050,7 +1050,7 @@ public abstract class DateFormat extends Format {
 
         /**
          * Constant identifying the time of day indicator
-         * (e.g. "a.m." or "p.m.") field.
+         * ({@literal e.g.} "a.m." or "p.m.") field.
          */
         public static final Field AM_PM = new
                             Field("am pm", Calendar.AM_PM);


### PR DESCRIPTION
This PR fixes a bad sentence break in DateFormat.FIELD AM_PM that caused incomplete API

Before:
<img width="1024" alt="Screen Shot 2023-03-27" src="https://user-images.githubusercontent.com/67398801/228359165-f8c66ca2-745b-47ea-bca9-9c4afc7af914.png">

After:
<img src="https://user-images.githubusercontent.com/67398801/228358935-9d978a7a-bfa5-42df-85a7-587e39d6c82c.png" width="800" height="40">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304993](https://bugs.openjdk.org/browse/JDK-8304993): bad sentence break in DateFormat


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13216/head:pull/13216` \
`$ git checkout pull/13216`

Update a local copy of the PR: \
`$ git checkout pull/13216` \
`$ git pull https://git.openjdk.org/jdk.git pull/13216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13216`

View PR using the GUI difftool: \
`$ git pr show -t 13216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13216.diff">https://git.openjdk.org/jdk/pull/13216.diff</a>

</details>
