### PR TITLE
8304990: unnecessary dash in @param gives double-dash in docs

### DIFF
--- a/src/java.sql/share/classes/java/sql/Connection.java
+++ b/src/java.sql/share/classes/java/sql/Connection.java
@@ -1108,12 +1108,11 @@ public interface Connection  extends Wrapper, AutoCloseable {
          * The query submitted by the driver to validate the connection shall be
          * executed in the context of the current transaction.
          *
-         * @param timeout -             The time in seconds to wait for the database operation
-         *                                              used to validate the connection to complete.  If
-         *                                              the timeout period expires before the operation
-         *                                              completes, this method returns false.  A value of
-         *                                              0 indicates a timeout is not applied to the
-         *                                              database operation.
+         * @param timeout The time in seconds to wait for the database operation
+         *                used to validate the connection to complete.  If the
+         *                timeout period expires before the operationcompletes,
+         *                this method returns false.  A value of 0 indicates a
+         *                timeout is not applied to the database operation.
          *
          * @return true if the connection is valid, false otherwise
          * @throws SQLException if the value supplied for {@code timeout}


### PR DESCRIPTION
Please review this trivial change which removes a redundant `-` from an `@param` and cleans up the formatting  for the `isValid` method.


It looks like there is some additional formatting clean up that can be done but I will handle that under a separate PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304990](https://bugs.openjdk.org/browse/JDK-8304990): unnecessary dash in @param gives double-dash in docs


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13217/head:pull/13217` \
`$ git checkout pull/13217`

Update a local copy of the PR: \
`$ git checkout pull/13217` \
`$ git pull https://git.openjdk.org/jdk.git pull/13217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13217`

View PR using the GUI difftool: \
`$ git pr show -t 13217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13217.diff">https://git.openjdk.org/jdk/pull/13217.diff</a>

</details>
