### PR TITLE
JDK-8304991: Redundant hyphen in @param results in double-dash in javadocs

### DIFF
--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1949,7 +1949,7 @@ public class List extends Component implements ItemSelectable, Accessible {
             /**
              * Resizes this object so that it has width and height.
              *
-             * @param d - The dimension specifying the new size of the object.
+             * @param d The dimension specifying the new size of the object.
              * @see #getSize
              */
             public void setSize(Dimension d) {

--- a/src/java.desktop/share/classes/java/awt/font/FontRenderContext.java
+++ b/src/java.desktop/share/classes/java/awt/font/FontRenderContext.java
@@ -126,13 +126,13 @@ public class FontRenderContext {
      * @param tx the transform which is used to scale typographical points
      * to pixels in this {@code FontRenderContext}.  If null, an
      * identity transform is used.
-     * @param aaHint - one of the text antialiasing rendering hint values
+     * @param aaHint one of the text antialiasing rendering hint values
      * defined in {@link java.awt.RenderingHints java.awt.RenderingHints}.
      * Any other value will throw {@code IllegalArgumentException}.
      * {@link java.awt.RenderingHints#VALUE_TEXT_ANTIALIAS_DEFAULT VALUE_TEXT_ANTIALIAS_DEFAULT}
      * may be specified, in which case the mode used is implementation
      * dependent.
-     * @param fmHint - one of the text fractional rendering hint values defined
+     * @param fmHint one of the text fractional rendering hint values defined
      * in {@link java.awt.RenderingHints java.awt.RenderingHints}.
      * {@link java.awt.RenderingHints#VALUE_FRACTIONALMETRICS_DEFAULT VALUE_FRACTIONALMETRICS_DEFAULT}
      * may be specified, in which case the mode used is implementation

--- a/src/java.desktop/share/classes/javax/accessibility/AccessibleContext.java
+++ b/src/java.desktop/share/classes/javax/accessibility/AccessibleContext.java
@@ -564,7 +564,7 @@ public abstract class AccessibleContext {
      * not be treated as the component's accessible parent and is a method that
      * should only be called by the parent of the accessible child.
      *
-     * @param  a - {@code Accessible} to be set as the parent
+     * @param  a {@code Accessible} to be set as the parent
      */
     public void setAccessibleParent(Accessible a) {
         accessibleParent = a;

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -581,7 +581,7 @@ public abstract class JComponent extends Container implements Serializable,
      * <p>
      * This is a bound property.
      *
-     * @param popup - the popup that will be assigned to this component
+     * @param popup the popup that will be assigned to this component
      *                may be null
      * @see #getComponentPopupMenu
      * @since 1.5


### PR DESCRIPTION
Minor change to Javadoc. Removed redundant hyphen for @param.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304991](https://bugs.openjdk.org/browse/JDK-8304991): Redundant hyphen in @param results in double-dash in javadocs


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13218/head:pull/13218` \
`$ git checkout pull/13218`

Update a local copy of the PR: \
`$ git checkout pull/13218` \
`$ git pull https://git.openjdk.org/jdk.git pull/13218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13218`

View PR using the GUI difftool: \
`$ git pr show -t 13218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13218.diff">https://git.openjdk.org/jdk/pull/13218.diff</a>

</details>
