### PR TITLE
8305142: Can't bootstrap ctw.jar

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,12 @@ LIB_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/ \
 WB_SRC_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/compiler $(TESTLIBRARY_DIR)/jdk/test/whitebox -name '*.java')
 EXPORTS=--add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.module=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.classfile=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.classfile.attribute=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.classfile.java.lang.constant=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.access=ALL-UNNAMED
 
 MAIN_CLASS = sun.hotspot.tools.ctw.CompileTheWorld


### PR DESCRIPTION
This patch add a few add-exports so CTW can access those internal packages of java.base module.

make succeeds and ctw.jar is generated as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305142](https://bugs.openjdk.org/browse/JDK-8305142): Can't bootstrap ctw.jar


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13220/head:pull/13220` \
`$ git checkout pull/13220`

Update a local copy of the PR: \
`$ git checkout pull/13220` \
`$ git pull https://git.openjdk.org/jdk.git pull/13220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13220`

View PR using the GUI difftool: \
`$ git pr show -t 13220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13220.diff">https://git.openjdk.org/jdk/pull/13220.diff</a>

</details>
