### PR TITLE
8305157: The java.util.Arrays class should be declared final

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -73,7 +73,7 @@ import java.util.stream.StreamSupport;
  * @author John Rose
  * @since  1.2
  */
-public class Arrays {
+public final class Arrays {
 
     // Suppresses default constructor, ensuring non-instantiability.
     private Arrays() {}


### PR DESCRIPTION
Non-instantiable utility classes should be declared `final` and have a private constructors. 

See Effective Java, Third Edition, Joshua Bloch (for example, Item 19 or Item 22).