### PR TITLE
JDK-8305118: Add RISC-V related content to building.md

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -134,6 +134,8 @@ id="toc-cross-compiling-with-debian-sysroots">Cross compiling with
 Debian sysroots</a></li>
 <li><a href="#building-for-armaarch64"
 id="toc-building-for-armaarch64">Building for ARM/aarch64</a></li>
+<li><a href="#building-for-risc-v" id="toc-building-for-risc-v">Building
+for RISC-V</a></li>
 <li><a href="#building-for-musl" id="toc-building-for-musl">Building for
 musl</a></li>
 <li><a href="#verifying-the-build"
@@ -1376,10 +1378,10 @@ No such file or directory cp: cannot stat
 Debian sysroots</h3>
 <p>Fortunately, you can create sysroots for foreign architectures with
 tools provided by your OS. On Debian/Ubuntu systems, one could use
-<code>qemu-deboostrap</code> to create the <em>target</em> system
-chroot, which would have the native libraries and headers specific to
-that <em>target</em> system. After that, we can use the cross-compiler
-on the <em>build</em> system, pointing into chroot to get the build
+<code>debootstrap</code> to create the <em>target</em> system chroot,
+which would have the native libraries and headers specific to that
+<em>target</em> system. After that, we can use the cross-compiler on the
+<em>build</em> system, pointing into chroot to get the build
 dependencies right. This allows building for foreign architectures with
 native compilation speed.</p>
 <p>For example, cross-compiling to AArch64 from x86_64 could be done
@@ -1389,7 +1391,7 @@ like this:</p>
 <code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></p></li>
 <li><p>Create chroot on the <em>build</em> system, configuring it for
 <em>target</em> system:
-<code>sudo qemu-debootstrap \       --arch=arm64 \       --verbose \       --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev \       --resolve-deps \       buster \       ~/sysroot-arm64 \       http://httpredir.debian.org/debian/</code></p></li>
+<code>sudo debootstrap \       --arch=arm64 \       --verbose \       --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev \       --resolve-deps \       buster \       ~/sysroot-arm64 \       http://httpredir.debian.org/debian/     # If the target architecture is `riscv64`,     # the path should be `debian-ports` instead of `debian`.</code></p></li>
 <li><p>Make sure the symlinks inside the newly created chroot point to
 proper locations:
 <code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></p></li>
@@ -1516,6 +1518,13 @@ are:</p>
 <td style="text-align: left;">sh4-linux-gnu</td>
 <td>zero</td>
 </tr>
+<tr class="even">
+<td style="text-align: left;">riscv64</td>
+<td style="text-align: left;">sid</td>
+<td style="text-align: left;">riscv64</td>
+<td style="text-align: left;">riscv64-linux-gnu</td>
+<td>(all)</td>
+</tr>
 </tbody>
 </table>
 <h3 id="building-for-armaarch64">Building for ARM/aarch64</h3>
@@ -1525,6 +1534,21 @@ profiles are available using <code>--with-abi-profile</code>:
 arm-vfp-sflt, arm-vfp-hflt, arm-sflt, armv5-vfp-sflt, armv6-vfp-hflt.
 Note that soft-float ABIs are no longer properly supported by the
 JDK.</p>
+<h3 id="building-for-risc-v">Building for RISC-V</h3>
+<p>The RISC-V community provides a basic <a
+href="https://github.com/riscv-collab/riscv-gnu-toolchain">GNU compiler
+toolchain</a>, but the <a href="#External-Library-Requirements">external
+libraries</a> required by OpenJDK complicate the building process. The
+placeholder <code>&lt;toolchain-installed-path&gt;</code> shown below is
+the path where you want to install the toolchain.</p>
+<ul>
+<li><p>Install the RISC-V GNU compiler toolchain:
+<code>git clone --recursive https://github.com/riscv-collab/riscv-gnu-toolchain     cd riscv-gnu-toolchain     ./configure --prefix=&lt;toolchain-installed-path&gt;     make linux     export PATH=&lt;toolchain-installed-path&gt;/bin:$PATH</code></p></li>
+<li><p>Cross-compile all the required libraries:
+<code># An example for libffi     git clone https://github.com/libffi/libffi     cd libffi     ./configure --host=riscv64-unknown-linux-gnu --prefix=&lt;toolchain-installed-path&gt;/sysroot/usr     make     make install</code></p></li>
+<li><p>Configure and build OpenJDK:
+<code>bash configure \       --with-boot-jdk=$BOOT_JDK \       --openjdk-target=riscv64-linux-gnu \       --with-sysroot=&lt;toolchain-installed-path&gt;/sysroot \       --with-toolchain-path=&lt;toolchain-installed-path&gt;/bin \       --with-extra-path=&lt;toolchain-installed-path&gt;/bin     make images</code></p></li>
+</ul>
 <h3 id="building-for-musl">Building for musl</h3>
 <p>Just like it's possible to cross-compile for a different CPU, it's
 possible to cross-compile for musl libc on a glibc-based <em>build</em>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1170,6 +1170,9 @@ For example, cross-compiling to AArch64 from x86_64 could be done like this:
       buster \
       ~/sysroot-arm64 \
       http://httpredir.debian.org/debian/
+    # An alternative mirror is `https://deb.debian.org/debian/`.
+    # If the target architecture is `riscv64`,
+    # the path should be `debian-ports` instead of `debian`.
     ```
 
   * Make sure the symlinks inside the newly created chroot point to proper locations:
@@ -1217,6 +1220,7 @@ Architectures that are known to successfully cross-compile like this are:
   m68k          sid          m68k          m68k-linux-gnu           zero
   alpha         sid          alpha         alpha-linux-gnu          zero
   sh4           sid          sh4           sh4-linux-gnu            zero
+  riscv64       sid          riscv64       riscv64-linux-gnu        (all)
 
 ### Building for ARM/aarch64
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -1226,6 +1226,42 @@ available using `--with-abi-profile`: arm-vfp-sflt, arm-vfp-hflt, arm-sflt,
 armv5-vfp-sflt, armv6-vfp-hflt. Note that soft-float ABIs are no longer
 properly supported by the JDK.
 
+### Building for RISC-V
+
+The RISC-V community provides a basic [GNU compiler toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).
+But the [external libraries](#External-Library-Requirements) required by OpenJDK complicate the building process.
+The placeholder `<toolchain-installed-path>` shown below is the path you want to install the toolchain.
+
+  * Install the RISC-V GNU compiler toolchain:
+    ```
+    git clone --recursive https://github.com/riscv-collab/riscv-gnu-toolchain
+    cd riscv-gnu-toolchain
+    ./configure --prefix=<toolchain-installed-path>
+    make linux
+    export PATH=<toolchain-installed-path>/bin:$PATH
+    ```
+
+  * Cross-compile all the required libraries:
+    ```
+    # An example about libffi
+    git clone https://github.com/libffi/libffi
+    cd libffi
+    ./configure --host=riscv64-unknown-linux-gnu --prefix=<toolchain-installed-path>/sysroot/usr
+    make
+    make install
+    ```
+
+  * Configure and build OpenJDK:
+    ```
+    bash configure \
+      --with-boot-jdk=$BOOT_JDK \
+      --openjdk-target=riscv64-linux-gnu \
+      --with-sysroot=<toolchain-installed-path>/sysroot \
+      --with-toolchain-path=<toolchain-installed-path>/bin \
+      --with-extra-path=<toolchain-installed-path>/bin
+    make images
+    ```
+
 ### Building for musl
 
 Just like it's possible to cross-compile for a different CPU, it's possible to

--- a/doc/building.md
+++ b/doc/building.md
@@ -1170,7 +1170,6 @@ For example, cross-compiling to AArch64 from x86_64 could be done like this:
       buster \
       ~/sysroot-arm64 \
       http://httpredir.debian.org/debian/
-    # An alternative mirror is `https://deb.debian.org/debian/`.
     # If the target architecture is `riscv64`,
     # the path should be `debian-ports` instead of `debian`.
     ```
@@ -1233,8 +1232,8 @@ properly supported by the JDK.
 ### Building for RISC-V
 
 The RISC-V community provides a basic
-[GNU compiler toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).
-But the [external libraries](#External-Library-Requirements) required by OpenJDK
+[GNU compiler toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain),
+but the [external libraries](#External-Library-Requirements) required by OpenJDK
 complicate the building process. The placeholder `<toolchain-installed-path>`
 shown below is the path where you want to install the toolchain.
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -1147,7 +1147,7 @@ Note that X11 is needed even if you only want to build a headless JDK.
 ### Cross compiling with Debian sysroots
 
 Fortunately, you can create sysroots for foreign architectures with tools
-provided by your OS. On Debian/Ubuntu systems, one could use `qemu-deboostrap` to
+provided by your OS. On Debian/Ubuntu systems, one could use `debootstrap` to
 create the *target* system chroot, which would have the native libraries and headers
 specific to that *target* system. After that, we can use the cross-compiler on the *build*
 system, pointing into chroot to get the build dependencies right. This allows building
@@ -1162,7 +1162,7 @@ For example, cross-compiling to AArch64 from x86_64 could be done like this:
 
   * Create chroot on the *build* system, configuring it for *target* system:
     ```
-    sudo qemu-debootstrap \
+    sudo debootstrap \
       --arch=arm64 \
       --verbose \
       --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev \

--- a/doc/building.md
+++ b/doc/building.md
@@ -1228,9 +1228,11 @@ properly supported by the JDK.
 
 ### Building for RISC-V
 
-The RISC-V community provides a basic [GNU compiler toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).
-But the [external libraries](#External-Library-Requirements) required by OpenJDK complicate the building process.
-The placeholder `<toolchain-installed-path>` shown below is the path you want to install the toolchain.
+The RISC-V community provides a basic
+[GNU compiler toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).
+But the [external libraries](#External-Library-Requirements) required by OpenJDK
+complicate the building process. The placeholder `<toolchain-installed-path>`
+shown below is the path where you want to install the toolchain.
 
   * Install the RISC-V GNU compiler toolchain:
     ```
@@ -1243,7 +1245,7 @@ The placeholder `<toolchain-installed-path>` shown below is the path you want to
 
   * Cross-compile all the required libraries:
     ```
-    # An example about libffi
+    # An example for libffi
     git clone https://github.com/libffi/libffi
     cd libffi
     ./configure --host=riscv64-unknown-linux-gnu --prefix=<toolchain-installed-path>/sysroot/usr


### PR DESCRIPTION
Hi all,

This patch adds the RISC-V related content to `building.md`. But I didn't 
generate `building.html` locally, because I know the `pandoc` version 
may influencethe the output of `building.html` (Need help here).

I know there are many steps and subtle points about cross-compiling the 
external libraries. Considering the content length and the libraries are 
introduced at `External Library Requirements`, I give only one example 
instead of all of them.

And I tried to build it by using `devkits` and `Debian sysroots`. But it failed locally.
Maybe someone who has built successfully can tell me how to change the
document, which mainly adds the right name to their supported target table.

Thanks for the review and assist.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305118](https://bugs.openjdk.org/browse/JDK-8305118): Add RISC-V related content to building.md


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13223/head:pull/13223` \
`$ git checkout pull/13223`

Update a local copy of the PR: \
`$ git checkout pull/13223` \
`$ git pull https://git.openjdk.org/jdk.git pull/13223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13223`

View PR using the GUI difftool: \
`$ git pr show -t 13223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13223.diff">https://git.openjdk.org/jdk/pull/13223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13223#issuecomment-1488334080)