### PR TITLE
8262294: java/net/httpclient/ProxyAuthDisabledSchemes.java fails with HTTP/1.1 parser received no bytes

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
@@ -533,7 +533,7 @@ final class Exchange<T> {
         Function<ExchangeImpl<T>, CompletableFuture<Response>> after407Check;
         bodyIgnored = null;
         if (request.expectContinue()) {
-            request.addSystemHeader("Expect", "100-Continue");
+            request.setSystemHeader("Expect", "100-Continue");
             Log.logTrace("Sending Expect: 100-Continue");
             // wait for 100-Continue before sending body
             after407Check = this::expectContinue;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -359,10 +359,6 @@ public class HttpRequestImpl extends HttpRequest implements WebSocketRequest {
 
     @Override
     public Optional<HttpClient.Version> version() { return version; }
-
-    void addSystemHeader(String name, String value) {
-        systemHeadersBuilder.addHeader(name, value);
-    }
 
     @Override
     public void setSystemHeader(String name, String value) {

--- a/test/jdk/java/net/httpclient/DigestEchoServer.java
+++ b/test/jdk/java/net/httpclient/DigestEchoServer.java
@@ -699,6 +699,7 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
                         throw new InternalError(key + ": Invalid combination scheme="
                              + schemeType + " authType=" + authType);
                 }
+                break;
             case NONE:
                 // No authentication at all.
                 ctxt.addFilter(new HttpNoAuthFilter(key, authType));

--- a/test/jdk/java/net/httpclient/ProxyAuthDisabledSchemes.java
+++ b/test/jdk/java/net/httpclient/ProxyAuthDisabledSchemes.java
@@ -27,7 +27,7 @@
  *          headers directly when connecting with a server, and
  *          it verifies that the client honor the jdk.http.auth.*.disabledSchemes
  *          net properties.
- * @bug 8087112
+ * @bug 8087112 8262294
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext DigestEchoServer DigestEchoClient
  *        ReferenceTracker ProxyAuthDisabledSchemes


### PR DESCRIPTION
Please review this trivial fix for setting "Expect" header.

The original code added a new header every time. As a result, when the request was retried, it was sent with two Expect headers.
The new code replaces the original Expect header instead of adding a new one.

Expect header allows only one value, "100-continue", so there's no risk of overwriting some other value.

No new test. I added the bug ID to the test that was intermittently failing because of this issue. Existing tests continue to pass.

Also fixed an unintentional passthrough in `switch` case that generated duplicate logs in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262294](https://bugs.openjdk.org/browse/JDK-8262294): java/net/httpclient/ProxyAuthDisabledSchemes.java fails with HTTP/1.1 parser received no bytes


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13224/head:pull/13224` \
`$ git checkout pull/13224`

Update a local copy of the PR: \
`$ git checkout pull/13224` \
`$ git pull https://git.openjdk.org/jdk.git pull/13224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13224`

View PR using the GUI difftool: \
`$ git pr show -t 13224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13224.diff">https://git.openjdk.org/jdk/pull/13224.diff</a>

</details>
