### PR TITLE
8305171: PPC: Should use IMA::load_resolved_indy_entry() in TIG::generate_return_entry_for()

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -488,7 +488,6 @@ void InterpreterMacroAssembler::load_resolved_indy_entry(Register cache, Registe
   ld_ptr(cache, in_bytes(ConstantPoolCache::invokedynamic_entries_offset()), R27_constPoolCache);
   // Scale the index to be the entry index * sizeof(ResolvedInvokeDynamicInfo)
   sldi(index, index, log2i_exact(sizeof(ResolvedIndyEntry)));
-  addi(index, index, Array<ResolvedIndyEntry>::base_offset_in_bytes());
   add(cache, cache, index);
 }
 

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -645,7 +645,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   const Register size  = R12_scratch2;
   if (index_size == sizeof(u4)) {
     __ load_resolved_indy_entry(cache, size /* tmp */);
-    __ lhz(size, in_bytes(ResolvedIndyEntry::num_parameters_offset()), cache);
+    __ lhz(size, Array<ResolvedIndyEntry>::base_offset_in_bytes() + in_bytes(ResolvedIndyEntry::num_parameters_offset()), cache);
   } else {
     __ get_cache_and_index_at_bcp(cache, 1, index_size);
 

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -644,13 +644,8 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   const Register cache = R11_scratch1;
   const Register size  = R12_scratch2;
   if (index_size == sizeof(u4)) {
-    __ get_cache_index_at_bcp(size, 1, index_size);  // Load index.
-    // Get address of invokedynamic array
-    __ ld_ptr(cache, in_bytes(ConstantPoolCache::invokedynamic_entries_offset()), R27_constPoolCache);
-    // Scale the index to be the entry index * sizeof(ResolvedInvokeDynamicInfo)
-    __ sldi(size, size, log2i_exact(sizeof(ResolvedIndyEntry)));
-    __ add(cache, cache, size);
-    __ lhz(size, Array<ResolvedIndyEntry>::base_offset_in_bytes() + in_bytes(ResolvedIndyEntry::num_parameters_offset()), cache);
+    __ load_resolved_indy_entry(cache, size /* tmp */);
+    __ lhz(size, in_bytes(ResolvedIndyEntry::num_parameters_offset()), cache);
   } else {
     __ get_cache_and_index_at_bcp(cache, 1, index_size);
 


### PR DESCRIPTION
This PR replaces a sequence of assembler instructions in the interpreter with an equivalent call of `InterpreterMacroAssembler::load_resolved_indy_entry()`.

Tested hotspot tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305171](https://bugs.openjdk.org/browse/JDK-8305171): PPC: Should use IMA::load_resolved_indy_entry() in TIG::generate_return_entry_for()


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13226/head:pull/13226` \
`$ git checkout pull/13226`

Update a local copy of the PR: \
`$ git checkout pull/13226` \
`$ git pull https://git.openjdk.org/jdk.git pull/13226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13226`

View PR using the GUI difftool: \
`$ git pr show -t 13226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13226.diff">https://git.openjdk.org/jdk/pull/13226.diff</a>

</details>
