### PR TITLE
8305174: disable dtrace for s390x builds

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -251,6 +251,9 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_DTRACE],
     if test "x$OPENJDK_TARGET_CPU_ARCH" = "xppc"; then
       AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU_ARCH])
       AVAILABLE=false
+    elif test "x$OPENJDK_TARGET_CPU_ARCH" = "xs390"; then
+      AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU_ARCH])
+      AVAILABLE=false
     elif test "x$DTRACE" != "x" && test -x "$DTRACE"; then
       AC_MSG_RESULT([$DTRACE])
     else


### PR DESCRIPTION
As stated in JBS-issue, `dtrace` functionality is not available on s390x. So disabling it explicitly in the build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305174](https://bugs.openjdk.org/browse/JDK-8305174): disable dtrace for s390x builds


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13228/head:pull/13228` \
`$ git checkout pull/13228`

Update a local copy of the PR: \
`$ git checkout pull/13228` \
`$ git pull https://git.openjdk.org/jdk.git pull/13228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13228`

View PR using the GUI difftool: \
`$ git pr show -t 13228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13228.diff">https://git.openjdk.org/jdk/pull/13228.diff</a>

</details>
