### PR TITLE
8304825: MacOS metal pipeline - window isn't painted if created during display sleep

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
@@ -41,6 +41,7 @@
 #include "MTLSamplerManager.h"
 
 @class MTLStencilManager;
+@class MTLLayer;
 
 // Constant from
 // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
@@ -73,7 +74,6 @@
 
 @property (readonly, strong)   id<MTLDevice>   device;
 @property (strong) id<MTLCommandQueue>         commandQueue;
-@property (strong) id<MTLCommandQueue>         blitCommandQueue;
 @property (strong) id<MTLBuffer>               vertexBuffer;
 
 @property (readonly) EncoderManager * encoderManager;
@@ -93,7 +93,7 @@
  */
 + (MTLContext*) setSurfacesEnv:(JNIEnv*)env src:(jlong)pSrc dst:(jlong)pDst;
 
-- (id)initWithDevice:(id<MTLDevice>)d shadersLib:(NSString*)shadersLib;
+- (id)initWithDevice:(jint)displayID shadersLib:(NSString*)shadersLib;
 - (void)dealloc;
 
 /**
@@ -228,7 +228,8 @@
 -(NSObject*)getBufImgOp;
 
 - (id<MTLCommandBuffer>)createCommandBuffer;
-- (id<MTLCommandBuffer>)createBlitCommandBuffer;
+- (void)startRedraw:(MTLLayer*)layer;
+- (void)stopRedraw:(MTLLayer*)layer;
 @end
 
 /**

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -24,6 +24,7 @@
  */
 
 #include <stdlib.h>
+#import <ThreadUtilities.h>
 
 #include "sun_java2d_SunGraphics2D.h"
 
@@ -33,6 +34,7 @@
 #import "MTLSamplerManager.h"
 #import "MTLStencilManager.h"
 
+#define KEEP_ALIVE_COUNT 4
 
 extern jboolean MTLSD_InitMTLWindow(JNIEnv *env, MTLSDOps *mtlsdo);
 
@@ -106,6 +108,10 @@ MTLTransform* tempTransform = nil;
 
 @implementation MTLContext {
     MTLCommandBufferWrapper * _commandBufferWrapper;
+    CVDisplayLinkRef _displayLink;
+    NSMutableSet* _layers;
+    int _displayLinkCount;
+    NSLock* _dlLock;
 
     MTLComposite *     _composite;
     MTLPaint *         _paint;
@@ -121,17 +127,22 @@ MTLTransform* tempTransform = nil;
 
 @synthesize textureFunction,
             vertexCacheEnabled, aaEnabled, device, pipelineStateStorage,
-            commandQueue, blitCommandQueue, vertexBuffer,
+            commandQueue, vertexBuffer,
             texturePool, paint=_paint, encoderManager=_encoderManager,
             samplerManager=_samplerManager, stencilManager=_stencilManager;
 
 extern void initSamplers(id<MTLDevice> device);
 
-- (id)initWithDevice:(id<MTLDevice>)d shadersLib:(NSString*)shadersLib {
+- (id)initWithDevice:(jint)displayID shadersLib:(NSString*)shadersLib {
     self = [super init];
     if (self) {
         // Initialization code here.
-        device = d;
+        device = CGDirectDisplayCopyCurrentMetalDevice(displayID);
+        if (device == nil) {
+            J2dRlsTraceLn1(J2D_TRACE_ERROR, "MTLContext.initWithDevice(): Cannot create device from displayID=%d",
+                           displayID);
+            return nil;
+        }
 
         pipelineStateStorage = [[MTLPipelineStatesStorage alloc] initWithDevice:device shaderLibPath:shadersLib];
         if (pipelineStateStorage == nil) {
@@ -159,9 +170,13 @@ extern void initSamplers(id<MTLDevice> device);
 
         // Create command queue
         commandQueue = [device newCommandQueue];
-        blitCommandQueue = [device newCommandQueue];
 
         _tempTransform = [[MTLTransform alloc] init];
+        _layers = [[NSMutableArray alloc] init];
+        _displayLinkCount = 0;
+        _dlLock = [[NSLock alloc] init];
+        CVDisplayLinkCreateWithCGDisplay(displayID, &_displayLink);
+        CVDisplayLinkSetOutputCallback(_displayLink, &mtlDisplayLinkCallback, (__bridge void *) self);
     }
     return self;
 }
@@ -174,7 +189,6 @@ extern void initSamplers(id<MTLDevice> device);
     //self.texturePool = nil;
     self.vertexBuffer = nil;
     self.commandQueue = nil;
-    self.blitCommandQueue = nil;
     self.pipelineStateStorage = nil;
 
     if (_encoderManager != nil) {
@@ -216,6 +230,17 @@ extern void initSamplers(id<MTLDevice> device);
         [_clip release];
         _clip = nil;
     }
+
+    [_layers release];
+
+    if (CVDisplayLinkIsRunning(_displayLink)) {
+        CVDisplayLinkStop(_displayLink);
+        J2dTraceLn1(J2D_TRACE_VERBOSE, "MTLContext_CVDisplayLinkStop: ctx=%p", self);
+    }
+    CVDisplayLinkRelease(_displayLink);
+
+    [_dlLock unlock];
+    [_dlLock release];
 
     [super dealloc];
 }
@@ -470,13 +495,6 @@ extern void initSamplers(id<MTLDevice> device);
     return [self.commandQueue commandBuffer];
 }
 
-/*
- * This should be exclusively used only for final blit
- * and present of CAMetalDrawable in MTLLayer
- */
-- (id<MTLCommandBuffer>)createBlitCommandBuffer {
-    return [self.blitCommandQueue commandBuffer];
-}
 
 -(void)setBufImgOp:(NSObject*)bufImgOp {
     if (_bufImgOp != nil) {
@@ -487,6 +505,76 @@ extern void initSamplers(id<MTLDevice> device);
 
 -(NSObject*)getBufImgOp {
     return _bufImgOp;
+}
+
+- (void) redraw {
+    AWT_ASSERT_APPKIT_THREAD;
+    [_dlLock lock];
+    @try {
+        for (MTLLayer *layer in _layers) {
+            [layer setNeedsDisplay];
+        }
+        if (_displayLinkCount > 0) {
+            _displayLinkCount--;
+        } else {
+            if (_layers.count > 0) {
+                [_layers removeAllObjects];
+            }
+            if (CVDisplayLinkIsRunning(_displayLink)) {
+                CVDisplayLinkStop(_displayLink);
+                J2dTraceLn1(J2D_TRACE_VERBOSE, "MTLContext_CVDisplayLinkStop: ctx=%p", self);
+            }
+        }
+    } @finally {
+        [_dlLock unlock];
+    }
+}
+
+CVReturn mtlDisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp* now, const CVTimeStamp* outputTime, CVOptionFlags flagsIn, CVOptionFlags* flagsOut, void* displayLinkContext)
+{
+    J2dTraceLn1(J2D_TRACE_VERBOSE, "MTLContext_mtlDisplayLinkCallback: ctx=%p", displayLinkContext);
+    @autoreleasepool {
+        MTLContext *ctx = (__bridge MTLContext *)displayLinkContext;
+        [ctx performSelectorOnMainThread:@selector(redraw) withObject:nil waitUntilDone:NO];
+    }
+    return kCVReturnSuccess;
+}
+
+- (void)startRedraw:(MTLLayer*)layer {
+    [_dlLock lock];
+    layer.redrawCount++;
+    J2dTraceLn2(J2D_TRACE_VERBOSE, "MTLContext_startRedraw: ctx=%p layer=%p", self, layer);
+    @try {
+        _displayLinkCount = KEEP_ALIVE_COUNT;
+        [_layers addObject:layer];
+        if (_displayLink != NULL && !CVDisplayLinkIsRunning(_displayLink)) {
+            CVDisplayLinkStart(_displayLink);
+            J2dTraceLn1(J2D_TRACE_VERBOSE, "MTLContext_CVDisplayLinkStart: ctx=%p", self);
+        }
+    } @finally {
+        [_dlLock unlock];
+    }
+}
+
+- (void)stopRedraw:(MTLLayer*) layer {
+    J2dTraceLn2(J2D_TRACE_VERBOSE, "MTLContext_stopRedraw: ctx=%p layer=%p", self, layer);
+    [_dlLock lock];
+    @try {
+        if (_displayLink != nil) {
+            if (--layer.redrawCount <= 0) {
+                [_layers removeObject:layer];
+                layer.redrawCount = 0;
+            }
+            if (_layers.count == 0 && _displayLinkCount == 0) {
+                if (CVDisplayLinkIsRunning(_displayLink)) {
+                    CVDisplayLinkStop(_displayLink);
+                    J2dTraceLn1(J2D_TRACE_VERBOSE, "MTLContext_CVDisplayLinkStop: ctx=%p", self);
+                }
+            }
+        }
+    } @finally {
+        [_dlLock unlock];
+    }
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
@@ -121,7 +121,7 @@ JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
 
-        mtlc = [[MTLContext alloc] initWithDevice:CGDirectDisplayCopyCurrentMetalDevice(displayID)
+        mtlc = [[MTLContext alloc] initWithDevice:displayID
                                        shadersLib:path];
         if (mtlc != 0L) {
             // create the MTLGraphicsConfigInfo record for this context

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
@@ -54,8 +54,7 @@
 @property (readwrite, assign) int nextDrawableCount;
 @property (readwrite, assign) int topInset;
 @property (readwrite, assign) int leftInset;
-@property (readwrite, assign) CVDisplayLinkRef displayLink;
-@property (readwrite, atomic) int displayLinkCount;
+@property (readwrite, atomic) int redrawCount;
 
 - (id) initWithJavaLayer:(jobject)layer;
 
@@ -69,8 +68,8 @@
 - (void) blitCallback;
 - (void) display;
 - (void) redraw;
-- (void) startDisplayLink;
-- (void) stopDisplayLink;
+- (void) startRedraw;
+- (void) stopRedraw:(BOOL)force;
 @end
 
 #endif /* MTLLayer_h_Included */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -890,7 +890,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                 MTLSDOps *dstMTLOps = (MTLSDOps *)dstOps->privOps;
                 MTLLayer *layer = (MTLLayer*)dstMTLOps->layer;
                 if (layer != NULL) {
-                    [layer startDisplayLink];
+                    [layer startRedraw];
                 }
             }
         }


### PR DESCRIPTION
Use one display link thread per MTLContext. Adjust the refresh rate with the current display.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304825](https://bugs.openjdk.org/browse/JDK-8304825): MacOS metal pipeline - window isn't painted if created during display sleep


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13230/head:pull/13230` \
`$ git checkout pull/13230`

Update a local copy of the PR: \
`$ git checkout pull/13230` \
`$ git pull https://git.openjdk.org/jdk.git pull/13230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13230`

View PR using the GUI difftool: \
`$ git pr show -t 13230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13230.diff">https://git.openjdk.org/jdk/pull/13230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13230#issuecomment-1488775834)