### PR TITLE
8304585: Method::invoke rewraps InvocationTargetException if a caller-sensitive method throws IAE

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/DirectMethodHandleAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/DirectMethodHandleAccessor.java
@@ -174,12 +174,8 @@ class DirectMethodHandleAccessor extends MethodAccessorImpl {
             // caller-sensitive method is invoked through a per-caller invoker while
             // the target MH is always spreading the args
             var invoker = JLIA.reflectiveInvoker(caller);
-            try {
-                // invoke the target method handle via an invoker
-                return invoker.invokeExact(target, obj, args);
-            } catch (IllegalArgumentException e) {
-                throw new InvocationTargetException(e);
-            }
+            // invoke the target method handle via an invoker
+            return invoker.invokeExact(target, obj, args);
         }
     }
 

--- a/test/jdk/java/lang/reflect/Method/CallerSensitiveMethodInvoke.java
+++ b/test/jdk/java/lang/reflect/Method/CallerSensitiveMethodInvoke.java
@@ -30,6 +30,7 @@
  */
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -52,7 +53,8 @@ public class CallerSensitiveMethodInvoke {
         try {
             // Field::get throws IAE
             Method m = Field.class.getDeclaredMethod("get", Object.class);
-            m.invoke(f, new Object());
+            m.invoke(f, new Object());  // illegal receiver type. IAE thrown
+            fail("should not reach here");
         } catch (InvocationTargetException e) {
             Throwable t = e.getCause();
             if (!(t instanceof IllegalArgumentException)) {
@@ -71,6 +73,7 @@ public class CallerSensitiveMethodInvoke {
             // m() throws InvocationTargetException which will be wrapped by Method::invoke
             Method m = CallerSensitiveMethodInvoke.class.getDeclaredMethod("m");
             m.invoke(new CallerSensitiveMethodInvoke());
+            fail("should not reach here");
         } catch (InvocationTargetException e) {
             Throwable t = e.getCause();
             if (!(t instanceof InvocationTargetException)) {

--- a/test/jdk/java/lang/reflect/Method/CallerSensitiveMethodInvoke.java
+++ b/test/jdk/java/lang/reflect/Method/CallerSensitiveMethodInvoke.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8304585
+ * @run junit CallerSensitiveMethodInvoke
+ * @run junit/othervm -Djdk.reflect.useDirectMethodHandle=false CallerSensitiveMethodInvoke
+ * @summary Test Method::invoke that wraps exception in InvocationTargetException properly
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class CallerSensitiveMethodInvoke {
+    private int value = 10;
+
+    private void m() throws Exception {
+        throw new InvocationTargetException(new IllegalArgumentException("testing"));
+    }
+
+    /**
+     * Tests the Field::get method being invoked via Method::invoke which
+     * should throw InvocationTargetException thrown by Field::get.
+     */
+    @Test
+    public void csMethodInvoke() throws ReflectiveOperationException {
+        Field f = CallerSensitiveMethodInvoke.class.getDeclaredField("value");
+        try {
+            // Field::get throws IAE
+            Method m = Field.class.getDeclaredMethod("get", Object.class);
+            m.invoke(f, new Object());
+        } catch (InvocationTargetException e) {
+            Throwable t = e.getCause();
+            if (!(t instanceof IllegalArgumentException)) {
+                throw new RuntimeException("Unexpected cause of InvocationTargetException: " + t);
+            }
+        }
+    }
+
+    /**
+     * Tests the method being invoked throws InvocationTargetException which
+     * will be wrapped with another InvocationTargetException by Method::invoke.
+     */
+    @Test
+    public void methodInvoke() throws ReflectiveOperationException {
+        try {
+            // m() throws InvocationTargetException which will be wrapped by Method::invoke
+            Method m = CallerSensitiveMethodInvoke.class.getDeclaredMethod("m");
+            m.invoke(new CallerSensitiveMethodInvoke());
+        } catch (InvocationTargetException e) {
+            Throwable t = e.getCause();
+            if (!(t instanceof InvocationTargetException)) {
+                throw new RuntimeException("Unexpected cause of InvocationTargetException: " + t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
A simple fix to `Method::invoke` which wraps IAE with `InvocationTargetException` twice if it's thrown by a caller-sensitive method which has no adapter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304585](https://bugs.openjdk.org/browse/JDK-8304585): Method::invoke rewraps InvocationTargetException if a caller-sensitive method throws IAE


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [45c7daf0](https://git.openjdk.org/jdk/pull/13233/files/45c7daf0554720e1f0caff61568f2887def8fc8f)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13233/head:pull/13233` \
`$ git checkout pull/13233`

Update a local copy of the PR: \
`$ git checkout pull/13233` \
`$ git pull https://git.openjdk.org/jdk.git pull/13233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13233`

View PR using the GUI difftool: \
`$ git pr show -t 13233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13233.diff">https://git.openjdk.org/jdk/pull/13233.diff</a>

</details>
