### PR TITLE
8305111: Locale.lookupTag has typo in parameter

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3592,7 +3592,7 @@ public final class Locale implements Cloneable, Serializable {
      *
      * @param priorityList user's Language Priority List in which each language
      *     tag is sorted in descending order based on priority or weight
-     * @param tags language tangs used for matching
+     * @param tags language tags used for matching
      * @return the best matching language tag chosen based on priority or
      *     weight, or {@code null} if nothing matches.
      * @throws NullPointerException if {@code priorityList} or {@code tags} is


### PR DESCRIPTION
Small typo fix in Locale.lookupTag

_tangs_ should be _tags_

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305111](https://bugs.openjdk.org/browse/JDK-8305111): Locale.lookupTag has typo in parameter


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13235/head:pull/13235` \
`$ git checkout pull/13235`

Update a local copy of the PR: \
`$ git checkout pull/13235` \
`$ git pull https://git.openjdk.org/jdk.git pull/13235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13235`

View PR using the GUI difftool: \
`$ git pr show -t 13235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13235.diff">https://git.openjdk.org/jdk/pull/13235.diff</a>

</details>
