### PR TITLE
8305055: IR check fails on some aarch64 platforms

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -58,8 +58,8 @@ public class TestVectorizeTypeConversion {
     @IR(counts = {IRNode.LOAD_VECTOR, ">0",
                   IRNode.VECTOR_CAST_I2X, ">0",
                   IRNode.STORE_VECTOR, ">0"},
-        // JDK-8298935 disabled the vectorization of some
-        // conversions when `+AlignVector`.
+        // The vectorization of some conversions may fail when `+AlignVector`.
+        // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"})
     private static void testConvI2D(double[] d, int[] a) {
         for(int i = 0; i < d.length; i++) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,10 @@ public class TestVectorizeTypeConversion {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR, ">0",
                   IRNode.VECTOR_CAST_I2X, ">0",
-                  IRNode.STORE_VECTOR, ">0"})
+                  IRNode.STORE_VECTOR, ">0"},
+        // JDK-8298935 disabled the vectorization of some
+        // conversions when `+AlignVector`.
+        applyIf = {"AlignVector", "false"})
     private static void testConvI2D(double[] d, int[] a) {
         for(int i = 0; i < d.length; i++) {
             d[i] = (double) (a[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -143,6 +143,9 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+        // JDK-8298935 disabled the vectorization of some
+        // conversions when `+AlignVector`.
+        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_I2X, ">0"})
     public double[] convertIntToDouble() {
         double[] res = new double[SIZE];
@@ -230,6 +233,9 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
+        // JDK-8298935 disabled the vectorization of some
+        // conversions when `+AlignVector`.
+        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2X, ">0"})
     public long[] convertFloatToLong() {
         long[] res = new long[SIZE];
@@ -311,6 +317,9 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert Between F & D ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+        // JDK-8298935 disabled the vectorization of some
+        // conversions when `+AlignVector`.
+        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2X, ">0"})
     public double[] convertFloatToDouble() {
         double[] res = new double[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -143,8 +143,8 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        // JDK-8298935 disabled the vectorization of some
-        // conversions when `+AlignVector`.
+        // The vectorization of some conversions may fail when `+AlignVector`.
+        // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_I2X, ">0"})
     public double[] convertIntToDouble() {
@@ -233,8 +233,8 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
-        // JDK-8298935 disabled the vectorization of some
-        // conversions when `+AlignVector`.
+        // The vectorization of some conversions may fail when `+AlignVector`.
+        // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2X, ">0"})
     public long[] convertFloatToLong() {
@@ -317,8 +317,8 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert Between F & D ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        // JDK-8298935 disabled the vectorization of some
-        // conversions when `+AlignVector`.
+        // The vectorization of some conversions may fail when `+AlignVector`.
+        // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2X, ">0"})
     public double[] convertFloatToDouble() {


### PR DESCRIPTION
As @eme64 said in [1], [JDK-8298935](https://bugs.openjdk.org/browse/JDK-8298935) introduced some "collateral damage", disabling the vectorization of some conversions when `+AlignVector`. That affects IR checks of `TestVectorizeTypeConversion.java` and `ArrayTypeConvertTest.java` on some `aarch64` platforms like ThunderX and ThunderX2 [2].

This trivial patch is to allow IR check only when we have `-AlignVector`.

[1] https://github.com/openjdk/jdk/pull/12350#issuecomment-1470065706
[2] https://github.com/openjdk/jdk/blob/7239150f8aff0e3dc07c5b27f6b7fb07237bfc55/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp#L154

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305055](https://bugs.openjdk.org/browse/JDK-8305055): IR check fails on some aarch64 platforms


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - Committer) ⚠️ Review applies to [78fcd6e5](https://git.openjdk.org/jdk/pull/13236/files/78fcd6e58b419fe5f39994def526e8e390bd3fef)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13236/head:pull/13236` \
`$ git checkout pull/13236`

Update a local copy of the PR: \
`$ git checkout pull/13236` \
`$ git pull https://git.openjdk.org/jdk.git pull/13236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13236`

View PR using the GUI difftool: \
`$ git pr show -t 13236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13236.diff">https://git.openjdk.org/jdk/pull/13236.diff</a>

</details>
