### PR TITLE
8304988: unnecessary dash in @param gives double-dash in docs

### DIFF
--- a/src/java.management/share/classes/javax/management/relation/RoleUnresolvedList.java
+++ b/src/java.management/share/classes/javax/management/relation/RoleUnresolvedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +151,7 @@ public class RoleUnresolvedList extends ArrayList<Object> {
     /**
      * Adds the RoleUnresolved specified as the last element of the list.
      *
-     * @param role - the unresolved role to be added.
+     * @param role the unresolved role to be added.
      *
      * @exception IllegalArgumentException  if the unresolved role is null.
      */
@@ -171,9 +171,9 @@ public class RoleUnresolvedList extends ArrayList<Object> {
      * Elements with an index greater than or equal to the current position are
      * shifted up.
      *
-     * @param index - The position in the list where the new
+     * @param index The position in the list where the new
      * RoleUnresolved object is to be inserted.
-     * @param role - The RoleUnresolved object to be inserted.
+     * @param role The RoleUnresolved object to be inserted.
      *
      * @exception IllegalArgumentException  if the unresolved role is null.
      * @exception IndexOutOfBoundsException if index is out of range
@@ -197,8 +197,8 @@ public class RoleUnresolvedList extends ArrayList<Object> {
      * specified.
      * The previous element at that position is discarded.
      *
-     * @param index - The position specified.
-     * @param role - The value to which the unresolved role element
+     * @param index The position specified.
+     * @param role The value to which the unresolved role element
      * should be set.
      *
      * @exception IllegalArgumentException   if the unresolved role is null.
@@ -223,7 +223,7 @@ public class RoleUnresolvedList extends ArrayList<Object> {
      * of the list, in the order in which they are returned by the Iterator of
      * the RoleUnresolvedList specified.
      *
-     * @param roleList - Elements to be inserted into the list
+     * @param roleList Elements to be inserted into the list
      * (can be null).
      *
      * @return true if this list changed as a result of the call.
@@ -246,9 +246,9 @@ public class RoleUnresolvedList extends ArrayList<Object> {
      * this list, starting at the specified position, in the order in which
      * they are returned by the Iterator of the RoleUnresolvedList specified.
      *
-     * @param index - Position at which to insert the first element from the
+     * @param index Position at which to insert the first element from the
      * RoleUnresolvedList specified.
-     * @param roleList - Elements to be inserted into the list.
+     * @param roleList Elements to be inserted into the list.
      *
      * @return true if this list changed as a result of the call.
      *


### PR DESCRIPTION
Can I please get a review of this trivial doc only change which addresses https://bugs.openjdk.org/browse/JDK-8304988?

I've run `make docs-image` after this change and the generated javadoc for this class looks fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304988](https://bugs.openjdk.org/browse/JDK-8304988): unnecessary dash in @param gives double-dash in docs


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13239/head:pull/13239` \
`$ git checkout pull/13239`

Update a local copy of the PR: \
`$ git checkout pull/13239` \
`$ git pull https://git.openjdk.org/jdk.git pull/13239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13239`

View PR using the GUI difftool: \
`$ git pr show -t 13239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13239.diff">https://git.openjdk.org/jdk/pull/13239.diff</a>

</details>
