### PR TITLE
JDK-8305223: IGV: mark osr compiled graphs with [OSR] in the name

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Group.java
@@ -126,7 +126,11 @@ public class Group extends Properties.Entity implements ChangedEventProvider<Gro
 
     @Override
     public String getDisplayName() {
-        return (getParent() == null ? "" : getParent().getElements().indexOf(this) + 1 + " - ") + getName();
+        String displayName = (getParent() == null ? "" : getParent().getElements().indexOf(this) + 1 + " - ") + getName();
+        if (getProperties().get("osr") != null) {
+            displayName += " [OSR]";
+        }
+        return displayName;
     }
 
     public String getType() {


### PR DESCRIPTION
Graphs in IGV that were osr compiled have an "osr" property. To make it easier to distinguish them from non-osr, append `[OSR]` to the name of the group in the outline

<img width="323" alt="osr" src="https://user-images.githubusercontent.com/71546117/228766255-ba43f50c-3059-43cb-98b4-9d0d5a8ff9ea.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305223](https://bugs.openjdk.org/browse/JDK-8305223): IGV: mark osr compiled graphs with [OSR] in the name


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [bfe14342](https://git.openjdk.org/jdk/pull/13241/files/bfe143422883744e58795498140af58079f95304)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Eric Liu](https://openjdk.org/census#eliu) (@theRealELiu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13241/head:pull/13241` \
`$ git checkout pull/13241`

Update a local copy of the PR: \
`$ git checkout pull/13241` \
`$ git pull https://git.openjdk.org/jdk.git pull/13241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13241`

View PR using the GUI difftool: \
`$ git pr show -t 13241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13241.diff">https://git.openjdk.org/jdk/pull/13241.diff</a>

</details>
