### PR TITLE
8305242: Remove non-invariant assert(EventThreadDump::is_enabled())

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrThreadDumpEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadDumpEvent.cpp
@@ -57,7 +57,6 @@ static bool execute_dcmd(bufferedStream& st, const char* const cmd) {
 
 // caller needs ResourceMark
 const char* JfrDcmdEvent::thread_dump() {
-  assert(EventThreadDump::is_enabled(), "invariant");
   bufferedStream st;
   execute_dcmd(st, "Thread.print");
   return st.as_string();


### PR DESCRIPTION
Greetings,

removing a non-invariant assert for EventThreadDump::is_enabled()).

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305242](https://bugs.openjdk.org/browse/JDK-8305242): Remove non-invariant assert(EventThreadDump::is_enabled())


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13243/head:pull/13243` \
`$ git checkout pull/13243`

Update a local copy of the PR: \
`$ git checkout pull/13243` \
`$ git pull https://git.openjdk.org/jdk.git pull/13243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13243`

View PR using the GUI difftool: \
`$ git pr show -t 13243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13243.diff">https://git.openjdk.org/jdk/pull/13243.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13243#issuecomment-1490248551)