### PR TITLE
8305247: On RISC-V generate_fixed_frame() sometimes generate a relativized locals value which is way too large

### DIFF
--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -760,7 +760,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   __ ld(xcpool, Address(xcpool, ConstantPool::cache_offset_in_bytes()));
   __ sd(xcpool, Address(sp, 3 * wordSize));
   __ sub(t0, xlocals, fp);
-  __ srli(t0, t0, Interpreter::logStackElementSize);   // t0 = xlocals - fp();
+  __ srai(t0, t0, Interpreter::logStackElementSize);   // t0 = xlocals - fp();
   // Store relativized xlocals, see frame::interpreter_frame_locals().
   __ sd(t0, Address(sp, 2 * wordSize));
 


### PR DESCRIPTION
The relativized locals value is supposed to contain the distance between the frame pointer and the local variables in an interpreter frame, expressed in number of words. It typically contains the value "frame::sender_sp_offset + padding + max_locals - 1"

On most architectures sender_sp_offset is 2. This gives us the value "1 + padding + max_locals", which is always greater or equal to 1.

However on RISC-V the value of frame::sender_sp_offset is 0, which means that if we don't have any padding and no local variables we end up with a relativized_locals value of -1.

When generate_fixed_frame() calculates the relativized_locals value it subtracts the frame pointer from the xlocals and then logically shifts the result right by Interpreter::logStackElementSize (to convert it into a word index).

This works fine on all platforms (except RISC-V), because the subtraction will never become negative. But since the subtraction can end up negative on RISC-V, the shift instruction must be a arithmetic-shift-right (not a logical-shift-right) to preserve the sign and not end up with a very large positive index.

This is currently not a real problem since the relativized_locals value is not used if max_local is zero, which is the only case the value is wrong.

It is however a real problem when implementing JDK-8300197.

The bug was introduced in JDK-8299795 and is fixed by changing a "srli" instruction to a "srai" in generate_fixed_frame().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305247](https://bugs.openjdk.org/browse/JDK-8305247): On RISC-V generate_fixed_frame() sometimes generate a relativized locals value which is way too large


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13245/head:pull/13245` \
`$ git checkout pull/13245`

Update a local copy of the PR: \
`$ git checkout pull/13245` \
`$ git pull https://git.openjdk.org/jdk.git pull/13245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13245`

View PR using the GUI difftool: \
`$ git pr show -t 13245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13245.diff">https://git.openjdk.org/jdk/pull/13245.diff</a>

</details>
