### PR TITLE
8305209: JDWP exit error AGENT_ERROR_INVALID_THREAD(203): missing entry in running thread table

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -253,16 +253,23 @@ findThread(ThreadList *list, jthread thread)
          * Otherwise the thread should not be on the runningThreads.
          */
         if ( !gdata->jvmtiCallBacksCleared ) {
-            /* The thread better not be on runningThreads if the TLS lookup failed. */
+            /* The thread better not be on either list if the TLS lookup failed. */
             JDI_ASSERT(!nonTlsSearch(getEnv(), &runningThreads, thread));
+            JDI_ASSERT(!nonTlsSearch(getEnv(), &runningVThreads, thread));
         } else {
             /*
-             * Search the runningThreads list. The TLS lookup may have failed because the
-             * thread has terminated, but we never got the THREAD_END event.
+             * Search the runningThreads and runningVThreads lists. The TLS lookup may have
+             * failed because the thread has terminated, but we never got the THREAD_END event.
+             * The big comment immediately above explains why this can happen.
              */
             if ( node == NULL ) {
                 if ( list == NULL || list == &runningThreads ) {
                     node = nonTlsSearch(getEnv(), &runningThreads, thread);
+                }
+                if ( node == NULL ) {
+                    if ( list == NULL || list == &runningVThreads ) {
+                        node = nonTlsSearch(getEnv(), &runningVThreads, thread);
+                    }
                 }
             }
         }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -260,7 +260,7 @@ findThread(ThreadList *list, jthread thread)
             /*
              * Search the runningThreads and runningVThreads lists. The TLS lookup may have
              * failed because the thread has terminated, but we never got the THREAD_END event.
-             * The big comment immediately above explains why this can happen.
+             * The big comment above explains why this can happen.
              */
             if ( node == NULL ) {
                 if ( list == NULL || list == &runningThreads ) {

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -710,6 +710,25 @@ abstract public class TestScaffold extends TargetAdapter {
             } catch (InterruptedException e) {
             }
         }
+
+        // Make sure debuggee exits with no errors. Otherwise failures might go unnoticed.
+        Process p = vm.process();
+        try {
+            p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if (p.isAlive()) {
+            throw new RuntimeException("Debuggee is still alive after disconnecting.");
+        } else {
+            int res = p.exitValue();
+            // Some tests purposefully exit with an exception, which produces exitValue
+            // 1, so we have to allow it also.
+            if (res != 0 && res != 1) {
+                throw new RuntimeException("Non-zero debuggee exitValue: " + res);
+            }
+        }
+
         traceln("TS: waitForVMDisconnect: done");
     }
 

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -714,19 +714,15 @@ abstract public class TestScaffold extends TargetAdapter {
         // Make sure debuggee exits with no errors. Otherwise failures might go unnoticed.
         Process p = vm.process();
         try {
-            p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+            p.waitFor();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        if (p.isAlive()) {
-            throw new RuntimeException("Debuggee is still alive after disconnecting.");
-        } else {
-            int res = p.exitValue();
-            // Some tests purposefully exit with an exception, which produces exitValue
-            // 1, so we have to allow it also.
-            if (res != 0 && res != 1) {
-                throw new RuntimeException("Non-zero debuggee exitValue: " + res);
-            }
+        int res = p.exitValue();
+        // Some tests purposefully exit with an exception, which produces exitValue
+        // 1, so we have to allow it also.
+        if (res != 0 && res != 1) {
+            throw new RuntimeException("Non-zero debuggee exitValue: " + res);
         }
 
         traceln("TS: waitForVMDisconnect: done");

--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -58,14 +58,23 @@ class ThreadMemoryLeakTarg {
         while (System.currentTimeMillis() - startTime < 100 * 1000) {
             iterations++;
             semaphore.acquire();
-            Executors.defaultThreadFactory().newThread(() -> {
+            TestScaffold.newThread(() -> {
                     adder.increment();
                     long sum = adder.sum();
                     if ((sum % 1000) == 0) {
                         System.out.println("Progress: " + sum);
                     }
                     try {
-                        Thread.sleep(50);
+                        String mainWrapper = System.getProperty("main.wrapper");
+                        if ("Virtual".equals(mainWrapper)) {
+                            // Virtual thread creation tends to overwhelm the debugger,
+                            // leading to high memory use for all the unprocessed events
+                            // that get queued up, so we need to slow it down a bit more
+                            // than we do for platform threads to avoid getting OOME.
+                            Thread.sleep(100);
+                        } else {
+                            Thread.sleep(50);
+                        }
                     }
                     catch (InterruptedException e) {
                         throw new RuntimeException(e);

--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -66,15 +66,12 @@ class ThreadMemoryLeakTarg {
                     }
                     try {
                         String mainWrapper = System.getProperty("main.wrapper");
-                        if ("Virtual".equals(mainWrapper)) {
-                            // Virtual thread creation tends to overwhelm the debugger,
-                            // leading to high memory use for all the unprocessed events
-                            // that get queued up, so we need to slow it down a bit more
-                            // than we do for platform threads to avoid getting OOME.
-                            Thread.sleep(100);
-                        } else {
-                            Thread.sleep(50);
-                        }
+                        // Virtual thread creation tends to overwhelm the debugger,
+                        // leading to high memory use for all the unprocessed events
+                        // that get queued up, so we need to slow it down a bit more
+                        // than we do for platform threads to avoid getting OOME.
+                        long timeToSleep = "Virtual".equals(mainWrapper) ? 100 : 50;
+                        Thread.sleep(timeToSleep);
                     }
                     catch (InterruptedException e) {
                         throw new RuntimeException(e);


### PR DESCRIPTION
The real purpose of this PR is to add virtual thread support to ThreadMemoryLeakTest.java, but this exposed bugs in both the debug agent and in TestScaffold, so those are being fixed also (and the debug agent bug is the CR being used).

The debug agent bug is due to a race condition during VM exit. The VM is in the process of shutting down. The debug agent has already disabled JVMTI callbacks and has sent the VMDeathEvent. At this point in time there are also threads exiting that the debug agent knows about, but it will not get a ThreadEndEvent for because of the callbacks being disabled. Thus these threads remain in the debug agent's list of known threads, even though they have exited. The debuggee receives the VMDeathEvent and does a VM.resume(). During the debug agent's handing of the VM.Resume command, it iterates over all known threads and needs to map each to its ThreadNode so it can be resumed, and this mapping requires accessing the JVMTI TLS for the thread. The problem is some of the threads may have exited already, and therefore no longer have TLS. This results in the assert in the debug agent. This debug agent issue was already addressed for platform threads, but not for virtual threads, which is why we started seeing this issue when this test was modified. The fix is to just replicate what is done for platform threads for virtual threads also.

The TestScaffold bug is that if the debuggee crashes/asserts, this is likely to go unnoticed, especially if it happens during VM exit (and the test essentially has already completed). Because of this TestScaffold bug, the debug agent bug above did not result in a test failure. After fixing TestScaffold to check the exitCode of the debuggee process, the test started to appropriately fail until the debug agent was fixed.

One other thing to point out is the OOME issue I started getting frequently when testing with virtual threads. Since virtual threads are created at a much higher rate than platform threads, their creation started to overwhelm the debugger (actually the JDI implementation). There is already a mechanism in place to do a VM.HoldEvents if JDI has queue up 10,000 events. The problem is that events are coming in so fast that even after doing the VM.HoldEvents, the number of queued events continues to go up for a while, and sometimes reaches 30,000 or more. This raises the peak memory usage of the test quite a bit. Since the test purposely uses a small heap so a memory leak is quickly and reliably detected, the large queue often results in an OOME. Because of this I make virtual threads sleep for 100ms instead of 50ms to slow down their creation, and this resolved the issue. 

I tested by running all of test/jdk/com/sun/jdi 25 times on each platform with and without virtual thread testing enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305209](https://bugs.openjdk.org/browse/JDK-8305209): JDWP exit error AGENT_ERROR_INVALID_THREAD(203): missing entry in running thread table


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13246/head:pull/13246` \
`$ git checkout pull/13246`

Update a local copy of the PR: \
`$ git checkout pull/13246` \
`$ git pull https://git.openjdk.org/jdk.git pull/13246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13246`

View PR using the GUI difftool: \
`$ git pr show -t 13246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13246.diff">https://git.openjdk.org/jdk/pull/13246.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13246#issuecomment-1490568067)