### PR TITLE
JDK-8305320: DbgStrings and AsmRemarks are leaking

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1249,6 +1249,7 @@ bool DbgStrings::is_empty() const {
 
 void DbgStrings::share(const DbgStrings &src) {
   precond(is_empty());
+  clear();
   _strings = src._strings->reuse();
 }
 

--- a/src/hotspot/share/interpreter/interpreter.cpp
+++ b/src/hotspot/share/interpreter/interpreter.cpp
@@ -114,6 +114,11 @@ CodeletMark::~CodeletMark() {
     NOT_PRODUCT(_clet->use_strings((*_masm)->code()->dbg_strings()));
 
     AbstractInterpreter::code()->commit(committed_code_size);
+  } else {
+    // InterpreterCodelet is not being commited and may be re-used. We need to free the storage for
+    // remarks and strings.
+    NOT_PRODUCT(_clet->clear_remarks());
+    NOT_PRODUCT(_clet->clear_strings());
   }
   // Make sure nobody can use _masm outside a CodeletMark lifespan.
   *_masm = nullptr;

--- a/src/hotspot/share/interpreter/interpreter.cpp
+++ b/src/hotspot/share/interpreter/interpreter.cpp
@@ -53,6 +53,12 @@
 void InterpreterCodelet::initialize(const char* description, Bytecodes::Code bytecode) {
   _description = description;
   _bytecode    = bytecode;
+#ifndef PRODUCT
+  AsmRemarks* arp = new(&_asm_remarks) AsmRemarks();
+  DbgStrings* dsp = new(&_dbg_strings) DbgStrings();
+  postcond(arp == &_asm_remarks);
+  postcond(dsp == &_dbg_strings);
+#endif
 }
 
 void InterpreterCodelet::verify() {}

--- a/src/hotspot/share/interpreter/interpreter.cpp
+++ b/src/hotspot/share/interpreter/interpreter.cpp
@@ -53,12 +53,6 @@
 void InterpreterCodelet::initialize(const char* description, Bytecodes::Code bytecode) {
   _description = description;
   _bytecode    = bytecode;
-#ifndef PRODUCT
-  AsmRemarks* arp = new(&_asm_remarks) AsmRemarks();
-  DbgStrings* dsp = new(&_dbg_strings) DbgStrings();
-  postcond(arp == &_asm_remarks);
-  postcond(dsp == &_dbg_strings);
-#endif
 }
 
 void InterpreterCodelet::verify() {}

--- a/src/hotspot/share/interpreter/interpreter.hpp
+++ b/src/hotspot/share/interpreter/interpreter.hpp
@@ -85,6 +85,9 @@ class InterpreterCodelet: public Stub {
   }
   void use_remarks(AsmRemarks &remarks) { _asm_remarks.share(remarks); }
   void use_strings(DbgStrings &strings) { _dbg_strings.share(strings); }
+
+  void clear_remarks() { _asm_remarks.clear(); }
+  void clear_strings() { _dbg_strings.clear(); }
 #endif
 };
 


### PR DESCRIPTION
Fix two leaks related to `DbgStrings` and `AsmRemarks` in debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305320](https://bugs.openjdk.org/browse/JDK-8305320): DbgStrings and AsmRemarks are leaking


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13249/head:pull/13249` \
`$ git checkout pull/13249`

Update a local copy of the PR: \
`$ git checkout pull/13249` \
`$ git pull https://git.openjdk.org/jdk.git pull/13249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13249`

View PR using the GUI difftool: \
`$ git pr show -t 13249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13249.diff">https://git.openjdk.org/jdk/pull/13249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13249#issuecomment-1490775234)