### PR TITLE
8305227: [s390x] build broken after JDK-8231349

### DIFF
--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -3152,6 +3152,13 @@ class StubGenerator: public StubCodeGenerator {
 
     // Arraycopy stubs used by compilers.
     generate_arraycopy_stubs();
+
+    // nmethod entry barriers for concurrent class unloading
+    BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
+    if (bs_nm != NULL) {
+      StubRoutines::zarch::_nmethod_entry_barrier = generate_nmethod_entry_barrier();
+    }
+
   }
 
   void generate_compiler_stubs() {
@@ -3197,12 +3204,6 @@ class StubGenerator: public StubCodeGenerator {
     if (UseSHA512Intrinsics) {
       StubRoutines::_sha512_implCompress   = generate_SHA512_stub(false, "SHA512_singleBlock");
       StubRoutines::_sha512_implCompressMB = generate_SHA512_stub(true,  "SHA512_multiBlock");
-    }
-
-    // nmethod entry barriers for concurrent class unloading
-    BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-    if (bs_nm != NULL) {
-      StubRoutines::zarch::_nmethod_entry_barrier = generate_nmethod_entry_barrier();
     }
 
 #ifdef COMPILER2


### PR DESCRIPTION
This PR moves nmethod entry barrier  from `generate_compiler_stubs()` to `generate_final_stubs()`. Test build for fastdebug, slow debug, release and optimised. Tier1 test in fastdebug seems clean as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305227](https://bugs.openjdk.org/browse/JDK-8305227): [s390x] build broken after JDK-8231349


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13259/head:pull/13259` \
`$ git checkout pull/13259`

Update a local copy of the PR: \
`$ git checkout pull/13259` \
`$ git pull https://git.openjdk.org/jdk.git pull/13259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13259`

View PR using the GUI difftool: \
`$ git pr show -t 13259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13259.diff">https://git.openjdk.org/jdk/pull/13259.diff</a>

</details>
