### PR TITLE
8302673: [SuperWord] MaxReduction and MinReduction should vectorize for int

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -1091,9 +1091,10 @@ Node* MaxINode::Ideal(PhaseGVN* phase, bool can_reshape) {
   // Force a right-spline graph
   Node* l = in(1);
   Node* r = in(2);
+
   // Transform  MaxI1(MaxI2(a, b), c)  into  MaxI1(a, MaxI2(b, c))
   // to force a right-spline graph for the rest of MaxINode::Ideal().
-  if (l->Opcode() == Op_MaxI) {
+  if (l->Opcode() == Op_MaxI && !l->is_reduction()) {
     assert(l != l->in(1), "dead loop in MaxINode::Ideal");
     r = phase->transform(new MaxINode(l->in(2), r));
     l = l->in(1);
@@ -1131,7 +1132,7 @@ Node* MaxINode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
   const TypeInt* tx = phase->type(x)->isa_int();
 
-  if (r->Opcode() == Op_MaxI) {
+  if (r->Opcode() == Op_MaxI && !r->is_reduction()) {
     assert(r != r->in(2), "dead loop in MaxINode::Ideal");
     y = r->in(1);
     // Check final part of MAX tree
@@ -1174,9 +1175,10 @@ Node *MinINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Force a right-spline graph
   Node *l = in(1);
   Node *r = in(2);
+
   // Transform  MinI1( MinI2(a,b), c)  into  MinI1( a, MinI2(b,c) )
   // to force a right-spline graph for the rest of MinINode::Ideal().
-  if( l->Opcode() == Op_MinI ) {
+  if( l->Opcode() == Op_MinI && !l->is_reduction()) {
     assert( l != l->in(1), "dead loop in MinINode::Ideal" );
     r = phase->transform(new MinINode(l->in(2),r));
     l = l->in(1);
@@ -1214,7 +1216,7 @@ Node *MinINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   const TypeInt* tx = phase->type(x)->isa_int();
 
-  if( r->Opcode() == Op_MinI ) {
+  if( r->Opcode() == Op_MinI && !r->is_reduction()) {
     assert( r != r->in(2), "dead loop in MinINode::Ideal" );
     y = r->in(1);
     // Check final part of MIN tree

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -744,6 +744,16 @@ public class IRNode {
         superWordNodes(MUL_REDUCTION_VL, "MulReductionVL");
     }
 
+    public static final String MIN_REDUCTION_V = PREFIX + "MIN_REDUCTION_V" + POSTFIX;
+    static {
+        superWordNodes(MIN_REDUCTION_V, "MinReductionV");
+    }
+
+    public static final String MAX_REDUCTION_V = PREFIX + "MAX_REDUCTION_V" + POSTFIX;
+    static {
+        superWordNodes(MAX_REDUCTION_V, "MaxReductionV");
+    }
+
     public static final String NEG_V = PREFIX + "NEG_V" + POSTFIX;
     static {
         beforeMatchingNameRegex(NEG_V, "NegV(F|D)");

--- a/test/hotspot/jtreg/compiler/loopopts/superword/MinMaxRed_Int.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/MinMaxRed_Int.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8302673
+ * @summary [SuperWord] MaxReduction and MinReduction should vectorize for int
+ * @library /test/lib /
+ * @run driver compiler.loopopts.superword.MinMaxRed_Int
+ */
+
+package compiler.loopopts.superword;
+
+import compiler.lib.ir_framework.*;
+
+public class MinMaxRed_Int {
+    public static void main(String[] args) throws Exception {
+        TestFramework framework = new TestFramework();
+        framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                           "-XX:LoopUnrollLimit=250",
+                           "-XX:CompileThresholdScaling=0.1");
+        framework.start();
+    }
+
+    @Run(test = {"maxReductionImplement"},
+         mode = RunMode.STANDALONE)
+    public void runMaxTest() {
+        int[] a = new int[1024];
+        int[] b = new int[1024];
+        ReductionInit(a, b);
+        int res = 0;
+        for (int j = 0; j < 2000; j++) {
+            res = maxReductionImplement(a, b, res);
+        }
+        if (res == 0) {
+            System.out.println("Success");
+        } else {
+            throw new AssertionError("Failed");
+        }
+    }
+
+
+    @Run(test = {"minReductionImplement"},
+         mode = RunMode.STANDALONE)
+    public void runMinTest() {
+        int[] a = new int[1024];
+        int[] b = new int[1024];
+        ReductionInit(a, b);
+        int res = 1;
+        for (int j = 0; j < 2000; j++) {
+            res = minReductionImplement(a, b, res);
+        }
+        if (res == -1023*1023) {
+            System.out.println("Success");
+        } else {
+            throw new AssertionError("Failed");
+        }
+    }
+
+    public static void ReductionInit(int[] a, int[] b) {
+        for (int i = 0; i < a.length; i++) {
+            a[i] = -i;
+            b[i] = i;
+        }
+    }
+
+    @Test
+    @IR(applyIf = {"SuperWordReductions", "true"},
+        applyIfCPUFeatureOr = { "sse4.1", "true" , "asimd" , "true"},
+        counts = {IRNode.MIN_REDUCTION_V, " > 0"})
+    public static int minReductionImplement(int[] a, int[] b, int res) {
+        for (int i = 0; i < a.length; i++) {
+            res = Math.min(res, a[i] * b[i]);
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIf = {"SuperWordReductions", "true"},
+        applyIfCPUFeatureOr = { "sse4.1", "true" , "asimd" , "true"},
+        counts = {IRNode.MAX_REDUCTION_V, " > 0"})
+    public static int maxReductionImplement(int[] a, int[] b, int res) {
+        for (int i = 0; i < a.length; i++) {
+            res = Math.max(res, a[i] * b[i]);
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
This bugfix patch bypasses couple of canonicalizing ideal transformations for MaxI/MinI IR nodes to prevent breaking reduction chain.

Kindly review.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302673](https://bugs.openjdk.org/browse/JDK-8302673): [SuperWord] MaxReduction and MinReduction should vectorize for int


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13260/head:pull/13260` \
`$ git checkout pull/13260`

Update a local copy of the PR: \
`$ git checkout pull/13260` \
`$ git pull https://git.openjdk.org/jdk.git pull/13260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13260`

View PR using the GUI difftool: \
`$ git pr show -t 13260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13260.diff">https://git.openjdk.org/jdk/pull/13260.diff</a>

</details>
