### PR TITLE
8305237: CompilerDirectives DCmds permissions correction

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -698,7 +698,7 @@ public:
   }
   static const JavaPermission permission() {
     JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
+                        "control", nullptr};
     return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
@@ -721,7 +721,7 @@ public:
   }
   static const JavaPermission permission() {
     JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
+                        "control", nullptr};
     return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
@@ -741,7 +741,7 @@ public:
   }
   static const JavaPermission permission() {
     JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
+                        "control", nullptr};
     return p;
   }
   virtual void execute(DCmdSource source, TRAPS);


### PR DESCRIPTION
The Permissions in DCmds relate to remote usage over JMX. 
"monitor" is generally for reading information, and "control" is generally for making changes.
The DCmds for changing compiler directives should have "control" as the required permission.

Tests in test/hotspot/jtreg/serviceability/dcmd/compiler and test/hotspot/jtreg/compiler/compilercontrol still pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305237](https://bugs.openjdk.org/browse/JDK-8305237): CompilerDirectives DCmds permissions correction


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13262/head:pull/13262` \
`$ git checkout pull/13262`

Update a local copy of the PR: \
`$ git checkout pull/13262` \
`$ git pull https://git.openjdk.org/jdk.git pull/13262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13262`

View PR using the GUI difftool: \
`$ git pr show -t 13262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13262.diff">https://git.openjdk.org/jdk/pull/13262.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13262#issuecomment-1491560217)