### PR TITLE
8305352: updateIconImages may lead to deadlock after JDK-8276849

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
@@ -600,7 +600,9 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
             newDev.addDisplayChangedListener(this);
         }
 
-        updateIconImages();
+        if (((Window)target).isVisible()) {
+            updateIconImages();
+        }
 
         AWTAccessor.getComponentAccessor().
             setGraphicsConfiguration((Component)target, winGraphicsConfig);


### PR DESCRIPTION
Please review this PR which suggests to skip updateIconImages() for not yet visible windows. The displayChanged notification can be sent to a window that is in the process of initiailization and calling updateIconImages() may lead to the deadlock.

Testing: the deadlock no longer happens with this patch. The reg test for JDK-8276849 works (window icon is updated after changing DPI settings).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305352](https://bugs.openjdk.org/browse/JDK-8305352): updateIconImages may lead to deadlock after JDK-8276849


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13263/head:pull/13263` \
`$ git checkout pull/13263`

Update a local copy of the PR: \
`$ git checkout pull/13263` \
`$ git pull https://git.openjdk.org/jdk.git pull/13263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13263`

View PR using the GUI difftool: \
`$ git pr show -t 13263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13263.diff">https://git.openjdk.org/jdk/pull/13263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13263#issuecomment-1491613791)