### PR TITLE
8288109: HttpExchangeImpl.setAttribute does not allow null value after JDK-8266897

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ExchangeImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ExchangeImpl.java
@@ -377,7 +377,11 @@ class ExchangeImpl {
         if (attributes == null) {
             attributes = getHttpContext().getAttributes();
         }
-        attributes.put (name, value);
+        if (value != null) {
+            attributes.put (name, value);
+        } else {
+            attributes.remove (name);
+        }
     }
 
     public void setStreams (InputStream i, OutputStream o) {

--- a/test/jdk/com/sun/net/httpserver/ExchangeAttributeTest.java
+++ b/test/jdk/com/sun/net/httpserver/ExchangeAttributeTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288109
+ * @summary Tests for HttpExchange set/getAttribute
+ * @run junit/othervm ExchangeAttributeTest
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExchangeAttributeTest {
+
+    static final InetAddress LOOPBACK_ADDR = InetAddress.getLoopbackAddress();
+    static final boolean ENABLE_LOGGING = true;
+    static final Logger logger = Logger.getLogger("com.sun.net.httpserver");
+
+    @BeforeAll
+    public static void setup() {
+        if (ENABLE_LOGGING) {
+            ConsoleHandler ch = new ConsoleHandler();
+            logger.setLevel(Level.ALL);
+            ch.setLevel(Level.ALL);
+            logger.addHandler(ch);
+        }
+    }
+
+    @Test
+    public void testExchangeAttributes() throws Exception {
+        var handler = new AttribHandler();
+        var server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR,0), 10);
+        server.createContext("/", handler);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "")).build();
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    // --- infra ---
+
+    static URI uri(HttpServer server, String path) {
+        return URI.create("http://localhost:%s/%s".formatted(server.getAddress().getPort(), path));
+    }
+
+    /**
+     * A test handler that discards the request and sends a response
+     */
+    static class AttribHandler implements HttpHandler {
+        @java.lang.Override
+        public void handle(HttpExchange exchange) throws IOException {
+            try {
+                exchange.setAttribute("attr", "val");
+                assertEquals("val", exchange.getAttribute("attr"));
+                exchange.setAttribute("attr", null);
+                assertNull(exchange.getAttribute("attr"));
+                exchange.sendResponseHeaders(200, -1);
+            } catch (Throwable t) {
+                t.printStackTrace();
+                exchange.sendResponseHeaders(500, -1);
+            }
+        }
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/ExchangeAttributeTest.java
+++ b/test/jdk/com/sun/net/httpserver/ExchangeAttributeTest.java
@@ -25,12 +25,14 @@
  * @test
  * @bug 8288109
  * @summary Tests for HttpExchange set/getAttribute
+ * @library /test/lib
  * @run junit/othervm ExchangeAttributeTest
  */
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -82,8 +85,13 @@ public class ExchangeAttributeTest {
 
     // --- infra ---
 
-    static URI uri(HttpServer server, String path) {
-        return URI.create("http://localhost:%s/%s".formatted(server.getAddress().getPort(), path));
+    static URI uri(HttpServer server, String path) throws URISyntaxException {
+        return URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(server.getAddress().getPort())
+                .path(path)
+                .build();
     }
 
     /**


### PR DESCRIPTION
Please review this fix for a regression in HttpExchange's setAttribute method.

The specification of setAttribute explicitly states that null values are allowed.
JDK-8266897 changed `attributes` to `ConcurrentHashMap`, which does not allow null values.

This patch modifies `setAttribute` to remove the attribute from the map when null value is requested.

A new test was added to verify that setting attributes works as expected both for null and non-null values.

Tier1-3 clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288109](https://bugs.openjdk.org/browse/JDK-8288109): HttpExchangeImpl.setAttribute does not allow null value after JDK-8266897


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13264/head:pull/13264` \
`$ git checkout pull/13264`

Update a local copy of the PR: \
`$ git checkout pull/13264` \
`$ git pull https://git.openjdk.org/jdk.git pull/13264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13264`

View PR using the GUI difftool: \
`$ git pr show -t 13264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13264.diff">https://git.openjdk.org/jdk/pull/13264.diff</a>

</details>
