### PR TITLE
8305368: G1 remset chunk claiming may use relaxed memory ordering

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -427,7 +427,7 @@ public:
 
   uint claim_cards_to_scan(uint region, uint increment) {
     assert(region < _max_reserved_regions, "Tried to access invalid region %u", region);
-    return Atomic::fetch_and_add(&_card_table_scan_state[region], increment);
+    return Atomic::fetch_and_add(&_card_table_scan_state[region], increment, memory_order_relaxed);
   }
 
   void add_dirty_region(uint const region) {


### PR DESCRIPTION
Hi all,

  please review this minor change that changes the atomic increment for claiming chunks during scanning remembered sets to use relaxed memory ordering.
Nothing depends on that, and nothing should. No particular performance improvements (expected; on x86 all atomics are "conservative" anyway).

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305368](https://bugs.openjdk.org/browse/JDK-8305368): G1 remset chunk claiming may use relaxed memory ordering


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * @M4ximumPizza (no known openjdk.org user name / role)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13266/head:pull/13266` \
`$ git checkout pull/13266`

Update a local copy of the PR: \
`$ git checkout pull/13266` \
`$ git pull https://git.openjdk.org/jdk.git pull/13266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13266`

View PR using the GUI difftool: \
`$ git pr show -t 13266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13266.diff">https://git.openjdk.org/jdk/pull/13266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13266#issuecomment-1491770825)