### PR TITLE
8305370: Inconsistent use of for_young_only_phase parameter in G1 predictions

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -143,7 +143,7 @@ private:
   double predict_base_time_ms(size_t pending_cards, size_t rs_length) const;
 
   // Copy time for a region is copying live data.
-  double predict_region_copy_time_ms(HeapRegion* hr) const;
+  double predict_region_copy_time_ms(HeapRegion* hr, bool for_young_only_phase) const;
   // Merge-scan time for a region is handling remembered sets of that region (as a single unit).
   double predict_region_merge_scan_time(HeapRegion* hr, bool for_young_only_phase) const;
   // Non-copy time for a region is handling remembered sets and other time.


### PR DESCRIPTION
Hi all,

  please review this change to fix some inconsistent use of `for_young_only_phase`: some methods that require it are not passed that parameter, and some methods, although getting passed that parameter partially re-load that value from collector state.

Fwiw, I am aware that `G1Policy::predict_region_total_time_ms` only ever gets passed `false` as this parameter. I would have changed that as well if some [upcoming change](https://github.com/openjdk/jdk/commit/6c2f18eba29ad9f6e4e5ed28f1521037fdc49398) did not use other values as well. We can always remove it later if not necessary, but if somebody insists on doing so I will do that as well (probably separately).

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305370](https://bugs.openjdk.org/browse/JDK-8305370): Inconsistent use of for_young_only_phase parameter in G1 predictions


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13267/head:pull/13267` \
`$ git checkout pull/13267`

Update a local copy of the PR: \
`$ git checkout pull/13267` \
`$ git pull https://git.openjdk.org/jdk.git pull/13267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13267`

View PR using the GUI difftool: \
`$ git pr show -t 13267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13267.diff">https://git.openjdk.org/jdk/pull/13267.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13267#issuecomment-1491775275)