### PR TITLE
7124527: [macosx] SwingSet2, label is not read by VoiceOver when focus is on textfield for Internalframe and Table demo.

### DIFF
--- a/src/demo/share/jfc/SwingSet2/InternalFrameDemo.java
+++ b/src/demo/share/jfc/SwingSet2/InternalFrameDemo.java
@@ -271,6 +271,7 @@ public class InternalFrameDemo extends DemoModule {
 
         windowTitleField = new JTextField(getString("InternalFrameDemo.frame_label"));
         windowTitleLabel = new JLabel(getString("InternalFrameDemo.title_text_field_label"));
+        windowTitleLabel.setLabelFor(windowTitleField);
 
         p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
         p.add(Box.createRigidArea(HGAP5));

--- a/src/demo/share/jfc/SwingSet2/InternalFrameDemo.java
+++ b/src/demo/share/jfc/SwingSet2/InternalFrameDemo.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -281,6 +281,7 @@ public class TableDemo extends DemoModule {
         selectionModeComboBox.addItem(getString("TableDemo.one_range"));
         selectionModeComboBox.addItem(getString("TableDemo.multiple_ranges"));
         selectionModeComboBox.setSelectedIndex(tableView.getSelectionModel().getSelectionMode());
+        selectionModeComboBox.getAccessibleContext().setAccessibleName(getString("TableDemo.selection_mode"));
         selectionModeComboBox.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 JComboBox<?> source = (JComboBox<?>)e.getSource();
@@ -310,6 +311,7 @@ public class TableDemo extends DemoModule {
         resizeModeComboBox.addItem(getString("TableDemo.last_column"));
         resizeModeComboBox.addItem(getString("TableDemo.all_columns"));
         resizeModeComboBox.setSelectedIndex(tableView.getAutoResizeMode());
+        resizeModeComboBox.getAccessibleContext().setAccessibleName(getString("TableDemo.autoresize_mode"));
         resizeModeComboBox.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 JComboBox<?> source = (JComboBox<?>)e.getSource();
@@ -330,6 +332,9 @@ public class TableDemo extends DemoModule {
         footerTextField = new JTextField(getString("TableDemo.footerText"), 15);
         fitWidth = new JCheckBox(getString("TableDemo.fitWidth"), true);
         printButton = new JButton(getString("TableDemo.print"));
+
+        headerLabel.setLabelFor(headerTextField);
+        footerLabel.setLabelFor(footerTextField);
         printButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent ae) {
                 printTable();


### PR DESCRIPTION
In SwingSet2, few label components are not set for textfield component in InternalFrame and Table demo and due to this VoiceOver doesn't announce the label along with the textfield value. Added a fix for that and verified in SwingSet2.

Apart from that for Selection mode combobox and Autoresize combobox, VoiceOver doesn't announce the combobox panel details along with combobox current item. 

Although the bug doesn't report this but in Slider demo it is observed that VoiceOver announces the slider value and panel details together.

So, added a fix similar to slider demo for combobox in tabledemo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7124527](https://bugs.openjdk.org/browse/JDK-7124527): [macosx] SwingSet2, label is not read by VoiceOver when focus is on textfield for Internalframe and Table demo.


### Reviewers
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer) ⚠️ Review applies to [70aca9e0](https://git.openjdk.org/jdk/pull/13268/files/70aca9e03078386db7e133e0207ece12f0c10a46)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13268/head:pull/13268` \
`$ git checkout pull/13268`

Update a local copy of the PR: \
`$ git checkout pull/13268` \
`$ git pull https://git.openjdk.org/jdk.git pull/13268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13268`

View PR using the GUI difftool: \
`$ git pr show -t 13268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13268.diff">https://git.openjdk.org/jdk/pull/13268.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13268#issuecomment-1491821637)