### PR TITLE
8274166: Some CDS tests ignore -Dtest.cds.runtime.options

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -415,7 +415,8 @@ public class TestCommon extends CDSTestUtils {
     public static OutputAnalyzer runWithArchive(CDSOptions opts)
         throws Exception {
 
-        ArrayList<String> cmd = opts.getRuntimePrefix();
+        ArrayList<String> cmd = new ArrayList<String>();
+        cmd.addAll(opts.prefix);
         cmd.add("-Xshare:" + opts.xShareMode);
         cmd.add("-showversion");
         cmd.add("-XX:SharedArchiveFile=" + getCurrentArchiveName());

--- a/test/lib/jdk/test/lib/cds/CDSOptions.java
+++ b/test/lib/jdk/test/lib/cds/CDSOptions.java
@@ -118,35 +118,6 @@ public class CDSOptions {
         return this;
     }
 
-    // Call by CDSTestUtils.runWithArchive() and TestCommon.runWithArchive().
-    //
-    // Example:
-    //  - The dumping will be done with the default G1GC so we can generate
-    //    the archived heap.
-    //  - The runtime execution will be done with the EpsilonGC, to test its
-    //    ability to load the archived heap.
-    //
-    // jtreg -vmoptions:-Dtest.cds.runtime.options=-XX:+UnlockExperimentalVMOptions,-XX:+UseEpsilonGC \
-    //       test/hotspot/jtreg/runtime/cds
-    public ArrayList<String> getRuntimePrefix() {
-        ArrayList<String> cmdline = new ArrayList<>();
-
-        String jtropts = System.getProperty("test.cds.runtime.options");
-        if (jtropts != null) {
-            for (String s : jtropts.split(",")) {
-                if (!disabledRuntimePrefixes.contains(s)) {
-                    cmdline.add(s);
-                }
-            }
-        }
-
-        for (String p : prefix) {
-            cmdline.add(p);
-        }
-
-        return cmdline;
-    }
-
     static ArrayList<String> disabledRuntimePrefixes = new ArrayList<>();
 
     // Do not use the command-line option s, even if it's specified in -Dtest.cds.runtime.options


### PR DESCRIPTION
The test.cds.runtime.options property is used to execute the CDS tests in a special mode. E.g., create the archived with G1 but load the archive with EpsilonGC.

Currently tests that are launched with TestCommon.runWithArchive() and CDSTestUtils.runWithArchive() can handle -Dtest.cds.runtime.options. However, some test cases, such as dynamicArchive/HelloDynamic.java, do not call the above two methods, so they ignore -Dtest.cds.runtime.options.

The fix is to move the handling of -Dtest.cds.runtime.options to TestCommon.executeAndLog, because most CDS tests use this function to launch a child JVM. Other considerations are necessary now that the option is exposed to other tests, so checks for GC and CDS are necessary.