### PR TITLE
8303943: jio_print doesn't allow for a short os::write

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2901,8 +2901,13 @@ void jio_print(const char* s, size_t len) {
   if (Arguments::vfprintf_hook() != nullptr) {
     jio_fprintf(defaultStream::output_stream(), "%.*s", (int)len, s);
   } else {
-    // Make an unused local variable to avoid warning from gcc compiler.
-    ssize_t count = os::write(defaultStream::output_fd(), s, (int)len);
+    ssize_t size = (ssize_t)len;
+    while (size > 0) {
+      // Make an unused local variable to avoid warning from gcc compiler.
+      ssize_t count = os::write(defaultStream::output_fd(), s, (int)size);
+      s += count;
+      size -= count;
+    }
   }
 }
 


### PR DESCRIPTION
`os::write` is used in a loop until all the requested size of write is done. `len` argument is casted to `ssize_t` to be able to check `> 0` in loop predicate.

### Test
local: hotspot:tier1
mach5: tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303943](https://bugs.openjdk.org/browse/JDK-8303943): jio_print doesn't allow for a short os::write


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13274/head:pull/13274` \
`$ git checkout pull/13274`

Update a local copy of the PR: \
`$ git checkout pull/13274` \
`$ git pull https://git.openjdk.org/jdk.git pull/13274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13274`

View PR using the GUI difftool: \
`$ git pr show -t 13274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13274.diff">https://git.openjdk.org/jdk/pull/13274.diff</a>

</details>
