### PR TITLE
Add flag to overwrite when HeapDumpOnMemoryError is enabled

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -563,6 +563,10 @@ const int ObjectAlignmentInBytes = 8;
           "compression. Otherwise the level must be between 1 and 9.")      \
           range(0, 9)                                                       \
                                                                             \
+  product(bool, HeapDumpOverwrite, false, MANAGEABLE,                       \
+          "When HeapDumpOnOutOfMemoryError is on, overwrite if the dump "   \
+          "file exists")                                                    \
+                                                                            \
   product(ccstr, NativeMemoryTracking, DEBUG_ONLY("summary") NOT_DEBUG("off"), \
           "Native memory tracking options")                                 \
                                                                             \

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2294,8 +2294,8 @@ void HeapDumper::set_error(char const* error) {
 
 // Called by out-of-memory error reporting by a single Java thread
 // outside of a JVM safepoint
-void HeapDumper::dump_heap_from_oome() {
-  HeapDumper::dump_heap(true);
+void HeapDumper::dump_heap_from_oome(bool overwrite) {
+  HeapDumper::dump_heap(true, overwrite);
 }
 
 // Called by error reporting by a single Java thread outside of a JVM safepoint,
@@ -2307,7 +2307,7 @@ void HeapDumper::dump_heap() {
   HeapDumper::dump_heap(false);
 }
 
-void HeapDumper::dump_heap(bool oome) {
+void HeapDumper::dump_heap(bool oome, bool overwrite) {
   static char base_path[JVM_MAXPATHLEN] = {'\0'};
   static uint dump_file_seq = 0;
   char* my_path;
@@ -2381,6 +2381,6 @@ void HeapDumper::dump_heap(bool oome) {
 
   HeapDumper dumper(false /* no GC before heap dump */,
                     oome  /* pass along out-of-memory-error flag */);
-  dumper.dump(my_path, tty, HeapDumpGzipLevel);
+  dumper.dump(my_path, tty, HeapDumpGzipLevel, overwrite);
   os::free(my_path);
 }

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -49,7 +49,7 @@ class HeapDumper : public StackObj {
   // internal timer.
   elapsedTimer* timer()                 { return &_t; }
 
-  static void dump_heap(bool oome);
+  static void dump_heap(bool oome, bool overwrite = false);
 
  public:
   HeapDumper(bool gc_before_heap_dump) :
@@ -68,7 +68,7 @@ class HeapDumper : public StackObj {
 
   static void dump_heap()    NOT_SERVICES_RETURN;
 
-  static void dump_heap_from_oome()    NOT_SERVICES_RETURN;
+  static void dump_heap_from_oome(bool overwrite = false)    NOT_SERVICES_RETURN;
 
   // Parallel thread number for heap dump, initialize based on active processor count.
   static uint default_num_of_dump_threads() {

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -259,7 +259,7 @@ void report_java_out_of_memory(const char* message) {
     // create heap dump before OnOutOfMemoryError commands are executed
     if (HeapDumpOnOutOfMemoryError) {
       tty->print_cr("java.lang.OutOfMemoryError: %s", message);
-      HeapDumper::dump_heap_from_oome();
+      HeapDumper::dump_heap_from_oome(HeapDumpOverwrite);
     }
 
     if (OnOutOfMemoryError && OnOutOfMemoryError[0]) {


### PR DESCRIPTION
This pr exposes the flag to overwrite a heap dump file when used with the `HeapDumpOnOutOfMemoryError` flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13276/head:pull/13276` \
`$ git checkout pull/13276`

Update a local copy of the PR: \
`$ git checkout pull/13276` \
`$ git pull https://git.openjdk.org/jdk.git pull/13276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13276`

View PR using the GUI difftool: \
`$ git pr show -t 13276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13276.diff">https://git.openjdk.org/jdk/pull/13276.diff</a>

</details>
