### PR TITLE
JDK-8304945: StringBuilder and StringBuffer should implement Appendable explicitly

### DIFF
--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  */
  public final class StringBuffer
     extends AbstractStringBuilder
-    implements Serializable, Comparable<StringBuffer>, CharSequence
+    implements Appendable, Serializable, Comparable<StringBuffer>, CharSequence
 {
 
     /**

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ import java.io.StreamCorruptedException;
  */
 public final class StringBuilder
     extends AbstractStringBuilder
-    implements java.io.Serializable, Comparable<StringBuilder>, CharSequence
+    implements Appendable, java.io.Serializable, Comparable<StringBuilder>, CharSequence
 {
 
     /** use serialVersionUID for interoperability */


### PR DESCRIPTION
The StringBuilder and StringBuffer classes are Appendable by virtue of from subclasses their non-public superclass AbstractStringBuilder.

It is slightly clearer to declare StringBuilder and StringBuffer to directly implement Appendable, as they already directly implement the CharSequence interface also implemented by their superclass.

There are no other interfaces implemented by AbstractStringBuilder other than Appendable and CharSequence.

Please also review the CSR https://bugs.openjdk.org/browse/JDK-8305408

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8305408](https://bugs.openjdk.org/browse/JDK-8305408) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8304945](https://bugs.openjdk.org/browse/JDK-8304945): StringBuilder and StringBuffer should implement Appendable explicitly
 * [JDK-8305408](https://bugs.openjdk.org/browse/JDK-8305408): StringBuilder and StringBuffer should implement Appendable explicitly (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * @M4ximumPizza (no known openjdk.org user name / role)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13278/head:pull/13278` \
`$ git checkout pull/13278`

Update a local copy of the PR: \
`$ git checkout pull/13278` \
`$ git pull https://git.openjdk.org/jdk.git pull/13278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13278`

View PR using the GUI difftool: \
`$ git pr show -t 13278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13278.diff">https://git.openjdk.org/jdk/pull/13278.diff</a>

</details>
