### PR TITLE
8305417: disable gtest/NMTGtests.java sub-tests failing due to JDK-8305414

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -99,13 +99,13 @@ TEST_VM(NMT, location_printing_cheap_live_6) { test_for_live_c_heap_block(4, 0);
 TEST_VM(NMT, location_printing_cheap_live_7) { test_for_live_c_heap_block(4, 4); }                  // just outside a very small block
 
 #ifdef LINUX
-TEST_VM(NMT, location_printing_cheap_dead_1) { test_for_dead_c_heap_block(2 * K, 0); }              // start of payload
-TEST_VM(NMT, location_printing_cheap_dead_2) { test_for_dead_c_heap_block(2 * K, -7); }             // into header
-TEST_VM(NMT, location_printing_cheap_dead_3) { test_for_dead_c_heap_block(2 * K, K + 1); }          // into payload
-TEST_VM(NMT, location_printing_cheap_dead_4) { test_for_dead_c_heap_block(2 * K, K + 2); }          // into payload (check for even/odd errors)
+DISABLE_TEST_VM(NMT, location_printing_cheap_dead_1) { test_for_dead_c_heap_block(2 * K, 0); }              // start of payload
+DISABLE_TEST_VM(NMT, location_printing_cheap_dead_2) { test_for_dead_c_heap_block(2 * K, -7); }             // into header
+DISABLE_TEST_VM(NMT, location_printing_cheap_dead_3) { test_for_dead_c_heap_block(2 * K, K + 1); }          // into payload
+DISABLE_TEST_VM(NMT, location_printing_cheap_dead_4) { test_for_dead_c_heap_block(2 * K, K + 2); }          // into payload (check for even/odd errors)
 TEST_VM(NMT, location_printing_cheap_dead_5) { test_for_dead_c_heap_block(2 * K + 1, 2 * K + 2); }  // just outside payload
-TEST_VM(NMT, location_printing_cheap_dead_6) { test_for_dead_c_heap_block(4, 0); }                  // into a very small block
-TEST_VM(NMT, location_printing_cheap_dead_7) { test_for_dead_c_heap_block(4, 4); }                  // just outside a very small block
+DISABLE_TEST_VM(NMT, location_printing_cheap_dead_6) { test_for_dead_c_heap_block(4, 0); }                  // into a very small block
+DISABLE_TEST_VM(NMT, location_printing_cheap_dead_7) { test_for_dead_c_heap_block(4, 4); }                  // just outside a very small block
 #endif
 
 static void test_for_mmap(size_t sz, ssize_t offset) {


### PR DESCRIPTION
A trivial fix to disable gtest/NMTGtests.java sub-tests failing due to JDK-8305414.