### PR TITLE
8305421: Work around JDK-8305420 in CDSJDITest.java

### DIFF
--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,6 @@ public class CDSJDITest {
             // pass them as JVM arguments to the debuggee process it creates.
             "-Xbootclasspath/a:" + appJar,
             "-XX:+UnlockDiagnosticVMOptions",
-            "-Xlog:class+path=info",
             "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
             "-Xshare:on",
             "-showversion"
@@ -73,7 +72,7 @@ public class CDSJDITest {
             "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
             "-XX:ExtraSharedClassListFile=" + jarClasslistFile.getPath(),
             "-Xshare:dump", "-Xlog:cds");
-        OutputAnalyzer outputDump = executeAndLog(pb, "exec");
+        OutputAnalyzer outputDump = executeAndLog(pb, "dump");
         for (String jarClass : jarClasses) {
             outputDump.shouldNotContain("Cannot find " + jarClass);
         }


### PR DESCRIPTION
Please review this trivial work-around that removes logging that would trigger [JDK-8305420](https://bugs.openjdk.org/browse/JDK-8305420).

I also fixed an incorrect parameter in the `executeAndLog()` call, which caused the dumping process's stdout/stderr to be logged in the wrong file.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305421](https://bugs.openjdk.org/browse/JDK-8305421): Work around JDK-8305420 in CDSJDITest.java


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13283/head:pull/13283` \
`$ git checkout pull/13283`

Update a local copy of the PR: \
`$ git checkout pull/13283` \
`$ git pull https://git.openjdk.org/jdk.git pull/13283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13283`

View PR using the GUI difftool: \
`$ git pr show -t 13283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13283.diff">https://git.openjdk.org/jdk/pull/13283.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13283#issuecomment-1493470562)