### PR TITLE
8305425: Thread.isAlive0 doesn't need to call into the VM

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -162,7 +162,6 @@ JVM_IsRecord
 JVM_IsSameClassPackage
 JVM_IsSharingEnabled
 JVM_IsSupportedJNIVersion
-JVM_IsThreadAlive
 JVM_IsVMGeneratedMethodIx
 JVM_LatestUserDefinedLoader
 JVM_LoadZipLibrary

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,9 +265,6 @@ JVM_SetStackWalkContinuation(JNIEnv *env, jobject stackStream, jlong anchor, job
  */
 JNIEXPORT void JNICALL
 JVM_StartThread(JNIEnv *env, jobject thread);
-
-JNIEXPORT jboolean JNICALL
-JVM_IsThreadAlive(JNIEnv *env, jobject thread);
 
 JNIEXPORT void JNICALL
 JVM_SetThreadPriority(JNIEnv *env, jobject thread, jint prio);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3020,12 +3020,6 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
 JVM_END
 
 
-JVM_ENTRY(jboolean, JVM_IsThreadAlive(JNIEnv* env, jobject jthread))
-  oop thread_oop = JNIHandles::resolve_non_null(jthread);
-  return java_lang_Thread::is_alive(thread_oop);
-JVM_END
-
-
 JVM_ENTRY(void, JVM_SetThreadPriority(JNIEnv* env, jobject jthread, jint prio))
   ThreadsListHandle tlh(thread);
   oop java_thread = nullptr;

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -739,7 +739,9 @@ static void ensure_join(JavaThread* thread) {
   // Thread is exiting. So set thread_status field in  java.lang.Thread class to TERMINATED.
   java_lang_Thread::set_thread_status(threadObj(), JavaThreadStatus::TERMINATED);
   // Clear the native thread instance - this makes isAlive return false and allows the join()
-  // to complete once we've done the notify_all below
+  // to complete once we've done the notify_all below. Needs a release() to obey Java Memory Model
+  // requirements.
+  OrderAccess::release();
   java_lang_Thread::set_thread(threadObj(), nullptr);
   lock.notify_all(thread);
   // Ignore pending exception, since we are exiting anyway

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -228,7 +228,10 @@ public class Thread implements Runnable {
 
     /* Reserved for exclusive use by the JVM. Cannot be moved to the FieldHolder
        as it needs to be set by the VM before executing the constructor that
-       will create the FieldHolder.
+       will create the FieldHolder. The historically named `eetop`holds the address
+       of the underlying VM JavaThread, and is set to non-zero when the thread is started,
+       and reset to zero when the thread terminates. A non-zero value indicates this thread
+       isAlive().
     */
     private long eetop;
 
@@ -1840,9 +1843,11 @@ public class Thread implements Runnable {
 
     /**
      * Returns true if this thread is alive.
-     * This method is non-final so it can be overridden.
+     * This method is non-final so it can be overridden by VirtualThread.
+     * This method needs to be synchronized to ensure that thread termination
+     * happens-before isAlive() returning false.
      */
-    boolean alive() {
+    synchronized boolean alive() {
         return eetop != 0;
     }
 

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -226,7 +226,10 @@ public class Thread implements Runnable {
         registerNatives();
     }
 
-    /* Reserved for exclusive use by the JVM, maybe move to FieldHolder */
+    /* Reserved for exclusive use by the JVM. Cannot be moved to FieldHolder
+       as it needs to be set by the VM before executing the constructor that
+       will set FieldHolder.
+    */
     private long eetop;
 
     // thread id
@@ -1840,9 +1843,8 @@ public class Thread implements Runnable {
      * This method is non-final so it can be overridden.
      */
     boolean alive() {
-        return isAlive0();
+        return eetop != 0;
     }
-    private native boolean isAlive0();
 
     /**
      * Throws {@code UnsupportedOperationException}.

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -226,12 +226,13 @@ public class Thread implements Runnable {
         registerNatives();
     }
 
-    /* Reserved for exclusive use by the JVM. Cannot be moved to the FieldHolder
-     * as it needs to be set by the VM before executing the constructor that
-     * will create the FieldHolder. The historically named `eetop` holds the address
-     * of the underlying VM JavaThread, and is set to non-zero when the thread is started,
-     * and reset to zero when the thread terminates. A non-zero value indicates this thread
-     * isAlive().
+    /*
+     * Reserved for exclusive use by the JVM. Cannot be moved to the FieldHolder
+     * as it needs to be set by the VM for JNI attaching threads, before executing
+     * the constructor that will create the FieldHolder. The historically named
+     * `eetop` holds the address of the underlying VM JavaThread, and is set to
+     * non-zero when the thread is started, and reset to zero when the thread terminates.
+     * A non-zero value indicates this thread isAlive().
      */
     private volatile long eetop;
 

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -227,12 +227,12 @@ public class Thread implements Runnable {
     }
 
     /* Reserved for exclusive use by the JVM. Cannot be moved to the FieldHolder
-       as it needs to be set by the VM before executing the constructor that
-       will create the FieldHolder. The historically named `eetop` holds the address
-       of the underlying VM JavaThread, and is set to non-zero when the thread is started,
-       and reset to zero when the thread terminates. A non-zero value indicates this thread
-       isAlive().
-    */
+     * as it needs to be set by the VM before executing the constructor that
+     * will create the FieldHolder. The historically named `eetop` holds the address
+     * of the underlying VM JavaThread, and is set to non-zero when the thread is started,
+     * and reset to zero when the thread terminates. A non-zero value indicates this thread
+     * isAlive().
+     */
     private volatile long eetop;
 
     // thread id

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -226,9 +226,9 @@ public class Thread implements Runnable {
         registerNatives();
     }
 
-    /* Reserved for exclusive use by the JVM. Cannot be moved to FieldHolder
+    /* Reserved for exclusive use by the JVM. Cannot be moved to the FieldHolder
        as it needs to be set by the VM before executing the constructor that
-       will set FieldHolder.
+       will create the FieldHolder.
     */
     private long eetop;
 

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -233,7 +233,7 @@ public class Thread implements Runnable {
        and reset to zero when the thread terminates. A non-zero value indicates this thread
        isAlive().
     */
-    private long eetop;
+    private volatile long eetop;
 
     // thread id
     private final long tid;
@@ -1843,11 +1843,9 @@ public class Thread implements Runnable {
 
     /**
      * Returns true if this thread is alive.
-     * This method is non-final so it can be overridden by VirtualThread.
-     * This method needs to be synchronized to ensure that thread termination
-     * happens-before isAlive() returning false.
+     * This method is non-final so it can be overridden.
      */
-    synchronized boolean alive() {
+    boolean alive() {
         return eetop != 0;
     }
 

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -228,7 +228,7 @@ public class Thread implements Runnable {
 
     /* Reserved for exclusive use by the JVM. Cannot be moved to the FieldHolder
        as it needs to be set by the VM before executing the constructor that
-       will create the FieldHolder. The historically named `eetop`holds the address
+       will create the FieldHolder. The historically named `eetop` holds the address
        of the underlying VM JavaThread, and is set to non-zero when the thread is started,
        and reset to zero when the thread terminates. A non-zero value indicates this thread
        isAlive().

--- a/src/java.base/share/native/libjava/Thread.c
+++ b/src/java.base/share/native/libjava/Thread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@
 
 static JNINativeMethod methods[] = {
     {"start0",           "()V",        (void *)&JVM_StartThread},
-    {"isAlive0",         "()Z",        (void *)&JVM_IsThreadAlive},
     {"setPriority0",     "(I)V",       (void *)&JVM_SetThreadPriority},
     {"yield0",           "()V",        (void *)&JVM_Yield},
     {"sleep0",           "(J)V",       (void *)&JVM_Sleep},

--- a/test/jdk/java/lang/Thread/IsAlive.java
+++ b/test/jdk/java/lang/Thread/IsAlive.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023, Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8305425
+ * @summary Check Thread.isAlive
+ * @run main/othervm/timeout=10 IsAlive
+ */
+
+public class IsAlive {
+
+    static boolean spinnerDone;
+
+    private static void spin() {
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                Thread.sleep(10);
+            }
+        } catch (InterruptedException ie) {
+            // Do nothing, just exit
+        }
+        spinnerDone = true;
+    }
+
+    static volatile boolean checkerReady;
+
+    private static void check(Thread t) {
+        while (!t.isAlive()) {
+            // Burn hard, without any sleeps.
+            // Check that we discover the thread is alive eventually.
+        }
+
+        checkerReady = true;
+
+        while (t.isAlive()) {
+            // Burn hard, without any sleeps.
+            // Check that we discover the thread is not alive eventually.
+        }
+
+        if (!spinnerDone) {
+            throw new RuntimeException("last write of terminated thread wasn't seen!");
+        }
+    }
+
+    private static void assertAlive(Thread t) {
+        if (!t.isAlive()) {
+            throw new IllegalStateException("Thread " + t + " is not alive, but it should be");
+        }
+    }
+
+    private static void assertNotAlive(Thread t) {
+        if (t.isAlive()) {
+            throw new IllegalStateException("Thread " + t + " is alive, but it should not be");
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        Thread spinner = new Thread(IsAlive::spin);
+        spinner.setName("Spinner");
+        spinner.setDaemon(true);
+
+        Thread checker = new Thread(() -> check(spinner));
+        checker.setName("Checker");
+        checker.setDaemon(true);
+
+        assertNotAlive(spinner);
+        assertNotAlive(checker);
+
+        System.out.println("Starting spinner");
+        spinner.start();
+        assertAlive(spinner);
+
+        System.out.println("Starting checker");
+        checker.start();
+        assertAlive(checker);
+
+        System.out.println("Waiting for checker to catch up");
+        while (!checkerReady) {
+            Thread.sleep(100);
+        }
+
+        System.out.println("Interrupting and joining spinner");
+        spinner.interrupt();
+        spinner.join();
+        assertNotAlive(spinner);
+
+        System.out.println("Joining checker");
+        checker.join();
+        assertNotAlive(checker);
+
+        System.out.println("Complete");
+    }
+}

--- a/test/jdk/java/lang/Thread/IsAlive.java
+++ b/test/jdk/java/lang/Thread/IsAlive.java
@@ -35,7 +35,7 @@ public class IsAlive {
     private static void spin() {
         try {
             while (!Thread.currentThread().isInterrupted()) {
-                Thread.sleep(10);
+                Thread.sleep(100);
             }
         } catch (InterruptedException ie) {
             // Do nothing, just exit
@@ -59,7 +59,7 @@ public class IsAlive {
         }
 
         if (!spinnerDone) {
-            throw new RuntimeException("last write of terminated thread wasn't seen!");
+            throw new RuntimeException("Last write of terminated thread was not seen!");
         }
     }
 


### PR DESCRIPTION
We have the strange situation where calling `t.isAlive()` on a `java.lang.Thread` `t`, will call into the VM (via `alive()` then `isAlive0()`) where the VM then examines the `eetop` field of `t` to extract its `JavaThread` pointer and compare it to null. We can simply read `eetop` directly in `Thread.alive()`:
```
boolean alive() {
  return eetop != 0;
} 
```
I also updated a comment in relation to `eetop`.

Testing: tiers 1-3

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305425](https://bugs.openjdk.org/browse/JDK-8305425): Thread.isAlive0 doesn't need to call into the VM


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [8e662cdf](https://git.openjdk.org/jdk/pull/13287/files/8e662cdf8d914da01e40bf32179d9ad46f60e57b)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [fc1e1aba](https://git.openjdk.org/jdk/pull/13287/files/fc1e1abaa63c593ab61ba48c87363aa2f02c15f9)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [dbb9a91a](https://git.openjdk.org/jdk/pull/13287/files/dbb9a91ad6698b595efad9977946cde56dc19a38)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13287/head:pull/13287` \
`$ git checkout pull/13287`

Update a local copy of the PR: \
`$ git checkout pull/13287` \
`$ git pull https://git.openjdk.org/jdk.git pull/13287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13287`

View PR using the GUI difftool: \
`$ git pr show -t 13287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13287.diff">https://git.openjdk.org/jdk/pull/13287.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13287#issuecomment-1493816606)