### PR TITLE
8305538: Avoid redundant HashMap.containsKey call in ModuleDescriptor.Builder

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -2010,10 +2010,9 @@ public class ModuleDescriptor
             if (automatic)
                 throw new IllegalStateException("Automatic modules can not declare"
                                                 + " service dependences");
-            if (uses.contains(requireServiceTypeName(service)))
+            if (!uses.add(requireServiceTypeName(service)))
                 throw new IllegalStateException("Dependence upon service "
                                                 + service + " already declared");
-            uses.add(service);
             return this;
         }
 

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1630,10 +1630,10 @@ public class ModuleDescriptor
             String mn = req.name();
             if (name.equals(mn))
                 throw new IllegalArgumentException("Dependence on self");
-            if (requires.containsKey(mn))
+            if (requires.putIfAbsent(mn, req) != null) {
                 throw new IllegalStateException("Dependence upon " + mn
                                                 + " already declared");
-            requires.put(mn, req);
+            }
             return this;
         }
 
@@ -1745,11 +1745,10 @@ public class ModuleDescriptor
                                                  + " exported packages");
             }
             String source = e.source();
-            if (exports.containsKey(source)) {
+            if (exports.putIfAbsent(source, e) != null) {
                 throw new IllegalStateException("Exported package " + source
                                                  + " already declared");
             }
-            exports.put(source, e);
             packages.add(source);
             return this;
         }
@@ -1878,11 +1877,10 @@ public class ModuleDescriptor
                                                 + " declare open packages");
             }
             String source = obj.source();
-            if (opens.containsKey(source)) {
+            if (opens.putIfAbsent(source, obj) != null) {
                 throw new IllegalStateException("Open package " + source
                                                 + " already declared");
             }
-            opens.put(source, obj);
             packages.add(source);
             return this;
         }
@@ -2035,10 +2033,10 @@ public class ModuleDescriptor
          */
         public Builder provides(Provides p) {
             String service = p.service();
-            if (provides.containsKey(service))
+            if (provides.putIfAbsent(service, p) != null) {
                 throw new IllegalStateException("Providers of service "
                                                 + service + " already declared");
-            provides.put(service, p);
+            }
             p.providers().forEach(name -> packages.add(packageName(name)));
             return this;
         }


### PR DESCRIPTION
`Map.containsKey` call is sometimes unnecessary, when it's known that `Map` doesn't contain `null` values.
Instead of pair containsKey+put we can use putIfAbsent and compare result with null.
Result code is shorter and a bit faster.
Same approach is used with `HashSet<String> uses` in `java.lang.module.ModuleDescriptor.Builder#uses`. Instead of separate `contains`+`add` - we can just call `add` then check what it returns.

Testing: Linux x64 `java/lang`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305538](https://bugs.openjdk.org/browse/JDK-8305538): Avoid redundant HashMap.containsKey call in ModuleDescriptor.Builder (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13288/head:pull/13288` \
`$ git checkout pull/13288`

Update a local copy of the PR: \
`$ git checkout pull/13288` \
`$ git pull https://git.openjdk.org/jdk.git pull/13288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13288`

View PR using the GUI difftool: \
`$ git pr show -t 13288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13288.diff">https://git.openjdk.org/jdk/pull/13288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13288#issuecomment-1495897089)