### PR TITLE
Ignore __.idea folder and dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ NashornProfile.txt
 /.project
 /.classpath
 /.cproject
+__.idea/
+**/hs_err_pid*.log


### PR DESCRIPTION
IntelliJ IDEA is a [supported IDE](https://github.com/openjdk/jdk/blob/master/doc/ide.md#intellij-idea). While working with it, I saw that my git client wanted to add many files. I think, there are all not needed in the repository. Therefore, I added appropriate .gitignore patterns.