### PR TITLE
Relax test assertions for ARM Thumb

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -882,7 +882,7 @@ TEST_VM(os, iso8601_time) {
 }
 
 TEST_VM(os, is_first_C_frame) {
-#if !defined(_WIN32) && !defined(ZERO)
+#if !defined(_WIN32) && !defined(ZERO) && !defined(__thumb__)
   frame invalid_frame;
   EXPECT_TRUE(os::is_first_C_frame(&invalid_frame)); // the frame has zeroes for all values
 

--- a/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
+++ b/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
@@ -320,6 +320,6 @@ public class VirtualAllocCommitMerge {
     public static void checkCommitted(OutputAnalyzer output, long addr, long size, String sizeString) {
         output.shouldMatch("\\[0x[0]*" + Long.toHexString(addr) + " - 0x[0]*"
                            + Long.toHexString(addr + size)
-                           + "\\] committed " + sizeString + " from.*");
+                           + "\\] committed " + sizeString + ".*");
     }
 }


### PR DESCRIPTION
os::current_frame() is stubbed out on the Linux Arm Thumb platform [1]
This causes gtest 'is_first_C_frame' to fail. 
This also affects 'MemDetailReporter::report_virtual_memory_region()'[2] causing the trace to miss 'from  <location>' part which breaks 'test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java'.

[1] https://github.com/openjdk/jdk/blob/0deb648985b018653ccdaf193dc13b3cf21c088a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp#L219
[2] https://github.com/openjdk/jdk/blob/aa762102e9328ca76663b56b3be6f6141b044744/src/hotspot/share/services/memReporter.cpp#L397

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13290/head:pull/13290` \
`$ git checkout pull/13290`

Update a local copy of the PR: \
`$ git checkout pull/13290` \
`$ git pull https://git.openjdk.org/jdk.git pull/13290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13290`

View PR using the GUI difftool: \
`$ git pr show -t 13290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13290.diff">https://git.openjdk.org/jdk/pull/13290.diff</a>

</details>
