### PR TITLE
JDK-8305356: Fix ignored bad CompileCommands in tests and add an assertion

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -794,6 +794,7 @@ void CompilerOracle::print_parse_error(char* error_msg, char* original_line) {
   tty->print_cr("Error: %s", error_msg);
   tty->print_cr("Line: '%s'", original_line);
   print_tip();
+  assert(false, "CompilerOracle::print_parse_error");
 }
 
 class LineCopy : StackObj {

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -794,7 +794,6 @@ void CompilerOracle::print_parse_error(char* error_msg, char* original_line) {
   tty->print_cr("Error: %s", error_msg);
   tty->print_cr("Line: '%s'", original_line);
   print_tip();
-  assert(false, "CompilerOracle::print_parse_error");
 }
 
 class LineCopy : StackObj {

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestNegAnd.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestNegAnd.java
@@ -29,7 +29,7 @@
  *
  * @library /test/lib
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand="dontinline,TestNegAnd::test*" TestNegAnd
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand=dontinline,TestNegAnd::test* TestNegAnd
  *
  */
 

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestNegMultiply.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestNegMultiply.java
@@ -29,7 +29,7 @@
  *
  * @library /test/lib
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand="dontinline,TestNegMultiply::test*" TestNegMultiply
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand=dontinline,TestNegMultiply::test* TestNegMultiply
  *
  */
 

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMulAdd.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMulAdd.java
@@ -31,11 +31,11 @@
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:-UseSquareToLenIntrinsic -XX:-UseMultiplyToLenIntrinsic
  *      -XX:CompileCommand=dontinline,compiler.intrinsics.bigInteger.TestMulAdd::main
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestMulAdd::base_multiply,ccstr,DisableIntrinsic,_mulAdd
- *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstr,DisableIntrinsic,_mulAdd
- *      -XX:CompileCommand=option,java.math.BigInteger::square,ccstr,DisableIntrinsic,_mulAdd
- *      -XX:CompileCommand=option,java.math.BigInteger::squareToLen,ccstr,DisableIntrinsic,_mulAdd
- *      -XX:CompileCommand=option,java.math.BigInteger::mulAdd,ccstr,DisableIntrinsic,_mulAdd
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestMulAdd::base_multiply,ccstrlist,DisableIntrinsic,_mulAdd
+ *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstrlist,DisableIntrinsic,_mulAdd
+ *      -XX:CompileCommand=option,java.math.BigInteger::square,ccstrlist,DisableIntrinsic,_mulAdd
+ *      -XX:CompileCommand=option,java.math.BigInteger::squareToLen,ccstrlist,DisableIntrinsic,_mulAdd
+ *      -XX:CompileCommand=option,java.math.BigInteger::mulAdd,ccstrlist,DisableIntrinsic,_mulAdd
  *      -XX:CompileCommand=inline,java.math.BigInteger::multiply
  *      -XX:CompileCommand=inline,java.math.BigInteger::square
  *      -XX:CompileCommand=inline,java.math.BigInteger::squareToLen

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java
@@ -30,8 +30,8 @@
  * @library /test/lib
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestMultiplyToLen::main
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestMultiplyToLen::base_multiply,ccstr,DisableIntrinsic,_multiplyToLen
- *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstr,DisableIntrinsic,_multiplyToLen
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestMultiplyToLen::base_multiply,ccstrlist,DisableIntrinsic,_multiplyToLen
+ *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstrlist,DisableIntrinsic,_multiplyToLen
  *      -XX:CompileCommand=inline,java.math.BigInteger::multiply
  *      compiler.intrinsics.bigInteger.TestMultiplyToLen
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestShift.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestShift.java
@@ -31,16 +31,16 @@
  *
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestShift::main
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_left_shift,ccstr,DisableIntrinsic,_bigIntegerLeftShiftWorker
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_right_shift,ccstr,DisableIntrinsic,_bigIntegerRightShiftWorker
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_left_shift,ccstrlist,DisableIntrinsic,_bigIntegerLeftShiftWorker
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_right_shift,ccstrlist,DisableIntrinsic,_bigIntegerRightShiftWorker
  *      -XX:CompileCommand=inline,java.math.BigInteger::shiftLeft
  *      -XX:CompileCommand=inline,java.math.BigInteger::shiftRight
  *      compiler.intrinsics.bigInteger.TestShift
  *
  * @run main/othervm/timeout=600
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestShift::main
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_left_shift,ccstr,DisableIntrinsic,_bigIntegerLeftShiftWorker
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_right_shift,ccstr,DisableIntrinsic,_bigIntegerRightShiftWorker
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_left_shift,ccstrlist,DisableIntrinsic,_bigIntegerLeftShiftWorker
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestShift::base_right_shift,ccstrlist,DisableIntrinsic,_bigIntegerRightShiftWorker
  *      -XX:CompileCommand=inline,java.math.BigInteger::shiftLeft
  *      -XX:CompileCommand=inline,java.math.BigInteger::shiftRight
  *      compiler.intrinsics.bigInteger.TestShift

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java
@@ -30,10 +30,10 @@
  *
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestSquareToLen::main
- *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestSquareToLen::base_multiply,ccstr,DisableIntrinsic,_squareToLen
- *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstr,DisableIntrinsic,_squareToLen
- *      -XX:CompileCommand=option,java.math.BigInteger::square,ccstr,DisableIntrinsic,_squareToLen
- *      -XX:CompileCommand=option,java.math.BigInteger::squareToLen,ccstr,DisableIntrinsic,_squareToLen
+ *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestSquareToLen::base_multiply,ccstrlist,DisableIntrinsic,_squareToLen
+ *      -XX:CompileCommand=option,java.math.BigInteger::multiply,ccstrlist,DisableIntrinsic,_squareToLen
+ *      -XX:CompileCommand=option,java.math.BigInteger::square,ccstrlist,DisableIntrinsic,_squareToLen
+ *      -XX:CompileCommand=option,java.math.BigInteger::squareToLen,ccstrlist,DisableIntrinsic,_squareToLen
  *      -XX:CompileCommand=inline,java.math.BigInteger::multiply
  *      -XX:CompileCommand=inline,java.math.BigInteger::square
  *      -XX:CompileCommand=inline,java.math.BigInteger::squareToLen

--- a/test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java
@@ -29,7 +29,7 @@
  * @summary PhaseIdealLoop::peeled_dom_test_elim wrongly moves a non-dominated test out of a loop together with control dependent data nodes.
  *          This results in a crash due to an out of bounds read of an array.
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:-TieredCompilation -XX:+StressGCM
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestPeelingRemoveDominatedTest compiler.loopopts.TestPeelingRemoveDominatedTest
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestPeelingRemoveDominatedTest::* compiler.loopopts.TestPeelingRemoveDominatedTest
  */
 
 package compiler.loopopts;


### PR DESCRIPTION
The following tests have a wrong `CompileCommand` and print an error message in `CompilerOracle::print_parse_error`: 

* missing `::*`:
   - `test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java` 

* used unsupported quotation marks `""`:
   - `test/hotspot/jtreg/compiler/integerArithmetic/TestNegMultiply.java` 
   - `test/hotspot/jtreg/compiler/integerArithmetic/TestNegAnd.java` 

* Use of the pattern `CompileCommand=option,Klass::method,type,option,value` but  `DisableIntrinsic`  has type option type `ccstrlist` and not `ccstr`:
   - `test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMulAdd.java` 
   - `test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java` 
   - `test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestShift.java` 
   - `test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305356](https://bugs.openjdk.org/browse/JDK-8305356): Fix ignored bad CompileCommands in tests and add an assertion


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13294/head:pull/13294` \
`$ git checkout pull/13294`

Update a local copy of the PR: \
`$ git checkout pull/13294` \
`$ git pull https://git.openjdk.org/jdk.git pull/13294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13294`

View PR using the GUI difftool: \
`$ git pr show -t 13294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13294.diff">https://git.openjdk.org/jdk/pull/13294.diff</a>

</details>
