### PR TITLE
8305423: Remove ObjectLocker usage from JavaThread::ensure_join()

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -402,6 +402,7 @@
   template(runWith_method_name,                       "runWith")                                  \
   template(interrupt_method_name,                     "interrupt")                                \
   template(exit_method_name,                          "exit")                                     \
+  template(setTerminated_method_name,                 "setTerminated")                            \
   template(remove_method_name,                        "remove")                                   \
   template(parent_name,                               "parent")                                   \
   template(maxPriority_name,                          "maxPriority")                              \

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -734,7 +734,7 @@ static void ensure_join(JavaThread* thread) {
     // other threads that know about this one.
     JavaValue result(T_VOID);
     Klass* thread_klass = vmClasses::Thread_klass();
-    JavaCalls::call_virtual(&result,
+    JavaCalls::call_special(&result,
                             threadObj, thread_klass,
                             vmSymbols::setTerminated_method_name(),
                             vmSymbols::void_method_signature(),

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2816,6 +2816,18 @@ public class Thread implements Runnable {
      */
     boolean isTerminated() {
         return threadState() == State.TERMINATED;
+    }
+
+    /**
+     * Called by HotSpot to set the state to terminated.
+     */
+    synchronized void setTerminated() {
+        // Thread is exiting. So set thread_status field in  java.lang.Thread class to TERMINATED.
+        holder.threadStatus = jdk.internal.misc.VM.terminated();
+        // Clear the native thread instance - this makes isAlive return false and allows the join()
+        // to complete once we've done the notify_all below
+        eetop = 0;
+        notifyAll();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -2821,7 +2821,7 @@ public class Thread implements Runnable {
     /**
      * Called by HotSpot to set the state to terminated.
      */
-    synchronized void setTerminated() {
+    private synchronized void setTerminated() {
         // Thread is exiting. So set thread_status field in  java.lang.Thread class to TERMINATED.
         holder.threadStatus = jdk.internal.misc.VM.terminated();
         // Clear the native thread instance - this makes isAlive return false and allows the join()

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -349,6 +349,8 @@ public class VM {
         }
     }
 
+    public static int terminated() { return JVMTI_THREAD_STATE_TERMINATED; }
+
     /* The threadStatus field is set by the VM at state transition
      * in the hotspot implementation. Its value is set according to
      * the JVM TI specification GetThreadState function.


### PR DESCRIPTION
popframe hates this code.  It needs @robehn special ignore-java-code-for-jvmti flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8305423](https://bugs.openjdk.org/browse/JDK-8305423): Remove ObjectLocker usage from JavaThread::ensure_join() (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13298/head:pull/13298` \
`$ git checkout pull/13298`

Update a local copy of the PR: \
`$ git checkout pull/13298` \
`$ git pull https://git.openjdk.org/jdk.git pull/13298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13298`

View PR using the GUI difftool: \
`$ git pr show -t 13298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13298.diff">https://git.openjdk.org/jdk/pull/13298.diff</a>

</details>
