### PR TITLE
JDK-8305484: Compiler::init_c1_runtime unnecessarily uses an Arena that lives for the lifetime of the process

### DIFF
--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -40,7 +40,6 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vm_version.hpp"
-#include "sanitizers/leak.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -50,17 +50,14 @@ Compiler::Compiler() : AbstractCompiler(compiler_c1) {
 
 void Compiler::init_c1_runtime() {
   BufferBlob* buffer_blob = CompilerThread::current()->get_buffer_blob();
-  Arena* arena = new (mtCompiler) Arena(mtCompiler);
-  // Ignore leaked arena, it is used by ValueType and Interval during initialization.
-  LSAN_IGNORE_OBJECT(arena);
   Runtime1::initialize(buffer_blob);
   FrameMap::initialize();
   // initialize data structures
-  ValueType::initialize(arena);
+  ValueType::initialize();
   GraphBuilder::initialize();
   // note: to use more than one instance of LinearScan at a time this function call has to
   //       be moved somewhere outside of this constructor:
-  Interval::initialize(arena);
+  Interval::initialize();
 }
 
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -4133,8 +4133,10 @@ Range::Range(int from, int to, Range* next) :
 
 // initialize sentinel
 Range* Range::_end = NULL;
-void Range::initialize(Arena* arena) {
-  _end = new (arena) Range(max_jint, max_jint, NULL);
+void Range::initialize() {
+  assert(_end == nullptr, "Range initialized more than once");
+  alignas(Range) static uint8_t end_storage[sizeof(Range)];
+  _end = ::new(static_cast<void*>(end_storage)) Range(max_jint, max_jint, NULL);
 }
 
 int Range::intersects_at(Range* r2) const {
@@ -4180,9 +4182,11 @@ void Range::print(outputStream* out) const {
 
 // initialize sentinel
 Interval* Interval::_end = NULL;
-void Interval::initialize(Arena* arena) {
-  Range::initialize(arena);
-  _end = new (arena) Interval(-1);
+void Interval::initialize() {
+  Range::initialize();
+  assert(_end == nullptr, "Interval initialized more than once");
+  alignas(Interval) static uint8_t end_storage[sizeof(Interval)];
+  _end = ::new(static_cast<void*>(end_storage)) Interval(-1);
 }
 
 Interval::Interval(int reg_num) :

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -474,7 +474,7 @@ class Range : public CompilationResourceObj {
  public:
   Range(int from, int to, Range* next);
 
-  static void      initialize(Arena* arena);
+  static void      initialize();
   static Range*    end()                         { return _end; }
 
   int              from() const                  { return _from; }
@@ -541,7 +541,7 @@ class Interval : public CompilationResourceObj {
  public:
   Interval(int reg_num);
 
-  static void      initialize(Arena* arena);
+  static void      initialize();
   static Interval* end()                         { return _end; }
 
   // accessors

--- a/src/hotspot/share/c1/c1_ValueType.cpp
+++ b/src/hotspot/share/c1/c1_ValueType.cpp
@@ -51,9 +51,6 @@ ObjectConstant* objectNull   = NULL;
 
 
 void ValueType::initialize() {
-  // Note: Must initialize all types for each compilation
-  //       as they are allocated within a ResourceMark!
-
 #define VALUE_TYPE_STORAGE_NAME(name) name##_storage
 #define VALUE_TYPE_STORAGE(name, type) alignas(type) static uint8_t VALUE_TYPE_STORAGE_NAME(name)[sizeof(type)]
 #define VALUE_TYPE(name, type, ...)                                \

--- a/src/hotspot/share/c1/c1_ValueType.cpp
+++ b/src/hotspot/share/c1/c1_ValueType.cpp
@@ -50,27 +50,37 @@ IntConstant*    intOne       = NULL;
 ObjectConstant* objectNull   = NULL;
 
 
-void ValueType::initialize(Arena* arena) {
+void ValueType::initialize() {
   // Note: Must initialize all types for each compilation
   //       as they are allocated within a ResourceMark!
 
-  // types
-  voidType     = new (arena) VoidType();
-  intType      = new (arena) IntType();
-  longType     = new (arena) LongType();
-  floatType    = new (arena) FloatType();
-  doubleType   = new (arena) DoubleType();
-  objectType   = new (arena) ObjectType();
-  arrayType    = new (arena) ArrayType();
-  instanceType = new (arena) InstanceType();
-  classType    = new (arena) ClassType();
-  addressType  = new (arena) AddressType();
-  illegalType  = new (arena) IllegalType();
+#define VALUE_TYPE_STORAGE_NAME(name) name##_storage
+#define VALUE_TYPE_STORAGE(name, type) alignas(type) static uint8_t VALUE_TYPE_STORAGE_NAME(name)[sizeof(type)]
+#define VALUE_TYPE(name, type, ...)                                \
+  assert(name == nullptr, "ValueType initialized more than once"); \
+  VALUE_TYPE_STORAGE(name, type);                                  \
+  name = ::new(static_cast<void*>(VALUE_TYPE_STORAGE_NAME(name))) type(__VA_ARGS__)
 
-  intZero     = new (arena) IntConstant(0);
-  intOne      = new (arena) IntConstant(1);
-  objectNull  = new (arena) ObjectConstant(ciNullObject::make());
-};
+  VALUE_TYPE(voidType    , VoidType);
+  VALUE_TYPE(intType     , IntType);
+  VALUE_TYPE(longType    , LongType);
+  VALUE_TYPE(floatType   , FloatType);
+  VALUE_TYPE(doubleType  , DoubleType);
+  VALUE_TYPE(objectType  , ObjectType);
+  VALUE_TYPE(arrayType   , ArrayType);
+  VALUE_TYPE(instanceType, InstanceType);
+  VALUE_TYPE(classType   , ClassType);
+  VALUE_TYPE(addressType , AddressType);
+  VALUE_TYPE(illegalType , IllegalType);
+
+  VALUE_TYPE(intZero     , IntConstant   , 0);
+  VALUE_TYPE(intOne      , IntConstant   , 1);
+  VALUE_TYPE(objectNull  , ObjectConstant, ciNullObject::Make());
+
+#undef VALUE_TYPE
+#undef VALUE_TYPE_STORAGE
+#undef VALUE_TYPE_STORAGE_NAME
+}
 
 
 ValueType* ValueType::meet(ValueType* y) const {

--- a/src/hotspot/share/c1/c1_ValueType.cpp
+++ b/src/hotspot/share/c1/c1_ValueType.cpp
@@ -75,7 +75,7 @@ void ValueType::initialize() {
 
   VALUE_TYPE(intZero     , IntConstant   , 0);
   VALUE_TYPE(intOne      , IntConstant   , 1);
-  VALUE_TYPE(objectNull  , ObjectConstant, ciNullObject::Make());
+  VALUE_TYPE(objectNull  , ObjectConstant, ciNullObject::make());
 
 #undef VALUE_TYPE
 #undef VALUE_TYPE_STORAGE

--- a/src/hotspot/share/c1/c1_ValueType.hpp
+++ b/src/hotspot/share/c1/c1_ValueType.hpp
@@ -105,7 +105,7 @@ class ValueType: public CompilationResourceObj {
 
  public:
   // initialization
-  static void initialize(Arena* arena);
+  static void initialize();
 
   // accessors
   virtual ValueType* base() const                = 0; // the 'canonical' type (e.g., intType for an IntConstant)


### PR DESCRIPTION
Remove unnecessary usage of Arena for globals that live the lifetime of the process and are initialized once.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305484](https://bugs.openjdk.org/browse/JDK-8305484): Compiler::init_c1_runtime unnecessarily uses an Arena that lives for the lifetime of the process


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13300/head:pull/13300` \
`$ git checkout pull/13300`

Update a local copy of the PR: \
`$ git checkout pull/13300` \
`$ git pull https://git.openjdk.org/jdk.git pull/13300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13300`

View PR using the GUI difftool: \
`$ git pr show -t 13300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13300.diff">https://git.openjdk.org/jdk/pull/13300.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13300#issuecomment-1494541210)