### PR TITLE
8304982: Emit warning for removal of `COMPAT` provider

### DIFF
--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -120,7 +120,7 @@ import java.util.Locale;
  * property on the java launcher command line. Setting it at runtime with
  * {@link System#setProperty(String, String)} is discouraged and it may not affect
  * the order.
- * @implNote The JDK Reference Implementation provides the following four
+ * JDK Reference Implementation provides the following four
  * locale providers:
  * <ul>
  * <li> "CLDR": A provider based on Unicode Consortium's

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -120,13 +120,12 @@ import java.util.Locale;
  * property on the java launcher command line. Setting it at runtime with
  * {@link System#setProperty(String, String)} is discouraged and it may not affect
  * the order.
- * <p>
- * Java Runtime Environment provides the following four locale providers:
+ * @implNote Java Runtime Environment provides the following four locale providers:
  * <ul>
  * <li> "CLDR": A provider based on Unicode Consortium's
  * <a href="http://cldr.unicode.org/">CLDR Project</a>.
  * <li> "COMPAT": represents the locale sensitive services that is compatible
- * with the prior JDK releases up to JDK8 (same as JDK8's "JRE"). The use of this
+ * with the prior JDK releases up to JDK 8 (same as JDK 8's "JRE"). This
  * provider is deprecated and will be removed in the future release of JDK.
  * <li> "SPI": represents the locale sensitive services implementing the subclasses of
  * this {@code LocaleServiceProvider} class.

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -120,7 +120,8 @@ import java.util.Locale;
  * property on the java launcher command line. Setting it at runtime with
  * {@link System#setProperty(String, String)} is discouraged and it may not affect
  * the order.
- * @implNote Java Runtime Environment provides the following four locale providers:
+ * @implNote The JDK Reference Implementation provides the following four
+ * locale providers:
  * <ul>
  * <li> "CLDR": A provider based on Unicode Consortium's
  * <a href="http://cldr.unicode.org/">CLDR Project</a>.
@@ -131,7 +132,7 @@ import java.util.Locale;
  * this {@code LocaleServiceProvider} class.
  * <li> "HOST": A provider that reflects the user's custom settings in the
  * underlying operating system. This provider may not be available, depending
- * on the Java Runtime Environment implementation.
+ * on the JDK Reference Implementation.
  * <li> "JRE": represents a synonym to "COMPAT". This name
  * is deprecated and will be removed in the future release of JDK.
  * </ul>

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -126,7 +126,8 @@ import java.util.Locale;
  * <li> "CLDR": A provider based on Unicode Consortium's
  * <a href="http://cldr.unicode.org/">CLDR Project</a>.
  * <li> "COMPAT": represents the locale sensitive services that is compatible
- * with the prior JDK releases up to JDK8 (same as JDK8's "JRE").
+ * with the prior JDK releases up to JDK8 (same as JDK8's "JRE"). The use of this
+ * provider is deprecated and will be removed in the future release of JDK.
  * <li> "SPI": represents the locale sensitive services implementing the subclasses of
  * this {@code LocaleServiceProvider} class.
  * <li> "HOST": A provider that reflects the user's custom settings in the

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -132,7 +132,7 @@ public abstract class LocaleProviderAdapter {
             for (String type : types) {
                 type = type.trim().toUpperCase(Locale.ROOT);
                 if (type.equals("COMPAT")) {
-                    compatWarningMessage = "COMPAT option will be removed in a future release of Java.";
+                    compatWarningMessage = "COMPAT locale provider will be removed in a future release";
                     type = "JRE";
                 }
                 try {

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.text.spi.DateFormatSymbolsProvider;
 import java.text.spi.DecimalFormatSymbolsProvider;
 import java.text.spi.NumberFormatProvider;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -125,6 +124,7 @@ public abstract class LocaleProviderAdapter {
         String order = GetPropertyAction.privilegedGetProperty("java.locale.providers");
         ArrayList<Type> typeList = new ArrayList<>();
         String invalidTypeMessage = null;
+        String compatWarningMessage = null;
 
         // Check user specified adapter preference
         if (order != null && !order.isEmpty()) {
@@ -132,6 +132,7 @@ public abstract class LocaleProviderAdapter {
             for (String type : types) {
                 type = type.trim().toUpperCase(Locale.ROOT);
                 if (type.equals("COMPAT")) {
+                    compatWarningMessage = "COMPAT option will be removed in a future release of Java.";
                     type = "JRE";
                 }
                 try {
@@ -168,6 +169,10 @@ public abstract class LocaleProviderAdapter {
             // provider name or format in the system property
             getLogger(LocaleProviderAdapter.class.getCanonicalName())
                 .log(Logger.Level.INFO, invalidTypeMessage);
+        }
+        if (compatWarningMessage != null) {
+            getLogger(LocaleProviderAdapter.class.getCanonicalName())
+                    .log(Logger.Level.WARNING, compatWarningMessage);
         }
     }
 

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -172,7 +172,7 @@ public abstract class LocaleProviderAdapter {
         }
         if (compatWarningMessage != null) {
             getLogger(LocaleProviderAdapter.class.getCanonicalName())
-                    .log(Logger.Level.WARNING, compatWarningMessage);
+                .log(Logger.Level.WARNING, compatWarningMessage);
         }
     }
 

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -131,7 +131,7 @@ public abstract class LocaleProviderAdapter {
             String[] types = order.split(",");
             for (String type : types) {
                 type = type.trim().toUpperCase(Locale.ROOT);
-                if (type.equals("COMPAT")) {
+                if (type.equals("COMPAT") || type.equals("JRE")) {
                     compatWarningMessage = "COMPAT locale provider will be removed in a future release";
                     type = "JRE";
                 }

--- a/test/jdk/java/util/Locale/CompatWarning.java
+++ b/test/jdk/java/util/Locale/CompatWarning.java
@@ -58,11 +58,11 @@ public class CompatWarning {
         public void publish(LogRecord record) {
             var level = record.getLevel();
             var msg = record.getMessage();
-            System.out.println("""
+            System.out.printf("""
                 LogRecord emitted:
                     Level: %s
                     Message: %s
-                """.formatted(level, msg));
+                """, level, msg);
             if (level == Level.WARNING && WARNING.equals(msg)) {
                 logged = true;
             }

--- a/test/jdk/java/util/Locale/CompatWarning.java
+++ b/test/jdk/java/util/Locale/CompatWarning.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8304982
+ * @summary Check if a warning is logged with COMPAT locale provider
+ * @run main/othervm -Djava.locale.providers=COMPAT CompatWarning
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+public class CompatWarning {
+    private static final String WARNING =
+            "COMPAT locale provider will be removed in a future release";
+    private static boolean logged;
+
+    public static void main(String[] args) throws Throwable {
+        File conf = new File(System.getProperty("test.src", "./src"), "compatlog.properties");
+        if (!conf.canRead()) {
+            throw new IOException("Can't read config file: " + conf.getAbsolutePath());
+        }
+        System.setProperty("java.util.logging.config.file", conf.getAbsolutePath());
+        DateFormat.getInstance();
+        if (!logged) {
+            throw new RuntimeException("COMPAT warning message was not emitted");
+        }
+    }
+
+    public static class CheckWarning extends Handler {
+        @Override
+        public void publish(LogRecord record) {
+            var level = record.getLevel();
+            var msg = record.getMessage();
+            System.out.println("""
+                LogRecord emitted:
+                    Level: %s
+                    Message: %s
+                """.formatted(level, msg));
+            if (level == Level.WARNING && WARNING.equals(msg)) {
+                logged = true;
+            }
+        }
+
+        @Override
+        public void flush() {}
+        @Override
+        public void close() throws SecurityException {}
+    }
+}

--- a/test/jdk/java/util/Locale/CompatWarning.java
+++ b/test/jdk/java/util/Locale/CompatWarning.java
@@ -26,6 +26,7 @@
  * @bug 8304982
  * @summary Check if a warning is logged with COMPAT locale provider
  * @run main/othervm -Djava.locale.providers=COMPAT CompatWarning
+ * @run main/othervm -Djava.locale.providers=JRE CompatWarning
  */
 
 import java.io.File;

--- a/test/jdk/java/util/Locale/compatlog.properties
+++ b/test/jdk/java/util/Locale/compatlog.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+handlers=CompatWarning$CheckWarning


### PR DESCRIPTION
This is a precursor to the future removal of the `COMPAT` locale data provider. Before the actual removal of the provider, warn the users who explicitly specify `COMPAT` at the command line in order for their smooth migration to CLDR. A CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8305402](https://bugs.openjdk.org/browse/JDK-8305402) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8304982](https://bugs.openjdk.org/browse/JDK-8304982): Emit warning for removal of `COMPAT` provider
 * [JDK-8305402](https://bugs.openjdk.org/browse/JDK-8305402): Emit warning for removal of `COMPAT` provider (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13302/head:pull/13302` \
`$ git checkout pull/13302`

Update a local copy of the PR: \
`$ git checkout pull/13302` \
`$ git pull https://git.openjdk.org/jdk.git pull/13302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13302`

View PR using the GUI difftool: \
`$ git pr show -t 13302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13302.diff">https://git.openjdk.org/jdk/pull/13302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13302#issuecomment-1494666387)