### PR TITLE
8305785: Avoid redundant HashMap.containsKey call in java.util.regex

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -1819,9 +1819,10 @@ public final class Matcher implements MatchResult {
     int getMatchedGroupIndex(String name) {
         Objects.requireNonNull(name, "Group name");
         checkMatch();
-        if (!namedGroups().containsKey(name))
+        Integer index = namedGroups().get(name);
+        if (index == null)
             throw new IllegalArgumentException("No group with name <" + name + ">");
-        return namedGroups().get(name);
+        return index;
     }
 
     private void checkGroup(int group) {

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -1075,10 +1075,11 @@ public final class Matcher implements MatchResult {
                             throw new IllegalArgumentException(
                                     "capturing group name {" + gname +
                                             "} starts with digit character");
-                        if (!namedGroups().containsKey(gname))
+                        Integer number = namedGroups().get(gname);
+                        if (number == null)
                             throw new IllegalArgumentException(
                                     "No group with name {" + gname + "}");
-                        refNum = namedGroups().get(gname);
+                        refNum = number;
                         cursor++;
                     } else {
                         // The first number is always a group
@@ -1819,10 +1820,10 @@ public final class Matcher implements MatchResult {
     int getMatchedGroupIndex(String name) {
         Objects.requireNonNull(name, "Group name");
         checkMatch();
-        Integer index = namedGroups().get(name);
-        if (index == null)
+        Integer number = namedGroups().get(name);
+        if (number == null)
             throw new IllegalArgumentException("No group with name <" + name + ">");
-        return index;
+        return number;
     }
 
     private void checkGroup(int group) {

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2603,14 +2603,15 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             if (read() != '<')
                 throw error("\\k is not followed by '<' for named capturing group");
             String name = groupname(read());
-            if (!namedGroupsMap().containsKey(name))
+            Integer index = namedGroupsMap().get(name);
+            if (index == null)
                 throw error("named capturing group <" + name + "> does not exist");
             if (create) {
                 hasGroupRef = true;
                 if (has(CASE_INSENSITIVE))
-                    root = new CIBackRef(namedGroupsMap().get(name), has(UNICODE_CASE));
+                    root = new CIBackRef(index, has(UNICODE_CASE));
                 else
-                    root = new BackRef(namedGroupsMap().get(name));
+                    root = new BackRef(index);
             }
             return -1;
         case 'l':

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2603,15 +2603,15 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             if (read() != '<')
                 throw error("\\k is not followed by '<' for named capturing group");
             String name = groupname(read());
-            Integer index = namedGroupsMap().get(name);
-            if (index == null)
+            Integer number = namedGroupsMap().get(name);
+            if (number == null)
                 throw error("named capturing group <" + name + "> does not exist");
             if (create) {
                 hasGroupRef = true;
                 if (has(CASE_INSENSITIVE))
-                    root = new CIBackRef(index, has(UNICODE_CASE));
+                    root = new CIBackRef(number, has(UNICODE_CASE));
                 else
-                    root = new BackRef(index);
+                    root = new BackRef(number);
             }
             return -1;
         case 'l':


### PR DESCRIPTION
`Pattern.namedGroups` and `Matcher.namedGroups` contains only non-null values. It means instead of separate `containsKey`+`get` calls, we can use single `HashMap.get` call and then compare result with null.
Result code is a bit simpler and faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305785](https://bugs.openjdk.org/browse/JDK-8305785): Avoid redundant HashMap.containsKey call in java.util.regex


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13303/head:pull/13303` \
`$ git checkout pull/13303`

Update a local copy of the PR: \
`$ git checkout pull/13303` \
`$ git pull https://git.openjdk.org/jdk.git pull/13303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13303`

View PR using the GUI difftool: \
`$ git pr show -t 13303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13303.diff">https://git.openjdk.org/jdk/pull/13303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13303#issuecomment-1501204402)