### PR TITLE
8305696: (zipfs) Avoid redundant LinkedHashMap.containsKey call ZipFileSystem.makeParentDirs

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1333,8 +1333,8 @@ class ZipFileSystem extends FileSystem {
             }
             // parent exists
             lookup = lookup.as(node.name, off);
-            if (inodes.containsKey(lookup)) {
-                parent = inodes.get(lookup);
+            parent = inodes.get(lookup);
+            if (parent != null) {
                 node.sibling = parent.child;
                 parent.child = node;
                 break;


### PR DESCRIPTION
`LinkedHashMap<IndexNode, IndexNode>` `ZipFileSystem.inodes` contains only non-null values. It means instead of separate `containsKey`+`get` calls, we can use single `LinkedHashMap.get` call and then compare result with `null`.
Result code is a bit simpler and faster.

Testing: Linux x64 `java/nio`, `jdk/nio`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305696](https://bugs.openjdk.org/browse/JDK-8305696): (zipfs) Avoid redundant LinkedHashMap.containsKey call ZipFileSystem.makeParentDirs


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13304/head:pull/13304` \
`$ git checkout pull/13304`

Update a local copy of the PR: \
`$ git checkout pull/13304` \
`$ git pull https://git.openjdk.org/jdk.git pull/13304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13304`

View PR using the GUI difftool: \
`$ git pr show -t 13304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13304.diff">https://git.openjdk.org/jdk/pull/13304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13304#issuecomment-1498740603)