### PR TITLE
6218123: (cal) API: Spec for GregorianCalendar constructors and Calendar getInstance is inconsistent.

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1632,6 +1632,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      *
      * @param zone the time zone to use
      * @return a Calendar.
+     * @throws NullPointerException if {@code zone} is {@code null}
      */
     public static Calendar getInstance(TimeZone zone)
     {
@@ -1649,6 +1650,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      *
      * @param aLocale the locale for the week data
      * @return a Calendar.
+     * @throws NullPointerException if {@code aLocale} is {@code null}
      */
     public static Calendar getInstance(Locale aLocale)
     {
@@ -1663,6 +1665,8 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * @param zone the time zone to use
      * @param aLocale the locale for the week data
      * @return a Calendar.
+     * @throws NullPointerException if either {@code zone} or {@code aLocale}
+     * is {@code null}
      */
     public static Calendar getInstance(TimeZone zone,
                                        Locale aLocale)

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1665,8 +1665,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * @param zone the time zone to use
      * @param aLocale the locale for the week data
      * @return a Calendar.
-     * @throws NullPointerException if either {@code zone} or {@code aLocale}
-     * is {@code null}
+     * @throws NullPointerException if {@code zone} or {@code aLocale} is {@code null}
      */
     public static Calendar getInstance(TimeZone zone,
                                        Locale aLocale)

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -599,6 +599,7 @@ public class GregorianCalendar extends Calendar {
      * {@link Locale.Category#FORMAT FORMAT} locale.
      *
      * @param zone the given time zone.
+     * @throws NullPointerException if {@code zone} is {@code null}
      */
     public GregorianCalendar(TimeZone zone) {
         this(zone, Locale.getDefault(Locale.Category.FORMAT));
@@ -609,6 +610,7 @@ public class GregorianCalendar extends Calendar {
      * in the default time zone with the given locale.
      *
      * @param aLocale the given locale.
+     * @throws NullPointerException if {@code aLocale} is {@code null}
      */
     public GregorianCalendar(Locale aLocale) {
         this(TimeZone.getDefaultRef(), aLocale);
@@ -621,6 +623,8 @@ public class GregorianCalendar extends Calendar {
      *
      * @param zone the given time zone.
      * @param aLocale the given locale.
+     * @throws NullPointerException if either {@code zone} or {@code aLocale}
+     * is {@code null}
      */
     public GregorianCalendar(TimeZone zone, Locale aLocale) {
         super(zone, aLocale);

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -623,8 +623,7 @@ public class GregorianCalendar extends Calendar {
      *
      * @param zone the given time zone.
      * @param aLocale the given locale.
-     * @throws NullPointerException if either {@code zone} or {@code aLocale}
-     * is {@code null}
+     * @throws NullPointerException if {@code zone} or {@code aLocale} is {@code null}
      */
     public GregorianCalendar(TimeZone zone, Locale aLocale) {
         super(zone, aLocale);


### PR DESCRIPTION
The GregorianCalendar constructors and Calendar.getInstance() methods that take TimeZone or Locale throw a NullPointerException if any values are null. 

This PR updates the javadoc to make this apparent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8305498](https://bugs.openjdk.org/browse/JDK-8305498) to be approved

### Issues
 * [JDK-6218123](https://bugs.openjdk.org/browse/JDK-6218123): (cal) API: Spec for GregorianCalendar constructors and Calendar getInstance is inconsistent.
 * [JDK-8305498](https://bugs.openjdk.org/browse/JDK-8305498): (cal) API: Spec for GregorianCalendar constructors and Calendar getInstance is inconsistent. (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13310/head:pull/13310` \
`$ git checkout pull/13310`

Update a local copy of the PR: \
`$ git checkout pull/13310` \
`$ git pull https://git.openjdk.org/jdk.git pull/13310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13310`

View PR using the GUI difftool: \
`$ git pr show -t 13310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13310.diff">https://git.openjdk.org/jdk/pull/13310.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13310#issuecomment-1500487908)