### PR TITLE
6241286: (cal) API: Calendar.DAY_OF_WEEK definition is wrong

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -461,9 +461,9 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * Field number for {@code get} and {@code set} indicating the day
      * of the week. If the calendar is non-lenient, this field takes values
      * {@code SUNDAY}, {@code MONDAY}, {@code TUESDAY}, {@code WEDNESDAY},
-     * {@code THURSDAY}, {@code FRIDAY}, and {@code SATURDAY}. Otherwise, if the
-     * calendar is lenient, any int values are accepted and normalized to one
-     * of the previously mentioned values.
+     * {@code THURSDAY}, {@code FRIDAY}, and {@code SATURDAY}. Otherwise, any
+     * int values are accepted and normalized to one of the previously
+     * mentioned values.
      *
      * @see #SUNDAY
      * @see #MONDAY

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -459,9 +459,11 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
 
     /**
      * Field number for {@code get} and {@code set} indicating the day
-     * of the week.  This field takes values {@code SUNDAY},
-     * {@code MONDAY}, {@code TUESDAY}, {@code WEDNESDAY},
-     * {@code THURSDAY}, {@code FRIDAY}, and {@code SATURDAY}.
+     * of the week. If the calendar is non-lenient, this field takes values
+     * {@code SUNDAY}, {@code MONDAY}, {@code TUESDAY}, {@code WEDNESDAY},
+     * {@code THURSDAY}, {@code FRIDAY}, and {@code SATURDAY}. Otherwise, if the
+     * calendar is lenient, any int values are accepted and normalized to one
+     * of the previously mentioned values.
      *
      * @see #SUNDAY
      * @see #MONDAY


### PR DESCRIPTION
This PR updates the Calendar.DAY_OF_WEEK documentation to make it clear that the field accepts _any_ value if the calendar is lenient and then normalizes it. Only if the calendar is non-lenient, will the field accept only one of SUNDAY ... SATURDAY.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8305501](https://bugs.openjdk.org/browse/JDK-8305501) to be approved

### Issues
 * [JDK-6241286](https://bugs.openjdk.org/browse/JDK-6241286): (cal) API: Calendar.DAY_OF_WEEK definition is wrong
 * [JDK-8305501](https://bugs.openjdk.org/browse/JDK-8305501): (cal) API: Calendar.DAY_OF_WEEK definition is wrong (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13311/head:pull/13311` \
`$ git checkout pull/13311`

Update a local copy of the PR: \
`$ git checkout pull/13311` \
`$ git pull https://git.openjdk.org/jdk.git pull/13311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13311`

View PR using the GUI difftool: \
`$ git pr show -t 13311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13311.diff">https://git.openjdk.org/jdk/pull/13311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13311#issuecomment-1496924339)