### PR TITLE
8305500: SystemDictionary::find_placeholder/find_class declared but not used

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -310,6 +310,11 @@ private:
   static InstanceKlass* load_instance_class(Symbol* class_name,
                                             Handle class_loader, TRAPS);
 
+  // Class loader constraints
+  static void check_constraints(InstanceKlass* k, ClassLoaderData* loader,
+                                bool defining, TRAPS);
+  static void update_dictionary(JavaThread* current, InstanceKlass* k, ClassLoaderData* loader_data);
+
   static bool is_shared_class_visible(Symbol* class_name, InstanceKlass* ik,
                                       PackageEntry* pkg_entry,
                                       Handle class_loader);
@@ -324,6 +329,7 @@ private:
                                                Handle protection_domain, TRAPS);
   // Second part of load_shared_class
   static void load_shared_class_misc(InstanceKlass* ik, ClassLoaderData* loader_data) NOT_CDS_RETURN;
+
 protected:
   // Used by SystemDictionaryShared
 
@@ -359,19 +365,6 @@ public:
 
   // Return Symbol or throw exception if name given is can not be a valid Symbol.
   static Symbol* class_name_symbol(const char* name, Symbol* exception, TRAPS);
-
-protected:
-
-  // Basic find on loaded classes
-  static InstanceKlass* find_class(Symbol* class_name, ClassLoaderData* loader_data);
-
-  // Basic find on classes in the midst of being loaded
-  static Symbol* find_placeholder(Symbol* name, ClassLoaderData* loader_data);
-
-  // Class loader constraints
-  static void check_constraints(InstanceKlass* k, ClassLoaderData* loader,
-                                bool defining, TRAPS);
-  static void update_dictionary(JavaThread* current, InstanceKlass* k, ClassLoaderData* loader_data);
 };
 
 #endif // SHARE_CLASSFILE_SYSTEMDICTIONARY_HPP


### PR DESCRIPTION
Removed two function declarations we don't use from SystemDictionary.
Tested tier1 on linux/macosx/windows x84/aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305500](https://bugs.openjdk.org/browse/JDK-8305500): SystemDictionary::find_placeholder/find_class declared but not used


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13313/head:pull/13313` \
`$ git checkout pull/13313`

Update a local copy of the PR: \
`$ git checkout pull/13313` \
`$ git pull https://git.openjdk.org/jdk.git pull/13313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13313`

View PR using the GUI difftool: \
`$ git pr show -t 13313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13313.diff">https://git.openjdk.org/jdk/pull/13313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13313#issuecomment-1495089372)