### PR TITLE
JDK-8305407: ExternalSpecsWriter should ignore white-space differences in spec titles

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ExternalSpecsWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ExternalSpecsWriter.java
@@ -132,7 +132,7 @@ public class ExternalSpecsWriter extends HtmlDocletWriter {
         for (IndexItem ii : configuration.mainIndex.getItems(DocTree.Kind.SPEC)) {
             if (ii.getDocTree() instanceof SpecTree st) {
                 String url = st.getURL().toString();
-                String title = st.getTitle().toString();
+                String title = ii.getLabel(); // normalized form of  st.getTitle()
                 itemsByTitle
                         .computeIfAbsent(title, l -> new HashMap<>())
                         .computeIfAbsent(url, u -> new ArrayList<>())

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -222,9 +222,9 @@ public class TagletWriterImpl extends TagletWriter {
         DocTree searchTerm = tag.getSearchTerm();
         String tagText = (searchTerm instanceof TextTree tt) ? tt.getBody() : "";
         if (tagText.charAt(0) == '"' && tagText.charAt(tagText.length() - 1) == '"') {
-            tagText = tagText.substring(1, tagText.length() - 1)
-                             .replaceAll("\\s+", " ");
+            tagText = tagText.substring(1, tagText.length() - 1);
         }
+        tagText = tagText.replaceAll("\\s+", " ");
 
         Content desc = htmlWriter.commentTagsToContent(element, tag.getDescription(), context.within(tag));
         String descText = extractText(desc);
@@ -771,7 +771,8 @@ public class TagletWriterImpl extends TagletWriter {
         String specTreeURL = specTree.getURL().getBody();
         List<? extends DocTree> specTreeLabel = specTree.getTitle();
         Content label = htmlWriter.commentTagsToContent(holder, specTreeLabel, isFirstSentence);
-        return getExternalSpecContent(holder, specTree, specTreeURL, textOf(specTreeLabel), label);
+        return getExternalSpecContent(holder, specTree, specTreeURL,
+                textOf(specTreeLabel).replaceAll("\\s+", " "), label);
     }
 
     Content getExternalSpecContent(Element holder, DocTree docTree, String url, String searchText, Content title) {

--- a/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6251738 8226279 8297802 8296546
+ * @bug 6251738 8226279 8297802 8296546 8305407
  * @summary JDK-8226279 javadoc should support a new at-spec tag
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -413,6 +413,51 @@ public class TestSpecTag extends JavadocTester {
                            ^
                     """
                     .replace("#FILE#", src.resolve("p").resolve("C.java").toString()));
+    }
+
+    @Test
+    public void testDifferentWhitespaceTitlesForURL(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                /** Class C. */
+                public class C {
+                    private C() { }
+
+                    /**
+                     * Method m1.
+                     * @spec http://example.com/index.html abc def
+                     */
+                     public void m1() { }
+
+                    /**
+                     * Method m2.
+                     * @spec http://example.com/index.html abc         def
+                     */
+                     public void m2() { }
+                }
+                """);
+
+        javadoc("-d", base.resolve("out").toString(),
+                "--source-path", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput(Output.OUT, false, "error");
+
+        checkOutput("external-specs.html", true,
+                """
+                    <div class="summary-table two-column-summary">
+                    <div class="table-header col-first">Specification</div>
+                    <div class="table-header col-last">Referenced In</div>
+                    <div class="col-first even-row-color"><a href="http://example.com/index.html">abc def</a></div>
+                    <div class="col-last even-row-color">
+                    <ul class="ref-list">
+                    <li><code><a href="p/C.html#abcdef">p.C.m1()</a></code></li>
+                    <li><code><a href="p/C.html#abcdef-1">p.C.m2()</a></code></li>
+                    </ul>
+                    </div>
+                    </div>""");
     }
 
     @Test


### PR DESCRIPTION
Please review a conceptually simple change to ignore whitespace differences in the titles of specifications listed on the External Specifications page.

The only tricky part was finding the right place to normalize the text.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305407](https://bugs.openjdk.org/browse/JDK-8305407): ExternalSpecsWriter should ignore white-space differences in spec titles


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13315/head:pull/13315` \
`$ git checkout pull/13315`

Update a local copy of the PR: \
`$ git checkout pull/13315` \
`$ git pull https://git.openjdk.org/jdk.git pull/13315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13315`

View PR using the GUI difftool: \
`$ git pr show -t 13315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13315.diff">https://git.openjdk.org/jdk/pull/13315.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13315#issuecomment-1495117298)