### PR TITLE
JDK-8305504: stutter typo in java.compiler files

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
@@ -123,7 +123,8 @@ import java.io.IOException;
  * annotation if the environment is configured so that that class or
  * interface is accessible.
  *
- * @spec https://www.rfc-editor.org/info/rfc3986 RFC 3986: RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+ * @spec https://www.rfc-editor.org/info/rfc3986
+ *      RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
  * @apiNote Some of the effect of overwriting a file can be
  * achieved by using a <i>decorator</i>-style pattern.  Instead of
  * modifying a class directly, the class is designed so that either

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -103,7 +103,8 @@ import static javax.tools.JavaFileObject.Kind;
  * <p>Unless explicitly allowed, all methods in this interface might
  * throw a NullPointerException if given a {@code null} argument.
  *
- * @spec https://www.rfc-editor.org/info/rfc3986 RFC 3986: RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+ * @spec https://www.rfc-editor.org/info/rfc3986
+ *      RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
  * @see JavaFileObject
  * @see FileObject
  * @since 1.6


### PR DESCRIPTION
Please review a trivial doc-only edit to fix an issue in a recent addition of some RFC `@spec` tags

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305504](https://bugs.openjdk.org/browse/JDK-8305504): stutter typo in java.compiler files


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13316/head:pull/13316` \
`$ git checkout pull/13316`

Update a local copy of the PR: \
`$ git checkout pull/13316` \
`$ git pull https://git.openjdk.org/jdk.git pull/13316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13316`

View PR using the GUI difftool: \
`$ git pr show -t 13316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13316.diff">https://git.openjdk.org/jdk/pull/13316.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13316#issuecomment-1495159094)