### PR TITLE
8305511: Remove ignore from com/sun/jdi/PopAndInvokeTest.java

### DIFF
--- a/test/jdk/com/sun/jdi/PopAndInvokeTest.java
+++ b/test/jdk/com/sun/jdi/PopAndInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
  * @bug 6517249
  * @summary JDWP: Cannot do an invokeMethod after a popFrames operation
  * @author jjh
- *
- * @ignore 6951287
  *
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g PopAndInvokeTest.java


### PR DESCRIPTION
Test com/sun/jdi/PopAndInvokeTest.java has
 @ignore 6951287
bug 6951287 is closed as a dup for 6417053 which is closed as not reproduced.