### PR TITLE
JDK-8305525: Problemlist runtime/ErrorHandling/TestDwarf on x86

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -99,7 +99,7 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/Thread/TestAlwaysPreTouchStacks.java 8305416 generic-all
-runtime/ErrorHandling/TestDwarf 8305521 linux-i586
+runtime/ErrorHandling/TestDwarf.java 8305489 linux-i586
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -99,6 +99,7 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/Thread/TestAlwaysPreTouchStacks.java 8305416 generic-all
+runtime/ErrorHandling/TestDwarf 8305521 linux-i586
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
Trivial change to problemlist runtime/ErrorHandling/TestDwarf for x86 until https://bugs.openjdk.org/browse/JDK-8305521 is solved, to reduce GHA noise.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305525](https://bugs.openjdk.org/browse/JDK-8305525): Problemlist runtime/ErrorHandling/TestDwarf on x86


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13319/head:pull/13319` \
`$ git checkout pull/13319`

Update a local copy of the PR: \
`$ git checkout pull/13319` \
`$ git pull https://git.openjdk.org/jdk.git pull/13319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13319`

View PR using the GUI difftool: \
`$ git pr show -t 13319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13319.diff">https://git.openjdk.org/jdk/pull/13319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13319#issuecomment-1495688462)