### PR TITLE
8305523: Some StoreStore barriers in the interpreter are unnecessary after JDK-8205683

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3621,8 +3621,6 @@ void TemplateTable::_new() {
 
   // continue
   __ bind(done);
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 void TemplateTable::newarray() {
@@ -3631,8 +3629,6 @@ void TemplateTable::newarray() {
   __ mov(c_rarg2, r0);
   call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::newarray),
           c_rarg1, c_rarg2);
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 void TemplateTable::anewarray() {
@@ -3642,8 +3638,6 @@ void TemplateTable::anewarray() {
   __ mov(c_rarg3, r0);
   call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::anewarray),
           c_rarg1, c_rarg2, c_rarg3);
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 void TemplateTable::arraylength() {

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3881,9 +3881,6 @@ void TemplateTable::_new() {
 
   // continue
   __ bind(Ldone);
-
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 void TemplateTable::newarray() {
@@ -3892,9 +3889,6 @@ void TemplateTable::newarray() {
   __ lbz(R4, 1, R14_bcp);
   __ extsw(R5, R17_tos);
   call_VM(R17_tos, CAST_FROM_FN_PTR(address, InterpreterRuntime::newarray), R4, R5 /* size */);
-
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 void TemplateTable::anewarray() {
@@ -3904,9 +3898,6 @@ void TemplateTable::anewarray() {
   __ get_2_byte_integer_at_bcp(1, R5, InterpreterMacroAssembler::Unsigned);
   __ extsw(R6, R17_tos); // size
   call_VM(R17_tos, CAST_FROM_FN_PTR(address, InterpreterRuntime::anewarray), R4 /* pool */, R5 /* index */, R6 /* size */);
-
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 // Allocate a multi dimensional array
@@ -3923,9 +3914,6 @@ void TemplateTable::multianewarray() {
   call_VM(R17_tos, CAST_FROM_FN_PTR(address, InterpreterRuntime::multianewarray), R4 /* first_size_address */);
   // Pop all dimensions off the stack.
   __ add(R15_esp, Rptr, R15_esp);
-
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(Assembler::StoreStore);
 }
 
 void TemplateTable::arraylength() {

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3529,8 +3529,6 @@ void TemplateTable::_new() {
 
   // continue
   __ bind(done);
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(MacroAssembler::StoreStore);
 }
 
 void TemplateTable::newarray() {
@@ -3539,8 +3537,6 @@ void TemplateTable::newarray() {
   __ mv(c_rarg2, x10);
   call_VM(x10, CAST_FROM_FN_PTR(address, InterpreterRuntime::newarray),
           c_rarg1, c_rarg2);
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(MacroAssembler::StoreStore);
 }
 
 void TemplateTable::anewarray() {
@@ -3550,8 +3546,6 @@ void TemplateTable::anewarray() {
   __ mv(c_rarg3, x10);
   call_VM(x10, CAST_FROM_FN_PTR(address, InterpreterRuntime::anewarray),
           c_rarg1, c_rarg2, c_rarg3);
-  // Must prevent reordering of stores for object initialization with stores that publish the new object.
-  __ membar(MacroAssembler::StoreStore);
 }
 
 void TemplateTable::arraylength() {


### PR DESCRIPTION
After JDK-8205683, InterpreterRuntime::_new() and InterpreterRuntime::newarray() eventually calls Atomic::release_store() to prevent reordering of stores for object initialization with stores that publish the new object. The stack call is as follows

Atomic::release_store((Klass**)raw_mem, k)
oopDesc::release_set_klass(HeapWord* mem, Klass* k)
oop MemAllocator::finish(HeapWord* mem)
ArrayKlass::cast(klass)->allocate_arrayArray(1, length, THREAD);
oopFactory::new_objArray(klass, size, CHECK);
InterpreterRuntime::anewarray(JavaThread* current, ConstantPool* pool, int index, jint size)

So StoreStore barriers trailing behind bytecode _new, newarray, anewarray is unnecessary.

aarch64, riscv and ppc have the same problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305523](https://bugs.openjdk.org/browse/JDK-8305523): Some StoreStore barriers in the interpreter are unnecessary after JDK-8205683


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13320/head:pull/13320` \
`$ git checkout pull/13320`

Update a local copy of the PR: \
`$ git checkout pull/13320` \
`$ git pull https://git.openjdk.org/jdk.git pull/13320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13320`

View PR using the GUI difftool: \
`$ git pr show -t 13320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13320.diff">https://git.openjdk.org/jdk/pull/13320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13320#issuecomment-1495483142)