### PR TITLE
8305490: CommandProcessor command "dumpclass" produces classes with invalid field descriptors

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -300,7 +300,7 @@ public class InstanceKlass extends Klass {
 
   public int getFieldSignatureIndex(int index) {
     if (index >= getJavaFieldsCount()) throw new IndexOutOfBoundsException("not a Java field;");
-    return getField(index).getGenericSignatureIndex();
+    return getField(index).getSignatureIndex();
   }
 
   public Symbol getFieldSignature(int index) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -81,6 +81,7 @@ public class ClhsdbDumpclass {
             System.err.println(out.getStderr());
             out.shouldHaveExitValue(0);
             out.shouldMatch("public class " + APP_DOT_CLASSNAME);
+            out.shouldNotContain("Error:");
         } catch (SkippedException se) {
             throw se;
         } catch (Exception ex) {


### PR DESCRIPTION
CommandProcessor command "dumpclass" produces classes with invalid field descriptors. 

Proposed patch fixes `sun.jvm.hotspot.oops.InstanceKlass::getFieldSignatureIndex` to return correct `getSignatureIndex` instead of invalid `getGenericSignatureIndex`.

Added condition to  `ClhsdbDumpclass` test assures no errors are reported by `javap` in the dumped classes.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8305490](https://bugs.openjdk.org/browse/JDK-8305490): CommandProcessor command "dumpclass" produces classes with invalid field descriptors


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [ff0b4c99](https://git.openjdk.org/jdk/pull/13321/files/ff0b4c9939c7861baa3aa8c6108355ded4494f14)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) ⚠️ Review applies to [ff0b4c99](https://git.openjdk.org/jdk/pull/13321/files/ff0b4c9939c7861baa3aa8c6108355ded4494f14)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13321/head:pull/13321` \
`$ git checkout pull/13321`

Update a local copy of the PR: \
`$ git checkout pull/13321` \
`$ git pull https://git.openjdk.org/jdk.git pull/13321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13321`

View PR using the GUI difftool: \
`$ git pr show -t 13321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13321.diff">https://git.openjdk.org/jdk/pull/13321.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13321#issuecomment-1495510056)