### PR TITLE
8305192: serial GC fails "assert(Universe::on_page_boundary(bottom) && Universe::on_page_boundary(end)) failed: invalid space boundaries"

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -394,8 +394,12 @@ void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
   uintx survivor_size = compute_survivor_size(size, SpaceAlignment);
   uintx eden_size = size - (2*survivor_size);
   if (eden_size > max_eden_size()) {
-    eden_size = max_eden_size();
-    survivor_size = (size - eden_size)/2;
+    // Need to reduce eden_size to satisfy the max constraint. The delta needs
+    // to be 2*SpaceAlignment aligned so that both survivors are properly
+    // aligned.
+    uintx eden_delta = align_up(eden_size - max_eden_size(), 2*SpaceAlignment);
+    eden_size     -= eden_delta;
+    survivor_size += eden_delta/2;
   }
   assert(eden_size > 0 && survivor_size <= eden_size, "just checking");
 


### PR DESCRIPTION
Fix to ensure survivor-space is properly aligned.

(I tried to reproduce the failure on master but to no avail.)

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305192](https://bugs.openjdk.org/browse/JDK-8305192): serial GC fails "assert(Universe::on_page_boundary(bottom) &amp;&amp; Universe::on_page_boundary(end)) failed: invalid space boundaries"


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13323/head:pull/13323` \
`$ git checkout pull/13323`

Update a local copy of the PR: \
`$ git checkout pull/13323` \
`$ git pull https://git.openjdk.org/jdk.git pull/13323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13323`

View PR using the GUI difftool: \
`$ git pr show -t 13323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13323.diff">https://git.openjdk.org/jdk/pull/13323.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13323#issuecomment-1495712452)