### PR TITLE
8305351: C2 setScopedValueCache intrinsic doesn't use access API

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3490,8 +3490,7 @@ bool LibraryCallKit::inline_native_setScopedValueCache() {
   Node* cache_obj_handle = scopedValueCache_helper();
 
   const TypePtr *adr_type = _gvn.type(cache_obj_handle)->isa_ptr();
-  store_to_memory(control(), cache_obj_handle, arr, T_OBJECT, adr_type,
-                  MemNode::unordered);
+  access_store_at(nullptr, cache_obj_handle, adr_type, arr, _gvn.type(arr), T_OBJECT, IN_NATIVE | MO_UNORDERED);
 
   return true;
 }


### PR DESCRIPTION
The setScopedValueCache intrinsic for C2 doesn't use the access API. Instead, we store into an OopHandle with a raw store. That doesn't necessarily play well with all GCs, for example Shenandoah and generational ZGC. We should use the access API to ensure the right barriers are emitted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305351](https://bugs.openjdk.org/browse/JDK-8305351): C2 setScopedValueCache intrinsic doesn't use access API


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13324/head:pull/13324` \
`$ git checkout pull/13324`

Update a local copy of the PR: \
`$ git checkout pull/13324` \
`$ git pull https://git.openjdk.org/jdk.git pull/13324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13324`

View PR using the GUI difftool: \
`$ git pr show -t 13324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13324.diff">https://git.openjdk.org/jdk/pull/13324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13324#issuecomment-1495914472)