### PR TITLE
8305543: Ensure GC barriers for arraycopy on AArch64 use caller saved neon temp registers

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -791,7 +791,7 @@ class StubGenerator: public StubCodeGenerator {
       t4 = r7, t5 = r11, t6 = r12, t7 = r13;
     const Register stride = r14;
     const Register gct1 = rscratch1, gct2 = rscratch2, gct3 = r10;
-    const FloatRegister gcvt1 = v6, gcvt2 = v7, gcvt3 = v8;
+    const FloatRegister gcvt1 = v6, gcvt2 = v7, gcvt3 = v16; // Note that v8-v15 are callee saved
     ArrayCopyBarrierSetHelper bs(_masm, decorators, type, gct1, gct2, gct3, gcvt1, gcvt2, gcvt3);
 
     assert_different_registers(rscratch1, rscratch2, t0, t1, t2, t3, t4, t5, t6, t7);
@@ -1185,7 +1185,7 @@ class StubGenerator: public StubCodeGenerator {
     const Register t6 = r12, t7 = r13, t8 = r14, t9 = r15;
     const Register send = r17, dend = r16;
     const Register gct1 = rscratch1, gct2 = rscratch2, gct3 = r10;
-    const FloatRegister gcvt1 = v6, gcvt2 = v7, gcvt3 = v8;
+    const FloatRegister gcvt1 = v6, gcvt2 = v7, gcvt3 = v16; // Note that v8-v15 are callee saved
     ArrayCopyBarrierSetHelper bs(_masm, decorators, type, gct1, gct2, gct3, gcvt1, gcvt2, gcvt3);
 
     if (PrefetchCopyIntervalInBytes > 0)


### PR DESCRIPTION
The arraycopy stubs on AArch64 now allows the GC to vectorize arraycopy barriers. That's great! But the gct3 registers we hand to the GC is v8 today, which is callee saved (well at least the lower 64 bits). Therefore, if the GC clobbers this temp registers, it can have unexpected side effects on the caller float/double registers. We should use a caller saved register instead. 
This is only used by generational ZGC, so isn't a mainline bug yet. We should fix it before it becomes one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305543](https://bugs.openjdk.org/browse/JDK-8305543): Ensure GC barriers for arraycopy on AArch64 use caller saved neon temp registers


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13325/head:pull/13325` \
`$ git checkout pull/13325`

Update a local copy of the PR: \
`$ git checkout pull/13325` \
`$ git pull https://git.openjdk.org/jdk.git pull/13325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13325`

View PR using the GUI difftool: \
`$ git pr show -t 13325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13325.diff">https://git.openjdk.org/jdk/pull/13325.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13325#issuecomment-1495949138)