### PR TITLE
8305509: C1 fails "assert(k != nullptr) failed: illegal use of unloaded klass"

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -508,9 +508,16 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
     return unloaded_klass;
   }
 
-  Klass* found_klass = SystemDictionary::find_constrained_or_local_klass(current, sym,
-                                               (accessing_klass == nullptr) ? nullptr : accessing_klass->get_Klass(),
-                                               require_local);
+  Handle loader;
+  Handle domain;
+  if (accessing_klass != nullptr) {
+    loader = Handle(current, accessing_klass->loader());
+    domain = Handle(current, accessing_klass->protection_domain());
+  }
+
+  Klass* found_klass = require_local ?
+                         SystemDictionary::find_instance_or_array_klass(current, sym, loader, domain) :
+                         SystemDictionary::find_constrained_instance_or_array_klass(current, sym, loader);
 
   // If we fail to find an array klass, look again for its element type.
   // The element type may be available either locally or via constraints.

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1732,22 +1732,6 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
   return klass;
 }
 
-// Called by the compiler to find a loaded class directly or referenced in the loader constraint table.
-Klass* SystemDictionary::find_constrained_or_local_klass(Thread* current, Symbol* sym,
-                                                         Klass* accessing_klass,
-                                                         bool require_local) {
-  HandleMark hm(current);
-  Handle loader;
-  Handle domain;
-  if (accessing_klass != nullptr) {
-    loader = Handle(current, accessing_klass->class_loader());
-    domain = Handle(current, accessing_klass->protection_domain());
-  }
-
-  return require_local ? find_instance_or_array_klass(current, sym, loader, domain) :
-                         find_constrained_instance_or_array_klass(current, sym, loader);
-}
-
 bool SystemDictionary::add_loader_constraint(Symbol* class_name,
                                              Klass* klass_being_linked,
                                              Handle class_loader1,

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -150,7 +150,6 @@ class SystemDictionary : AllStatic {
                                              Handle class_loader,
                                              Handle protection_domain);
 
- private:
   // Lookup an instance or array class that has already been loaded
   // either into the given class loader, or else into another class
   // loader that is constrained (via loader constraints) to produce
@@ -175,13 +174,6 @@ class SystemDictionary : AllStatic {
   static Klass* find_constrained_instance_or_array_klass(Thread* current,
                                                          Symbol* class_name,
                                                          Handle class_loader);
-
- public:
-  // Called by the compiler to find a loaded class directly or referenced in the
-  // loader constraint table.
-  static Klass* find_constrained_or_local_klass(Thread* current, Symbol* sym,
-                                                Klass* accessing_klass,
-                                                bool require_local);
 
   static void classes_do(MetaspaceClosure* it);
   // Iterate over all methods in all klasses

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1664,8 +1664,16 @@ Klass* JVMCIRuntime::get_klass_by_name_impl(Klass*& accessing_klass,
     return get_klass_by_name_impl(accessing_klass, cpool, strippedsym, require_local);
   }
 
-  Klass* found_klass = SystemDictionary::find_constrained_or_local_klass(THREAD, sym,
-                                                      accessing_klass, require_local);
+  Handle loader;
+  Handle domain;
+  if (accessing_klass != nullptr) {
+    loader = Handle(THREAD, accessing_klass->class_loader());
+    domain = Handle(THREAD, accessing_klass->protection_domain());
+  }
+
+  Klass* found_klass = require_local ?
+                         SystemDictionary::find_instance_or_array_klass(THREAD, sym, loader, domain) :
+                         SystemDictionary::find_constrained_instance_or_array_klass(THREAD, sym, loader);
 
   // If we fail to find an array klass, look again for its element type.
   // The element type may be available either locally or via constraints.


### PR DESCRIPTION
I tested the fix for JDK-8304743 on tier1-8, then did this refactoring which required a ciKlass::get_Klass() call that failed.  This fix reverts the refactoring.

Here was the commit for JDK-8304743: https://github.com/openjdk/jdk/commit/b062b1bd8126610d9288dc179d69e54a40b81015

I added the HandleMark to the utility function.  It wasn't there in the original code.

Tested with tier4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305509](https://bugs.openjdk.org/browse/JDK-8305509): C1 fails "assert(k != nullptr) failed: illegal use of unloaded klass"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13327/head:pull/13327` \
`$ git checkout pull/13327`

Update a local copy of the PR: \
`$ git checkout pull/13327` \
`$ git pull https://git.openjdk.org/jdk.git pull/13327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13327`

View PR using the GUI difftool: \
`$ git pr show -t 13327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13327.diff">https://git.openjdk.org/jdk/pull/13327.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13327#issuecomment-1496092733)