### PR TITLE
8296420: javac has long lines in its command-line help

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -66,7 +66,8 @@ javac.opt.processorpath=\
 javac.opt.processormodulepath=\
     Specify a module path where to find annotation processors
 javac.opt.processor=\
-    Names of the annotation processors to run; bypasses default discovery process
+    Names of the annotation processors to run;\n\
+    bypasses default discovery process
 javac.opt.parameters=\
     Generate metadata for reflection on method parameters
 javac.opt.proc.none.only=\
@@ -85,17 +86,21 @@ javac.opt.profile=\
     Check that API used is available in the specified profile.\n\
     This option is deprecated and may be removed in a future release.
 javac.opt.target=\
-    Generate class files suitable for the specified Java SE release. Supported releases: {0}
+    Generate class files suitable for the specified Java SE release.\n\
+    Supported releases: {0}
 javac.opt.release=\
-    Compile for the specified Java SE release. Supported releases: {0}
+    Compile for the specified Java SE release.\n\
+    Supported releases: {0}
 javac.opt.source=\
-    Provide source compatibility with the specified Java SE release. Supported releases: {0}
+    Provide source compatibility with the specified Java SE release.\n\
+    Supported releases: {0}
 javac.opt.Werror=\
     Terminate compilation if warnings occur
 javac.opt.A=\
     Options to pass to annotation processors
 javac.opt.implicit=\
-    Specify whether or not to generate class files for implicitly referenced files
+    Specify whether or not to generate class files\n\
+    for implicitly referenced files
 javac.opt.pkginfo=\
     Specify handling of package-info files
 javac.opt.multi-release=\
@@ -291,17 +296,18 @@ javac.opt.Xdoclint.subopts = \
 # L10N: do not localize: public protected package private
 javac.opt.Xdoclint.custom=\
     Enable or disable specific checks for problems in javadoc comments,\n\
-    where <group> is one of accessibility, html, missing, reference, or syntax,\n\
-    and <access> is one of public, protected, package, or private.
+    where <group> is one of accessibility, html, missing, reference,\n\
+    or syntax, and <access> is one of public, protected, package,\n\
+    or private.
 
 javac.opt.Xdoclint.package.args = \
     [-]<packages>(,[-]<package>)*
 
 javac.opt.Xdoclint.package.desc=\
-    Enable or disable checks in specific packages. Each <package> is either the\n\
-    qualified name of a package or a package name prefix followed by '.*', which\n\
-    expands to all sub-packages of the given package. Each <package> can be prefixed\n\
-    with '-' to disable checks for the specified package or packages.
+    Enable or disable checks in specific packages. Each <package> is either\n\
+    the qualified name of a package or a package name prefix followed by '.*',\n\
+    which expands to all sub-packages of the given package. Each <package>\n\
+    can be prefixed with '-' to disable checks for the specified package(s).
 
 javac.opt.Xstdout=\
     Redirect standard output
@@ -318,25 +324,30 @@ javac.opt.print=\
 javac.opt.printRounds=\
     Print information about rounds of annotation processing
 javac.opt.printProcessorInfo=\
-    Print information about which annotations a processor is asked to process
+    Print information about which annotations a processor\n\
+    is asked to process
 javac.opt.userpathsfirst=\
     Search classpath and sourcepath for classes before the bootclasspath instead of after
 javac.opt.prefer=\
-    Specify which file to read when both a source file and class file are found for an implicitly compiled class
+    Specify which file to read when both a source file and class file\n\
+    are found for an implicitly compiled class
 javac.opt.preview=\
-    Enable preview language features. To be used in conjunction with either -source or --release.
+    Enable preview language features. To be used in conjunction\n\
+    with either -source or --release.
 javac.opt.AT=\
     Read options and filenames from file
 javac.opt.diags=\
     Select a diagnostic mode
 javac.opt.addExports=\
-    Specify a package to be considered as exported from its defining module\n\
-    to additional modules, or to all unnamed modules if <other-module> is ALL-UNNAMED.
+    Specify a package to be considered as exported from its\n\
+    defining module to additional modules, or to all unnamed modules\n\
+    if <other-module> is ALL-UNNAMED.
 javac.opt.arg.addExports=\
     <module>/<package>=<other-module>(,<other-module>)*
 javac.opt.addReads=\
-    Specify additional modules to be considered as required by a given module.\n\
-    <other-module> may be ALL-UNNAMED to require the unnamed module.
+    Specify additional modules to be considered as required by\n\
+    a given module; <other-module> may be ALL-UNNAMED to require\n\
+    the unnamed module.
 javac.opt.arg.addReads=\
     <module>=<other-module>(,<other-module>)*
 javac.opt.patch=\
@@ -345,8 +356,8 @@ javac.opt.patch=\
 javac.opt.arg.patch=\
     <module>=<file>(:<file>)*
 javac.opt.addmods=\
-    Root modules to resolve in addition to the initial modules, or all modules\n\
-    on the module path if <module> is ALL-MODULE-PATH.
+    Root modules to resolve in addition to the initial modules,\n\
+    or all modules on the module path if <module> is ALL-MODULE-PATH.
 javac.opt.arg.addmods=\
     <module>(,<module>)*
 javac.opt.limitmods=\
@@ -360,7 +371,8 @@ javac.opt.arg.module.version=\
 javac.opt.inherit_runtime_environment=\
     Inherit module system configuration options from the runtime environment.
 javac.opt.default.module.for.created.files=\
-    Fallback target module for files created by annotation processors, if none specified or inferred.
+    Fallback target module for files created by annotation processors,\n\
+    if none specified or inferred.
 
 ## messages
 

--- a/test/langtools/tools/javac/options/HelpOutputColumnWidthTest.java
+++ b/test/langtools/tools/javac/options/HelpOutputColumnWidthTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8296420
+ * @summary Verify command line help output does not exceed maximum column width
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main HelpOutputColumnWidthTest
+*/
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+import toolbox.JavacTask;
+import toolbox.Task;
+
+public class HelpOutputColumnWidthTest extends TestRunner {
+
+    public static final int MAX_COLUMNS = 80;
+
+    protected ToolBox tb;
+
+    public HelpOutputColumnWidthTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void testHelp(Path base) throws Exception {
+        this.checkColumnWidth("--help");
+    }
+
+    @Test
+    public void testHelpExtra(Path base) throws Exception {
+        this.checkColumnWidth("--help-extra");
+    }
+
+    private void checkColumnWidth(String... args) throws Exception {
+
+        // Compile source
+        List<String> log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .options(args)
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        // Check column width
+        final String tooLongLine = log.stream()
+          .filter(line -> line.length() > MAX_COLUMNS)
+          .findFirst()
+          .orElse(null);
+        if (tooLongLine != null)
+            throw new Exception("output line too long: \"" + tooLongLine.trim() + "\"");
+    }
+
+    public static void main(String... args) throws Exception {
+        new HelpOutputColumnWidthTest().runTests();
+    }
+}


### PR DESCRIPTION
The issue states that the output of `javac --help` and `javac --help-extra` should not overflow 80 columns.

This patch updates `javac.properties` to add newlines, etc. to address this issue, and adds a regression test.