### PR TITLE
8054022: HttpURLConnection timeouts with Expect: 100-Continue and no chunking

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1333,9 +1333,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                 http.parseHTTP(responses, this);
             } catch (SocketTimeoutException se) {
                 if (logger.isLoggable(PlatformLogger.Level.FINE)) {
-                    logger.fine(
-                            "SocketTimeoutException caught, will attempt to send body regardless"
-                    );
+                    logger.fine("SocketTimeoutException caught, will attempt to send body regardless");
                 }
                 timedOut = true;
                 http.setIgnoreContinue(true);

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1316,63 +1316,74 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
     }
 
     private void expect100Continue() throws IOException {
-            // Expect: 100-Continue was set, so check the return code for
-            // Acceptance
-            int oldTimeout = http.getReadTimeout();
-            boolean timedOut = false;
-            if (oldTimeout <= 0 || oldTimeout > 5000) {
-                if (logger.isLoggable(PlatformLogger.Level.FINE)) {
-                    logger.fine("Timeout currently set to " + oldTimeout +" temporarily setting it to 5 seconds");
-                }
-                // 5s read timeout in case the server doesn't understand
-                // Expect: 100-Continue
-                http.setReadTimeout(5000);
+        // Expect: 100-Continue was set, so check the return code for
+        // Acceptance
+        int oldTimeout = http.getReadTimeout();
+        boolean timedOut = false;
+        boolean tempTimeOutSet = false;
+        if (oldTimeout <= 0 || oldTimeout > 5000) {
+            if (logger.isLoggable(PlatformLogger.Level.FINE)) {
+                logger.fine("Timeout currently set to " +
+                        oldTimeout + " temporarily setting it to 5 seconds");
             }
+            // 5s read timeout in case the server doesn't understand
+            // Expect: 100-Continue
+            http.setReadTimeout(5000);
+            tempTimeOutSet = true;
+        }
 
-            try {
-                http.parseHTTP(responses, this);
-            } catch (SocketTimeoutException se) {
-                if (logger.isLoggable(PlatformLogger.Level.FINE)) {
-                    logger.fine("SocketTimeoutException caught, will attempt to send body regardless");
-                }
-                timedOut = true;
-                http.setIgnoreContinue(true);
+        try {
+            http.parseHTTP(responses, this);
+        } catch (SocketTimeoutException se) {
+            if (logger.isLoggable(PlatformLogger.Level.FINE)) {
+                logger.fine("SocketTimeoutException caught," +
+                        " will attempt to send body regardless");
             }
-            if (!timedOut) {
-                // Can't use getResponseCode() yet
-                String resp = responses.getValue(0);
-                // Parse the response which is of the form:
-                // HTTP/1.1 417 Expectation Failed
-                // HTTP/1.1 100 Continue
-                if (resp != null && resp.startsWith("HTTP/")) {
-                    String[] sa = resp.split("\\s+");
-                    responseCode = -1;
-                    try {
-                        // Response code is 2nd token on the line
-                        if (sa.length > 1)
-                            responseCode = Integer.parseInt(sa[1]);
-                        if (logger.isLoggable(PlatformLogger.Level.FINE)) {
-                            logger.fine("response code received " + responseCode);
-                        }
-                    } catch (NumberFormatException numberFormatException) {
+            timedOut = true;
+        }
+
+        if (!timedOut) {
+            // Can't use getResponseCode() yet
+            String resp = responses.getValue(0);
+            // Parse the response which is of the form:
+            // HTTP/1.1 417 Expectation Failed
+            // HTTP/1.1 100 Continue
+            if (resp != null && resp.startsWith("HTTP/")) {
+                String[] sa = resp.split("\\s+");
+                responseCode = -1;
+                try {
+                    // Response code is 2nd token on the line
+                    if (sa.length > 1)
+                        responseCode = Integer.parseInt(sa[1]);
+                    if (logger.isLoggable(PlatformLogger.Level.FINE)) {
+                        logger.fine("response code received " + responseCode);
                     }
-                }
-                if (responseCode != 100) {
-                    // responseCode will be returned to caller
-                    throw new ProtocolException("Server rejected operation");
+                } catch (NumberFormatException numberFormatException) {
                 }
             }
+            if (responseCode != 100) {
+                // responseCode will be returned to caller
+                throw new ProtocolException("Server rejected operation");
+            }
+        }
 
+        // If timeout was changed, restore to original value
+        if (tempTimeOutSet) {
             if (logger.isLoggable(PlatformLogger.Level.FINE)) {
                 logger.fine("Restoring original timeout : " + oldTimeout);
             }
-
-            http.setIgnoreContinue(true);
             http.setReadTimeout(oldTimeout);
+        }
 
-            responseCode = -1;
-            responses.reset();
-            // Proceed
+        // Ignore any future 100 continue messages
+        http.setIgnoreContinue(true);
+        if (logger.isLoggable(PlatformLogger.Level.FINE)) {
+            logger.fine("Set Ignore Continue to true");
+        }
+
+        responseCode = -1;
+        responses.reset();
+        // Proceed
     }
 
     /*
@@ -1441,7 +1452,6 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             boolean expectContinue = false;
             String expects = requests.findValue("Expect");
             if ("100-Continue".equalsIgnoreCase(expects) && streaming()) {
-                http.setIgnoreContinue(false);
                 expectContinue = true;
             }
 
@@ -1489,6 +1499,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
         }
     }
 
+    // Streaming returns true if there is a request body to send
     public boolean streaming () {
         return (fixedContentLength != -1) || (fixedContentLengthLong != -1) ||
                (chunkLength != -1);

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -58,7 +58,7 @@ public class HttpURLConnectionExpectContinueTest {
     }
 
     private Thread serverThread = null;
-    private Control control = null;
+    private volatile Control control;
     static final Logger logger;
 
     static {
@@ -69,7 +69,7 @@ public class HttpURLConnectionExpectContinueTest {
 
     @BeforeAll
     public void startServerSocket() throws Exception {
-        control = new Control();
+        Control control = this.control = new Control();
 
         control.serverSocket = new ServerSocket();
         control.serverSocket.setReuseAddress(true);
@@ -172,6 +172,7 @@ public class HttpURLConnectionExpectContinueTest {
 
     @AfterAll
     public void stopServerSocket() throws Exception {
+        Control control = this.control;
         control.stop = true;
         control.serverSocket.close();
         serverThread.join();
@@ -180,6 +181,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testNonChunkedRequestAndNoExpect100ContinueResponse() throws Exception {
         String body = "testNonChunkedRequestAndNoExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -205,6 +207,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testNonChunkedRequestWithExpect100ContinueResponse() throws Exception {
         String body = "testNonChunkedRequestWithExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -230,6 +233,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testNonChunkedRequestWithDoubleExpect100ContinueResponse() throws Exception {
         String body = "testNonChunkedRequestWithDoubleExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -255,6 +259,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testChunkedRequestAndNoExpect100ContinueResponse() throws Exception {
         String body = "testChunkedRequestAndNoExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -281,6 +286,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testChunkedRequestWithExpect100ContinueResponse() throws Exception {
         String body = "testChunkedRequestWithExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -307,6 +313,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testChunkedRequestWithDoubleExpect100ContinueResponse() throws Exception {
         String body = "testChunkedRequestWithDoubleExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -333,6 +340,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testFixedLengthRequestAndNoExpect100ContinueResponse() throws Exception {
         String body = "testFixedLengthRequestAndNoExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -359,6 +367,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testFixedLengthRequestWithExpect100ContinueResponse() throws Exception {
         String body = "testFixedLengthRequestWithExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +
@@ -385,6 +394,7 @@ public class HttpURLConnectionExpectContinueTest {
     @Test
     public void testFixedLengthRequestWithDoubleExpect100ContinueResponse() throws Exception {
         String body = "testFixedLengthRequestWithDoubleExpect100ContinueResponse";
+        Control control = this.control;
         control.response = "HTTP/1.1 200 OK\r\n" +
                 "Connection: close\r\n" +
                 "Content-Length: " + body.length() + "\r\n" +

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -50,15 +50,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpURLConnectionExpectContinueTest {
 
     class Control {
-        ServerSocket serverSocket = null;
-        boolean stop = false;
-        boolean respondWith100Continue = false;
-        boolean write100ContinueTwice = false;
-        String response = null;
+        volatile ServerSocket serverSocket = null;
+        volatile boolean stop = false;
+        volatile boolean respondWith100Continue = false;
+        volatile boolean write100ContinueTwice = false;
+        volatile String response = null;
     }
 
     private Thread serverThread = null;
-    private volatile Control control = null;
+    private Control control = null;
     static final Logger logger;
 
     static {

--- a/test/jdk/java/net/HttpURLConnection/HttpUrlConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpUrlConnectionExpectContinueTest.java
@@ -1,0 +1,380 @@
+/**
+ * @test
+ * @bug 8054022
+ * @summary Verify that expect 100-continue doesn't hang
+ * @library /test/lib
+ * @run junit/othervm HttpUrlConnectionExpectContinueTest
+ */
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.*;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class HttpUrlConnectionExpectContinueTest {
+
+
+    class Control {
+        ServerSocket serverSocket = null;
+        boolean stop = false;
+        boolean respondWith100Continue = false;
+        boolean write100ContinueTwice = false;
+        String request = null;
+        String response = null;
+    }
+
+    static final Logger logger;
+
+    static {
+        logger = Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
+        logger.setLevel(Level.ALL);
+        Logger.getLogger("").getHandlers()[0].setLevel(Level.ALL);
+    }
+
+    private Thread serverThread = null;
+    private volatile Control control = null;
+
+    @BeforeAll
+    public void startServerSocket() throws Exception {
+
+        control = new Control();
+
+        control.serverSocket = new ServerSocket();
+        control.serverSocket.setReuseAddress(true);
+        control.serverSocket.bind(new InetSocketAddress("127.0.0.1", 54321));
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                while (!control.stop) {
+                    try {
+                        Socket socket = control.serverSocket.accept();
+                        InputStream inputStream = socket.getInputStream();
+                        InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+
+                        StringBuilder stringBuilder = new StringBuilder();
+
+                        byte b = -1;
+                        while (true) {
+                            b = (byte)inputStreamReader.read();
+                            stringBuilder.append((char)b);
+
+                            if (stringBuilder.length() >= 4) {
+                                char[] lastBytes = new char[4];
+                                stringBuilder.getChars(stringBuilder.length() - 4, stringBuilder.length(), lastBytes, 0);
+                                if (Arrays.equals(lastBytes, new char[]{'\r', '\n', '\r', '\n'})) {
+                                    break;
+                                }
+                            }
+                        }
+
+                        OutputStream outputStream = socket.getOutputStream();
+
+                        String header = stringBuilder.toString();
+                        System.err.println(header);
+                        String contentLengthString = "Content-Length:";
+                        int idx = header.indexOf(contentLengthString);
+                        if (idx >= 0) {
+                            String substr = header.substring(idx + contentLengthString.length());
+                            idx = substr.indexOf('\r');
+                            substr = substr.substring(0, idx);
+                            int contentLength = Integer.parseInt(substr.trim());
+
+                            if (control.respondWith100Continue) {
+                                outputStream.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes());
+                                outputStream.flush();
+                                if (control.write100ContinueTwice) {
+                                    outputStream.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes());
+                                    outputStream.flush();
+                                }
+                            }
+
+                            char[] body = new char[contentLength];
+                            inputStreamReader.read(body);
+                        } else {
+
+                            if (control.respondWith100Continue) {
+                                outputStream.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes());
+                                outputStream.flush();
+                                if (control.write100ContinueTwice) {
+                                    outputStream.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes());
+                                    outputStream.flush();
+                                }
+                            }
+
+                            StringBuilder contentLengthBuilder = new StringBuilder();
+                            b = -1;
+                            while (true) {
+                                b = (byte)inputStreamReader.read();
+                                contentLengthBuilder.append((char)b);
+
+                                if (contentLengthBuilder.length() >= 2) {
+                                    char[] lastBytes = new char[2];
+                                    contentLengthBuilder.getChars(contentLengthBuilder.length() - 2, contentLengthBuilder.length(), lastBytes, 0);
+                                    if (Arrays.equals(lastBytes, new char[]{'\r', '\n'})) {
+                                        System.err.println("here " + contentLengthBuilder.substring(0, contentLengthBuilder.length() - 2));
+                                        String lengthInHex = contentLengthBuilder.substring(0, contentLengthBuilder.length() - 2);
+                                        int contentLength = Integer.parseInt(lengthInHex, 16);
+                                        char[] body = new char[contentLength];
+                                        System.err.println("about to try to read " + body.length);
+                                        inputStreamReader.read(body);
+                                        break;
+                                        //normally we have to parse more data, but for simplicity we expect no more chunks...
+                                    }
+                                }
+                            }
+                        }
+                        outputStream.write(control.response.getBytes());
+                        outputStream.flush();
+                    } catch (SocketException e) {
+                        //ignore
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        serverThread = new Thread(runnable);
+        serverThread.start();
+    }
+
+    @AfterAll
+    public void stopServerSocket() throws Exception {
+        control.stop = true;
+        control.serverSocket.close();
+        serverThread.join();
+    }
+
+    @Test
+    public void testNonChunkedRequestWithExpect100ContinueResponse() throws Exception {
+        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+
+        String body = "testNonChunkedRequestWithExpect100ContinueResponse";
+        control.response = "HTTP/1.1 200 OK\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: " + body.length() + "\r\n" +
+                "\r\n" +
+                body+"\r\n";
+
+        control.respondWith100Continue = true;
+        control.write100ContinueTwice = false;
+
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(5000);
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Connection", "Close");
+        connection.setRequestProperty("Expect", "100-Continue");
+        OutputStream outputStream = connection.getOutputStream();
+        outputStream.write(body.getBytes());
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        String responseBody = new String(connection.getInputStream().readAllBytes(), "UTF-8").strip();
+        System.err.println("resposne body: " + responseBody);
+        assertTrue(responseCode == 200,
+                String.format("Expected 200 response, instead received %s", responseCode));
+        assertTrue(body.equals(responseBody),
+                String.format("Expected response %s, instead received %s", body, responseBody));
+    }
+
+    @Test
+    public void testNonChunkedRequestAndNoExpect100ContinueResponse() throws Exception {
+        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+
+        String body = "testNonChunkedRequestAndNoExpect100ContinueResponse";
+        control.response = "HTTP/1.1 200 OK\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: " + body.length() + "\r\n" +
+                "\r\n" +
+                body+"\r\n";
+
+        control.respondWith100Continue = false;
+        control.write100ContinueTwice = false;
+
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(5000);
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Connection", "Close");
+        connection.setRequestProperty("Expect", "100-Continue");
+        OutputStream outputStream = connection.getOutputStream();
+        outputStream.write(body.getBytes());
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        System.err.println("got response code " + responseCode);
+        String responseBody = new String(connection.getInputStream().readAllBytes(), "UTF-8").strip();
+        System.err.println("resposne body: " + responseBody);
+        assertTrue(responseCode == 200,
+                String.format("Expected 200 response, instead received %s", responseCode));
+        assertTrue(body.equals(responseBody),
+                String.format("Expected response %s, instead received %s", body, responseBody));
+
+    }
+
+    @Test
+    public void testChunkedRequestWithExpect100ContinueResponse() throws Exception {
+        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+
+        String body = "testChunkedRequestWithExpect100ContinueResponse";
+        control.response = "HTTP/1.1 200 OK\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: " + body.length() + "\r\n" +
+                "\r\n" +
+                body+"\r\n";
+
+        control.respondWith100Continue = true;
+        control.write100ContinueTwice = false;
+
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(5000);
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestMethod("POST");
+        connection.setChunkedStreamingMode(-1);
+        connection.setRequestProperty("Connection", "Close");
+        connection.setRequestProperty("Expect", "100-Continue");
+        OutputStream outputStream = connection.getOutputStream();
+        outputStream.write(body.getBytes());
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        String responseBody = new String(connection.getInputStream().readAllBytes(), "UTF-8").strip();
+        System.err.println("resposne body: " + responseBody);
+        assertTrue(responseCode == 200,
+                String.format("Expected 200 response, instead received %s", responseCode));
+        assertTrue(body.equals(responseBody),
+                String.format("Expected response %s, instead received %s", body, responseBody));
+    }
+
+    @Test
+    public void testChunkedRequestWithDoubleExpect100ContinueResponse() throws Exception {
+        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+
+        String body = "testChunkedRequestWithDoubleExpect100ContinueResponse";
+        control.response = "HTTP/1.1 200 OK\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: " + body.length() + "\r\n" +
+                "\r\n" +
+                body+"\r\n";
+
+        control.respondWith100Continue = true;
+        control.write100ContinueTwice = true;
+
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(5000);
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestMethod("POST");
+        connection.setChunkedStreamingMode(-1);
+        connection.setRequestProperty("Connection", "Close");
+        connection.setRequestProperty("Expect", "100-Continue");
+        OutputStream outputStream = connection.getOutputStream();
+        outputStream.write(body.getBytes());
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        System.err.println("resposne code: " + responseCode);
+        String responseBody = new String(connection.getInputStream().readAllBytes(), "UTF-8").strip();
+        System.err.println("resposne body: " + responseBody);
+        assertTrue(responseCode == 200,
+                String.format("Expected 200 response, instead received %s", responseCode));
+        assertTrue(body.equals(responseBody),
+                String.format("Expected response %s, instead received %s", body, responseBody));
+    }
+
+    @Test
+    public void testChunkedRequestAndNoExpect100ContinueResponse() throws Exception {
+        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+
+        String body = "testChunkedRequestAndNoExpect100ContinueResponse";
+        control.response = "HTTP/1.1 200 OK\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: " + body.length() + "\r\n" +
+                "\r\n" +
+                body+"\r\n";
+
+        control.respondWith100Continue = false;
+        control.write100ContinueTwice = false;
+
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(5000);
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestMethod("POST");
+        connection.setChunkedStreamingMode(-1);
+        connection.setRequestProperty("Connection", "Close");
+        connection.setRequestProperty("Expect", "100-Continue");
+        OutputStream outputStream = connection.getOutputStream();
+        outputStream.write(body.getBytes());
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        String responseBody = new String(connection.getInputStream().readAllBytes(), "UTF-8").strip();
+        System.err.println("resposne body: " + responseBody);
+        assertTrue(responseCode == 200,
+                String.format("Expected 200 response, instead received %s", responseCode));
+        assertTrue(body.equals(responseBody),
+                String.format("Expected response %s, instead received %s", body, responseBody));
+    }
+
+    @Test
+    public void testNonChunkedRequestWithDoubleExpect100ContinueResponse() throws Exception {
+        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+
+        String body = "testNonChunkedRequestWithDoubleExpect100ContinueResponse";
+        control.response = "HTTP/1.1 200 OK\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: " + body.length() + "\r\n" +
+                "\r\n" +
+                body+"\r\n";
+
+        control.respondWith100Continue = true;
+        control.write100ContinueTwice = true;
+
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(1000);
+        connection.setReadTimeout(5000);
+        connection.setUseCaches(false);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Connection", "Close");
+        connection.setRequestProperty("Expect", "100-Continue");
+        OutputStream outputStream = connection.getOutputStream();
+        outputStream.write(body.getBytes());
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        String responseBody = new String(connection.getInputStream().readAllBytes(), "UTF-8").strip();
+        System.err.println("resposne body: " + responseBody);
+        assertTrue(responseCode == 200,
+                String.format("Expected 200 response, instead received %s", responseCode));
+        assertTrue(body.equals(responseBody),
+                String.format("Expected response %s, instead received %s", body, responseBody));
+    }
+}


### PR DESCRIPTION
Currently it is possible for `HttpURLConnection` with the `Expect: 100-Continue` header to timeout awaiting for a server response. According to [RFC-7231](https://www.rfc-editor.org/rfc/rfc7231#section-5.1.1) a client `SHOULD NOT wait for an indefinite period before sending the message body`.

This PR changes the existing `expect100Continue` method to wait for a maximum of 5 seconds for a server response, this will be shorter if a timeout is set. If no response is received, the message is sent regardless.

Tests have been added to account for different scenarios that currently timeout, and the changes have been tested against tiers 1,2 and 3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8054022](https://bugs.openjdk.org/browse/JDK-8054022): HttpURLConnection timeouts with Expect: 100-Continue and no chunking


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13330/head:pull/13330` \
`$ git checkout pull/13330`

Update a local copy of the PR: \
`$ git checkout pull/13330` \
`$ git pull https://git.openjdk.org/jdk.git pull/13330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13330`

View PR using the GUI difftool: \
`$ git pr show -t 13330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13330.diff">https://git.openjdk.org/jdk/pull/13330.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13330#issuecomment-1496325183)