### PR TITLE
8278856: javac documentation does not mention use of Manifest class-path attribute

### DIFF
--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -1530,6 +1530,11 @@ Also as a general rule, path options whose name includes the word
 specify module hierarchies, although some module-related path options
 allow a package hierarchy to be specified on a per-module basis.
 All other path options are used to specify package hierarchies.
+.PP
+When a JAR file in the user class path has a \f[B]\f[VB]Class-Path\f[B]\f[R]
+manifest attribute, and the specified file(s) exist, they are automatically
+inserted into the user class path after the JAR file.
+This rule also applies recursively to any new JAR files found.
 .SS Package Hierarchy
 .PP
 In a package hierarchy, directories and subdirectories are used to


### PR DESCRIPTION
JAR files appearing in `--class-path` are implicitly scanned for manifest `Class-Path` attributes, but this behavior is not documented.

This patch adds a blurb to the `javac(1)` man page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278856](https://bugs.openjdk.org/browse/JDK-8278856): javac documentation does not mention use of Manifest class-path attribute


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13332/head:pull/13332` \
`$ git checkout pull/13332`

Update a local copy of the PR: \
`$ git checkout pull/13332` \
`$ git pull https://git.openjdk.org/jdk.git pull/13332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13332`

View PR using the GUI difftool: \
`$ git pr show -t 13332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13332.diff">https://git.openjdk.org/jdk/pull/13332.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13332#issuecomment-1496370053)