### PR TITLE
8305602: ProblemList java/lang/invoke/lambda/LogGeneratedClassesTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -484,6 +484,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
+java/lang/invoke/lambda/LogGeneratedClassesTest.java            8305600 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
This gives time to investigate JDK-8305600 and understand why the test didn't fail on my testing before the push.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305602](https://bugs.openjdk.org/browse/JDK-8305602): ProblemList java/lang/invoke/lambda/LogGeneratedClassesTest.java


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13334/head:pull/13334` \
`$ git checkout pull/13334`

Update a local copy of the PR: \
`$ git checkout pull/13334` \
`$ git pull https://git.openjdk.org/jdk.git pull/13334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13334`

View PR using the GUI difftool: \
`$ git pr show -t 13334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13334.diff">https://git.openjdk.org/jdk/pull/13334.diff</a>

</details>
