### PR TITLE
8304911: Use OperatingSystem enum in some modules

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -288,8 +288,7 @@ module java.base {
         java.security.jgss,
         java.smartcardio,
         jdk.charsets,
-        jdk.net,
-        jdk.zipfs;
+        jdk.net;
     exports sun.net to
         java.net.http,
         jdk.naming.dns;

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -283,7 +283,12 @@ module java.base {
     exports jdk.internal.util.random to
         jdk.random;
     exports jdk.internal.util to
-        java.desktop;
+        java.desktop,
+        java.security.jgss,
+        java.smartcardio,
+        jdk.charsets,
+        jdk.net,
+        jdk.zipfs;
     exports sun.net to
         java.net.http,
         jdk.naming.dns;

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -284,6 +284,7 @@ module java.base {
         jdk.random;
     exports jdk.internal.util to
         java.desktop,
+        java.prefs,
         java.security.jgss,
         java.smartcardio,
         jdk.charsets,

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -50,6 +50,8 @@ grant codeBase "jrt:/java.smartcardio" {
                    "accessClassInPackage.sun.security.jca";
     permission java.lang.RuntimePermission
                    "accessClassInPackage.sun.security.util";
+    permission java.lang.RuntimePermission
+                   "accessClassInPackage.jdk.internal.util";
     permission java.util.PropertyPermission
                    "javax.smartcardio.TerminalFactory.DefaultType", "read";
     permission java.util.PropertyPermission "os.name", "read";
@@ -118,6 +120,8 @@ grant codeBase "jrt:/jdk.charsets" {
                    "accessClassInPackage.jdk.internal.access";
     permission java.lang.RuntimePermission
                    "accessClassInPackage.jdk.internal.misc";
+    permission java.lang.RuntimePermission
+                   "accessClassInPackage.jdk.internal.util";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.cs";
 };
 
@@ -215,6 +219,7 @@ grant codeBase "jrt:/jdk.zipfs" {
     permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
     permission java.lang.RuntimePermission "fileSystemProvider";
     permission java.lang.RuntimePermission "accessUserInformation";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.util";
     permission java.util.PropertyPermission "os.name", "read";
     permission java.util.PropertyPermission "user.dir", "read";
     permission java.util.PropertyPermission "user.name", "read";

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -219,7 +219,6 @@ grant codeBase "jrt:/jdk.zipfs" {
     permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
     permission java.lang.RuntimePermission "fileSystemProvider";
     permission java.lang.RuntimePermission "accessUserInformation";
-    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.util";
     permission java.util.PropertyPermission "os.name", "read";
     permission java.util.PropertyPermission "user.dir", "read";
     permission java.util.PropertyPermission "user.name", "read";

--- a/src/java.prefs/share/classes/java/util/prefs/Preferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/Preferences.java
@@ -296,7 +296,7 @@ public abstract class Preferences {
         // 3. Use platform-specific system-wide default
         String platformFactory = switch (OperatingSystem.current()) {
             case WINDOWS -> "java.util.prefs.WindowsPreferencesFactory";
-            case MACOS ->  "java.util.prefs.MacOSXPreferencesFactory";
+            case MACOS -> "java.util.prefs.MacOSXPreferencesFactory";
             default -> "java.util.prefs.FileSystemPreferencesFactory";
         };
         try {

--- a/src/java.prefs/share/classes/java/util/prefs/Preferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/Preferences.java
@@ -25,6 +25,8 @@
 
 package java.util.prefs;
 
+import jdk.internal.util.OperatingSystem;
+
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -292,15 +294,11 @@ public abstract class Preferences {
         }
 
         // 3. Use platform-specific system-wide default
-        String osName = System.getProperty("os.name");
-        String platformFactory;
-        if (osName.startsWith("Windows")) {
-            platformFactory = "java.util.prefs.WindowsPreferencesFactory";
-        } else if (osName.contains("OS X")) {
-            platformFactory = "java.util.prefs.MacOSXPreferencesFactory";
-        } else {
-            platformFactory = "java.util.prefs.FileSystemPreferencesFactory";
-        }
+        String platformFactory = switch (OperatingSystem.current()) {
+            case WINDOWS -> "java.util.prefs.WindowsPreferencesFactory";
+            case MACOS ->  "java.util.prefs.MacOSXPreferencesFactory";
+            default -> "java.util.prefs.FileSystemPreferencesFactory";
+        };
         try {
             @SuppressWarnings("deprecation")
             Object result = Class.forName(platformFactory, false,

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -30,6 +30,9 @@ import java.util.HashMap;
 import java.security.Provider;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
+import jdk.internal.util.OperatingSystem;
+import jdk.internal.util.StaticProperty;
 import org.ietf.jgss.Oid;
 import sun.security.action.GetBooleanAction;
 import sun.security.action.PutAllAction;
@@ -87,25 +90,21 @@ public final class SunNativeProvider extends Provider {
                         String defaultLib
                                 = System.getProperty("sun.security.jgss.lib");
                         if (defaultLib == null || defaultLib.trim().equals("")) {
-                            String osname = System.getProperty("os.name");
-                            if (osname.startsWith("Linux")) {
-                                gssLibs = new String[]{
-                                    "libgssapi.so",
-                                    "libgssapi_krb5.so",
-                                    "libgssapi_krb5.so.2",
+                            gssLibs = switch (OperatingSystem.current()) {
+                                case LINUX -> new String[]{
+                                        "libgssapi.so",
+                                        "libgssapi_krb5.so",
+                                        "libgssapi_krb5.so.2",
                                 };
-                            } else if (osname.contains("OS X")) {
-                                gssLibs = new String[]{
-                                    "libgssapi_krb5.dylib",
-                                    "/usr/lib/sasl2/libgssapiv2.2.so",
-                               };
-                            } else if (osname.contains("Windows")) {
-                                // Full path needed, DLL is in jre/bin
-                                gssLibs = new String[]{ System.getProperty("java.home")
-                                        + "\\bin\\sspi_bridge.dll" };
-                            } else {
-                                gssLibs = new String[0];
-                            }
+                                case MACOS -> new String[]{
+                                        "libgssapi_krb5.dylib",
+                                        "/usr/lib/sasl2/libgssapiv2.2.so",
+                                };
+                                case WINDOWS -> // Full path needed, DLL is in jre/bin
+                                        new String[]{StaticProperty.javaHome()
+                                                + "\\bin\\sspi_bridge.dll"};
+                                default -> new String[0];
+                            };
                         } else {
                             gssLibs = new String[]{ defaultLib };
                         }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -100,9 +100,9 @@ public final class SunNativeProvider extends Provider {
                                         "libgssapi_krb5.dylib",
                                         "/usr/lib/sasl2/libgssapiv2.2.so",
                                 };
-                                case WINDOWS -> // Full path needed, DLL is in jre/bin
-                                        new String[]{StaticProperty.javaHome()
-                                                + "\\bin\\sspi_bridge.dll"};
+                                case WINDOWS -> new String[]{ // Full path needed, DLL is in jre/bin
+                                        StaticProperty.javaHome() + "\\bin\\sspi_bridge.dll",
+                                };
                                 default -> new String[0];
                             };
                         } else {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -100,7 +100,8 @@ public final class SunNativeProvider extends Provider {
                                         "libgssapi_krb5.dylib",
                                         "/usr/lib/sasl2/libgssapiv2.2.so",
                                 };
-                                case WINDOWS -> new String[]{ // Full path needed, DLL is in jre/bin
+                                case WINDOWS -> new String[]{
+                                        // Full path needed, DLL is in jre/bin
                                         StaticProperty.javaHome() + "\\bin\\sspi_bridge.dll",
                                 };
                                 default -> new String[0];

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jdk.internal.util.OperatingSystem;
 import sun.net.dns.ResolverConfiguration;
 import sun.security.action.GetPropertyAction;
 import sun.security.krb5.internal.crypto.EType;
@@ -159,8 +160,7 @@ public class Config {
 
     private static boolean isMacosLionOrBetter() {
         // split the "10.x.y" version number
-        String osname = GetPropertyAction.privilegedGetProperty("os.name");
-        if (!osname.contains("OS X")) {
+        if (!OperatingSystem.isMacOS()) {
             return false;
         }
 
@@ -892,8 +892,7 @@ public class Config {
      */
     private String getNativeFileName() {
         String name = null;
-        String osname = GetPropertyAction.privilegedGetProperty("os.name");
-        if (osname.startsWith("Windows")) {
+        if (OperatingSystem.isWindows()) {
             try {
                 Credentials.ensureLoaded();
             } catch (Exception e) {
@@ -926,7 +925,7 @@ public class Config {
             if (name == null) {
                 name = "c:\\winnt\\krb5.ini";
             }
-        } else if (osname.contains("OS X")) {
+        } else if (OperatingSystem.isMacOS()) {
             name = findMacosConfigFile();
         } else {
             name =  "/etc/krb5.conf";
@@ -1193,8 +1192,7 @@ public class Config {
                     new java.security.PrivilegedAction<String>() {
                 @Override
                 public String run() {
-                    String osname = System.getProperty("os.name");
-                    if (osname.startsWith("Windows")) {
+                    if (OperatingSystem.isWindows()) {
                         return System.getenv("USERDNSDOMAIN");
                     }
                     return null;
@@ -1241,8 +1239,7 @@ public class Config {
                     new java.security.PrivilegedAction<String>() {
                 @Override
                 public String run() {
-                    String osname = System.getProperty("os.name");
-                    if (osname.startsWith("Windows")) {
+                    if (OperatingSystem.isWindows()) {
                         String logonServer = System.getenv("LOGONSERVER");
                         if (logonServer != null
                                 && logonServer.startsWith("\\\\")) {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Credentials.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
 
 package sun.security.krb5;
 
-import sun.security.action.GetPropertyAction;
+import jdk.internal.util.OperatingSystem;
 import sun.security.krb5.internal.*;
 import sun.security.krb5.internal.ccache.CredentialsCache;
 import sun.security.krb5.internal.crypto.EType;
@@ -39,7 +39,6 @@ import sun.security.util.SecurityProperties;
 
 import java.io.IOException;
 import java.util.Date;
-import java.util.Locale;
 import java.net.InetAddress;
 
 /**
@@ -327,9 +326,8 @@ public class Credentials {
 
         if (ticketCache == null) {
             // The default ticket cache on Windows and Mac is not a file.
-            String os = GetPropertyAction.privilegedGetProperty("os.name");
-            if (os.toUpperCase(Locale.ENGLISH).startsWith("WINDOWS") ||
-                    os.toUpperCase(Locale.ENGLISH).contains("OS X")) {
+            if (OperatingSystem.isWindows() ||
+                    OperatingSystem.isMacOS()) {
                 Credentials creds = acquireDefaultCreds();
                 if (creds == null) {
                     if (DEBUG) {
@@ -530,7 +528,7 @@ public class Credentials {
         java.security.AccessController.doPrivileged(
                 new java.security.PrivilegedAction<Void> () {
                         public Void run() {
-                                if (System.getProperty("os.name").contains("OS X")) {
+                                if (OperatingSystem.isMacOS()) {
                                     System.loadLibrary("osxkrb5");
                                 } else {
                                     System.loadLibrary("w2k_lsa_auth");

--- a/src/java.security.jgss/share/classes/sun/security/krb5/SCDynamicStoreConfig.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/SCDynamicStoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package sun.security.krb5;
 
+import jdk.internal.util.OperatingSystem;
+
 import java.io.IOException;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -47,8 +49,7 @@ public class SCDynamicStoreConfig {
         boolean isMac = java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Boolean>() {
                 public Boolean run() {
-                    String osname = System.getProperty("os.name");
-                    if (osname.contains("OS X")) {
+                    if (OperatingSystem.isMacOS()) {
                         System.loadLibrary("osxkrb5");
                         return true;
                     }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
  */
 package sun.security.krb5.internal.ccache;
 
+import jdk.internal.util.OperatingSystem;
 import sun.security.action.GetPropertyAction;
 import sun.security.krb5.*;
 import sun.security.krb5.internal.*;
@@ -465,9 +466,6 @@ public class FileCredentialsCache extends CredentialsCache
             return name;
         }
 
-        // get cache name from system.property
-        String osname = GetPropertyAction.privilegedGetProperty("os.name");
-
         /*
          * For Unix platforms we use the default cache name to be
          * /tmp/krb5cc_uid ; for all other platforms  we use
@@ -479,7 +477,7 @@ public class FileCredentialsCache extends CredentialsCache
          * Windows.
          */
 
-        if (osname != null && !osname.startsWith("Windows")) {
+        if (!OperatingSystem.isWindows()) {
             long uid = jdk.internal.misc.VM.getuid();
             if (uid != -1) {
                 name = File.separator + "tmp" +

--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/CardImpl.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/CardImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,8 @@
 
 package sun.security.smartcardio;
 
-import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import jdk.internal.util.OperatingSystem;
+
 import javax.smartcardio.*;
 import static sun.security.smartcardio.PCSC.*;
 
@@ -62,16 +61,6 @@ final class CardImpl extends Card {
     // thread holding exclusive access to the card, or null
     private volatile Thread exclusiveThread;
 
-    // used for platform specific logic
-    private static final boolean isWindows;
-
-    static {
-        @SuppressWarnings("removal")
-        final String osName = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("os.name"));
-        isWindows = osName.startsWith("Windows");
-    }
-
     CardImpl(TerminalImpl terminal, String protocol) throws PCSCException {
         this.terminal = terminal;
         int sharingMode = SCARD_SHARE_SHARED;
@@ -88,7 +77,7 @@ final class CardImpl extends Card {
             // MSDN states that the preferred protocol can be zero, but doesn't
             //     specify whether other values are allowed.
             // pcsc-lite implementation expects the preferred protocol to be non zero.
-            connectProtocol = isWindows ? 0 : SCARD_PROTOCOL_RAW;
+            connectProtocol = OperatingSystem.isWindows() ? 0 : SCARD_PROTOCOL_RAW;
 
             sharingMode = SCARD_SHARE_DIRECT;
         } else {

--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/JISAutoDetect.java
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/JISAutoDetect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,10 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.MalformedInputException;
 import sun.nio.cs.DelegatableDecoder;
 import sun.nio.cs.HistoricallyNamedCharset;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import sun.nio.cs.*;
 import static java.lang.Character.UnicodeBlock;
 
+import jdk.internal.util.OperatingSystem;
 
 public class JISAutoDetect
     extends Charset
@@ -93,9 +92,6 @@ public class JISAutoDetect
     }
 
     private static class Decoder extends CharsetDecoder {
-        @SuppressWarnings("removal")
-        private static final String osName = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("os.name"));
 
         private static final String SJISName = getSJISName();
         private static final String EUCJPName = "EUC_JP";
@@ -226,7 +222,7 @@ public class JISAutoDetect
          * Returned Shift_JIS Charset name is OS dependent
          */
         private static String getSJISName() {
-            if (osName.startsWith("Windows"))
+            if (OperatingSystem.isWindows())
                 return("windows-31J");
             else
                 return("Shift_JIS");

--- a/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
+++ b/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,12 @@ import java.io.FileDescriptor;
 import java.net.SocketException;
 import java.net.SocketOption;
 import java.net.StandardProtocolFamily;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.util.OperatingSystem;
 
 /**
  * Defines extended socket options, beyond those defined in
@@ -400,22 +399,12 @@ public final class ExtendedSocketOptions {
         }
 
         private static PlatformSocketOptions create() {
-            @SuppressWarnings("removal")
-            String osname = AccessController.doPrivileged(
-                    new PrivilegedAction<String>() {
-                        public String run() {
-                            return System.getProperty("os.name");
-                        }
-                    });
-            if ("Linux".equals(osname)) {
-                return newInstance("jdk.net.LinuxSocketOptions");
-            } else if (osname.startsWith("Mac")) {
-                return newInstance("jdk.net.MacOSXSocketOptions");
-            } else if (osname.startsWith("Windows")) {
-                return newInstance("jdk.net.WindowsSocketOptions");
-            } else {
-                return new PlatformSocketOptions();
-            }
+            return switch (OperatingSystem.current()) {
+                case LINUX -> newInstance("jdk.net.LinuxSocketOptions");
+                case MACOS -> newInstance("jdk.net.MacOSXSocketOptions");
+                case WINDOWS -> newInstance("jdk.net.WindowsSocketOptions");
+                default -> new PlatformSocketOptions();
+            };
         }
 
         private static final PlatformSocketOptions instance = create();

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpNet.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpNet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,6 @@ import com.sun.nio.sctp.SctpSocketOption;
 import static com.sun.nio.sctp.SctpStandardSocketOptions.*;
 
 public class SctpNet {
-    @SuppressWarnings("removal")
-    private static final String osName = AccessController.doPrivileged(
-        (PrivilegedAction<String>) () -> System.getProperty("os.name"));
-
     /* -- Miscellaneous SCTP utilities -- */
 
     private static boolean IPv4MappedAddresses() {
@@ -350,4 +346,3 @@ public class SctpNet {
         init();
     }
 }
-

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package jdk.nio.zipfs;
+
+import jdk.internal.util.OperatingSystem;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -83,9 +85,6 @@ import static jdk.nio.zipfs.ZipUtils.*;
 class ZipFileSystem extends FileSystem {
     // statics
     @SuppressWarnings("removal")
-    private static final boolean isWindows = AccessController.doPrivileged(
-        (PrivilegedAction<Boolean>)()->System.getProperty("os.name")
-                                             .startsWith("Windows"));
     private static final byte[] ROOTPATH = new byte[] { '/' };
     private static final String PROPERTY_POSIX = "enablePosixFileAttributes";
     private static final String PROPERTY_DEFAULT_OWNER = "defaultOwner";
@@ -2877,7 +2876,7 @@ class ZipFileSystem extends FileSystem {
                 eoff += (4 + sz);
             }
             if (!foundExtraTime) {
-                if (isWindows) {             // use NTFS
+                if (OperatingSystem.isWindows()) { // use NTFS
                     elenNTFS = 36;           // total 36 bytes
                 } else {                     // Extended Timestamp otherwise
                     elenEXTT = 9;            // only mtime in cen
@@ -2996,7 +2995,7 @@ class ZipFileSystem extends FileSystem {
                 eoff += (4 + sz);
             }
             if (!foundExtraTime) {
-                if (isWindows) {
+                if (OperatingSystem.isWindows()) {
                     elenNTFS = 36;              // NTFS, total 36 bytes
                 } else {                        // on unix use "ext time"
                     elenEXTT = 9;

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 
 package jdk.nio.zipfs;
-
-import jdk.internal.util.OperatingSystem;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -85,6 +83,9 @@ import static jdk.nio.zipfs.ZipUtils.*;
 class ZipFileSystem extends FileSystem {
     // statics
     @SuppressWarnings("removal")
+    private static final boolean isWindows = AccessController.doPrivileged(
+        (PrivilegedAction<Boolean>)()->System.getProperty("os.name")
+                                             .startsWith("Windows"));
     private static final byte[] ROOTPATH = new byte[] { '/' };
     private static final String PROPERTY_POSIX = "enablePosixFileAttributes";
     private static final String PROPERTY_DEFAULT_OWNER = "defaultOwner";
@@ -2876,7 +2877,7 @@ class ZipFileSystem extends FileSystem {
                 eoff += (4 + sz);
             }
             if (!foundExtraTime) {
-                if (OperatingSystem.isWindows()) { // use NTFS
+                if (isWindows) {             // use NTFS
                     elenNTFS = 36;           // total 36 bytes
                 } else {                     // Extended Timestamp otherwise
                     elenEXTT = 9;            // only mtime in cen
@@ -2995,7 +2996,7 @@ class ZipFileSystem extends FileSystem {
                 eoff += (4 + sz);
             }
             if (!foundExtraTime) {
-                if (OperatingSystem.isWindows()) {
+                if (isWindows) {
                     elenNTFS = 36;              // NTFS, total 36 bytes
                 } else {                        // on unix use "ext time"
                     elenEXTT = 9;


### PR DESCRIPTION
With the addition of `jdk.internal.util.OperatingSystem` references to the system property `os.name` can be replaced.
This PR exports jdk.internal.util to:
 - java.prefs,
 - java.security.jgss,
 - java.smartcardio,
 - jdk.charsets,
 - jdk.net,
 - jdk.zipfs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304911](https://bugs.openjdk.org/browse/JDK-8304911): Use OperatingSystem enum in some modules


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [72cff1ed](https://git.openjdk.org/jdk/pull/13335/files/72cff1edb8b07ff116f903f2c1d50caafc4a996f)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [72cff1ed](https://git.openjdk.org/jdk/pull/13335/files/72cff1edb8b07ff116f903f2c1d50caafc4a996f)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [5546b824](https://git.openjdk.org/jdk/pull/13335/files/5546b824949e83fd31e32f2b47a1745574ca47ca)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [5546b824](https://git.openjdk.org/jdk/pull/13335/files/5546b824949e83fd31e32f2b47a1745574ca47ca)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13335/head:pull/13335` \
`$ git checkout pull/13335`

Update a local copy of the PR: \
`$ git checkout pull/13335` \
`$ git pull https://git.openjdk.org/jdk.git pull/13335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13335`

View PR using the GUI difftool: \
`$ git pr show -t 13335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13335.diff">https://git.openjdk.org/jdk/pull/13335.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13335#issuecomment-1496489875)