### PR TITLE
8303563: GetCurrentThreadCpuTime and GetThreadCpuTime need further clarification for virtual threads

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -11022,7 +11022,8 @@ myInit() {
             the current thread (see
             <functionlink id="GetCurrentThreadCpuTimerInfo"/> vs
             <functionlink id="GetThreadCpuTimerInfo"/>).
-            The current thread may not be a virtual thread. Otherwise, the error code
+            An implementation is not required to support this function
+            when the current thread is a virtual thread, in which case 
             <errorlink id="JVMTI_ERROR_UNSUPPORTED_OPERATION"></errorlink> will be returned.
             On many platforms this call will be equivalent to:
 <example>
@@ -11125,7 +11126,8 @@ myInit() {
           <jthread null="current" impl="noconvert"/>
             <description>
               The thread to query.
-              The <code>thread</code> may not be a virtual thread. Otherwise, the error code
+              An implementation is not required to support this function
+              when the given thread is a virtual thread, in which case
                <errorlink id="JVMTI_ERROR_UNSUPPORTED_OPERATION"></errorlink> will be returned.
              </description>
         </param>


### PR DESCRIPTION
This is a follow-up to [JDK-8302615](https://bugs.openjdk.org/browse/JDK-8302615) where GetCurrentThreadCpuTime and GetThreadCpuTime were changed from being not supported to optional, when called from/with a virtual thread. There are two additional sentences that need adjustment to avoid creating a conflict in the spec.

In the functions `GetCurrentThreadCpuTime` and `GetThreadCpuTime`:

The fragment:
`"The current thread may not be a virtual thread. Otherwise, the error code"`

is replaced with:
```
"An implementation is not required to support this function
 when the current thread is a virtual thread, in which case"
```

CSR:  [JDK-8305617](https://bugs.openjdk.org/browse/JDK-8305617)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8305617](https://bugs.openjdk.org/browse/JDK-8305617) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8303563](https://bugs.openjdk.org/browse/JDK-8303563): GetCurrentThreadCpuTime and GetThreadCpuTime need further clarification for virtual threads
 * [JDK-8305617](https://bugs.openjdk.org/browse/JDK-8305617): GetCurrentThreadCpuTime and GetThreadCpuTime need further clarification for virtual threads (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13338/head:pull/13338` \
`$ git checkout pull/13338`

Update a local copy of the PR: \
`$ git checkout pull/13338` \
`$ git pull https://git.openjdk.org/jdk.git pull/13338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13338`

View PR using the GUI difftool: \
`$ git pr show -t 13338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13338.diff">https://git.openjdk.org/jdk/pull/13338.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13338#issuecomment-1496577644)