### PR TITLE
8305618: Move gcold out of tier1

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -306,7 +306,7 @@ tier1_gc_epsilon = \
 
 tier2_gc_epsilon =
 
-tier1_gc_gcold = \
+tier3_gc_gcold = \
   gc/stress/gcold/TestGCOldWithG1.java \
   gc/stress/gcold/TestGCOldWithSerial.java \
   gc/stress/gcold/TestGCOldWithParallel.java
@@ -558,6 +558,7 @@ tier2 = \
 
 tier3 = \
   :hotspot_tier3_runtime \
+  :tier3_gc_gcold \
   :tier3_compiler \
   :tier3_gc_shenandoah
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -558,8 +558,8 @@ tier2 = \
 
 tier3 = \
   :hotspot_tier3_runtime \
-  :tier3_gc_gcold \
   :tier3_compiler \
+  :tier3_gc_gcold \
   :tier3_gc_shenandoah
 
 # Everything that is not in other tiers, but not apps

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -276,7 +276,6 @@ ctw_3 = \
 tier1_gc = \
   :tier1_gc_1 \
   :tier1_gc_2 \
-  :tier1_gc_gcold \
   :tier1_gc_gcbasher \
   :tier1_gc_epsilon \
   :tier1_gc_shenandoah


### PR DESCRIPTION
8305618: Move gcold out of tier1

Remove gcold out from tier1. Related to [JDK-8298981](https://bugs.openjdk.org/browse/JDK-8298981). Moving gcbasher out of tier1 was more controversial, and will be done later --- if at all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305618](https://bugs.openjdk.org/browse/JDK-8305618): Move gcold out of tier1


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13340/head:pull/13340` \
`$ git checkout pull/13340`

Update a local copy of the PR: \
`$ git checkout pull/13340` \
`$ git pull https://git.openjdk.org/jdk.git pull/13340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13340`

View PR using the GUI difftool: \
`$ git pr show -t 13340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13340.diff">https://git.openjdk.org/jdk/pull/13340.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13340#issuecomment-1496590198)