### PR TITLE
JDK-8305591: Cleanup use of `newline` flag in DocCommentParser

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -174,9 +174,6 @@ public class DocCommentParser {
         while (bp < buflen) {
             switch (ch) {
                 case '\n': case '\r': case '\f':
-                    newline = true;
-                    // fallthrough
-
                 case ' ': case '\t':
                     nextChar();
                     break;
@@ -417,9 +414,6 @@ public class DocCommentParser {
         while (bp < buflen) {
             switch (ch) {
                 case '\n': case '\r': case '\f':
-                    newline = true;
-                    break;
-
                 case ' ': case '\t':
                     break;
 
@@ -464,9 +458,6 @@ public class DocCommentParser {
         while (bp < buflen) {
             switch (ch) {
                 case '\n': case '\r': case '\f':
-                    newline = true;
-                    // fallthrough
-
                 case ' ': case '\t':
                     if (depth == 0)
                         break loop;
@@ -544,9 +535,6 @@ public class DocCommentParser {
         while (bp < buflen) {
             switch (ch) {
                 case '\n': case '\r': case '\f':
-                    newline = true;
-                    break;
-
                 case ' ': case '\t':
                     break;
 
@@ -577,9 +565,6 @@ public class DocCommentParser {
         while (bp < buflen) {
             switch (ch) {
                 case '\n':
-                    newline = true;
-                    // fallthrough
-
                 case '\r': case '\f': case ' ': case '\t':
                     return m.at(pos).newTextTree(newString(pos, bp));
 
@@ -621,9 +606,6 @@ public class DocCommentParser {
 
             switch (ch) {
                 case '\n': case '\r': case '\f':
-                    newline = true;
-                    // fall through
-
                 case ' ': case '\t':
                     nextChar();
                     break;


### PR DESCRIPTION
Please remove a simple cleanup fix, to remove unnecessary assignments to set the `newline` flag  to `true` in `DocCommentParser`. The flag is always set appropriately in `nextChar()`.

This removes a number of "fall-through" cases in switch statements. In reviewing the use of `@SuppressWarnings("fall through")` it was noted that there is a missing `break` in `case '@'` in `inlineWord()`. Fixing this breaks a test. This will be addressed separately. [JDK-8305620](https://bugs.openjdk.org/browse/JDK-8305620)