### PR TITLE
8305596: (fc) Two java/nio/channels tests fail after JDK-8303260

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -539,10 +539,6 @@ java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc6
 
 # jdk_nio
 
-java/nio/channels/AsyncCloseAndInterrupt.java                   8305596 generic-all
-
-java/nio/channels/FileChannel/Transfer.java                     8305596 generic-all
-
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -469,8 +469,9 @@ public class AsyncCloseAndInterrupt {
                     SocketChannel sc = (SocketChannel)ch;
                     if (!sc.socket().isOutputShutdown())
                         throw new RuntimeException("Output not shutdown");
-                } else if ((test == TEST_INTR) && (op == TRANSFER_FROM)) {
-                    // Let this case pass -- CBIE applies to other channel
+                } else if ((test == TEST_INTR || test == TEST_PREINTR)
+                        && (op == TRANSFER_FROM)) {
+                    // Let these cases pass -- CBIE applies to other channel
                 } else {
                     throw new RuntimeException("Channel still open");
                 }

--- a/test/jdk/java/nio/channels/FileChannel/Transfer.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer.java
@@ -98,7 +98,7 @@ public class Transfer {
         if (bytesWritten > 10)
             throw new RuntimeException("Wrote too many bytes");
 
-        if (sinkChannel.size() != 1010)
+        if (sinkChannel.size() != 1000 + bytesWritten)
             throw new RuntimeException("Unexpected sink size");
 
         sourceChannel.close();

--- a/test/jdk/java/nio/channels/FileChannel/Transfer.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,8 +95,11 @@ public class Transfer {
 
         bytesWritten = sinkChannel.transferFrom(sourceChannel, 1000, 10);
 
-        if (bytesWritten > 0)
-            throw new RuntimeException("Wrote past file size");
+        if (bytesWritten > 10)
+            throw new RuntimeException("Wrote too many bytes");
+
+        if (sinkChannel.size() != 1010)
+            throw new RuntimeException("Unexpected sink size");
 
         sourceChannel.close();
         sinkChannel.close();


### PR DESCRIPTION
Update the tests to conform to the specification change in  [JDK-8303260](https://bugs.openjdk.org/browse/JDK-8303260) which allows writing to a position beyond the channel's size in `FileChannel::transferFrom`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305596](https://bugs.openjdk.org/browse/JDK-8305596): (fc) Two java/nio/channels tests fail after JDK-8303260


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13342/head:pull/13342` \
`$ git checkout pull/13342`

Update a local copy of the PR: \
`$ git checkout pull/13342` \
`$ git pull https://git.openjdk.org/jdk.git pull/13342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13342`

View PR using the GUI difftool: \
`$ git pr show -t 13342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13342.diff">https://git.openjdk.org/jdk/pull/13342.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13342#issuecomment-1496666287)