### PR TITLE
JDK-8305620: Missing `break` in DocCommentParser `inlineWord()`

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -586,14 +586,16 @@ public class DocCommentParser {
                 case '@':
                     if (newline)
                         break loop;
+                    break;
 
                 case '{':
                     depth++;
                     break;
 
                 case '}':
-                    if (depth == 0 || --depth == 0)
+                    if (depth == 0)
                         return m.at(pos).newTextTree(newString(pos, bp));
+                    depth--;
                     break;
             }
             newline = false;

--- a/test/langtools/tools/javac/doctree/IndexTest.java
+++ b/test/langtools/tools/javac/doctree/IndexTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144287 8273244 8284908
+ * @bug 8144287 8273244 8284908 8305620
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -155,12 +155,12 @@ DocComment[DOC_COMMENT, pos:1
 */
 
     /**
-     * abc {@index {@xyz} "{@see xyz}" def}
+     * abc {@index {@xyz} "{@see xyz}"} def
      */
     void term_and_description_with_nested_tag() {}
 /*
 DocComment[DOC_COMMENT, pos:1
-  firstSentence: 2
+  firstSentence: 3
     Text[TEXT, pos:1, abc_]
     Index[INDEX, pos:5
       term:
@@ -172,8 +172,9 @@ DocComment[DOC_COMMENT, pos:1
           content: 1
             Text[TEXT, pos:27, xyz]
         ]
-        Text[TEXT, pos:31, "_def]
+        Text[TEXT, pos:31, "]
     ]
+    Text[TEXT, pos:33, _def]
   body: empty
   block tags: empty
 ]


### PR DESCRIPTION
Please review a fix for the `depth` counting in `DocCommentParser` `inlineWord`.
There was a missing break that caused the count to go high, and because of that the code for the down count needed to be adjusted as well.

The test is modified to be stylistically more like the others with `abc` and `def` surrounding the `{@index...}` tag.  This looks like it may have been a typo, and helped hide the counting issue.