### PR TITLE
8305578: X11GraphicsDevice.pGetBounds() is slow in remote X11 sessions

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -888,15 +888,17 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
     @Override
     public Insets getScreenInsets(final GraphicsConfiguration gc) {
         final X11GraphicsDevice device = (X11GraphicsDevice) gc.getDevice();
-        synchronized (device) {
-            Insets insets = device.getInsets();
-            if (insets == null) {
-                insets = getScreenInsetsImpl(gc);
-                device.setInsets(insets);
+        Insets insets = device.getInsets();
+        if (insets == null) {
+            synchronized (device) {
+                insets = device.getInsets();
+                if (insets == null) {
+                    insets = getScreenInsetsImpl(gc);
+                    device.setInsets(insets);
+                }
             }
-
-            return (Insets)insets.clone();
         }
+        return (Insets) insets.clone();
     }
 
     /*

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,6 +116,7 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
@@ -355,9 +356,15 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
                         try {
                             ((X11GraphicsEnvironment)GraphicsEnvironment.
                              getLocalGraphicsEnvironment()).rebuildDevices();
+                            resetScreenInsetsCache();
                         } finally {
                             awtLock();
                         }
+                    } else {
+                        final XAtom XA_NET_WORKAREA = XAtom.get("_NET_WORKAREA");
+                        final boolean rootWindowWorkareaResized = (ev.get_type() == XConstants.PropertyNotify
+                                && ev.get_xproperty().get_atom() == XA_NET_WORKAREA.getAtom());
+                        if (rootWindowWorkareaResized) resetScreenInsetsCache();
                     }
                 }
             });
@@ -843,8 +850,7 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
      * When two screens overlap and the first contains a dock(*****), then
      * _NET_WORKAREA may start at point x1,y1 and end at point x2,y2.
      */
-    @Override
-    public Insets getScreenInsets(final GraphicsConfiguration gc) {
+    private Insets getScreenInsetsImpl(final GraphicsConfiguration gc) {
         GraphicsDevice gd = gc.getDevice();
         XNETProtocol np = XWM.getWM().getNETProtocol();
         if (np == null || !(gd instanceof X11GraphicsDevice) || !np.active()) {
@@ -870,6 +876,16 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
         } finally {
             XToolkit.awtUnlock();
         }
+    }
+
+    private final Hashtable<GraphicsConfiguration, Insets> cachedInsets = new Hashtable<>();
+    private void resetScreenInsetsCache() {
+        cachedInsets.clear();
+    }
+
+    @Override
+    public Insets getScreenInsets(final GraphicsConfiguration gc) {
+        return (Insets)cachedInsets.computeIfAbsent(gc, this::getScreenInsetsImpl).clone();
     }
 
     /*

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -66,6 +66,7 @@ public final class X11GraphicsDevice extends GraphicsDevice
     private static Boolean xrandrExtSupported;
     private SunDisplayChanger topLevels = new SunDisplayChanger();
     private DisplayMode origDisplayMode;
+    private Rectangle bounds;
     private boolean shutdownHookRegistered;
     private int scale;
 
@@ -129,25 +130,10 @@ public final class X11GraphicsDevice extends GraphicsDevice
         return rect;
     }
 
-    private volatile Rectangle boundsCached;
-
-    private Rectangle getBoundsCached() {
-        final Rectangle localBoundsCached = boundsCached;
-        if (localBoundsCached == null) {
-            final Rectangle newBounds = getBoundsImpl();
-            boundsCached = newBounds;
-            return newBounds;
-        } else {
-            return localBoundsCached;
-        }
-    }
-
-    public void resetBoundsCache() {
-        boundsCached = null;
-    }
-
     public Rectangle getBounds() {
-        return new Rectangle(getBoundsCached());
+        synchronized (this) {
+            return bounds.getBounds();
+        }
     }
 
     /**
@@ -537,6 +523,7 @@ public final class X11GraphicsDevice extends GraphicsDevice
     @Override
     public synchronized void displayChanged() {
         scale = initScaleFactor();
+        bounds = getBoundsImpl();
         // On X11 the visuals do not change, and therefore we don't need
         // to reset the defaultConfig, config, doubleBufferVisuals,
         // neither do we need to reset the native data.
@@ -601,6 +588,5 @@ public final class X11GraphicsDevice extends GraphicsDevice
         assert XToolkit.isAWTLockHeldByCurrentThread();
 
         screen = device.screen;
-        resetBoundsCache();
     }
 }

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -30,6 +30,7 @@ import java.awt.DisplayMode;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.security.AccessController;
@@ -37,6 +38,7 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Objects;
 
 import sun.awt.util.ThreadGroupUtils;
 import sun.java2d.SunGraphicsEnvironment;
@@ -67,6 +69,7 @@ public final class X11GraphicsDevice extends GraphicsDevice
     private SunDisplayChanger topLevels = new SunDisplayChanger();
     private DisplayMode origDisplayMode;
     private Rectangle bounds;
+    private Insets    insets;
     private boolean shutdownHookRegistered;
     private int scale;
 
@@ -134,6 +137,25 @@ public final class X11GraphicsDevice extends GraphicsDevice
     public Rectangle getBounds() {
         synchronized (this) {
             return bounds.getBounds();
+        }
+    }
+
+    public Insets getInsets() {
+        synchronized (this) {
+            return insets;
+        }
+    }
+
+    public void setInsets(Insets newInsets) {
+        Objects.requireNonNull(newInsets);
+        synchronized (this) {
+            insets = newInsets;
+        }
+    }
+
+    public void resetInsets() {
+        synchronized (this) {
+            insets = null;
         }
     }
 
@@ -525,6 +547,7 @@ public final class X11GraphicsDevice extends GraphicsDevice
     public synchronized void displayChanged() {
         scale = initScaleFactor();
         bounds = getBoundsImpl();
+        insets = null;
         // On X11 the visuals do not change, and therefore we don't need
         // to reset the defaultConfig, config, doubleBufferVisuals,
         // neither do we need to reset the native data.

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -73,6 +73,7 @@ public final class X11GraphicsDevice extends GraphicsDevice
     public X11GraphicsDevice(int screennum) {
         this.screen = screennum;
         this.scale = initScaleFactor();
+        this.bounds = getBoundsImpl();
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -68,8 +68,8 @@ public final class X11GraphicsDevice extends GraphicsDevice
     private static Boolean xrandrExtSupported;
     private SunDisplayChanger topLevels = new SunDisplayChanger();
     private DisplayMode origDisplayMode;
-    private Rectangle bounds;
-    private Insets    insets;
+    private volatile Rectangle bounds;
+    private volatile Insets insets;
     private boolean shutdownHookRegistered;
     private int scale;
 
@@ -135,28 +135,20 @@ public final class X11GraphicsDevice extends GraphicsDevice
     }
 
     public Rectangle getBounds() {
-        synchronized (this) {
-            return bounds.getBounds();
-        }
+        return bounds.getBounds();
     }
 
     public Insets getInsets() {
-        synchronized (this) {
-            return insets;
-        }
+        return insets;
     }
 
     public void setInsets(Insets newInsets) {
         Objects.requireNonNull(newInsets);
-        synchronized (this) {
-            insets = newInsets;
-        }
+        insets = newInsets;
     }
 
     public void resetInsets() {
-        synchronized (this) {
-            insets = null;
-        }
+        insets = null;
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -257,6 +257,9 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
                 // no more references to this device, remove it
                 it.remove();
             }
+        }
+        for (final X11GraphicsDevice gd : devices.values()) {
+            gd.resetBoundsCache();
         }
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -258,9 +258,6 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
                 it.remove();
             }
         }
-        for (final X11GraphicsDevice gd : devices.values()) {
-            gd.resetBoundsCache();
-        }
     }
 
     @Override


### PR DESCRIPTION
Getting bounds of a `GraphicsDevice` and insets of a screen are fairly frequent operations. When working over the network (remote X session), those can take several *seconds* to complete, introducing repeated freezes even when typing in an editor feels only slightly sluggish.

On the other hand, neither bounds nor insets change very often - if at all - during the lifetime of an application. So caching their values seems like a natural solution to the problem. The caches need to be reset only when there's a possibility of change in the screens configuration.

A similar patch has been living in [JetBrains Runtime](https://github.com/JetBrains/JetBrainsRuntime/) for well over a year.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305578](https://bugs.openjdk.org/browse/JDK-8305578): X11GraphicsDevice.pGetBounds() is slow in remote X11 sessions


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer) ⚠️ Review applies to [670df083](https://git.openjdk.org/jdk/pull/13346/files/670df083c70a84d69df7409621ccbaf86ca9fdc0)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13346/head:pull/13346` \
`$ git checkout pull/13346`

Update a local copy of the PR: \
`$ git checkout pull/13346` \
`$ git pull https://git.openjdk.org/jdk.git pull/13346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13346`

View PR using the GUI difftool: \
`$ git pr show -t 13346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13346.diff">https://git.openjdk.org/jdk/pull/13346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13346#issuecomment-1497113785)