### PR TITLE
JDK-8170945: Collectors$Partition should override more Map methods

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -1973,6 +1973,25 @@ public final class Collectors {
         }
 
         @Override
+        public int size() {
+            return 2;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public T get(Object key) {
+            if (key instanceof Boolean b) {
+                return b.booleanValue() ? forTrue : forFalse;
+            } else {
+                return null;
+            }
+        }
+
+        @Override
         public Set<Map.Entry<Boolean, T>> entrySet() {
             return new AbstractSet<>() {
                 @Override

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -1992,6 +1992,16 @@ public final class Collectors {
         }
 
         @Override
+        public boolean containsKey(Object key) {
+            return key instanceof Boolean;
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return Objects.equals(value, forTrue) || Objects.equals(value, forFalse);
+        }
+
+        @Override
         public Set<Map.Entry<Boolean, T>> entrySet() {
             return new AbstractSet<>() {
                 @Override


### PR DESCRIPTION
Adds overrides for common Map operations to avoid having to allocate the entrySet for Collectors$Partition maps.