### PR TITLE
JDK-8305644: IGV: Node text not updated when switching from/to CFG view

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -118,6 +118,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
 
     public void setShowCFG(boolean enable) {
         showCFG = enable;
+        diagram.setCFG(enable);
         if (enable) {
             diagramChangedEvent.fire();
         }
@@ -469,7 +470,6 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     }
 
     public Diagram getDiagram() {
-        diagram.setCFG(getShowCFG());
         return diagram;
     }
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -469,6 +469,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     }
 
     public Diagram getDiagram() {
+        diagram.setCFG(getShowCFG());
         return diagram;
     }
 


### PR DESCRIPTION
When switching the layouting mode to or from CFG the node text is not updated.

- Switching to `CFG view` gave the wrong node text: 
<img width="487" alt="fail_to" src="https://user-images.githubusercontent.com/71546117/230041157-9f6613ef-112c-44d6-8263-63f33c9e56e3.png">
- with this fix it looks like this
<img width="514" alt="fix_to" src="https://user-images.githubusercontent.com/71546117/230041139-09f10865-958c-415c-96fe-b036cc2c061a.png">

- Switching from `CFG view` gave the wrong node text: 
<img width="682" alt="fail_from" src="https://user-images.githubusercontent.com/71546117/230041151-7c56e33e-7fd2-46cb-b73d-70a7d194f666.png">
- with this fix it looks like this
<img width="599" alt="fix-from" src="https://user-images.githubusercontent.com/71546117/230041147-734d1fd0-507b-462e-a4d2-d8b039f333dc.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305644](https://bugs.openjdk.org/browse/JDK-8305644): IGV: Node text not updated when switching from/to CFG view


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13348/head:pull/13348` \
`$ git checkout pull/13348`

Update a local copy of the PR: \
`$ git checkout pull/13348` \
`$ git pull https://git.openjdk.org/jdk.git pull/13348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13348`

View PR using the GUI difftool: \
`$ git pr show -t 13348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13348.diff">https://git.openjdk.org/jdk/pull/13348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13348#issuecomment-1497205454)