### PR TITLE
JDK-8305646: compile error on Alpine with gcc12 after 8298619 in libGetXSpace.c

### DIFF
--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -28,7 +28,7 @@
 #include <fileapi.h>
 #include <winerror.h>
 #else
-#include <sys/errno.h>
+#include <errno.h>
 #include <string.h>
 #if __APPLE__
 #include <sys/param.h>


### PR DESCRIPTION
On Alpine Linux, using gcc12, we run now into this compile warning as error :
In file included from /openjdk/linuxmuslx86_64/jdk/test/jdk/java/io/File/libGetXSpace.c:31:
/usr/include/sys/errno.h:1:2: error: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
      | ^~~~~~~
cc1: all warnings being treated as errors

We probably better just include <errno.h> like it is done at almost all other places in the codebase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305646](https://bugs.openjdk.org/browse/JDK-8305646): compile error on Alpine with gcc12 after 8298619 in libGetXSpace.c


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13349/head:pull/13349` \
`$ git checkout pull/13349`

Update a local copy of the PR: \
`$ git checkout pull/13349` \
`$ git pull https://git.openjdk.org/jdk.git pull/13349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13349`

View PR using the GUI difftool: \
`$ git pr show -t 13349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13349.diff">https://git.openjdk.org/jdk/pull/13349.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13349#issuecomment-1497292433)