### PR TITLE
8305650: os::lasterror incorrectly truncates buffer in os_windows.cpp

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2150,7 +2150,7 @@ size_t os::lasterror(char* buf, size_t len) {
     size_t n = strlen(s);
     if (n >= len) n = len - 1;
     strncpy(buf, s, n);
-    buf[n] = '\0';
+    buf[n + 1] = '\0';
     return n;
   }
 


### PR DESCRIPTION
n in os::lasterror defined by os_windows.cpp is only the length of the string's actual character data, not accounting for the null character terminating the string. We should terminate the n + 1 character, not the n'th character

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305650](https://bugs.openjdk.org/browse/JDK-8305650): os::lasterror incorrectly truncates buffer in os_windows.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13350/head:pull/13350` \
`$ git checkout pull/13350`

Update a local copy of the PR: \
`$ git checkout pull/13350` \
`$ git pull https://git.openjdk.org/jdk.git pull/13350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13350`

View PR using the GUI difftool: \
`$ git pr show -t 13350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13350.diff">https://git.openjdk.org/jdk/pull/13350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13350#issuecomment-1497347606)