### PR TITLE
8305659: ProblemList com/sun/jdi/PopAndInvokeTest.java with virtual threads

### DIFF
--- a/test/jdk/ProblemList-svc-vthread.txt
+++ b/test/jdk/ProblemList-svc-vthread.txt
@@ -53,7 +53,7 @@ com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/StepTest.java 8285422 generic-all
 com/sun/jdi/redefine/RedefineTest.java 8285422 generic-all
 com/sun/jdi/redefineMethod/RedefineTest.java 8285422 generic-all
-com/sun/jdi/PopAndInvokeTest.java 8305659 generic-all
+com/sun/jdi/PopAndInvokeTest.java 8305632 generic-all
 
 ####
 # JDI SDE Tests

--- a/test/jdk/ProblemList-svc-vthread.txt
+++ b/test/jdk/ProblemList-svc-vthread.txt
@@ -53,6 +53,7 @@ com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/StepTest.java 8285422 generic-all
 com/sun/jdi/redefine/RedefineTest.java 8285422 generic-all
 com/sun/jdi/redefineMethod/RedefineTest.java 8285422 generic-all
+com/sun/jdi/PopAndInvokeTest.java 8305659 generic-all
 
 ####
 # JDI SDE Tests


### PR DESCRIPTION
A trivial fix to ProblemList com/sun/jdi/PopAndInvokeTest.java with virtual threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305659](https://bugs.openjdk.org/browse/JDK-8305659): ProblemList com/sun/jdi/PopAndInvokeTest.java with virtual threads


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13351/head:pull/13351` \
`$ git checkout pull/13351`

Update a local copy of the PR: \
`$ git checkout pull/13351` \
`$ git pull https://git.openjdk.org/jdk.git pull/13351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13351`

View PR using the GUI difftool: \
`$ git pr show -t 13351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13351.diff">https://git.openjdk.org/jdk/pull/13351.diff</a>

</details>
