### PR TITLE
JDK-8304350:  Font.getStringBounds calculates wrong width for TextAttribute.TRACKING other than 0.0

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -2629,8 +2629,10 @@ public class Font implements java.io.Serializable
         // quick check for simple text, assume GV ok to use if simple
 
         boolean simple = values == null ||
-            (values.getKerning() == 0 && values.getLigatures() == 0 &&
-              values.getBaselineTransform() == null);
+            (values.getKerning() == 0
+             && values.getLigatures() == 0
+             && values.getTracking() == 0
+             && values.getBaselineTransform() == null);
         if (simple) {
             simple = ! FontUtilities.isComplexText(chars, beginIndex, limit);
         }


### PR DESCRIPTION
This is one proposed solution for https://bugs.openjdk.org/browse/JDK-8304350

`java.awt.Font.getStringBounds(char[],int,int,FontRenderContext)` applies a heuristic to determine whether the question it's answering is "simple" or not. The bug described in 8304350 only occurs in the simple=true branch.

Extend the "simple?" heuristic to consider a tracking attribute not-simple and to use the complex branch in those cases.

One could argue that the root bug still exists: the simple path goes on to delegate to `sun.font.FontDesignMetrics.getMetrics(Font,FontRenderContext)`, although that's a private/internal API.