### PR TITLE
8305664: [BACKOUT] (fs) Remove FileSystem support for resolving against a default directory (chdir configuration)

### DIFF
--- a/src/java.base/aix/classes/sun/nio/fs/AixFileSystem.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,8 +38,8 @@ import static sun.nio.fs.AixNativeDispatcher.*;
 
 class AixFileSystem extends UnixFileSystem {
 
-    AixFileSystem(UnixFileSystemProvider provider) {
-        super(provider);
+    AixFileSystem(UnixFileSystemProvider provider, String dir) {
+        super(provider, dir);
     }
 
     @Override

--- a/src/java.base/aix/classes/sun/nio/fs/AixFileSystemProvider.java
+++ b/src/java.base/aix/classes/sun/nio/fs/AixFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,8 +38,8 @@ class AixFileSystemProvider extends UnixFileSystemProvider {
     }
 
     @Override
-    AixFileSystem newFileSystem() {
-        return new AixFileSystem(this);
+    AixFileSystem newFileSystem(String dir) {
+        return new AixFileSystem(this, dir);
     }
 
     /**

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxFileSystem.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import static sun.nio.fs.UnixConstants.*;
  */
 
 class LinuxFileSystem extends UnixFileSystem {
-    LinuxFileSystem(UnixFileSystemProvider provider) {
-        super(provider);
+    LinuxFileSystem(UnixFileSystemProvider provider, String dir) {
+        super(provider, dir);
     }
 
     @Override

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxFileSystemProvider.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ class LinuxFileSystemProvider extends UnixFileSystemProvider {
     }
 
     @Override
-    LinuxFileSystem newFileSystem() {
-        return new LinuxFileSystem(this);
+    LinuxFileSystem newFileSystem(String dir) {
+        return new LinuxFileSystem(this, dir);
     }
 
     @Override

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ import static sun.nio.fs.UnixNativeDispatcher.unlink;
 
 class BsdFileSystem extends UnixFileSystem {
 
-    BsdFileSystem(UnixFileSystemProvider provider) {
-        super(provider);
+    BsdFileSystem(UnixFileSystemProvider provider, String dir) {
+        super(provider, dir);
     }
 
     @Override

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystemProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ class BsdFileSystemProvider extends UnixFileSystemProvider {
     }
 
     @Override
-    BsdFileSystem newFileSystem() {
-        return new BsdFileSystem(this);
+    BsdFileSystem newFileSystem(String dir) {
+        return new BsdFileSystem(this, dir);
     }
 
     @Override

--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,8 @@ class MacOSXFileSystem extends BsdFileSystem {
             && ("".equals(value) || Boolean.parseBoolean(value));
     }
 
-    MacOSXFileSystem(UnixFileSystemProvider provider) {
-        super(provider);
+    MacOSXFileSystem(UnixFileSystemProvider provider, String dir) {
+        super(provider, dir);
     }
 
     boolean isCaseInsensitiveAndPreserving() {

--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystemProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ class MacOSXFileSystemProvider extends BsdFileSystemProvider {
     }
 
     @Override
-    MacOSXFileSystem newFileSystem() {
-        return new MacOSXFileSystem(this);
+    MacOSXFileSystem newFileSystem(String dir) {
+        return new MacOSXFileSystem(this, dir);
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public abstract class UnixFileSystemProvider
     private final UnixFileSystem theFileSystem;
 
     public UnixFileSystemProvider() {
-        theFileSystem = newFileSystem();
+        theFileSystem = newFileSystem(StaticProperty.userDir());
     }
 
     UnixFileSystem theFileSystem() {
@@ -83,9 +83,9 @@ public abstract class UnixFileSystemProvider
     }
 
     /**
-     * Constructs a new file system.
+     * Constructs a new file system using the given default directory.
      */
-    abstract UnixFileSystem newFileSystem();
+    abstract UnixFileSystem newFileSystem(String dir);
 
     @Override
     public final String getScheme() {

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,11 @@ class UnixNativeDispatcher {
         buffer.setOwner(path);
         return buffer;
     }
+
+    /**
+     * char *getcwd(char *buf, size_t size);
+     */
+    static native byte[] getcwd();
 
     /**
      * int dup(int filedes)

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -322,6 +322,25 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
 #endif
 
     return capabilities;
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_sun_nio_fs_UnixNativeDispatcher_getcwd(JNIEnv* env, jclass this) {
+    jbyteArray result = NULL;
+    char buf[PATH_MAX+1];
+
+    /* EINTR not listed as a possible error */
+    char* cwd = getcwd(buf, sizeof(buf));
+    if (cwd == NULL) {
+        throwUnixException(env, errno);
+    } else {
+        jsize len = (jsize)strlen(buf);
+        result = (*env)->NewByteArray(env, len);
+        if (result != NULL) {
+            (*env)->SetByteArrayRegion(env, result, 0, len, (jbyte*)buf);
+        }
+    }
+    return result;
 }
 
 JNIEXPORT jbyteArray

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -31,7 +31,6 @@ import java.nio.file.spi.*;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.io.IOException;
-import jdk.internal.util.StaticProperty;
 
 class WindowsFileSystem
     extends FileSystem
@@ -43,11 +42,12 @@ class WindowsFileSystem
     private final String defaultRoot;
 
     // package-private
-    WindowsFileSystem(WindowsFileSystemProvider provider) {
+    WindowsFileSystem(WindowsFileSystemProvider provider,
+                      String dir)
+    {
         this.provider = provider;
 
         // parse default directory and check it is absolute
-        String dir = StaticProperty.userDir();
         WindowsPathParser.Result result = WindowsPathParser.parse(dir);
 
         if ((result.type() != WindowsPathType.ABSOLUTE) &&

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.util.concurrent.ExecutorService;
 import java.io.*;
 import java.util.*;
+import jdk.internal.util.StaticProperty;
 import sun.nio.ch.ThreadPool;
 import sun.security.util.SecurityConstants;
 
@@ -48,7 +49,7 @@ class WindowsFileSystemProvider
     private final WindowsFileSystem theFileSystem;
 
     public WindowsFileSystemProvider() {
-        theFileSystem = new WindowsFileSystem(this);
+        theFileSystem = new WindowsFileSystem(this, StaticProperty.userDir());
     }
 
     WindowsFileSystem theFileSystem() {


### PR DESCRIPTION
Revert removal of FileSystem resolution against a default directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305664](https://bugs.openjdk.org/browse/JDK-8305664): [BACKOUT] (fs) Remove FileSystem support for resolving against a default directory (chdir configuration)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13355/head:pull/13355` \
`$ git checkout pull/13355`

Update a local copy of the PR: \
`$ git checkout pull/13355` \
`$ git pull https://git.openjdk.org/jdk.git pull/13355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13355`

View PR using the GUI difftool: \
`$ git pr show -t 13355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13355.diff">https://git.openjdk.org/jdk/pull/13355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13355#issuecomment-1497716586)