### PR TITLE
8305666: Add system property for fair AWT lock

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -231,7 +231,9 @@ public abstract class SunToolkit extends Toolkit
      *     }
      */
 
-    private static final ReentrantLock AWT_LOCK = new ReentrantLock();
+    @SuppressWarnings("removal")
+    private static final ReentrantLock AWT_LOCK = new ReentrantLock(
+            AccessController.doPrivileged(new GetBooleanAction("awt.lock.fair")));
     private static final Condition AWT_LOCK_COND = AWT_LOCK.newCondition();
 
     public static final void awtLock() {


### PR DESCRIPTION
There are freezes reported on some Linux configurations which are believed to may be caused by the toolkit thread quickly reacquiring AWT_LOCK while polling for events, which starves EDT waiting on that lock.
Adding new `awt.lock.fair` system property can help diagnosing such issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305666](https://bugs.openjdk.org/browse/JDK-8305666): Add system property for fair AWT lock


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13356/head:pull/13356` \
`$ git checkout pull/13356`

Update a local copy of the PR: \
`$ git checkout pull/13356` \
`$ git pull https://git.openjdk.org/jdk.git pull/13356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13356`

View PR using the GUI difftool: \
`$ git pr show -t 13356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13356.diff">https://git.openjdk.org/jdk/pull/13356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13356#issuecomment-1497749076)