### PR TITLE
8304738: UnregisteredClassesTable_lock never created

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -522,7 +522,7 @@ void SystemDictionaryShared::handle_class_unloading(InstanceKlass* klass) {
     remove_dumptime_info(klass);
   }
 
-  {
+  if (Arguments::is_dumping_archive() || ClassListWriter::is_enabled()) {
     MutexLocker ml(Thread::current(), UnregisteredClassesTable_lock, Mutex::_no_safepoint_check_flag);
     if (_unregistered_classes_table != nullptr) {
       // Remove the class from _unregistered_classes_table: keep the entry but
@@ -533,6 +533,8 @@ void SystemDictionaryShared::handle_class_unloading(InstanceKlass* klass) {
         *v = nullptr;
       }
     }
+  } else {
+    assert(_unregistered_classes_table == nullptr, "must not be used");
   }
 
   if (ClassListWriter::is_enabled()) {

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -522,14 +522,16 @@ void SystemDictionaryShared::handle_class_unloading(InstanceKlass* klass) {
     remove_dumptime_info(klass);
   }
 
-  if (_unregistered_classes_table != nullptr) {
-    // Remove the class from _unregistered_classes_table: keep the entry but
-    // set it to null. This ensure no classes with the same name can be
-    // added again.
+  {
     MutexLocker ml(Thread::current(), UnregisteredClassesTable_lock, Mutex::_no_safepoint_check_flag);
-    InstanceKlass** v = _unregistered_classes_table->get(klass->name());
-    if (v != nullptr) {
-      *v = nullptr;
+    if (_unregistered_classes_table != nullptr) {
+      // Remove the class from _unregistered_classes_table: keep the entry but
+      // set it to null. This ensure no classes with the same name can be
+      // added again.
+      InstanceKlass** v = _unregistered_classes_table->get(klass->name());
+      if (v != nullptr) {
+        *v = nullptr;
+      }
     }
   }
 

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -438,7 +438,7 @@ bool SystemDictionaryShared::add_unregistered_class(Thread* current, InstanceKla
   // We only archive the first class with that name that succeeds putting
   // itself into the table.
   assert(Arguments::is_dumping_archive() || ClassListWriter::is_enabled(), "sanity");
-  MutexLocker ml(current, UnregisteredClassesTable_lock);
+  MutexLocker ml(current, UnregisteredClassesTable_lock, Mutex::_no_safepoint_check_flag);
   Symbol* name = klass->name();
   if (_unregistered_classes_table == nullptr) {
     _unregistered_classes_table = new (mtClass)UnregisteredClassesTable();
@@ -526,7 +526,7 @@ void SystemDictionaryShared::handle_class_unloading(InstanceKlass* klass) {
     // Remove the class from _unregistered_classes_table: keep the entry but
     // set it to null. This ensure no classes with the same name can be
     // added again.
-    MutexLocker ml(Thread::current(), UnregisteredClassesTable_lock);
+    MutexLocker ml(Thread::current(), UnregisteredClassesTable_lock, Mutex::_no_safepoint_check_flag);
     InstanceKlass** v = _unregistered_classes_table->get(klass->name());
     if (v != nullptr) {
       *v = nullptr;

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -324,6 +324,7 @@ void mutex_init() {
   MUTEX_DEFN(CDSLambda_lock                  , PaddedMutex  , nosafepoint);
   MUTEX_DEFN(DumpRegion_lock                 , PaddedMutex  , nosafepoint);
   MUTEX_DEFN(ClassListFile_lock              , PaddedMutex  , nosafepoint);
+  MUTEX_DEFN(UnregisteredClassesTable_lock   , PaddedMutex  , nosafepoint-1);
   MUTEX_DEFN(LambdaFormInvokers_lock         , PaddedMutex  , safepoint);
   MUTEX_DEFN(ScratchObjects_lock             , PaddedMutex  , nosafepoint-1); // Holds DumpTimeTable_lock
 #endif // INCLUDE_CDS


### PR DESCRIPTION
UnregisteredClassesTable_lock is never created in mutex_init() and is always nullptr. This lock is referenced in a few places and all of those are effectively thread unsafe. Some of the places `unregistered_classes_table` is accessed are under other locks, so the rank of this lock has to be adjusted appropriately. The lock will be initialized to enable the intended behavior. Verified with tier 1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304738](https://bugs.openjdk.org/browse/JDK-8304738): UnregisteredClassesTable_lock never created


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Justin King](https://openjdk.org/census#jcking) (@jcking - Committer) ⚠️ Review applies to [be1a754a](https://git.openjdk.org/jdk/pull/13358/files/be1a754a1c65a9431022bb7940e4f2a9f74f60f9)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13358/head:pull/13358` \
`$ git checkout pull/13358`

Update a local copy of the PR: \
`$ git checkout pull/13358` \
`$ git pull https://git.openjdk.org/jdk.git pull/13358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13358`

View PR using the GUI difftool: \
`$ git pr show -t 13358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13358.diff">https://git.openjdk.org/jdk/pull/13358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13358#issuecomment-1497842585)