### PR TITLE
8305667: Some fonts installed in user directory are not detected on Windows

### DIFF
--- a/src/java.desktop/windows/native/libfontmanager/fontpath.c
+++ b/src/java.desktop/windows/native/libfontmanager/fontpath.c
@@ -516,9 +516,10 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
                                                 GdiFontMapInfo *fmi,
                                                 jobject fontToFileMap)
 {
-#define MAX_BUFFER (FILENAME_MAX+1)
-    const wchar_t wname[MAX_BUFFER];
-    const char data[MAX_BUFFER];
+#define MAX_NAME_BUFFER (MAX_PATH+1)
+#define MAX_DATA_BUFFER (MAX_PATH*2+2)
+    const wchar_t wname[MAX_NAME_BUFFER];
+    const char data[MAX_DATA_BUFFER];
 
     DWORD type;
     LONG ret;
@@ -540,14 +541,14 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
                            &dwMaxValueDataLen, NULL, NULL);
 
     if (ret != ERROR_SUCCESS ||
-        dwMaxValueNameLen >= MAX_BUFFER ||
-        dwMaxValueDataLen >= MAX_BUFFER) {
+        dwMaxValueNameLen >= MAX_NAME_BUFFER ||
+        dwMaxValueDataLen >= MAX_DATA_BUFFER) {
         RegCloseKey(hkeyFonts);
         return;
     }
     for (nval = 0; nval < dwNumValues; nval++ ) {
-        dwNameSize = MAX_BUFFER;
-        dwDataValueSize = MAX_BUFFER;
+        dwNameSize = MAX_NAME_BUFFER;
+        dwDataValueSize = MAX_DATA_BUFFER;
         ret = RegEnumValueW(hkeyFonts, nval, (LPWSTR)wname, &dwNameSize,
                             NULL, &type, (LPBYTE)data, &dwDataValueSize);
 

--- a/src/java.desktop/windows/native/libfontmanager/fontpath.c
+++ b/src/java.desktop/windows/native/libfontmanager/fontpath.c
@@ -26,6 +26,7 @@
 #include <windows.h>
 #include <strsafe.h>
 #include <stdio.h>
+#include <malloc.h>
 
 #include <jni.h>
 #include <jni_util.h>
@@ -516,16 +517,9 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
                                                 GdiFontMapInfo *fmi,
                                                 jobject fontToFileMap)
 {
-#define MAX_NAME_BUFFER (MAX_PATH+1)
-#define MAX_DATA_BUFFER (MAX_PATH*2+2)
-    const wchar_t wname[MAX_NAME_BUFFER];
-    const char data[MAX_DATA_BUFFER];
-
     DWORD type;
     LONG ret;
     HKEY hkeyFonts;
-    DWORD dwNameSize;
-    DWORD dwDataValueSize;
     DWORD nval;
     DWORD dwNumValues, dwMaxValueNameLen, dwMaxValueDataLen;
 
@@ -540,16 +534,17 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
                            &dwNumValues, &dwMaxValueNameLen,
                            &dwMaxValueDataLen, NULL, NULL);
 
-    if (ret != ERROR_SUCCESS ||
-        dwMaxValueNameLen >= MAX_NAME_BUFFER ||
-        dwMaxValueDataLen >= MAX_DATA_BUFFER) {
+    if (ret != ERROR_SUCCESS) {
         RegCloseKey(hkeyFonts);
         return;
     }
+    dwMaxValueNameLen++; /* Account for NULL-terminator */
+    wchar_t *wname = (wchar_t*)malloc(dwMaxValueNameLen * sizeof(wchar_t));
+    wchar_t *data = (wchar_t*)malloc(dwMaxValueDataLen);
     for (nval = 0; nval < dwNumValues; nval++ ) {
-        dwNameSize = MAX_NAME_BUFFER;
-        dwDataValueSize = MAX_DATA_BUFFER;
-        ret = RegEnumValueW(hkeyFonts, nval, (LPWSTR)wname, &dwNameSize,
+        DWORD dwNameSize = dwMaxValueNameLen;
+        DWORD dwDataValueSize = dwMaxValueDataLen;
+        ret = RegEnumValueW(hkeyFonts, nval, wname, &dwNameSize,
                             NULL, &type, (LPBYTE)data, &dwDataValueSize);
 
         if (ret != ERROR_SUCCESS) {
@@ -559,20 +554,22 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
             continue;
         }
 
-        if (!RegistryToBaseTTNameW((LPWSTR)wname) ) {
+        if (!RegistryToBaseTTNameW(wname) ) {
             /* If the filename ends with ".ttf" or ".otf" also accept it.
              * Not expecting to need to do this for .ttc files.
              * Also note this code is not mirrored in the "A" (win9x) path.
              */
-            LPWSTR dot = wcsrchr((LPWSTR)data, L'.');
+            LPWSTR dot = wcsrchr(data, L'.');
             if (dot == NULL || ((wcsicmp(dot, L".ttf") != 0)
                                   && (wcsicmp(dot, L".otf") != 0))) {
                 continue;  /* not a TT font... */
             }
         }
-        registerFontW(fmi, fontToFileMap, (LPWSTR)wname, (LPWSTR)data);
+        registerFontW(fmi, fontToFileMap, wname, data);
     }
 
+    free(wname);
+    free(data);
     RegCloseKey(hkeyFonts);
 }
 


### PR DESCRIPTION
`data` array has size of `MAX_BUFFER` like `wname`, but it has a char type, so its size is twice smaller than actual path limit, because paths returned by `RegEnumValueW` use wide chars. We need to double this limit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305667](https://bugs.openjdk.org/browse/JDK-8305667): Some fonts installed in user directory are not detected on Windows (**Bug** - P4)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer) ⚠️ Review applies to [63d26f84](https://git.openjdk.org/jdk/pull/13359/files/63d26f847c16c721626a6a5d4ff1cdbd744485b4)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13359/head:pull/13359` \
`$ git checkout pull/13359`

Update a local copy of the PR: \
`$ git checkout pull/13359` \
`$ git pull https://git.openjdk.org/jdk.git pull/13359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13359`

View PR using the GUI difftool: \
`$ git pr show -t 13359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13359.diff">https://git.openjdk.org/jdk/pull/13359.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13359#issuecomment-1497844783)