### PR TITLE
8305600: java/lang/invoke/lambda/LogGeneratedClassesTest.java fails after JDK-8304846 and JDK-8202110

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -484,7 +484,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
-java/lang/invoke/lambda/LogGeneratedClassesTest.java            8305600 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The test failure was caused by [JDK-8202110](https://bugs.openjdk.org/browse/JDK-8202110) if  `-Duser.dir` is set to a path different from current working directory. JDK-8202110 has been backout ([JDK-8305664](https://bugs.openjdk.org/browse/JDK-8305664)).

This PR removes the test from the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305600](https://bugs.openjdk.org/browse/JDK-8305600): java/lang/invoke/lambda/LogGeneratedClassesTest.java fails after JDK-8304846 and JDK-8202110


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13364/head:pull/13364` \
`$ git checkout pull/13364`

Update a local copy of the PR: \
`$ git checkout pull/13364` \
`$ git pull https://git.openjdk.org/jdk.git pull/13364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13364`

View PR using the GUI difftool: \
`$ git pr show -t 13364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13364.diff">https://git.openjdk.org/jdk/pull/13364.diff</a>

</details>
