### PR TITLE
8305678: ProblemList serviceability/sa/ClhsdbInspect.java on windows-x64 in Xcomp

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -41,3 +41,5 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
 
 gc/cslocker/TestCSLocker.java 8293289 generic-x64
+
+serviceability/sa/ClhsdbInspect.java 8283578 windows-x64

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -27,4 +27,4 @@
 #
 #############################################################################
 
-java/util/concurrent/locks/Lock/OOMEInAQS.java 8298066 windows-x64
+java/util/concurrent/locks/Lock/OOMEInAQS.java 8298066 linux-aarch64,windows-x64


### PR DESCRIPTION
Trivial fixes to ProblemList a couple of tests:
[JDK-8305678](https://bugs.openjdk.org/browse/JDK-8305678) ProblemList serviceability/sa/ClhsdbInspect.java on windows-x64 in Xcomp
[JDK-8305679](https://bugs.openjdk.org/browse/JDK-8305679) ProblemList java/util/concurrent/locks/Lock/OOMEInAQS.java on linux-aarch64 with ZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8305678](https://bugs.openjdk.org/browse/JDK-8305678): ProblemList serviceability/sa/ClhsdbInspect.java on windows-x64 in Xcomp
 * [JDK-8305679](https://bugs.openjdk.org/browse/JDK-8305679): ProblemList java/util/concurrent/locks/Lock/OOMEInAQS.java on linux-aarch64 with ZGC


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13365/head:pull/13365` \
`$ git checkout pull/13365`

Update a local copy of the PR: \
`$ git checkout pull/13365` \
`$ git pull https://git.openjdk.org/jdk.git pull/13365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13365`

View PR using the GUI difftool: \
`$ git pr show -t 13365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13365.diff">https://git.openjdk.org/jdk/pull/13365.diff</a>

</details>
