### PR TITLE
JDK-8269843: typo in LinkedHashMap::removeEldestEntry spec

### DIFF
--- a/src/java.base/share/classes/java/util/LinkedHashMap.java
+++ b/src/java.base/share/classes/java/util/LinkedHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -505,7 +505,7 @@ public class LinkedHashMap<K,V>
      *
      * @param    eldest The least recently inserted entry in the map, or if
      *           this is an access-ordered map, the least recently accessed
-     *           entry.  This is the entry that will be removed it this
+     *           entry.  This is the entry that will be removed if this
      *           method returns {@code true}.  If the map was empty prior
      *           to the {@code put} or {@code putAll} invocation resulting
      *           in this invocation, this will be the entry that was just


### PR DESCRIPTION
Fix a typo in the specification of `java.util.LinkedHashMap.removeEldestEntry(Map.Entry)`.

> This is the entry that will be removed **it** this method returns `true`.

will become:

> This is the entry that will be removed **if** this method returns `true`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269843](https://bugs.openjdk.org/browse/JDK-8269843): typo in LinkedHashMap::removeEldestEntry spec


### Reviewers
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13367/head:pull/13367` \
`$ git checkout pull/13367`

Update a local copy of the PR: \
`$ git checkout pull/13367` \
`$ git pull https://git.openjdk.org/jdk.git pull/13367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13367`

View PR using the GUI difftool: \
`$ git pr show -t 13367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13367.diff">https://git.openjdk.org/jdk/pull/13367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13367#issuecomment-1498350292)