### PR TITLE
8305690: [X86] Do not emit two REX prefixes in Assembler::prefix

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -12547,7 +12547,7 @@ void Assembler::prefix(Register dst, Address adr, Prefix p) {
     if (adr.index_needs_rex()) {
       assert(false, "prefix(Register dst, Address adr, Prefix p) does not support handling of an X");
     } else {
-      prefix(REX_B);
+      p = (Prefix)(p | REX_B);
     }
   } else {
     if (adr.index_needs_rex()) {


### PR DESCRIPTION
Hi all,

This patch prevents `Assembler::prefix` from emitting two `REX prefixes`. The current code in mainline works well because the corresponding code path is not triggered.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305690](https://bugs.openjdk.org/browse/JDK-8305690): [X86] Do not emit two REX prefixes in Assembler::prefix


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13369/head:pull/13369` \
`$ git checkout pull/13369`

Update a local copy of the PR: \
`$ git checkout pull/13369` \
`$ git pull https://git.openjdk.org/jdk.git pull/13369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13369`

View PR using the GUI difftool: \
`$ git pr show -t 13369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13369.diff">https://git.openjdk.org/jdk/pull/13369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13369#issuecomment-1498522719)