### PR TITLE
8305663: Wrong iteration order of pause array in g1MMUTracker

### DIFF
--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -147,7 +147,7 @@ double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
   double limit = current_timestamp + pause_time - _time_slice;
   // Iterate from newest to oldest.
   for (int i = 0; i < _no_entries; ++i) {
-    int index = trim_index(_head_index + i);
+    int index = trim_index(_head_index - i);
     G1MMUTrackerElem *elem = &_array[index];
     // Outside the window.
     if (elem->end_time() <= limit) {


### PR DESCRIPTION
G1 pause _array is iterated from oldest pause to newer pause in order to calculate the pause budget, but it should be iterated in the opposite direction (newest to oldest).