### PR TITLE
8305680: Remove Permissions from jcmd help output

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -193,16 +193,6 @@ void HelpDCmd::execute(DCmdSource source, TRAPS) {
                          factory->is_enabled() ? "" : " [disabled]");
       output()->print_cr("%s", factory->description());
       output()->print_cr("\nImpact: %s", factory->impact());
-      JavaPermission p = factory->permission();
-      if(p._class != nullptr) {
-        if(p._action != nullptr) {
-          output()->print_cr("\nPermission: %s(%s, %s)",
-                  p._class, p._name == nullptr ? "null" : p._name, p._action);
-        } else {
-          output()->print_cr("\nPermission: %s(%s)",
-                  p._class, p._name == nullptr ? "null" : p._name);
-        }
-      }
       output()->cr();
       cmd = factory->create_resource_instance(output());
       if (cmd != nullptr) {


### PR DESCRIPTION
Like the removal of Permission information from the man page in JDK-8305622, this change removes Permission information from the jcmd help output.

These Permissions are not relevant to jcmd users.  The Permissions can be relevant when connecting remotely to JMX with a Security Manager in place. That usage is clearly deprecated with JEP 411.

We don't specifically test for this output, but we have dcmd tests in test/hotspot/jtreg/serviceability which all continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305680](https://bugs.openjdk.org/browse/JDK-8305680): Remove Permissions from jcmd help output


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13371/head:pull/13371` \
`$ git checkout pull/13371`

Update a local copy of the PR: \
`$ git checkout pull/13371` \
`$ git pull https://git.openjdk.org/jdk.git pull/13371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13371`

View PR using the GUI difftool: \
`$ git pr show -t 13371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13371.diff">https://git.openjdk.org/jdk/pull/13371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13371#issuecomment-1498714398)