### PR TITLE
JDK-8305506: Add support for fractional values of SafepointTimeoutDelay

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1289,9 +1289,10 @@ const int ObjectAlignmentInBytes = 8;
           "(0 means none)")                                                 \
           range(0, max_jint)                                                \
                                                                             \
-  product(intx, SafepointTimeoutDelay, 10000,                               \
-          "Delay in milliseconds for option SafepointTimeout")              \
-          range(0, max_intx LP64_ONLY(/MICROUNITS))                         \
+  product(double, SafepointTimeoutDelay, 10000,                             \
+          "Delay in milliseconds for option SafepointTimeout; "             \
+          "supports sub-millisecond resolution with fractional values.")    \
+          range(0, max_jlongDouble LP64_ONLY(/MICROUNITS))                  \
                                                                             \
   product(bool, UseSystemMemoryBarrier, false,                              \
           "Try to enable system memory barrier if supported by OS")         \

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -795,7 +795,7 @@ void SafepointSynchronize::print_safepoint_timeout() {
         os::naked_sleep(3000);
       }
     }
-    fatal("Safepoint sync time longer than " JDOUBLE_FORMAT_P(6) "ms detected when executing %s.",
+    fatal("Safepoint sync time longer than %.6f ms detected when executing %s.",
           SafepointTimeoutDelay, VMThread::vm_operation()->name());
   }
 }

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -379,7 +379,7 @@ void SafepointSynchronize::begin() {
   if (SafepointTimeout) {
     // Set the limit time, so that it can be compared to see if this has taken
     // too long to complete.
-    safepoint_limit_time = SafepointTracing::start_of_safepoint() + (jlong)SafepointTimeoutDelay * NANOSECS_PER_MILLISEC;
+    safepoint_limit_time = SafepointTracing::start_of_safepoint() + (jlong)(SafepointTimeoutDelay * NANOSECS_PER_MILLISEC);
     timeout_error_printed = false;
   }
 

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -379,7 +379,7 @@ void SafepointSynchronize::begin() {
   if (SafepointTimeout) {
     // Set the limit time, so that it can be compared to see if this has taken
     // too long to complete.
-    safepoint_limit_time = SafepointTracing::start_of_safepoint() + (jlong)SafepointTimeoutDelay * (NANOUNITS / MILLIUNITS);
+    safepoint_limit_time = SafepointTracing::start_of_safepoint() + (jlong)SafepointTimeoutDelay * NANOSECS_PER_MILLISEC;
     timeout_error_printed = false;
   }
 
@@ -795,7 +795,7 @@ void SafepointSynchronize::print_safepoint_timeout() {
         os::naked_sleep(3000);
       }
     }
-    fatal("Safepoint sync time longer than " INTX_FORMAT "ms detected when executing %s.",
+    fatal("Safepoint sync time longer than " JDOUBLE_FORMAT_P(6) "ms detected when executing %s.",
           SafepointTimeoutDelay, VMThread::vm_operation()->name());
   }
 }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -166,6 +166,9 @@ class oopDesc;
 #define JULONG_FORMAT_X          UINT64_FORMAT_X
 #endif
 
+// Format jdouble with defined precision
+#define JDOUBLE_FORMAT_P(precision) "%." #precision "f"
+
 // Format pointers which change size between 32- and 64-bit.
 #ifdef  _LP64
 #define INTPTR_FORMAT            "0x%016"     PRIxPTR

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -166,9 +166,6 @@ class oopDesc;
 #define JULONG_FORMAT_X          UINT64_FORMAT_X
 #endif
 
-// Format jdouble with defined precision
-#define JDOUBLE_FORMAT_P(precision) "%." #precision "f"
-
 // Format pointers which change size between 32- and 64-bit.
 #ifdef  _LP64
 #define INTPTR_FORMAT            "0x%016"     PRIxPTR

--- a/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
@@ -50,7 +50,7 @@ public class DoubleFlagWithIntegerValue {
     testDoubleFlagWithValue("-XX:SweeperThreshold", "10");
 
     // Test double format for -XX:SafepointTimeoutDelay
-    testDoubleFlagWithValue("-XX:SafepointTimeoutDelay", "0.050");
+    testDoubleFlagWithValue("-XX:SafepointTimeoutDelay", "5.0");
 
     // Test integer format -XX:SafepointTimeoutDelay
     testDoubleFlagWithValue("-XX:SafepointTimeoutDelay", "5");

--- a/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
@@ -35,18 +35,24 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class DoubleFlagWithIntegerValue {
-  public static void testDoubleFlagWithValue(String value) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:SweeperThreshold=" + value, "-version");
+  public static void testDoubleFlagWithValue(String flag, String value) throws Exception {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flag + "=" + value, "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldNotContain("Improperly specified VM option");
     output.shouldHaveExitValue(0);
   }
 
   public static void main(String[] args) throws Exception {
-    // Test double format
-    testDoubleFlagWithValue("10.0");
+    // Test double format for -XX:SweeperThreshold
+    testDoubleFlagWithValue("-XX:SweeperThreshold", "10.0");
 
-    // Test integer format
-    testDoubleFlagWithValue("10");
+    // Test integer format -XX:SweeperThreshold
+    testDoubleFlagWithValue("-XX:SweeperThreshold", "10");
+
+    // Test double format for -XX:SafepointTimeoutDelay
+    testDoubleFlagWithValue("-XX:SafepointTimeoutDelay", "0.050");
+
+    // Test integer format -XX:SafepointTimeoutDelay
+    testDoubleFlagWithValue("-XX:SafepointTimeoutDelay", "5");
   }
 }


### PR DESCRIPTION
As stated in https://bugs.openjdk.org/browse/JDK-8305506 this change replaces SafepointTimeoutDelay as integer value with a floating point type to support sub-millisecond SafepointTimeout thresholds.
This is immensely useful for investigating time-to-safepoint issues in low latency space.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305506](https://bugs.openjdk.org/browse/JDK-8305506): Add support for fractional values of SafepointTimeoutDelay (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [3b22f3a2](https://git.openjdk.org/jdk/pull/13373/files/3b22f3a2c2ae83d3cb3b974ca5ea898a28b3290e)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13373/head:pull/13373` \
`$ git checkout pull/13373`

Update a local copy of the PR: \
`$ git checkout pull/13373` \
`$ git pull https://git.openjdk.org/jdk.git pull/13373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13373`

View PR using the GUI difftool: \
`$ git pr show -t 13373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13373.diff">https://git.openjdk.org/jdk/pull/13373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13373#issuecomment-1517582612)