### PR TITLE
4825182: DefaultBoundedRangeModel.setMinimum() changes extent unnecessarily

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/DefaultBoundedRangeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultBoundedRangeModel.java
@@ -206,7 +206,12 @@ public class DefaultBoundedRangeModel implements BoundedRangeModel, Serializable
     public void setMinimum(int n) {
         int newMax = Math.max(n, max);
         int newValue = Math.max(n, value);
-        int newExtent = Math.min(newMax - newValue, extent);
+        int newExtent = 0;
+        if (((long)newMax - (long)newValue) > (long)newMax) {
+            newExtent = extent;
+        } else {
+            newExtent = Math.min(newMax - newValue, extent);
+        }
         setRangeProperties(newValue, newExtent, n, newMax, isAdjusting);
     }
 

--- a/test/jdk/javax/swing/RangeTest.java
+++ b/test/jdk/javax/swing/RangeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4825182
+ * @summary Verifies DefaultBoundedRangeModel.setMinimum() doesn't change extent
+ * @run main RangeTest
+ */
+import javax.swing.DefaultBoundedRangeModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+public class RangeTest implements ChangeListener {
+
+    DefaultBoundedRangeModel model;
+
+    static public void main(String s[]) {
+        new RangeTest();
+    }
+
+    public RangeTest() {
+        model = new DefaultBoundedRangeModel(-32768, Integer.MAX_VALUE,
+                                             Integer.MIN_VALUE,
+                                             Integer.MAX_VALUE);
+        model.addChangeListener(this);
+        printState("Initial State");
+        System.out.println("Set min to -32768");
+        int extent = model.getExtent();
+        model.setMinimum(-32768);
+        if (model.getExtent() != extent) {
+            throw new RuntimeException("extent is changed to " + model.getExtent());
+        }
+    }
+
+    public void stateChanged(ChangeEvent e) {
+        printState("... State Changed");
+    }
+
+    private void printState(String msg) {
+        System.out.println(msg + ": value=" + model.getValue()
+                           + ", extent=" + model.getExtent()
+                           + ", min=" + model.getMinimum()
+                           + ", max=" + model.getMaximum());
+    }
+}
+


### PR DESCRIPTION
[DefaultBoundedRangeModel spec](https://docs.oracle.com/en/java/javase/19/docs/api/java.desktop/javax/swing/DefaultBoundedRangeModel.html#%3Cinit%3E(int,int,int,int))
set maximum, minimun., extent as per the constraint "min <= value <= value+extent <= max"
Now, when DefaultBoundedRangeModel.setMinimum() is called with same negative "value" then because of the integer overflow in `setMinimum` method, it causes the `extent `to become 0.

Fix the integer overflow and make sure the extent is not changed unncessarily.
All jtreg/jck tests are ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4825182](https://bugs.openjdk.org/browse/JDK-4825182): DefaultBoundedRangeModel.setMinimum() changes extent unnecessarily


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13374/head:pull/13374` \
`$ git checkout pull/13374`

Update a local copy of the PR: \
`$ git checkout pull/13374` \
`$ git pull https://git.openjdk.org/jdk.git pull/13374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13374`

View PR using the GUI difftool: \
`$ git pr show -t 13374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13374.diff">https://git.openjdk.org/jdk/pull/13374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13374#issuecomment-1499147186)