### PR TITLE
JDK-8305711: Arm: C2 always enters slowpath for monitorexit

### DIFF
--- a/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
@@ -148,7 +148,7 @@ void C2_MacroAssembler::fast_unlock(Register Roop, Register Rbox, Register Rscra
   // Restore the object header
   bool allow_fallthrough_on_failure = true;
   bool one_shot = true;
-  cas_for_lock_release(Rmark, Rbox, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
+  cas_for_lock_release(Rbox, Rmark, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
 
   bind(done);
 }


### PR DESCRIPTION
A small bug in the C2 implementation of monitorexit for thin locks causes us to always enter the slow path.

This seems to be a day zero bug of the arm port, since JEP 297: "Unified arm32/arm64 Port". It has a significant effect on locking performance, but its effect had been hidden until JDK 15 by biased locking. Biased locking removal made the bug appearant.

With this patch, @rkennke's artificial microbenchmark that does nothing but uncontended locking improves greatly (see https://github.com/rkennke/fastlockbench):

```
Benchmark                      (backoff)  Mode  Cnt      Score   Error  Units
FastLockingBenchmark.testSync          0  avgt    2    110.600          ns/op
FastLockingBenchmark.testSync          1  avgt    2    105.725          ns/op
FastLockingBenchmark.testSync          2  avgt    2    122.780          ns/op
FastLockingBenchmark.testSync          4  avgt    2    125.133          ns/op
FastLockingBenchmark.testSync          8  avgt    2    151.915          ns/op
FastLockingBenchmark.testSync         16  avgt    2    206.458          ns/op
FastLockingBenchmark.testSync         32  avgt    2    313.980          ns/op
FastLockingBenchmark.testSync         64  avgt    2    522.206          ns/op
```

New:
```
Benchmark                      (backoff)  Mode  Cnt      Score   Error  Units
FastLockingBenchmark.testSync          0  avgt    2     60.102          ns/op
FastLockingBenchmark.testSync          1  avgt    2     61.667          ns/op
FastLockingBenchmark.testSync          2  avgt    2     74.950          ns/op
FastLockingBenchmark.testSync          4  avgt    2     85.480          ns/op
FastLockingBenchmark.testSync          8  avgt    2    115.019          ns/op
FastLockingBenchmark.testSync         16  avgt    2    178.046          ns/op
FastLockingBenchmark.testSync         32  avgt    2    273.376          ns/op
FastLockingBenchmark.testSync         64  avgt    2    500.287          ns/op
```

Please note that Arm remains broken since JDK-8301995; I based and tested this patch on the parent of that change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305711](https://bugs.openjdk.org/browse/JDK-8305711): Arm: C2 always enters slowpath for monitorexit


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13376/head:pull/13376` \
`$ git checkout pull/13376`

Update a local copy of the PR: \
`$ git checkout pull/13376` \
`$ git pull https://git.openjdk.org/jdk.git pull/13376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13376`

View PR using the GUI difftool: \
`$ git pr show -t 13376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13376.diff">https://git.openjdk.org/jdk/pull/13376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13376#issuecomment-1499336773)