### PR TITLE
8305716: Enhancements for printing age tables

### DIFF
--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -33,15 +33,16 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/perfData.hpp"
 #include "utilities/copy.hpp"
+#include "logging/logStream.hpp"
 
 /* Copyright (c) 1992, 2021, Oracle and/or its affiliates, and Stanford University.
    See the LICENSE file for license information. */
 
-AgeTable::AgeTable(bool global) {
+AgeTable::AgeTable(bool global) : _use_perf_data(UsePerfData && global) {
 
   clear();
 
-  if (UsePerfData && global) {
+  if (_use_perf_data) {
 
     ResourceMark rm;
     EXCEPTION_MARK;
@@ -70,7 +71,7 @@ void AgeTable::clear() {
   }
 }
 
-void AgeTable::merge(AgeTable* subTable) {
+void AgeTable::merge(const AgeTable* subTable) {
   for (int i = 0; i < table_size; i++) {
     sizes[i]+= subTable->sizes[i];
   }
@@ -105,25 +106,30 @@ uint AgeTable::compute_tenuring_threshold(size_t desired_survivor_size) {
 }
 
 void AgeTable::print_age_table(uint tenuring_threshold) {
-  if (log_is_enabled(Trace, gc, age) || UsePerfData || AgeTableTracer::is_tenuring_distribution_event_enabled()) {
-    log_trace(gc, age)("Age table with threshold %u (max threshold " UINTX_FORMAT ")",
-                       tenuring_threshold, MaxTenuringThreshold);
-
-    size_t total = 0;
-    uint age = 1;
-    while (age < table_size) {
-      size_t wordSize = sizes[age];
-      total += wordSize;
-      if (wordSize > 0) {
-        log_trace(gc, age)("- age %3u: " SIZE_FORMAT_W(10) " bytes, " SIZE_FORMAT_W(10) " total",
-                            age, wordSize * oopSize, total * oopSize);
-      }
-      AgeTableTracer::send_tenuring_distribution_event(age, wordSize * oopSize);
-      if (UsePerfData) {
-        _perf_sizes[age]->set_value(wordSize * oopSize);
-      }
-      age++;
-    }
+  LogTarget(Trace, gc, age) lt;
+  if (lt.is_enabled() || _use_perf_data || AgeTableTracer::is_tenuring_distribution_event_enabled()) {
+    LogStream st(lt);
+    print_on(&st, tenuring_threshold);
   }
 }
 
+void AgeTable::print_on(outputStream* st, uint tenuring_threshold) {
+  st->print_cr("Age table with threshold %u (max threshold " UINTX_FORMAT ")",
+           tenuring_threshold, MaxTenuringThreshold);
+
+  size_t total = 0;
+  uint age = 1;
+  while (age < table_size) {
+    size_t word_size = sizes[age];
+    total += word_size;
+    if (word_size > 0) {
+      st->print_cr("- age %3u: " SIZE_FORMAT_W(10) " bytes, " SIZE_FORMAT_W(10) " total",
+                   age, word_size * oopSize, total * oopSize);
+    }
+    AgeTableTracer::send_tenuring_distribution_event(age, word_size * oopSize);
+    if (_use_perf_data) {
+      _perf_sizes[age]->set_value(word_size * oopSize);
+    }
+    age++;
+  }
+}

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -115,7 +115,7 @@ void AgeTable::print_age_table(uint tenuring_threshold) {
 
 void AgeTable::print_on(outputStream* st, uint tenuring_threshold) {
   st->print_cr("Age table with threshold %u (max threshold " UINTX_FORMAT ")",
-           tenuring_threshold, MaxTenuringThreshold);
+               tenuring_threshold, MaxTenuringThreshold);
 
   size_t total = 0;
   uint age = 1;

--- a/src/hotspot/share/gc/shared/ageTable.hpp
+++ b/src/hotspot/share/gc/shared/ageTable.hpp
@@ -63,14 +63,15 @@ class AgeTable {
 
   // Merge another age table with the current one.  Used
   // for parallel young generation gc.
-  void merge(AgeTable* subTable);
+  void merge(const AgeTable* subTable);
 
   // Calculate new tenuring threshold based on age information.
   uint compute_tenuring_threshold(size_t desired_survivor_size);
   void print_age_table(uint tenuring_threshold);
+  void print_on(outputStream* st, uint tenuring_threshold);
 
  private:
-
+  bool _use_perf_data;
   PerfVariable* _perf_sizes[table_size];
 };
 


### PR DESCRIPTION
In order to reduce the number of changes for the upcoming PR for the generational mode for Shenandoah we are opening separate PRs for the changes in common code. Shenandoah will be using this `AgeTable` class. There are two changes here:
* `AgeTables` created with global=false will no longer SEGV when printing
* A method was added to allow the `AgeTable` to print to an existing output stream

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305716](https://bugs.openjdk.org/browse/JDK-8305716): Enhancements for printing age tables


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [0c1fcefa](https://git.openjdk.org/jdk/pull/13377/files/0c1fcefaa6d7e5bf2371254dc10ae66cb0504585)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [0c1fcefa](https://git.openjdk.org/jdk/pull/13377/files/0c1fcefaa6d7e5bf2371254dc10ae66cb0504585)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [0c1fcefa](https://git.openjdk.org/jdk/pull/13377/files/0c1fcefaa6d7e5bf2371254dc10ae66cb0504585)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13377/head:pull/13377` \
`$ git checkout pull/13377`

Update a local copy of the PR: \
`$ git checkout pull/13377` \
`$ git pull https://git.openjdk.org/jdk.git pull/13377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13377`

View PR using the GUI difftool: \
`$ git pr show -t 13377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13377.diff">https://git.openjdk.org/jdk/pull/13377.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13377#issuecomment-1499456633)