### PR TITLE
JDK-8305688 jdk build --with-memory-size=1024 broken by JDK-8305100

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -96,7 +96,7 @@ public class JavadocTokenizer extends JavaTokenizer {
         /**
          * StringBuilder used to extract the relevant portion of the Javadoc comment.
          */
-        private final StringBuilder sb;
+        private StringBuilder sb;
 
         /**
          * Indicates if newline is required.
@@ -166,6 +166,8 @@ public class JavadocTokenizer extends JavaTokenizer {
                 super.scanDocComment();
             } finally {
                 docComment = sb.toString();
+                sb = null;
+                offsetMap.trim();
             }
         }
     }
@@ -308,6 +310,13 @@ public class JavadocTokenizer extends JavaTokenizer {
             } else if (grow != map.length) {
                 map = Arrays.copyOf(map, grow);
             }
+        }
+
+        /**
+         * Reduce map to minimum size.
+         */
+        void trim() {
+            map = Arrays.copyOf(map, size);
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/UnicodeReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/UnicodeReader.java
@@ -55,6 +55,11 @@ public class UnicodeReader {
     private final int length;
 
     /**
+     * Virtual position offset in the original buffer.
+     */
+    private final int offset;
+
+    /**
      * Character buffer index of character currently being observed.
      */
     private int position;
@@ -115,7 +120,7 @@ public class UnicodeReader {
      * @param length  length of meaningful content in buffer.
      */
     protected UnicodeReader(Log log, char[] array, int length) {
-        this(log, array, 0, length);
+        this(log, array, 0, 0, length);
     }
 
     /**
@@ -127,9 +132,10 @@ public class UnicodeReader {
       * @param endPos  end of meaningful content in buffer.
       */
     @SuppressWarnings("this-escape")
-    protected UnicodeReader(Log log, char[] array, int pos, int endPos) {
+    protected UnicodeReader(Log log, char[] array, int offset, int pos, int endPos) {
         this.buffer = array;
         this.length = endPos;
+        this.offset = offset;
         this.position = pos;
         this.width = 0;
         this.character = '\0';
@@ -315,22 +321,22 @@ public class UnicodeReader {
     }
 
     /**
-     * Return the current position in the character buffer.
+     * Return the virtual position in the character buffer.
      *
-     * @return  current position in the character buffer.
+     * @return  virtual position in the character buffer.
      */
     protected int position() {
-        return position;
+        return offset + position;
     }
 
 
     /**
-     * Reset the reader to the specified position.
+     * Reset the reader to the specified virtual position.
      * Warning: Do not use when previous character was an ASCII or unicode backslash.
      * @param pos
      */
     protected void reset(int pos) {
-        position = pos;
+        position = pos - offset;
         width = 0;
         wasBackslash = false;
         wasUnicodeEscape = false;
@@ -474,7 +480,7 @@ public class UnicodeReader {
         int endPos = position;
         accept('\r');
         accept('\n');
-        return lineReader(pos, endPos);
+        return new UnicodeReader(log, buffer, offset, pos, endPos);
     }
 
     /**
@@ -487,7 +493,7 @@ public class UnicodeReader {
      * @return a new reader
      */
     protected UnicodeReader lineReader(int pos, int endPos) {
-        return new UnicodeReader(log, buffer, pos, endPos);
+        return new UnicodeReader(log, buffer, offset, pos - offset, endPos - offset);
     }
 
     /**
@@ -561,7 +567,7 @@ public class UnicodeReader {
         }
 
         // Be prepared to retreat if not a match.
-        int savedPosition = position;
+        int savedPosition = position();
 
         nextCodePoint();
 
@@ -695,7 +701,7 @@ public class UnicodeReader {
          * @param endPos  end of meaningful content in buffer.
          */
         protected PositionTrackingReader(UnicodeReader reader, int pos, int endPos) {
-            super(reader.log, reader.buffer, pos, endPos);
+            super(reader.log, reader.getRawCharacters(pos, endPos), reader.offset + pos, 0, endPos - pos);
             this.column = 0;
         }
 


### PR DESCRIPTION
JDK-8305100 [REDO] Clean up JavadocTokenizer included a change where comments were not copied but instead had their position tracked in the original source. This led to source buffers being held on to longer than desirable. This PR reverts the behaviour.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305688](https://bugs.openjdk.org/browse/JDK-8305688): jdk build --with-memory-size=1024 broken by JDK-8305100


### Reviewers
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13378/head:pull/13378` \
`$ git checkout pull/13378`

Update a local copy of the PR: \
`$ git checkout pull/13378` \
`$ git pull https://git.openjdk.org/jdk.git pull/13378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13378`

View PR using the GUI difftool: \
`$ git pr show -t 13378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13378.diff">https://git.openjdk.org/jdk/pull/13378.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13378#issuecomment-1499474431)