### PR TITLE
8305748: Clarify reentrant behavior of close() in FileInputStream, FileOutputStream, and RandomAccessFile

### DIFF
--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -499,6 +499,11 @@ public class FileInputStream extends InputStream
      * If cleanup of native resources is needed, other mechanisms such as
      * {@linkplain java.lang.ref.Cleaner} should be used.
      *
+     * @implNote
+     * When this stream has an associated channel, this method may invoke
+     * itself reentrantly. Therefore, subclasses that override this method
+     * should be prepared to handle possible reentrant invocation.
+     *
      * @throws     IOException  {@inheritDoc}
      *
      * @revised 1.4

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -499,7 +499,7 @@ public class FileInputStream extends InputStream
      * If cleanup of native resources is needed, other mechanisms such as
      * {@linkplain java.lang.ref.Cleaner} should be used.
      *
-     * @implNote
+     * @apiNote
      * When this stream has an associated channel, this method may invoke
      * itself reentrantly. Therefore, subclasses that override this method
      * should be prepared to handle possible reentrant invocation.

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -499,10 +499,10 @@ public class FileInputStream extends InputStream
      * If cleanup of native resources is needed, other mechanisms such as
      * {@linkplain java.lang.ref.Cleaner} should be used.
      *
-     * @apiNote
-     * When this stream has an associated channel, this method may invoke
-     * itself reentrantly. Therefore, subclasses that override this method
-     * should be prepared to handle possible reentrant invocation.
+     * <p>
+     * If this stream has an associated channel then this method will close the
+     * channel, which in turn will close this stream. Subclasses that override
+     * this method should be prepared to handle possible reentrant invocation.
      *
      * @throws     IOException  {@inheritDoc}
      *

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -392,6 +392,11 @@ public class FileOutputStream extends OutputStream
      * If cleanup of native resources is needed, other mechanisms such as
      * {@linkplain java.lang.ref.Cleaner} should be used.
      *
+     * @implNote
+     * When this stream has an associated channel, this method may invoke
+     * itself reentrantly. Therefore, subclasses that override this method
+     * should be prepared to handle possible reentrant invocation.
+     *
      * @throws     IOException  if an I/O error occurs.
      *
      * @revised 1.4

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -392,7 +392,7 @@ public class FileOutputStream extends OutputStream
      * If cleanup of native resources is needed, other mechanisms such as
      * {@linkplain java.lang.ref.Cleaner} should be used.
      *
-     * @implNote
+     * @apiNote
      * When this stream has an associated channel, this method may invoke
      * itself reentrantly. Therefore, subclasses that override this method
      * should be prepared to handle possible reentrant invocation.

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -392,10 +392,10 @@ public class FileOutputStream extends OutputStream
      * If cleanup of native resources is needed, other mechanisms such as
      * {@linkplain java.lang.ref.Cleaner} should be used.
      *
-     * @apiNote
-     * When this stream has an associated channel, this method may invoke
-     * itself reentrantly. Therefore, subclasses that override this method
-     * should be prepared to handle possible reentrant invocation.
+     * <p>
+     * If this stream has an associated channel then this method will close the
+     * channel, which in turn will close this stream. Subclasses that override
+     * this method should be prepared to handle possible reentrant invocation.
      *
      * @throws     IOException  if an I/O error occurs.
      *

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -697,6 +697,11 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * <p> If this file has an associated channel then the channel is closed
      * as well.
      *
+     * @implNote
+     * When this file has an associated channel, this method may invoke
+     * itself reentrantly. Therefore, subclasses that override this method
+     * should be prepared to handle possible reentrant invocation.
+     *
      * @throws     IOException  if an I/O error occurs.
      *
      * @revised 1.4

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -697,7 +697,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * <p> If this file has an associated channel then the channel is closed
      * as well.
      *
-     * @implNote
+     * @apiNote
      * When this file has an associated channel, this method may invoke
      * itself reentrantly. Therefore, subclasses that override this method
      * should be prepared to handle possible reentrant invocation.

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -698,9 +698,9 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * as well.
      *
      * @apiNote
-     * When this file has an associated channel, this method may invoke
-     * itself reentrantly. Therefore, subclasses that override this method
-     * should be prepared to handle possible reentrant invocation.
+     * If this stream has an associated channel then this method will close the
+     * channel, which in turn will close this stream. Subclasses that override
+     * this method should be prepared to handle possible reentrant invocation.
      *
      * @throws     IOException  if an I/O error occurs.
      *

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -122,7 +122,8 @@ import jdk.internal.javac.PreviewFeature;
  * the originating object, and vice versa. Changing the file's length via the
  * file channel will change the length seen via the originating object, and vice
  * versa.  Changing the file's content by writing bytes will change the content
- * seen by the originating object, and vice versa.
+ * seen by the originating object, and vice versa. Closing the channel will
+ * close the originating object.
  *
  * <a id="open-mode"></a> <p> At various points this class specifies that an
  * instance that is "open for reading," "open for writing," or "open for


### PR DESCRIPTION
IO stream classes like `FileOutputStream` can have assocated NIO channels.

When `close()` is invoked on one of these classes, it in turn invokes `close()` on the associated channel (if any). But when the associated channel's `close()` method is invoked, it in turn invokes `close()` on the associated stream (if any).

As a result, these IO stream `close()` methods invoke themselves reentrantly when there is an associated channel.

This is not a problem for these classes because they are written to handle this (i.e., they are idempotent), but it can be surprising (or worse, just silently bug-inducing) for subclasses that override `close()`.

There are two possible ways to address this:
1. Modify the code to detect and avoid the (unnecessary) reentrant invocations
2. Add a `@implNote` to the Javadoc so subclass implementers are made aware

This patch takes the second, more conservative approach.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8305752](https://bugs.openjdk.org/browse/JDK-8305752) to be approved

### Issues
 * [JDK-8305748](https://bugs.openjdk.org/browse/JDK-8305748): Clarify reentrant behavior of close() in FileInputStream, FileOutputStream, and RandomAccessFile
 * [JDK-8305752](https://bugs.openjdk.org/browse/JDK-8305752): Clarify reentrant behavior of close() in FileInputStream, FileOutputStream, and RandomAccessFile (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13379/head:pull/13379` \
`$ git checkout pull/13379`

Update a local copy of the PR: \
`$ git checkout pull/13379` \
`$ git pull https://git.openjdk.org/jdk.git pull/13379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13379`

View PR using the GUI difftool: \
`$ git pr show -t 13379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13379.diff">https://git.openjdk.org/jdk/pull/13379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13379#issuecomment-1499718770)