### PR TITLE
JDK-8282232: [Win] GetMousePositionWithPopup test fails due to wrong mouse position

### DIFF
--- a/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
+++ b/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
@@ -24,6 +24,7 @@
 import java.awt.Frame;
 import java.awt.Point;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import javax.swing.SwingUtilities;
@@ -59,36 +60,39 @@ public class GetMousePositionWithPopup {
 
     private static Frame frame1;
     private static Frame frame2;
+    private static Robot robot;
+
+    private static final int MOUSE_POS1 = 0;
+    private static final int MOUSE_POS2 = 149;
+    private static final int MOUSE_POS3 = 170;
+
+    private static final int FRAME1_DIM = 100;
+    private static final int FRAME2_DIM = 120;
 
     //expected mouse position w.r.t to Component
-    //(2nd Frame in this test) after final mouse move.
-    private static final int EXPECTED_MOUSE_POS = 50;
+    //(2nd Frame in this test) after 3rd mouse move.
+    private static final int EXPECTED_MOUSE_POS = MOUSE_POS3 - FRAME2_DIM;
 
     public static void main(String[] args) throws Exception {
         try {
-            Robot r = new Robot();
-            r.setAutoDelay(300);
+            robot = new Robot();
+            robot.setAutoDelay(200);
 
             //1st mouse move
-            r.mouseMove(0, 0);
-            r.waitForIdle();
-            r.delay(100);
+            robot.mouseMove(MOUSE_POS1, MOUSE_POS1);
+            syncLocationToWindowManager();
 
             SwingUtilities.invokeAndWait(GetMousePositionWithPopup::createTestUI);
-            r.waitForIdle();
-            r.delay(200);
+            syncLocationToWindowManager();
 
             //2nd mouse move
-            r.mouseMove(149, 149);
-            r.waitForIdle();
-            r.delay(200);
+            robot.mouseMove(MOUSE_POS2, MOUSE_POS2);
+            syncLocationToWindowManager();
 
             SwingUtilities.invokeAndWait(GetMousePositionWithPopup::addMouseListenerToFrame2);
             //3rd mouse move
-            r.mouseMove(170, 170);
-            r.waitForIdle();
-            r.delay(100);
-
+            robot.mouseMove(MOUSE_POS3, MOUSE_POS3);
+            syncLocationToWindowManager();
         } finally {
             SwingUtilities.invokeLater(() -> {
                 frame1.dispose();
@@ -99,7 +103,7 @@ public class GetMousePositionWithPopup {
 
     private static void createTestUI() {
         frame1 = new Frame();
-        frame1.setBounds(100, 100, 100, 100);
+        frame1.setBounds(FRAME1_DIM, FRAME1_DIM, FRAME1_DIM, FRAME1_DIM);
         frame1.setVisible(true);
         frame1.addMouseMotionListener(new MouseMotionAdapter() {
             @Override
@@ -108,7 +112,7 @@ public class GetMousePositionWithPopup {
                     return;
                 }
                 frame2 = new Frame();
-                frame2.setBounds(120, 120, 120, 120);
+                frame2.setBounds(FRAME2_DIM, FRAME2_DIM, FRAME2_DIM, FRAME2_DIM);
                 frame2.setVisible(true);
             }
         });
@@ -134,5 +138,15 @@ public class GetMousePositionWithPopup {
                 }
             }
         });
+    }
+
+    private static void syncLocationToWindowManager() {
+        Toolkit.getDefaultToolkit().sync();
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        robot.waitForIdle();
     }
 }


### PR DESCRIPTION
This test issue was due to race condition that occured when using `-Dsun.java2d.uiScale >= 2`.
As a result it led to incorrect mouse position being compared as opposed to the updated mouse position after the final mouse move event.

Following is the event log before and after fix.

**Before fix:**
```
1st mouse move
2nd mouse move
Frame-1 Mouse Event
Frame-2 Mouse Event
java.awt.Point[x=29,y=29]
```

**After fix:**
```
1st mouse move
2nd mouse move
Frame-1 Mouse Event
3rd mouse move
Frame-2 Mouse Event
java.awt.Point[x=50,y=50]
```

Earlier Frame-2's mouseMoved() was being triggered on Robot's 2nd mouse move instead of 3rd mouse move. To fix it, the mouseMotionListener for Frame-2 is now added after Robot's 2nd mouse move is processed to avoid the race condition.

The updated test fix is checked on multiple uiScales including fractional scales for windows platform.
CI testing works as expected on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282232](https://bugs.openjdk.org/browse/JDK-8282232): [Win] GetMousePositionWithPopup test fails due to wrong mouse position


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13380/head:pull/13380` \
`$ git checkout pull/13380`

Update a local copy of the PR: \
`$ git checkout pull/13380` \
`$ git pull https://git.openjdk.org/jdk.git pull/13380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13380`

View PR using the GUI difftool: \
`$ git pr show -t 13380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13380.diff">https://git.openjdk.org/jdk/pull/13380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13380#issuecomment-1499770078)