### PR TITLE
8305721: add `make compile-commands` artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ NashornProfile.txt
 /.project
 /.classpath
 /.cproject
+/compile_commands.json
+/.cache


### PR DESCRIPTION
`make compile-commands` produces

* `compile-commands.json` - so clangd knows how to build the project
* `.cache` - I believe clangd uses this as an indexing cache

Tested by confirming artifacts are not shown when running `git status`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305721](https://bugs.openjdk.org/browse/JDK-8305721): add `make compile-commands` artifacts to .gitignore


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13381/head:pull/13381` \
`$ git checkout pull/13381`

Update a local copy of the PR: \
`$ git checkout pull/13381` \
`$ git pull https://git.openjdk.org/jdk.git pull/13381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13381`

View PR using the GUI difftool: \
`$ git pr show -t 13381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13381.diff">https://git.openjdk.org/jdk/pull/13381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13381#issuecomment-1499779078)