### PR TITLE
8305524: AArch64: Fix arraycopy issue on SVE caused by matching rule vmask_gen_sub

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -5726,7 +5726,7 @@ instruct vmask_gen_I(pReg pd, iRegIorL2I src, rFlagsReg cr) %{
   format %{ "vmask_gen_I $pd, $src\t# KILL cr" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelow($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
+    __ sve_whileltw($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -5738,7 +5738,7 @@ instruct vmask_gen_L(pReg pd, iRegL src, rFlagsReg cr) %{
   format %{ "vmask_gen_L $pd, $src\t# KILL cr" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
+    __ sve_whilelt($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5762,7 +5762,7 @@ instruct vmask_gen_sub(pReg pd, iRegL src1, iRegL src2, rFlagsReg cr) %{
   format %{ "vmask_gen_sub $pd, $src2, $src1\t# KILL cr" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo($pd$$PRegister, __ elemType_to_regVariant(bt), $src2$$Register, $src1$$Register);
+    __ sve_whilelt($pd$$PRegister, __ elemType_to_regVariant(bt), $src2$$Register, $src1$$Register);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -6521,7 +6521,7 @@ instruct mcompress(pReg dst, pReg pg, rFlagsReg cr) %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
     __ sve_cntp(rscratch1, size, ptrue, $pg$$PRegister);
-    __ sve_whilelo(as_PRegister($dst$$reg), size, zr, rscratch1);
+    __ sve_whilelt(as_PRegister($dst$$reg), size, zr, rscratch1);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -4090,7 +4090,7 @@ instruct vmask_gen_I(pReg pd, iRegIorL2I src, rFlagsReg cr) %{
   format %{ "vmask_gen_I $pd, $src\t# KILL cr" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelow($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
+    __ sve_whileltw($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -4102,7 +4102,7 @@ instruct vmask_gen_L(pReg pd, iRegL src, rFlagsReg cr) %{
   format %{ "vmask_gen_L $pd, $src\t# KILL cr" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
+    __ sve_whilelt($pd$$PRegister, __ elemType_to_regVariant(bt), zr, $src$$Register);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4126,7 +4126,7 @@ instruct vmask_gen_sub(pReg pd, iRegL src1, iRegL src2, rFlagsReg cr) %{
   format %{ "vmask_gen_sub $pd, $src2, $src1\t# KILL cr" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo($pd$$PRegister, __ elemType_to_regVariant(bt), $src2$$Register, $src1$$Register);
+    __ sve_whilelt($pd$$PRegister, __ elemType_to_regVariant(bt), $src2$$Register, $src1$$Register);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4852,7 +4852,7 @@ instruct mcompress(pReg dst, pReg pg, rFlagsReg cr) %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
     __ sve_cntp(rscratch1, size, ptrue, $pg$$PRegister);
-    __ sve_whilelo(as_PRegister($dst$$reg), size, zr, rscratch1);
+    __ sve_whilelt(as_PRegister($dst$$reg), size, zr, rscratch1);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -1763,9 +1763,9 @@ void C2_MacroAssembler::sve_gen_mask_imm(PRegister dst, BasicType bt, uint32_t l
   } else if (lane_cnt == max_vector_length - (max_vector_length % 3)) {
     sve_ptrue(dst, size, /* MUL3 */ 0b11110);
   } else {
-    // Encode to "whilelow" for the remaining cases.
+    // Encode to "whileltw" for the remaining cases.
     mov(rscratch1, lane_cnt);
-    sve_whilelow(dst, size, zr, rscratch1);
+    sve_whileltw(dst, size, zr, rscratch1);
   }
 }
 

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyMaskedWithSub.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyMaskedWithSub.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8305524
+ * @run main/othervm -Xbatch compiler.arraycopy.TestArrayCopyMaskedWithSub
+ */
+
+package compiler.arraycopy;
+
+public class TestArrayCopyMaskedWithSub {
+    private static char[] src = {'A', 'A', 'A', 'A', 'A'};
+    private static char[] dst = {'B', 'B', 'B', 'B', 'B'};
+
+    private static void copy(int nlen) {
+      System.arraycopy(src, 0, dst, 0, -nlen);
+    }
+
+    public static void main(String[] args) {
+      for (int i = 0; i < 25000; i++) {
+        copy(0);
+      }
+      copy(-5);
+      for (char c : dst) {
+        if (c != 'A') {
+          throw new RuntimeException("Wrong value!");
+        }
+      }
+      System.out.println("PASS");
+    }
+}


### PR DESCRIPTION
From recent tests, we find that `System.arraycopy()` call with a negated variable as its length argument does not perform the copy. This issue is reproducible by below test case on AArch64 platforms with SVE.

```
public class Test {
  static char[] src = {'A', 'A', 'A', 'A', 'A'};
  static char[] dst = {'B', 'B', 'B', 'B', 'B'};

  static void copy(int nlen) {
    System.arraycopy(src, 0, dst, 0, -nlen);
  }

  public static void main(String[] args) {
    for (int i = 0; i < 25000; i++) {
      copy(0);
    }
    copy(-5);
    for (char c : dst) {
      if (c != 'A') {
        throw new RuntimeException("Wrong value!");
      }
    }
    System.out.println("PASS");
  }
}

/*
$ java -Xint Test
PASS
$ java -Xbatch Test
Exception in thread "main" java.lang.RuntimeException: Wrong value!
        at Test.main(Test.java:16)
*/
```

Cause of this is a new AArch64 matching rule `vmask_gen_sub` introduced by JDK-8293198. It matches `VectorMaskGen (SubL src1 src2)` on AArch64 platforms with SVE and generates SVE `whilelo` instructions. Current C2 compiler uses a technique called "partial inlining" to vectorize small array copy operations by generating vector masks. In above test case, a negated variable `-nlen` is used as the length argument of the call and `-nlen` has a small positive value, so it is a "partial inlining" case. C2 will transform the ideal graph to `VectorMaskGen (SubL 0 nlen)` and eventually output an instruction of `whilelo p0, nlen, zr` which always generates an all-false vector mask. That's why arraycopy does nothing.

The problem of that matching rule is that it regards inputs `src1` and `src2` as unsigned long integers but they can be signed in use cases of arraycopy. To fix the issue, this patch replaces `whilelo` instruction by `whilelt` in that rule as well as some other places.

We tested tier1~3 on SVE and found no new failure. A jtreg math library test jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java which fails on SVE before can pass now.