### PR TITLE
8305774: String.join(CharSequence, Iterable) can be optimized if Iterable is a Collection

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -36,7 +36,6 @@ import java.nio.CharBuffer;
 import java.nio.charset.*;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.Formatter;
 import java.util.List;
@@ -3455,7 +3454,14 @@ public final class String
         Objects.requireNonNull(delimiter);
         Objects.requireNonNull(elements);
         var delim = delimiter.toString();
-        var elems = new String[elements instanceof Collection<?> c ? c.size() : 8];
+        String[] elems;
+        long initLen = elements.spliterator().estimateSize();
+        if (initLen <= 8L || initLen >= ArraysSupport.SOFT_MAX_ARRAY_LENGTH) {
+            // This usually means the size of the Iterable cannot be computed easily.
+            elems = new String[8];
+        } else {
+            elems = new String[(int)initLen];
+        }
         int size = 0;
         for (CharSequence cs: elements) {
             if (size >= elems.length) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -36,6 +36,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Formatter;
 import java.util.List;
@@ -3454,7 +3455,7 @@ public final class String
         Objects.requireNonNull(delimiter);
         Objects.requireNonNull(elements);
         var delim = delimiter.toString();
-        var elems = new String[8];
+        var elems = new String[elements instanceof Collection<?> c ? c.size() : 8];
         int size = 0;
         for (CharSequence cs: elements) {
             if (size >= elems.length) {

--- a/test/micro/org/openjdk/bench/java/lang/StringJoinWithIterable.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringJoinWithIterable.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations=20, time=500, timeUnit=TimeUnit.MILLISECONDS)
+@Measurement(iterations=10, time=1000, timeUnit=TimeUnit.MILLISECONDS)
+@Fork(3)
+public class StringJoinWithIterable {
+    private ArrayList<String> arrayList;
+    private LinkedHashSet<String> linkedHashSet;
+    private LinkedBlockingDeque<String> blockingDeque;
+    private LinkedTransferQueue<String> transferQueue;
+    private Iterable<String> iterable;
+
+    private static final int STRING_COUNT = 5000000;
+
+    @Setup
+    public void setup() {
+        ArrayList<String> list = arrayList = new ArrayList<>(STRING_COUNT);
+        for (int i = 0; i < STRING_COUNT; i++) {
+            list.add(Integer.toString(i));
+        }
+        linkedHashSet = new LinkedHashSet<>(list);
+        blockingDeque = new LinkedBlockingDeque<>(list);
+        transferQueue = new LinkedTransferQueue<>(list);
+        iterable = new Iterable<String>() {
+            @Override
+            public Iterator<String> iterator() {
+                return list.iterator();
+            }
+        };
+    }
+
+    @Benchmark
+    public String joinWithArrayList() {
+        return String.join(" ", arrayList);
+    }
+
+    @Benchmark
+    public String joinWithLinkedHashSet() {
+        return String.join(" ", linkedHashSet);
+    }
+
+    @Benchmark
+    public String joinWithLinkedBlockingDeque() {
+        return String.join(" ", blockingDeque);
+    }
+
+    @Benchmark
+    public String joinWithLinkedTransferQueue() {
+        return String.join(" ", transferQueue);
+    }
+
+    @Benchmark
+    public String joinWithIterable() {
+        return String.join(" ", iterable);
+    }
+}


### PR DESCRIPTION
In the current implementation of `String.join(CharSequence, Iterable)`, the temp array `elems` is always initialized with a length of 8. It will cause many array recreations when the `Iterable` contains more than 8 elements. Furthermore, it's very common that an `Iterable` is also a `Collection`. So if the `Iterable` is an instance of `Collection`, the initial length of the array can be `((Collection<?>)elements).size()`. It will not change the current behavior even if the `Collection` is modified asynchronously.

I don't know whether this change requires a CSR request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305774](https://bugs.openjdk.org/browse/JDK-8305774): String.join(CharSequence, Iterable) can be optimized if Iterable is a Collection


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13383/head:pull/13383` \
`$ git checkout pull/13383`

Update a local copy of the PR: \
`$ git checkout pull/13383` \
`$ git pull https://git.openjdk.org/jdk.git pull/13383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13383`

View PR using the GUI difftool: \
`$ git pr show -t 13383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13383.diff">https://git.openjdk.org/jdk/pull/13383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13383#issuecomment-1500982619)