### PR TITLE
8304532: Add asserts before C1 BAILOUT

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -335,6 +335,7 @@ void ArrayCopyStub::emit_code(LIR_Assembler* ce) {
                   relocInfo::static_call_type);
   address call = __ trampoline_call(resolve);
   if (call == NULL) {
+    assert(false, "trampoline stub overflow");
     ce->bailout("trampoline stub overflow");
     return;
   }

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -112,6 +112,7 @@ LIR_Opr LIR_Assembler::osrBufferPointer() {
 address LIR_Assembler::float_constant(float f) {
   address const_addr = __ float_constant(f);
   if (const_addr == NULL) {
+    assert(false, "const section overflow");
     bailout("const section overflow");
     return __ code()->consts()->start();
   } else {
@@ -123,6 +124,7 @@ address LIR_Assembler::float_constant(float f) {
 address LIR_Assembler::double_constant(double d) {
   address const_addr = __ double_constant(d);
   if (const_addr == NULL) {
+    assert(false, "const section overflow");
     bailout("const section overflow");
     return __ code()->consts()->start();
   } else {
@@ -133,6 +135,7 @@ address LIR_Assembler::double_constant(double d) {
 address LIR_Assembler::int_constant(jlong n) {
   address const_addr = __ long_constant(n);
   if (const_addr == NULL) {
+    assert(false, "const section overflow");
     bailout("const section overflow");
     return __ code()->consts()->start();
   } else {
@@ -381,6 +384,7 @@ int LIR_Assembler::emit_exception_handler() {
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == NULL) {
     // not enough space left for the handler
+    assert(false, "exception handler overflow");
     bailout("exception handler overflow");
     return -1;
   }
@@ -468,6 +472,7 @@ int LIR_Assembler::emit_deopt_handler() {
   address handler_base = __ start_a_stub(deopt_handler_size());
   if (handler_base == NULL) {
     // not enough space left for the handler
+    assert(false, "deopt handler overflow");
     bailout("deopt handler overflow");
     return -1;
   }
@@ -2034,6 +2039,7 @@ void LIR_Assembler::align_call(LIR_Code code) {  }
 void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
   address call = __ trampoline_call(Address(op->addr(), rtype));
   if (call == NULL) {
+    assert(false, "trampoline stub overflow");
     bailout("trampoline stub overflow");
     return;
   }
@@ -2045,6 +2051,7 @@ void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
 void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
   address call = __ ic_call(op->addr());
   if (call == NULL) {
+    assert(false, "trampoline stub overflow");
     bailout("trampoline stub overflow");
     return;
   }
@@ -2056,6 +2063,7 @@ void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
   address stub = __ start_a_stub(call_stub_size());
   if (stub == NULL) {
+    assert(false, "static call stub overflow");
     bailout("static call stub overflow");
     return;
   }

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -1181,6 +1181,7 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
   CodeStub* slow_path = new NewObjectArrayStub(klass_reg, len, reg, info);
   ciKlass* obj = (ciKlass*) ciObjArrayKlass::make(x->klass());
   if (obj == ciEnv::unloaded_ciobjarrayklass()) {
+    assert(false, "encountered unloaded_ciobjarrayklass due to out of memory error");
     BAILOUT("encountered unloaded_ciobjarrayklass due to out of memory error");
   }
   klass2reg_with_patching(klass_reg, obj, patching_info);

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -203,6 +203,7 @@ void C1_MacroAssembler::initialize_body(Register obj, Register len_in_bytes, int
 
   bind(done);
   if (tpc == nullptr) {
+    assert(false, "no space for trampoline stub");
     Compilation::current()->bailout("no space for trampoline stub");
   }
 }
@@ -239,6 +240,7 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
        lea(t1, Address(obj, hdr_size_in_bytes));
        address tpc = zero_words(t1, con_size_in_bytes / BytesPerWord);
        if (tpc == nullptr) {
+         assert(false, "no space for trampoline stub");
          Compilation::current()->bailout("no space for trampoline stub");
          return;
        }

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -145,6 +145,7 @@ LIR_Opr LIR_Assembler::osrBufferPointer() {
 address LIR_Assembler::float_constant(float f) {
   address const_addr = __ float_constant(f);
   if (const_addr == nullptr) {
+    assert(false, "const section overflow");
     bailout("const section overflow");
     return __ code()->consts()->start();
   } else {
@@ -156,6 +157,7 @@ address LIR_Assembler::float_constant(float f) {
 address LIR_Assembler::double_constant(double d) {
   address const_addr = __ double_constant(d);
   if (const_addr == nullptr) {
+    assert(false, "const section overflow");
     bailout("const section overflow");
     return __ code()->consts()->start();
   } else {
@@ -402,6 +404,7 @@ int LIR_Assembler::emit_exception_handler() {
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == nullptr) {
     // not enough space left for the handler
+    assert(false, "exception handler overflow");
     bailout("exception handler overflow");
     return -1;
   }
@@ -496,6 +499,7 @@ int LIR_Assembler::emit_deopt_handler() {
   address handler_base = __ start_a_stub(deopt_handler_size());
   if (handler_base == nullptr) {
     // not enough space left for the handler
+    assert(false, "deopt handler overflow");
     bailout("deopt handler overflow");
     return -1;
   }
@@ -2888,6 +2892,7 @@ void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
   address stub = __ start_a_stub(call_stub_size());
   if (stub == nullptr) {
+    assert(false, "static call stub overflow");
     bailout("static call stub overflow");
     return;
   }

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1355,6 +1355,7 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
   CodeStub* slow_path = new NewObjectArrayStub(klass_reg, len, reg, info);
   ciKlass* obj = (ciKlass*) ciObjArrayKlass::make(x->klass());
   if (obj == ciEnv::unloaded_ciobjarrayklass()) {
+    assert(false, "encountered unloaded_ciobjarrayklass due to out of memory error");
     BAILOUT("encountered unloaded_ciobjarrayklass due to out of memory error");
   }
   klass2reg_with_patching(klass_reg, obj, patching_info);

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -154,6 +154,7 @@ void Compilation::build_hir() {
   }
   if (log)  log->done("parse");
   if (!_hir->is_valid()) {
+    assert(false, "invalid parsing");
     bailout("invalid parsing");
     return;
   }
@@ -287,6 +288,7 @@ void Compilation::emit_code_epilog(LIR_Assembler* assembler) {
   CodeOffsets* code_offsets = assembler->offsets();
 
   if (!code()->finalize_stubs()) {
+    assert(false, "CodeCache is full");
     bailout("CodeCache is full");
     return;
   }
@@ -341,6 +343,7 @@ bool Compilation::setup_code_buffer(CodeBuffer* code, int call_stub_estimate) {
 int Compilation::emit_code_body() {
   // emit code
   if (!setup_code_buffer(code(), allocator()->num_calls())) {
+    assert(false, "size requested greater than avail code buffer size");
     BAILOUT_("size requested greater than avail code buffer size", 0);
   }
   code()->initialize_oop_recorder(env()->oop_recorder());
@@ -374,6 +377,7 @@ int Compilation::compile_java_method() {
 
   if (BailoutOnExceptionHandlers) {
     if (method()->has_exception_handlers()) {
+      assert(false, "linear scan can't handle exception handlers");
       bailout("linear scan can't handle exception handlers");
     }
   }
@@ -381,6 +385,7 @@ int Compilation::compile_java_method() {
   CHECK_BAILOUT_(no_frame_size);
 
   if (is_profiling() && !method()->ensure_method_data()) {
+    assert(false, "mdo allocation failed");
     BAILOUT_("mdo allocation failed", no_frame_size);
   }
 
@@ -450,6 +455,7 @@ void Compilation::compile_method() {
   if (!method()->can_be_compiled()) {
     // Prevent race condition 6328518.
     // This can happen if the method is obsolete or breakpointed.
+    assert(false, "Bailing out because method is not compilable");
     bailout("Bailing out because method is not compilable");
     return;
   }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -125,6 +125,7 @@ LIR_Assembler::~LIR_Assembler() {
 void LIR_Assembler::check_codespace() {
   CodeSection* cs = _masm->code_section();
   if (cs->remaining() < (int)(NOT_LP64(1*K)LP64_ONLY(2*K))) {
+    assert(false, "CodeBuffer overflow");
     BAILOUT("CodeBuffer overflow");
   }
 }

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -431,6 +431,7 @@ CodeEmitInfo* LIRGenerator::state_for(Instruction* x, ValueStack* state, bool ig
     }
     if (!liveness.is_valid()) {
       // Degenerate or breakpointed method.
+      assert(false, "Degenerate or breakpointed method");
       bailout("Degenerate or breakpointed method");
     } else {
       assert((int)liveness.size() == s->locals_size(), "error in use of liveness");
@@ -968,6 +969,7 @@ void LIRGenerator::move_to_phi(PhiResolver* resolver, Value cur_val, Value sux_v
       for (int i = 0; i < phi->operand_count(); i++) {
         Value op = phi->operand_at(i);
         if (op != NULL && op->type()->is_illegal()) {
+          assert(false, "illegal phi operand");
           bailout("illegal phi operand");
         }
       }
@@ -977,6 +979,7 @@ void LIRGenerator::move_to_phi(PhiResolver* resolver, Value cur_val, Value sux_v
       // Phi and local would need to get invalidated
       // (which is unexpected for Linear Scan).
       // But this case is very rare so we simply bail out.
+      assert(false, "propagation of illegal phi");
       bailout("propagation of illegal phi");
       return;
     }
@@ -1029,6 +1032,7 @@ LIR_Opr LIRGenerator::new_register(BasicType type) {
   // Add a little fudge factor for the bailout since the bailout is only checked periodically. This allows us to hand out
   // a few extra registers before we really run out which helps to avoid to trip over assertions.
   if (vreg_num + 20 >= LIR_Opr::vreg_max) {
+    assert(false, "out of virtual registers in LIR generator");
     bailout("out of virtual registers in LIR generator");
     if (vreg_num + 2 >= LIR_Opr::vreg_max) {
       // Wrap it around and continue until bailout really happens to avoid hitting assertions.
@@ -3261,6 +3265,7 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
   if (level == CompLevel_limited_profile) {
     MethodCounters* counters_adr = method->ensure_method_counters();
     if (counters_adr == NULL) {
+      assert(false, "method counters allocation failed");
       bailout("method counters allocation failed");
       return;
     }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -241,6 +241,7 @@ int LinearScan::allocate_spill_slot(bool double_word) {
 
   // if too many slots used, bailout compilation.
   if (result > 2000) {
+    assert(false, "too many stack slots used");
     bailout("too many stack slots used");
   }
 
@@ -261,6 +262,7 @@ void LinearScan::assign_spill_slot(Interval* it) {
 
 void LinearScan::propagate_spill_slots() {
   if (!frame_map()->finalize_frame(max_spills())) {
+    assert(false, "frame too large");
     bailout("frame too large");
   }
 }
@@ -809,6 +811,7 @@ void LinearScan::compute_global_live_sets() {
     iteration_count++;
 
     if (change_occurred && iteration_count > 50) {
+      assert(false, "too many iterations in compute_global_live_sets");
       BAILOUT("too many iterations in compute_global_live_sets");
     }
   } while (change_occurred);
@@ -1675,6 +1678,7 @@ void LinearScan::allocate_registers() {
     assert(not_precolored_fpu_intervals == Interval::end(), "missed an uncolored fpu interval");
 #else
     if (not_precolored_fpu_intervals != Interval::end()) {
+      assert(false, "missed an uncolored fpu interval");
       BAILOUT("missed an uncolored fpu interval");
     }
 #endif
@@ -2530,11 +2534,13 @@ void LinearScan::init_compute_debug_info() {
 MonitorValue* LinearScan::location_for_monitor_index(int monitor_index) {
   Location loc;
   if (!frame_map()->location_for_monitor_object(monitor_index, &loc)) {
+    assert(false, "too large frame");
     bailout("too large frame");
   }
   ScopeValue* object_scope_value = new LocationValue(loc);
 
   if (!frame_map()->location_for_monitor_lock(monitor_index, &loc)) {
+    assert(false, "too large frame");
     bailout("too large frame");
   }
   return new MonitorValue(object_scope_value, loc);
@@ -2543,6 +2549,7 @@ MonitorValue* LinearScan::location_for_monitor_index(int monitor_index) {
 LocationValue* LinearScan::location_for_name(int name, Location::Type loc_type) {
   Location loc;
   if (!frame_map()->locations_for_slot(name, loc_type, &loc)) {
+    assert(false, "too large frame");
     bailout("too large frame");
   }
   return new LocationValue(loc);
@@ -2711,6 +2718,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
       Location loc1;
       Location::Type loc_type = opr->type() == T_LONG ? Location::lng : Location::dbl;
       if (!frame_map()->locations_for_slot(opr->double_stack_ix(), loc_type, &loc1, NULL)) {
+        assert(false, "too large frame");
         bailout("too large frame");
       }
 
@@ -2719,6 +2727,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
 #else
       Location loc1, loc2;
       if (!frame_map()->locations_for_slot(opr->double_stack_ix(), Location::normal, &loc1, &loc2)) {
+        assert(false, "too large frame");
         bailout("too large frame");
       }
       first =  new LocationValue(loc1);
@@ -3971,6 +3980,7 @@ LIR_Opr MoveResolver::get_virtual_register(Interval* interval) {
   // a few extra registers before we really run out which helps to avoid to trip over assertions.
   int reg_num = interval->reg_num();
   if (reg_num + 20 >= LIR_Opr::vreg_max) {
+    assert(false, "out of virtual registers in linear scan");
     _allocator->bailout("out of virtual registers in linear scan");
     if (reg_num + 2 >= LIR_Opr::vreg_max) {
       // Wrap it around and continue until bailout really happens to avoid hitting assertions.

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -343,6 +343,7 @@ class LinearScan : public CompilationResourceObj {
     if (map->legal_vm_reg_name(name)) {
       map->set_oop(name);
     } else {
+      assert(false, "illegal oopMap register name");
       bailout("illegal oopMap register name");
     }
   }

--- a/src/hotspot/share/jfr/instrumentation/jfrResolution.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrResolution.cpp
@@ -108,6 +108,7 @@ static inline bool is_compiler_linking_event_writer(const ciKlass * holder, cons
 // C1
 void JfrResolution::on_c1_resolution(const GraphBuilder * builder, const ciKlass * holder, const ciMethod * target) {
   if (is_compiler_linking_event_writer(holder, target) && !IS_METHOD_BLESSED(builder->method()->get_Method())) {
+    assert(false, "linking error: %s", link_error_msg);
     builder->bailout(link_error_msg);
   }
 }


### PR DESCRIPTION
I inserted asserts everywhere I could find a `BAILOUT` or `bailout` in C1.
Some of them I have already accepted as legitimate bailouts, and instead added a comment.

But a lot of them are left with asserts. And lots of them trigger. I do not know which are legitimate and which may hide bugs, or which may be easily fixed/extended to work without bailouts. One idea is for example to handle more cases with traps instead of bailouts. One would have to investigate and test performance.

@TobiHartmann said that he suspects that almost all of these bailouts would be legitimate.

If anyone feels like this is important, please feel free to take it up!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8304532](https://bugs.openjdk.org/browse/JDK-8304532): Add asserts before C1 BAILOUT (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13384/head:pull/13384` \
`$ git checkout pull/13384`

Update a local copy of the PR: \
`$ git checkout pull/13384` \
`$ git pull https://git.openjdk.org/jdk.git pull/13384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13384`

View PR using the GUI difftool: \
`$ git pr show -t 13384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13384.diff">https://git.openjdk.org/jdk/pull/13384.diff</a>

</details>
