### PR TITLE
8305740: C2: add print statements to assert: Can't determine return type.

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1048,6 +1048,15 @@ void Parse::do_exits() {
       // loading.  It could also be due to an error, so mark this method as not compilable because
       // otherwise this could lead to an infinite compile loop.
       // In any case, this code path is rarely (and never in my testing) reached.
+#ifdef ASSERT
+      tty->print_cr("# Can't determine return type.");
+      tty->print_cr("# exit control");
+      _exits.control()->dump(2);
+      tty->print_cr("# ret phi type");
+      _gvn.type(ret_phi)->dump();
+      tty->print_cr("# ret phi");
+      ret_phi->dump(2);
+#endif // ASSERT
       assert(false, "Can't determine return type.");
       C->record_method_not_compilable("Can't determine return type.");
       return;


### PR DESCRIPTION
I added this assert before the bailout, because it probably hides bugs. Now we have failure reports with [JDK-8305185](https://bugs.openjdk.org/browse/JDK-8305185).

It is difficult to reproduce, so I'd like to add some print statements to get at least a bit of info.

Passed tests up to tier5 and stress testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305740](https://bugs.openjdk.org/browse/JDK-8305740): C2: add print statements to assert: Can't determine return type.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13385/head:pull/13385` \
`$ git checkout pull/13385`

Update a local copy of the PR: \
`$ git checkout pull/13385` \
`$ git pull https://git.openjdk.org/jdk.git pull/13385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13385`

View PR using the GUI difftool: \
`$ git pr show -t 13385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13385.diff">https://git.openjdk.org/jdk/pull/13385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13385#issuecomment-1501598416)