### PR TITLE
JDK-8305507 Add support for grace period before AbortVMOnSafepointTimeout triggers

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -429,6 +429,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, AbortVMOnSafepointTimeout, false, DIAGNOSTIC,               \
           "Abort upon failure to reach safepoint (see SafepointTimeout)")   \
                                                                             \
+  product(uint64_t, AbortVMOnSafepointTimeoutDelay, 0, DIAGNOSTIC,          \
+          "Delay in milliseconds for option AbortVMOnSafepointTimeout")     \
+          range(0, max_jlong)                                               \
+                                                                            \
   product(bool, AbortVMOnVMOperationTimeout, false, DIAGNOSTIC,             \
           "Abort upon failure to complete VM operation promptly")           \
                                                                             \

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -67,6 +67,7 @@
 #include "runtime/threadSMR.hpp"
 #include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/timerTrace.hpp"
+#include "services/management.hpp"
 #include "services/runtimeService.hpp"
 #include "utilities/events.hpp"
 #include "utilities/macros.hpp"
@@ -784,7 +785,7 @@ void SafepointSynchronize::print_safepoint_timeout() {
 
   // To debug the long safepoint, specify both AbortVMOnSafepointTimeout &
   // ShowMessageBoxOnError.
-  if (AbortVMOnSafepointTimeout) {
+  if (AbortVMOnSafepointTimeout && Management::ticks_to_ms(os::elapsed_counter()) > (jlong)AbortVMOnSafepointTimeoutDelay) {
     // Send the blocking thread a signal to terminate and write an error file.
     for (JavaThreadIteratorWithHandle jtiwh; JavaThread *cur_thread = jtiwh.next(); ) {
       if (cur_thread->safepoint_state()->is_running()) {

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -67,7 +67,6 @@
 #include "runtime/threadSMR.hpp"
 #include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/timerTrace.hpp"
-#include "services/management.hpp"
 #include "services/runtimeService.hpp"
 #include "utilities/events.hpp"
 #include "utilities/macros.hpp"
@@ -785,7 +784,7 @@ void SafepointSynchronize::print_safepoint_timeout() {
 
   // To debug the long safepoint, specify both AbortVMOnSafepointTimeout &
   // ShowMessageBoxOnError.
-  if (AbortVMOnSafepointTimeout && Management::ticks_to_ms(os::elapsed_counter()) > (jlong)AbortVMOnSafepointTimeoutDelay) {
+  if (AbortVMOnSafepointTimeout && (os::elapsedTime() * MILLIUNITS > AbortVMOnSafepointTimeoutDelay)) {
     // Send the blocking thread a signal to terminate and write an error file.
     for (JavaThreadIteratorWithHandle jtiwh; JavaThread *cur_thread = jtiwh.next(); ) {
       if (cur_thread->safepoint_state()->is_running()) {

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -68,7 +68,7 @@ public class TestAbortVMOnSafepointTimeout {
                 "-XX:+SafepointTimeout",
                 "-XX:+SafepointALot",
                 "-XX:+AbortVMOnSafepointTimeout",
-                "-XX:AbortVMOnSafepointTimeoutDelay=1500",
+                "-XX:AbortVMOnSafepointTimeoutDelay=2500",
                 "-XX:SafepointTimeoutDelay=50",
                 "-XX:GuaranteedSafepointInterval=1",
                 "-XX:-CreateCoredumpOnCrash",

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -28,7 +28,8 @@ import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test TestAbortVMOnSafepointTimeout
- * @summary Check if VM can kill thread which doesn't reach safepoint.
+ * @summary Check if VM can kill thread which doesn't reach safepoint,
+ *          test grace period before AbortVMOnSafepointTimeout kicks in
  * @bug 8219584 8227528
  * @requires vm.flagless
  * @library /testlibrary /test/lib
@@ -39,7 +40,7 @@ import jdk.test.whitebox.WhiteBox;
 
 public class TestAbortVMOnSafepointTimeout {
 
-    public static void main(String[] args) throws Exception {
+    public static void testThreadKilledOnSafepointTimeout() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-Xbootclasspath/a:.",
                 "-XX:+UnlockDiagnosticVMOptions",
@@ -56,6 +57,31 @@ public class TestAbortVMOnSafepointTimeout {
         );
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        verifyAbortVmApplied(output);
+    }
+
+    public static void testGracePeriodAppliedBeforeVmAbort() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Xbootclasspath/a:.",
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+WhiteBoxAPI",
+                "-XX:+SafepointTimeout",
+                "-XX:+SafepointALot",
+                "-XX:+AbortVMOnSafepointTimeout",
+                "-XX:AbortVMOnSafepointTimeoutDelay=1500",
+                "-XX:SafepointTimeoutDelay=50",
+                "-XX:GuaranteedSafepointInterval=1",
+                "-XX:-CreateCoredumpOnCrash",
+                "-Xms64m",
+                "TestAbortVMOnSafepointTimeout$TestWithDelay"
+        );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain(TestWithDelay.PRE_STALL_TEXT);
+        verifyAbortVmApplied(output);
+    }
+
+    private static void verifyAbortVmApplied(OutputAnalyzer output) {
         output.shouldContain("Timed out while spinning to reach a safepoint.");
         if (Platform.isWindows()) {
             output.shouldContain("Safepoint sync time longer than");
@@ -68,6 +94,14 @@ public class TestAbortVMOnSafepointTimeout {
         output.shouldNotHaveExitValue(0);
     }
 
+    public static void main(String[] args) throws Exception {
+        // test basic AbortVMOnSafepointTimeout functionality
+        testThreadKilledOnSafepointTimeout();
+
+        // verify -XX:AbortVMOnSafepointTimeoutDelay functionality
+        testGracePeriodAppliedBeforeVmAbort();
+    }
+
     public static class Test {
         public static void main(String[] args) throws Exception {
             Integer waitTime = Integer.parseInt(args[0]);
@@ -75,6 +109,23 @@ public class TestAbortVMOnSafepointTimeout {
             // Loop here to cause a safepoint timeout.
             while (true) {
                 wb.waitUnsafe(waitTime);
+            }
+        }
+    }
+
+    public static class TestWithDelay {
+
+        public static final String PRE_STALL_TEXT = "THE FOLLOWING STALL SHOULD BE CAPTURED";
+
+        public static void main(String[] args) throws Exception {
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            // induce a stall that should not be picked up before grace period
+            wb.waitUnsafe(999);
+            System.out.println(PRE_STALL_TEXT);
+
+            // trigger safepoint timeout
+            while (true) {
+                wb.waitUnsafe(999);
             }
         }
     }


### PR DESCRIPTION
As described https://bugs.openjdk.org/browse/JDK-8305507 this change adds a grace period before AbortVMOnSafepointTimeout activates to allow for JVM warm-up to conclude

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305507](https://bugs.openjdk.org/browse/JDK-8305507): Add support for grace period before AbortVMOnSafepointTimeout triggers (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [9649c3fe](https://git.openjdk.org/jdk/pull/13386/files/9649c3fe40f992d832a49bce52be107df62e0f40)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13386/head:pull/13386` \
`$ git checkout pull/13386`

Update a local copy of the PR: \
`$ git checkout pull/13386` \
`$ git pull https://git.openjdk.org/jdk.git pull/13386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13386`

View PR using the GUI difftool: \
`$ git pr show -t 13386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13386.diff">https://git.openjdk.org/jdk/pull/13386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13386#issuecomment-1517580013)