### PR TITLE
8305744: (ch) InputStream returned by Channels.newInputStream should have fast path for ReadbleByteChannel/WritableByteChannel

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -251,25 +251,24 @@ class ChannelInputStream extends InputStream {
             }
         }
 
-        if (out instanceof ChannelOutputStream cos && cos.channel() instanceof FileChannel fc) {
-            ReadableByteChannel rbc = ch;
-
-            if (rbc instanceof SelectableChannel sc) {
-                synchronized (sc.blockingLock()) {
-                    if (!sc.isBlocking())
-                        throw new IllegalBlockingModeException();
-                    return transfer(rbc, fc);
-                }
-            }
-
-            return transfer(rbc, fc);
-        }
-
-        // ReadableByteChannel -> WritableByteChannel
         if (out instanceof ChannelOutputStream cos) {
             ReadableByteChannel rbc = ch;
             WritableByteChannel wbc = cos.channel();
 
+            // ReadableByteChannel -> FileChannel
+            if (wbc instanceof FileChannel fc) {
+                if (rbc instanceof SelectableChannel sc) {
+                    synchronized (sc.blockingLock()) {
+                        if (!sc.isBlocking())
+                            throw new IllegalBlockingModeException();
+                        return transfer(rbc, fc);
+                    }
+                }
+
+                return transfer(rbc, fc);
+            }
+
+            // ReadableByteChannel -> WritableByteChannel
             if (rbc instanceof SelectableChannel rsc) {
                 synchronized (rsc.blockingLock()) {
                     if (!rsc.isBlocking())

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -265,7 +265,7 @@ class ChannelInputStream extends InputStream {
             return transfer(rbc, fc);
         }
 
-        // ReableByteChannel -> WritableByteChannel
+        // ReadableByteChannel -> WritableByteChannel
         if (out instanceof ChannelOutputStream cos) {
             ReadableByteChannel rbc = ch;
             WritableByteChannel wbc = cos.channel();

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -73,6 +73,10 @@ public class TransferTo extends TransferToBase {
             // optimized case
             {fileChannelInput(), writableByteChannelOutput()},
 
+            // tests ReadableFileChannel transfer to WritableByteChannelOutput
+            // optimized case
+            {readableByteChannelInput(), writableByteChannelOutput()},
+
             // tests InputStream.transferTo(OutputStream) default case
             {readableByteChannelInput(), defaultOutput()}
         };


### PR DESCRIPTION
This sub-issue defines the work to be done to implement JDK-8265891 solely for the particular case of ReadableByteChannel-to-WritableByteChannel transfers, where neither Channel is a FileChannel, but including special treatment of SelectableByteChannel.

*Without* this optimization, the JRE applies a loop where a temporary 16k byte array on the Java heap is used to transport the data between both channels. This implies that data is first transported from the source channel into the Java heap and then from the Java heap to the target channel. For most Channels, as these are NIO citizen, this implies two transfers between Java heap and OS resources, which is rather time consuming. As the data is in no way modified by transferTo(), the temporary allocation of valuable heap memory is just as unnecessary as both transfers to and from the heap. It makes sense to prevent the use of Java heap memory.

This optimization omits the byte array on the Java heap, effectively omitting the transfers to and from that array in turn. Instead, the transfer happens directly from Channel to Channel reusing a ByteBuffer taken from the JRE's internal buffer management utility which also has a size of 16k. Both measures make the transfer more efficient, as just the very essential resources are used, but not more.

Using JMH on an in-memory data transfer using custom Channels (to prevent interception by other optimizations already existing in transferTo()) it was possible to measure a 2,5% performance gain. While this does not sound much, just as the spared 16k of Java heap doesn't, we need to consider that this also means sparing GC pressure, power consumption and CO2 footprint, and we need to consider that it could be higher when using different (possibly third-party) kinds of custom Channels (as "real I/O" between heap and OS-resources is way slower than the RAM-to-RAM benchmark applied by me). As the change does not induce new, extraordinary risks compared to the existing source code, I think it is worth gaining that 2,5+ percent. Possibly there might exist some kind of scalable Java-implemented cloud service that is bound to exactly this loop and that transports very heavy traffic, those particular 2,5+ percent could be a huge amount of kWh or CO2 in absolute numbers. Even if not now, there might be in future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305744](https://bugs.openjdk.org/browse/JDK-8305744): (ch) InputStream returned by Channels.newInputStream should have fast path for ReadbleByteChannel/WritableByteChannel (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13387/head:pull/13387` \
`$ git checkout pull/13387`

Update a local copy of the PR: \
`$ git checkout pull/13387` \
`$ git pull https://git.openjdk.org/jdk.git pull/13387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13387`

View PR using the GUI difftool: \
`$ git pr show -t 13387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13387.diff">https://git.openjdk.org/jdk/pull/13387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13387#issuecomment-1500218245)