### PR TITLE
8305734: BitSet.get(int, int) always returns the empty BitSet when the Integer.MAX VALUE is set

### DIFF
--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -650,7 +650,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
         checkInvariants();
 
         int len = length();
-        if ( len < 0 )
+        if (len < 0)
             len = Integer.MAX_VALUE;
 
         // If no set bits in range return empty bitset

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -650,6 +650,8 @@ public class BitSet implements Cloneable, java.io.Serializable {
         checkInvariants();
 
         int len = length();
+        if ( len < 0 ) 
+            len = Integer.MAX_VALUE;
 
         // If no set bits in range return empty bitset
         if (len <= fromIndex || fromIndex == toIndex)

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -650,7 +650,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
         checkInvariants();
 
         int len = length();
-        if ( len < 0 ) 
+        if ( len < 0 )
             len = Integer.MAX_VALUE;
 
         // If no set bits in range return empty bitset


### PR DESCRIPTION
See https://bugs.java.com/bugdatabase/view_bug?bug_id=8305734 and https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8311905

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8307539](https://bugs.openjdk.org/browse/JDK-8307539) to be approved

### Issues
 * [JDK-8305734](https://bugs.openjdk.org/browse/JDK-8305734): BitSet.get(int, int) always returns the empty BitSet when the Integer.MAX VALUE is set (**Bug** - P4)
 * [JDK-8311905](https://bugs.openjdk.org/browse/JDK-8311905): BitSet.valueOf(...) allows bitsets to be created that behave incorrectly. (**Bug** - P4)
 * [JDK-8307539](https://bugs.openjdk.org/browse/JDK-8307539): BitSet.get(int, int) always returns the empty BitSet when the Integer.MAX VALUE is set (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13388/head:pull/13388` \
`$ git checkout pull/13388`

Update a local copy of the PR: \
`$ git checkout pull/13388` \
`$ git pull https://git.openjdk.org/jdk.git pull/13388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13388`

View PR using the GUI difftool: \
`$ git pr show -t 13388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13388.diff">https://git.openjdk.org/jdk/pull/13388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13388#issuecomment-1504120599)