### PR TITLE
8305757: Call Method::compute_has_loops_flag() when creating CDS archive

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -839,6 +839,7 @@ bool MetaspaceShared::try_link_class(JavaThread* current, InstanceKlass* ik) {
       SystemDictionaryShared::set_class_has_failed_verification(ik);
       _has_error_classes = true;
     }
+    ik->compute_has_loops_flag_for_methods();
     BytecodeVerificationLocal = saved;
     return true;
   } else {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2627,7 +2627,7 @@ void InstanceKlass::init_shared_package_entry() {
 void InstanceKlass::compute_has_loops_flag_for_methods() {
   Array<Method*>* methods = this->methods();
   for (int index = 0; index < methods->length(); ++index) {
-    Method *m = methods->at(index);
+    Method* m = methods->at(index);
     if (!m->is_overpass()) { // work around JDK-8305771
       m->compute_has_loops_flag();
     }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2624,6 +2624,16 @@ void InstanceKlass::init_shared_package_entry() {
 #endif
 }
 
+void InstanceKlass::compute_has_loops_flag_for_methods() {
+  Array<Method*>* methods = this->methods();
+  for (int index = 0; index < methods->length(); ++index) {
+    Method *m = methods->at(index);
+    if (!m->is_overpass()) { // work around JDK-8305771
+      m->compute_has_loops_flag();
+    }
+  }
+}
+
 void InstanceKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain,
                                              PackageEntry* pkg_entry, TRAPS) {
   // InstanceKlass::add_to_hierarchy() sets the init_state to loaded

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1141,6 +1141,7 @@ public:
   void init_shared_package_entry();
   bool can_be_verified_at_dumptime() const;
   bool methods_contain_jsr_bytecode() const;
+  void compute_has_loops_flag_for_methods();
 #endif
 
   jint compute_modifier_flags() const;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -405,13 +405,10 @@ void Method::metaspace_pointers_do(MetaspaceClosure* it) {
 // (to objects outside the shared spaces).  We won't be able to predict
 // where they should point in a new JVM.  Further initialize some
 // entries now in order allow them to be write protected later.
+
 void Method::remove_unshareable_info() {
   unlink_method();
   JFR_ONLY(REMOVE_METHOD_ID(this);)
-  // extra optimization, so we don't need to do this at runtime
-  if (!is_overpass() && !access_flags().loops_flag_init()) {
-    compute_has_loops_flag();
-  }
 }
 
 void Method::restore_unshareable_info(TRAPS) {

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -405,12 +405,11 @@ void Method::metaspace_pointers_do(MetaspaceClosure* it) {
 // (to objects outside the shared spaces).  We won't be able to predict
 // where they should point in a new JVM.  Further initialize some
 // entries now in order allow them to be write protected later.
-
 void Method::remove_unshareable_info() {
   unlink_method();
   JFR_ONLY(REMOVE_METHOD_ID(this);)
   // extra optimization, so we don't need to do this at runtime
-  if (!access_flags().loops_flag_init()) {
+  if (!is_overpass() && !access_flags().loops_flag_init()) {
     compute_has_loops_flag();
   }
 }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -409,6 +409,10 @@ void Method::metaspace_pointers_do(MetaspaceClosure* it) {
 void Method::remove_unshareable_info() {
   unlink_method();
   JFR_ONLY(REMOVE_METHOD_ID(this);)
+  // extra optimization, so we don't need to do this at runtime
+  if (!access_flags().loops_flag_init()) {
+    compute_has_loops_flag();
+  }
 }
 
 void Method::restore_unshareable_info(TRAPS) {


### PR DESCRIPTION
A simple optimization -- call Method::compute_has_loops_flag() for all methods during CDS archive dump. This way, the JIT doesn't need to do this at runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305757](https://bugs.openjdk.org/browse/JDK-8305757): Call Method::compute_has_loops_flag() when creating CDS archive


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [9f5ef50d](https://git.openjdk.org/jdk/pull/13390/files/9f5ef50d52a9658301fcea3b103137a92696c951)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13390/head:pull/13390` \
`$ git checkout pull/13390`

Update a local copy of the PR: \
`$ git checkout pull/13390` \
`$ git pull https://git.openjdk.org/jdk.git pull/13390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13390`

View PR using the GUI difftool: \
`$ git pr show -t 13390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13390.diff">https://git.openjdk.org/jdk/pull/13390.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13390#issuecomment-1500585413)