### PR TITLE
8305419: JDK-8301995 broke building libgraal

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -376,14 +376,14 @@ final class CompilerToVM {
      * Ensures that the type referenced by the specified {@code JVM_CONSTANT_InvokeDynamic} entry at
      * index {@code cpi} in {@code constantPool} is loaded and initialized.
      *
-     * The behavior of this method is undefined if {@code cpi} does not denote a
-     * {@code JVM_CONSTANT_InvokeDynamic} entry.
+     * @throws IllegalArgumentException if {@code cpi} is not an invokedynamic index
+     * @return the invokedynamic index
      */
-    void resolveInvokeDynamicInPool(HotSpotConstantPool constantPool, int cpi) {
-        resolveInvokeDynamicInPool(constantPool, constantPool.getConstantPoolPointer(), cpi);
+    int resolveInvokeDynamicInPool(HotSpotConstantPool constantPool, int cpi) {
+        return resolveInvokeDynamicInPool(constantPool, constantPool.getConstantPoolPointer(), cpi);
     }
 
-    private native void resolveInvokeDynamicInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int cpi);
+    private native int resolveInvokeDynamicInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int cpi);
 
     /**
      * Resolves the details for invoking the bootstrap method associated with the

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -278,22 +278,6 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
     }
 
     /**
-     * Decode a constant pool cache index to a constant pool index.
-     *
-     * See {@code ConstantPool::decode_cpcache_index}.
-     *
-     * @param index constant pool cache index
-     * @return decoded index
-     */
-    private static int decodeConstantPoolCacheIndex(int index) {
-        if (isInvokedynamicIndex(index)) {
-            return decodeInvokedynamicIndex(index);
-        } else {
-            return index - config().constantPoolCpCacheIndexTag;
-        }
-    }
-
-    /**
      * See {@code ConstantPool::is_invokedynamic_index}.
      */
     private static boolean isInvokedynamicIndex(int index) {
@@ -877,10 +861,10 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
                 break;
             case Bytecodes.INVOKEDYNAMIC: {
                 // invokedynamic indices are different from constant pool cache indices
-                index = decodeConstantPoolCacheIndex(cpi);
-                if (isInvokedynamicIndex(cpi)) {
-                    compilerToVM().resolveInvokeDynamicInPool(this, index);
+                if (!isInvokedynamicIndex(cpi)) {
+                    throw new IllegalArgumentException("must use invokedynamic index but got " + cpi);
                 }
+                index = compilerToVM().resolveInvokeDynamicInPool(this, cpi);
                 break;
             }
             case Bytecodes.GETSTATIC:


### PR DESCRIPTION
There were some minor mismatches is where the indy index was passed and where the real constant pool index was used.  There's no general test of `loadReferencedType` but I modified TestDynamicConstant to exercise it.  The arguments to the invokedynamic in that test were mildly broken as well which was only exposed once we tried to resolve it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305419](https://bugs.openjdk.org/browse/JDK-8305419): JDK-8301995 broke building libgraal


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13392/head:pull/13392` \
`$ git checkout pull/13392`

Update a local copy of the PR: \
`$ git checkout pull/13392` \
`$ git pull https://git.openjdk.org/jdk.git pull/13392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13392`

View PR using the GUI difftool: \
`$ git pr show -t 13392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13392.diff">https://git.openjdk.org/jdk/pull/13392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13392#issuecomment-1500590342)