### PR TITLE
8305670: Performance regression in LockSupport.unpark with lots of idle threads

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -949,7 +949,7 @@ const int ObjectAlignmentInBytes = 8;
           "null (+offset) will not raise a SIGSEGV, i.e.,"                  \
           "ImplicitNullChecks don't work (PPC64).")                         \
                                                                             \
-  product(bool, EnableThreadSMRExtraValidityChecks, true, DIAGNOSTIC,       \
+  product(bool, EnableThreadSMRExtraValidityChecks, trueInDebug, DIAGNOSTIC, \
              "Enable Thread SMR extra validity checks")                     \
                                                                             \
   product(bool, EnableThreadSMRStatistics, trueInDebug, DIAGNOSTIC,         \


### PR DESCRIPTION
A trivial fix to only check the ThreadsList in a `ThreadsListHandle::cv_internal_thread_to_JavaThread()`
call in fastdebug or slowdebug bits by default. The `-XX:+EnableThreadSMRExtraValidityChecks` option
can enable the check in release bits and the `-XX:-EnableThreadSMRExtraValidityChecks` option can
disable the check in fastdebug or slowdebug bits.

fastdebug or slowdebug bits will now fail an `assert()` if the `java_thread` is NOT found on the
ThreadsList (which should never happen).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305670](https://bugs.openjdk.org/browse/JDK-8305670): Performance regression in LockSupport.unpark with lots of idle threads


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13393/head:pull/13393` \
`$ git checkout pull/13393`

Update a local copy of the PR: \
`$ git checkout pull/13393` \
`$ git pull https://git.openjdk.org/jdk.git pull/13393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13393`

View PR using the GUI difftool: \
`$ git pr show -t 13393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13393.diff">https://git.openjdk.org/jdk/pull/13393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13393#issuecomment-1500608105)