### PR TITLE
8305766: ProblemList runtime/CompressedOops/CompressedClassPointers.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -97,6 +97,7 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
+runtime/CompressedOops/CompressedClassPointers.java 8305765 generic-all
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/Thread/TestAlwaysPreTouchStacks.java 8305416 generic-all
 runtime/ErrorHandling/TestDwarf.java 8305489 linux-i586


### PR DESCRIPTION
This test has a high tendency of failing on hosts with strong ASLR settings. It should be problem listed to avoid noise in testing, until the test bug is properly fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305766](https://bugs.openjdk.org/browse/JDK-8305766): ProblemList runtime/CompressedOops/CompressedClassPointers.java


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13394/head:pull/13394` \
`$ git checkout pull/13394`

Update a local copy of the PR: \
`$ git checkout pull/13394` \
`$ git pull https://git.openjdk.org/jdk.git pull/13394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13394`

View PR using the GUI difftool: \
`$ git pr show -t 13394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13394.diff">https://git.openjdk.org/jdk/pull/13394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13394#issuecomment-1500714072)