### PR TITLE
8305767: HdrSeq: support for a merge() method

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -120,6 +120,42 @@ double HdrSeq::percentile(double level) const {
   return maximum();
 }
 
+// Merge this HdrSeq into hdr2: clear optional and on-by-default
+// Note: this method isn't intrinsically MT-safe; callers must take care
+// of any mutual exclusion as necessary.
+void HdrSeq::merge(HdrSeq& hdr2, bool clear_this) {
+  for (int mag = 0; mag < MagBuckets; mag++) {
+    if (_hdr[mag] != NULL) {
+      int* that_bucket = hdr2._hdr[mag];
+      if (that_bucket == NULL) {
+        if (clear_this) {
+          // the target doesn't have any values, swap in ours.
+          // Could this cause native memory fragmentation?
+          hdr2._hdr[mag] = _hdr[mag];
+          _hdr[mag] = NULL;
+        } else {
+          // We can't clear this, so we create the entries & add in below
+          that_bucket = NEW_C_HEAP_ARRAY(int, ValBuckets, mtInternal);
+          for (int val = 0; val < ValBuckets; val++) {
+            that_bucket[val] = _hdr[mag][val];
+          }
+          hdr2._hdr[mag] = that_bucket;
+        }
+      } else {
+        // Add in our values into target
+        for (int val = 0; val < ValBuckets; val++) {
+          that_bucket[val] += _hdr[mag][val];
+          if (clear_this) {
+            _hdr[mag][val] = 0;
+          }
+        }
+      }
+    }
+  }
+  // Merge up the class hierarchy
+  NumberSeq::merge(hdr2, clear_this);
+}
+
 BinaryMagnitudeSeq::BinaryMagnitudeSeq() {
   _mags = NEW_C_HEAP_ARRAY(size_t, BitsPerSize_t, mtInternal);
   clear();

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.hpp
@@ -50,6 +50,9 @@ public:
 
   virtual void add(double val);
   double percentile(double level) const;
+
+  // Merge this HdrSeq into hdr2, optionally clearing this HdrSeq
+  void merge(HdrSeq& hdr2, bool clear_this = true);
 };
 
 // Binary magnitude sequence stores the power-of-two histogram.

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -110,6 +110,34 @@ double AbsSeq::dsd() const {
   return sqrt(var);
 }
 
+
+void AbsSeq::merge(AbsSeq& abs2, bool clear_this) {
+
+  if (num() == 0) return;  // nothing to do
+
+  abs2._num += _num;
+  abs2._sum += _sum;
+  abs2._sum_of_squares += _sum_of_squares;
+
+  // Decaying stats need a bit more thought
+  assert(abs2._alpha == _alpha, "Caution: merge incompatible?");
+
+  // Until JDK-... is fixed, we taint the decaying statistics
+  if (abs2._davg != NAN) {
+    abs2._davg = NAN;
+    abs2._dvariance = NAN;
+  }
+
+  if (clear_this) {
+    _num = 0;
+    _sum = 0;
+    _sum_of_squares = 0;
+    _davg = 0;
+    _dvariance = 0;
+  }
+}
+
+
 NumberSeq::NumberSeq(double alpha) :
   AbsSeq(alpha), _last(0.0), _maximum(0.0) {
 }
@@ -135,6 +163,22 @@ void NumberSeq::add(double val) {
   _sum += val;
   _sum_of_squares += val * val;
   ++_num;
+}
+
+void NumberSeq::merge(NumberSeq& nseq2, bool clear_this) {
+
+  if (num() == 0) return;  // nothing to do
+
+  nseq2._last = _last;   // this is newer than that
+  nseq2._maximum = MAX2(_maximum, nseq2._maximum);
+
+  AbsSeq::merge(nseq2, clear_this);
+
+  if (clear_this) {
+    _last = 0;
+    _maximum = 0;
+    assert(num() == 0, "Not cleared");
+  }
 }
 
 

--- a/src/hotspot/share/utilities/numberSeq.hpp
+++ b/src/hotspot/share/utilities/numberSeq.hpp
@@ -83,6 +83,9 @@ public:
   // Debugging/Printing
   virtual void dump();
   virtual void dump_on(outputStream* s);
+
+  // Merge this AbsSeq into seq2, optionally clearing this AbsSeq
+  void merge(AbsSeq& seq2, bool clear_this = true);
 };
 
 class NumberSeq: public AbsSeq {
@@ -102,6 +105,9 @@ public:
 
   // Debugging/Printing
   virtual void dump_on(outputStream* s);
+
+  // Merge this NumberSeq into seq2, optionally clearing this NumberSeq
+  void merge(NumberSeq& seq2, bool clear_this = true);
 };
 
 class TruncatedSeq: public AbsSeq {
@@ -129,6 +135,9 @@ public:
 
   // Debugging/Printing
   virtual void dump_on(outputStream* s);
+
+  // Merge this AbsSeq into seq2, optionally clearing this AbsSeq
+  void merge(AbsSeq& seq2, bool clear_this = true);
 };
 
 #endif // SHARE_UTILITIES_NUMBERSEQ_HPP

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,45 +33,105 @@
 
 class ShenandoahNumberSeqTest: public ::testing::Test {
  protected:
-  HdrSeq seq;
+  const double err = 0.5;
+
+  HdrSeq seq1;
+  HdrSeq seq2;
+  HdrSeq seq3;
+
+  void print() {
+    if (seq1.num() > 0) {
+      print(seq1, "seq1");
+    }
+    if (seq2.num() > 0) {
+      print(seq2, "seq2");
+    }
+    if (seq3.num() > 0) {
+      print(seq3, "seq3");
+    }
+  }
+
+  void print(HdrSeq& seq, const char* msg) {
+    std::cout << "[";
+    for (int i = 0; i <= 100; i += 10) {
+      std::cout << "\t" << seq.percentile(i);
+    }
+    std::cout << " ] : " << msg << "\n";
+  }
 };
 
 class BasicShenandoahNumberSeqTest: public ShenandoahNumberSeqTest {
- protected:
-  const double err = 0.5;
+ public:
   BasicShenandoahNumberSeqTest() {
-    seq.add(0);
-    seq.add(1);
-    seq.add(10);
+    seq1.add(0);
+    seq1.add(1);
+    seq1.add(10);
     for (int i = 0; i < 7; i++) {
-      seq.add(100);
+      seq1.add(100);
     }
-    std::cout << " p0 = " << seq.percentile(0);
-    std::cout << " p10 = " << seq.percentile(10);
-    std::cout << " p20 = " << seq.percentile(20);
-    std::cout << " p30 = " << seq.percentile(30);
-    std::cout << " p50 = " << seq.percentile(50);
-    std::cout << " p80 = " << seq.percentile(80);
-    std::cout << " p90 = " << seq.percentile(90);
-    std::cout << " p100 = " << seq.percentile(100);
+    ShenandoahNumberSeqTest::print();
+  }
+};
+
+class ShenandoahNumberSeqMergeTest: public ShenandoahNumberSeqTest {
+ public:
+  ShenandoahNumberSeqMergeTest() {
+    for (int i = 0; i < 80; i++) {
+      seq1.add(1);
+      seq3.add(1);
+    }
+
+    for (int i = 0; i < 20; i++) {
+      seq2.add(100);
+      seq3.add(100);
+    }
+    ShenandoahNumberSeqTest::print();
   }
 };
 
 TEST_VM_F(BasicShenandoahNumberSeqTest, maximum_test) {
-  EXPECT_EQ(seq.maximum(), 100);
+  EXPECT_EQ(seq1.maximum(), 100);
 }
 
 TEST_VM_F(BasicShenandoahNumberSeqTest, minimum_test) {
-  EXPECT_EQ(0, seq.percentile(0));
+  EXPECT_EQ(0, seq1.percentile(0));
 }
 
 TEST_VM_F(BasicShenandoahNumberSeqTest, percentile_test) {
-  EXPECT_NEAR(0, seq.percentile(10), err);
-  EXPECT_NEAR(1, seq.percentile(20), err);
-  EXPECT_NEAR(10, seq.percentile(30), err);
-  EXPECT_NEAR(100, seq.percentile(40), err);
-  EXPECT_NEAR(100, seq.percentile(50), err);
-  EXPECT_NEAR(100, seq.percentile(75), err);
-  EXPECT_NEAR(100, seq.percentile(90), err);
-  EXPECT_NEAR(100, seq.percentile(100), err);
+  EXPECT_NEAR(0, seq1.percentile(10), err);
+  EXPECT_NEAR(1, seq1.percentile(20), err);
+  EXPECT_NEAR(10, seq1.percentile(30), err);
+  EXPECT_NEAR(100, seq1.percentile(40), err);
+  EXPECT_NEAR(100, seq1.percentile(50), err);
+  EXPECT_NEAR(100, seq1.percentile(75), err);
+  EXPECT_NEAR(100, seq1.percentile(90), err);
+  EXPECT_NEAR(100, seq1.percentile(100), err);
+}
+
+TEST_VM_F(ShenandoahNumberSeqMergeTest, merge_test) {
+  EXPECT_EQ(seq1.num(), 80);
+  EXPECT_EQ(seq2.num(), 20);
+  EXPECT_FALSE(isnan(seq2.davg()));  // Exercise the path; not a nan
+  EXPECT_FALSE(isnan(seq2.dsd()));
+  EXPECT_FALSE(isnan(seq2.dvariance()));
+
+  std::cout << "Pre-merge: \n";
+  print();
+  seq1.merge(seq2);    // clears seq1, after merging into seq2
+  std::cout << "Post-merge: \n";
+  print();
+
+  EXPECT_EQ(seq1.num(), 0);
+  EXPECT_EQ(seq2.num(), 100);
+  EXPECT_EQ(seq2.num(), seq3.num());
+  EXPECT_TRUE(isnan(seq2.davg()));  // until we fix decayed stats
+  EXPECT_TRUE(isnan(seq2.dvariance()));
+
+  EXPECT_EQ(seq2.maximum(), seq3.maximum());
+  EXPECT_EQ(seq2.percentile(0), seq3.percentile(0));
+  for (int i = 0; i <= 100; i += 10) {
+    EXPECT_NEAR(seq2.percentile(i), seq3.percentile(i), err);
+  }
+  EXPECT_NEAR(seq2.avg(), seq3.avg(), err);
+  EXPECT_NEAR(seq2.sd(),  seq3.sd(),  err);
 }


### PR DESCRIPTION
A merge functionality on stats (distributions) was needed for the remembered set scan that I was using in some companion work. This PR implements a first cut at that, which is sufficient for our first (and only) use case.

Unfortunately, for expediency, I am deferring work on decaying statistics, as a result of which users that want decaying statistics will get NaNs instead (or trigger guarantees).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305767](https://bugs.openjdk.org/browse/JDK-8305767): HdrSeq: support for a merge() method


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13395/head:pull/13395` \
`$ git checkout pull/13395`

Update a local copy of the PR: \
`$ git checkout pull/13395` \
`$ git pull https://git.openjdk.org/jdk.git pull/13395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13395`

View PR using the GUI difftool: \
`$ git pr show -t 13395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13395.diff">https://git.openjdk.org/jdk/pull/13395.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13395#issuecomment-1500714092)