### PR TITLE
8305761: Resolve multiple definition of 'jvm' when statically linking with JDK native libraries

### DIFF
--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -32,14 +32,14 @@
 #define ERR_MSG_SIZE 128
 
 const JmmInterface* jmm_interface = NULL;
-JavaVM* jvm = NULL;
+JavaVM* jvm_management = NULL;
 jint jmm_version = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;
 
-    jvm = vm;
+    jvm_management = vm;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_ERR;
     }
@@ -57,6 +57,6 @@ JNIEXPORT jint JNICALL
 void throw_internal_error(JNIEnv* env, const char* msg) {
     char errmsg[128];
 
-    sprintf(errmsg, "errno: %d error: %s\n", errno, msg);
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
     JNU_ThrowInternalError(env, errmsg);
 }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -73,12 +73,12 @@ jfieldID mech_pHandleID;
 jclass jByteArrayClass;
 jclass jLongClass;
 
-JavaVM* jvm = NULL;
+JavaVM* jvm_j2pkcs11 = NULL;
 
 jboolean debug = 0;
 
 JNIEXPORT jint JNICALL DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
-    jvm = vm;
+    jvm_j2pkcs11 = vm;
     return JNI_VERSION_1_4;
 }
 
@@ -210,7 +210,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1Initialize
 (JNIEnv *env, jobject obj, jobject jInitArgs)
 {
     /*
-     * Initalize Cryptoki
+     * Initialize Cryptoki
      */
     CK_C_INITIALIZE_ARGS_PTR ckpInitArgs;
     CK_RV rv;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
@@ -198,7 +198,7 @@ CK_C_INITIALIZE_ARGS_PTR makeCKInitArgsAdapter(JNIEnv *env, jobject jInitArgs)
  */
 CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -215,21 +215,21 @@ CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ;} /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ;} /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -275,7 +275,7 @@ CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;
@@ -291,7 +291,7 @@ CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
  */
 CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -308,21 +308,21 @@ CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -367,7 +367,7 @@ CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;
@@ -383,7 +383,7 @@ CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
  */
 CK_RV callJLockMutex(CK_VOID_PTR pMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -400,21 +400,21 @@ CK_RV callJLockMutex(CK_VOID_PTR pMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -455,7 +455,7 @@ CK_RV callJLockMutex(CK_VOID_PTR pMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;
@@ -471,7 +471,7 @@ CK_RV callJLockMutex(CK_VOID_PTR pMutex)
  */
 CK_RV callJUnlockMutex(CK_VOID_PTR pMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -488,21 +488,21 @@ CK_RV callJUnlockMutex(CK_VOID_PTR pMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -543,7 +543,7 @@ CK_RV callJUnlockMutex(CK_VOID_PTR pMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -272,6 +272,33 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1GetSessionI
 }
 #endif
 
+#ifdef P11_ENABLE_C_SESSIONCANCEL
+/*
+ * Class:     sun_security_pkcs11_wrapper_PKCS11
+ * Method:    C_SessionCancel
+ * Signature: (JJ)V
+ * Parametermapping:                    *PKCS11*
+ * @param   jlong jSessionHandle        CK_SESSION_HANDLE hSession
+ * @param   jlong jFlags                CK_FLAGS flags
+ */
+JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SessionCancel
+    (JNIEnv *env, jobject obj, jlong jSessionHandle, jlong jFlags)
+{
+    CK_SESSION_HANDLE ckSessionHandle;
+    CK_RV rv;
+
+    CK_FUNCTION_LIST_3_0_PTR ckpFunctions30 = getFunctionList30(env, obj);
+    if (ckpFunctions30 == NULL) { return; }
+
+    ckSessionHandle = jLongToCKULong(jSessionHandle);
+
+    rv = (*ckpFunctions30->C_SessionCancel)(ckSessionHandle,
+            jLongToCKULong(jFlags));
+
+    ckAssertReturnValueOK(env, rv);
+}
+#endif
+
 #ifdef P11_ENABLE_C_GETOPERATIONSTATE
 /*
  * Class:     sun_security_pkcs11_wrapper_PKCS11
@@ -351,7 +378,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SetOperationSt
 
     free(ckpState);
 
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+    ckAssertReturnValueOK(env, rv);
 }
 #endif
 
@@ -367,28 +394,83 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SetOperationSt
  *                                      CK_ULONG ulPinLen
  */
 JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Login
-    (JNIEnv *env, jobject obj, jlong jSessionHandle, jlong jUserType, jcharArray jPin)
+    (JNIEnv *env, jobject obj, jlong jSessionHandle, jlong jUserType,
+     jcharArray jPin)
 {
     CK_SESSION_HANDLE ckSessionHandle;
     CK_USER_TYPE ckUserType;
     CK_CHAR_PTR ckpPinArray = NULL_PTR;
     CK_ULONG ckPinLength;
     CK_RV rv;
+    CK_FUNCTION_LIST_PTR ckpFunctions;
 
-    CK_FUNCTION_LIST_PTR ckpFunctions = getFunctionList(env, obj);
-    if (ckpFunctions == NULL) { return; }
+    ckpFunctions = getFunctionList(env, obj);
+
+    if (ckpFunctions == NULL) {
+        return;
+    }
 
     ckSessionHandle = jLongToCKULong(jSessionHandle);
     ckUserType = jLongToCKULong(jUserType);
     jCharArrayToCKCharArray(env, jPin, &ckpPinArray, &ckPinLength);
     if ((*env)->ExceptionCheck(env)) { return; }
 
-    rv = (*ckpFunctions->C_Login)(ckSessionHandle, ckUserType, ckpPinArray, ckPinLength);
-
+    rv = (*ckpFunctions->C_Login)(ckSessionHandle, ckUserType, ckpPinArray,
+            ckPinLength);
     free(ckpPinArray);
 
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+    ckAssertReturnValueOK(env, rv);
 }
+#endif
+
+#ifdef P11_ENABLE_C_LOGINUSER
+/*
+ * Class:     sun_security_pkcs11_wrapper_PKCS11
+ * Method:    C_LoginUser
+ * Signature: (JJ[C;Ljava/lang/String;)V
+ * Parametermapping:                    *PKCS11*
+ * @param   jlong jSessionHandle        CK_SESSION_HANDLE hSession
+ * @param   jlong jUserType             CK_USER_TYPE userType
+ * @param   jcharArray jPin             CK_CHAR_PTR pPin
+ *                                      CK_ULONG ulPinLen
+ * @param   jstring jUsername           CK_CHAR_PTR pUsername
+ *                                      CK_ULONG ulUsernameLen
+ */
+JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1LoginUser
+    (JNIEnv *env, jobject obj, jlong jSessionHandle, jlong jUserType,
+     jcharArray jPin, jstring jUsername)
+{
+    CK_SESSION_HANDLE ckSessionHandle;
+    CK_USER_TYPE ckUserType;
+    CK_CHAR_PTR ckpPinArray = NULL_PTR;
+    CK_ULONG ckPinLength;
+    CK_CHAR_PTR ckpUsername = NULL_PTR;
+    CK_ULONG ckUsernameLength;
+    CK_RV rv;
+    CK_FUNCTION_LIST_3_0_PTR ckpFunctions30;
+
+    ckpFunctions30 = getFunctionList30(env, obj);
+
+    ckSessionHandle = jLongToCKULong(jSessionHandle);
+    ckUserType = jLongToCKULong(jUserType);
+    jCharArrayToCKCharArray(env, jPin, &ckpPinArray, &ckPinLength);
+    if ((*env)->ExceptionCheck(env)) { return; }
+    jStringToCKUTF8CharArray(env, jUsername, &ckpUsername,
+            &ckUsernameLength);
+    if ((*env)->ExceptionCheck(env)) { return; }
+
+    if (ckpFunctions30 == NULL) {
+        return;
+    }
+    rv = (*ckpFunctions30->C_LoginUser)(ckSessionHandle, ckUserType,
+            ckpPinArray, ckPinLength, ckpUsername, ckUsernameLength);
+
+    free(ckpPinArray);
+    free(ckpUsername);
+
+    ckAssertReturnValueOK(env, rv);
+}
+
 #endif
 
 #ifdef P11_ENABLE_C_LOGOUT
@@ -411,7 +493,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Logout
     ckSessionHandle = jLongToCKULong(jSessionHandle);
 
     rv = (*ckpFunctions->C_Logout)(ckSessionHandle);
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+    ckAssertReturnValueOK(env, rv);
 }
 #endif
 
@@ -543,7 +625,7 @@ NotifyEncapsulation * removeFirstNotifyEntry(JNIEnv *env) {
  * back to a NotifyEncapsulation structure and retrieves the Notify object and
  * the application data from it.
  *
- * @param hSession The session, this callback is comming from.
+ * @param hSession The session, this callback is coming from.
  * @param event The type of event that occurred.
  * @param pApplication The application data as passed in upon OpenSession. In
                        this wrapper we always pass in a NotifyEncapsulation
@@ -558,7 +640,7 @@ CK_RV notifyCallback(
 )
 {
     NotifyEncapsulation *notifyEncapsulation;
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jlong jSessionHandle;
@@ -576,21 +658,21 @@ CK_RV notifyCallback(
     notifyEncapsulation = (NotifyEncapsulation *) pApplication;
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -625,7 +707,7 @@ CK_RV notifyCallback(
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -32,14 +32,14 @@
 #define ERR_MSG_SIZE 128
 
 const JmmInterface* jmm_interface = NULL;
-JavaVM* jvm = NULL;
+JavaVM* jvm_management_ext = NULL;
 jint jmm_version = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;
 
-    jvm = vm;
+    jvm_management_ext = vm;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_ERR;
     }
@@ -57,6 +57,6 @@ JNIEXPORT jint JNICALL
 void throw_internal_error(JNIEnv* env, const char* msg) {
     char errmsg[128];
 
-    sprintf(errmsg, "errno: %d error: %s\n", errno, msg);
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
     JNU_ThrowInternalError(env, errmsg);
 }


### PR DESCRIPTION
Rename various 'jvm' variables to 'jvm_<lib_name>' to avoid duplicate symbol problems when statically linking the launcher executable with JDK native libraries.

8305761: Resolve multiple definition of 'jvm' when statically linking with JDK native libraries

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305761](https://bugs.openjdk.org/browse/JDK-8305761): Resolve multiple definition of 'jvm' when statically linking with JDK native libraries


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13396/head:pull/13396` \
`$ git checkout pull/13396`

Update a local copy of the PR: \
`$ git checkout pull/13396` \
`$ git pull https://git.openjdk.org/jdk.git pull/13396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13396`

View PR using the GUI difftool: \
`$ git pr show -t 13396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13396.diff">https://git.openjdk.org/jdk/pull/13396.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13396#issuecomment-1500728718)