### PR TITLE
8305761: Resolve multiple definition of 'jvm' when statically linking with JDK native libraries

### DIFF
--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -32,14 +32,14 @@
 #define ERR_MSG_SIZE 128
 
 const JmmInterface* jmm_interface = NULL;
-JavaVM* jvm_management = NULL;
+static JavaVM* jvm = NULL;
 jint jmm_version = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;
 
-    jvm_management = vm;
+    jvm = vm;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_ERR;
     }

--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -32,14 +32,14 @@
 #define ERR_MSG_SIZE 128
 
 const JmmInterface* jmm_interface = NULL;
-JavaVM* jvm = NULL;
+JavaVM* jvm_management = NULL;
 jint jmm_version = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;
 
-    jvm = vm;
+    jvm_management = vm;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_ERR;
     }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -73,12 +73,12 @@ jfieldID mech_pHandleID;
 jclass jByteArrayClass;
 jclass jLongClass;
 
-JavaVM* jvm = NULL;
+JavaVM* jvm_j2pkcs11 = NULL;
 
 jboolean debug = 0;
 
 JNIEXPORT jint JNICALL DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
-    jvm = vm;
+    jvm_j2pkcs11 = vm;
     return JNI_VERSION_1_4;
 }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
@@ -198,7 +198,7 @@ CK_C_INITIALIZE_ARGS_PTR makeCKInitArgsAdapter(JNIEnv *env, jobject jInitArgs)
  */
 CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -215,21 +215,21 @@ CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ;} /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ;} /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -275,7 +275,7 @@ CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;
@@ -291,7 +291,7 @@ CK_RV callJCreateMutex(CK_VOID_PTR_PTR ppMutex)
  */
 CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -308,21 +308,21 @@ CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -367,7 +367,7 @@ CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;
@@ -383,7 +383,7 @@ CK_RV callJDestroyMutex(CK_VOID_PTR pMutex)
  */
 CK_RV callJLockMutex(CK_VOID_PTR pMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -400,21 +400,21 @@ CK_RV callJLockMutex(CK_VOID_PTR pMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -455,7 +455,7 @@ CK_RV callJLockMutex(CK_VOID_PTR pMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;
@@ -471,7 +471,7 @@ CK_RV callJLockMutex(CK_VOID_PTR pMutex)
  */
 CK_RV callJUnlockMutex(CK_VOID_PTR pMutex)
 {
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jthrowable pkcs11Exception;
@@ -488,21 +488,21 @@ CK_RV callJUnlockMutex(CK_VOID_PTR pMutex)
 
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -543,7 +543,7 @@ CK_RV callJUnlockMutex(CK_VOID_PTR pMutex)
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
@@ -640,7 +640,7 @@ CK_RV notifyCallback(
 )
 {
     NotifyEncapsulation *notifyEncapsulation;
-    extern JavaVM *jvm;
+    extern JavaVM *jvm_j2pkcs11;
     JNIEnv *env;
     jint returnValue;
     jlong jSessionHandle;
@@ -658,21 +658,21 @@ CK_RV notifyCallback(
     notifyEncapsulation = (NotifyEncapsulation *) pApplication;
 
     /* Get the currently running Java VM */
-    if (jvm == NULL) { return rv ; } /* there is no VM running */
+    if (jvm_j2pkcs11 == NULL) { return rv ; } /* there is no VM running */
 
     /* Determine, if current thread is already attached */
-    returnValue = (*jvm)->GetEnv(jvm, (void **) &env, JNI_VERSION_1_2);
+    returnValue = (*jvm_j2pkcs11)->GetEnv(jvm_j2pkcs11, (void **) &env, JNI_VERSION_1_2);
     if (returnValue == JNI_EDETACHED) {
         /* thread detached, so attach it */
         wasAttached = 0;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else if (returnValue == JNI_EVERSION) {
         /* this version of JNI is not supported, so just try to attach */
         /* we assume it was attached to ensure that this thread is not detached
          * afterwards even though it should not
          */
         wasAttached = 1;
-        returnValue = (*jvm)->AttachCurrentThread(jvm, (void **) &env, NULL);
+        returnValue = (*jvm_j2pkcs11)->AttachCurrentThread(jvm_j2pkcs11, (void **) &env, NULL);
     } else {
         /* attached */
         wasAttached = 1;
@@ -707,7 +707,7 @@ CK_RV notifyCallback(
 
     /* if we attached this thread to the VM just for callback, we detach it now */
     if (wasAttached) {
-        returnValue = (*jvm)->DetachCurrentThread(jvm);
+        returnValue = (*jvm_j2pkcs11)->DetachCurrentThread(jvm_j2pkcs11);
     }
 
     return rv ;

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -32,14 +32,14 @@
 #define ERR_MSG_SIZE 128
 
 const JmmInterface* jmm_interface = NULL;
-JavaVM* jvm = NULL;
+JavaVM* jvm_management_ext = NULL;
 jint jmm_version = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;
 
-    jvm = vm;
+    jvm_management_ext = vm;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_ERR;
     }

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -32,14 +32,14 @@
 #define ERR_MSG_SIZE 128
 
 const JmmInterface* jmm_interface = NULL;
-JavaVM* jvm_management_ext = NULL;
+static JavaVM* jvm = NULL;
 jint jmm_version = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;
 
-    jvm_management_ext = vm;
+    jvm = vm;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_ERR;
     }


### PR DESCRIPTION
Rename various 'jvm' variables to 'jvm_<lib_name>' to avoid duplicate symbol problems when statically linking the launcher executable with JDK native libraries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305761](https://bugs.openjdk.org/browse/JDK-8305761): Resolve multiple definition of 'jvm' when statically linking with JDK native libraries


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13397/head:pull/13397` \
`$ git checkout pull/13397`

Update a local copy of the PR: \
`$ git checkout pull/13397` \
`$ git pull https://git.openjdk.org/jdk.git pull/13397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13397`

View PR using the GUI difftool: \
`$ git pr show -t 13397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13397.diff">https://git.openjdk.org/jdk/pull/13397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13397#issuecomment-1500752845)