### PR TITLE
6441827: Documentation mentions nonexistent NullReferenceException

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -585,7 +585,7 @@ public class ObjectOutputStream
      * substituted or the original object.
      *
      * <p>Null can be returned as the object to be substituted, but may cause
-     * {@code NullPointerException} in classes that contain references to the
+     * {@link NullPointerException} in classes that contain references to the
      * original object since they may be expecting an object instead of
      * null.
      *

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -585,7 +585,7 @@ public class ObjectOutputStream
      * substituted or the original object.
      *
      * <p>Null can be returned as the object to be substituted, but may cause
-     * NullReferenceException in classes that contain references to the
+     * {@code NullPointerException} in classes that contain references to the
      * original object since they may be expecting an object instead of
      * null.
      *


### PR DESCRIPTION
Can I please get a review of this doc only change which fixes a trivial typo in the documentation of `ObjectOutputStream.replaceObject()` method, as noted in https://bugs.openjdk.org/browse/JDK-6441827?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6441827](https://bugs.openjdk.org/browse/JDK-6441827): Documentation mentions nonexistent NullReferenceException


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13399/head:pull/13399` \
`$ git checkout pull/13399`

Update a local copy of the PR: \
`$ git checkout pull/13399` \
`$ git pull https://git.openjdk.org/jdk.git pull/13399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13399`

View PR using the GUI difftool: \
`$ git pr show -t 13399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13399.diff">https://git.openjdk.org/jdk/pull/13399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13399#issuecomment-1500799171)