### PR TITLE
8305758: Update the JAR tool man page to indicate -i/--generate-file is deprecated 

### DIFF
--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAR" "1" "2023" "JDK 21-internal" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -108,6 +108,7 @@ Creates the archive.
 .TP
 \f[V]-i\f[R] \f[I]FILE\f[R] or \f[V]--generate-index=\f[R]\f[I]FILE\f[R]
 Generates index information for the specified JAR file.
+This option is deprecated and may be removed in a future release.
 .TP
 \f[V]-t\f[R] or \f[V]--list\f[R]
 Lists the table of contents for the archive.

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2023" "JDK 21-internal" "JDK Commands"
+.TH "JAR" "1" "2023" "JDK 21-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP


### PR DESCRIPTION
Hi all,

Please review this MR which updates the jar man page to to indicate that  --generate-index/-I are deprecated and may be removed in a future release

Support for JAR Index is being removed via JDK-8302819.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305758](https://bugs.openjdk.org/browse/JDK-8305758): Update the JAR tool man page to indicate -i/--generate-file is deprecated


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13400/head:pull/13400` \
`$ git checkout pull/13400`

Update a local copy of the PR: \
`$ git checkout pull/13400` \
`$ git pull https://git.openjdk.org/jdk.git pull/13400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13400`

View PR using the GUI difftool: \
`$ git pr show -t 13400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13400.diff">https://git.openjdk.org/jdk/pull/13400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13400#issuecomment-1500863466)