### PR TITLE
JDK-8305782: Provide MacroAssembler::breakpoint on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -140,7 +140,7 @@ address LIR_Assembler::int_constant(jlong n) {
   }
 }
 
-void LIR_Assembler::breakpoint() { Unimplemented(); }
+void LIR_Assembler::breakpoint() { __ breakpoint(); }
 
 void LIR_Assembler::push(LIR_Opr opr) { Unimplemented(); }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2520,6 +2520,12 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
   bind(done);
 }
 
+void MacroAssembler::breakpoint(uint16_t hint_imm16) {
+  // BRK with hint
+  const uint32_t c = 0xD4200000 | (((uint32_t)hint_imm16) << 5);
+  emit_int32(c) ;
+}
+
 void MacroAssembler::stop(const char* msg) {
   BLOCK_COMMENT(msg);
   dcps1(0xdeae);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2521,9 +2521,7 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 }
 
 void MacroAssembler::breakpoint(uint16_t hint_imm16) {
-  // BRK with hint
-  const uint32_t c = 0xD4200000 | (((uint32_t)hint_imm16) << 5);
-  emit_int32(c) ;
+  brk(hint_imm16);
 }
 
 void MacroAssembler::stop(const char* msg) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1027,6 +1027,9 @@ public:
   // only if +VerifyFPU
   void verify_FPU(int stack_depth, const char* s = "illegal FPU state");
 
+  // emit unconditional trap.
+  void breakpoint(uint16_t hint_uimm16 = 0);
+
   // prints msg, dumps registers and stops execution
   void stop(const char* msg);
 


### PR DESCRIPTION
The ability to emit debug traps was useful for me on arm, and I miss it on aarch64.

Tested manually on Linux aarch64 in gdb with various values for hint covering the whole 16-bit range set. Hint gets encoded in the instruction (gdb decodes instruction as "BRK xxx" with xxx being the hint). According to documentation the hint ends up in ESR.ELx.ISS after the trap hit, but gdb refused to display the ESR register, so I could not verify that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305782](https://bugs.openjdk.org/browse/JDK-8305782): Provide MacroAssembler::breakpoint on aarch64


### Reviewers
 * [Eric Liu](https://openjdk.org/census#eliu) (@theRealELiu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13401/head:pull/13401` \
`$ git checkout pull/13401`

Update a local copy of the PR: \
`$ git checkout pull/13401` \
`$ git pull https://git.openjdk.org/jdk.git pull/13401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13401`

View PR using the GUI difftool: \
`$ git pr show -t 13401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13401.diff">https://git.openjdk.org/jdk/pull/13401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13401#issuecomment-1501196806)