### PR TITLE
8305783: x86_64: Optimize AbsI and AbsL

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -8462,44 +8462,34 @@ instruct xchgN( memory mem, rRegN newval) %{
 //----------Abs Instructions-------------------------------------------
 
 // Integer Absolute Instructions
-instruct absI_rReg(rRegI dst, rRegI src, rRegI tmp, rFlagsReg cr)
+instruct absI_rReg(rRegI dst, rRegI src, rFlagsReg cr)
 %{
   match(Set dst (AbsI src));
-  effect(TEMP dst, TEMP tmp, KILL cr);
-  format %{ "movl $tmp, $src\n\t"
-            "sarl $tmp, 31\n\t"
-            "movl $dst, $src\n\t"
-            "xorl $dst, $tmp\n\t"
-            "subl $dst, $tmp\n"
-          %}
+  effect(TEMP dst, KILL cr);
+  format %{ "xorl    $dst, $dst\n\t"
+            "subl    $dst, $src\n\t"
+            "cmovllt $dst, $src" %}
   ins_encode %{
-    __ movl($tmp$$Register, $src$$Register);
-    __ sarl($tmp$$Register, 31);
-    __ movl($dst$$Register, $src$$Register);
-    __ xorl($dst$$Register, $tmp$$Register);
-    __ subl($dst$$Register, $tmp$$Register);
+    __ xorl($dst$$Register, $dst$$Register);
+    __ subl($dst$$Register, $src$$Register);
+    __ cmovl(Assembler::less, $dst$$Register, $src$$Register);
   %}
 
   ins_pipe(ialu_reg_reg);
 %}
 
 // Long Absolute Instructions
-instruct absL_rReg(rRegL dst, rRegL src, rRegL tmp, rFlagsReg cr)
+instruct absL_rReg(rRegL dst, rRegL src, rFlagsReg cr)
 %{
   match(Set dst (AbsL src));
-  effect(TEMP dst, TEMP tmp, KILL cr);
-  format %{ "movq $tmp, $src\n\t"
-            "sarq $tmp, 63\n\t"
-            "movq $dst, $src\n\t"
-            "xorq $dst, $tmp\n\t"
-            "subq $dst, $tmp\n"
-          %}
+  effect(TEMP dst, KILL cr);
+  format %{ "xorl    $dst, $dst\n\t"
+            "subq    $dst, $src\n\t"
+            "cmovqlt $dst, $src" %}
   ins_encode %{
-    __ movq($tmp$$Register, $src$$Register);
-    __ sarq($tmp$$Register, 63);
-    __ movq($dst$$Register, $src$$Register);
-    __ xorq($dst$$Register, $tmp$$Register);
-    __ subq($dst$$Register, $tmp$$Register);
+    __ xorl($dst$$Register, $dst$$Register);
+    __ subq($dst$$Register, $src$$Register);
+    __ cmovq(Assembler::less, $dst$$Register, $src$$Register);
   %}
 
   ins_pipe(ialu_reg_reg);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -8466,7 +8466,7 @@ instruct absI_rReg(rRegI dst, rRegI src, rFlagsReg cr)
 %{
   match(Set dst (AbsI src));
   effect(TEMP dst, KILL cr);
-  format %{ "xorl    $dst, $dst\n\t"
+  format %{ "xorl    $dst, $dst\t# abs int\n\t"
             "subl    $dst, $src\n\t"
             "cmovllt $dst, $src" %}
   ins_encode %{
@@ -8483,7 +8483,7 @@ instruct absL_rReg(rRegL dst, rRegL src, rFlagsReg cr)
 %{
   match(Set dst (AbsL src));
   effect(TEMP dst, KILL cr);
-  format %{ "xorl    $dst, $dst\n\t"
+  format %{ "xorl    $dst, $dst\t# abs long\n\t"
             "subq    $dst, $src\n\t"
             "cmovqlt $dst, $src" %}
   ins_encode %{

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -8468,7 +8468,7 @@ instruct absI_rReg(rRegI dst, rRegI src, rFlagsReg cr)
   effect(TEMP dst, KILL cr);
   format %{ "xorl    $dst, $dst\t# abs int\n\t"
             "subl    $dst, $src\n\t"
-            "cmovllt $dst, $src" %}
+            "cmovll  $dst, $src" %}
   ins_encode %{
     __ xorl($dst$$Register, $dst$$Register);
     __ subl($dst$$Register, $src$$Register);
@@ -8485,7 +8485,7 @@ instruct absL_rReg(rRegL dst, rRegL src, rFlagsReg cr)
   effect(TEMP dst, KILL cr);
   format %{ "xorl    $dst, $dst\t# abs long\n\t"
             "subq    $dst, $src\n\t"
-            "cmovqlt $dst, $src" %}
+            "cmovlq  $dst, $src" %}
   ins_encode %{
     __ xorl($dst$$Register, $dst$$Register);
     __ subq($dst$$Register, $src$$Register);


### PR DESCRIPTION
Hi,

This patch optimizes the sequence emitted by `AbsINode` and `AbsLNode` to save some instructions and 1 temp register. Please take a look and kindly leave your reviews.

Thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305783](https://bugs.openjdk.org/browse/JDK-8305783): x86_64: Optimize AbsI and AbsL


### Reviewers
 * [Jasmine Karthikeyan](https://openjdk.org/census#jkarthikeyan) (@jaskarth - Author)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13402/head:pull/13402` \
`$ git checkout pull/13402`

Update a local copy of the PR: \
`$ git checkout pull/13402` \
`$ git pull https://git.openjdk.org/jdk.git pull/13402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13402`

View PR using the GUI difftool: \
`$ git pr show -t 13402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13402.diff">https://git.openjdk.org/jdk/pull/13402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13402#issuecomment-1501089241)