### PR TITLE
8305787: Wrong debugging information printed with TraceOptoOutput

### DIFF
--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -402,6 +402,13 @@ class ResourceForm : public Form {
 public:
   unsigned mask() const { return _resmask; };
 
+  // A discrete resource is a simple definition of a resource, while compound resources can be composed of multiple resources.
+  // A discrete resource will always have a power of two mask, so this check succeeds in that case.
+  // As compound resources have different masks added together, this check will not succeed there.
+  bool is_discrete() const {
+    return (_resmask & (_resmask - 1)) == 0;
+  }
+
 private:
   // Public Data
   unsigned _resmask;         // Resource Mask (OR of resource specifier bits)

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -272,20 +272,26 @@ static int pipeline_res_stages_initializer(
   }
 
   // Compute the length needed for the resource list
+  const char* resource;
   int commentlen = 0;
   int max_stage = 0;
-  for (i = 0; i < pipeline->_rescount; i++) {
-    if (res_stages[i] == 0) {
-      if (max_stage < 9)
-        max_stage = 9;
-    }
-    else {
-      int stagelen = (int)strlen(pipeline->_stages.name(res_stages[i]-1));
-      if (max_stage < stagelen)
-        max_stage = stagelen;
-    }
+  i = 0;
+  for (pipeline->_reslist.reset(); (resource = pipeline->_reslist.iter()) != NULL;) {
+    if (pipeline->_resdict[resource]->is_resource()->is_discrete()) {
+      if (res_stages[i] == 0) {
+        if (max_stage < 9) {
+          max_stage = 9;
+        }
+      } else {
+        int stagelen = (int)strlen(pipeline->_stages.name(res_stages[i]-1));
+        if (max_stage < stagelen) {
+          max_stage = stagelen;
+        }
+      }
 
-    commentlen += (int)strlen(pipeline->_reslist.name(i));
+      commentlen += (int)strlen(resource);
+      i++;
+    }
   }
 
   int templen = 1 + commentlen + pipeline->_rescount * (max_stage + 14);
@@ -295,14 +301,16 @@ static int pipeline_res_stages_initializer(
   char * resource_stages = new char [templen];
 
   templen = 0;
-  for (i = 0; i < pipeline->_rescount; i++) {
-    const char * const resname =
-      res_stages[i] == 0 ? "undefined" : pipeline->_stages.name(res_stages[i]-1);
+  i = 0;
+  for (pipeline->_reslist.reset(); (resource = pipeline->_reslist.iter()) != NULL;) {
+    if (pipeline->_resdict[resource]->is_resource()->is_discrete()) {
+      const char* const resname = res_stages[i] == 0 ? "undefined" : pipeline->_stages.name(res_stages[i] - 1);
 
-    templen += snprintf_checked(&resource_stages[templen], resource_stages_size - templen, "  stage_%s%-*s // %s\n",
-      resname, max_stage - (int)strlen(resname) + 1,
-      (i < pipeline->_rescount-1) ? "," : "",
-      pipeline->_reslist.name(i));
+      templen += snprintf_checked(&resource_stages[templen], resource_stages_size - templen,"  stage_%s%-*s // %s\n",
+          resname, max_stage - (int)strlen(resname) + 1,
+          (i < pipeline->_rescount - 1) ? "," : "", resource);
+      i++;
+    }
   }
 
   // See if the same string is in the table
@@ -355,13 +363,22 @@ static int pipeline_res_cycles_initializer(
   int max_cycles = 0;
   char temp[32];
 
-  for (i = 0; i < pipeline->_rescount; i++) {
-    if (max_cycles < res_cycles[i])
-      max_cycles = res_cycles[i];
-    templen = snprintf_checked(temp, sizeof(temp), "%d", res_cycles[i]);
-    if (cyclelen < templen)
-      cyclelen = templen;
-    commentlen += (int)strlen(pipeline->_reslist.name(i));
+  const char* resource;
+  i = 0;
+  for (pipeline->_reslist.reset(); (resource = pipeline->_reslist.iter()) != NULL;) {
+    if (pipeline->_resdict[resource]->is_resource()->is_discrete()) {
+      if (max_cycles < res_cycles[i]) {
+        max_cycles = res_cycles[i];
+      }
+
+      templen = snprintf_checked(temp, sizeof(temp), "%d", res_cycles[i]);
+      if (cyclelen < templen) {
+        cyclelen = templen;
+      }
+
+      commentlen += (int)strlen(resource);
+      i++;
+    }
   }
 
   templen = 1 + commentlen + (cyclelen + 8) * pipeline->_rescount;
@@ -372,9 +389,13 @@ static int pipeline_res_cycles_initializer(
 
   templen = 0;
 
-  for (i = 0; i < pipeline->_rescount; i++) {
-    templen += snprintf_checked(&resource_cycles[templen], resource_cycles_size - templen, "  %*d%c // %s\n",
-      cyclelen, res_cycles[i], (i < pipeline->_rescount-1) ? ',' : ' ', pipeline->_reslist.name(i));
+  i = 0;
+  for (pipeline->_reslist.reset(); (resource = pipeline->_reslist.iter()) != NULL;) {
+    if (pipeline->_resdict[resource]->is_resource()->is_discrete()) {
+      templen += snprintf_checked(&resource_cycles[templen], resource_cycles_size - templen, "  %*d%c // %s\n",
+      cyclelen, res_cycles[i], (i < pipeline->_rescount-1) ? ',' : ' ', resource);
+      i++;
+    }
   }
 
   // See if the same string is in the table
@@ -982,8 +1003,15 @@ void ArchDesc::build_pipe_classes(FILE *fp_cpp) {
   fprintf(fp_cpp, "  };\n\n");
 
   fprintf(fp_cpp, "  static const char *resource_names[%d] = {", _pipeline->_rescount);
-  for (i = 0; i < _pipeline->_rescount; i++)
-    fprintf(fp_cpp, " \"%s\"%c", _pipeline->_reslist.name(i), i < _pipeline->_rescount-1 ? ',' : ' ');
+  // Don't add compound resources to the list of resource names
+  const char* resource;
+  i = 0;
+  for (_pipeline->_reslist.reset(); (resource = _pipeline->_reslist.iter()) != NULL;) {
+    if (_pipeline->_resdict[resource]->is_resource()->is_discrete()) {
+      fprintf(fp_cpp, " \"%s\"%c", resource, i < _pipeline->_rescount - 1 ? ',' : ' ');
+      i++;
+    }
+  }
   fprintf(fp_cpp, "};\n\n");
 
   // See if the same string is in the table

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -825,10 +825,10 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
   uint rescount = 0;
   const char *resource;
 
-  for ( _pipeline->_reslist.reset(); (resource = _pipeline->_reslist.iter()) != NULL; ) {
-      int mask = _pipeline->_resdict[resource]->is_resource()->mask();
-      if ((mask & (mask-1)) == 0)
+  for (_pipeline->_reslist.reset(); (resource = _pipeline->_reslist.iter()) != NULL;) {
+      if (_pipeline->_resdict[resource]->is_resource()->is_discrete()) {
         rescount++;
+      }
     }
 
   fprintf(fp_hpp, "// Pipeline_Use_Element Class\n");
@@ -2230,9 +2230,9 @@ void ArchDesc::build_pipeline_enums(FILE *fp_hpp) {
 
     for ( _pipeline->_reslist.reset(); (resource = _pipeline->_reslist.iter()) != NULL; ) {
       const ResourceForm *resform = _pipeline->_resdict[resource]->is_resource();
-      int mask = resform->mask();
-      if ((mask & (mask-1)) == 0)
+      if (resform->is_discrete()) {
         fprintf(fp_hpp, "   resource_%-*s = %d,\n", reslen, resource, rescount++);
+      }
     }
     fprintf(fp_hpp, "\n");
     for ( _pipeline->_reslist.reset(); (resource = _pipeline->_reslist.iter()) != NULL; ) {


### PR DESCRIPTION
This patch fixes a minor bug in aldc where the wrong resource names are printed when the flag TraceOptoOutput is enabled to debug instruction scheduling.
As an example, the output:
```
*** Bundle: 1 instr, resources: D0 BR
 126 salI_rReg_imm === _ 240 |271 [[ 127 125 ]] #5/0x00000005
```
states that the bundle is using resources D0 and BR, but the second resource used is actually ALU0.

The issue is caused because `pipeline->_rescount` is only incremented for discrete resources [(here)](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/adlc/adlparse.cpp#L1612), resources specified without `=`. However, the list of names is added to for *all* resources [(here)](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/adlc/adlparse.cpp#L1652), so using `_rescount` to index the names causes it to go out of sync. The fix is found in [output_h.cpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/adlc/output_h.cpp#L2231), where it uses the iterator to go through all the resources and use only the ones that are discrete. I applied that fix to this case, and also fixed the other instances of this bug. Reviews on this fix would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8305787](https://bugs.openjdk.org/browse/JDK-8305787): Wrong debugging information printed with TraceOptoOutput


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [79e3f744](https://git.openjdk.org/jdk/pull/13403/files/79e3f74453c8030adb06445ac871da06d893eab3)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [79e3f744](https://git.openjdk.org/jdk/pull/13403/files/79e3f74453c8030adb06445ac871da06d893eab3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13403/head:pull/13403` \
`$ git checkout pull/13403`

Update a local copy of the PR: \
`$ git checkout pull/13403` \
`$ git pull https://git.openjdk.org/jdk.git pull/13403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13403`

View PR using the GUI difftool: \
`$ git pr show -t 13403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13403.diff">https://git.openjdk.org/jdk/pull/13403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13403#issuecomment-1501357853)