### PR TITLE
8305324: C2: Wrong execution of vectorizing Interger.reverseBytes

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3941,7 +3941,7 @@ void SuperWord::compute_vector_element_type() {
             // vectorized if the signedness info is imprecise.
             const Type* vt = vtn;
             int op = in->Opcode();
-            if (VectorNode::is_shift_opcode(op) || op == Op_AbsI) {
+            if (VectorNode::is_shift_opcode(op) || op == Op_AbsI || op == Op_ReverseBytesI) {
               Node* load = in->in(1);
               if (load->is_Load() && in_bb(load) && (velt_type(load)->basic_type() == T_INT)) {
                 // Only Load nodes distinguish signed (LoadS/LoadB) and unsigned

--- a/test/hotspot/jtreg/compiler/c2/Test8305324.java
+++ b/test/hotspot/jtreg/compiler/c2/Test8305324.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8305324
+ * @summary C2: Wrong execution of vectorizing Interger.reverseBytes
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.Test8305324::* compiler.c2.Test8305324
+ */
+
+package compiler.c2;
+
+public class Test8305324 {
+
+    static final int LEN = 33;
+    static byte byteArray[] = new byte[LEN];
+
+    static void test() {
+        for (int i = 0; i < LEN; i++) {
+            byteArray[i] = (byte) Integer.reverseBytes(i);
+        }
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 2; i++) {
+            test();
+        }
+        for (int i = 0; i < byteArray.length; i++) {
+            if (byteArray[i] != 0) {
+                System.err.println("FAILED: all the elements should be zero");
+                System.exit(1);
+            }
+        }
+        System.out.println("PASSED");
+    }
+
+}


### PR DESCRIPTION
This patch should fix [JDK-8305324](https://bugs.openjdk.org/browse/JDK-8305324).

`SuperWord::compute_vector_element_type()` propagates backward a narrower integer type when the upper bits of the value are not needed. However, `Integer.reverseBytes()` depends on higher order bits of an integer and should be prevented from being vectorized like `Math.abs()`( which is `Op_AbsI` in the following code).

https://github.com/openjdk/jdk/blob/0243da2e4adc1b7ab6fcd5b10778532101158dce/src/hotspot/share/opto/superword.cpp#L3935-L3945

I have tested this patch for tier 1-3 on x86-64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305324](https://bugs.openjdk.org/browse/JDK-8305324): C2: Wrong execution of vectorizing Interger.reverseBytes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13404/head:pull/13404` \
`$ git checkout pull/13404`

Update a local copy of the PR: \
`$ git checkout pull/13404` \
`$ git pull https://git.openjdk.org/jdk.git pull/13404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13404`

View PR using the GUI difftool: \
`$ git pr show -t 13404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13404.diff">https://git.openjdk.org/jdk/pull/13404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13404#issuecomment-1501675111)