### PR TITLE
JDK-8306860: Avoid unnecessary allocation in List.map() when list is empty

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/List.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/List.java
@@ -419,6 +419,9 @@ public class List<A> extends AbstractCollection<A> implements java.util.List<A> 
 
     @SuppressWarnings("unchecked")
     public <Z> List<Z> map(Function<A, Z> mapper) {
+        if (isEmpty()) {
+            return (List<Z>)this;
+        }
         boolean changed = false;
         ListBuffer<Z> buf = new ListBuffer<>();
         for (A a : this) {


### PR DESCRIPTION
Hi,

I've been profiling our compilation tasks lately and noticed that `List.map` is under the top consumers.

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/6304496/230922012-d9c8f63f-beba-4e8a-a33c-367fb3cbf147.png">

There are probably more aggressive options to optimize this, but I found that checking for empty lists already reduces the overall allocations by ~500MB for one of our compilation tasks with no measurable regressions (but also no noticeable improvements) in timings.

<img width="943" alt="image" src="https://user-images.githubusercontent.com/6304496/230922383-e0363eca-bc87-4ad2-8465-ca1e801bd164.png">

In case you consider this worthwhile, I'd appreciate a sponsoring of this (including a ticket because I have no rights to create one, review etc.). I've found https://bugs.openjdk.org/browse/JDK-8032359 but this was closed as won't fix.

Let me know what you think.

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306860](https://bugs.openjdk.org/browse/JDK-8306860): Avoid unnecessary allocation in List.map() when list is empty


### Reviewers
 * @lprakashv (no known openjdk.org user name / role)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13407/head:pull/13407` \
`$ git checkout pull/13407`

Update a local copy of the PR: \
`$ git checkout pull/13407` \
`$ git pull https://git.openjdk.org/jdk.git pull/13407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13407`

View PR using the GUI difftool: \
`$ git pr show -t 13407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13407.diff">https://git.openjdk.org/jdk/pull/13407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13407#issuecomment-1522020821)