### PR TITLE
8305807: Spurious right brace in ConstantDescs field Javadocs

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -228,7 +228,7 @@ public final class ConstantDescs {
             CD_Object, CD_MethodHandle, CD_Object.arrayType());
 
     /**
-     * {@link MethodHandleDesc} representing {@link ConstantBootstraps#explicitCast(Lookup, String, Class, Object)} ConstantBootstraps.explicitCast}
+     * {@link MethodHandleDesc} representing {@link ConstantBootstraps#explicitCast(Lookup, String, Class, Object) ConstantBootstraps.explicitCast}
      * @since 15
      */
     public static final DirectMethodHandleDesc BSM_EXPLICIT_CAST
@@ -263,7 +263,7 @@ public final class ConstantDescs {
     public static final ClassDesc CD_void = ClassDesc.ofDescriptor("V");
 
     /**
-     * {@link MethodHandleDesc} representing {@link MethodHandles#classData(Lookup, String, Class)} MethodHandles.classData}
+     * {@link MethodHandleDesc} representing {@link MethodHandles#classData(Lookup, String, Class) MethodHandles.classData}
      * @since 21
      */
     public static final DirectMethodHandleDesc BSM_CLASS_DATA
@@ -271,7 +271,7 @@ public final class ConstantDescs {
             CD_Object);
 
     /**
-     * {@link MethodHandleDesc} representing {@link MethodHandles#classDataAt(Lookup, String, Class, int)} MethodHandles.classDataAt}
+     * {@link MethodHandleDesc} representing {@link MethodHandles#classDataAt(Lookup, String, Class, int) MethodHandles.classDataAt}
      * @since 21
      */
     public static final DirectMethodHandleDesc BSM_CLASS_DATA_AT


### PR DESCRIPTION
Please review a small patch, fixing extraneous right braces in field javadocs of BSM_EXPLICIT_CAST, BSM_CLASS_DATA, and BSM_CLASS_DATA_AT.

JDK 20: https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/constant/ConstantDescs.html#BSM_EXPLICIT_CAST
JDK 21: https://download.java.net/java/early_access/jdk21/docs/api/java.base/java/lang/constant/ConstantDescs.html#field-summary
With this patch: https://cr.openjdk.org/~liach/8305807/java.base/java/lang/constant/ConstantDescs.html#field-summary

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305807](https://bugs.openjdk.org/browse/JDK-8305807): Spurious right brace in ConstantDescs field Javadocs


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13410/head:pull/13410` \
`$ git checkout pull/13410`

Update a local copy of the PR: \
`$ git checkout pull/13410` \
`$ git pull https://git.openjdk.org/jdk.git pull/13410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13410`

View PR using the GUI difftool: \
`$ git pr show -t 13410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13410.diff">https://git.openjdk.org/jdk/pull/13410.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13410#issuecomment-1502130031)