### PR TITLE
8305808: Typo in javadoc of ConstantDescs::BSM_VARHANDLE_STATIC_FIELD

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -212,7 +212,7 @@ public final class ConstantDescs {
             = ofConstantBootstrap(CD_ConstantBootstraps, "fieldVarHandle",
             CD_VarHandle, CD_Class, CD_Class);
 
-    /** {@link MethodHandleDesc} representing {@link ConstantBootstraps#staticFieldVarHandle(Lookup, String, Class, Class, Class) ConstantBootstraps.staticVarHandle} */
+    /** {@link MethodHandleDesc} representing {@link ConstantBootstraps#staticFieldVarHandle(Lookup, String, Class, Class, Class) ConstantBootstraps.staticFieldVarHandle} */
     public static final DirectMethodHandleDesc BSM_VARHANDLE_STATIC_FIELD
             = ofConstantBootstrap(CD_ConstantBootstraps, "staticFieldVarHandle",
             CD_VarHandle, CD_Class, CD_Class);


### PR DESCRIPTION
`s/ConstantBootstraps.staticVarHandle/ConstantBootstraps.staticFieldVarHandle`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305808](https://bugs.openjdk.org/browse/JDK-8305808): Typo in javadoc of ConstantDescs::BSM_VARHANDLE_STATIC_FIELD


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13411/head:pull/13411` \
`$ git checkout pull/13411`

Update a local copy of the PR: \
`$ git checkout pull/13411` \
`$ git pull https://git.openjdk.org/jdk.git pull/13411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13411`

View PR using the GUI difftool: \
`$ git pr show -t 13411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13411.diff">https://git.openjdk.org/jdk/pull/13411.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13411#issuecomment-1502155833)