### PR TITLE
8294806: jpackaged-app ignores splash screen from jar file

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.ResourceBundle;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -507,15 +504,6 @@ public class Arguments {
                 }
             }
 
-            if (hasMainJar && !hasMainClass) {
-                // try to get main-class from manifest
-                String mainClass = getMainClassFromManifest();
-                if (mainClass != null) {
-                    CLIOptions.setOptionValue(
-                            CLIOptions.APPCLASS.getId(), mainClass);
-                }
-            }
-
             // display error for arguments that are not supported
             // for current configuration.
 
@@ -825,27 +813,4 @@ public class Arguments {
         }
         return sb.toString();
     }
-
-    private String getMainClassFromManifest() {
-        if (mainJarPath == null ||
-            input == null ) {
-            return null;
-        }
-
-        JarFile jf;
-        try {
-            Path file = Path.of(input, mainJarPath);
-            if (!Files.exists(file)) {
-                return null;
-            }
-            jf = new JarFile(file.toFile());
-            Manifest m = jf.getManifest();
-            Attributes attrs = (m != null) ? m.getMainAttributes() : null;
-            if (attrs != null) {
-                return attrs.getValue(Attributes.Name.MAIN_CLASS);
-            }
-        } catch (IOException ignore) {}
-        return null;
-    }
-
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/CfgFile.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/CfgFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,16 +66,21 @@ final class CfgFile {
             content.add(Map.entry("app.mainmodule", launcherData.moduleName()
                     + "/" + launcherData.qualifiedClassName()));
         } else {
-            // If the app is contained in an unnamed jar then launch it the
-            // legacy way and the main class string must be
-            // of the format com/foo/Main
             if (launcherData.mainJarName() != null) {
-                content.add(Map.entry("app.classpath",
-                        appCfgLayout.appDirectory().resolve(
-                                launcherData.mainJarName())));
+                Path mainJarPath = appCfgLayout.appDirectory().resolve(
+                        launcherData.mainJarName());
+
+                if (launcherData.isClassNameFromMainJar()) {
+                    content.add(Map.entry("app.mainjar", mainJarPath));
+                } else {
+                    content.add(Map.entry("app.classpath", mainJarPath));
+                }
             }
-            content.add(Map.entry("app.mainclass",
-                    launcherData.qualifiedClassName()));
+
+            if (!launcherData.isClassNameFromMainJar()) {
+                content.add(Map.entry("app.mainclass",
+                        launcherData.qualifiedClassName()));
+            }
         }
 
         for (var value : launcherData.classPath()) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,10 @@ final class LauncherData {
 
     String qualifiedClassName() {
         return qualifiedClassName;
+    }
+
+    boolean isClassNameFromMainJar() {
+        return jarMainClass != null;
     }
 
     String packageName() {
@@ -209,6 +213,7 @@ final class LauncherData {
                 if (attrs != null) {
                     launcherData.qualifiedClassName = attrs.getValue(
                             Attributes.Name.MAIN_CLASS);
+                    launcherData.jarMainClass = launcherData.qualifiedClassName;
                 }
             }
         }
@@ -315,6 +320,7 @@ final class LauncherData {
     }
 
     private String qualifiedClassName;
+    private String jarMainClass;
     private Path mainJarName;
     private List<Path> classPath;
     private List<Path> modulePath;


### PR DESCRIPTION
When `--main-jar` is specified and the name of the main class is picked from the jar's manifest, set `app.jarfile` property in launcher cfg file instead of `app.mainclass` and `app.classpath` properties to make app launcher run the app from the jar and not as a class from the classpath.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294806](https://bugs.openjdk.org/browse/JDK-8294806): jpackaged-app ignores splash screen from jar file


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13413/head:pull/13413` \
`$ git checkout pull/13413`

Update a local copy of the PR: \
`$ git checkout pull/13413` \
`$ git pull https://git.openjdk.org/jdk.git pull/13413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13413`

View PR using the GUI difftool: \
`$ git pr show -t 13413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13413.diff">https://git.openjdk.org/jdk/pull/13413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13413#issuecomment-1502346598)