### PR TITLE
8305811: (bf) Improve performance of CharBuffer::append(CharSequence[,int,int])

### DIFF
--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -280,11 +280,13 @@ class Heap$Type$Buffer$RW$
 
     //
     // Use getChars() to load chars directly into the heap buffer array.
-    // This improves performance versus converting the StringBuilder to a
-    // String and then appending the String as StringBuilder::toString
-    // allocates memory for and copies all the contained chars
+    // For a String or StringBuffer source this improves performance if
+    // a proper subsequence is being appended as copying to a new intermediate
+    // String object is avoided. For a StringBuilder where either a subsequence
+    // or the full sequence of chars is being appended, copying the chars to
+    // an intermedite String in StringBuilder::toString is avoided.
     //
-    private $Type$Buffer append(StringBuilder sb, int start, int end) {
+    private $Type$Buffer appendChars(CharSequence csq, int start, int end) {
         checkSession();
 
         int length = end - start;
@@ -294,15 +296,23 @@ class Heap$Type$Buffer$RW$
         if (length > rem)
             throw new BufferOverflowException();
 
-        sb.getChars(start, end, hb, ix(pos));
+        if (csq instanceof StringBuilder bld) {
+            bld.getChars(start, end, hb, ix(pos));
+        } else if (csq instanceof String str) {
+            str.getChars(start, end, hb, ix(pos));
+        } else if (csq instanceof StringBuffer buf) {
+            buf.getChars(start, end, hb, ix(pos));
+        }
+
         position(pos + length);
+
         return this;
     }
 
     public $Type$Buffer append(CharSequence csq) {
 #if[rw]
-        if (csq instanceof StringBuilder sb)
-            return append(sb, 0, sb.length());
+        if (csq instanceof StringBuilder)
+            return appendChars(csq, 0, csq.length());
 
         return super.append(csq);
 #else[rw]
@@ -312,8 +322,12 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer append(CharSequence csq, int start, int end) {
 #if[rw]
-        if (csq instanceof StringBuilder sb)
-            return append(sb, start, end);
+        if (start == 0 && end == csq.length())
+            return append(csq);
+
+        if (csq instanceof String || csq instanceof StringBuffer ||
+            csq instanceof StringBuilder)
+            return appendChars(csq, start, end);
 
         return super.append(csq, start, end);
 #else[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -298,10 +298,10 @@ class Heap$Type$Buffer$RW$
 
         if (csq instanceof String str) {
             str.getChars(start, end, hb, ix(pos));
-        } else if (csq instanceof StringBuilder bld) {
-            bld.getChars(start, end, hb, ix(pos));
-        } else if (csq instanceof StringBuffer buf) {
-            buf.getChars(start, end, hb, ix(pos));
+        } else if (csq instanceof StringBuilder sb) {
+            sb.getChars(start, end, hb, ix(pos));
+        } else if (csq instanceof StringBuffer sb) {
+            sb.getChars(start, end, hb, ix(pos));
         }
 
         position(pos + length);

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -311,6 +311,16 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer append(CharSequence csq) {
 #if[rw]
+        //
+        // No special casing of String here as the implementation of
+        // append(String) in the base class uses put(String) which is
+        // already using getChars().
+        //
+        // No special casing of StringBuffer as it is uninteresting
+        // legacy code superseded by StringBuilder. Also as it caches
+        // the String value little difference is observed in the
+        // microbenchmark.
+        //
         if (csq instanceof StringBuilder)
             return appendChars(csq, 0, csq.length());
 

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -296,10 +296,10 @@ class Heap$Type$Buffer$RW$
         if (length > rem)
             throw new BufferOverflowException();
 
-        if (csq instanceof StringBuilder bld) {
-            bld.getChars(start, end, hb, ix(pos));
-        } else if (csq instanceof String str) {
+        if (csq instanceof String str) {
             str.getChars(start, end, hb, ix(pos));
+        } else if (csq instanceof StringBuilder bld) {
+            bld.getChars(start, end, hb, ix(pos));
         } else if (csq instanceof StringBuffer buf) {
             buf.getChars(start, end, hb, ix(pos));
         }

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -322,9 +322,6 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer append(CharSequence csq, int start, int end) {
 #if[rw]
-        if (start == 0 && end == csq.length())
-            return append(csq);
-
         if (csq instanceof String || csq instanceof StringBuffer ||
             csq instanceof StringBuilder)
             return appendChars(csq, start, end);

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -284,23 +284,25 @@ class Heap$Type$Buffer$RW$
     // String and then appending the String as StringBuilder::toString
     // allocates memory for and copies all the contained chars
     //
-    private $Type$Buffer append(StringBuilder strbld, int start, int end) {
+    private $Type$Buffer append(StringBuilder sb, int start, int end) {
         checkSession();
 
         int length = end - start;
         int pos = position();
-        if (length > limit() - pos)
+        int lim = limit();
+        int rem = (pos <= lim) ? lim - pos : 0;
+        if (length > rem)
             throw new BufferOverflowException();
 
-        strbld.getChars(start, end, hb, ix(pos));
+        sb.getChars(start, end, hb, ix(pos));
         position(pos + length);
         return this;
     }
 
     public $Type$Buffer append(CharSequence csq) {
 #if[rw]
-        if (csq instanceof StringBuilder strbld)
-            return append(strbld, 0, strbld.length());
+        if (csq instanceof StringBuilder sb)
+            return append(sb, 0, sb.length());
 
         return super.append(csq);
 #else[rw]
@@ -310,8 +312,8 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer append(CharSequence csq, int start, int end) {
 #if[rw]
-        if (csq instanceof StringBuilder strbld)
-            return append(strbld, start, end);
+        if (csq instanceof StringBuilder sb)
+            return append(sb, start, end);
 
         return super.append(csq, start, end);
 #else[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -278,9 +278,31 @@ class Heap$Type$Buffer$RW$
 
 #if[char]
 
+    //
+    // Use getChars() to load chars directly into the heap buffer array.
+    // This improves performance versus converting the StringBuilder to a
+    // String and then appending the String as StringBuilder::toString
+    // allocates memory for and copies all the contained chars
+    //
+    private $Type$Buffer append(StringBuilder strbld, int start, int end) {
+        checkSession();
+
+        int length = end - start;
+        int pos = position();
+        if (length > limit() - pos)
+            throw new BufferOverflowException();
+
+        strbld.getChars(start, end, hb, ix(pos));
+        position(pos + length);
+        return this;
+    }
+
     public $Type$Buffer append(CharSequence csq) {
 #if[rw]
-        return append(csq, 0, csq.length());
+        if (csq instanceof StringBuilder strbld)
+            return append(strbld, 0, strbld.length());
+
+        return super.append(csq);
 #else[rw]
         throw new ReadOnlyBufferException();
 #end[rw]
@@ -288,29 +310,8 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer append(CharSequence csq, int start, int end) {
 #if[rw]
-        checkSession();
-
-        if (csq == null)
-            csq = "null";
-
-        int length = end - start;
-        int pos = position();
-        if (length > limit() - pos)
-            throw new BufferOverflowException();
-
-        if (csq instanceof String str) {
-            str.getChars(start, end, hb, ix(pos));
-            position(pos + length);
-            return this;
-        } else if (csq instanceof StringBuffer strbuf) {
-            strbuf.getChars(start, end, hb, ix(pos));
-            position(pos + length);
-            return this;
-        } else if (csq instanceof StringBuilder strbld) {
-            strbld.getChars(start, end, hb, ix(pos));
-            position(pos + length);
-            return this;
-        }
+        if (csq instanceof StringBuilder strbld)
+            return append(strbld, start, end);
 
         return super.append(csq, start, end);
 #else[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,6 +277,41 @@ class Heap$Type$Buffer$RW$
     }
 
 #if[char]
+
+    public $Type$Buffer append(CharSequence csq) {
+#if[rw]
+        return append(csq, 0, csq.length());
+#else[rw]
+        throw new ReadOnlyBufferException();
+#end[rw]
+    }
+
+    public $Type$Buffer append(CharSequence csq, int start, int end) {
+#if[rw]
+        checkSession();
+
+        if (csq == null)
+            csq = "null";
+
+        if (csq instanceof String str) {
+            str.getChars(start, end, hb, ix(position()));
+            position(position() + end - start);
+            return this;
+        } else if (csq instanceof StringBuffer strbuf) {
+            strbuf.getChars(start, end, hb, ix(position()));
+            position(position() + end - start);
+            return this;
+        } else if (csq instanceof StringBuilder strbld) {
+            strbld.getChars(start, end, hb, ix(position()));
+            position(position() + end - start);
+            return this;
+        }
+
+        return super.append(csq, start, end);
+#else[rw]
+        throw new ReadOnlyBufferException();
+#end[rw]
+    }
 
     public $Type$Buffer put(String src, int start, int end) {
 #if[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -293,17 +293,22 @@ class Heap$Type$Buffer$RW$
         if (csq == null)
             csq = "null";
 
+        int length = end - start;
+        int pos = position();
+        if (length > limit() - pos)
+            throw new BufferOverflowException();
+
         if (csq instanceof String str) {
-            str.getChars(start, end, hb, ix(position()));
-            position(position() + end - start);
+            str.getChars(start, end, hb, ix(pos));
+            position(pos + length);
             return this;
         } else if (csq instanceof StringBuffer strbuf) {
-            strbuf.getChars(start, end, hb, ix(position()));
-            position(position() + end - start);
+            strbuf.getChars(start, end, hb, ix(pos));
+            position(pos + length);
             return this;
         } else if (csq instanceof StringBuilder strbld) {
-            strbld.getChars(start, end, hb, ix(position()));
-            position(position() + end - start);
+            strbld.getChars(start, end, hb, ix(pos));
+            position(pos + length);
             return this;
         }
 

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -311,16 +311,6 @@ class Heap$Type$Buffer$RW$
 
     public $Type$Buffer append(CharSequence csq) {
 #if[rw]
-        //
-        // No special casing of String here as the implementation of
-        // append(String) in the base class uses put(String) which is
-        // already using getChars().
-        //
-        // No special casing of StringBuffer as it is uninteresting
-        // legacy code superseded by StringBuilder. Also as it caches
-        // the String value little difference is observed in the
-        // microbenchmark.
-        //
         if (csq instanceof StringBuilder)
             return appendChars(csq, 0, csq.length());
 

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -2044,7 +2044,6 @@ public abstract sealed class $Type$Buffer
      * @since  1.5
      */
     public $Type$Buffer append(CharSequence csq, int start, int end) {
-        CharSequence cs = (csq == null ? "null" : csq);
         if (csq instanceof CharBuffer cb) {
             int pos = position();
             int length = end - start;
@@ -2052,6 +2051,7 @@ public abstract sealed class $Type$Buffer
             position(pos + length);
             return this;
         }
+        CharSequence cs = (csq == null ? "null" : csq);
         return put(cs.subSequence(start, end).toString());
     }
 

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -2005,6 +2005,8 @@ public abstract sealed class $Type$Buffer
     public $Type$Buffer append(CharSequence csq) {
         if (csq == null)
             return put("null");
+        else if (csq instanceof CharBuffer cb)
+            return put(cb);
         else
             return put(csq.toString());
     }
@@ -2043,6 +2045,13 @@ public abstract sealed class $Type$Buffer
      */
     public $Type$Buffer append(CharSequence csq, int start, int end) {
         CharSequence cs = (csq == null ? "null" : csq);
+        if (csq instanceof CharBuffer cb) {
+            int pos = position();
+            int length = end - start;
+            put(pos, cb, start, length);
+            position(pos + length);
+            return this;
+        }
         return put(cs.subSequence(start, end).toString());
     }
 

--- a/test/micro/org/openjdk/bench/java/nio/CharBufferAppend.java
+++ b/test/micro/org/openjdk/bench/java/nio/CharBufferAppend.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.nio;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for {@code CharBuffer} implementations of the {@code Appendable}
+ * methods which accept a {@code CharSequence} source.
+ */
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+public class CharBufferAppend {
+
+    static final int SIZE = 8192;
+
+    static String str;
+    static StringBuffer strbuf;
+    static StringBuilder strbld;
+    static CharBuffer hbDst;
+    static CharBuffer hbSrc;
+    static CharBuffer dbSrc;
+    static CharBuffer dbDst;
+
+    static {
+        char[] chars = new char[SIZE];
+        Arrays.fill(chars, (char)27);
+
+        strbld = new StringBuilder(SIZE);
+        strbld.append(chars);
+
+        str = strbld.toString();
+
+        strbuf = new StringBuffer(SIZE);
+        strbuf.append(chars);
+
+        hbDst = CharBuffer.allocate(SIZE);
+        hbSrc = CharBuffer.wrap(chars);
+
+        dbDst = ByteBuffer.allocateDirect(2*SIZE).asCharBuffer();
+        dbSrc = ByteBuffer.allocateDirect(2*SIZE).asCharBuffer();
+        dbSrc.put(chars);
+        dbSrc.clear();
+    };
+
+    @Benchmark
+    public CharBuffer appendDirectToDirect() {
+        dbDst.clear();
+        dbSrc.clear();
+        return dbDst.append(dbSrc);
+    }
+
+    @Benchmark
+    public CharBuffer appendDirectToHeap() {
+        hbDst.clear();
+        dbSrc.clear();
+        return hbDst.append(dbSrc);
+    }
+
+    @Benchmark
+    public CharBuffer appendHeapToHeap() {
+        hbDst.clear();
+        hbSrc.clear();
+        return hbDst.append(hbSrc);
+    }
+
+    @Benchmark
+    public CharBuffer appendHeapToDirect() {
+        dbDst.clear();
+        hbSrc.clear();
+        return dbDst.append(hbSrc);
+    }
+
+    @Benchmark
+    public CharBuffer appendString() {
+        hbDst.clear();
+        return hbDst.append(str);
+    }
+
+    @Benchmark
+    public CharBuffer appendStringBuffer() {
+        hbDst.clear();
+        return hbDst.append(strbuf);
+    }
+
+    @Benchmark
+    public CharBuffer appendStringBuilder() {
+        hbDst.clear();
+        return hbDst.append(strbld);
+    }
+
+    @Benchmark
+    public CharBuffer appendSubString() {
+        hbDst.clear();
+        return hbDst.append(str, SIZE/4, 3*SIZE/4);
+    }
+
+    @Benchmark
+    public CharBuffer appendSubStringBuffer() {
+        hbDst.clear();
+        return hbDst.append(strbuf, SIZE/4, 3*SIZE/4);
+    }
+
+    @Benchmark
+    public CharBuffer appendSubStringBuilder() {
+        hbDst.clear();
+        return hbDst.append(strbld, SIZE/4, 3*SIZE/4);
+    }
+}


### PR DESCRIPTION
Use the `getChars` method of `String`, `StringBuffer`, and `StringBuilder` to load the chars directly into the array of the heap buffer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305811](https://bugs.openjdk.org/browse/JDK-8305811): (bf) Improve performance of CharBuffer::append(CharSequence[,int,int])


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [bf403f90](https://git.openjdk.org/jdk/pull/13415/files/bf403f90bce165ad71e45a0372d22be4165c3e61)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13415/head:pull/13415` \
`$ git checkout pull/13415`

Update a local copy of the PR: \
`$ git checkout pull/13415` \
`$ git pull https://git.openjdk.org/jdk.git pull/13415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13415`

View PR using the GUI difftool: \
`$ git pr show -t 13415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13415.diff">https://git.openjdk.org/jdk/pull/13415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13415#issuecomment-1502503505)