### PR TITLE
8305780: javax/swing/JTable/7068740/bug7068740.java fails on Ubunutu 20.04

### DIFF
--- a/test/jdk/javax/swing/JTable/7068740/bug7068740.java
+++ b/test/jdk/javax/swing/JTable/7068740/bug7068740.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,79 +26,68 @@
  * @key headful
  * @bug 7068740
  * @summary JTable wrapped in JLayer can't use PGUP/PGDOWN keys
- * @author Vladislav Karnaukhov
  * @run main bug7068740
  */
 
-import javax.swing.*;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLayer;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.plaf.LayerUI;
 import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.table.DefaultTableModel;
-import java.awt.*;
-import java.awt.event.KeyEvent;
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class bug7068740 extends JFrame {
+public class bug7068740 {
 
     private static Robot robot = null;
     private static JTable table = null;
+    private static JFrame frame;
 
-    bug7068740() {
-        super();
-        setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-
-        DefaultTableModel model = new DefaultTableModel() {
-            @Override
-            public int getRowCount() {
-                return 20;
-            }
-
-            @Override
-            public int getColumnCount() {
-                return 2;
-            }
-
-            @Override
-            public Object getValueAt(int row, int column) {
-                return "(" + row + "," + column + ")";
-            }
-        };
-
-        table = new JTable(model);
-        table.setRowSelectionInterval(0, 0);
-        LayerUI<JComponent> layerUI = new LayerUI<>();
-        JLayer<JComponent> layer = new JLayer<>(table, layerUI);
-        JScrollPane scrollPane = new JScrollPane(layer);
-        add(scrollPane);
-        pack();
-        setLocationRelativeTo(null);
-    }
-
-    private static void setUp() {
-        try {
-            if (robot == null) {
-                robot = new Robot();
-                robot.setAutoDelay(50);
-            }
-
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    bug7068740 test = new bug7068740();
-                    test.setVisible(true);
-                }
-            });
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Test failed");
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Test failed");
-        } catch (AWTException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Test failed");
+    private static void setUp() throws Exception {
+        if (robot == null) {
+            robot = new Robot();
+            robot.setAutoDelay(100);
         }
+
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                DefaultTableModel model = new DefaultTableModel() {
+                    @Override
+                    public int getRowCount() {
+                        return 20;
+                    }
+
+                    @Override
+                    public int getColumnCount() {
+                        return 2;
+                    }
+
+                    @Override
+                    public Object getValueAt(int row, int column) {
+                        return "(" + row + "," + column + ")";
+                    }
+                };
+
+                table = new JTable(model);
+                table.setRowSelectionInterval(0, 0);
+                LayerUI<JComponent> layerUI = new LayerUI<>();
+                JLayer<JComponent> layer = new JLayer<>(table, layerUI);
+                JScrollPane scrollPane = new JScrollPane(layer);
+                frame = new JFrame();
+                frame.add(scrollPane);
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            }
+        });
     }
 
     private static int getSelectedRow() throws Exception {
@@ -123,6 +112,7 @@ public class bug7068740 extends JFrame {
             throw new RuntimeException("Test failed");
         }
 
+        robot.delay(1000);
         robot.keyPress(KeyEvent.VK_PAGE_UP);
         robot.keyRelease(KeyEvent.VK_PAGE_UP);
         robot.waitForIdle();
@@ -135,10 +125,18 @@ public class bug7068740 extends JFrame {
         try {
             UIManager.setLookAndFeel(new MetalLookAndFeel());
             setUp();
+            robot.waitForIdle();
+            robot.delay(1000);	    
             doTest();
         } catch (UnsupportedLookAndFeelException e) {
             e.printStackTrace();
             throw new RuntimeException("Test failed");
-        }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });		
+        }	    
     }
 }

--- a/test/jdk/javax/swing/JTable/7068740/bug7068740.java
+++ b/test/jdk/javax/swing/JTable/7068740/bug7068740.java
@@ -126,7 +126,7 @@ public class bug7068740 {
             UIManager.setLookAndFeel(new MetalLookAndFeel());
             setUp();
             robot.waitForIdle();
-            robot.delay(1000);	    
+            robot.delay(1000);
             doTest();
         } catch (UnsupportedLookAndFeelException e) {
             e.printStackTrace();
@@ -136,7 +136,7 @@ public class bug7068740 {
                 if (frame != null) {
                     frame.dispose();
                 }
-            });		
-        }	    
+            });
+        }
     }
 }


### PR DESCRIPTION
Although not able to reproduce this locally or in mach5, it can happen when robot key movements start happening before frame is visible,
so added stability fixes like delay of 1s after frame is visible and key movements are done, added waitForIdle, increase autodelay time, added frame dispose also at end.

Several iterations of the test pass in all platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305780](https://bugs.openjdk.org/browse/JDK-8305780): javax/swing/JTable/7068740/bug7068740.java fails on Ubunutu 20.04


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13416/head:pull/13416` \
`$ git checkout pull/13416`

Update a local copy of the PR: \
`$ git checkout pull/13416` \
`$ git pull https://git.openjdk.org/jdk.git pull/13416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13416`

View PR using the GUI difftool: \
`$ git pr show -t 13416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13416.diff">https://git.openjdk.org/jdk/pull/13416.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13416#issuecomment-1502651249)