### PR TITLE
8305778: javax/swing/JTableHeader/6884066/bug6884066.java: Unexpected header's value; index = 4 value = E

### DIFF
--- a/test/jdk/javax/swing/JTableHeader/6884066/bug6884066.java
+++ b/test/jdk/javax/swing/JTableHeader/6884066/bug6884066.java
@@ -46,7 +46,7 @@ public class bug6884066 {
     private static volatile Point point;
 
     public static void main(String[] args) throws Exception {
-        try {	    
+        try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 
             Robot robot = new Robot();

--- a/test/jdk/javax/swing/JTableHeader/6884066/bug6884066.java
+++ b/test/jdk/javax/swing/JTableHeader/6884066/bug6884066.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,56 +23,74 @@
 
 /*
    @test
-  @key headful
+   @key headful
    @bug 6884066
    @summary JTableHeader listens mouse in disabled state and doesn't work when not attached to a table
-   @author Alexander Potochkin
    @run main bug6884066
 */
 
-import javax.swing.*;
+import java.awt.event.InputEvent;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JTable;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableColumn;
-import java.awt.*;
-import java.awt.event.InputEvent;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class bug6884066 {
+    private static JFrame frame;
     private static JTableHeader header;
+    private static volatile Point point;
 
     public static void main(String[] args) throws Exception {
+        try {	    
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-
-        Robot robot = new Robot();
-        robot.setAutoDelay(20);
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                // just to quickly grab a column model
-                JTable table = new JTable(10, 5);
-                header = new JTableHeader(table.getColumnModel());
-                checkColumn(0, "A");
-                JFrame frame = new JFrame("standalone header");
-                frame.add(header);
-                frame.pack();
-                frame.setVisible(true);
-                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    // just to quickly grab a column model
+                    JTable table = new JTable(10, 5);
+                    header = new JTableHeader(table.getColumnModel());
+                    checkColumn(0, "A");
+                    frame = new JFrame("standalone header");
+                    frame.add(header);
+                    frame.pack();
+                    frame.setLocationRelativeTo(null);
+                    frame.setVisible(true);
+                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                }
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                point = header.getLocationOnScreen();
+            });
+            robot.mouseMove(point.x + 3, point.y + 3);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int i = 0; i < header.getWidth() - 3; i++) {
+                robot.mouseMove(point.x + i, point.y + 3);
             }
-        });
-        robot.waitForIdle();
-        Point point = header.getLocationOnScreen();
-        robot.mouseMove(point.x + 3, point.y + 3);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        for (int i = 0; i < header.getWidth() - 3; i++) {
-            robot.mouseMove(point.x + i, point.y + 3);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    TableColumnModel model = header.getColumnModel();
+                    checkColumn(model.getColumnCount() - 1, "A");
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                TableColumnModel model = header.getColumnModel();
-                checkColumn(model.getColumnCount() - 1, "A");
-            }
-        });
     }
 
     private static void checkColumn(int index, String str) {


### PR DESCRIPTION
Although not reproducible locally or in mach5, some stability fixes have been added in the test like
induce 1s delay after frame is made visible, increase autodelay time, move frame to center of screen and also dispose frame at end.

Modified test pass for several iterations in all platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305778](https://bugs.openjdk.org/browse/JDK-8305778): javax/swing/JTableHeader/6884066/bug6884066.java: Unexpected header's value; index = 4 value = E


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13417/head:pull/13417` \
`$ git checkout pull/13417`

Update a local copy of the PR: \
`$ git checkout pull/13417` \
`$ git pull https://git.openjdk.org/jdk.git pull/13417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13417`

View PR using the GUI difftool: \
`$ git pr show -t 13417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13417.diff">https://git.openjdk.org/jdk/pull/13417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13417#issuecomment-1502698479)