### PR TITLE
8305079: Remove finalize() from compiler/c2/Test719030

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7190310.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7190310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,16 +39,12 @@ package compiler.c2;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.lang.ref.Cleaner;
 
 public class Test7190310 {
     private static Object str = new Object() {
         public String toString() {
             return "The Object";
-        }
-
-        protected void finalize() throws Throwable {
-            System.out.println("The Object is being finalized");
-            super.finalize();
         }
     };
     private final static ReferenceQueue<Object> rq =
@@ -58,6 +54,7 @@ public class Test7190310 {
 
     public static void main(String[] args)
             throws InterruptedException {
+        Cleaner.create().register(str, () -> System.out.println("The Object is being finalized"));
         Thread reader = new Thread() {
             public void run() {
                 while (wr.get() != null) {


### PR DESCRIPTION
The `finalize()` method is replaced by a Cleaner callback.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305079](https://bugs.openjdk.org/browse/JDK-8305079): Remove finalize() from compiler/c2/Test719030


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13418/head:pull/13418` \
`$ git checkout pull/13418`

Update a local copy of the PR: \
`$ git checkout pull/13418` \
`$ git pull https://git.openjdk.org/jdk.git pull/13418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13418`

View PR using the GUI difftool: \
`$ git pr show -t 13418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13418.diff">https://git.openjdk.org/jdk/pull/13418.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13418#issuecomment-1504944943)