### PR TITLE
8305080: Remove finalize() from test/hotspot/jtreg/compiler/jvmci/common/testcases that used in compiler/jvmci/compilerToVM/ tests

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/common/testcases/AbstractClassExtender.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/testcases/AbstractClassExtender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,5 @@ public class AbstractClassExtender extends AbstractClass {
     @Override
     public void abstractMethod() {
         // empty
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize();
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/common/testcases/MultipleImplementer1.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/testcases/MultipleImplementer1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,5 @@ public class MultipleImplementer1 implements MultipleImplementersInterface {
     @Override
     public void testMethod() {
         // empty
-    }
-    @Override
-    public void finalize() throws Throwable {
-        super.finalize();
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/common/testcases/MultipleImplementersInterface.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/testcases/MultipleImplementersInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,6 @@ public interface MultipleImplementersInterface {
     }
 
     void testMethod();
-
-    default void finalize() throws Throwable {
-        // empty
-    }
 
     default void lambdaUsingMethod() {
         Thread t = new Thread(this::defaultMethod);

--- a/test/hotspot/jtreg/compiler/jvmci/common/testcases/MultipleSuperImplementers.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/testcases/MultipleSuperImplementers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,4 @@
 package compiler.jvmci.common.testcases;
 
 public abstract class MultipleSuperImplementers implements DuplicateSimpleSingleImplementerInterface, SimpleSingleImplementerInterface {
-    public void finalize() {
-    }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/common/testcases/SingleImplementer.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/testcases/SingleImplementer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,5 @@ public class SingleImplementer implements SingleImplementerInterface {
 
     public void nonInterfaceMethod() {
         // empty
-    }
-
-    @Override
-    public void finalize() throws Throwable {
-        super.finalize();
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/common/testcases/SingleImplementerInterface.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/testcases/SingleImplementerInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,5 +32,5 @@ public interface SingleImplementerInterface {
 
     void interfaceMethod();
 
-    void finalize() throws Throwable;
+    //void finalize() throws Throwable;
 }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/HasFinalizableSubclassTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/HasFinalizableSubclassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,10 +73,13 @@ public class HasFinalizableSubclassTest {
         result.add(new TestCase(SingleImplementerInterface.class, false));
         // iface with default finalize method
         result.add(new TestCase(MultipleImplementersInterface.class, false));
-        // class which implements iface w/ default finalize method
-        result.add(new TestCase(MultipleImplementer1.class, true));
-        // abstract class with finalizeable subclass
-        result.add(new TestCase(AbstractClass.class, true));
+        // class which implements iface
+        // since the deprecated finalize() method is removed from the class,
+        // the expected value here should be false
+        result.add(new TestCase(MultipleImplementer1.class, false));
+        // abstract class with subclass that has no finalize
+        // The finalize() method of the exxtender is removed due to deprecation
+        result.add(new TestCase(AbstractClass.class, false));
         // non-implemented iface
         result.add(new TestCase(DoNotImplementInterface.class, false));
         return result;


### PR DESCRIPTION
The finalise() methods are removed and replaced by Cleaner callbacks.

Note:
`test/hotspot/jtreg/compiler/jvmci/compilerToVM/HasFinalizableSubclassTest.java` may be removed since there is no need to test if finalize() exists in the subclasses or not..