### PR TITLE
8305819: LogConfigurationTest intermittently fails on AArch64

### DIFF
--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -127,7 +127,7 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
        node->_next = node->_next->_next) {
   }
 
-  OrderAccess::storestore();
+  OrderAccess::release();
 
   // Update the _level_start index
   for (int l = LogLevel::Last; l >= level; l--) {

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -127,6 +127,8 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
        node->_next = node->_next->_next) {
   }
 
+  //Prevent the reordering of adding node to list and setting the value of node.
+  //Such a reordering would lead to reading incorrect values.
   OrderAccess::release();
 
   // Update the _level_start index

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -127,21 +127,22 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
        node->_next = node->_next->_next) {
   }
 
-  // Prevent the reordering of adding node to list and setting the value of node.
-  // Such a reordering would lead to reading incorrect values.
+  // To allow lock-free iteration of the output list the updates in the loops
+  // below require release semantics.
   OrderAccess::release();
 
   // Update the _level_start index
   for (int l = LogLevel::Last; l >= level; l--) {
-    if (_level_start[l] == nullptr || _level_start[l]->_level < level) {
-      _level_start[l] = node;
+    LogOutputNode* lnode = Atomic::load(&_level_start[l]);
+    if (lnode == nullptr || lnode->_level < level) {
+      Atomic::store(&_level_start[l], node);
     }
   }
 
   // Add the node the list
-  for (LogOutputNode* cur = _level_start[LogLevel::Last]; cur != nullptr; cur = cur->_next) {
-    if (cur != node && cur->_next == node->_next) {
-      cur->_next = node;
+  for (LogOutputNode* cur = Atomic::load(&_level_start[LogLevel::Last]); cur != nullptr; cur = Atomic::load(&cur->_next)) {
+    if (cur != node && Atomic::load(&cur->_next) == node->_next) {
+      Atomic::store(&cur->_next, node);
       break;
     }
   }

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -127,8 +127,8 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
        node->_next = node->_next->_next) {
   }
 
-  //Prevent the reordering of adding node to list and setting the value of node.
-  //Such a reordering would lead to reading incorrect values.
+  // Prevent the reordering of adding node to list and setting the value of node.
+  // Such a reordering would lead to reading incorrect values.
   OrderAccess::release();
 
   // Update the _level_start index

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -127,6 +127,8 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
        node->_next = node->_next->_next) {
   }
 
+  OrderAccess::storestore();
+
   // Update the _level_start index
   for (int l = LogLevel::Last; l >= level; l--) {
     if (_level_start[l] == nullptr || _level_start[l]->_level < level) {

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -125,6 +125,7 @@ class LogOutputList {
     }
 
     void operator++(int) {
+      // FIXME: memory_order_consume could be used here.
       // Atomic access on the reading side for LogOutputList.
       _current = Atomic::load_acquire(&_current->_next);
     }
@@ -140,6 +141,7 @@ class LogOutputList {
 
   Iterator iterator(LogLevelType level = LogLevel::Last) {
     increase_readers();
+    // FIXME: memory_order_consume could be used here.
     // Atomic access on the reading side for LogOutputList.
     return Iterator(this, Atomic::load_acquire(&_level_start[level]));
   }

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -26,6 +26,7 @@
 
 #include "logging/logLevel.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class LogOutput;
@@ -48,11 +49,11 @@ class LogOutputList {
  private:
   struct LogOutputNode : public CHeapObj<mtLogging> {
     LogOutput*      _value;
-    LogOutputNode*  _next;
+    LogOutputNode* volatile _next;
     LogLevelType    _level;
   };
 
-  LogOutputNode*  _level_start[LogLevel::Count];
+  LogOutputNode* volatile _level_start[LogLevel::Count];
   volatile jint   _active_readers;
 
   LogOutputNode* find(const LogOutput* output) const;
@@ -124,7 +125,8 @@ class LogOutputList {
     }
 
     void operator++(int) {
-      _current = _current->_next;
+      // Atomic access on the reading side for LogOutputList.
+      _current = Atomic::load_acquire(&_current->_next);
     }
 
     bool operator!=(const LogOutputNode *ref) const {
@@ -138,7 +140,8 @@ class LogOutputList {
 
   Iterator iterator(LogLevelType level = LogLevel::Last) {
     increase_readers();
-    return Iterator(this, _level_start[level]);
+    // Atomic access on the reading side for LogOutputList.
+    return Iterator(this, Atomic::load_acquire(&_level_start[level]));
   }
 
   LogOutputNode* end() const {


### PR DESCRIPTION
LogConfigurationTest\*reconfigure\*MT* crash intermittently on AArch64.
According to the crash log and coredump, we found it crash as follows:
```
void LogTagSet::log(LogLevelType level, const char* msg) {
  LogOutputList::Iterator it = _output_list.iterator(level);
  LogDecorations decorations(level, *this, _decorators);

  for (; it != _output_list.end(); it++) {
    (*it)->write(decorations, msg);//crash 
  }
}
```
In the test, two threads write into the log while another thread dynamically changes the decorators and tags. During this time, the  _output_list will be modified. Because of the relax memory model of aarch64, while adding LogOutputNode to LogOutputList, adding node to list and setting the value of node may be reordered, therefore the read thread may not read the correct value of the node's content. Consequently, storestore memory barrier is needed to ensure the order of writing. 
By the way, applying this patch may affect performance.

How to reproduce on Linux aarch64:
test case
```
/* @test
 * @library /test/lib
 * @modules java.base/jdk.internal.misc
 *          java.xml
 * @run main/native GTestWrapper --gtest_filter=LogConfigurationTest*reconfigure*MT*
 */
```
Crash may occasionally occur after running continuously for 5000 times.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305819](https://bugs.openjdk.org/browse/JDK-8305819): LogConfigurationTest intermittently fails on AArch64


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer) ⚠️ Review applies to [e5480649](https://git.openjdk.org/jdk/pull/13421/files/e5480649205a276c0876da7c70cd9624f004d8ce)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13421/head:pull/13421` \
`$ git checkout pull/13421`

Update a local copy of the PR: \
`$ git checkout pull/13421` \
`$ git pull https://git.openjdk.org/jdk.git pull/13421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13421`

View PR using the GUI difftool: \
`$ git pr show -t 13421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13421.diff">https://git.openjdk.org/jdk/pull/13421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13421#issuecomment-1521591308)