### PR TITLE
8305084: Remove the removal warnings for finalize() from test/hotspot/jtreg/serviceability/dcmd/gc/FinalizerInfoTest.java and RunFinalizationTest.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/FinalizationRunner.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/FinalizationRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/FinalizationRunner.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/FinalizationRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class FinalizationRunner {
 
     static class MyObject {
         @Override
+        @SuppressWarnings("removal")
         protected void finalize() {
             if (Thread.currentThread().getName().equals("Finalizer")) {
                 try {

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/FinalizerInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/FinalizerInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class FinalizerInfoTest {
             // Make sure object allocation/deallocation is not optimized out
             wasInitialized += 1;
         }
-
+        @SuppressWarnings("removal")
         protected void finalize() {
             // Trap the object in a finalization queue
             wasTrapped += 1;


### PR DESCRIPTION
The `removal` warnings are suppressed out.
Test:
`FinalizerInfoTest` and `RunFinalizationTest` are executed locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305084](https://bugs.openjdk.org/browse/JDK-8305084): Remove the removal warnings for finalize() from test/hotspot/jtreg/serviceability/dcmd/gc/FinalizerInfoTest.java and RunFinalizationTest.java


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13423/head:pull/13423` \
`$ git checkout pull/13423`

Update a local copy of the PR: \
`$ git checkout pull/13423` \
`$ git pull https://git.openjdk.org/jdk.git pull/13423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13423`

View PR using the GUI difftool: \
`$ git pr show -t 13423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13423.diff">https://git.openjdk.org/jdk/pull/13423.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13423#issuecomment-1503073448)