### PR TITLE
8305529: DefaultProxySelector.select(URI) in certain cases returns a List with null element

### DIFF
--- a/test/jdk/sun/net/spi/SystemProxyDriver.java
+++ b/test/jdk/sun/net/spi/SystemProxyDriver.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @bug 8305529
+ * @summary Verifies that the sun.net.spi.DefaultProxySelector#select(URI) doesn't return a List
+ *          with null elements in it
+ * @modules java.base/sun.net.spi:+open
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools SystemProxyTest
+ * @run driver SystemProxyDriver
+ */
+public class SystemProxyDriver {
+    // launches the SystemProxyTest as a separate process and verifies that the test passes
+    public static void main(final String[] args) throws Exception {
+        final String[] commandArgs = new String[]{
+                "--add-opens",
+                "java.base/sun.net.spi=ALL-UNNAMED",
+                // trigger use of the http_proxy environment variable that we pass when launching
+                // this Java program
+                "-Djava.net.useSystemProxies=true",
+                "SystemProxyTest"
+        };
+        final ProcessBuilder pb = ProcessTools.createTestJvm(commandArgs);
+        pb.inheritIO();
+        pb.environment().put("http_proxy", "foo://"); // intentionally use a value without host/port
+        final Process p = pb.start();
+        final int exitCode = p.waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException("Test failed, exitCode: " + exitCode);
+        }
+    }
+}

--- a/test/jdk/sun/net/spi/SystemProxyTest.java
+++ b/test/jdk/sun/net/spi/SystemProxyTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.List;
+
+import sun.net.spi.DefaultProxySelector;
+
+// this test is launched from SystemProxyDriver
+public class SystemProxyTest {
+
+    // calls the DefaultProxySelector.select(URI) and verifies that the returned List is
+    // not null, not empty and doesn't contain null elements.
+    public static void main(final String[] args) throws Exception {
+        final ProxySelector ps = new DefaultProxySelector();
+        final URI uri = new URI("http://example.com"); // the target URL doesn't matter
+        final List<Proxy> proxies = ps.select(uri);
+        if (proxies == null) {
+            // null isn't expected to be returned by the select() API
+            throw new AssertionError("DefaultProxySelector.select(URI) returned null for uri: "
+                    + uri);
+        }
+        if (proxies.isEmpty()) {
+            // empty list isn't expected to be returned by the select() API, instead when
+            // no proxy is configured, the returned list is expected to contain one entry with
+            // a Proxy instance representing direct connection
+            throw new AssertionError("DefaultProxySelector.select(URI) returned empty list" +
+                    " for uri: " + uri);
+        }
+        System.out.println("returned proxies list: " + proxies);
+        for (final Proxy p : proxies) {
+            if (p == null) {
+                throw new AssertionError("null proxy in proxies list for uri: " + uri);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue reported in https://bugs.openjdk.org/browse/JDK-8305529?

There were a couple of places in the `DefaultProxySelector.c` (for unix variant) where we would end up returning an array with `null` element in it, when an error was detected by the underlying library that we invoke upon. The change here fixes those places to immediately return a `null` instance instead of an array, when iterating over the configured proxies. This matches with how we handle similar issues within the code (as well as on other OS, like windows and macos).

A jtreg test case has been added which reproduces on variant of the reported bug and verifies the fix. As noted in the JBS issue, the other variant of the bug (where environment variables have empty values) isn't reproducible and that appears to be because the underlying library that we use, now has a fix/change to ignore such proxy values.

One round of testing has completed without any issues. I have triggered a more extensive tier testing to make sure nothing regresses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305529](https://bugs.openjdk.org/browse/JDK-8305529): DefaultProxySelector.select(URI) in certain cases returns a List with null element


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13424/head:pull/13424` \
`$ git checkout pull/13424`

Update a local copy of the PR: \
`$ git checkout pull/13424` \
`$ git pull https://git.openjdk.org/jdk.git pull/13424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13424`

View PR using the GUI difftool: \
`$ git pr show -t 13424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13424.diff">https://git.openjdk.org/jdk/pull/13424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13424#issuecomment-1503162089)