### PR TITLE
8305847

### DIFF
--- a/test/jdk/java/net/httpclient/ReferenceTracker.java
+++ b/test/jdk/java/net/httpclient/ReferenceTracker.java
@@ -63,6 +63,14 @@ public class ReferenceTracker {
         return diagnose(warnings, (t) -> t.getOutstandingHttpOperations() > 0);
     }
 
+    public StringBuilder diagnose(Tracker tracker) {
+        return diagnose(tracker, new StringBuilder(), (t) -> t.getOutstandingHttpOperations() > 0);
+    }
+
+    public StringBuilder diagnose(HttpClient client) {
+        return diagnose(getTracker(client));
+    }
+
     public StringBuilder diagnose(Tracker tracker, StringBuilder warnings, Predicate<Tracker> hasOutstanding) {
         checkOutstandingOperations(warnings, tracker, hasOutstanding);
         return warnings;


### PR DESCRIPTION
The HttpClient close tests could be improved to provide better diagnosis. 

The tests make some requests and register some dependents action to check the response state, followed by some dependent action that will read the request body (from an input stream). But if the first dependent action asserts, the second will not be executed, and the body will neither be read or closed.
This will later prevent HttpClient::close method, or the HttpClient::awaitTermination method, to terminate as expected, and the test will then later fail in timeout (either from jtreg or awaitTermination). This behaviour can be confusing for failure analysis. 

The tests could also be further simplified by creating the executor in which the responses bodies will eventually be read (called `readerService`) in the `setup()` method and later close it in `teardown()`. This will simplify the cleanup phase, and ensure the service does not get closed until all dependent actions have been scheduled.
