### PR TITLE
8305091: Change ChaCha20 cipher init behavior to match AES-GCM

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20NoReuse.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20NoReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8153029
+ * @bug 8153029 8305091
  * @library /test/lib
  * @run main ChaCha20NoReuse
  * @summary ChaCha20 Cipher Implementation (key/nonce reuse protection)
@@ -376,7 +376,7 @@ public class ChaCha20NoReuse {
                 }
                 SecretKey key = new SecretKeySpec(testData.key, ALG_CC20);
 
-                // Initialize and encrypt
+                // Initialize and decrypt
                 cipher.init(testData.direction, key, spec);
                 if (algorithm.equals(ALG_CC20_P1305)) {
                     cipher.updateAAD(testData.aad);
@@ -384,18 +384,12 @@ public class ChaCha20NoReuse {
                 cipher.doFinal(testData.input);
                 System.out.println("First decryption complete");
 
-                // Now attempt to encrypt again without changing the key/IV
-                // This should fail.
-                try {
-                    if (algorithm.equals(ALG_CC20_P1305)) {
-                        cipher.updateAAD(testData.aad);
-                    }
-                    cipher.doFinal(testData.input);
-                    throw new RuntimeException(
-                            "Expected IllegalStateException not thrown");
-                } catch (IllegalStateException ise) {
-                    // Do nothing, this is what we expected to happen
+                // Now attempt to decrypt again without changing the key/IV
+                // We allow this scenario.
+                if (algorithm.equals(ALG_CC20_P1305)) {
+                    cipher.updateAAD(testData.aad);
                 }
+                cipher.doFinal(testData.input);
             } catch (Exception exc) {
                 System.out.println("Unexpected exception: " + exc);
                 exc.printStackTrace();
@@ -408,7 +402,8 @@ public class ChaCha20NoReuse {
 
     /**
      * Perform an AEAD decryption with corrupted data so the tag does not
-     * match.  Then attempt to reuse the cipher without initialization.
+     * match.  Then use the uncorrupted test vector input and attempt to
+     * reuse the cipher without initialization.
      */
     public static final TestMethod decFailNoInit = new TestMethod() {
         @Override
@@ -441,16 +436,16 @@ public class ChaCha20NoReuse {
                     System.out.println("Expected decryption failure occurred");
                 }
 
-                // Make sure that despite the exception, the Cipher object is
-                // not in a state that would leave it initialized and able
-                // to process future decryption operations without init.
-                try {
-                    cipher.updateAAD(testData.aad);
-                    cipher.doFinal(testData.input);
-                    throw new RuntimeException(
-                            "Expected IllegalStateException not thrown");
-                } catch (IllegalStateException ise) {
-                    // Do nothing, this is what we expected to happen
+                // Even though an exception occurred during decryption, the
+                // Cipher object should be returned to its post-init state.
+                // Since this is a decryption operation, we should allow
+                // key/nonce reuse.  It should properly decrypt the uncorrupted
+                // input.
+                cipher.updateAAD(testData.aad);
+                byte[] pText = cipher.doFinal(testData.input);
+                if (!Arrays.equals(pText, testData.expOutput)) {
+                    throw new RuntimeException("FAIL: Attempted decryption " +
+                            "did not match expected plaintext");
                 }
             } catch (Exception exc) {
                 System.out.println("Unexpected exception: " + exc);
@@ -562,18 +557,17 @@ public class ChaCha20NoReuse {
                 if (algorithm.equals(ALG_CC20_P1305)) {
                     cipher.updateAAD(testData.aad);
                 }
-                cipher.doFinal(testData.input);
+                byte[] pText = cipher.doFinal(testData.input);
+                if (!Arrays.equals(pText, testData.expOutput)) {
+                    throw new RuntimeException("FAIL: Attempted decryption " +
+                            "did not match expected plaintext");
+                }
                 System.out.println("First decryption complete");
 
                 // Initializing after the completed decryption with
-                // the same key and nonce should fail.
-                try {
-                    cipher.init(testData.direction, key, spec);
-                    throw new RuntimeException(
-                            "Expected InvalidKeyException not thrown");
-                } catch (InvalidKeyException ike) {
-                    // Do nothing, this is what we expected to happen
-                }
+                // the same key and nonce is allowed.
+                cipher.init(testData.direction, key, spec);
+                System.out.println("Successful reinit in DECRYPT_MODE");
             } catch (Exception exc) {
                 System.out.println("Unexpected exception: " + exc);
                 exc.printStackTrace();


### PR DESCRIPTION
This fixes an issue where the key/nonce reuse policy for SunJCE ChaCha20 and ChaCha20-Poly1305 was overly strict in enforcing no-reuse when the Cipher was in DECRYPT_MODE.  For decryption, this should be allowed and be consistent with the AES-GCM decryption initialization behavior.

- Issue: https://bugs.openjdk.org/browse/JDK-8305091
- CSR: https://bugs.openjdk.org/browse/JDK-8305822

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8305822](https://bugs.openjdk.org/browse/JDK-8305822) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8305091](https://bugs.openjdk.org/browse/JDK-8305091): Change ChaCha20 cipher init behavior to match AES-GCM
 * [JDK-8305822](https://bugs.openjdk.org/browse/JDK-8305822): Change ChaCha20 cipher init behavior to match AES-GCM (**CSR**)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13428/head:pull/13428` \
`$ git checkout pull/13428`

Update a local copy of the PR: \
`$ git checkout pull/13428` \
`$ git pull https://git.openjdk.org/jdk.git pull/13428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13428`

View PR using the GUI difftool: \
`$ git pr show -t 13428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13428.diff">https://git.openjdk.org/jdk/pull/13428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13428#issuecomment-1503822968)