### PR TITLE
8305763 : Parsing a URI with an underscore goes through a silent exception, negatively impacting performance

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3154,6 +3154,13 @@ public final class URI
             return p;
         }
 
+        // parse as a Registry-based authority if not insisting
+        // upon a server-based authority
+        private boolean parseRegistryChars()
+        {
+            return requireServerAuthority?false:true;
+        }
+
         // Check that each of the chars in [start, end) matches the given mask
         //
         private void checkChars(int start, int end,
@@ -3522,6 +3529,15 @@ public final class URI
                     break;
                 p = q;
             } while (p < n);
+
+            if(parseRegistryChars())
+            {
+                while(p < n &&  !at(p, n, ':'))
+                {
+                    q = scan(p, p+1, L_REG_NAME, H_REG_NAME);
+                    p = q;
+                }
+            }
 
             if ((p < n) && !at(p, n, ':'))
                 fail("Illegal character in hostname", p);

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3308,11 +3308,12 @@ public final class URI
                             host = null;
                             port = -1;
                             q = p;
-                        } else
+                        } else {
                             failExpecting("end of authority", q);
-                    } else
+                        }
+                    } else {
                         authority = input.substring(p, n);
-
+                    }
                 } catch (URISyntaxException x) {
                     // Undo results of failed parse
                     userInfo = null;
@@ -3407,7 +3408,7 @@ public final class URI
                     }
                     p = q;
                 }
-            } else if(skipParseException) {
+            } else if( p < n && skipParseException) {
                     return p;
             }
 

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3303,7 +3303,7 @@ public final class URI
                 try {
                     q = parseServer(p, n, skipParseException);
                     if (q < n) {
-                        if(skipParseException) {
+                        if (skipParseException) {
                             userInfo = null;
                             host = null;
                             port = -1;
@@ -3408,8 +3408,8 @@ public final class URI
                     }
                     p = q;
                 }
-            } else if( p < n && skipParseException) {
-                    return p;
+            } else if (p < n && skipParseException) {
+                return p;
             }
 
             if (p < n)
@@ -3540,10 +3540,8 @@ public final class URI
                 p = q;
             } while (p < n);
 
-            if ((p < n) && !at(p, n, ':'))
-            {
-                if(skipParseException)
-                {
+            if ((p < n) && !at(p, n, ':')) {
+                if (skipParseException) {
                     return p;
                 }
                 fail("Illegal character in hostname", p);


### PR DESCRIPTION
Issue 8305763 : Using underscores in the name for a URI triggers a silent exception in the java standard library, which consumes 5% of the CPU.

Exception:
java.net.URISyntaxException: Illegal character in hostname at index N: xyz1_abcd.com
    at java.base/java.net.URI$Parser.fail(URI.java:2943)
    at java.base/java.net.URI$Parser.parseHostname(URI.java:3487)
    at java.base/java.net.URI$Parser.parseServer(URI.java:3329)
    
    This exception is silent and does not produce any messages, except for ODP profiler, there is no other evidence that it’s happening (the stack trace above was printed after changes to Java library). The reason for this is because of how the URI creation is implemented in the java.net.URI class. There are two paths for creating a valid URI, and one of them goes through an exception.

We can see that if parseServer fails, there is still a way the authority gets assigned and we don’t throw an exception from the method. This means, not being able to parse the server is ok and the exception is silenced. In our case, the server parsing fails because we find an illegal character, as only alphanumeric and dash characters are allowed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305763](https://bugs.openjdk.org/browse/JDK-8305763): Parsing a URI with an underscore goes through a silent exception, negatively impacting performance


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13430/head:pull/13430` \
`$ git checkout pull/13430`

Update a local copy of the PR: \
`$ git checkout pull/13430` \
`$ git pull https://git.openjdk.org/jdk.git pull/13430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13430`

View PR using the GUI difftool: \
`$ git pr show -t 13430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13430.diff">https://git.openjdk.org/jdk/pull/13430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13430#issuecomment-1504383491)