### PR TITLE
8305858: Resolve multiple definition of 'handleSocketError' when statically linking with JDK native libraries

### DIFF
--- a/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
@@ -70,7 +70,7 @@ static jmethodID ss_ctrID;     /* sun.nio.ch.sctp.Shutdown.<init>            */
 /* defined in SctpNet.c */
 jobject SockAddrToInetSocketAddress(JNIEnv* env, struct sockaddr* addr);
 
-jint handleSocketError(JNIEnv *env, jint errorValue);
+jint sctpHandleSocketError(JNIEnv *env, jint errorValue);
 
 /*
  * Class:     sun_nio_ch_sctp_SctpChannelImpl
@@ -247,7 +247,7 @@ void handleSendFailed
         if (remaining > 0) {
             if ((rv = recvmsg(fd, msg, 0)) < 0) {
                 free(addressP);
-                handleSocketError(env, errno);
+                sctpHandleSocketError(env, errno);
                 return;
             }
 
@@ -458,7 +458,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_receive0
 #endif /* __linux__ */
 
             } else {
-                handleSocketError(env, errno);
+                sctpHandleSocketError(env, errno);
                 return 0;
             }
         }
@@ -482,7 +482,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_receive0
                 iov->iov_base = newBuf + rv;
                 iov->iov_len = SCTP_NOTIFICATION_SIZE - rv;
                 if ((rv = recvmsg(fd, msg, flags)) < 0) {
-                    handleSocketError(env, errno);
+                    sctpHandleSocketError(env, errno);
                     free(newBuf);
                     return 0;
                 }
@@ -582,7 +582,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_send0
             JNU_ThrowByName(env, JNU_JAVANETPKG "SocketException",
                             "Socket is shutdown for writing");
         } else {
-            handleSocketError(env, errno);
+            sctpHandleSocketError(env, errno);
             return 0;
         }
     }

--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c
@@ -118,7 +118,7 @@ jboolean loadSocketExtensionFuncs
 }
 
 jint
-handleSocketError(JNIEnv *env, jint errorValue)
+sctpHandleSocketError(JNIEnv *env, jint errorValue)
 {
     char *xn;
     switch (errorValue) {
@@ -195,7 +195,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpNet_socket0
                                          "Protocol not supported");
             return IOS_THROWN;
         } else {
-            return handleSocketError(env, errno);
+            return sctpHandleSocketError(env, errno);
         }
     }
 
@@ -210,7 +210,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpNet_socket0
     //event.sctp_partial_delivery_event = 1;
     //event.sctp_adaptation_layer_event = 1;
     if (setsockopt(fd, IPPROTO_SCTP, SCTP_EVENTS, &event, sizeof(event)) != 0) {
-       handleSocketError(env, errno);
+       sctpHandleSocketError(env, errno);
     }
     return fd;
 }
@@ -248,7 +248,7 @@ JNIEXPORT void JNICALL Java_sun_nio_ch_sctp_SctpNet_bindx
 
     if (nio_sctp_bindx(fd, (void *)sap, addrsLength, add ? SCTP_BINDX_ADD_ADDR :
                        SCTP_BINDX_REM_ADDR) != 0) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
     }
 
     free(sap);
@@ -263,7 +263,7 @@ JNIEXPORT void JNICALL
 Java_sun_nio_ch_sctp_SctpNet_listen0
   (JNIEnv *env, jclass cl, jint fd, jint backlog) {
     if (listen(fd, backlog) < 0)
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
 }
 
 /*
@@ -290,7 +290,7 @@ Java_sun_nio_ch_sctp_SctpNet_connect0
         } else if (errno == EINTR) {
             return IOS_INTERRUPTED;
         }
-        return handleSocketError(env, errno);
+        return sctpHandleSocketError(env, errno);
     }
     return 1;
 }
@@ -365,7 +365,7 @@ JNIEXPORT jobjectArray JNICALL Java_sun_nio_ch_sctp_SctpNet_getLocalAddresses0
     jobjectArray isaa;
 
     if ((addrCount = nio_sctp_getladdrs(fd, 0, (struct sockaddr **)&addr_buf)) == -1) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
         return NULL;
     }
 
@@ -410,7 +410,7 @@ jobjectArray getRemoteAddresses(JNIEnv *env, jint fd, sctp_assoc_t id) {
     jobjectArray isaa;
 
     if ((addrCount = nio_sctp_getpaddrs(fd, id, (struct sockaddr **)&addr_buf)) == -1) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
         return NULL;
     }
 
@@ -732,7 +732,7 @@ JNIEXPORT void JNICALL Java_sun_nio_ch_sctp_SctpNet_shutdown0
     msg->msg_controllen = cmsg->cmsg_len;
 
     if ((rv = sendmsg(fd, msg, 0)) < 0) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
     }
 }
 
@@ -745,7 +745,7 @@ JNIEXPORT int JNICALL Java_sun_nio_ch_sctp_SctpNet_branch0
   (JNIEnv *env, jclass klass, jint fd, jint assocId) {
     int newfd = 0;
     if ((newfd = nio_sctp_peeloff(fd, assocId)) < 0) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
     }
 
     return newfd;


### PR DESCRIPTION
Rename 'handleSocketError' to 'sctpHandleSocketError' in libsctp. This resolves related duplicate symbol failure when both libnio and libsctp are statically linked with.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305858](https://bugs.openjdk.org/browse/JDK-8305858): Resolve multiple definition of 'handleSocketError' when statically linking with JDK native libraries


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13433/head:pull/13433` \
`$ git checkout pull/13433`

Update a local copy of the PR: \
`$ git checkout pull/13433` \
`$ git pull https://git.openjdk.org/jdk.git pull/13433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13433`

View PR using the GUI difftool: \
`$ git pr show -t 13433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13433.diff">https://git.openjdk.org/jdk/pull/13433.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13433#issuecomment-1503976439)