### PR TITLE
JDK-8305712: [MacOS] Deprecated Cocoa-NSEvent names

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformResponder.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformResponder.java
@@ -139,7 +139,7 @@ final class CPlatformResponder {
                         short keyCode, boolean needsKeyTyped, boolean needsKeyReleased) {
         boolean isFlagsChangedEvent =
             isNpapiCallback ? (eventType == CocoaConstants.NPCocoaEventFlagsChanged) :
-                              (eventType == CocoaConstants.NSFlagsChanged);
+                              (eventType == CocoaConstants.NSEventTypeFlagsChanged);
 
         int jeventType = KeyEvent.KEY_PRESSED;
         int jkeyCode = KeyEvent.VK_UNDEFINED;

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformView.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformView.java
@@ -187,7 +187,7 @@ public class CPlatformView extends CFRetainedResource {
         int absX = event.getAbsX();
         int absY = event.getAbsY();
 
-        if (event.getType() == CocoaConstants.NSScrollWheel) {
+        if (event.getType() == CocoaConstants.NSEventTypeScrollWheel) {
             responder.handleScrollEvent(x, y, absX, absY, event.getModifierFlags(),
                                         event.getScrollDeltaX(), event.getScrollDeltaY(),
                                         event.getScrollPhase());

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -1022,7 +1022,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
             // We are going to show a modal window. Previously displayed window will be
             // blocked/disabled. So we have to send mouse exited event to it now, since
             // all mouse events are discarded for blocked/disabled windows.
-            execute(ptr -> nativeSynthesizeMouseEnteredExitedEvents(ptr, CocoaConstants.NSMouseExited));
+            execute(ptr -> nativeSynthesizeMouseEnteredExitedEvents(ptr, CocoaConstants.NSEventTypeMouseExited));
         }
 
         execute(ptr -> nativeSetEnabled(ptr, !blocked));

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CocoaConstants.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CocoaConstants.java
@@ -30,38 +30,38 @@ public final class CocoaConstants {
     private CocoaConstants(){}
 
     //from the NSEvent class reference:
-    public static final int NSLeftMouseDown      = 1;
-    public static final int NSLeftMouseUp        = 2;
-    public static final int NSRightMouseDown     = 3;
-    public static final int NSRightMouseUp       = 4;
-    public static final int NSMouseMoved         = 5;
-    public static final int NSLeftMouseDragged   = 6;
-    public static final int NSRightMouseDragged  = 7;
-    public static final int NSMouseEntered       = 8;
-    public static final int NSMouseExited        = 9;
-    public static final int NSKeyDown            = 10;
-    public static final int NSKeyUp              = 11;
-    public static final int NSFlagsChanged       = 12;
+    public static final int NSEventTypeLeftMouseDown      = 1;
+    public static final int NSEventTypeLeftMouseUp        = 2;
+    public static final int NSEventTypeRightMouseDown     = 3;
+    public static final int NSEventTypeRightMouseUp       = 4;
+    public static final int NSEventTypeMouseMoved         = 5;
+    public static final int NSEventTypeLeftMouseDragged   = 6;
+    public static final int NSEventTypeRightMouseDragged  = 7;
+    public static final int NSEventTypeMouseEntered       = 8;
+    public static final int NSEventTypeMouseExited        = 9;
+    public static final int NSEventTypeKeyDown            = 10;
+    public static final int NSEventTypeKeyUp              = 11;
+    public static final int NSEventTypeFlagsChanged       = 12;
 
-    public static final int NSScrollWheel        = 22;
-    public static final int NSOtherMouseDown     = 25;
-    public static final int NSOtherMouseUp       = 26;
-    public static final int NSOtherMouseDragged  = 27;
+    public static final int NSEventTypeScrollWheel        = 22;
+    public static final int NSEventTypeOtherMouseDown     = 25;
+    public static final int NSEventTypeOtherMouseUp       = 26;
+    public static final int NSEventTypeOtherMouseDragged  = 27;
 
     public static final int AllLeftMouseEventsMask =
-        1 << NSLeftMouseDown |
-        1 << NSLeftMouseUp |
-        1 << NSLeftMouseDragged;
+        1 << NSEventTypeLeftMouseDown |
+        1 << NSEventTypeLeftMouseUp |
+        1 << NSEventTypeLeftMouseDragged;
 
     public static final int AllRightMouseEventsMask =
-        1 << NSRightMouseDown |
-        1 << NSRightMouseUp |
-        1 << NSRightMouseDragged;
+        1 << NSEventTypeRightMouseDown |
+        1 << NSEventTypeRightMouseUp |
+        1 << NSEventTypeRightMouseDragged;
 
     public static final int AllOtherMouseEventsMask =
-        1 << NSOtherMouseDown |
-        1 << NSOtherMouseUp |
-        1 << NSOtherMouseDragged;
+        1 << NSEventTypeOtherMouseDown |
+        1 << NSEventTypeOtherMouseUp |
+        1 << NSEventTypeOtherMouseDragged;
 
     /*
     NSAppKitDefined      = 13,
@@ -69,7 +69,7 @@ public final class CocoaConstants {
     NSApplicationDefined = 15,
     NSPeriodic           = 16,
     NSCursorUpdate       = 17,
-    NSScrollWheel        = 22,
+    NSEventTypeScrollWheel        = 22,
     NSTabletPoint        = 23,
     NSTabletProximity    = 24,
     NSEventTypeGesture   = 29,

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CocoaConstants.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CocoaConstants.java
@@ -64,20 +64,20 @@ public final class CocoaConstants {
         1 << NSEventTypeOtherMouseDragged;
 
     /*
-    NSAppKitDefined      = 13,
-    NSSystemDefined      = 14,
-    NSApplicationDefined = 15,
-    NSPeriodic           = 16,
-    NSCursorUpdate       = 17,
+    NSEventTypeAppKitDefined      = 13,
+    NSEventTypeSystemDefined      = 14,
+    NSEventTypeApplicationDefined = 15,
+    NSEventTypePeriodic           = 16,
+    NSEventTypeCursorUpdate       = 17,
     NSEventTypeScrollWheel        = 22,
-    NSTabletPoint        = 23,
-    NSTabletProximity    = 24,
-    NSEventTypeGesture   = 29,
-    NSEventTypeMagnify   = 30,
-    NSEventTypeSwipe     = 31,
-    NSEventTypeRotate    = 18,
-    NSEventTypeBeginGesture = 19,
-    NSEventTypeEndGesture   = 20
+    NSEventTypeTabletPoint        = 23,
+    NSEventTypeTabletProximity    = 24,
+    NSEventTypeGesture            = 29,
+    NSEventTypeMagnify            = 30,
+    NSEventTypeSwipe              = 31,
+    NSEventTypeRotate             = 18,
+    NSEventTypeBeginGesture       = 19,
+    NSEventTypeEndGesture         = 20
     */
 
     // See http://developer.apple.com/library/mac/#documentation/Carbon/Reference/QuartzEventServicesRef/Reference/reference.html

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/NSEvent.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/NSEvent.java
@@ -207,37 +207,37 @@ final class NSEvent {
     static int nsToJavaEventType(int nsEventType) {
         int jeventType = 0;
         switch (nsEventType) {
-            case CocoaConstants.NSLeftMouseDown:
-            case CocoaConstants.NSRightMouseDown:
-            case CocoaConstants.NSOtherMouseDown:
+            case CocoaConstants.NSEventTypeLeftMouseDown:
+            case CocoaConstants.NSEventTypeRightMouseDown:
+            case CocoaConstants.NSEventTypeOtherMouseDown:
                 jeventType = MouseEvent.MOUSE_PRESSED;
                 break;
-            case CocoaConstants.NSLeftMouseUp:
-            case CocoaConstants.NSRightMouseUp:
-            case CocoaConstants.NSOtherMouseUp:
+            case CocoaConstants.NSEventTypeLeftMouseUp:
+            case CocoaConstants.NSEventTypeRightMouseUp:
+            case CocoaConstants.NSEventTypeOtherMouseUp:
                 jeventType = MouseEvent.MOUSE_RELEASED;
                 break;
-            case CocoaConstants.NSMouseMoved:
+            case CocoaConstants.NSEventTypeMouseMoved:
                 jeventType = MouseEvent.MOUSE_MOVED;
                 break;
-            case CocoaConstants.NSLeftMouseDragged:
-            case CocoaConstants.NSRightMouseDragged:
-            case CocoaConstants.NSOtherMouseDragged:
+            case CocoaConstants.NSEventTypeLeftMouseDragged:
+            case CocoaConstants.NSEventTypeRightMouseDragged:
+            case CocoaConstants.NSEventTypeOtherMouseDragged:
                 jeventType = MouseEvent.MOUSE_DRAGGED;
                 break;
-            case CocoaConstants.NSMouseEntered:
+            case CocoaConstants.NSEventTypeMouseEntered:
                 jeventType = MouseEvent.MOUSE_ENTERED;
                 break;
-            case CocoaConstants.NSMouseExited:
+            case CocoaConstants.NSEventTypeMouseExited:
                 jeventType = MouseEvent.MOUSE_EXITED;
                 break;
-            case CocoaConstants.NSScrollWheel:
+            case CocoaConstants.NSEventTypeScrollWheel:
                 jeventType = MouseEvent.MOUSE_WHEEL;
                 break;
-            case CocoaConstants.NSKeyDown:
+            case CocoaConstants.NSEventTypeKeyDown:
                 jeventType = KeyEvent.KEY_PRESSED;
                 break;
-            case CocoaConstants.NSKeyUp:
+            case CocoaConstants.NSEventTypeKeyUp:
                 jeventType = KeyEvent.KEY_RELEASED;
                 break;
         }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -354,9 +354,9 @@ static BOOL shouldUsePressAndHold() {
     NSEventType type = [event type];
 
     // check synthesized mouse entered/exited events
-    if ((type == NSMouseEntered && mouseIsOver) || (type == NSMouseExited && !mouseIsOver)) {
+    if ((type == NSEventTypeMouseEntered && mouseIsOver) || (type == NSEventTypeMouseExited && !mouseIsOver)) {
         return;
-    }else if ((type == NSMouseEntered && !mouseIsOver) || (type == NSMouseExited && mouseIsOver)) {
+    }else if ((type == NSEventTypeMouseEntered && !mouseIsOver) || (type == NSEventTypeMouseExited && mouseIsOver)) {
         mouseIsOver = !mouseIsOver;
     }
 
@@ -376,10 +376,10 @@ static BOOL shouldUsePressAndHold() {
     absP.y = screenRect.size.height - absP.y;
     jint clickCount;
 
-    if (type == NSMouseEntered ||
-        type == NSMouseExited ||
-        type == NSScrollWheel ||
-        type == NSMouseMoved) {
+    if (type == NSEventTypeMouseEntered ||
+        type == NSEventTypeMouseExited ||
+        type == NSEventTypeScrollWheel ||
+        type == NSEventTypeMouseMoved) {
         clickCount = 0;
     } else {
         clickCount = [event clickCount];
@@ -458,7 +458,7 @@ static BOOL shouldUsePressAndHold() {
 
     jstring characters = NULL;
     jstring charactersIgnoringModifiers = NULL;
-    if ([event type] != NSFlagsChanged) {
+    if ([event type] != NSEventTypeFlagsChanged) {
         characters = NSStringToJavaString(env, [event characters]);
         charactersIgnoringModifiers = NSStringToJavaString(env, [event charactersIgnoringModifiers]);
     }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -439,7 +439,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
     NSPoint screenLocation = [NSEvent mouseLocation];
     NSPoint windowLocation = [window convertScreenToBase: screenLocation];
-    int modifierFlags = (eventType == NSMouseEntered) ? NSMouseEnteredMask : NSMouseExitedMask;
+    int modifierFlags = (eventType == NSEventTypeMouseEntered) ? NSMouseEnteredMask : NSMouseExitedMask;
 
     NSEvent *mouseEvent = [NSEvent enterExitEventWithType: eventType
                                                  location: windowLocation
@@ -467,9 +467,9 @@ AWT_ASSERT_APPKIT_THREAD;
             BOOL isUnderMouse = ([window windowNumber] == topmostWindowUnderMouseID);
             BOOL mouseIsOver = [[window contentView] mouseIsOver];
             if (isUnderMouse && !mouseIsOver) {
-                [AWTWindow synthesizeMouseEnteredExitedEvents:window withType:NSMouseEntered];
+                [AWTWindow synthesizeMouseEnteredExitedEvents:window withType:NSEventTypeMouseEntered];
             } else if (!isUnderMouse && mouseIsOver) {
-                [AWTWindow synthesizeMouseEnteredExitedEvents:window withType:NSMouseExited];
+                [AWTWindow synthesizeMouseEnteredExitedEvents:window withType:NSEventTypeMouseExited];
             }
         }
     }
@@ -999,7 +999,7 @@ AWT_ASSERT_APPKIT_THREAD;
 }
 
 - (void)sendEvent:(NSEvent *)event {
-        if ([event type] == NSLeftMouseDown || [event type] == NSRightMouseDown || [event type] == NSOtherMouseDown) {
+        if ([event type] == NSEventTypeLeftMouseDown || [event type] == NSEventTypeRightMouseDown || [event type] == NSEventTypeOtherMouseDown) {
             if ([self isBlocked]) {
                 // Move parent windows to front and make sure that a child window is displayed
                 // in front of its nearest parent.
@@ -1602,7 +1602,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSynthesizeMou
 {
 JNI_COCOA_ENTER(env);
 
-    if (eventType == NSMouseEntered || eventType == NSMouseExited) {
+    if (eventType == NSEventTypeMouseEntered || eventType == NSEventTypeMouseExited) {
         NSWindow *nsWindow = OBJC(windowPtr);
 
         [ThreadUtilities performOnMainThreadWaiting:NO block:^(){

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
@@ -82,7 +82,7 @@
     // means we have to handle it here.
     NSEvent *currEvent = [[NSApplication sharedApplication] currentEvent];
 
-    if ([currEvent type] == NSKeyDown) {
+    if ([currEvent type] == NSEventTypeKeyDown) {
         // The action event can be ignored only if the key window is an AWT window.
         // Otherwise, the action event is the only notification and must be processed.
         NSWindow *keyWindow = [NSApp keyWindow];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/DnDUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/DnDUtilities.m
@@ -163,32 +163,32 @@ There are several problems with Drag and Drop - notably, the mismatch between Ja
 // Mouse and key modifiers mapping:
 + (NSUInteger)mapJavaExtModifiersToNSMouseDownButtons:(jint)modifiers
 {
-    NSUInteger result = NSLeftMouseDown;
+    NSUInteger result = NSEventTypeLeftMouseDown;
 
     if ((modifiers & java_awt_event_InputEvent_BUTTON1_DOWN_MASK) != 0)
-        result = NSLeftMouseDown;
+        result = NSEventTypeLeftMouseDown;
 
     if ((modifiers & java_awt_event_InputEvent_BUTTON2_DOWN_MASK) != 0)
-        result = NSOtherMouseDown;
+        result = NSEventTypeOtherMouseDown;
 
     if ((modifiers & java_awt_event_InputEvent_BUTTON3_DOWN_MASK) != 0)
-        result = NSRightMouseDown;
+        result = NSEventTypeRightMouseDown;
 
     return result;
 }
 
 + (NSUInteger)mapJavaExtModifiersToNSMouseUpButtons:(jint)modifiers
 {
-    NSUInteger result = NSLeftMouseUp;
+    NSUInteger result = NSEventTypeLeftMouseUp;
 
     if ((modifiers & java_awt_event_InputEvent_BUTTON1_DOWN_MASK) != 0)
-        result = NSLeftMouseUp;
+        result = NSEventTypeLeftMouseUp;
 
     if ((modifiers & java_awt_event_InputEvent_BUTTON2_DOWN_MASK) != 0)
-        result = NSOtherMouseUp;
+        result = NSEventTypeOtherMouseUp;
 
     if ((modifiers & java_awt_event_InputEvent_BUTTON3_DOWN_MASK) != 0)
-        result = NSRightMouseUp;
+        result = NSEventTypeRightMouseUp;
 
     return result;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -98,7 +98,7 @@ static BOOL inDoDragDropLoop;
 
 + (jint) scrollStateWithEvent: (NSEvent*) event {
 
-    if ([event type] != NSScrollWheel) {
+    if ([event type] != NSEventTypeScrollWheel) {
         return 0;
     }
 
@@ -126,7 +126,7 @@ static BOOL inDoDragDropLoop;
 }
 
 + (BOOL) hasPreciseScrollingDeltas: (NSEvent*) event {
-    return [event type] == NSScrollWheel
+    return [event type] == NSEventTypeScrollWheel
         && [event respondsToSelector:@selector(hasPreciseScrollingDeltas)]
         && [event hasPreciseScrollingDeltas];
 }

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
@@ -370,7 +370,7 @@ untilDate:(NSDate *)expiration inMode:(NSString *)mode dequeue:(BOOL)deqFlag {
         void (^block)() = (void (^)()) [event data1];
         block();
         [block release];
-    } else if ([event type] == NSKeyUp && ([event modifierFlags] & NSCommandKeyMask)) {
+    } else if ([event type] == NSEventTypeKeyUp && ([event modifierFlags] & NSCommandKeyMask)) {
         // Cocoa won't send us key up event when releasing a key while Cmd is down,
         // so we have to do it ourselves.
         [[self keyWindow] sendEvent:event];

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
@@ -173,16 +173,16 @@ static jlong NSTimeIntervalToJavaMilliseconds(NSTimeInterval interval) {
     jint javaKind = 0;
 
     switch (kind) {
-        case NSLeftMouseUp: case NSRightMouseUp: case NSOtherMouseUp:
+        case NSEventTypeLeftMouseUp: case NSEventTypeRightMouseUp: case NSEventTypeOtherMouseUp:
             javaKind = java_awt_event_MouseEvent_MOUSE_RELEASED;
             break;
-        case NSLeftMouseDown: case NSRightMouseDown: case NSOtherMouseDown:
+        case NSEventTypeLeftMouseDown: case NSEventTypeRightMouseDown: case NSEventTypeOtherMouseDown:
             javaKind = java_awt_event_MouseEvent_MOUSE_PRESSED;
             break;
-        case NSMouseMoved:
+        case NSEventTypeMouseMoved:
             javaKind = java_awt_event_MouseEvent_MOUSE_MOVED;
             break;
-        case NSLeftMouseDragged: case NSRightMouseDragged: case NSOtherMouseDragged:
+        case NSEventTypeLeftMouseDragged: case NSEventTypeRightMouseDragged: case NSEventTypeOtherMouseDragged:
             javaKind = java_awt_event_MouseEvent_MOUSE_DRAGGED;
             break;
     }

--- a/test/jdk/java/awt/Mouse/MacTouchPressEventModifiers/MouseMacTouchPressEventModifiers.java
+++ b/test/jdk/java/awt/Mouse/MacTouchPressEventModifiers/MouseMacTouchPressEventModifiers.java
@@ -205,17 +205,17 @@ class MyFrame extends JFrame {
     }
 
     public Future<MouseEvent> sendNativeMousePress(int modifierFlags, int buttonNumber, int clickCount, int x, int y) {
-        final int eventType = (buttonNumber == CocoaConstants.kCGMouseButtonLeft) ? CocoaConstants.NSLeftMouseDown
-                              : (buttonNumber == CocoaConstants.kCGMouseButtonRight) ? CocoaConstants.NSRightMouseDown
-                              : CocoaConstants.NSOtherMouseDown;
+        final int eventType = (buttonNumber == CocoaConstants.kCGMouseButtonLeft) ? CocoaConstants.NSEventTypeLeftMouseDown
+                              : (buttonNumber == CocoaConstants.kCGMouseButtonRight) ? CocoaConstants.NSEventTypeRightMouseDown
+                              : CocoaConstants.NSEventTypeOtherMouseDown;
 
         return sendNativeMouseEvent(eventType, modifierFlags, buttonNumber, clickCount, x, y, getX() + x, getY() + y);
     }
 
     public Future<MouseEvent> sendNativeMouseRelease(int modifierFlags, int buttonNumber, int clickCount, int x, int y) {
-        final int eventType = (buttonNumber == CocoaConstants.kCGMouseButtonLeft) ? CocoaConstants.NSLeftMouseUp
-                              : (buttonNumber == CocoaConstants.kCGMouseButtonRight) ? CocoaConstants.NSRightMouseUp
-                              : CocoaConstants.NSOtherMouseUp;
+        final int eventType = (buttonNumber == CocoaConstants.kCGMouseButtonLeft) ? CocoaConstants.NSEventTypeLeftMouseUp
+                              : (buttonNumber == CocoaConstants.kCGMouseButtonRight) ? CocoaConstants.NSEventTypeRightMouseUp
+                              : CocoaConstants.NSEventTypeOtherMouseUp;
 
         return sendNativeMouseEvent(eventType, modifierFlags, buttonNumber, clickCount, x, y, getX() + x, getY() + y);
     }


### PR DESCRIPTION
There are a few deprecated Cocoa NSEvent names currently in use in JDK.

https://github.com/openjdk/jdk/blob/jdk-21+17/src/java.desktop/macosx/classes/sun/lwawt/macosx/CocoaConstants.java
https://developer.apple.com/documentation/appkit/nsmousemoved 

Since these event names are marked for deprecation it is better to switch to the newer names.