### PR TITLE
8305875: Test TraceVirtualThreadLocals should be run with continuations only

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/TraceVirtualThreadLocals.java
+++ b/test/jdk/java/lang/Thread/virtual/TraceVirtualThreadLocals.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Test diagnostic option for detecting a virtual thread using thread locals
+ * @requires vm.continuations
  * @library /test/lib
  * @run junit/othervm -Djdk.traceVirtualThreadLocals TraceVirtualThreadLocals
  * @run junit/othervm -Djdk.traceVirtualThreadLocals=true TraceVirtualThreadLocals


### PR DESCRIPTION
Test TraceVirtualThreadLocals verifies that thread locals are dumped for virtual threads. It fails when continuations are not available and virtual threads are emulated.

The test failed on linux-x86 so I just want to mark it to have green github actions results.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305875](https://bugs.openjdk.org/browse/JDK-8305875): Test TraceVirtualThreadLocals should be run with continuations only


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13436/head:pull/13436` \
`$ git checkout pull/13436`

Update a local copy of the PR: \
`$ git checkout pull/13436` \
`$ git pull https://git.openjdk.org/jdk.git pull/13436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13436`

View PR using the GUI difftool: \
`$ git pr show -t 13436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13436.diff">https://git.openjdk.org/jdk/pull/13436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13436#issuecomment-1504553581)