### PR TITLE
8305762: FileInputStream and FileOutputStream implSpec should be corrected or removed

### DIFF
--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -41,13 +41,13 @@ import sun.nio.ch.FileChannelImpl;
  * {@code FileReader}.
  *
  * @apiNote
- * To release resources used by this stream {@link #close} should be called
- * directly or by try-with-resources.
+ * The {@link #close} method should be called to release resources used by this
+ * stream, either directly, or by try-with-resources.
  *
  * @implSpec
  * Subclasses are responsible for the cleanup of resources acquired by the subclass.
  * Subclasses requiring that resource cleanup take place after a stream becomes
- * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
+ * unreachable should use {@link java.lang.ref.Cleaner} or some other mechanism.
  *
  * @author  Arthur van Hoff
  * @see     java.io.File

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -42,7 +42,7 @@ import sun.nio.ch.FileChannelImpl;
  *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this
- * stream, either directly, or by try-with-resources.
+ * stream, either directly, or with the {@code try}-with-resources statement.
  *
  * @implSpec
  * Subclasses are responsible for the cleanup of resources acquired by the subclass.

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -42,18 +42,12 @@ import sun.nio.ch.FileChannelImpl;
  *
  * @apiNote
  * To release resources used by this stream {@link #close} should be called
- * directly or by try-with-resources. Subclasses are responsible for the cleanup
- * of resources acquired by the subclass.
- * Subclasses that override {@link #finalize} in order to perform cleanup
- * should be modified to use alternative cleanup mechanisms such as
- * {@link java.lang.ref.Cleaner} and remove the overriding {@code finalize} method.
+ * directly or by try-with-resources.
  *
  * @implSpec
- * If this FileInputStream has been subclassed and the {@link #close}
- * method has been overridden, the {@link #close} method will be
- * called when the FileInputStream is unreachable.
- * Otherwise, it is implementation specific how the resource cleanup described in
- * {@link #close} is performed.
+ * Subclasses are responsible for the cleanup of resources acquired by the subclass.
+ * Subclasses requiring that resource cleanup take place after a stream becomes
+ * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
  *
  * @author  Arthur van Hoff
  * @see     java.io.File
@@ -494,10 +488,10 @@ public class FileInputStream extends InputStream
      * @apiNote
      * Overriding {@link #close} to perform cleanup actions is reliable
      * only when called directly or when called by try-with-resources.
-     * Do not depend on finalization to invoke {@code close};
-     * finalization is not reliable and is deprecated.
-     * If cleanup of native resources is needed, other mechanisms such as
-     * {@linkplain java.lang.ref.Cleaner} should be used.
+     *
+     * @implSpec
+     * Subclasses requiring that resource cleanup take place after a stream becomes
+     * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
      *
      * @throws     IOException  {@inheritDoc}
      *

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -46,13 +46,13 @@ import sun.nio.ch.FileChannelImpl;
  * {@code FileWriter}.
  *
  * @apiNote
- * To release resources used by this stream {@link #close} should be called
- * directly or by try-with-resources.
+ * The {@link #close} method should be called to release resources used by this
+ * stream, either directly, or by try-with-resources.
  *
  * @implSpec
  * Subclasses are responsible for the cleanup of resources acquired by the subclass.
  * Subclasses requiring that resource cleanup take place after a stream becomes
- * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
+ * unreachable should use {@link java.lang.ref.Cleaner} or some other mechanism.
  *
  * @author  Arthur van Hoff
  * @see     java.io.File

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -47,18 +47,13 @@ import sun.nio.ch.FileChannelImpl;
  *
  * @apiNote
  * To release resources used by this stream {@link #close} should be called
- * directly or by try-with-resources. Subclasses are responsible for the cleanup
- * of resources acquired by the subclass.
- * Subclasses that override {@link #finalize} in order to perform cleanup
- * should be modified to use alternative cleanup mechanisms such as
- * {@link java.lang.ref.Cleaner} and remove the overriding {@code finalize} method.
+ * directly or by try-with-resources.
  *
  * @implSpec
- * If this FileOutputStream has been subclassed and the {@link #close}
- * method has been overridden, the {@link #close} method will be
- * called when the FileInputStream is unreachable.
- * Otherwise, it is implementation specific how the resource cleanup described in
- * {@link #close} is performed.
+ * Subclasses are responsible for the cleanup of resources acquired by the subclass.
+ * Subclasses requiring that resource cleanup take place after a stream becomes
+ * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
+
  *
  * @author  Arthur van Hoff
  * @see     java.io.File
@@ -387,10 +382,10 @@ public class FileOutputStream extends OutputStream
      * @apiNote
      * Overriding {@link #close} to perform cleanup actions is reliable
      * only when called directly or when called by try-with-resources.
-     * Do not depend on finalization to invoke {@code close};
-     * finalization is not reliable and is deprecated.
-     * If cleanup of native resources is needed, other mechanisms such as
-     * {@linkplain java.lang.ref.Cleaner} should be used.
+     *
+     * @implSpec
+     * Subclasses requiring that resource cleanup take place after a stream becomes
+     * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
      *
      * @throws     IOException  if an I/O error occurs.
      *

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -47,7 +47,7 @@ import sun.nio.ch.FileChannelImpl;
  *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this
- * stream, either directly, or by try-with-resources.
+ * stream, either directly, or with the {@code try}-with-resources statement.
  *
  * @implSpec
  * Subclasses are responsible for the cleanup of resources acquired by the subclass.

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -53,7 +53,6 @@ import sun.nio.ch.FileChannelImpl;
  * Subclasses are responsible for the cleanup of resources acquired by the subclass.
  * Subclasses requiring that resource cleanup take place after a stream becomes
  * unreachable should use the {@link java.lang.ref.Cleaner} mechanism.
-
  *
  * @author  Arthur van Hoff
  * @see     java.io.File


### PR DESCRIPTION
With the removal of the AltFinalizer mechanism from `FileInputStream` and `FileOutputStream` in [JDK-8192939](https://bugs.openjdk.org/browse/JDK-8192939), this portion of the Implementation Requirement in the class JavaDoc is no longer true:

> If this FileOutputStream has been subclassed and the close() method has been overridden, the close() method will be called when the FileInputStream is unreachable."

The class doc, and the doc for close(), are updated to correctly reflect current behavior, and guidance for subclasses is clarified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305762](https://bugs.openjdk.org/browse/JDK-8305762): FileInputStream and FileOutputStream implSpec should be corrected or removed


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [db7c33e0](https://git.openjdk.org/jdk/pull/13437/files/db7c33e0f5971150d217d9d91b6e3afba58bc7fe)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13437/head:pull/13437` \
`$ git checkout pull/13437`

Update a local copy of the PR: \
`$ git checkout pull/13437` \
`$ git pull https://git.openjdk.org/jdk.git pull/13437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13437`

View PR using the GUI difftool: \
`$ git pr show -t 13437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13437.diff">https://git.openjdk.org/jdk/pull/13437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13437#issuecomment-1505626575)