### PR TITLE
8305892: G1: Fix G1MMUTracker::when_sec documentation

### DIFF
--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -115,13 +115,13 @@ void G1MMUTracker::add_pause(double start, double end) {
 //                       GC events               /  pause_time
 //                 /     |     \     \          | /  /
 // -------------[----]-[---]--[--]---[---]------|[--]-----> Time
-//              |         |                     |
-//              |         |                     |
-//              |<- limit |                     |
-//              |         |<- balance_timestamp |
-//              |         ^                     |
-//              |                               |
-//              |<--------  _time_slice  ------>|
+//              |         |                         |
+//              |         |                         |
+//              |<- limit |                         |
+//              |         |<- balance_timestamp     |
+//              |         ^                         |
+//              |                                   |
+//              |<--------  _time_slice   --------->|
 //
 // The MMU constraint requires that we can spend up to `max_gc_time()` on GC
 // pauses inside a window of `_time_slice` length. Therefore, we have a GC
@@ -134,7 +134,7 @@ void G1MMUTracker::add_pause(double start, double end) {
 // time inside [balance_timestamp, current_timestamp] is equal to the budget.
 // Next, return `balance_timestamp - limit`.
 //
-// When there are no enough GC events, i.e. we have a surplus buget, a new GC
+// When there are no enough GC events, i.e. we have a surplus budget, a new GC
 // pause can start right away, so return 0.
 double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
   assert(pause_time > 0.0, "precondition");

--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -134,7 +134,7 @@ void G1MMUTracker::add_pause(double start, double end) {
 // time inside [balance_timestamp, current_timestamp] is equal to the budget.
 // Next, return `balance_timestamp - limit`.
 //
-// When there are no enough GC events, i.e. we have a surplus budget, a new GC
+// When there are not enough GC events, i.e. we have a surplus budget, a new GC
 // pause can start right away, so return 0.
 double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
   assert(pause_time > 0.0, "precondition");


### PR DESCRIPTION
Trivial comment-only change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305892](https://bugs.openjdk.org/browse/JDK-8305892): G1: Fix G1MMUTracker::when_sec documentation


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [2ed8c5b5](https://git.openjdk.org/jdk/pull/13441/files/2ed8c5b5386f6a85bdd9f8482a431312872f7dd2)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [2ed8c5b5](https://git.openjdk.org/jdk/pull/13441/files/2ed8c5b5386f6a85bdd9f8482a431312872f7dd2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13441/head:pull/13441` \
`$ git checkout pull/13441`

Update a local copy of the PR: \
`$ git checkout pull/13441` \
`$ git pull https://git.openjdk.org/jdk.git pull/13441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13441`

View PR using the GUI difftool: \
`$ git pr show -t 13441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13441.diff">https://git.openjdk.org/jdk/pull/13441.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13441#issuecomment-1504943238)