### PR TITLE
8306038: SystemModulesPlugin generates code that doesn't pop when return value not used

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
@@ -1085,7 +1085,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 }
                 cob.invokevirtual(CD_MODULE_BUILDER,
                                   "requires",
-                                  MTD_REQUIRES_ARRAY);
+                                  MTD_REQUIRES_ARRAY)
+                    .pop();
             }
 
             /*
@@ -1129,7 +1130,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 }
                 cob.invokevirtual(CD_MODULE_BUILDER,
                                   "exports",
-                                  MTD_EXPORTS_ARRAY);
+                                  MTD_EXPORTS_ARRAY)
+                    .pop();
             }
 
             /*
@@ -1185,7 +1187,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 }
                 cob.invokevirtual(CD_MODULE_BUILDER,
                                   "opens",
-                                  MTD_OPENS_ARRAY);
+                                  MTD_OPENS_ARRAY)
+                    .pop();
             }
 
             /*
@@ -1254,7 +1257,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 }
                 cob.invokevirtual(CD_MODULE_BUILDER,
                                   "provides",
-                                  MTD_PROVIDES_ARRAY);
+                                  MTD_PROVIDES_ARRAY)
+                    .pop();
             }
 
             /*


### PR DESCRIPTION
This refs [8306038](https://bugs.openjdk.org/browse/JDK-8306038)

(Before this referenced 8240567)

Although this change is rather small, I think, it's good to have a "more clean" SystemModulesPlugin available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8306038](https://bugs.openjdk.org/browse/JDK-8306038): SystemModulesPlugin generates code that doesn't pop when return value not used


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13442/head:pull/13442` \
`$ git checkout pull/13442`

Update a local copy of the PR: \
`$ git checkout pull/13442` \
`$ git pull https://git.openjdk.org/jdk.git pull/13442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13442`

View PR using the GUI difftool: \
`$ git pr show -t 13442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13442.diff">https://git.openjdk.org/jdk/pull/13442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13442#issuecomment-1504954892)