### PR TITLE
8305902: (cs) Resolve default Charset only once in StreamEncoder and StreamDecoder

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -71,11 +71,10 @@ public class StreamDecoder extends Reader {
                                                      String charsetName)
         throws UnsupportedEncodingException
     {
-        String csn = charsetName;
         try {
-            return new StreamDecoder(in, lock, csn == null ? Charset.defaultCharset() : Charset.forName(csn));
+            return new StreamDecoder(in, lock, Charset.forName(charsetName));
         } catch (IllegalCharsetNameException | UnsupportedCharsetException x) {
-            throw new UnsupportedEncodingException (csn);
+            throw new UnsupportedEncodingException (charsetName);
         }
     }
 

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,11 +72,8 @@ public class StreamDecoder extends Reader {
         throws UnsupportedEncodingException
     {
         String csn = charsetName;
-        if (csn == null) {
-            csn = Charset.defaultCharset().name();
-        }
         try {
-            return new StreamDecoder(in, lock, Charset.forName(csn));
+            return new StreamDecoder(in, lock, csn == null ? Charset.defaultCharset() : Charset.forName(csn));
         } catch (IllegalCharsetNameException | UnsupportedCharsetException x) {
             throw new UnsupportedEncodingException (csn);
         }

--- a/src/java.base/share/classes/sun/nio/cs/StreamEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,11 +59,8 @@ public final class StreamEncoder extends Writer {
         throws UnsupportedEncodingException
     {
         String csn = charsetName;
-        if (csn == null) {
-            csn = Charset.defaultCharset().name();
-        }
         try {
-            return new StreamEncoder(out, lock, Charset.forName(csn));
+            return new StreamEncoder(out, lock, csn == null ? Charset.defaultCharset() : Charset.forName(csn));
         } catch (IllegalCharsetNameException | UnsupportedCharsetException x) {
             throw new UnsupportedEncodingException (csn);
         }

--- a/src/java.base/share/classes/sun/nio/cs/StreamEncoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamEncoder.java
@@ -58,11 +58,10 @@ public final class StreamEncoder extends Writer {
                                                       String charsetName)
         throws UnsupportedEncodingException
     {
-        String csn = charsetName;
         try {
-            return new StreamEncoder(out, lock, csn == null ? Charset.defaultCharset() : Charset.forName(csn));
+            return new StreamEncoder(out, lock, Charset.forName(charsetName));
         } catch (IllegalCharsetNameException | UnsupportedCharsetException x) {
-            throw new UnsupportedEncodingException (csn);
+            throw new UnsupportedEncodingException (charsetName);
         }
     }
 


### PR DESCRIPTION
If `charsetName` passed into `forOutputStreamWriter()` method is null then `Charset.forName()` is redundant as we can use already resolved default Charset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305902](https://bugs.openjdk.org/browse/JDK-8305902): (cs) Resolve default Charset only once in StreamEncoder and StreamDecoder


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13443/head:pull/13443` \
`$ git checkout pull/13443`

Update a local copy of the PR: \
`$ git checkout pull/13443` \
`$ git pull https://git.openjdk.org/jdk.git pull/13443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13443`

View PR using the GUI difftool: \
`$ git pr show -t 13443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13443.diff">https://git.openjdk.org/jdk/pull/13443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13443#issuecomment-1505128024)