### PR TITLE
8305625: Stress test crashes with SEGV in Deoptimization::deoptimize_frame_internal(JavaThread*, long*, Deoptimization::DeoptReason)

### DIFF
--- a/src/hotspot/share/runtime/escapeBarrier.cpp
+++ b/src/hotspot/share/runtime/escapeBarrier.cpp
@@ -124,7 +124,7 @@ bool EscapeBarrier::deoptimize_objects_all_threads() {
   ResourceMark rm(calling_thread());
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *jt = jtiwh.next(); ) {
     // Skip thread with mounted continuation
-    if (jt->last_continuation()) {
+    if (jt->last_continuation() != nullptr) {
       continue;
     }
     if (jt->frames_to_pop_failed_realloc() > 0) {

--- a/src/hotspot/share/runtime/escapeBarrier.cpp
+++ b/src/hotspot/share/runtime/escapeBarrier.cpp
@@ -123,8 +123,8 @@ bool EscapeBarrier::deoptimize_objects_all_threads() {
   if (!barrier_active()) return true;
   ResourceMark rm(calling_thread());
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *jt = jtiwh.next(); ) {
-    // Skip virtual threads
-    if (jt->is_vthread_mounted()) {
+    // Skip thread with mounted continuation
+    if (jt->last_continuation()) {
       continue;
     }
     if (jt->frames_to_pop_failed_realloc() > 0) {

--- a/src/hotspot/share/runtime/escapeBarrier.cpp
+++ b/src/hotspot/share/runtime/escapeBarrier.cpp
@@ -123,9 +123,8 @@ bool EscapeBarrier::deoptimize_objects_all_threads() {
   if (!barrier_active()) return true;
   ResourceMark rm(calling_thread());
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *jt = jtiwh.next(); ) {
-    oop vt_oop = jt->jvmti_vthread();
     // Skip virtual threads
-    if (vt_oop != nullptr && java_lang_VirtualThread::is_instance(vt_oop)) {
+    if (jt->is_vthread_mounted()) {
       continue;
     }
     if (jt->frames_to_pop_failed_realloc() > 0) {


### PR DESCRIPTION
Please review this fix. The check to skip walking stacks of virtual threads will not identify a thread in a transition since it relies on the jvmti_vthread() which would have already changed at the very beginning of it. The crash happens because the anchor might have changed between walking the stack of the thread in a transition and executing the deopt handshake for a particular frame. The frame is never found and looping executing fr.sender() crashes. This scenario can happen if the initial EscapeBarrierSuspendHandshake executed to synchronize against all threads finds the thread blocked in the stackchunk allocation path. Because the thread will actually block on the next transition to Java, and not on a blocked->vm transition, it will continue executing and change its anchor while the requester is walking its stack. There are more details in the bug comments.
The fix modifies the conditional to check if the continuation is mounted or not. This will identify the transition case too and won't face the anchor change issue since the continuation entry will be removed after returning from the freeze call.
The fix was tested against a reproducer which I attached to the bug.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305625](https://bugs.openjdk.org/browse/JDK-8305625): Stress test crashes with SEGV in Deoptimization::deoptimize_frame_internal(JavaThread*, long*, Deoptimization::DeoptReason)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [73ac9b0a](https://git.openjdk.org/jdk/pull/13446/files/73ac9b0a36e37507f6d9abd0502294805baa401d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13446/head:pull/13446` \
`$ git checkout pull/13446`

Update a local copy of the PR: \
`$ git checkout pull/13446` \
`$ git pull https://git.openjdk.org/jdk.git pull/13446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13446`

View PR using the GUI difftool: \
`$ git pr show -t 13446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13446.diff">https://git.openjdk.org/jdk/pull/13446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13446#issuecomment-1505558035)