### PR TITLE
8305922: [aix,linux] Avoid comparing 'this' to nullptr

### DIFF
--- a/src/hotspot/os/aix/osThread_aix.cpp
+++ b/src/hotspot/os/aix/osThread_aix.cpp
@@ -34,7 +34,6 @@
 #include "runtime/vmThread.hpp"
 
 void OSThread::pd_initialize() {
-  assert(this != nullptr, "check");
   _thread_id        = 0;
   _kernel_thread_id = 0;
   _siginfo = nullptr;

--- a/src/hotspot/os/linux/osThread_linux.cpp
+++ b/src/hotspot/os/linux/osThread_linux.cpp
@@ -30,7 +30,6 @@
 #include <signal.h>
 
 void OSThread::pd_initialize() {
-  assert(this != nullptr, "check");
   _thread_id        = 0;
   _pthread_id       = 0;
   _siginfo = nullptr;


### PR DESCRIPTION
This PR removes the remaining 'this' vs. 'nullptr' checks from osThread_linux.cpp and osThread_aix.cpp which cause a build warning on AIX and Linux (when building with Clang). My grepping finds no other occurrences.

As the warning indicates, `this` cannot be `nullptr` in well-formed C++ code. Previous issues have removed these checks, and I believe it makes sense to do so again in these places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305922](https://bugs.openjdk.org/browse/JDK-8305922): [aix,linux] Avoid comparing 'this' to nullptr


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13448/head:pull/13448` \
`$ git checkout pull/13448`

Update a local copy of the PR: \
`$ git checkout pull/13448` \
`$ git pull https://git.openjdk.org/jdk.git pull/13448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13448`

View PR using the GUI difftool: \
`$ git pr show -t 13448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13448.diff">https://git.openjdk.org/jdk/pull/13448.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13448#issuecomment-1516955764)