### PR TITLE
8305934: PPC64: Disable VMContinuations on Big Endian

### DIFF
--- a/src/hotspot/cpu/ppc/globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globals_ppc.hpp
@@ -56,7 +56,7 @@ define_pd_global(intx, StackRedPages,         DEFAULT_STACK_RED_PAGES);
 define_pd_global(intx, StackShadowPages,      DEFAULT_STACK_SHADOW_PAGES);
 define_pd_global(intx, StackReservedPages,    DEFAULT_STACK_RESERVED_PAGES);
 
-define_pd_global(bool,  VMContinuations, AIX_ONLY(false) NOT_AIX(true));
+define_pd_global(bool,  VMContinuations, true BIG_ENDIAN_ONLY(&& false));
 
 // Use large code-entry alignment.
 define_pd_global(uintx, CodeCacheSegmentSize,  128);


### PR DESCRIPTION
Disable VMContinuations on PPC64 big endian in general (not only on AIX) because there are known failures in jdk:jdk_loom tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305934](https://bugs.openjdk.org/browse/JDK-8305934): PPC64: Disable VMContinuations on Big Endian


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13449/head:pull/13449` \
`$ git checkout pull/13449`

Update a local copy of the PR: \
`$ git checkout pull/13449` \
`$ git pull https://git.openjdk.org/jdk.git pull/13449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13449`

View PR using the GUI difftool: \
`$ git pr show -t 13449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13449.diff">https://git.openjdk.org/jdk/pull/13449.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13449#issuecomment-1505970291)