### PR TITLE
8305935: Resolve multiple definition of 'jmm_<interface|version>' when statically linking with JDK native libraries

### DIFF
--- a/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
@@ -30,19 +30,19 @@
 
 JNIEXPORT void JNICALL Java_com_sun_management_internal_DiagnosticCommandImpl_setNotificationEnabled
 (JNIEnv *env, jobject dummy, jboolean enabled) {
-    if (jmm_version <= JMM_VERSION_1_2_2) {
+    if (jmm_version_management_ext <= JMM_VERSION_1_2_2) {
         JNU_ThrowByName(env, "java/lang/UnsupportedOperationException",
                         "JMX interface to diagnostic framework notifications is not supported by this VM");
         return;
     }
-    jmm_interface->SetDiagnosticFrameworkNotificationEnabled(env, enabled);
+    jmm_interface_management_ext->SetDiagnosticFrameworkNotificationEnabled(env, enabled);
 }
 
 JNIEXPORT jobjectArray JNICALL
 Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommands
   (JNIEnv *env, jobject dummy)
 {
-  return jmm_interface->GetDiagnosticCommands(env);
+  return jmm_interface_management_ext->GetDiagnosticCommands(env);
 }
 
 //
@@ -78,7 +78,7 @@ jobject getDiagnosticCommandArgumentInfoArray(JNIEnv *env, jstring command,
     JNU_ThrowOutOfMemoryError(env, 0);
     return NULL;
   }
-  jmm_interface->GetDiagnosticCommandArgumentsInfo(env, command,
+  jmm_interface_management_ext->GetDiagnosticCommandArgumentsInfo(env, command,
                                                    dcmd_arg_info_array, num_arg);
   dcmdArgInfoCls = (*env)->FindClass(env,
                                      "com/sun/management/internal/DiagnosticCommandArgumentInfo");
@@ -151,7 +151,7 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
   jobjectArray args;
   jobject obj;
   jmmOptionalSupport mos;
-  jint ret = jmm_interface->GetOptionalSupport(env, &mos);
+  jint ret = jmm_interface_management_ext->GetOptionalSupport(env, &mos);
   jsize num_commands;
   dcmdInfo* dcmd_info_array;
   jstring jname, jdesc, jimpact, cmd;
@@ -189,7 +189,7 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
       JNU_ThrowOutOfMemoryError(env, NULL);
       return NULL;
   }
-  jmm_interface->GetDiagnosticCommandInfo(env, commands, dcmd_info_array);
+  jmm_interface_management_ext->GetDiagnosticCommandInfo(env, commands, dcmd_info_array);
   for (i=0; i<num_commands; i++) {
       // Ensure capacity for 6 + 3 local refs:
       //  6 => jname, jdesc, jimpact, cmd, args, obj
@@ -247,5 +247,5 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
 JNIEXPORT jstring JNICALL
 Java_com_sun_management_internal_DiagnosticCommandImpl_executeDiagnosticCommand
 (JNIEnv *env, jobject dummy, jstring command) {
-  return jmm_interface->ExecuteDiagnosticCommand(env, command);
+  return jmm_interface_management_ext->ExecuteDiagnosticCommand(env, command);
 }

--- a/src/jdk.management/share/native/libmanagement_ext/Flag.c
+++ b/src/jdk.management/share/native/libmanagement_ext/Flag.c
@@ -43,7 +43,7 @@ JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_Flag_getInternalFlagCount
   (JNIEnv *env, jclass cls)
 {
-    jlong count = jmm_interface->GetLongAttribute(env, NULL,
+    jlong count = jmm_interface_management_ext->GetLongAttribute(env, NULL,
                                                   JMM_VM_GLOBAL_COUNT);
     return (jint) count;
 }
@@ -52,7 +52,7 @@ JNIEXPORT jobjectArray JNICALL
   Java_com_sun_management_internal_Flag_getAllFlagNames
 (JNIEnv *env, jclass cls)
 {
-  return jmm_interface->GetVMGlobalNames(env);
+  return jmm_interface_management_ext->GetVMGlobalNames(env);
 }
 
 static jobject find_origin_constant(JNIEnv* env, const char* enum_name) {
@@ -110,7 +110,7 @@ Java_com_sun_management_internal_Flag_getFlags
     }
 
     memset(globals, 0, gsize);
-    num_flags = jmm_interface->GetVMGlobals(env, names, globals, count);
+    num_flags = jmm_interface_management_ext->GetVMGlobals(env, names, globals, count);
     if (num_flags == 0) {
         free(globals);
         return 0;
@@ -209,7 +209,7 @@ Java_com_sun_management_internal_Flag_setLongValue
    jvalue v;
    v.j = value;
 
-   jmm_interface->SetVMGlobal(env, name, v);
+   jmm_interface_management_ext->SetVMGlobal(env, name, v);
 }
 
 JNIEXPORT void JNICALL
@@ -219,7 +219,7 @@ Java_com_sun_management_internal_Flag_setDoubleValue
    jvalue v;
    v.d = value;
 
-   jmm_interface->SetVMGlobal(env, name, v);
+   jmm_interface_management_ext->SetVMGlobal(env, name, v);
 }
 
 JNIEXPORT void JNICALL
@@ -229,7 +229,7 @@ Java_com_sun_management_internal_Flag_setBooleanValue
    jvalue v;
    v.z = value;
 
-   jmm_interface->SetVMGlobal(env, name, v);
+   jmm_interface_management_ext->SetVMGlobal(env, name, v);
 }
 
 JNIEXPORT void JNICALL
@@ -239,5 +239,5 @@ Java_com_sun_management_internal_Flag_setStringValue
    jvalue v;
    v.l = value;
 
-   jmm_interface->SetVMGlobal(env, name, v);
+   jmm_interface_management_ext->SetVMGlobal(env, name, v);
 }

--- a/src/jdk.management/share/native/libmanagement_ext/GarbageCollectorExtImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/GarbageCollectorExtImpl.c
@@ -34,8 +34,8 @@ JNIEXPORT void JNICALL Java_com_sun_management_internal_GarbageCollectorExtImpl_
         JNU_ThrowNullPointerException(env, "Invalid GarbageCollectorMXBean");
         return;
     }
-    if((jmm_version > JMM_VERSION_1_2)
-       || (jmm_version == JMM_VERSION_1_2 && ((jmm_version&0xFF)>=1))) {
-      jmm_interface->SetGCNotificationEnabled(env, gc, enabled);
+    if((jmm_version_management_ext > JMM_VERSION_1_2)
+       || (jmm_version_management_ext == JMM_VERSION_1_2 && ((jmm_version_management_ext&0xFF)>=1))) {
+      jmm_interface_management_ext->SetGCNotificationEnabled(env, gc, enabled);
     }
 }

--- a/src/jdk.management/share/native/libmanagement_ext/GcInfoBuilder.c
+++ b/src/jdk.management/share/native/libmanagement_ext/GcInfoBuilder.c
@@ -37,7 +37,7 @@ JNIEXPORT jint JNICALL Java_com_sun_management_internal_GcInfoBuilder_getNumGcEx
         JNU_ThrowNullPointerException(env, "Invalid GarbageCollectorMXBean");
         return 0;
     }
-    value = jmm_interface->GetLongAttribute(env, gc,
+    value = jmm_interface_management_ext->GetLongAttribute(env, gc,
                                             JMM_GC_EXT_ATTRIBUTE_INFO_SIZE);
     return (jint) value;
 }
@@ -70,7 +70,7 @@ JNIEXPORT void JNICALL Java_com_sun_management_internal_GcInfoBuilder_fillGcAttr
         JNU_ThrowOutOfMemoryError(env, 0);
         return;
     }
-    ret = jmm_interface->GetGCExtAttributeInfo(env, gc,
+    ret = jmm_interface_management_ext->GetGCExtAttributeInfo(env, gc,
                                                ext_att_info, num_attributes);
     if (ret != num_attributes) {
         JNU_ThrowInternalError(env, "Unexpected num_attributes");
@@ -231,7 +231,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_management_internal_GcInfoBuilder_getLast
     }
 
 
-    jmm_interface->GetLastGCStat(env, gc, &gc_stat);
+    jmm_interface_management_ext->GetLastGCStat(env, gc, &gc_stat);
     if (gc_stat.gc_index == 0) {
         if (gc_stat.gc_ext_attribute_values != NULL) {
             free(gc_stat.gc_ext_attribute_values);

--- a/src/jdk.management/share/native/libmanagement_ext/HotSpotDiagnostic.c
+++ b/src/jdk.management/share/native/libmanagement_ext/HotSpotDiagnostic.c
@@ -32,5 +32,5 @@ JNIEXPORT void JNICALL
 Java_com_sun_management_internal_HotSpotDiagnostic_dumpHeap0
   (JNIEnv *env, jobject dummy, jstring outputfile, jboolean live)
 {
-    jmm_interface->DumpHeap0(env, outputfile, live);
+    jmm_interface_management_ext->DumpHeap0(env, outputfile, live);
 }

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -31,9 +31,9 @@
 
 #define ERR_MSG_SIZE 128
 
-const JmmInterface* jmm_interface = NULL;
+const JmmInterface* jmm_interface_management_ext = NULL;
 static JavaVM* jvm = NULL;
-jint jmm_version = 0;
+jint jmm_version_management_ext = 0;
 
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -44,13 +44,13 @@ JNIEXPORT jint JNICALL
         return JNI_ERR;
     }
 
-    jmm_interface = (JmmInterface*) JVM_GetManagement(JMM_VERSION);
-    if (jmm_interface == NULL) {
+    jmm_interface_management_ext = (JmmInterface*) JVM_GetManagement(JMM_VERSION);
+    if (jmm_interface_management_ext == NULL) {
         JNU_ThrowInternalError(env, "Unsupported Management version");
         return JNI_ERR;
     }
 
-    jmm_version = jmm_interface->GetVersion(env);
+    jmm_version_management_ext = jmm_interface_management_ext->GetVersion(env);
     return (*env)->GetVersion(env);
 }
 

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.h
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.h
@@ -31,8 +31,8 @@
 #ifndef _MANAGEMENT_EXT_H_
 #define _MANAGEMENT_EXT_H_
 
-extern const JmmInterface* jmm_interface;
-extern jint jmm_version;
+extern const JmmInterface* jmm_interface_management_ext;
+extern jint jmm_version_management_ext;
 extern void throw_internal_error(JNIEnv* env, const char* msg);
 
 #endif

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.h
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.h
@@ -31,6 +31,9 @@
 #ifndef _MANAGEMENT_EXT_H_
 #define _MANAGEMENT_EXT_H_
 
+// These symbols are global in this library but need to be uniquely named to
+// avoid conflicts with same-named symbols in other native libraries, when
+// statically linking.
 extern const JmmInterface* jmm_interface_management_ext;
 extern jint jmm_version_management_ext;
 extern void throw_internal_error(JNIEnv* env, const char* msg);


### PR DESCRIPTION
Rename 'jmm_<interface|version>' to 'jmm_<interface|version>_management_ext' in libmanagement_ext to resolve related linker errors when statically linking with both libmanagement and libmanagement_ext.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305935](https://bugs.openjdk.org/browse/JDK-8305935): Resolve multiple definition of 'jmm_&lt;interface|version&gt;' when statically linking with JDK native libraries


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [f10e1a06](https://git.openjdk.org/jdk/pull/13451/files/f10e1a0676fcdd26966e2ad9b3931e8293d46416)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13451/head:pull/13451` \
`$ git checkout pull/13451`

Update a local copy of the PR: \
`$ git checkout pull/13451` \
`$ git pull https://git.openjdk.org/jdk.git pull/13451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13451`

View PR using the GUI difftool: \
`$ git pr show -t 13451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13451.diff">https://git.openjdk.org/jdk/pull/13451.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13451#issuecomment-1506102597)