### PR TITLE
One CJK Font Bug

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
@@ -128,11 +128,6 @@ public class DoubleByte {
         }
 
         protected CoderResult crMalformedOrUnmappable(int b1, int b2) {
-            if (b2c[b1] == B2C_UNMAPPABLE ||                // isNotLeadingByte(b1)
-                b2c[b2] != B2C_UNMAPPABLE ||                // isLeadingByte(b2)
-                decodeSingle(b2) != UNMAPPABLE_DECODING) {  // isSingle(b2)
-                return CoderResult.malformedForLength(1);
-            }
             return CoderResult.unmappableForLength(2);
         }
 


### PR DESCRIPTION
       The patch fixed the bug that the Chinese characters are garbled when using the font in the package.
       The bug is : when you installed the font in the uploaded zip file and used it, the Chinese characters are garble.
We fixed it and you can download the attachment drawTextWithCyjbs.jar.
       Because the zip file is not supported, when you download the attachment, please change the extension of mp4 to zip. The package contains the font and reproduction samples.


https://user-images.githubusercontent.com/60084517/231624684-166fde8a-c279-4951-bc82-c5101e39fa46.mp4

