### PR TITLE
8305936: JavaThread::create_system_thread_object has unused is_visible argument

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -759,7 +759,7 @@ void CompileBroker::compilation_init_phase2() {
 }
 
 Handle CompileBroker::create_thread_oop(const char* name, TRAPS) {
-  Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK_NH);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, CHECK_NH);
   return thread_oop;
 }
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -2067,8 +2067,7 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 // Helper function to create the java.lang.Thread object for a
 // VM-internal thread. The thread will have the given name, and be
 // a member of the "system" ThreadGroup.
-Handle JavaThread::create_system_thread_object(const char* name,
-                                               bool is_visible, TRAPS) {
+Handle JavaThread::create_system_thread_object(const char* name, TRAPS) {
   Handle string = java_lang_String::create_from_str(name, CHECK_NH);
 
   // Initialize thread_oop to put it into the system threadGroup.

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1152,10 +1152,9 @@ public:
   static void verify_cross_modify_fence_failure(JavaThread *thread) PRODUCT_RETURN;
 
   // Helper function to create the java.lang.Thread object for a
-  // VM-internal thread. The thread will have the given name, be
-  // part of the System ThreadGroup and if is_visible is true will be
-  // discoverable via the system ThreadGroup.
-  static Handle create_system_thread_object(const char* name, bool is_visible, TRAPS);
+  // VM-internal thread. The thread will have the given name and be
+  // part of the System ThreadGroup.
+  static Handle create_system_thread_object(const char* name, TRAPS);
 
   // Helper function to start a VM-internal daemon thread.
   // E.g. ServiceThread, NotificationThread, CompilerThread etc.

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ void MonitorDeflationThread::initialize() {
   EXCEPTION_MARK;
 
   const char* name = "Monitor Deflation Thread";
-  Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, CHECK);
 
   MonitorDeflationThread* thread = new MonitorDeflationThread(&monitor_deflation_thread_entry);
   JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/notificationThread.cpp
+++ b/src/hotspot/share/runtime/notificationThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ void NotificationThread::initialize() {
   EXCEPTION_MARK;
 
   const char* name = "Notification Thread";
-  Handle thread_oop = JavaThread::create_system_thread_object(name, true /* visible */, CHECK);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, CHECK);
 
    NotificationThread* thread = new NotificationThread(&notification_thread_entry);
    JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -476,7 +476,7 @@ void os::initialize_jdk_signal_support(TRAPS) {
   if (!ReduceSignalUsage) {
     // Setup JavaThread for processing signals
     const char* name = "Signal Dispatcher";
-    Handle thread_oop = JavaThread::create_system_thread_object(name, true /* visible */, CHECK);
+    Handle thread_oop = JavaThread::create_system_thread_object(name, CHECK);
 
     JavaThread* thread = new JavaThread(&signal_thread_entry);
     JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -63,7 +63,7 @@ void ServiceThread::initialize() {
   EXCEPTION_MARK;
 
   const char* name = "Service Thread";
-  Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, CHECK);
 
   ServiceThread* thread = new ServiceThread(&service_thread_entry);
   JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -457,7 +457,7 @@ void AttachListener::init() {
   EXCEPTION_MARK;
 
   const char* name = "Attach Listener";
-  Handle thread_oop = JavaThread::create_system_thread_object(name, true /* visible */, THREAD);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, THREAD);
   if (has_init_error(THREAD)) {
     set_state(AL_NOT_INITIALIZED);
     return;

--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,10 @@ static void startTestThread(JavaThread* thread, const char* name) {
   // or by an existing JavaTestThread, which is _thread_in_vm.
   if (THREAD->thread_state() == _thread_in_native) {
     ThreadInVMfromNative tivfn(THREAD);
-    thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK);
+    thread_oop = JavaThread::create_system_thread_object(name, CHECK);
     JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
   } else {
-    thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK);
+    thread_oop = JavaThread::create_system_thread_object(name, CHECK);
     JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
   }
 }


### PR DESCRIPTION
Please review this simple cleanup of an unused parameter in  `create_system_thread_object`. Details are in JBS.

Testing: tiers 1-3

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305936](https://bugs.openjdk.org/browse/JDK-8305936): JavaThread::create_system_thread_object has unused is_visible argument


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13455/head:pull/13455` \
`$ git checkout pull/13455`

Update a local copy of the PR: \
`$ git checkout pull/13455` \
`$ git pull https://git.openjdk.org/jdk.git pull/13455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13455`

View PR using the GUI difftool: \
`$ git pr show -t 13455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13455.diff">https://git.openjdk.org/jdk/pull/13455.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13455#issuecomment-1506382136)