### PR TITLE
8305404: Compile_lock not needed for InstanceKlass::implementor()

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -623,14 +623,14 @@ ciInstanceKlass* ciInstanceKlass::implementor() {
     } else {
       // Go into the VM to fetch the implementor.
       VM_ENTRY_MARK;
-      MutexLocker ml(Compile_lock);
-      Klass* k = get_instanceKlass()->implementor();
-      if (k != nullptr) {
-        if (k == get_instanceKlass()) {
+      InstanceKlass* ik = get_instanceKlass();
+      Klass* implk = ik->implementor();
+      if (implk != nullptr) {
+        if (implk == ik) {
           // More than one implementors. Use 'this' in this case.
           impl = this;
         } else {
-          impl = CURRENT_THREAD_ENV->get_instance_klass(k);
+          impl = CURRENT_THREAD_ENV->get_instance_klass(implk);
         }
       }
     }

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -450,12 +450,7 @@ C2V_VMENTRY_NULL(jobject, getImplementor, (JNIEnv* env, jobject, ARGUMENT_PAIR(k
         err_msg("Expected interface type, got %s", klass->external_name()));
   }
   InstanceKlass* iklass = InstanceKlass::cast(klass);
-  JVMCIKlassHandle handle(THREAD);
-  {
-    // Need Compile_lock around implementor()
-    MutexLocker locker(Compile_lock);
-    handle = iklass->implementor();
-  }
+  JVMCIKlassHandle handle(THREAD, iklass->implementor());
   JVMCIObject implementor = JVMCIENV->get_jvmci_type(handle, JVMCI_CHECK_NULL);
   return JVMCIENV->get_jobject(implementor);
 C2V_END


### PR DESCRIPTION
See CR for details.
Tested with tier1-4, 7, 8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305404](https://bugs.openjdk.org/browse/JDK-8305404): Compile_lock not needed for InstanceKlass::implementor()


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13458/head:pull/13458` \
`$ git checkout pull/13458`

Update a local copy of the PR: \
`$ git checkout pull/13458` \
`$ git pull https://git.openjdk.org/jdk.git pull/13458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13458`

View PR using the GUI difftool: \
`$ git pr show -t 13458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13458.diff">https://git.openjdk.org/jdk/pull/13458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13458#issuecomment-1506885340)