### PR TITLE
8305937: com/sun/jdi/SetLocalWhileThreadInNative.java fails with -XX:+TieredCompilation

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -548,7 +548,7 @@ abstract public class TestScaffold extends TargetAdapter {
     public void connect(String args[]) {
         ArgInfo argInfo = parseArgs(args);
 
-        argInfo.targetVMArgs += VMConnection.getDebuggeeVMOptions();
+        argInfo.targetVMArgs = VMConnection.getDebuggeeVMOptions() + " " + argInfo.targetVMArgs;
         connection = new VMConnection(argInfo.connectorSpec,
                                       argInfo.traceFlags);
 


### PR DESCRIPTION
Could you please review following trivial fix which correct jvm options order in TestScaffold.
TestScaffold combines test optionos and jtreg vm options. Before [JDK-8304834](https://bugs.openjdk.org/browse/JDK-8304834) it passed test jvm args as part of targetAppCommandLine. So the test VM args are added to the jtreg vm options. But after JDK-8304834 it parse then into targetVMArgs. So test vm args should append to jtreg vm options to override them.

Testing: tier1-tier5 (including failing combination and testing with wrapper)
I haven't added requires to filter out the test, because e filter only failing combination usually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305937](https://bugs.openjdk.org/browse/JDK-8305937): com/sun/jdi/SetLocalWhileThreadInNative.java fails with -XX:+TieredCompilation


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13462/head:pull/13462` \
`$ git checkout pull/13462`

Update a local copy of the PR: \
`$ git checkout pull/13462` \
`$ git pull https://git.openjdk.org/jdk.git pull/13462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13462`

View PR using the GUI difftool: \
`$ git pr show -t 13462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13462.diff">https://git.openjdk.org/jdk/pull/13462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13462#issuecomment-1507124202)