### PR TITLE
8305966: ProblemList com/sun/jdi/JdbLastErrorTest.java on windows-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -694,6 +694,8 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-all
 
+com/sun/jdi/JdbLastErrorTest.java                               8305913 windows-x64
+
 ############################################################################
 
 # jdk_time


### PR DESCRIPTION
A trivial fix to ProblemList com/sun/jdi/JdbLastErrorTest.java on windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305966](https://bugs.openjdk.org/browse/JDK-8305966): ProblemList com/sun/jdi/JdbLastErrorTest.java on windows-x64


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13465/head:pull/13465` \
`$ git checkout pull/13465`

Update a local copy of the PR: \
`$ git checkout pull/13465` \
`$ git pull https://git.openjdk.org/jdk.git pull/13465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13465`

View PR using the GUI difftool: \
`$ git pr show -t 13465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13465.diff">https://git.openjdk.org/jdk/pull/13465.diff</a>

</details>
