### PR TITLE
8305944: assert(is_aligned(ref, HeapWordSize)) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public:
 
   void do_oop(narrowOop* ref) {
     assert(ref != NULL, "invariant");
-    assert(is_aligned(ref, HeapWordSize), "invariant");
+    assert(is_aligned(ref, sizeof(narrowOop)), "invariant");
     if (!CompressedOops::is_null(*ref)) {
       _delegate->do_root(UnifiedOopRef::encode_as_raw(ref));
     }


### PR DESCRIPTION
For narrowOop, the alignment should be sizeof(narrowOop) instead of HeapWordSize.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305944](https://bugs.openjdk.org/browse/JDK-8305944): assert(is_aligned(ref, HeapWordSize)) failed: invariant


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13471/head:pull/13471` \
`$ git checkout pull/13471`

Update a local copy of the PR: \
`$ git checkout pull/13471` \
`$ git pull https://git.openjdk.org/jdk.git pull/13471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13471`

View PR using the GUI difftool: \
`$ git pr show -t 13471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13471.diff">https://git.openjdk.org/jdk/pull/13471.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13471#issuecomment-1507889593)