### PR TITLE
8041676: remove the java.compiler system property

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1307,8 +1307,7 @@ bool Arguments::add_property(const char* prop, PropertyWriteable writeable, Prop
     // passed to Java, like any other system property
     if (strlen(value) == 0 || strcasecmp(value, "NONE") == 0) {
         // for applications using NONE or empty value, log a more informative message
-        warning("The java.compiler system property is obsolete and no longer supported,"
-                " use -Xint if you want to run the application in interpreted-only mode.");
+        warning("The java.compiler system property is obsolete and no longer supported, use -Xint");
     } else {
         warning("The java.compiler system property is obsolete and no longer supported.");
     }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -84,7 +84,6 @@ char*  Arguments::_java_command                 = nullptr;
 SystemProperty* Arguments::_system_properties   = nullptr;
 size_t Arguments::_conservative_max_heap_alignment = 0;
 Arguments::Mode Arguments::_mode                = _mixed;
-bool   Arguments::_java_compiler                = false;
 bool   Arguments::_xdebug_mode                  = false;
 const char*  Arguments::_java_vendor_url_bug    = nullptr;
 const char*  Arguments::_sun_java_launcher      = DEFAULT_JAVA_LAUNCHER;
@@ -1304,8 +1303,15 @@ bool Arguments::add_property(const char* prop, PropertyWriteable writeable, Prop
 #endif
 
   if (strcmp(key, "java.compiler") == 0) {
-    process_java_compiler_argument(value);
-    // Record value in Arguments, but let it get passed to Java.
+    // we no longer support java.compiler system property, log a warning and let it get
+    // passed to Java, like any other system property
+    if (strlen(value) == 0 || strcasecmp(value, "NONE") == 0) {
+        // for applications using NONE or empty value, log a more informative message
+        warning("The java.compiler system property is obsolete and no longer supported,"
+                " use -Xint if you want to run the application in interpreted-only mode.");
+    } else {
+        warning("The java.compiler system property is obsolete and no longer supported.");
+    }
   } else if (strcmp(key, "sun.java.launcher.is_altjvm") == 0) {
     // sun.java.launcher.is_altjvm property is
     // private and is processed in process_sun_java_launcher_properties();
@@ -1410,7 +1416,6 @@ void Arguments::set_mode_flags(Mode mode) {
   // Set up default values for all flags.
   // If you add a flag to any of the branches below,
   // add a default value for it here.
-  set_java_compiler(false);
   _mode                      = mode;
 
   // Ensure Agent_OnLoad has the correct initial values.
@@ -1900,16 +1905,6 @@ jint Arguments::set_aggressive_opts_flags() {
 }
 
 //===========================================================================================================
-// Parsing of java.compiler property
-
-void Arguments::process_java_compiler_argument(const char* arg) {
-  // For backwards compatibility, Djava.compiler=NONE or ""
-  // causes us to switch to -Xint mode UNLESS -Xdebug
-  // is also specified.
-  if (strlen(arg) == 0 || strcasecmp(arg, "NONE") == 0) {
-    set_java_compiler(true);    // "-Djava.compiler[=...]" most recently seen.
-  }
-}
 
 void Arguments::process_java_launcher_argument(const char* launcher, void* extra_info) {
   if (_sun_java_launcher != _default_java_launcher) {
@@ -3039,15 +3034,6 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     if (result != JNI_OK) {
       return result;
     }
-  }
-
-  // This must be done after all arguments have been processed.
-  // java_compiler() true means set to "NONE" or empty.
-  if (java_compiler() && !xdebug_mode()) {
-    // For backwards compatibility, we switch to interpreted mode if
-    // -Djava.compiler="NONE" or "" is specified AND "-Xdebug" was
-    // not specified.
-    set_mode_flags(_int);
   }
 
   // CompileThresholdScaling == 0.0 is same as -Xint: Disable compilation (enable interpreter-only mode),

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -346,9 +346,6 @@ class Arguments : AllStatic {
   // Operation modi
   static Mode _mode;
   static void set_mode_flags(Mode mode);
-  static bool _java_compiler;
-  static void set_java_compiler(bool arg) { _java_compiler = arg; }
-  static bool java_compiler()   { return _java_compiler; }
 
   // -Xdebug flag
   static bool _xdebug_mode;
@@ -406,7 +403,6 @@ class Arguments : AllStatic {
   static bool parse_argument(const char* arg, JVMFlagOrigin origin);
   static bool process_argument(const char* arg, jboolean ignore_unrecognized, JVMFlagOrigin origin);
   static void process_java_launcher_argument(const char*, void*);
-  static void process_java_compiler_argument(const char* arg);
   static jint parse_options_environment_variable(const char* name, ScopedVMInitArgs* vm_args);
   static jint parse_java_tool_options_environment_variable(ScopedVMInitArgs* vm_args);
   static jint parse_java_options_environment_variable(ScopedVMInitArgs* vm_args);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -760,8 +760,6 @@ public final class System {
      *     <td>List of paths to search when loading libraries</td></tr>
      * <tr><th scope="row">{@systemProperty java.io.tmpdir}</th>
      *     <td>Default temp file path</td></tr>
-     * <tr><th scope="row">{@systemProperty java.compiler}</th>
-     *     <td>Name of JIT compiler to use</td></tr>
      * <tr><th scope="row">{@systemProperty os.name}</th>
      *     <td>Operating system name</td></tr>
      * <tr><th scope="row">{@systemProperty os.arch}</th>


### PR DESCRIPTION
Can I please get a review of this change which removes the `java.compiler` system property? This addresses https://bugs.openjdk.org/browse/JDK-8041676.

A CSR has been filed for this change and is available at https://bugs.openjdk.org/browse/JDK-8305998. The CSR has more details about this proposed change, but to summarize, the `java.compiler` system property wasn't used in any practical way. With the recent removal of `java.lang.Compiler` interface from the JDK, the presence of this system property wasn't of any practical importance.

The commit in this PR, removes its reference from the `System.getProperties()` documentation and also removes the specific implementation from hotspot where it treated the values `NONE` and empty string in the absence of `-Xdebug` in a specific manner and considered it to be an instruction to run the application in interpreter-only mode. `-Xint` option has been around for this purpose, so removal of this `java.compiler` system property support from hotspot implementation wouldn't remove any usable feature for the applications.

Additionally, the hotspot implementation now logs a warning message when it detects the presence of `java.compiler` system property when `java` is launched. This warning message will be removed after a few releases.

The current JDK source has reference to the `java.compiler` system property in numerous NetBeans project build files. The usage of this system property in such files isn't necessary. However, this PR doesn't intend to cleanup those references, since it isn't clear which of those NetBeans projects are still relevant. I think we can use a separate PR to do that cleanup.

tier1, tier2, tier3 testing has been done with these changes and those tests have passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8305998](https://bugs.openjdk.org/browse/JDK-8305998) to be approved

### Issues
 * [JDK-8041676](https://bugs.openjdk.org/browse/JDK-8041676): remove the java.compiler system property
 * [JDK-8305998](https://bugs.openjdk.org/browse/JDK-8305998): remove the java.compiler system property (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [3a4bf8f7](https://git.openjdk.org/jdk/pull/13475/files/3a4bf8f755fc52d2855bc0cbef7bb34186713f47)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [3a4bf8f7](https://git.openjdk.org/jdk/pull/13475/files/3a4bf8f755fc52d2855bc0cbef7bb34186713f47)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13475/head:pull/13475` \
`$ git checkout pull/13475`

Update a local copy of the PR: \
`$ git checkout pull/13475` \
`$ git pull https://git.openjdk.org/jdk.git pull/13475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13475`

View PR using the GUI difftool: \
`$ git pr show -t 13475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13475.diff">https://git.openjdk.org/jdk/pull/13475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13475#issuecomment-1508433716)