### PR TITLE
8306006: strace001.java fails due to unknown methods on stack

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,8 @@ public class strace001 {
         expectedSystemTrace = new String[]{
                 "java.lang.Thread.sleep",
                 "java.lang.Thread.sleep0",
+                "java.lang.Thread.beforeSleep",
+                "java.lang.Thread.afterSleep",
                 "java.lang.Thread.yield",
                 "java.lang.Thread.yield0",
                 "java.lang.Thread.currentCarrierThread",

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -147,6 +147,7 @@ public class strace001 {
                 "java.lang.Thread.yield0",
                 "java.lang.Thread.currentCarrierThread",
                 "java.lang.Thread.currentThread",
+                "java.util.concurrent.TimeUnit.toNanos",
                 "jdk.internal.event.ThreadSleepEvent.<clinit>",
                 "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
                 "jdk.internal.event.ThreadSleepEvent.isEnabled"

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -204,13 +204,15 @@ public class strace001 {
     // The method performs checks of the stack trace
     private static boolean checkTrace(StackTraceElement[] elements) {
         int length = elements.length;
-        int expectedLength = depth + 5;
+        // The length of the trace must not be greater than
+        // expectedLength.  Number of recursionJava() or
+        // recursionNative() methods must not be greater than depth,
+        // also one run() and one waitForSign(), plus whatever can be
+        // reached from Thread.yield or Thread.sleep.
+        int expectedLength = depth + 6;
         boolean result = true;
 
-        // Check the length of the trace. It must not be greater than
-        // expectedLength. Number of recursionJava() or recursionNative()
-        // methods must not ne greater than depth, also one Object.wait() or
-        // Thread.yield() method, one run( ) and one waitForSign().
+        // Check the length of the trace
         if (length > expectedLength) {
             log.complain("Length of the stack trace is " + length + ", but "
                        + "expected to be not greater than " + expectedLength);

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace005/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace006/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace007/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace008/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace009/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,9 @@
  *     Main thread makes a snapshot of stack trace for all threads and checks it:
  *         1. If a thread is alive, ThreadMonitor.getThreadInfo(long, -1) must
  *            return not null ThreadInfo.
- *         2. The length of a trace must not be greater than (depth + 3). Number
- *            of recursionJava() or recursionNative() methods must not be greater
- *            than depth, also one Object.wait() or Thread.yield() method, one
- *            run(), and one waitForSign().
+ *         2. Number of recursionJava() or recursionNative() methods must not be
+ *            greater than depth + X, where X is implementation dependent.
+ *            See strace001.java for more info.
  *         3. The latest method of the stack trace must be RunningThread.run().
  *         4. getClassName() and getMethodName() methods must return expected
  *            values for each element of the stack trace.


### PR DESCRIPTION
Added the missing java.lang.Thread.beforeSleep and java.lang.afterSleep to expectedSystemTrace.
Tested on my local machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306006](https://bugs.openjdk.org/browse/JDK-8306006): strace001.java fails due to unknown methods on stack


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [6d7f9163](https://git.openjdk.org/jdk/pull/13476/files/6d7f91635b377a146a19ea208f5b44a7efa3e365)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13476/head:pull/13476` \
`$ git checkout pull/13476`

Update a local copy of the PR: \
`$ git checkout pull/13476` \
`$ git pull https://git.openjdk.org/jdk.git pull/13476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13476`

View PR using the GUI difftool: \
`$ git pr show -t 13476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13476.diff">https://git.openjdk.org/jdk/pull/13476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13476#issuecomment-1508516662)