### PR TITLE
8281149: (fs) java/nio/file/FileStore/Basic.java fails with java.lang.RuntimeException: values differ by more than 1GB

### DIFF
--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,11 +57,12 @@ public class Basic {
             throw new RuntimeException("Assertion failed");
     }
 
-    static void checkWithin1GB(long expected, long actual) {
+    static void checkWithin1GB(String space, long expected, long actual) {
         long diff = Math.abs(actual - expected);
         if (diff > G) {
-            String msg = String.format("|actual %d - expected %d| = %d (%f G)",
-                                       actual, expected, diff, (float)diff/G);
+            String msg = String.format("%s: |actual %d - expected %d| = %d (%f G)",
+                                       space, actual, expected, diff,
+                                       (float)diff/G);
             throw new RuntimeException(msg);
         }
     }
@@ -110,19 +111,19 @@ public class Basic {
          * Test: Space atributes
          */
         File f = file1.toFile();
-        long total = f.getTotalSpace();
-        long free = f.getFreeSpace();
-        long usable = f.getUsableSpace();
 
         // check values are "close"
-        checkWithin1GB(total,  store1.getTotalSpace());
-        checkWithin1GB(free,   store1.getUnallocatedSpace());
-        checkWithin1GB(usable, store1.getUsableSpace());
+        checkWithin1GB("total",  f.getTotalSpace(),  store1.getTotalSpace());
+        checkWithin1GB("free",   f.getFreeSpace(),   store1.getUnallocatedSpace());
+        checkWithin1GB("usable", f.getUsableSpace(), store1.getUsableSpace());
 
         // get values by name
-        checkWithin1GB(total,  (Long)store1.getAttribute("totalSpace"));
-        checkWithin1GB(free,   (Long)store1.getAttribute("unallocatedSpace"));
-        checkWithin1GB(usable, (Long)store1.getAttribute("usableSpace"));
+        checkWithin1GB("total",  f.getTotalSpace(),
+                       (Long)store1.getAttribute("totalSpace"));
+        checkWithin1GB("free",   f.getFreeSpace(),
+                       (Long)store1.getAttribute("unallocatedSpace"));
+        checkWithin1GB("usable", f.getUsableSpace(),
+                       (Long)store1.getAttribute("usableSpace"));
 
         /**
          * Test: Enumerate all FileStores


### PR DESCRIPTION
Modify the disk space verification to retrieve the expected value dynamically as the first parameter of the check method, as is done for the value being tested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281149](https://bugs.openjdk.org/browse/JDK-8281149): (fs) java/nio/file/FileStore/Basic.java  fails with java.lang.RuntimeException: values differ by more than 1GB


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13480/head:pull/13480` \
`$ git checkout pull/13480`

Update a local copy of the PR: \
`$ git checkout pull/13480` \
`$ git pull https://git.openjdk.org/jdk.git pull/13480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13480`

View PR using the GUI difftool: \
`$ git pr show -t 13480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13480.diff">https://git.openjdk.org/jdk/pull/13480.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13480#issuecomment-1509056274)