### PR TITLE
8305945: (zipfs) Opening a directory to get input stream produces incorrect exception message

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -860,7 +860,7 @@ class ZipFileSystem extends FileSystem {
             if (e == null)
                 throw new NoSuchFileException(getString(path));
             if (e.isDir())
-                throw new FileSystemException(getString(path), "is a directory", null);
+                throw new FileSystemException(getString(path), null, "is a directory");
             return getInputStream(e);
         } finally {
             endRead();

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
@@ -85,6 +85,7 @@ public class ZipFSDirectoryExceptionMessageTest {
     /**
      * Validate that Zip FS returns the correct Exception message when
      * attempting to obtain an InputStream from a path representing a directory
+     * and the FileSystemException::getOtherfile returns null
      *
      * @throws IOException If an error occurs
      */
@@ -93,6 +94,8 @@ public class ZipFSDirectoryExceptionMessageTest {
         try (FileSystem zipfs = FileSystems.newFileSystem(ZIP_FILE)) {
             var file = zipfs.getPath(DIRECTORY_NAME);
             var x = assertThrows(FileSystemException.class, () -> Files.newInputStream(file));
+            // validate that other file should be null
+            assertNull(x.getOtherFile());
             assertEquals(DIR_EXCEPTION_MESSAGE, x.getMessage());
         }
     }

--- a/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
@@ -93,7 +93,7 @@ public class ZipFSDirectoryExceptionMessageTest {
         try (FileSystem zipfs = FileSystems.newFileSystem(ZIP_FILE)) {
             var file = zipfs.getPath(DIRECTORY_NAME);
             var x = assertThrows(FileSystemException.class, () -> Files.newInputStream(file));
-            assertEquals(x.getMessage(), DIR_EXCEPTION_MESSAGE);
+            assertEquals(DIR_EXCEPTION_MESSAGE, x.getMessage());
         }
     }
 }

--- a/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
@@ -37,7 +37,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @test
  * @bug 8305945
- * @summary Validate that Zip FS provides the correct exception message
+ * @summary Validate that Zip FS provides the correct exception message when an
+ * attempt is made to obtain an InputStream from a directory entry
  * @modules jdk.zipfs
  * @run junit ZipFSDirectoryExceptionMessageTest
  */
@@ -53,7 +54,7 @@ public class ZipFSDirectoryExceptionMessageTest {
     /**
      * Zip file to create
      */
-    public static final String ZIP_FILE = "directoryExceptionTest.zip";
+    public static final Path ZIP_FILE = Path.of("directoryExceptionTest.zip");
 
     /**
      * Create a Zip file which contains a single directory entry
@@ -67,7 +68,7 @@ public class ZipFSDirectoryExceptionMessageTest {
         ze.setSize(0);
         ze.setCrc(0);
         try (ZipOutputStream zos = new ZipOutputStream(
-                Files.newOutputStream(Path.of(ZIP_FILE)))) {
+                Files.newOutputStream(ZIP_FILE))) {
             zos.putNextEntry(ze);
         }
     }
@@ -78,7 +79,7 @@ public class ZipFSDirectoryExceptionMessageTest {
      */
     @AfterEach
     public void cleanup() throws IOException {
-        Files.deleteIfExists(Path.of(ZIP_FILE));
+        Files.deleteIfExists(ZIP_FILE);
     }
 
     /**
@@ -89,7 +90,7 @@ public class ZipFSDirectoryExceptionMessageTest {
      */
     @Test
     public void testException() throws IOException {
-        try (FileSystem zipfs = FileSystems.newFileSystem(Path.of(ZIP_FILE))) {
+        try (FileSystem zipfs = FileSystems.newFileSystem(ZIP_FILE)) {
             var file = zipfs.getPath(DIRECTORY_NAME);
             var x = assertThrows(FileSystemException.class, () -> Files.newInputStream(file));
             assertEquals(x.getMessage(), DIR_EXCEPTION_MESSAGE);

--- a/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @test
+ * @bug 8305945
+ * @summary Validate that Zip FS provides the correct exception message
+ * @modules jdk.zipfs
+ * @run junit ZipFSDirectoryExceptionMessageTest
+ */
+public class ZipFSDirectoryExceptionMessageTest {
+    /**
+     * Name of Directory created within the Zip file
+     */
+    public static final String DIRECTORY_NAME = "folder/";
+    /**
+     * The expected error message
+     */
+    public static final String DIR_EXCEPTION_MESSAGE = "/folder: is a directory";
+    /**
+     * Zip file to create
+     */
+    public static final String ZIP_FILE = "directoryExceptionTest.zip";
+
+    /**
+     * Create a Zip file which contains a single directory entry
+     * @throws IOException if an error occurs
+     */
+    @BeforeEach
+    public void setup() throws IOException {
+        var ze = new ZipEntry(DIRECTORY_NAME);
+        ze.setMethod(ZipEntry.STORED);
+        ze.setCompressedSize(0);
+        ze.setSize(0);
+        ze.setCrc(0);
+        try (ZipOutputStream zos = new ZipOutputStream(
+                Files.newOutputStream(Path.of(ZIP_FILE)))) {
+            zos.putNextEntry(ze);
+        }
+    }
+
+    /**
+     * Delete the Zip file used by the test
+     * @throws IOException If an error occurs
+     */
+    @AfterEach
+    public void cleanup() throws IOException {
+        Files.deleteIfExists(Path.of(ZIP_FILE));
+    }
+
+    /**
+     * Validate that Zip FS throws the correct Exception message was thrown when
+     * attempting to obtain an InputStream from a path representing a directory
+     *
+     * @throws IOException If an error occurs
+     */
+    @Test
+    public void testException() throws IOException {
+        try (FileSystem zipfs = FileSystems.newFileSystem(Path.of(ZIP_FILE))) {
+            var file = zipfs.getPath(DIRECTORY_NAME);
+            var x = assertThrows(FileSystemException.class, () -> Files.newInputStream(file));
+            assertEquals(x.getMessage(), DIR_EXCEPTION_MESSAGE);
+        }
+    }
+}

--- a/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSDirectoryExceptionMessageTest.java
@@ -82,7 +82,7 @@ public class ZipFSDirectoryExceptionMessageTest {
     }
 
     /**
-     * Validate that Zip FS throws the correct Exception message was thrown when
+     * Validate that Zip FS returns the correct Exception message when
      * attempting to obtain an InputStream from a path representing a directory
      *
      * @throws IOException If an error occurs


### PR DESCRIPTION
Please review this trivial change when ZipFS returns the wrong java.nio.file.FileSystemException message due the the parameters being reversed.

I also included a simple junit test as part of the fix.

Mach5 tiers1-3 are clean

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305945](https://bugs.openjdk.org/browse/JDK-8305945): (zipfs) Opening a directory to get input stream produces incorrect exception message


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [e99a91bf](https://git.openjdk.org/jdk/pull/13482/files/e99a91bf58ead0ecf43d94a02e39c3d0cf86a8a8)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [e99a91bf](https://git.openjdk.org/jdk/pull/13482/files/e99a91bf58ead0ecf43d94a02e39c3d0cf86a8a8)
 * @eirbjo (no known openjdk.org user name / role) ⚠️ Review applies to [e99a91bf](https://git.openjdk.org/jdk/pull/13482/files/e99a91bf58ead0ecf43d94a02e39c3d0cf86a8a8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13482/head:pull/13482` \
`$ git checkout pull/13482`

Update a local copy of the PR: \
`$ git checkout pull/13482` \
`$ git pull https://git.openjdk.org/jdk.git pull/13482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13482`

View PR using the GUI difftool: \
`$ git pr show -t 13482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13482.diff">https://git.openjdk.org/jdk/pull/13482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13482#issuecomment-1509218828)