### PR TITLE
8305336: java.security.debug=sunpkcs11 breaks PKCS#11 configuration with slotListIndex

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -363,8 +363,8 @@ public final class SunPKCS11 extends AuthProvider {
                 long[] slots = p11.C_GetSlotList(false);
                 if (showInfo) {
                     System.out.println("All slots: " + toString(slots));
-                    slots = p11.C_GetSlotList(true);
-                    System.out.println("Slots with tokens: " + toString(slots));
+                    System.out.println("Slots with tokens: " +
+                            toString(p11.C_GetSlotList(true)));
                 }
                 if (slotID < 0) {
                     if ((slotListIndex < 0)


### PR DESCRIPTION
Could someone help review this trivial fix?

Inside the debugging block, the slot list variable "slots" is overridden with slots with tokens, this causes problem when trying to access the slot list with slotListIndex configuration option. Fix is to print out the slot with tokens info w/o storing it into the slot list variable.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305336](https://bugs.openjdk.org/browse/JDK-8305336): java.security.debug=sunpkcs11 breaks PKCS#11 configuration with slotListIndex


### Reviewers
 * [Mark Powers](https://openjdk.org/census#mpowers) (@mcpowers - Author)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13483/head:pull/13483` \
`$ git checkout pull/13483`

Update a local copy of the PR: \
`$ git checkout pull/13483` \
`$ git pull https://git.openjdk.org/jdk.git pull/13483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13483`

View PR using the GUI difftool: \
`$ git pr show -t 13483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13483.diff">https://git.openjdk.org/jdk/pull/13483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13483#issuecomment-1509332138)