### PR TITLE
8306029: ProblemList runtime/ErrorHandling/TestDwarf.java on linux

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -100,7 +100,7 @@ runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/CompressedOops/CompressedClassPointers.java 8305765 generic-all
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/Thread/TestAlwaysPreTouchStacks.java 8305416 generic-all
-runtime/ErrorHandling/TestDwarf.java 8305489 linux-i586
+runtime/ErrorHandling/TestDwarf.java 8305489 linux-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to change problem-listing of runtime/ErrorHandling/TestDwarf.java
from linux-i586 to linux-all, since there's no reason to think it's limited to
just 32bit platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306029](https://bugs.openjdk.org/browse/JDK-8306029): ProblemList runtime/ErrorHandling/TestDwarf.java on linux


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13485/head:pull/13485` \
`$ git checkout pull/13485`

Update a local copy of the PR: \
`$ git checkout pull/13485` \
`$ git pull https://git.openjdk.org/jdk.git pull/13485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13485`

View PR using the GUI difftool: \
`$ git pr show -t 13485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13485.diff">https://git.openjdk.org/jdk/pull/13485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13485#issuecomment-1509498820)