### PR TITLE
speed up : LocalDate.of & LocalTime.of checkValidValue

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -249,9 +249,13 @@ public final class LocalDate
      *  or if the day-of-month is invalid for the month-year
      */
     public static LocalDate of(int year, Month month, int dayOfMonth) {
-        YEAR.checkValidValue(year);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
         Objects.requireNonNull(month, "month");
-        DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        if (dayOfMonth < 1 || dayOfMonth > 31) {
+            throw new DateTimeException("Invalid value for DayOfMonth (valid values 1 - 28/31): " + dayOfMonth);
+        }
         return create(year, month.getValue(), dayOfMonth);
     }
 
@@ -269,9 +273,15 @@ public final class LocalDate
      *  or if the day-of-month is invalid for the month-year
      */
     public static LocalDate of(int year, int month, int dayOfMonth) {
-        YEAR.checkValidValue(year);
-        MONTH_OF_YEAR.checkValidValue(month);
-        DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
+        if (month < 1 || month > 12) {
+            throw new DateTimeException("Invalid value for MonthOfYear (valid values 1 - 12): " + month);
+        }
+        if (dayOfMonth < 1 || dayOfMonth > 31) {
+            throw new DateTimeException("Invalid value for DayOfMonth (valid values 1 - 28/31): " + dayOfMonth);
+        }
         return create(year, month, dayOfMonth);
     }
 
@@ -289,8 +299,12 @@ public final class LocalDate
      *  or if the day-of-year is invalid for the year
      */
     public static LocalDate ofYearDay(int year, int dayOfYear) {
-        YEAR.checkValidValue(year);
-        DAY_OF_YEAR.checkValidValue(dayOfYear);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
+        if (dayOfYear < 1 || dayOfYear > 366) {
+            throw new DateTimeException("Invalid value for DayOfYear (valid values 1 - 365/366): " + dayOfYear);
+        }
         boolean leap = IsoChronology.INSTANCE.isLeapYear(year);
         if (dayOfYear == 366 && leap == false) {
             throw new DateTimeException("Invalid date 'DayOfYear 366' as '" + year + "' is not a leap year");
@@ -1066,7 +1080,9 @@ public final class LocalDate
         if (this.year == year) {
             return this;
         }
-        YEAR.checkValidValue(year);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
         return resolvePreviousValid(year, month, day);
     }
 
@@ -1085,7 +1101,9 @@ public final class LocalDate
         if (this.month == month) {
             return this;
         }
-        MONTH_OF_YEAR.checkValidValue(month);
+        if (month < 1 || month > 12) {
+            throw new DateTimeException("Invalid value for MonthOfYear (valid values 1 - 12): " + month);
+        }
         return resolvePreviousValid(year, month, day);
     }
 
@@ -1365,7 +1383,9 @@ public final class LocalDate
                 } else if (month < 12) {
                     return new LocalDate(year, month + 1, (int) (dom - monthLen));
                 } else {
-                    YEAR.checkValidValue(year + 1);
+                    if (year + 1 < Year.MIN_VALUE || year + 1 > Year.MAX_VALUE) {
+                        throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+                    }
                     return new LocalDate(year + 1, 1, (int) (dom - monthLen));
                 }
             }

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -303,11 +303,15 @@ public final class LocalTime
      * @throws DateTimeException if the value of any field is out of range
      */
     public static LocalTime of(int hour, int minute) {
-        HOUR_OF_DAY.checkValidValue(hour);
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
         if (minute == 0) {
             return HOURS[hour];  // for performance
         }
-        MINUTE_OF_HOUR.checkValidValue(minute);
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
         return new LocalTime(hour, minute, 0, 0);
     }
 
@@ -324,12 +328,18 @@ public final class LocalTime
      * @throws DateTimeException if the value of any field is out of range
      */
     public static LocalTime of(int hour, int minute, int second) {
-        HOUR_OF_DAY.checkValidValue(hour);
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
         if ((minute | second) == 0) {
             return HOURS[hour];  // for performance
         }
-        MINUTE_OF_HOUR.checkValidValue(minute);
-        SECOND_OF_MINUTE.checkValidValue(second);
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
+        if (second < 0 || second > 59) {
+            throw new DateTimeException("Invalid value for SecondOfMinute (valid values 0 - 59): " + second);
+        }
         return new LocalTime(hour, minute, second, 0);
     }
 
@@ -346,10 +356,18 @@ public final class LocalTime
      * @throws DateTimeException if the value of any field is out of range
      */
     public static LocalTime of(int hour, int minute, int second, int nanoOfSecond) {
-        HOUR_OF_DAY.checkValidValue(hour);
-        MINUTE_OF_HOUR.checkValidValue(minute);
-        SECOND_OF_MINUTE.checkValidValue(second);
-        NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
+        if (second < 0 || second > 59) {
+            throw new DateTimeException("Invalid value for SecondOfMinute (valid values 0 - 59): " + second);
+        }
+        if (nanoOfSecond < 0 || nanoOfSecond > 999_999_999) {
+            throw new DateTimeException("Invalid value for NanoOfSecond (valid values 0 - 999999999): " + nanoOfSecond);
+        }
         return create(hour, minute, second, nanoOfSecond);
     }
 
@@ -387,7 +405,10 @@ public final class LocalTime
      * @throws DateTimeException if the second-of-day value is invalid
      */
     public static LocalTime ofSecondOfDay(long secondOfDay) {
-        SECOND_OF_DAY.checkValidValue(secondOfDay);
+        if (secondOfDay < 0 || secondOfDay > 86399L) {
+            throw new DateTimeException("Invalid value for SecondOfDay (valid values 0 - 86399): " + secondOfDay);
+        }
+
         int hours = (int) (secondOfDay / SECONDS_PER_HOUR);
         secondOfDay -= hours * SECONDS_PER_HOUR;
         int minutes = (int) (secondOfDay / SECONDS_PER_MINUTE);
@@ -405,7 +426,10 @@ public final class LocalTime
      * @throws DateTimeException if the nanos of day value is invalid
      */
     public static LocalTime ofNanoOfDay(long nanoOfDay) {
-        NANO_OF_DAY.checkValidValue(nanoOfDay);
+        if (nanoOfDay < 0 || nanoOfDay > 86399999999999L) {
+            throw new DateTimeException("Invalid value for NanoOfDay (valid values 0 - 86399999999999): " + nanoOfDay);
+        }
+
         int hours = (int) (nanoOfDay / NANOS_PER_HOUR);
         nanoOfDay -= hours * NANOS_PER_HOUR;
         int minutes = (int) (nanoOfDay / NANOS_PER_MINUTE);
@@ -901,7 +925,11 @@ public final class LocalTime
         if (this.hour == hour) {
             return this;
         }
-        HOUR_OF_DAY.checkValidValue(hour);
+
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
+
         return create(hour, minute, second, nano);
     }
 
@@ -918,7 +946,11 @@ public final class LocalTime
         if (this.minute == minute) {
             return this;
         }
-        MINUTE_OF_HOUR.checkValidValue(minute);
+
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
+
         return create(hour, minute, second, nano);
     }
 
@@ -935,7 +967,11 @@ public final class LocalTime
         if (this.second == second) {
             return this;
         }
-        SECOND_OF_MINUTE.checkValidValue(second);
+
+        if (second < 0 || second > 59) {
+            throw new DateTimeException("Invalid value for SecondOfMinute (valid values 0 - 59): " + second);
+        }
+
         return create(hour, minute, second, nano);
     }
 
@@ -952,7 +988,11 @@ public final class LocalTime
         if (this.nano == nanoOfSecond) {
             return this;
         }
-        NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+
+        if (nanoOfSecond < 0 || nanoOfSecond > 999_999_999) {
+            throw new DateTimeException("Invalid value for NanoOfSecond (valid values 0 - 999999999): " + nanoOfSecond);
+        }
+
         return create(hour, minute, second, nanoOfSecond);
     }
 


### PR DESCRIPTION
LocalDate & LocalTime is small object, ChronoField#checkValidValue is too slow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13488/head:pull/13488` \
`$ git checkout pull/13488`

Update a local copy of the PR: \
`$ git checkout pull/13488` \
`$ git pull https://git.openjdk.org/jdk.git pull/13488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13488`

View PR using the GUI difftool: \
`$ git pr show -t 13488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13488.diff">https://git.openjdk.org/jdk/pull/13488.diff</a>

</details>
