### PR TITLE
8306075: Micro-optimize Enum.hashCode

### DIFF
--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -168,13 +168,13 @@ public abstract class Enum<E extends Enum<E>>
         return this==other;
     }
 
-    /**
+    /*
      * The hash code of this enumeration constant.
      *
-     * @implNote Once initialized, the field value does not change.
+     * Once initialized, the field value does not change.
      * HotSpot's identity hash code generation also never returns zero
      * as the identity hash code. This makes zero a convenient marker
-     * for the un-initialized value for both {@link @Stable} and the lazy
+     * for the un-initialized value for both Stable and the lazy
      * initialization code.
      */
     @Stable

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -172,9 +172,9 @@ public abstract class Enum<E extends Enum<E>>
      * The hash code of this enumeration constant.
      *
      * @implNote Once initialized, the field value does not change.
-     * Hotspot's identity hash code generation also never returns zero
-     * as the identity hash code. This allows to treat zero as the marker
-     * for the un-initialized value for both {#link @Stable} and the lazy
+     * HotSpot's identity hash code generation also never returns zero
+     * as the identity hash code. This makes zero a convenient marker
+     * for the un-initialized value for both {@link @Stable} and the lazy
      * initialization code.
      */
     @Stable

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -37,6 +37,8 @@ import java.lang.constant.DynamicConstantDesc;
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
+import jdk.internal.vm.annotation.Stable;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -167,12 +169,28 @@ public abstract class Enum<E extends Enum<E>>
     }
 
     /**
+     * The hash code of this enumeration constant.
+     *
+     * @implNote Once initialized, the field value does not change.
+     * Hotspot's identity hash code generation also never returns zero
+     * as the identity hash code. This allows to treat zero as the marker
+     * for the un-initialized value for both {#link @Stable} and the lazy
+     * initialization code.
+     */
+    @Stable
+    private int hash;
+
+    /**
      * Returns a hash code for this enum constant.
      *
      * @return a hash code for this enum constant.
      */
     public final int hashCode() {
-        return super.hashCode();
+        int hc = hash;
+        if (hc == 0) {
+            hc = hash = System.identityHashCode(this);
+        }
+        return hc;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -168,14 +168,8 @@ public abstract class Enum<E extends Enum<E>>
         return this==other;
     }
 
-    /*
+    /**
      * The hash code of this enumeration constant.
-     *
-     * Once initialized, the field value does not change.
-     * HotSpot's identity hash code generation also never returns zero
-     * as the identity hash code. This makes zero a convenient marker
-     * for the un-initialized value for both Stable and the lazy
-     * initialization code.
      */
     @Stable
     private int hash;
@@ -186,6 +180,11 @@ public abstract class Enum<E extends Enum<E>>
      * @return a hash code for this enum constant.
      */
     public final int hashCode() {
+        // Once initialized, the hash field value does not change.
+        // HotSpot's identity hash code generation also never returns zero
+        // as the identity hash code. This makes zero a convenient marker
+        // for the un-initialized value for both @Stable and the lazy
+        // initialization code below.
         int hc = hash;
         if (hc == 0) {
             hc = hash = System.identityHashCode(this);

--- a/test/micro/org/openjdk/bench/java/lang/EnumHashCode.java
+++ b/test/micro/org/openjdk/bench/java/lang/EnumHashCode.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class EnumHashCode {
+
+    enum E {
+        A, B, C;
+    }
+
+    Enum e = E.A;
+
+    @Benchmark
+    public int constant() {
+        // Tests that hash code is constant-foldable
+        return E.A.hashCode();
+    }
+
+    @Benchmark
+    public int field() {
+        // Tests that hash code is efficient
+        return e.hashCode();
+    }
+
+}


### PR DESCRIPTION
Improve the speed of Enum.hashCode by caching the identity hashcode on first use. I've seen an application where Enum.hashCode is a hot path, and this is fairly simple speedup. The memory overhead is low; in enums with no extra fields there is already a 4-byte space due to alignment so this new field can slot in 'for free'. In other cases, the singleton nature of enum values means that the number of total instances is typically very low, so a small per-instance overhead is not a concern.

Please see more discussion/explanation in the [original enhancement request](https://bugs.openjdk.org/browse/JDK-8306075). [Benchmark results and generated code analysis moved to comment]

Thanks @shipilev for help with the implementation and interpreting the generated code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306075](https://bugs.openjdk.org/browse/JDK-8306075): Micro-optimize Enum.hashCode


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [5039ffff](https://git.openjdk.org/jdk/pull/13491/files/5039ffffb5072935f032509198e08088706a5706)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Andrei Pangin](https://openjdk.org/census#apangin) (@apangin - no project role)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13491/head:pull/13491` \
`$ git checkout pull/13491`

Update a local copy of the PR: \
`$ git checkout pull/13491` \
`$ git pull https://git.openjdk.org/jdk.git pull/13491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13491`

View PR using the GUI difftool: \
`$ git pr show -t 13491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13491.diff">https://git.openjdk.org/jdk/pull/13491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13491#issuecomment-1511145340)