### PR TITLE
8305781: compiler/c2/irTests/TestVectorizationMultiInvar.java failed with "IRViolationException: There were one or multiple IR rule failures."

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
@@ -25,6 +25,7 @@ package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
 import jdk.test.lib.Utils;
+import jdk.test.whitebox.WhiteBox;
 import jdk.internal.misc.Unsafe;
 import java.util.Objects;
 import java.util.Random;
@@ -36,14 +37,20 @@ import java.util.Random;
  * @summary C2: vectorization fails on some simple Memory Segment loops
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver compiler.c2.irTests.TestVectorizationMultiInvar
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.TestVectorizationMultiInvar
  */
 
 public class TestVectorizationMultiInvar {
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private final static WhiteBox wb = WhiteBox.getWhiteBox();
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+        Object alignVector = wb.getVMFlag("AlignVector");
+        if (alignVector != null && !((Boolean)alignVector)) {
+            TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+        }
     }
 
     static int size = 1024;


### PR DESCRIPTION
The test case only works if unaligned accesses are allowed (that is
AlignVector false). I added a runtime check similar to what I did with
TestVectorizationMismatchedAccess.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305781](https://bugs.openjdk.org/browse/JDK-8305781): compiler/c2/irTests/TestVectorizationMultiInvar.java failed with "IRViolationException: There were one or multiple IR rule failures."


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13492/head:pull/13492` \
`$ git checkout pull/13492`

Update a local copy of the PR: \
`$ git checkout pull/13492` \
`$ git pull https://git.openjdk.org/jdk.git pull/13492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13492`

View PR using the GUI difftool: \
`$ git pr show -t 13492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13492.diff">https://git.openjdk.org/jdk/pull/13492.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13492#issuecomment-1511175595)