### PR TITLE
8306033: Resolve multiple definition of 'throwIOException' and friends when statically linking with JDK native libraries

### DIFF
--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -53,10 +53,3 @@ JNIEXPORT jint JNICALL
     jmm_version = jmm_interface->GetVersion(env);
     return (*env)->GetVersion(env);
 }
-
-void throw_internal_error(JNIEnv* env, const char* msg) {
-    char errmsg[128];
-
-    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
-    JNU_ThrowInternalError(env, errmsg);
-}

--- a/src/java.management/share/native/libmanagement/management.h
+++ b/src/java.management/share/native/libmanagement/management.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/native/libmanagement/management.h
+++ b/src/java.management/share/native/libmanagement/management.h
@@ -33,6 +33,5 @@
 
 extern const JmmInterface* jmm_interface;
 extern jint jmm_version;
-extern void throw_internal_error(JNIEnv* env, const char* msg);
 
 #endif

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -198,7 +198,7 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
 
   cb = malloc(sizeof(struct gss_channel_bindings_struct));
   if (cb == NULL) {
-    throwOutOfMemoryError(env,NULL);
+    gssThrowOutOfMemoryError(env,NULL);
     return NULL;
   }
 

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,7 +198,7 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
 
   cb = malloc(sizeof(struct gss_channel_bindings_struct));
   if (cb == NULL) {
-    gssThrowOutOfMemoryError(env,NULL);
+    gssThrowOutOfMemoryError(env, NULL);
     return NULL;
   }
 

--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -451,18 +451,12 @@ jint getJavaErrorCode(int cNonCallingErr) {
   return GSS_S_COMPLETE;
 }
 
-
-/* Throws a Java Exception by name */
-static void throwByName(JNIEnv *env, const char *name, const char *msg) {
-    jclass cls = (*env)->FindClass(env, name);
+void gssThrowOutOfMemoryError(JNIEnv *env, const char *message) {
+    jclass cls = (*env)->FindClass(env, "java/lang/OutOfMemoryError");
 
     if (cls != NULL) {
-        (*env)->ThrowNew(env, cls, msg);
+        (*env)->ThrowNew(env, cls, message);
     }
-}
-
-void gssThrowOutOfMemoryError(JNIEnv *env, const char *message) {
-    throwByName(env, "java/lang/OutOfMemoryError", message);
 }
 
 /*

--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
@@ -453,7 +453,7 @@ jint getJavaErrorCode(int cNonCallingErr) {
 
 
 /* Throws a Java Exception by name */
-void throwByName(JNIEnv *env, const char *name, const char *msg) {
+static void throwByName(JNIEnv *env, const char *name, const char *msg) {
     jclass cls = (*env)->FindClass(env, name);
 
     if (cls != NULL) {
@@ -461,7 +461,7 @@ void throwByName(JNIEnv *env, const char *name, const char *msg) {
     }
 }
 
-void throwOutOfMemoryError(JNIEnv *env, const char *message) {
+void gssThrowOutOfMemoryError(JNIEnv *env, const char *message) {
     throwByName(env, "java/lang/OutOfMemoryError", message);
 }
 
@@ -602,7 +602,7 @@ void initGSSBuffer(JNIEnv *env, jbyteArray jbytes,
     len = (*env)->GetArrayLength(env, jbytes);
     value = malloc(len);
     if (value == NULL) {
-      throwOutOfMemoryError(env, NULL);
+      gssThrowOutOfMemoryError(env, NULL);
       return;
     } else {
       (*env)->GetByteArrayRegion(env, jbytes, 0, len, value);
@@ -677,13 +677,13 @@ gss_OID newGSSOID(JNIEnv *env, jobject jOid) {
     }
     cOid = malloc(sizeof(struct gss_OID_desc_struct));
     if (cOid == NULL) {
-      throwOutOfMemoryError(env,NULL);
+      gssThrowOutOfMemoryError(env,NULL);
       return GSS_C_NO_OID;
     }
     cOid->length = (*env)->GetArrayLength(env, jbytes) - 2;
     cOid->elements = malloc(cOid->length);
     if (cOid->elements == NULL) {
-      throwOutOfMemoryError(env,NULL);
+      gssThrowOutOfMemoryError(env,NULL);
       goto cleanup;
     }
     (*env)->GetByteArrayRegion(env, jbytes, 2, cOid->length,

--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.h
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.h
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.h
@@ -37,8 +37,8 @@ extern "C" {
   extern jint getJavaTime(OM_uint32);
   extern OM_uint32 getGSSTime(jint);
   extern void checkStatus(JNIEnv *, jobject, OM_uint32, OM_uint32, char*);
-  extern void gssThrowOutOfMemoryError(JNIEnv *, const char*);
   extern jint checkTime(OM_uint32);
+  extern void gssThrowOutOfMemoryError(JNIEnv *, const char*);
   extern void initGSSBuffer(JNIEnv *, jbyteArray, gss_buffer_t);
   extern void resetGSSBuffer(gss_buffer_t);
 

--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.h
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.h
@@ -37,8 +37,8 @@ extern "C" {
   extern jint getJavaTime(OM_uint32);
   extern OM_uint32 getGSSTime(jint);
   extern void checkStatus(JNIEnv *, jobject, OM_uint32, OM_uint32, char*);
+  extern void gssThrowOutOfMemoryError(JNIEnv *, const char*);
   extern jint checkTime(OM_uint32);
-  extern void throwOutOfMemoryError(JNIEnv *, const char*);
   extern void initGSSBuffer(JNIEnv *, jbyteArray, gss_buffer_t);
   extern void resetGSSBuffer(gss_buffer_t);
 

--- a/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
+++ b/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
+++ b/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
@@ -66,7 +66,7 @@
 
 #define J2PCSC_EXCEPTION_NAME "sun/security/smartcardio/PCSCException"
 
-void throwOutOfMemoryError(JNIEnv *env, const char *msg) {
+static void throwOutOfMemoryError(JNIEnv *env, const char *msg) {
     jclass cls = (*env)->FindClass(env, "java/lang/OutOfMemoryError");
 
     if (cls != NULL) /* Otherwise an exception has already been thrown */

--- a/src/java.smartcardio/unix/native/libj2pcsc/pcsc_md.c
+++ b/src/java.smartcardio/unix/native/libj2pcsc/pcsc_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.smartcardio/unix/native/libj2pcsc/pcsc_md.c
+++ b/src/java.smartcardio/unix/native/libj2pcsc/pcsc_md.c
@@ -51,7 +51,7 @@ FPTR_SCardControl scardControl;
 /*
  * Throws a Java Exception by name
  */
-void throwByName(JNIEnv *env, const char *name, const char *msg)
+static void throwByName(JNIEnv *env, const char *name, const char *msg)
 {
     jclass cls = (*env)->FindClass(env, name);
 
@@ -62,7 +62,7 @@ void throwByName(JNIEnv *env, const char *name, const char *msg)
 /*
  * Throws java.lang.NullPointerException
  */
-void throwNullPointerException(JNIEnv *env, const char *msg)
+static void throwNullPointerException(JNIEnv *env, const char *msg)
 {
     throwByName(env, "java/lang/NullPointerException", msg);
 }
@@ -70,7 +70,7 @@ void throwNullPointerException(JNIEnv *env, const char *msg)
 /*
  * Throws java.io.IOException
  */
-void throwIOException(JNIEnv *env, const char *msg)
+static void throwIOException(JNIEnv *env, const char *msg)
 {
     throwByName(env, "java/io/IOException", msg);
 }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -271,7 +271,7 @@ jVersionToCKVersionPtr(JNIEnv *env, jobject jVersion)
     // allocate memory for CK_VERSION pointer
     ckpVersion = (CK_VERSION_PTR) calloc(1, sizeof(CK_VERSION));
     if (ckpVersion == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -320,7 +320,7 @@ CK_DATE * jDateObjectToCKDatePtr(JNIEnv *env, jobject jDate)
     // allocate memory for CK_DATE pointer
     ckpDate = (CK_DATE *) calloc(1, sizeof(CK_DATE));
     if (ckpDate == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -334,7 +334,7 @@ CK_DATE * jDateObjectToCKDatePtr(JNIEnv *env, jobject jDate)
         ckLength = (*env)->GetArrayLength(env, jYear);
         jTempChars = (jchar*) calloc(ckLength, sizeof(jchar));
         if (jTempChars == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         (*env)->GetCharArrayRegion(env, jYear, 0, ckLength, jTempChars);
@@ -355,7 +355,7 @@ CK_DATE * jDateObjectToCKDatePtr(JNIEnv *env, jobject jDate)
         ckLength = (*env)->GetArrayLength(env, jMonth);
         jTempChars = (jchar*) calloc(ckLength, sizeof(jchar));
         if (jTempChars == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         (*env)->GetCharArrayRegion(env, jMonth, 0, ckLength, jTempChars);
@@ -376,7 +376,7 @@ CK_DATE * jDateObjectToCKDatePtr(JNIEnv *env, jobject jDate)
         ckLength = (*env)->GetArrayLength(env, jDay);
         jTempChars = (jchar*) calloc(ckLength, sizeof(jchar));
         if (jTempChars == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         (*env)->GetCharArrayRegion(env, jDay, 0, ckLength, jTempChars);
@@ -525,7 +525,7 @@ jSsl3MasterKeyDeriveParamToCKSsl3MasterKeyDeriveParamPtr(JNIEnv *env,
     // allocate memory for CK_SSL3_MASTER_KEY_DERIVE_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_SSL3_MASTER_KEY_DERIVE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -585,7 +585,7 @@ jTls12MasterKeyDeriveParamToCKTls12MasterKeyDeriveParamPtr(JNIEnv *env,
     // allocate memory for CK_TLS12_MASTER_KEY_DERIVE_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_TLS12_MASTER_KEY_DERIVE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -644,7 +644,7 @@ jTlsPrfParamsToCKTlsPrfParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     // allocate memory for CK_TLS_PRF_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_TLS_PRF_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -716,7 +716,7 @@ jTlsMacParamsToCKTlsMacParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     // allocate memory for CK_TLS_MAC_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_TLS_MAC_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -810,7 +810,7 @@ void keyMatParamToCKKeyMatParam(JNIEnv *env, jobject jParam,
     *cKKeyMatParamPReturnedKeyMaterial =
             (CK_SSL3_KEY_MAT_OUT_PTR) calloc(1, sizeof(CK_SSL3_KEY_MAT_OUT));
     if (*cKKeyMatParamPReturnedKeyMaterial == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         goto cleanup;
     }
 
@@ -867,7 +867,7 @@ jSsl3KeyMatParamToCKSsl3KeyMatParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pL
     // allocate memory for CK_SSL3_KEY_MAT_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_SSL3_KEY_MAT_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -927,7 +927,7 @@ CK_TLS12_KEY_MAT_PARAMS_PTR jTls12KeyMatParamToCKTls12KeyMatParamPtr(JNIEnv *env
     // allocate memory for CK_TLS12_KEY_MAT_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_TLS12_KEY_MAT_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -989,7 +989,7 @@ jAesCtrParamsToCKAesCtrParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     // allocate memory for CK_AES_CTR_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_AES_CTR_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1056,7 +1056,7 @@ jGCMParamsToCKGCMParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     // allocate memory for CK_GCM_PARAMS_NO_IVBITS pointer
     ckParamPtr = calloc(1, sizeof(CK_GCM_PARAMS_NO_IVBITS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1128,7 +1128,7 @@ jCCMParamsToCKCCMParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     // allocate memory for CK_CCM_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_CCM_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1198,7 +1198,7 @@ jSalsaChaChaPolyParamsToCKSalsaChaChaPolyParamPtr(
     // allocate memory for CK_SALSA20_CHACHA20_POLY1305_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_SALSA20_CHACHA20_POLY1305_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1243,7 +1243,7 @@ CK_MECHANISM_PTR jMechanismToCKMechanismPtr(JNIEnv *env, jobject jMech)
     /* allocate memory for CK_MECHANISM_PTR */
     ckpMech =  (CK_MECHANISM_PTR) calloc(1, sizeof(CK_MECHANISM));
     if (ckpMech == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     TRACE1("DEBUG jMechanismToCKMechanismPtr: allocated mech %p\n", ckpMech);
@@ -1553,7 +1553,7 @@ CK_VOID_PTR jMechParamToCKMechParamPtrSlow(JNIEnv *env, jobject jParam,
         case CKM_SKIPJACK_PRIVATE_WRAP: // CK_SKIPJACK_PRIVATE_WRAP_PARAMS
         case CKM_SKIPJACK_RELAYX: // CK_SKIPJACK_RELAYX_PARAMS
         case CKM_KEY_WRAP_SET_OAEP: // CK_KEY_WRAP_SET_OAEP_PARAMS
-            throwPKCS11RuntimeException(env, "No parameter support for this mechanism");
+            p11ThrowPKCS11RuntimeException(env, "No parameter support for this mechanism");
             break;
         default:
             /* if everything failed up to here */
@@ -1612,7 +1612,7 @@ jRsaPkcsOaepParamToCKRsaPkcsOaepParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *
     // allocate memory for CK_RSA_PKCS_OAEP_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_RSA_PKCS_OAEP_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1674,7 +1674,7 @@ jPbeParamToCKPbeParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     // allocate memory for CK_PBE_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_PBE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1811,7 +1811,7 @@ jPkcs5Pbkd2ParamToCKPkcs5Pbkd2ParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pL
     // allocate memory for CK_PKCS5_PBKD2_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_PKCS5_PBKD2_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1879,7 +1879,7 @@ jRsaPkcsPssParamToCKRsaPkcsPssParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pL
     // allocate memory for CK_RSA_PKCS_PSS_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_RSA_PKCS_PSS_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -1936,7 +1936,7 @@ jEcdh1DeriveParamToCKEcdh1DeriveParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *
     // allocate memory for CK_ECDH1_DERIVE_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_ECDH1_DERIVE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -2007,7 +2007,7 @@ jEcdh2DeriveParamToCKEcdh2DeriveParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *
     // allocate memory for CK_ECDH2_DERIVE_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_ECDH2_DERIVE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -2081,7 +2081,7 @@ jX942Dh1DeriveParamToCKX942Dh1DeriveParamPtr(JNIEnv *env, jobject jParam, CK_ULO
     // allocate memory for CK_X9_42_DH1_DERIVE_PARAMS pointer
     ckParamPtr = calloc(1, sizeof(CK_X9_42_DH1_DERIVE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -2156,7 +2156,7 @@ jX942Dh2DeriveParamToCKX942Dh2DeriveParamPtr(JNIEnv *env, jobject jParam, CK_ULO
     // allocate memory for CK_DATE pointer
     ckParamPtr = calloc(1, sizeof(CK_X9_42_DH2_DERIVE_PARAMS));
     if (ckParamPtr == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_digest.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_digest.c
@@ -125,7 +125,7 @@ JNIEXPORT jint JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1DigestSingle
         /* always use single part op, even for large data */
         bufP = (CK_BYTE_PTR) malloc((size_t)jInLen);
         if (bufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
     }
@@ -187,7 +187,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1DigestUpdate
         bufLen = min(MAX_HEAP_BUFFER_LEN, jInLen);
         bufP = (CK_BYTE_PTR) malloc((size_t)bufLen);
         if (bufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return;
         }
     }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_digest.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_digest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_dual.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_dual.c
@@ -92,7 +92,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1DigestEn
     ckpEncryptedPart = (CK_BYTE_PTR) malloc(ckEncryptedPartLength * sizeof(CK_BYTE));
     if (ckpEncryptedPart == NULL) {
         free(ckpPart);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -144,7 +144,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptD
     ckpPart = (CK_BYTE_PTR) malloc(ckPartLength * sizeof(CK_BYTE));
     if (ckpPart == NULL) {
         free(ckpEncryptedPart);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -196,7 +196,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignEncr
     ckpEncryptedPart = (CK_BYTE_PTR) malloc(ckEncryptedPartLength * sizeof(CK_BYTE));
     if (ckpEncryptedPart == NULL) {
         free(ckpPart);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -248,7 +248,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptV
     ckpPart = (CK_BYTE_PTR) malloc(ckPartLength * sizeof(CK_BYTE));
     if (ckpPart == NULL) {
         free(ckpEncryptedPart);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_dual.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_dual.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -385,7 +385,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1GetSlotList
 
     ckpSlotList = (CK_SLOT_ID_PTR) malloc(ckTokenNumber * sizeof(CK_SLOT_ID));
     if (ckpSlotList == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -686,7 +686,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1GetMechanismList
     ckpMechanismList = (CK_MECHANISM_TYPE_PTR)
       malloc(ckMechanismNumber * sizeof(CK_MECHANISM_TYPE));
     if (ckpMechanismList == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
@@ -200,7 +200,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_getNativeKeyInfo
     ckpAttributes = (CK_ATTRIBUTE_PTR) calloc(
             CK_ATTRIBUTES_TEMPLATE_LENGTH, sizeof(CK_ATTRIBUTE));
     if (ckpAttributes == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         goto cleanup;
     }
     memcpy(ckpAttributes, ckpAttributesTemplate,
@@ -599,7 +599,7 @@ JNIEXPORT jlongArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Generate
 
     ckpKeyHandles = (CK_OBJECT_HANDLE_PTR) calloc(2, sizeof(CK_OBJECT_HANDLE));
     if (ckpKeyHandles == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         goto cleanup;
     }
     ckpPublicKeyHandle = ckpKeyHandles;   /* first element of array is Public Key */
@@ -699,7 +699,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1WrapKey
         ckpWrappedKey = (CK_BYTE_PTR)
                 calloc(ckWrappedKeyLength, sizeof(CK_BYTE));
         if (ckpWrappedKey == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
@@ -92,7 +92,7 @@ CK_C_INITIALIZE_ARGS_PTR makeCKInitArgsAdapter(JNIEnv *env, jobject jInitArgs)
     /* convert the Java InitArgs object to a pointer to a CK_C_INITIALIZE_ARGS structure */
     ckpInitArgs = (CK_C_INITIALIZE_ARGS_PTR) malloc(sizeof(CK_C_INITIALIZE_ARGS));
     if (ckpInitArgs == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL_PTR;
     }
     ckpInitArgs->flags = (CK_FLAGS)0;
@@ -155,7 +155,7 @@ CK_C_INITIALIZE_ARGS_PTR makeCKInitArgsAdapter(JNIEnv *env, jobject jInitArgs)
         ckpGlobalInitArgs = (CK_C_INITIALIZE_ARGS_PTR) malloc(sizeof(CK_C_INITIALIZE_ARGS));
         if (ckpGlobalInitArgs == NULL) {
             free(ckpInitArgs);
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return NULL_PTR;
         }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_mutex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_objmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_objmgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_objmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_objmgmt.c
@@ -252,7 +252,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1GetAttributeVa
         if (rv == CKR_ATTRIBUTE_SENSITIVE || rv == CKR_ATTRIBUTE_TYPE_INVALID) {
             msg = malloc(80); // should be more than sufficient
             if (msg == NULL) {
-                throwOutOfMemoryError(env, 0);
+                p11ThrowOutOfMemoryError(env, 0);
                 free(ckpAttributes);
                 return;
             }
@@ -282,7 +282,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1GetAttributeVa
         ckpAttributes[i].pValue = (void *) malloc(ckBufferLength);
         if (ckpAttributes[i].pValue == NULL) {
             freeCKAttributeArray(ckpAttributes, i);
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return;
         }
         ckpAttributes[i].ulValueLen = ckBufferLength;
@@ -415,7 +415,7 @@ JNIEXPORT jlongArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1FindObje
     ckMaxObjectLength = jLongToCKULong(jMaxObjectCount);
     ckpObjectHandleArray = (CK_OBJECT_HANDLE_PTR) malloc(sizeof(CK_OBJECT_HANDLE) * ckMaxObjectLength);
     if (ckpObjectHandleArray == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
@@ -98,7 +98,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1OpenSession
     if (jNotify != NULL) {
         notifyEncapsulation = (NotifyEncapsulation *) malloc(sizeof(NotifyEncapsulation));
         if (notifyEncapsulation == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return 0L;
         }
         notifyEncapsulation->jApplicationData = (jApplication != NULL)
@@ -328,7 +328,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1GetOpera
 
     ckpState = (CK_BYTE_PTR) malloc(ckStateLength);
     if (ckpState == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
 
@@ -517,7 +517,7 @@ void putNotifyEntry(JNIEnv *env, CK_SESSION_HANDLE hSession, NotifyEncapsulation
 
     newNode = (NotifyListNode *) malloc(sizeof(NotifyListNode));
     if (newNode == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     newNode->hSession = hSession;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -147,7 +147,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Sign
     if (rv == CKR_BUFFER_TOO_SMALL) {
         bufP = (CK_BYTE_PTR) malloc(ckSignatureLength);
         if (bufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         rv = (*ckpFunctions->C_Sign)(ckSessionHandle, ckpData, ckDataLength,
@@ -205,7 +205,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignUpdate
         bufLen = min(MAX_HEAP_BUFFER_LEN, jInLen);
         bufP = (CK_BYTE_PTR) malloc((size_t)bufLen);
         if (bufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return;
         }
     }
@@ -264,7 +264,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignFina
     if (rv == CKR_BUFFER_TOO_SMALL) {
         bufP = (CK_BYTE_PTR) malloc(ckSignatureLength);
         if (bufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return NULL;
         }
         rv = (*ckpFunctions->C_SignFinal)(ckSessionHandle, bufP, &ckSignatureLength);
@@ -355,7 +355,7 @@ JNIEXPORT jint JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignRecover
     } else {
         inBufP = (CK_BYTE_PTR) malloc((size_t)jInLen);
         if (inBufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return 0;
         }
         ckSignatureLength = jInLen;
@@ -371,7 +371,7 @@ JNIEXPORT jint JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignRecover
     if ((rv == CKR_BUFFER_TOO_SMALL) && (ckSignatureLength <= jIntToCKULong(jOutLen))) {
         outBufP = (CK_BYTE_PTR) malloc(ckSignatureLength);
         if (outBufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         rv = (*ckpFunctions->C_SignRecover)(ckSessionHandle, inBufP, jInLen, outBufP, &ckSignatureLength);
@@ -516,7 +516,7 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1VerifyUpdate
         bufLen = min(MAX_HEAP_BUFFER_LEN, jInLen);
         bufP = (CK_BYTE_PTR) malloc((size_t)bufLen);
         if (bufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
     }
@@ -653,7 +653,7 @@ JNIEXPORT jint JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1VerifyRecover
     } else {
         inBufP = (CK_BYTE_PTR) malloc((size_t)jInLen);
         if (inBufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return 0;
         }
         ckDataLength = jInLen;
@@ -670,7 +670,7 @@ JNIEXPORT jint JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1VerifyRecover
     if ((rv == CKR_BUFFER_TOO_SMALL) && (ckDataLength <= jIntToCKULong(jOutLen))) {
         outBufP = (CK_BYTE_PTR) malloc(ckDataLength);
         if (outBufP == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         rv = (*ckpFunctions->C_VerifyRecover)(ckSessionHandle, inBufP, jInLen, outBufP, &ckDataLength);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -58,6 +58,17 @@ ModuleData * getModuleEntry(JNIEnv *env, jobject pkcs11Implementation);
 int isModulePresent(JNIEnv *env, jobject pkcs11Implementation);
 void removeAllModuleEntries(JNIEnv *env);
 
+/*
+ * This function simply throws a PKCS#11RuntimeException. The message says that
+ * the object is not connected to the module.
+ *
+ * @param env Used to call JNI functions and to get the Exception class.
+ */ 
+static void throwDisconnectedRuntimeException(JNIEnv *env)
+{       
+    p11ThrowPKCS11RuntimeException(env, "This object is not connected to a module.");
+}
+
 
 /* ************************************************************************** */
 /* Functions for keeping track of currently active and loaded modules         */
@@ -237,7 +248,7 @@ jlong ckAssertReturnValueOK2(JNIEnv *env, CK_RV returnValue, const char* msg) {
 /*
  * Throws a Java Exception by name
  */
-void throwByName(JNIEnv *env, const char *name, const char *msg)
+static void throwByName(JNIEnv *env, const char *name, const char *msg)
 {
     jclass cls = (*env)->FindClass(env, name);
 
@@ -248,7 +259,7 @@ void throwByName(JNIEnv *env, const char *name, const char *msg)
 /*
  * Throws java.lang.OutOfMemoryError
  */
-void throwOutOfMemoryError(JNIEnv *env, const char *msg)
+void p11ThrowOutOfMemoryError(JNIEnv *env, const char *msg)
 {
     throwByName(env, "java/lang/OutOfMemoryError", msg);
 }
@@ -256,7 +267,7 @@ void throwOutOfMemoryError(JNIEnv *env, const char *msg)
 /*
  * Throws java.lang.NullPointerException
  */
-void throwNullPointerException(JNIEnv *env, const char *msg)
+void p11ThrowNullPointerException(JNIEnv *env, const char *msg)
 {
     throwByName(env, "java/lang/NullPointerException", msg);
 }
@@ -264,7 +275,7 @@ void throwNullPointerException(JNIEnv *env, const char *msg)
 /*
  * Throws java.io.IOException
  */
-void throwIOException(JNIEnv *env, const char *msg)
+void p11ThrowIOException(JNIEnv *env, const char *msg)
 {
     throwByName(env, "java/io/IOException", msg);
 }
@@ -276,20 +287,9 @@ void throwIOException(JNIEnv *env, const char *msg)
  * @param env Used to call JNI functions and to get the Exception class.
  * @param jmessage The message string of the Exception object.
  */
-void throwPKCS11RuntimeException(JNIEnv *env, const char *message)
+void p11ThrowPKCS11RuntimeException(JNIEnv *env, const char *message)
 {
     throwByName(env, CLASS_PKCS11RUNTIMEEXCEPTION, message);
-}
-
-/*
- * This function simply throws a PKCS#11RuntimeException. The message says that
- * the object is not connected to the module.
- *
- * @param env Used to call JNI functions and to get the Exception class.
- */
-void throwDisconnectedRuntimeException(JNIEnv *env)
-{
-    throwPKCS11RuntimeException(env, "This object is not connected to a module.");
 }
 
 /* This function frees the specified CK_ATTRIBUTE array.
@@ -448,7 +448,7 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
             (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS_NO_IVBITS))) {
         pGcmParams2 = calloc(1, sizeof(CK_GCM_PARAMS));
         if (pGcmParams2 == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return NULL;
         }
         pParams = (CK_GCM_PARAMS_NO_IVBITS*) mechPtr->pParameter;
@@ -524,7 +524,7 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
     *ckpLength = (*env)->GetArrayLength(env, jArray);
     jpTemp = (jboolean*) calloc(*ckpLength, sizeof(jboolean));
     if (jpTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     (*env)->GetBooleanArrayRegion(env, jArray, 0, *ckpLength, jpTemp);
@@ -536,7 +536,7 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
     *ckpArray = (CK_BBOOL*) calloc (*ckpLength, sizeof(CK_BBOOL));
     if (*ckpArray == NULL) {
         free(jpTemp);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     for (i=0; i<(*ckpLength); i++) {
@@ -566,7 +566,7 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
     *ckpLength = (*env)->GetArrayLength(env, jArray);
     jpTemp = (jbyte*) calloc(*ckpLength, sizeof(jbyte));
     if (jpTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     (*env)->GetByteArrayRegion(env, jArray, 0, *ckpLength, jpTemp);
@@ -582,7 +582,7 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
         *ckpArray = (CK_BYTE_PTR) calloc (*ckpLength, sizeof(CK_BYTE));
         if (*ckpArray == NULL) {
             free(jpTemp);
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return;
         }
         for (i=0; i<(*ckpLength); i++) {
@@ -613,7 +613,7 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
     *ckpLength = (*env)->GetArrayLength(env, jArray);
     jTemp = (jlong*) calloc(*ckpLength, sizeof(jlong));
     if (jTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     (*env)->GetLongArrayRegion(env, jArray, 0, *ckpLength, jTemp);
@@ -625,7 +625,7 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
     *ckpArray = (CK_ULONG_PTR) calloc(*ckpLength, sizeof(CK_ULONG));
     if (*ckpArray == NULL) {
         free(jTemp);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     for (i=0; i<(*ckpLength); i++) {
@@ -655,7 +655,7 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
     *ckpLength = (*env)->GetArrayLength(env, jArray);
     jpTemp = (jchar*) calloc(*ckpLength, sizeof(jchar));
     if (jpTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     (*env)->GetCharArrayRegion(env, jArray, 0, *ckpLength, jpTemp);
@@ -667,7 +667,7 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
     *ckpArray = (CK_CHAR_PTR) calloc (*ckpLength, sizeof(CK_CHAR));
     if (*ckpArray == NULL) {
         free(jpTemp);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     for (i=0; i<(*ckpLength); i++) {
@@ -697,7 +697,7 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
     *ckpLength = (*env)->GetArrayLength(env, jArray);
     jTemp = (jchar*) calloc(*ckpLength, sizeof(jchar));
     if (jTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     (*env)->GetCharArrayRegion(env, jArray, 0, *ckpLength, jTemp);
@@ -709,7 +709,7 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
     *ckpArray = (CK_UTF8CHAR_PTR) calloc(*ckpLength, sizeof(CK_UTF8CHAR));
     if (*ckpArray == NULL) {
         free(jTemp);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     for (i=0; i<(*ckpLength); i++) {
@@ -744,7 +744,7 @@ void jStringToCKUTF8CharArray(JNIEnv *env, const jstring jArray, CK_UTF8CHAR_PTR
     *ckpArray = (CK_UTF8CHAR_PTR) calloc(*ckpLength + 1, sizeof(CK_UTF8CHAR));
     if (*ckpArray == NULL) {
         (*env)->ReleaseStringUTFChars(env, (jstring) jArray, pCharArray);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     strcpy((char*)*ckpArray, pCharArray);
@@ -777,7 +777,7 @@ void jAttributeArrayToCKAttributeArray(JNIEnv *env, jobjectArray jArray, CK_ATTR
     *ckpLength = jLongToCKULong(jLength);
     *ckpArray = (CK_ATTRIBUTE_PTR) calloc(*ckpLength, sizeof(CK_ATTRIBUTE));
     if (*ckpArray == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return;
     }
     TRACE1(", converting %lld attributes", (long long int) jLength);
@@ -818,7 +818,7 @@ jbyteArray ckByteArrayToJByteArray(JNIEnv *env, const CK_BYTE_PTR ckpArray, CK_U
     } else {
         jpTemp = (jbyte*) calloc(ckLength, sizeof(jbyte));
         if (jpTemp == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             return NULL;
         }
         for (i=0; i<ckLength; i++) {
@@ -852,7 +852,7 @@ jlongArray ckULongArrayToJLongArray(JNIEnv *env, const CK_ULONG_PTR ckpArray, CK
 
     jpTemp = (jlong*) calloc(ckLength, sizeof(jlong));
     if (jpTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     for (i=0; i<ckLength; i++) {
@@ -883,7 +883,7 @@ jcharArray ckCharArrayToJCharArray(JNIEnv *env, const CK_CHAR_PTR ckpArray, CK_U
 
     jpTemp = (jchar*) calloc(ckLength, sizeof(jchar));
     if (jpTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     for (i=0; i<ckLength; i++) {
@@ -914,7 +914,7 @@ jcharArray ckUTF8CharArrayToJCharArray(JNIEnv *env, const CK_UTF8CHAR_PTR ckpArr
 
     jpTemp = (jchar*) calloc(ckLength, sizeof(jchar));
     if (jpTemp == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     for (i=0; i<ckLength; i++) {
@@ -1017,7 +1017,7 @@ CK_BBOOL* jBooleanObjectToCKBBoolPtr(JNIEnv *env, jobject jObject)
     jValue = (*env)->CallBooleanMethod(env, jObject, jValueMethod);
     ckpValue = (CK_BBOOL *) malloc(sizeof(CK_BBOOL));
     if (ckpValue == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     *ckpValue = jBooleanToCKBBool(jValue);
@@ -1047,7 +1047,7 @@ CK_BYTE_PTR jByteObjectToCKBytePtr(JNIEnv *env, jobject jObject)
     jValue = (*env)->CallByteMethod(env, jObject, jValueMethod);
     ckpValue = (CK_BYTE_PTR) malloc(sizeof(CK_BYTE));
     if (ckpValue == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     *ckpValue = jByteToCKByte(jValue);
@@ -1076,7 +1076,7 @@ CK_ULONG* jIntegerObjectToCKULongPtr(JNIEnv *env, jobject jObject)
     jValue = (*env)->CallIntMethod(env, jObject, jValueMethod);
     ckpValue = (CK_ULONG *) malloc(sizeof(CK_ULONG));
     if (ckpValue == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     *ckpValue = jLongToCKLong(jValue);
@@ -1105,7 +1105,7 @@ CK_ULONG* jLongObjectToCKULongPtr(JNIEnv *env, jobject jObject)
     jValue = (*env)->CallLongMethod(env, jObject, jValueMethod);
     ckpValue = (CK_ULONG *) malloc(sizeof(CK_ULONG));
     if (ckpValue == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     *ckpValue = jLongToCKULong(jValue);
@@ -1135,7 +1135,7 @@ CK_CHAR_PTR jCharObjectToCKCharPtr(JNIEnv *env, jobject jObject)
     jValue = (*env)->CallCharMethod(env, jObject, jValueMethod);
     ckpValue = (CK_CHAR_PTR) malloc(sizeof(CK_CHAR));
     if (ckpValue == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     *ckpValue = jCharToCKChar(jValue);
@@ -1291,13 +1291,13 @@ CK_VOID_PTR jObjectToPrimitiveCKObjectPtr(JNIEnv *env, jobject jObject, CK_ULONG
         malloc(strlen(exceptionMsgPrefix) + strlen(classNameString) + 1);
     if (exceptionMsg == NULL) {
         (*env)->ReleaseStringUTFChars(env, jClassNameString, classNameString);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
     strcpy(exceptionMsg, exceptionMsgPrefix);
     strcat(exceptionMsg, classNameString);
     (*env)->ReleaseStringUTFChars(env, jClassNameString, classNameString);
-    throwPKCS11RuntimeException(env, exceptionMsg);
+    p11ThrowPKCS11RuntimeException(env, exceptionMsg);
     free(exceptionMsg);
     *ckpLength = 0;
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -63,12 +63,11 @@ void removeAllModuleEntries(JNIEnv *env);
  * the object is not connected to the module.
  *
  * @param env Used to call JNI functions and to get the Exception class.
- */ 
+ */
 static void throwDisconnectedRuntimeException(JNIEnv *env)
-{       
+{
     p11ThrowPKCS11RuntimeException(env, "This object is not connected to a module.");
 }
-
 
 /* ************************************************************************** */
 /* Functions for keeping track of currently active and loaded modules         */

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -314,11 +314,10 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr);
 
 jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue);
 jlong ckAssertReturnValueOK2(JNIEnv *env, CK_RV returnValue, const char *msg);
-void throwOutOfMemoryError(JNIEnv *env, const char *message);
-void throwNullPointerException(JNIEnv *env, const char *message);
-void throwIOException(JNIEnv *env, const char *message);
-void throwPKCS11RuntimeException(JNIEnv *env, const char *message);
-void throwDisconnectedRuntimeException(JNIEnv *env);
+void p11ThrowOutOfMemoryError(JNIEnv *env, const char *message);
+void p11ThrowNullPointerException(JNIEnv *env, const char *message);
+void p11ThrowIOException(JNIEnv *env, const char *message);
+void p11ThrowPKCS11RuntimeException(JNIEnv *env, const char *message);
 
 /* functions to free CK structures and pointers
  */

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/j2secmod_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/j2secmod_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/j2secmod_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/j2secmod_md.c
@@ -40,7 +40,7 @@ void *findFunction(JNIEnv *env, jlong jHandle, const char *functionName) {
     if (fAddress == NULL) {
         char errorMessage[256];
         snprintf(errorMessage, sizeof(errorMessage), "Symbol not found: %s", functionName);
-        throwNullPointerException(env, errorMessage);
+        p11ThrowNullPointerException(env, errorMessage);
         return NULL;
     }
     return fAddress;
@@ -81,7 +81,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssLoadLibrary
     dprintf2("-handle: %u (0X%X)\n", hModule, hModule);
 
     if (hModule == NULL) {
-        throwIOException(env, dlerror());
+        p11ThrowIOException(env, dlerror());
         return 0;
     }
 

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -114,12 +114,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
         systemErrorMessage = dlerror();
         exceptionMessage = (char *) malloc(sizeof(char) * (strlen(systemErrorMessage) + strlen(libraryNameStr) + 1));
         if (exceptionMessage == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         strcpy(exceptionMessage, systemErrorMessage);
         strcat(exceptionMessage, libraryNameStr);
-        throwIOException(env, exceptionMessage);
+        p11ThrowIOException(env, exceptionMessage);
         free(exceptionMessage);
         goto cleanup;
     }
@@ -167,12 +167,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
         C_GetFunctionList = (CK_C_GetFunctionList) dlsym(hModule,
             getFunctionListStr);
         if ((systemErrorMessage = dlerror()) != NULL){
-            throwIOException(env, systemErrorMessage);
+            p11ThrowIOException(env, systemErrorMessage);
             goto cleanup;
         }
         if (C_GetFunctionList == NULL) {
             TRACE1("Connect: No %s func\n", getFunctionListStr);
-            throwIOException(env, "ERROR: C_GetFunctionList == NULL");
+            p11ThrowIOException(env, "ERROR: C_GetFunctionList == NULL");
             goto cleanup;
         }
         TRACE1("Connect: Found %s func\n", getFunctionListStr);
@@ -189,12 +189,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
         C_GetFunctionList = (CK_C_GetFunctionList) dlsym(hModule,
                 "C_GetFunctionList");
         if ((systemErrorMessage = dlerror()) != NULL){
-            throwIOException(env, systemErrorMessage);
+            p11ThrowIOException(env, systemErrorMessage);
             goto cleanup;
         }
         if (C_GetFunctionList == NULL) {
             TRACE0("Connect: No C_GetFunctionList func\n");
-            throwIOException(env, "ERROR: C_GetFunctionList == NULL");
+            p11ThrowIOException(env, "ERROR: C_GetFunctionList == NULL");
             goto cleanup;
         }
         TRACE0("Connect: Found C_GetFunctionList func\n");
@@ -207,7 +207,7 @@ setModuleData:
     moduleData = (ModuleData *) malloc(sizeof(ModuleData));
     if (moduleData == NULL) {
         dlclose(hModule);
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         goto cleanup;
     }
     moduleData->hModule = hModule;
@@ -224,7 +224,7 @@ setModuleData:
         }
     } else {
         // should never happen
-        throwIOException(env, "ERROR: No function list ptr found");
+        p11ThrowIOException(env, "ERROR: No function list ptr found");
         goto cleanup;
     }
     if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3) {

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.c
@@ -31,8 +31,8 @@
 
 #include "j2secmod.h"
 
-extern void throwNullPointerException(JNIEnv *env, const char *message);
-extern void throwIOException(JNIEnv *env, const char *message);
+extern void p11ThrowNullPointerException(JNIEnv *env, const char *message);
+extern void p11ThrowIOException(JNIEnv *env, const char *message);
 
 void *findFunction(JNIEnv *env, jlong jHandle, const char *functionName) {
     HINSTANCE hModule = (HINSTANCE)jHandle;
@@ -40,7 +40,7 @@ void *findFunction(JNIEnv *env, jlong jHandle, const char *functionName) {
     if (fAddress == NULL) {
         char errorMessage[256];
         _snprintf(errorMessage, sizeof(errorMessage), "Symbol not found: %s", functionName);
-        throwNullPointerException(env, errorMessage);
+        p11ThrowNullPointerException(env, errorMessage);
         return NULL;
     }
     return fAddress;
@@ -81,7 +81,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssLoadLibrary
             NULL
         );
         dprintf1("-error: %s\n", lpMsgBuf);
-        throwIOException(env, (char*)lpMsgBuf);
+        p11ThrowIOException(env, (char*)lpMsgBuf);
         LocalFree(lpMsgBuf);
         return 0;
     }

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -116,12 +116,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
         exceptionMessage = (char *) malloc(sizeof(char) *
                 (strlen((LPTSTR) lpMsgBuf) + strlen(libraryNameStr) + 1));
         if (exceptionMessage == NULL) {
-            throwOutOfMemoryError(env, 0);
+            p11ThrowOutOfMemoryError(env, 0);
             goto cleanup;
         }
         strcpy(exceptionMessage, (LPTSTR) lpMsgBuf);
         strcat(exceptionMessage, libraryNameStr);
-        throwIOException(env, (LPTSTR) exceptionMessage);
+        p11ThrowIOException(env, (LPTSTR) exceptionMessage);
         goto cleanup;
     }
 
@@ -175,7 +175,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
                 0,
                 NULL
             );
-            throwIOException(env, (LPTSTR) lpMsgBuf);
+            p11ThrowIOException(env, (LPTSTR) lpMsgBuf);
             goto cleanup;
         }
         TRACE1("Connect: Found %s func\n", getFunctionListStr);
@@ -205,7 +205,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
                 0,
                 NULL
             );
-            throwIOException(env, (LPTSTR) lpMsgBuf);
+            p11ThrowIOException(env, (LPTSTR) lpMsgBuf);
             goto cleanup;
         }
         TRACE0("Connect: Found C_GetFunctionList func\n");
@@ -217,7 +217,7 @@ setModuleData:
      */
     moduleData = (ModuleData *) malloc(sizeof(ModuleData));
     if (moduleData == NULL) {
-        throwOutOfMemoryError(env, 0);
+        p11ThrowOutOfMemoryError(env, 0);
         goto cleanup;
     }
     moduleData->hModule = hModule;
@@ -231,7 +231,7 @@ setModuleData:
         moduleData->ckFunctionListPtr = interface->pFunctionList;
     } else {
         // should never happen
-        throwIOException(env, "ERROR: No function list ptr found");
+        p11ThrowIOException(env, "ERROR: No function list ptr found");
         goto cleanup;
     }
     if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3) {

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -53,10 +53,3 @@ JNIEXPORT jint JNICALL
     jmm_version_management_ext = jmm_interface_management_ext->GetVersion(env);
     return (*env)->GetVersion(env);
 }
-
-void throw_internal_error(JNIEnv* env, const char* msg) {
-    char errmsg[128];
-
-    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
-    JNU_ThrowInternalError(env, errmsg);
-}

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.h
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.h
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.h
@@ -36,6 +36,5 @@
 // statically linking.
 extern const JmmInterface* jmm_interface_management_ext;
 extern jint jmm_version_management_ext;
-extern void throw_internal_error(JNIEnv* env, const char* msg);
 
 #endif

--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -82,6 +82,13 @@ static jlong page_size = 0;
   #define closedir closedir64
 #endif
 
+static void throw_internal_error(JNIEnv* env, const char* msg) {
+    char errmsg[128];
+
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
+    JNU_ThrowInternalError(env, errmsg);
+}
+
 // true = get available swap in bytes
 // false = get total swap in bytes
 static jlong get_total_or_available_swap_space_size(JNIEnv* env, jboolean available) {


### PR DESCRIPTION
- Make functions 'static' when feasible:
  - throwByName() in src/java.security.jgss/share/native/libj2gss/NativeUtil.c.
  - throwByName(), throwIOException() and throwNullPointerException() in src/java.smartcardio/unix/native/libj2pcsc/pcsc_md.c.
  - throwByName() in src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c.
  - throwOutOfMemoryError() in src/java.smartcardio/share/native/libj2pcsc/pcsc.c.
  - Move throwDisconnectedRuntimeException() to src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c since it's only used in the file. Make it static.
  - Move throw_internal_error() to src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c as it's only used in the file. Make it static.

- Rename functions by following the existing naming usages in different libraries code:
  - Rename throwOutOfMemoryError() to gssThrowOutOfMemoryError() in libj2gss.
  - Rename throwOutOfMemoryError() to p11ThrowOutOfMemoryError() in libj2pks11.
  - Rename throwNullPointerException() to p11ThrowNullPointerException() in libj2pks11.
  - Rename throwIOException() to p11ThrowIOException() in libj2pks11.
  - Rename throwPKCS11RuntimeException() to p11ThrowPKCS11RuntimeException() in libj2pks11. This function only exists in libj2pks11. The rename is done so the function naming is consistent with the other throw<exception> functions.

- Remove throw_internal_error() from src/java.management/share/native/libmanagement/management.h and src/java.management/share/native/libmanagement/management.c. It's not used.
- Remove throw_internal_error() from src/jdk.management/share/native/libmanagement_ext/management_ext.h and src/jdk.management/share/native/libmanagement_ext/management_ext.c.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306033](https://bugs.openjdk.org/browse/JDK-8306033): Resolve multiple definition of 'throwIOException' and friends when statically linking with JDK native libraries


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13497/head:pull/13497` \
`$ git checkout pull/13497`

Update a local copy of the PR: \
`$ git checkout pull/13497` \
`$ git pull https://git.openjdk.org/jdk.git pull/13497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13497`

View PR using the GUI difftool: \
`$ git pr show -t 13497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13497.diff">https://git.openjdk.org/jdk/pull/13497.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13497#issuecomment-1511781826)