### PR TITLE
8305590: Remove nothrow exception specifications from operator new

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -494,7 +494,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
-    TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -fcheck-new -fstack-protector"
+    TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -fstack-protector"
     TOOLCHAIN_CFLAGS_JDK="-pipe -fstack-protector"
     # reduce lib size on linux in link step, this needs also special compile flags
     # do this on s390x also for libjvm (where serviceability agent is not supported)

--- a/src/hotspot/share/jfr/utilities/jfrAllocation.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrAllocation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/utilities/jfrAllocation.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrAllocation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,9 @@ class JfrCHeapObj : public CHeapObj<mtTracing> {
   static char* allocate_array_noinline(size_t elements, size_t element_size);
 
  public:
-  NOINLINE void* operator new(size_t size) throw();
+  NOINLINE void* operator new(size_t size);
   NOINLINE void* operator new (size_t size, const std::nothrow_t&  nothrow_constant) throw();
-  NOINLINE void* operator new [](size_t size) throw();
+  NOINLINE void* operator new [](size_t size);
   NOINLINE void* operator new [](size_t size, const std::nothrow_t&  nothrow_constant) throw();
   void  operator delete(void* p, size_t size);
   void  operator delete [] (void* p, size_t size);

--- a/src/hotspot/share/jfr/utilities/jfrAllocation.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrAllocation.hpp
@@ -53,9 +53,9 @@ class JfrCHeapObj : public CHeapObj<mtTracing> {
   static char* allocate_array_noinline(size_t elements, size_t element_size);
 
  public:
-  NOINLINE void* operator new(size_t size);
+  NOINLINE void* operator new(size_t size) throw();
   NOINLINE void* operator new (size_t size, const std::nothrow_t&  nothrow_constant) throw();
-  NOINLINE void* operator new [](size_t size);
+  NOINLINE void* operator new [](size_t size) throw();
   NOINLINE void* operator new [](size_t size, const std::nothrow_t&  nothrow_constant) throw();
   void  operator delete(void* p, size_t size);
   void  operator delete [] (void* p, size_t size);

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -71,11 +71,6 @@ void FreeHeap(void* p) {
 void* MetaspaceObj::_shared_metaspace_base = nullptr;
 void* MetaspaceObj::_shared_metaspace_top  = nullptr;
 
-void* StackObj::operator new(size_t size)     throw() { ShouldNotCallThis(); return 0; }
-void  StackObj::operator delete(void* p)              { ShouldNotCallThis(); }
-void* StackObj::operator new [](size_t size)  throw() { ShouldNotCallThis(); return 0; }
-void  StackObj::operator delete [](void* p)           { ShouldNotCallThis(); }
-
 void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
                                  size_t word_size,
                                  MetaspaceObj::Type type, TRAPS) throw() {

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -282,9 +282,9 @@ class CHeapObj {
 // Calling new or delete will result in fatal error.
 
 class StackObj {
- private:
-  void* operator new(size_t size) throw() = delete;
-  void* operator new [](size_t size) throw() = delete;
+ public:
+  void* operator new(size_t size) = delete;
+  void* operator new [](size_t size) = delete;
   void  operator delete(void* p) = delete;
   void  operator delete [](void* p) = delete;
 };
@@ -515,8 +515,8 @@ protected:
     return res;
   }
 
-  void* operator new [](size_t size) throw() = delete;
-  void* operator new [](size_t size, const std::nothrow_t& nothrow_constant) throw() = delete;
+  void* operator new [](size_t size) = delete;
+  void* operator new [](size_t size, const std::nothrow_t& nothrow_constant) = delete;
   void  operator delete(void* p);
   void  operator delete [](void* p) = delete;
 

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -179,13 +179,13 @@ void FreeHeap(void* p);
 
 class CHeapObjBase {
  public:
-  ALWAYSINLINE void* operator new(size_t size, MEMFLAGS f) throw() {
+  ALWAYSINLINE void* operator new(size_t size, MEMFLAGS f) {
     return AllocateHeap(size, f);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
                                   MEMFLAGS f,
-                                  const NativeCallStack& stack) throw() {
+                                  const NativeCallStack& stack) {
     return AllocateHeap(size, f, stack);
   }
 
@@ -202,13 +202,13 @@ class CHeapObjBase {
     return AllocateHeap(size, f, AllocFailStrategy::RETURN_NULL);
   }
 
-  ALWAYSINLINE void* operator new[](size_t size, MEMFLAGS f) throw() {
+  ALWAYSINLINE void* operator new[](size_t size, MEMFLAGS f) {
     return AllocateHeap(size, f);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
                                     MEMFLAGS f,
-                                    const NativeCallStack& stack) throw() {
+                                    const NativeCallStack& stack) {
     return AllocateHeap(size, f, stack);
   }
 
@@ -233,12 +233,12 @@ class CHeapObjBase {
 template<MEMFLAGS F>
 class CHeapObj {
  public:
-  ALWAYSINLINE void* operator new(size_t size) throw() {
+  ALWAYSINLINE void* operator new(size_t size) {
     return CHeapObjBase::operator new(size, F);
   }
 
   ALWAYSINLINE void* operator new(size_t size,
-                                  const NativeCallStack& stack) throw() {
+                                  const NativeCallStack& stack) {
     return CHeapObjBase::operator new(size, F, stack);
   }
 
@@ -251,12 +251,12 @@ class CHeapObj {
     return CHeapObjBase::operator new(size, F, nt);
   }
 
-  ALWAYSINLINE void* operator new[](size_t size) throw() {
+  ALWAYSINLINE void* operator new[](size_t size) {
     return CHeapObjBase::operator new[](size, F);
   }
 
   ALWAYSINLINE void* operator new[](size_t size,
-                                    const NativeCallStack& stack) throw() {
+                                    const NativeCallStack& stack) {
     return CHeapObjBase::operator new[](size, F, stack);
   }
 
@@ -283,10 +283,10 @@ class CHeapObj {
 
 class StackObj {
  private:
-  void* operator new(size_t size) throw();
-  void* operator new [](size_t size) throw();
-  void  operator delete(void* p);
-  void  operator delete [](void* p);
+  void* operator new(size_t size) throw() = delete;
+  void* operator new [](size_t size) throw() = delete;
+  void  operator delete(void* p) = delete;
+  void  operator delete [](void* p) = delete;
 };
 
 // Base class for objects stored in Metaspace.
@@ -432,7 +432,7 @@ extern void resource_free_bytes( Thread* thread, char *old, size_t size );
 // Base class for objects allocated in the resource area.
 class ResourceObj {
  public:
-  void* operator new(size_t size) throw() {
+  void* operator new(size_t size) {
     return resource_allocate_bytes(size);
   }
 
@@ -500,11 +500,11 @@ protected:
   void* operator new [](size_t size, const std::nothrow_t&  nothrow_constant, MEMFLAGS flags) throw() = delete;
 
   // Arena allocations
-  void* operator new(size_t size, Arena *arena) throw();
-  void* operator new [](size_t size, Arena *arena) throw() = delete;
+  void* operator new(size_t size, Arena *arena);
+  void* operator new [](size_t size, Arena *arena) = delete;
 
   // Resource allocations
-  void* operator new(size_t size) throw() {
+  void* operator new(size_t size) {
     address res = (address)resource_allocate_bytes(size);
     DEBUG_ONLY(set_allocation_type(res, RESOURCE_AREA);)
     return res;

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -3651,7 +3651,7 @@ JvmtiEnv::IsMethodObsolete(Method* method, jboolean* is_obsolete_ptr) {
 // monitor_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::CreateRawMonitor(const char* name, jrawMonitorID* monitor_ptr) {
-  JvmtiRawMonitor* rmonitor = new JvmtiRawMonitor(name);
+  JvmtiRawMonitor* rmonitor = new(std::nothrow) JvmtiRawMonitor(name);
   NULL_CHECK(rmonitor, JVMTI_ERROR_OUT_OF_MEMORY);
 
   *monitor_ptr = (jrawMonitorID)rmonitor;

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -3651,7 +3651,7 @@ JvmtiEnv::IsMethodObsolete(Method* method, jboolean* is_obsolete_ptr) {
 // monitor_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::CreateRawMonitor(const char* name, jrawMonitorID* monitor_ptr) {
-  JvmtiRawMonitor* rmonitor = new(std::nothrow) JvmtiRawMonitor(name);
+  JvmtiRawMonitor* rmonitor = new (std::nothrow) JvmtiRawMonitor(name);
   NULL_CHECK(rmonitor, JVMTI_ERROR_OUT_OF_MEMORY);
 
   *monitor_ptr = (jrawMonitorID)rmonitor;

--- a/src/hotspot/share/prims/jvmtiRawMonitor.hpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.hpp
@@ -110,11 +110,6 @@ class JvmtiRawMonitor : public CHeapObj<mtSynchronizer>  {
     M_INTERRUPTED            // Thread.interrupt()
   };
 
-  // Non-aborting operator new
-  void* operator new(size_t size, const std::nothrow_t&  nothrow_constant) throw() {
-    return CHeapObj::operator new(size, nothrow_constant);
-  }
-
   JvmtiRawMonitor(const char* name);
   ~JvmtiRawMonitor();
 

--- a/src/hotspot/share/prims/jvmtiRawMonitor.hpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ class JvmtiRawMonitor : public CHeapObj<mtSynchronizer>  {
   };
 
   // Non-aborting operator new
-  void* operator new(size_t size) throw() {
+  void* operator new(size_t size) {
     return CHeapObj::operator new(size, std::nothrow);
   }
 

--- a/src/hotspot/share/prims/jvmtiRawMonitor.hpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.hpp
@@ -111,8 +111,8 @@ class JvmtiRawMonitor : public CHeapObj<mtSynchronizer>  {
   };
 
   // Non-aborting operator new
-  void* operator new(size_t size) {
-    return CHeapObj::operator new(size, std::nothrow);
+  void* operator new(size_t size, const std::nothrow_t&  nothrow_constant) throw() {
+    return CHeapObj::operator new(size, nothrow_constant);
   }
 
   JvmtiRawMonitor(const char* name);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -58,15 +58,6 @@ THREAD_LOCAL Thread* Thread::_thr_current = nullptr;
 #endif
 
 // ======= Thread ========
-void* Thread::allocate(size_t size, bool throw_excpt, MEMFLAGS flags) {
-  return throw_excpt ? AllocateHeap(size, flags, CURRENT_PC)
-                       : AllocateHeap(size, flags, CURRENT_PC, AllocFailStrategy::RETURN_NULL);
-}
-
-void Thread::operator delete(void* p) {
-  FreeHeap(p);
-}
-
 // Base class for all threads: VMThread, WatcherThread, ConcurrentMarkSweepThread,
 // JavaThread
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -200,9 +200,6 @@ class Thread: public ThreadShadow {
   // with the calling Thread?
   static bool is_JavaThread_protected_by_TLH(const JavaThread* target);
 
-  void* operator new(size_t size) { return allocate(size, true); }
-  void* operator new(size_t size, const std::nothrow_t& nothrow_constant) throw() {
-    return allocate(size, false); }
   void  operator delete(void* p);
 
  protected:

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -200,7 +200,7 @@ class Thread: public ThreadShadow {
   // with the calling Thread?
   static bool is_JavaThread_protected_by_TLH(const JavaThread* target);
 
-  void* operator new(size_t size) throw() { return allocate(size, true); }
+  void* operator new(size_t size) { return allocate(size, true); }
   void* operator new(size_t size, const std::nothrow_t& nothrow_constant) throw() {
     return allocate(size, false); }
   void  operator delete(void* p);

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -200,11 +200,6 @@ class Thread: public ThreadShadow {
   // with the calling Thread?
   static bool is_JavaThread_protected_by_TLH(const JavaThread* target);
 
-  void  operator delete(void* p);
-
- protected:
-  static void* allocate(size_t size, bool throw_excpt, MEMFLAGS flags = mtThread);
-
  private:
   DEBUG_ONLY(bool _suspendible_thread;)
 

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -809,12 +809,15 @@ public:
     this->clear_and_deallocate();
   }
 
-  void* operator new(size_t size) throw() {
+  void* operator new(size_t size) {
     return AnyObj::operator new(size, F);
   }
 
   void* operator new(size_t size, const std::nothrow_t&  nothrow_constant) throw() {
     return AnyObj::operator new(size, nothrow_constant, F);
+  }
+  void operator delete(void *p) {
+    AnyObj::operator delete(p);
   }
 };
 


### PR DESCRIPTION
- The `throw()` (i.e., no throw) specifications are removed from the instances of `operator new` where _do not_ return `nullptr`.

- The `-fcheck-new` is removed from the gcc compile flags.

- The `operator new` and `operator delete` are deleted from `StackObj`.

- The `GrowableArrayCHeap::operator delete` is added to be matched with its corresponding allocation`AnyObj::operator new`, because gcc complains on that after removing the `-fcheck-new` flag. 
- The `Thread::operator new`with and without `null` return are removed.

### Tests
local: linux-x64 gtest:GrowableArrayCHeap, macosx-aarch64 hotspot:tier1
mach5: tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305590](https://bugs.openjdk.org/browse/JDK-8305590): Remove nothrow exception specifications from operator new


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13498/head:pull/13498` \
`$ git checkout pull/13498`

Update a local copy of the PR: \
`$ git checkout pull/13498` \
`$ git pull https://git.openjdk.org/jdk.git pull/13498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13498`

View PR using the GUI difftool: \
`$ git pr show -t 13498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13498.diff">https://git.openjdk.org/jdk/pull/13498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13498#issuecomment-1513082950)