### PR TITLE
8305746: InitializeEncoding should cache Charset object instead of charset name

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -625,11 +625,11 @@ getStringCp1252Chars(JNIEnv *env, jstring jstr)
 }
 
 static int fastEncoding = NO_ENCODING_YET;
-static jstring jnuEncoding = NULL;
+static jobject jnuEncoding = NULL;
 
 /* Cached method IDs */
-static jmethodID String_init_ID;        /* String(byte[], enc) */
-static jmethodID String_getBytes_ID;    /* String.getBytes(enc) */
+static jmethodID String_init_ID;        /* String(byte[], Charset) */
+static jmethodID String_getBytes_ID;    /* String.getBytes(Charset) */
 
 /* Cached field IDs */
 static jfieldID String_coder_ID;        /* String.coder */
@@ -712,18 +712,15 @@ InitializeEncoding(JNIEnv *env, const char *encname)
          *   "en_GB" locale -> "ISO8859-1"                   (on Sol 7/8)
          *   "en_UK" locale -> "ISO8859-1"                   (on 2.6)
          */
+        const char *charsetname = NULL;
         if ((strcmp(encname, "8859_1") == 0) ||
             (strcmp(encname, "ISO8859-1") == 0) ||
             (strcmp(encname, "ISO8859_1") == 0) ||
             (strcmp(encname, "ISO-8859-1") == 0)) {
             fastEncoding = FAST_8859_1;
         } else if (strcmp(encname, "UTF-8") == 0) {
-            jstring enc = (*env)->NewStringUTF(env, encname);
-            if (enc == NULL)
-                return;
+            charsetname = encname;
             fastEncoding = FAST_UTF_8;
-            jnuEncoding = (jstring)(*env)->NewGlobalRef(env, enc);
-            (*env)->DeleteLocalRef(env, enc);
         } else if (strcmp(encname, "ISO646-US") == 0) {
             fastEncoding = FAST_646_US;
         } else if (strcmp(encname, "Cp1252") == 0 ||
@@ -733,31 +730,38 @@ InitializeEncoding(JNIEnv *env, const char *encname)
             strcmp(encname, "utf-16le") == 0) {
             fastEncoding = FAST_CP1252;
         } else {
-            jboolean exe;
-            jstring enc = (*env)->NewStringUTF(env, encname);
-            if (enc == NULL)
+            charsetname = encname;
+            fastEncoding = NO_FAST_ENCODING;
+        }
+        while (charsetname != NULL) {
+            jstring enc = (*env)->NewStringUTF(env, charsetname);
+            if (enc == NULL) {
+                fastEncoding = NO_ENCODING_YET;
                 return;
-
-            if ((jboolean) JNU_CallStaticMethodByName (
-                                            env, &exe,
-                                            "java/nio/charset/Charset",
-                                            "isSupported",
-                                            "(Ljava/lang/String;)Z",
-                                            enc).z == JNI_TRUE) {
-                fastEncoding = NO_FAST_ENCODING;
-                jnuEncoding = (jstring)(*env)->NewGlobalRef(env, enc);
-            } else {
-                // jnuEncoding falls back to UTF-8
-                jstring utf8 = (*env)->NewStringUTF(env, "UTF-8");
-                if (utf8 == NULL) {
-                    (*env)->DeleteLocalRef(env, enc);
-                    return;
-                }
-                fastEncoding = FAST_UTF_8;
-                jnuEncoding = (jstring)(*env)->NewGlobalRef(env, utf8);
-                (*env)->DeleteLocalRef(env, utf8);
+            }
+            jboolean exc;
+            jvalue charset = JNU_CallStaticMethodByName(
+                    env, &exc,
+                    "java/nio/charset/Charset",
+                    "forName",
+                    "(Ljava/lang/String;)Ljava/nio/charset/Charset;",
+                    enc);
+            if (exc) {
+                (*env)->ExceptionClear(env);
             }
             (*env)->DeleteLocalRef(env, enc);
+
+            if (!exc && charset.l != NULL) {
+                jnuEncoding = (*env)->NewGlobalRef(env, charset.l);
+                (*env)->DeleteLocalRef(env, charset.l);
+                break;
+            } else if (strcmp(charsetname, "UTF-8") != 0) { // fall back
+                charsetname = "UTF-8";
+                fastEncoding = FAST_UTF_8;
+            } else { // give up
+                fastEncoding = NO_ENCODING_YET;
+                return;
+            }
         }
     } else {
         JNU_ThrowInternalError(env, "platform encoding undefined");
@@ -766,10 +770,10 @@ InitializeEncoding(JNIEnv *env, const char *encname)
 
     /* Initialize method-id cache */
     String_getBytes_ID = (*env)->GetMethodID(env, strClazz,
-                                             "getBytes", "(Ljava/lang/String;)[B");
+                                             "getBytes", "(Ljava/nio/charset/Charset;)[B");
     CHECK_NULL(String_getBytes_ID);
     String_init_ID = (*env)->GetMethodID(env, strClazz,
-                                         "<init>", "([BLjava/lang/String;)V");
+                                         "<init>", "([BLjava/nio/charset/Charset;)V");
     CHECK_NULL(String_init_ID);
     String_coder_ID = (*env)->GetFieldID(env, strClazz, "coder", "B");
     CHECK_NULL(String_coder_ID);

--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -625,7 +625,7 @@ getStringCp1252Chars(JNIEnv *env, jstring jstr)
 }
 
 static int fastEncoding = NO_ENCODING_YET;
-static jobject jnuEncoding = NULL;
+static jobject jnuCharset = NULL;
 
 /* Cached method IDs */
 static jmethodID String_init_ID;        /* String(byte[], Charset) */
@@ -653,7 +653,7 @@ newSizedStringJava(JNIEnv *env, const char *str, const int len)
         CHECK_NULL_RETURN(strClazz, 0);
         (*env)->SetByteArrayRegion(env, bytes, 0, len, (jbyte *)str);
         result = (*env)->NewObject(env, strClazz,
-                                   String_init_ID, bytes, jnuEncoding);
+                                   String_init_ID, bytes, jnuCharset);
         (*env)->DeleteLocalRef(env, bytes);
         return result;
     }
@@ -752,9 +752,9 @@ InitializeEncoding(JNIEnv *env, const char *encname)
             (*env)->DeleteLocalRef(env, enc);
 
             if (!exc && charset.l != NULL) {
-                jnuEncoding = (*env)->NewGlobalRef(env, charset.l);
+                jnuCharset = (*env)->NewGlobalRef(env, charset.l);
                 (*env)->DeleteLocalRef(env, charset.l);
-                break;
+                break; // success, continue below
             } else if (strcmp(charsetname, "UTF-8") != 0) { // fall back
                 charsetname = "UTF-8";
                 fastEncoding = FAST_UTF_8;
@@ -812,7 +812,7 @@ static const char* getStringBytes(JNIEnv *env, jstring jstr) {
     if ((*env)->EnsureLocalCapacity(env, 2) < 0)
         return 0;
 
-    hab = (*env)->CallObjectMethod(env, jstr, String_getBytes_ID, jnuEncoding);
+    hab = (*env)->CallObjectMethod(env, jstr, String_getBytes_ID, jnuCharset);
     if (hab != 0) {
         if (!(*env)->ExceptionCheck(env)) {
             jint len = (*env)->GetArrayLength(env, hab);


### PR DESCRIPTION
Store `Charset` object in `jnuEncoding` and use `String(byte[], Charset)` and `String.getBytes(Charset)` instead of passing the charset name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305746](https://bugs.openjdk.org/browse/JDK-8305746): InitializeEncoding should cache Charset object instead of charset name


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13499/head:pull/13499` \
`$ git checkout pull/13499`

Update a local copy of the PR: \
`$ git checkout pull/13499` \
`$ git pull https://git.openjdk.org/jdk.git pull/13499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13499`

View PR using the GUI difftool: \
`$ git pr show -t 13499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13499.diff">https://git.openjdk.org/jdk/pull/13499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13499#issuecomment-1512894106)