### PR TITLE
8306031: Update IANA Language Subtag Registry to Version 2023-04-13

### DIFF
--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -282,11 +282,11 @@ public class EquivMapsGenerator {
                 Paths.get(fileName))) {
             writer.write(getOpenJDKCopyright());
             writer.write(headerText
-                + (int)(sortedLanguageMap1.size() / 0.75f + 1) + ");\n"
+                + sortedLanguageMap1.size() + ");\n"
                 + "        multiEquivsMap = HashMap.newHashMap("
-                + (int)(sortedLanguageMap2.size() / 0.75f + 1) + ");\n"
+                + sortedLanguageMap2.size() + ");\n"
                 + "        regionVariantEquivMap = HashMap.newHashMap("
-                + (int)(sortedRegionVariantMap.size() / 0.75f + 1) + ");\n\n"
+                + sortedRegionVariantMap.size() + ");\n\n"
                 + "        // This is an auto-generated file and should not be manually edited.\n"
                 + "        //   LSR Revision: " + LSRrevisionDate);
             writer.newLine();

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -136,10 +136,29 @@ public class EquivMapsGenerator {
             }
         } else { // language, extlang, legacy, and redundant
             if (!initialLanguageMap.containsKey(preferred)) {
-                sb = new StringBuilder(preferred);
-                sb.append(',');
-                sb.append(tag);
-                initialLanguageMap.put(preferred, sb);
+                // IANA update 4/13 introduced case where a preferred value
+                // can have a preferred value itself.
+                // eg: ar-ajp has pref ajp which has pref apc
+                boolean foundInOther = false;
+                final String finalPref = ","+preferred;
+                final String inbtwnPref = ","+preferred+",";
+                // Check if current pref exists inside a value for another pref
+                List<StringBuilder> doublePrefs = initialLanguageMap.entrySet()
+                        .stream().filter(e -> (e.getValue().toString().endsWith(finalPref) ||
+                                e.getValue().toString().contains(inbtwnPref)))
+                        .map(Map.Entry::getValue)
+                        .collect(Collectors.toList());
+                for (StringBuilder otherPrefVal : doublePrefs) {
+                    otherPrefVal.append(",");
+                    otherPrefVal.append(tag);
+                    foundInOther = true;
+                }
+                if (!foundInOther) { // does not exist in other pref value, so add as new entry
+                    sb = new StringBuilder(preferred);
+                    sb.append(',');
+                    sb.append(tag);
+                    initialLanguageMap.put(preferred, sb);
+                }
             } else {
                 sb = initialLanguageMap.get(preferred);
                 sb.append(',');

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -140,7 +140,7 @@ public class EquivMapsGenerator {
                 // can have a preferred value itself.
                 // eg: ar-ajp has pref ajp which has pref apc
                 boolean foundInOther = false;
-                Pattern pattern = Pattern.compile("\\b"+preferred+"\\b");
+                Pattern pattern = Pattern.compile(","+preferred+"(,|$)");
                 // Check if current pref exists inside a value for another pref
                 List<StringBuilder> doublePrefs = initialLanguageMap
                         .values()

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -37,9 +37,9 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.TimeZone;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 /**
  * This tool reads the IANA Language Subtag Registry data file downloaded from

--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-03-22
+File-Date: 2023-04-13
 %%
 Type: language
 Subtag: aa
@@ -42986,7 +42986,7 @@ Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
 Deprecated: 2023-03-17
-Preferred-Value: apc
+Preferred-Value: ajp
 Prefix: ar
 Macrolanguage: ar
 %%

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -44,7 +44,7 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajp, ajs, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
+        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
         + " en-gb-oed, gti, iba, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
         + " ngv, nns, ola, oyb, pat, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
         + " umi, uss, uth, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
@@ -56,14 +56,13 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("aeb", 1.0),
             new LanguageRange("ar-aeb", 1.0),
             new LanguageRange("ajt", 1.0),
-            new LanguageRange("ajp", 1.0),
-            new LanguageRange("ar-ajp", 1.0),
             new LanguageRange("ajs", 1.0),
             new LanguageRange("sgn-ajs", 1.0),
             new LanguageRange("aog", 1.0),
             new LanguageRange("myd", 1.0),
             new LanguageRange("apc", 1.0),
             new LanguageRange("ar-apc", 1.0),
+            new LanguageRange("ajp", 1.0),
             new LanguageRange("aue", 1.0),
             new LanguageRange("ktz", 1.0),
             new LanguageRange("bcg", 1.0),

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038 8287180 8302512 8304761
+ *      8258795 8267038 8287180 8302512 8304761 8306031
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-03-22) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-04-13) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */
@@ -44,7 +44,7 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
+        "Accept-Language: aam, adp, aeb, ajs, ajp, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
         + " en-gb-oed, gti, iba, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
         + " ngv, nns, ola, oyb, pat, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
         + " umi, uss, uth, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
@@ -58,12 +58,12 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("ajt", 1.0),
             new LanguageRange("ajs", 1.0),
             new LanguageRange("sgn-ajs", 1.0),
+            new LanguageRange("ajp", 1.0),
+            new LanguageRange("ar-ajp", 1.0),
             new LanguageRange("aog", 1.0),
             new LanguageRange("myd", 1.0),
             new LanguageRange("apc", 1.0),
             new LanguageRange("ar-apc", 1.0),
-            new LanguageRange("ar-ajp", 1.0),
-            new LanguageRange("ajp", 1.0),
             new LanguageRange("aue", 1.0),
             new LanguageRange("ktz", 1.0),
             new LanguageRange("bcg", 1.0),

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -62,6 +62,7 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("myd", 1.0),
             new LanguageRange("apc", 1.0),
             new LanguageRange("ar-apc", 1.0),
+            new LanguageRange("ar-ajp", 1.0),
             new LanguageRange("ajp", 1.0),
             new LanguageRange("aue", 1.0),
             new LanguageRange("ktz", 1.0),

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -44,7 +44,7 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, ajp, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
+        "Accept-Language: aam, adp, aeb, ajp, ajs, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
         + " en-gb-oed, gti, iba, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
         + " ngv, nns, ola, oyb, pat, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
         + " umi, uss, uth, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
@@ -56,10 +56,10 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("aeb", 1.0),
             new LanguageRange("ar-aeb", 1.0),
             new LanguageRange("ajt", 1.0),
-            new LanguageRange("ajs", 1.0),
-            new LanguageRange("sgn-ajs", 1.0),
             new LanguageRange("ajp", 1.0),
             new LanguageRange("ar-ajp", 1.0),
+            new LanguageRange("ajs", 1.0),
+            new LanguageRange("sgn-ajs", 1.0),
             new LanguageRange("aog", 1.0),
             new LanguageRange("myd", 1.0),
             new LanguageRange("apc", 1.0),


### PR DESCRIPTION
Update the registry and accompanying tests with the **IANA 4/13/2022** update.

This update introduces the case where an IANA entry can have a preferred value, but that preferred value has a preferred value as well.

This causes unexpected failures in JDK tests because of how locale equivalencies are created.

eg: `ar-ajp` has a preferred value of `ajp` but `ajp` has a preferred value of `apc`

Normally, when the JDK is built, _LocaleEquivlalentMaps.java_ generates the following

```
...
singleEquivMap.put("ar-ajp", "ajp");
singleEquivMap.put("ajp", "ar-ajp");
...
multiEquivsMap.put("ajp", new String[] {"apc", "ar-apc"});
multiEquivsMap.put("apc", new String[] {"ajp", "ar-apc"});
multiEquivsMap.put("ar-apc", new String[] {"apc", "ajp"});
...
```

When `LocaleMatcher.parse(ACCEPT_LANGUAGE)` is called with `ACCEPT_LANGUAGE` containing `apc` and `ajp` in that order, the following occurs:

`apc` is found, `apc` is added, all of `apc's` equivalencies are added: `ajp` and `ar-apc`

When parse iterates to `ajp`, it finds that it is already added to the list, and does not add it's equivalency `ar-ajp`.

To address this, the build process must be adjusted so that the equivalencies are built as 

```
...
multiEquivsMap.put("ajp", new String[] {"apc", "ar-ajp", "ar-apc"});
multiEquivsMap.put("apc", new String[] {"ajp", "ar-ajp", "ar-apc"});
multiEquivsMap.put("ar-ajp", new String[] {"apc", "ajp", "ar-apc"});
multiEquivsMap.put("ar-apc", new String[] {"apc", "ajp", "ar-ajp"});
...
```

As, if `ar-ajp` has a preferred value of `ajp`, and `ajp` has a preferred value of `apc`, this technically means that `ar-ajp` is equivalent to `apc` and its equivalencies as well. This way, when `LocaleMatcher.parse(ACCEPT_LANGUAGE)` iterates to `apc`, it will add all of it's equivalencies including `ar-ajp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306031](https://bugs.openjdk.org/browse/JDK-8306031): Update IANA Language Subtag Registry to Version 2023-04-13


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13501/head:pull/13501` \
`$ git checkout pull/13501`

Update a local copy of the PR: \
`$ git checkout pull/13501` \
`$ git pull https://git.openjdk.org/jdk.git pull/13501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13501`

View PR using the GUI difftool: \
`$ git pr show -t 13501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13501.diff">https://git.openjdk.org/jdk/pull/13501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13501#issuecomment-1515302412)