### PR TITLE
8306059: improve the reliability of TestSerialGCWithCDS.java and ArchiveRelocationTest.java tests

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,12 +76,6 @@ public class ArchiveRelocationTest {
             .assertNormalExit(output -> {
                     if (run_reloc) {
                         output.shouldContain("Try to map archive(s) at an alternative address");
-                        if (output.getOutput().contains("Trying to map heap") || output.getOutput().contains("Loaded heap")) {
-                          // The native data in the RO/RW regions have been relocated. If the CDS heap is
-                          // mapped/loaded, we must patch all the native pointers. (CDS heap is
-                          // not supported on all platforms)
-                          output.shouldContain("Patching native pointers in heap region");
-                        }
                     }
                 });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,12 +136,6 @@ public class TestSerialGCWithCDS {
                               "-Xlog:cds,cds+heap",
                               "-XX:ArchiveRelocationMode=1", // always relocate shared metadata
                               "Hello");
-        if (out.getOutput().contains("Trying to map heap") || out.getOutput().contains("Loaded heap")) {
-            // The native data in the RO/RW regions have been relocated. If the CDS heap is
-            // mapped/loaded, we must patch all the native pointers. (CDS heap is
-            // not supported on all platforms)
-            out.shouldContain("Patching native pointers in heap region");
-        }
         checkExecOutput(dumpWithSerial, execWithSerial, out);
 
         int n = 2;


### PR DESCRIPTION
Remove the check for "Patching native pointers in heap region" from the tests because the CDS archive could be mapped to the requested address even if ArchiveRelocationMode=1.

Passed tiers 1, 2, 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306059](https://bugs.openjdk.org/browse/JDK-8306059): improve the reliability of TestSerialGCWithCDS.java and ArchiveRelocationTest.java tests


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13502/head:pull/13502` \
`$ git checkout pull/13502`

Update a local copy of the PR: \
`$ git checkout pull/13502` \
`$ git pull https://git.openjdk.org/jdk.git pull/13502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13502`

View PR using the GUI difftool: \
`$ git pr show -t 13502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13502.diff">https://git.openjdk.org/jdk/pull/13502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13502#issuecomment-1512249164)