### PR TITLE
8305505: NPE in javazic compiler

### DIFF
--- a/test/jdk/sun/util/calendar/zi/GenDoc.java
+++ b/test/jdk/sun/util/calendar/zi/GenDoc.java
@@ -156,9 +156,10 @@ class GenDoc extends BackEnd {
             /* If mapfile is available, add a link to the appropriate map */
             if (mapList == null) {
                 mapList = new HashMap<String, LatitudeAndLongitude>();
+                FileReader fr = new FileReader(Main.getMapFile());
+                BufferedReader in = new BufferedReader(fr);
+                
                 if (Main.getMapFile() != null) {
-                    FileReader fr = new FileReader(Main.getMapFile());
-                    BufferedReader in = new BufferedReader(fr);
                     String line;
                     while ((line = in.readLine()) != null) {
                         // skip blank and comment lines

--- a/test/jdk/sun/util/calendar/zi/GenDoc.java
+++ b/test/jdk/sun/util/calendar/zi/GenDoc.java
@@ -154,27 +154,24 @@ class GenDoc extends BackEnd {
             outD.mkdirs();
 
             /* If mapfile is available, add a link to the appropriate map */
-            if (mapList == null) {
+            if (mapList == null && Main.getMapFile() != null) {
                 mapList = new HashMap<String, LatitudeAndLongitude>();
                 FileReader fr = new FileReader(Main.getMapFile());
                 BufferedReader in = new BufferedReader(fr);
-
-                if (Main.getMapFile() != null) {
-                    String line;
-                    while ((line = in.readLine()) != null) {
-                        // skip blank and comment lines
-                        if (line.length() == 0 || line.charAt(0) == '#') {
-                            continue;
-                        }
-                        StringTokenizer tokens = new StringTokenizer(line);
-                        String token = tokens.nextToken();  /* We don't use the first token. */
-                        token = tokens.nextToken();
-                        LatitudeAndLongitude location = new LatitudeAndLongitude(token);
-                        token = tokens.nextToken();
-                        mapList.put(token, location);
+                String line;
+                while ((line = in.readLine()) != null) {
+                    // skip blank and comment lines
+                    if (line.length() == 0 || line.charAt(0) == '#') {
+                        continue;
                     }
-                    in.close();
+                    StringTokenizer tokens = new StringTokenizer(line);
+                    String token = tokens.nextToken();  /* We don't use the first token. */
+                    token = tokens.nextToken();
+                    LatitudeAndLongitude location = new LatitudeAndLongitude(token);
+                    token = tokens.nextToken();
+                    mapList.put(token, location);
                 }
+                in.close();
             }
 
             /* Open zoneinfo file to write. */
@@ -183,7 +180,7 @@ class GenDoc extends BackEnd {
 
             out.write(header1 + new Date() + header3 + zonename + header4);
             out.write(body1 + "<FONT size=\"+2\"><B>" + zonename + "</B></FONT>");
-            LatitudeAndLongitude location = mapList.get(zonename);
+            LatitudeAndLongitude location = (mapList != null ? mapList.get(zonename) : null);
             if (location != null) {
                 int deg, min, sec;
 

--- a/test/jdk/sun/util/calendar/zi/GenDoc.java
+++ b/test/jdk/sun/util/calendar/zi/GenDoc.java
@@ -158,7 +158,7 @@ class GenDoc extends BackEnd {
                 mapList = new HashMap<String, LatitudeAndLongitude>();
                 FileReader fr = new FileReader(Main.getMapFile());
                 BufferedReader in = new BufferedReader(fr);
-                
+
                 if (Main.getMapFile() != null) {
                     String line;
                     while ((line = in.readLine()) != null) {

--- a/test/jdk/sun/util/calendar/zi/GenDoc.java
+++ b/test/jdk/sun/util/calendar/zi/GenDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,24 +154,26 @@ class GenDoc extends BackEnd {
             outD.mkdirs();
 
             /* If mapfile is available, add a link to the appropriate map */
-            if ((mapList == null) && (Main.getMapFile() != null)) {
-                FileReader fr = new FileReader(Main.getMapFile());
-                BufferedReader in = new BufferedReader(fr);
-                mapList = new HashMap<String,LatitudeAndLongitude>();
-                String line;
-                while ((line = in.readLine()) != null) {
-                    // skip blank and comment lines
-                    if (line.length() == 0 || line.charAt(0) == '#') {
-                        continue;
+            if (mapList == null) {
+                mapList = new HashMap<String, LatitudeAndLongitude>();
+                if (Main.getMapFile() != null) {
+                    FileReader fr = new FileReader(Main.getMapFile());
+                    BufferedReader in = new BufferedReader(fr);
+                    String line;
+                    while ((line = in.readLine()) != null) {
+                        // skip blank and comment lines
+                        if (line.length() == 0 || line.charAt(0) == '#') {
+                            continue;
+                        }
+                        StringTokenizer tokens = new StringTokenizer(line);
+                        String token = tokens.nextToken();  /* We don't use the first token. */
+                        token = tokens.nextToken();
+                        LatitudeAndLongitude location = new LatitudeAndLongitude(token);
+                        token = tokens.nextToken();
+                        mapList.put(token, location);
                     }
-                    StringTokenizer tokens = new StringTokenizer(line);
-                    String token = tokens.nextToken();  /* We don't use the first token. */
-                    token = tokens.nextToken();
-                    LatitudeAndLongitude location = new LatitudeAndLongitude(token);
-                    token = tokens.nextToken();
-                    mapList.put(token, location);
+                    in.close();
                 }
-                in.close();
             }
 
             /* Open zoneinfo file to write. */


### PR DESCRIPTION
Please review this PR.  
With this minor change, the javazic compiler (Main.java) can produce the HTML files that display given time zone data correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305505](https://bugs.openjdk.org/browse/JDK-8305505): NPE in javazic compiler


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13504/head:pull/13504` \
`$ git checkout pull/13504`

Update a local copy of the PR: \
`$ git checkout pull/13504` \
`$ git pull https://git.openjdk.org/jdk.git pull/13504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13504`

View PR using the GUI difftool: \
`$ git pr show -t 13504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13504.diff">https://git.openjdk.org/jdk/pull/13504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13504#issuecomment-1521169847)