### PR TITLE
8306320: BufferedImage spec needs clarification w.r.t its implementation of the WritableRenderedImage interface

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
@@ -1541,8 +1541,8 @@ public class BufferedImage extends java.awt.Image
    * Adds a tile observer.  If the observer is already present,
    * it receives multiple notifications.
    * <p>
-   * The default implementation ignores its parameters and does
-   * nothing, since {@code BufferedImage} is always checked out
+   * This method ignores its parameters and does nothing,
+   * since {@code BufferedImage} is always checked out
    * for writing and cannot be made read-only,
    * so there can never be events to dispatch.
    *
@@ -1556,7 +1556,7 @@ public class BufferedImage extends java.awt.Image
    * nothing happens.  If the observer was registered for multiple
    * notifications, it is now registered for one fewer notification.
    * <p>
-   * The default implementation ignores the given observer,
+   * This method ignores the given observer,
    * since {@link #addTileObserver(TileObserver)} adds none.
    *
    * @param to the specified {@code TileObserver}.
@@ -1566,6 +1566,10 @@ public class BufferedImage extends java.awt.Image
 
     /**
      * Returns whether or not a tile is currently checked out for writing.
+     * The only tile in a {@code BufferedImage} is at (0,0) and it is always
+     * writable, so calling this method with (0,0) will always return
+     * {@code true}, and any other coordinate will cause an exception
+     * to be thrown.
      *
      * @param tileX the x index of the tile.
      * @param tileY the y index of the tile.
@@ -1589,8 +1593,8 @@ public class BufferedImage extends java.awt.Image
      * checked out.
      * <p>
      * Since a {@code BufferedImage} consists of a single tile,
-     * and that tile is always checked out for writing, the
-     * default implementation returns an array of one point.
+     * and that tile is always checked out for writing,
+     * this method returns an array of one point.
      * Further, the offset shall be consistent with
      * {@link #getMinTileX()} and {@link #getMinTileY()},
      * which are always (0,0) in {@code BufferedImage}.
@@ -1626,7 +1630,7 @@ public class BufferedImage extends java.awt.Image
    * {@code TileObservers} are notified when a tile goes from having
    * no writers to having one writer.
    * <p>
-   * The default implementation unconditionally returns the
+   * This method unconditionally returns the
    * {@linkplain #getRaster() single tile} without checking
    * the passed values. No listeners are notified since the
    * returned tile is always checked out for writing.
@@ -1649,10 +1653,9 @@ public class BufferedImage extends java.awt.Image
    * are notified when a tile goes from having one writer to having no
    * writers.
    * <p>
-   * The default implementation is a no-op and immediately returns
-   * without checking the passed values. No listeners are notified
-   * since the {@linkplain #getRaster() single tile} is always
-   * checked out for writing.
+   * This method immediately returns without checking the passed values.
+   * No listeners are notified since the {@linkplain #getRaster() single tile}
+   * is always checked out for writing.
    *
    * @param tileX the x index of the tile
    * @param tileY the y index of the tile

--- a/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
@@ -1540,6 +1540,13 @@ public class BufferedImage extends java.awt.Image
   /**
    * Adds a tile observer.  If the observer is already present,
    * it receives multiple notifications.
+   *
+   * @implSpec
+   * The default implementation ignores the given observer since
+   * {@code BufferedImage} {@linkplain #getRaster() single tile}
+   * is always checked out for writing, so there is no event to
+   * dispatch.
+   *
    * @param to the specified {@link TileObserver}
    */
     public void addTileObserver (TileObserver to) {
@@ -1549,6 +1556,11 @@ public class BufferedImage extends java.awt.Image
    * Removes a tile observer.  If the observer was not registered,
    * nothing happens.  If the observer was registered for multiple
    * notifications, it is now registered for one fewer notification.
+   *
+   * @implSpec
+   * The default implementation ignores the given observer since
+   * {@link #addTileObserver(TileObserver)} adds none.
+   *
    * @param to the specified {@code TileObserver}.
    */
     public void removeTileObserver (TileObserver to) {
@@ -1561,8 +1573,8 @@ public class BufferedImage extends java.awt.Image
      * @return {@code true} if the tile specified by the specified
      *          indices is checked out for writing; {@code false}
      *          otherwise.
-     * @throws ArrayIndexOutOfBoundsException if both
-     *          {@code tileX} and {@code tileY} are not equal
+     * @throws IllegalArgumentException if either
+     *          {@code tileX} or {@code tileY} is not equal
      *          to 0
      */
     public boolean isTileWritable (int tileX, int tileY) {
@@ -1576,13 +1588,20 @@ public class BufferedImage extends java.awt.Image
      * Returns an array of {@link Point} objects indicating which tiles
      * are checked out for writing.  Returns {@code null} if none are
      * checked out.
+     *
+     * @implSpec
+     * The default implementation unconditionally returns a single
+     * point with (0,0) coordinates since {@code BufferedImage}
+     * {@linkplain #getRaster() single tile} is always checked out
+     * for writing.
+     *
      * @return a {@code Point} array that indicates the tiles that
      *          are checked out for writing, or {@code null} if no
      *          tiles are checked out for writing.
      */
     public Point[] getWritableTileIndices() {
         Point[] p = new Point[1];
-        p[0] = new Point(0, 0);
+        p[0] = new Point();         // Default to (0,0).
 
         return p;
     }
@@ -1604,6 +1623,13 @@ public class BufferedImage extends java.awt.Image
    * Checks out a tile for writing.  All registered
    * {@code TileObservers} are notified when a tile goes from having
    * no writers to having one writer.
+   *
+   * @implSpec
+   * The default implementation unconditionally returns the
+   * {@linkplain #getRaster() single tile} without checking
+   * the passed values. No listeners are notified since the
+   * returned tile is always checked out for writing.
+   *
    * @param tileX the x index of the tile
    * @param tileY the y index of the tile
    * @return a {@code WritableRaster} that is the tile, indicated by
@@ -1621,6 +1647,13 @@ public class BufferedImage extends java.awt.Image
    * to undefined results.  All registered {@code TileObservers}
    * are notified when a tile goes from having one writer to having no
    * writers.
+   *
+   * @implSpec
+   * The default implementation is a no-op and immediately returns
+   * without checking the passed values. No listeners are notified
+   * since the {@linkplain #getRaster() single tile} is always
+   * checked out for writing.
+   *
    * @param tileX the x index of the tile
    * @param tileY the y index of the tile
    */

--- a/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
@@ -1540,12 +1540,11 @@ public class BufferedImage extends java.awt.Image
   /**
    * Adds a tile observer.  If the observer is already present,
    * it receives multiple notifications.
-   *
-   * @implSpec
-   * The default implementation ignores the given observer since
-   * {@code BufferedImage} {@linkplain #getRaster() single tile}
-   * is always checked out for writing, so there is no event to
-   * dispatch.
+   * <p>
+   * The default implementation ignores its parameters and does
+   * nothing, since {@code BufferedImage} is always checked out
+   * for writing and cannot be made read-only,
+   * so there can never be events to dispatch.
    *
    * @param to the specified {@link TileObserver}
    */
@@ -1556,10 +1555,9 @@ public class BufferedImage extends java.awt.Image
    * Removes a tile observer.  If the observer was not registered,
    * nothing happens.  If the observer was registered for multiple
    * notifications, it is now registered for one fewer notification.
-   *
-   * @implSpec
-   * The default implementation ignores the given observer since
-   * {@link #addTileObserver(TileObserver)} adds none.
+   * <p>
+   * The default implementation ignores the given observer,
+   * since {@link #addTileObserver(TileObserver)} adds none.
    *
    * @param to the specified {@code TileObserver}.
    */
@@ -1568,6 +1566,7 @@ public class BufferedImage extends java.awt.Image
 
     /**
      * Returns whether or not a tile is currently checked out for writing.
+     *
      * @param tileX the x index of the tile.
      * @param tileY the y index of the tile.
      * @return {@code true} if the tile specified by the specified
@@ -1588,12 +1587,15 @@ public class BufferedImage extends java.awt.Image
      * Returns an array of {@link Point} objects indicating which tiles
      * are checked out for writing.  Returns {@code null} if none are
      * checked out.
-     *
-     * @implSpec
-     * The default implementation unconditionally returns a single
-     * point with (0,0) coordinates since {@code BufferedImage}
-     * {@linkplain #getRaster() single tile} is always checked out
-     * for writing.
+     * <p>
+     * Since a {@code BufferedImage} consists of a single tile,
+     * and that tile is always checked out for writing, the
+     * default implementation returns an array of one point.
+     * Further, the offset shall be consistent with
+     * {@link #getMinTileX()} and {@link #getMinTileY()},
+     * which are always (0,0) in {@code BufferedImage}.
+     * That will always be the coordinates of the single
+     * returned {@code Point}.
      *
      * @return a {@code Point} array that indicates the tiles that
      *          are checked out for writing, or {@code null} if no
@@ -1623,8 +1625,7 @@ public class BufferedImage extends java.awt.Image
    * Checks out a tile for writing.  All registered
    * {@code TileObservers} are notified when a tile goes from having
    * no writers to having one writer.
-   *
-   * @implSpec
+   * <p>
    * The default implementation unconditionally returns the
    * {@linkplain #getRaster() single tile} without checking
    * the passed values. No listeners are notified since the
@@ -1647,8 +1648,7 @@ public class BufferedImage extends java.awt.Image
    * to undefined results.  All registered {@code TileObservers}
    * are notified when a tile goes from having one writer to having no
    * writers.
-   *
-   * @implSpec
+   * <p>
    * The default implementation is a no-op and immediately returns
    * without checking the passed values. No listeners are notified
    * since the {@linkplain #getRaster() single tile} is always


### PR DESCRIPTION
`BufferedImage` implements the `WritableRenderedImage` interface. But the Javadoc is copied from `WritableRenderedImage`, while `BufferedImage` does something quite different. In particular, `TileObserver` are ignored. This pull request add `@implSlec` for explaining the default behaviour.

This commit has one specification change in `isTileWritable`: the exception type is changed from `ArrayIndexOutOfBoundsException` to `IllegalArgumentException` for matching the implementation. The logical conditions is also corrected.

This commit contains a trivial code change: `new Point(0,0)` is replaced by `new Point()` for saving a few byte codes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8306875](https://bugs.openjdk.org/browse/JDK-8306875) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8306320](https://bugs.openjdk.org/browse/JDK-8306320): BufferedImage spec needs clarification w.r.t its implementation of the WritableRenderedImage interface
 * [JDK-8306875](https://bugs.openjdk.org/browse/JDK-8306875): BufferedImage spec needs clarification w.r.t its implementation of the WritableRenderedImage interface (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13506/head:pull/13506` \
`$ git checkout pull/13506`

Update a local copy of the PR: \
`$ git checkout pull/13506` \
`$ git pull https://git.openjdk.org/jdk.git pull/13506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13506`

View PR using the GUI difftool: \
`$ git pr show -t 13506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13506.diff">https://git.openjdk.org/jdk/pull/13506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13506#issuecomment-1513696768)