### PR TITLE
8306279: Build failure after JDK-8299592

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -134,6 +134,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
     CFLAGS := $(CFLAGS_JDKLIB) $(LIBAWT_CFLAGS), \
     EXTRA_HEADER_DIRS := $(LIBAWT_EXTRA_HEADER_DIRS), \
     DISABLED_WARNINGS_gcc_awt_LoadLibrary.c := unused-result, \
+    DISABLED_WARNINGS_gcc_debug_mem.c := format-nonliteral, \
     DISABLED_WARNINGS_gcc_ProcessPath.c := maybe-uninitialized, \
     DISABLED_WARNINGS_gcc_Region.c := maybe-uninitialized, \
     DISABLED_WARNINGS_gcc_SurfaceData.c := unused-value, \


### PR DESCRIPTION
Please review this patch that disables a warning that appeared on linux builds in slowdebug configuration after [JDK-8299592](https://bugs.openjdk.org/browse/JDK-8299592).

I plan to investigate why this failure appears only in slowdebug mode; this patch is intended to unblock the CI.

Verified that the slowdebug builds pass with this patch applied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306279](https://bugs.openjdk.org/browse/JDK-8306279): Build failure after JDK-8299592


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13507/head:pull/13507` \
`$ git checkout pull/13507`

Update a local copy of the PR: \
`$ git checkout pull/13507` \
`$ git pull https://git.openjdk.org/jdk.git pull/13507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13507`

View PR using the GUI difftool: \
`$ git pr show -t 13507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13507.diff">https://git.openjdk.org/jdk/pull/13507.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13507#issuecomment-1512973758)