### PR TITLE
8306008: Several Vector API tests fail for client VM after JDK-8304450

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -805,13 +805,17 @@ final class Double128Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -805,16 +805,30 @@ final class Double128Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -809,13 +809,17 @@ final class Double256Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -809,16 +809,30 @@ final class Double256Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -817,16 +817,30 @@ final class Double512Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -817,13 +817,17 @@ final class Double512Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -803,16 +803,30 @@ final class Double64Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -803,7 +803,17 @@ final class Double64Vector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            a[offset] = laneSource(0);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -802,13 +802,17 @@ final class DoubleMaxVector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -802,16 +802,30 @@ final class DoubleMaxVector extends DoubleVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -806,13 +806,17 @@ final class Long128Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -806,16 +806,30 @@ final class Long128Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -810,16 +810,30 @@ final class Long256Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -810,13 +810,17 @@ final class Long256Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -818,13 +818,17 @@ final class Long512Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -818,16 +818,30 @@ final class Long512Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -804,16 +804,30 @@ final class Long64Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -804,7 +804,17 @@ final class Long64Vector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            a[offset] = laneSource(0);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -804,16 +804,30 @@ final class LongMaxVector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -804,13 +804,17 @@ final class LongMaxVector extends LongVector {
         @Override
         @ForceInline
         public void intoArray(int[] a, int offset) {
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
         }
 
         private static long[] prepare(int[] indices, int offset) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1132,16 +1132,30 @@ final class $vectortype$ extends $abstractvectortype$ {
             toBitsVector().intoArray(a, offset);
 #end[intOrFloat]
 #if[longOrDouble]
-            if (VSPECIES.laneCount() == 1) {
-                a[offset] = laneSource(0);
-            } else {
-                VectorSpecies<Integer> species = VectorSpecies.of(
-                        int.class,
-                        VectorShape.forBitSize(length() * Integer.SIZE));
-                Vector<Long> v = toBitsVector();
-                v.convertShape(VectorOperators.L2I, species, 0)
+            switch (length()) {
+                case 1 -> a[offset] = laneSource(0);
+                case 2 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_64, 0)
                         .reinterpretAsInts()
                         .intoArray(a, offset);
+                case 4 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_128, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 8 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_256, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                case 16 -> toBitsVector()
+                        .convertShape(VectorOperators.L2I, IntVector.SPECIES_512, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+                default -> {
+                    VectorIntrinsics.checkFromIndexSize(offset, length(), a.length);
+                    for (int i = 0; i < length(); i++) {
+                        a[offset + i] = laneSource(i);
+                    }
+                }
             }
 #end[longOrDouble]
         }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1132,18 +1132,17 @@ final class $vectortype$ extends $abstractvectortype$ {
             toBitsVector().intoArray(a, offset);
 #end[intOrFloat]
 #if[longOrDouble]
-#if[!1L]
-            VectorSpecies<Integer> species = VectorSpecies.of(
-                    int.class,
-                    VectorShape.forBitSize(length() * Integer.SIZE));
-            Vector<Long> v = toBitsVector();
-            v.convertShape(VectorOperators.L2I, species, 0)
-                    .reinterpretAsInts()
-                    .intoArray(a, offset);
-#end[!1L]
-#if[1L]
-            a[offset] = laneSource(0);
-#end[1L]
+            if (VSPECIES.laneCount() == 1) {
+                a[offset] = laneSource(0);
+            } else {
+                VectorSpecies<Integer> species = VectorSpecies.of(
+                        int.class,
+                        VectorShape.forBitSize(length() * Integer.SIZE));
+                Vector<Long> v = toBitsVector();
+                v.convertShape(VectorOperators.L2I, species, 0)
+                        .reinterpretAsInts()
+                        .intoArray(a, offset);
+            }
 #end[longOrDouble]
         }
 


### PR DESCRIPTION
Hi,

Please review this patch which fixes the errors on machines where TypeMaxVector has a length of 64 bits. I take an extra cautious approach and fall back to putting elements one by one if the length is an unexpected value.

All jdk/incubator/vector tests passed with MaxVectorSize=8, which fails without this patch.

Thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306008](https://bugs.openjdk.org/browse/JDK-8306008): Several Vector API tests fail for client VM after JDK-8304450


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13508/head:pull/13508` \
`$ git checkout pull/13508`

Update a local copy of the PR: \
`$ git checkout pull/13508` \
`$ git pull https://git.openjdk.org/jdk.git pull/13508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13508`

View PR using the GUI difftool: \
`$ git pr show -t 13508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13508.diff">https://git.openjdk.org/jdk/pull/13508.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13508#issuecomment-1513046213)