### PR TITLE
8306284: G1: Remove assertion in G1ScanHRForRegionClosure::do_claimed_block

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -549,11 +549,6 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
     _blocks_scanned++;
 
     HeapWord* const card_start = _ct->addr_for(dirty_l);
-#ifdef ASSERT
-    HeapRegion* hr = _g1h->region_at_or_null(region_idx);
-    assert(hr == NULL || hr->is_in_reserved(card_start),
-             "Card start " PTR_FORMAT " to scan outside of region %u", p2i(card_start), _g1h->region_at(region_idx)->hrm_index());
-#endif
     HeapWord* const top = _scan_state->scan_top(region_idx);
     if (card_start >= top) {
       return;


### PR DESCRIPTION
Simple removing of a superfluous assertion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306284](https://bugs.openjdk.org/browse/JDK-8306284): G1: Remove assertion in G1ScanHRForRegionClosure::do_claimed_block


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13509/head:pull/13509` \
`$ git checkout pull/13509`

Update a local copy of the PR: \
`$ git checkout pull/13509` \
`$ git pull https://git.openjdk.org/jdk.git pull/13509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13509`

View PR using the GUI difftool: \
`$ git pr show -t 13509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13509.diff">https://git.openjdk.org/jdk/pull/13509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13509#issuecomment-1513046093)