### PR TITLE
JDK-8306285: Missing file in search test

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/channels/FileChannel.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/channels/FileChannel.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package channels;
+
+/**
+ * Test case for parameter type "masking" the method name and then getting dropped.
+ */
+public class FileChannel {
+
+    /**
+     * Type name "FileChanne.Map masks method below
+     */
+    public static class Map {}
+
+    /**
+     * Method "FileChannel.map" is masked by the type of its first parameter
+     */
+    public FileChannel map(Map map, int i) {
+        return this;
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/javadoc-search.js
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/javadoc-search.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ function indexFilesLoaded() {
         && tagSearchIndex;
 }
 
+// jquery mock functions
 var $ = function(f) {
     if (typeof f === "function") {
         f();
@@ -69,6 +70,9 @@ var $ = function(f) {
                 return this;
             },
             addClass: function() {
+                return this;
+            },
+            each: function() {
                 return this;
             },
             removeClass: function() {


### PR DESCRIPTION
Please review a simple fix for the javadoc `TestSearchScript` test which is skipped during normal test runs and only run manually. This adds a test file which was missing in a previous commit and a mock function for jQuery method `each()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306285](https://bugs.openjdk.org/browse/JDK-8306285): Missing file in search test


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13510/head:pull/13510` \
`$ git checkout pull/13510`

Update a local copy of the PR: \
`$ git checkout pull/13510` \
`$ git pull https://git.openjdk.org/jdk.git pull/13510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13510`

View PR using the GUI difftool: \
`$ git pr show -t 13510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13510.diff">https://git.openjdk.org/jdk/pull/13510.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13510#issuecomment-1513067574)