### PR TITLE
8306278: jvmtiAgentList.cpp:253 assert(offset >= 0) failed: invariant occurs on AIX after JDK-8257967

### DIFF
--- a/src/hotspot/share/prims/jvmtiAgentList.cpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.cpp
@@ -245,7 +245,6 @@ JvmtiAgent* JvmtiAgentList::lookup(JvmtiEnv* env, void* f_ptr) {
     return nullptr;
   }
   assert(buffer[0] != '\0', "invariant");
-  assert(offset >= 0, "invariant");
   const void* const os_module_address = reinterpret_cast<address>(f_ptr) - offset;
 
   JvmtiAgentList::Iterator it = JvmtiAgentList::agents();


### PR DESCRIPTION
Greetings,

For most platforms, os::dll_address_to_library_name() only sets offset = -1 in case of errors. If there is an error, the function returns false. This is fine.

On AIX, the offset, being optional, is invariantly set to -1, even in the case of non-errors.

Easiest to remove the assertion for a positive offset.

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306278](https://bugs.openjdk.org/browse/JDK-8306278): jvmtiAgentList.cpp:253 assert(offset &gt;= 0) failed: invariant occurs on AIX after JDK-8257967


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13513/head:pull/13513` \
`$ git checkout pull/13513`

Update a local copy of the PR: \
`$ git checkout pull/13513` \
`$ git pull https://git.openjdk.org/jdk.git pull/13513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13513`

View PR using the GUI difftool: \
`$ git pr show -t 13513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13513.diff">https://git.openjdk.org/jdk/pull/13513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13513#issuecomment-1513515724)