### PR TITLE
8306321: Add an accessor for the top of a PLAB

### DIFF
--- a/src/hotspot/share/gc/shared/plab.hpp
+++ b/src/hotspot/share/gc/shared/plab.hpp
@@ -138,6 +138,10 @@ public:
   // Fills in the unallocated portion of the buffer with a garbage object and updates
   // statistics. To be called during GC.
   void retire();
+
+  HeapWord* top() const {
+    return _top;
+  }
 };
 
 // PLAB book-keeping.


### PR DESCRIPTION
The generational mode for Shenandoah needs to know the top of a PLAB when it is retired.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306321](https://bugs.openjdk.org/browse/JDK-8306321): Add an accessor for the top of a PLAB


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13516/head:pull/13516` \
`$ git checkout pull/13516`

Update a local copy of the PR: \
`$ git checkout pull/13516` \
`$ git pull https://git.openjdk.org/jdk.git pull/13516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13516`

View PR using the GUI difftool: \
`$ git pr show -t 13516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13516.diff">https://git.openjdk.org/jdk/pull/13516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13516#issuecomment-1513570141)