### PR TITLE
8306135: Clean up and open source some AWT tests

### DIFF
--- a/test/jdk/java/awt/Cursor/SingleColorCursorTest.java
+++ b/test/jdk/java/awt/Cursor/SingleColorCursorTest.java
@@ -39,6 +39,7 @@ import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.InvocationTargetException;
+
 public class SingleColorCursorTest extends Panel {
     public void init() {
         setLayout (new BorderLayout());

--- a/test/jdk/java/awt/Cursor/SingleColorCursorTest.java
+++ b/test/jdk/java/awt/Cursor/SingleColorCursorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4653170
+  @summary Make sure setCursor does not produce Arithmetic Exception.
+  @key headful
+  @run main SingleColorCursorTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Cursor;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+public class SingleColorCursorTest extends Panel {
+    public void init() {
+        setLayout (new BorderLayout());
+        setSize (200,200);
+        add(new Button("JButton"));
+    }
+
+    public void start () {
+        Cursor singleColorCursor = Toolkit.getDefaultToolkit()
+                .createCustomCursor(new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_BINARY),
+                                    new Point(0,0), "Single Color Cursor");
+        try {
+            setCursor(singleColorCursor);
+        } catch (ArithmeticException ae) {
+            throw new RuntimeException("Setting a 1x1 custom cursor causes arithmetic exception");
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+            Frame frame = new Frame("Test window");
+            try {
+                SingleColorCursorTest test = new SingleColorCursorTest();
+                test.init();
+                frame.add(test);
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                test.start();
+                frame.setVisible(false);
+            } finally {
+                frame.dispose();
+            }
+        });
+    }
+}

--- a/test/jdk/java/awt/Dialog/ComponentShownEvent.java
+++ b/test/jdk/java/awt/Dialog/ComponentShownEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4274360
+  @summary Ensures that Dialogs receive COMPONENT_SHOWN events
+  @key headful
+  @run main ComponentShownEvent
+*/
+
+import java.awt.AWTException;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class ComponentShownEvent {
+
+    volatile boolean componentShown = false;
+    Frame f;
+    Dialog d;
+
+    public void start() throws InterruptedException, InvocationTargetException, AWTException {
+        Robot robot = new Robot();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                f = new Frame();
+                d = new Dialog(f);
+
+                d.addComponentListener(new ComponentAdapter() {
+                    public void componentShown(ComponentEvent e) {
+                        componentShown = true;
+                    }
+                });
+
+                f.setSize(100, 100);
+                f.setLocationRelativeTo(null);
+                f.setVisible(true);
+                d.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            if (!componentShown) {
+                throw new RuntimeException("test failed");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (d != null) {
+                    d.setVisible(false);
+                    d.dispose();
+                }
+                if (f != null) {
+                    f.setVisible(false);
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException, AWTException {
+        ComponentShownEvent test = new ComponentShownEvent();
+        test.start();
+        System.out.println("test passed");
+    }
+}

--- a/test/jdk/java/awt/Dialog/ComponentShownEvent.java
+++ b/test/jdk/java/awt/Dialog/ComponentShownEvent.java
@@ -44,7 +44,8 @@ public class ComponentShownEvent {
     Frame f;
     Dialog d;
 
-    public void start() throws InterruptedException, InvocationTargetException, AWTException {
+    public void start() throws InterruptedException,
+                        InvocationTargetException, AWTException {
         Robot robot = new Robot();
         try {
             EventQueue.invokeAndWait(() -> {
@@ -83,7 +84,8 @@ public class ComponentShownEvent {
         }
     }
 
-    public static void main(String[] args) throws InterruptedException, InvocationTargetException, AWTException {
+    public static void main(String[] args) throws InterruptedException,
+                               InvocationTargetException, AWTException {
         ComponentShownEvent test = new ComponentShownEvent();
         test.start();
         System.out.println("test passed");

--- a/test/jdk/java/awt/Dialog/DialogAsParentOfFileDialog.java
+++ b/test/jdk/java/awt/Dialog/DialogAsParentOfFileDialog.java
@@ -102,7 +102,8 @@ public class DialogAsParentOfFileDialog {
         fdialog = new FileDialog(dlg, title);
         passed =
             fdialog.getOwner() == dlg
-            && (fdialog.getTitle() == null || fdialog.getTitle().equals(""));
+            && (fdialog.getTitle() == null
+                || fdialog.getTitle().equals(""));
         System.out.println(passed ? "passed" : "FAILED");
         if (!passed) {
             errors.append(nl);
@@ -179,7 +180,8 @@ public class DialogAsParentOfFileDialog {
         }
     }
 
-    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+    public static void main(String[] args) throws InterruptedException,
+                                           InvocationTargetException {
         EventQueue.invokeAndWait(() -> {
             new DialogAsParentOfFileDialog().start();
         });

--- a/test/jdk/java/awt/Dialog/DialogAsParentOfFileDialog.java
+++ b/test/jdk/java/awt/Dialog/DialogAsParentOfFileDialog.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4221123
+  @summary Why Dialog can't be an owner of FileDialog?
+  @key headful
+  @run main DialogAsParentOfFileDialog
+*/
+
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class DialogAsParentOfFileDialog {
+    FileDialog fdialog;
+
+    public void start () {
+        StringBuilder errors = new StringBuilder();
+        String nl = System.lineSeparator();
+        Dialog dlg;
+        String title;
+        int mode;
+        boolean passed;
+
+        System.out.println("DialogAsParentOfFileDialog");
+
+        /*
+         * public FileDialog(Dialog parent),
+         * checks owner and default settings.
+         */
+        System.out.print("\ttest 01: ");
+        dlg = new Dialog(new Frame());
+        fdialog = new FileDialog(dlg);
+        passed =
+            fdialog.getOwner() == dlg
+            && fdialog.isModal()
+            && fdialog.getTitle().equals("")
+            && fdialog.getMode() == FileDialog.LOAD
+            && fdialog.getFile() == null
+            && fdialog.getDirectory() == null
+            && fdialog.getFilenameFilter() == null;
+        System.out.println(passed ? "passed" : "FAILED");
+        if (!passed) {
+            errors.append(nl);
+            errors.append("DialogAsParentOfFileDialog FAILED");
+        }
+
+        /*
+         * public FileDialog(Dialog parent, String title),
+         * checks owner, title and default settings.
+         */
+        System.out.print("\ttest 02: ");
+        dlg = new Dialog(new Frame());
+        title = "Title";
+        fdialog = new FileDialog(dlg, title);
+        passed =
+            fdialog.getOwner() == dlg
+            && fdialog.isModal()
+            && fdialog.getTitle().equals(title)
+            && fdialog.getMode() == FileDialog.LOAD
+            && fdialog.getFile() == null
+            && fdialog.getDirectory() == null
+            && fdialog.getFilenameFilter() == null;
+        System.out.println(passed ? "passed" : "FAILED");
+        if (!passed) {
+            errors.append(nl);
+            errors.append("DialogAsParentOfFileDialog FAILED");
+        }
+
+        /*
+         * public FileDialog(Dialog parent, String title),
+         * title: null.
+         * expected results: FileDialog object with a null title
+         */
+        System.out.print("\ttest 03: ");
+        dlg = new Dialog(new Frame());
+        title = null;
+        fdialog = new FileDialog(dlg, title);
+        passed =
+            fdialog.getOwner() == dlg
+            && (fdialog.getTitle() == null || fdialog.getTitle().equals(""));
+        System.out.println(passed ? "passed" : "FAILED");
+        if (!passed) {
+            errors.append(nl);
+            errors.append("DialogAsParentOfFileDialog FAILED");
+        }
+
+        /*
+         * public FileDialog(Dialog parent, String title, int mode),
+         * checks owner, title and mode.
+         */
+        dlg = new Dialog(new Frame());
+        title = "Title";
+
+        System.out.print("\ttest 04: ");
+        mode = FileDialog.SAVE;
+        fdialog = new FileDialog(dlg, title, mode);
+        passed =
+            fdialog.getOwner() == dlg
+            && fdialog.isModal()
+            && fdialog.getTitle().equals(title)
+            && fdialog.getMode() == mode
+            && fdialog.getFile() == null
+            && fdialog.getDirectory() == null
+            && fdialog.getFilenameFilter() == null;
+        System.out.println(passed ? "passed" : "FAILED");
+        if (!passed) {
+            errors.append(nl);
+            errors.append("DialogAsParentOfFileDialog FAILED");
+        }
+
+        System.out.print("\ttest 05: ");
+        mode = FileDialog.LOAD;
+        fdialog = new FileDialog(dlg, title, mode);
+        passed =
+            fdialog.getOwner() == dlg
+            && fdialog.isModal()
+            && fdialog.getTitle().equals(title)
+            && fdialog.getMode() == mode
+            && fdialog.getFile() == null
+            && fdialog.getDirectory() == null
+            && fdialog.getFilenameFilter() == null;
+        System.out.println(passed ? "passed" : "FAILED");
+        if (!passed) {
+            errors.append(nl);
+            errors.append("DialogAsParentOfFileDialog FAILED");
+        }
+
+        /*
+         * public FileDialog(Dialog parent, String title, int mode),
+         * mode: Integer.MIN_VALUE, Integer.MIN_VALUE+1,
+         *       Integer.MAX_VALUE-1, Integer.MAX_VALUE
+         * expected results: IllegalArgumentException should be thrown
+         */
+        System.out.print("\ttest 06: ");
+        dlg = new Dialog(new Frame());
+        title = "Title";
+        int[] modes = {Integer.MIN_VALUE, Integer.MIN_VALUE+1,
+                       Integer.MAX_VALUE-1, Integer.MAX_VALUE};
+        passed = true;
+        for (int i = 0; i < modes.length; i++) {
+            try {
+                fdialog = new FileDialog(dlg, title, modes[i]);
+                passed = false;
+            } catch (IllegalArgumentException e) {}
+        }
+        System.out.println(passed ? "passed" : "FAILED");
+        if (!passed) {
+            errors.append(nl);
+            errors.append("DialogAsParentOfFileDialog FAILED");
+        }
+
+        if (!errors.isEmpty()) {
+            throw new RuntimeException("Following tests failed:" + errors);
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+            new DialogAsParentOfFileDialog().start();
+        });
+    }
+}


### PR DESCRIPTION
Cleaning up and open sourcing three AWT tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306135](https://bugs.openjdk.org/browse/JDK-8306135): Clean up and open source some AWT tests


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13518/head:pull/13518` \
`$ git checkout pull/13518`

Update a local copy of the PR: \
`$ git checkout pull/13518` \
`$ git pull https://git.openjdk.org/jdk.git pull/13518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13518`

View PR using the GUI difftool: \
`$ git pr show -t 13518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13518.diff">https://git.openjdk.org/jdk/pull/13518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13518#issuecomment-1513661787)