### PR TITLE
8306408: Fix the format of several tables in building.md

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -353,22 +353,22 @@ to date at the time of writing.</p>
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Operating system</th>
-<th style="text-align: left;">Vendor/version used</th>
+<th>Operating system</th>
+<th>Vendor/version used</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">Linux</td>
-<td style="text-align: left;">Oracle Enterprise Linux 6.4 / 7.6</td>
+<td>Linux</td>
+<td>Oracle Enterprise Linux 6.4 / 7.6</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">macOS</td>
-<td style="text-align: left;">Mac OS X 10.13 (High Sierra)</td>
+<td>macOS</td>
+<td>Mac OS X 10.13 (High Sierra)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">Windows</td>
-<td style="text-align: left;">Windows Server 2012 R2</td>
+<td>Windows</td>
+<td>Windows Server 2012 R2</td>
 </tr>
 </tbody>
 </table>

--- a/doc/building.html
+++ b/doc/building.html
@@ -1195,27 +1195,27 @@ following targets are known to work:</p>
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Supported devkit targets</th>
+<th>Supported devkit targets</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">x86_64-linux-gnu</td>
+<td>x86_64-linux-gnu</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">aarch64-linux-gnu</td>
+<td>aarch64-linux-gnu</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">arm-linux-gnueabihf</td>
+<td>arm-linux-gnueabihf</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64-linux-gnu</td>
+<td>ppc64-linux-gnu</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">ppc64le-linux-gnu</td>
+<td>ppc64le-linux-gnu</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">s390x-linux-gnu</td>
+<td>s390x-linux-gnu</td>
 </tr>
 </tbody>
 </table>
@@ -1417,112 +1417,119 @@ example <code>${sysroot}/usr/lib/${target}/</code></p></li>
 <p>Architectures that are known to successfully cross-compile like this
 are:</p>
 <table>
+<colgroup>
+<col style="width: 13%" />
+<col style="width: 13%" />
+<col style="width: 15%" />
+<col style="width: 27%" />
+<col style="width: 29%" />
+</colgroup>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Target</th>
-<th style="text-align: left;">Debian tree</th>
-<th style="text-align: left;">Debian arch</th>
-<th style="text-align: left;"><code>--openjdk-target=...</code></th>
+<th>Target</th>
+<th>Debian tree</th>
+<th>Debian arch</th>
+<th><code>--openjdk-target=...</code></th>
 <th><code>--with-jvm-variants=...</code></th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">x86</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">i386</td>
-<td style="text-align: left;">i386-linux-gnu</td>
+<td>x86</td>
+<td>buster</td>
+<td>i386</td>
+<td>i386-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">arm</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">armhf</td>
-<td style="text-align: left;">arm-linux-gnueabihf</td>
+<td>arm</td>
+<td>buster</td>
+<td>armhf</td>
+<td>arm-linux-gnueabihf</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">aarch64</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">arm64</td>
-<td style="text-align: left;">aarch64-linux-gnu</td>
+<td>aarch64</td>
+<td>buster</td>
+<td>arm64</td>
+<td>aarch64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64le</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">ppc64el</td>
-<td style="text-align: left;">powerpc64le-linux-gnu</td>
+<td>ppc64le</td>
+<td>buster</td>
+<td>ppc64el</td>
+<td>powerpc64le-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">s390x</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">s390x</td>
-<td style="text-align: left;">s390x-linux-gnu</td>
+<td>s390x</td>
+<td>buster</td>
+<td>s390x</td>
+<td>s390x-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">mipsle</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">mipsel</td>
-<td style="text-align: left;">mipsel-linux-gnu</td>
+<td>mipsle</td>
+<td>buster</td>
+<td>mipsel</td>
+<td>mipsel-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">mips64le</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">mips64el</td>
-<td style="text-align: left;">mips64el-linux-gnueabi64</td>
+<td>mips64le</td>
+<td>buster</td>
+<td>mips64el</td>
+<td>mips64el-linux-gnueabi64</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">armel</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">arm</td>
-<td style="text-align: left;">arm-linux-gnueabi</td>
+<td>armel</td>
+<td>buster</td>
+<td>arm</td>
+<td>arm-linux-gnueabi</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">ppc</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">powerpc</td>
-<td style="text-align: left;">powerpc-linux-gnu</td>
+<td>ppc</td>
+<td>sid</td>
+<td>powerpc</td>
+<td>powerpc-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64be</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">ppc64</td>
-<td style="text-align: left;">powerpc64-linux-gnu</td>
+<td>ppc64be</td>
+<td>sid</td>
+<td>ppc64</td>
+<td>powerpc64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">m68k</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">m68k</td>
-<td style="text-align: left;">m68k-linux-gnu</td>
+<td>m68k</td>
+<td>sid</td>
+<td>m68k</td>
+<td>m68k-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">alpha-linux-gnu</td>
+<td>alpha</td>
+<td>sid</td>
+<td>alpha</td>
+<td>alpha-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">sh4</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">sh4</td>
-<td style="text-align: left;">sh4-linux-gnu</td>
+<td>sh4</td>
+<td>sid</td>
+<td>sh4</td>
+<td>sh4-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">riscv64</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">riscv64</td>
-<td style="text-align: left;">riscv64-linux-gnu</td>
+<td>riscv64</td>
+<td>sid</td>
+<td>riscv64</td>
+<td>riscv64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 </tbody>

--- a/doc/building.md
+++ b/doc/building.md
@@ -162,11 +162,11 @@ This table lists the OS versions used by Oracle when building the JDK. Such
 information is always subject to change, but this table is up to date at the
 time of writing.
 
- Operating system   Vendor/version used
- -----------------  -------------------------------------------------------
- Linux              Oracle Enterprise Linux 6.4 / 7.6
- macOS              Mac OS X 10.13 (High Sierra)
- Windows            Windows Server 2012 R2
+| Operating system  | Vendor/version used                |
+| ----------------- | ---------------------------------- |
+| Linux             | Oracle Enterprise Linux 6.4 / 7.6  |
+| macOS             | Mac OS X 10.13 (High Sierra)       |
+| Windows           | Windows Server 2012 R2             |
 
 The double version numbers for Linux are due to the hybrid model
 used at Oracle, where header files and external libraries from an older version

--- a/doc/building.md
+++ b/doc/building.md
@@ -970,14 +970,14 @@ https://sourceware.org/autobook/autobook/autobook_17.html). If no
 targets are given, a native toolchain for the current platform will be
 created. Currently, at least the following targets are known to work:
 
- Supported devkit targets
- -------------------------
- x86_64-linux-gnu
- aarch64-linux-gnu
- arm-linux-gnueabihf
- ppc64-linux-gnu
- ppc64le-linux-gnu
- s390x-linux-gnu
+| Supported devkit targets |
+| ------------------------ |
+| x86_64-linux-gnu         |
+| aarch64-linux-gnu        |
+| arm-linux-gnueabihf      |
+| ppc64-linux-gnu          |
+| ppc64le-linux-gnu        |
+| s390x-linux-gnu          |
 
 `BASE_OS` must be one of "OEL6" for Oracle Enterprise Linux 6 or
 "Fedora" (if not specified "OEL6" will be the default). If the base OS
@@ -1204,22 +1204,22 @@ it might require a little nudge with:
 
 Architectures that are known to successfully cross-compile like this are:
 
-  Target        Debian tree  Debian arch   `--openjdk-target=...`   `--with-jvm-variants=...`
-  ------------  ------------ ------------- ------------------------ --------------
-  x86           buster       i386          i386-linux-gnu           (all)
-  arm           buster       armhf         arm-linux-gnueabihf      (all)
-  aarch64       buster       arm64         aarch64-linux-gnu        (all)
-  ppc64le       buster       ppc64el       powerpc64le-linux-gnu    (all)
-  s390x         buster       s390x         s390x-linux-gnu          (all)
-  mipsle        buster       mipsel        mipsel-linux-gnu         zero
-  mips64le      buster       mips64el      mips64el-linux-gnueabi64 zero
-  armel         buster       arm           arm-linux-gnueabi        zero
-  ppc           sid          powerpc       powerpc-linux-gnu        zero
-  ppc64be       sid          ppc64         powerpc64-linux-gnu      (all)
-  m68k          sid          m68k          m68k-linux-gnu           zero
-  alpha         sid          alpha         alpha-linux-gnu          zero
-  sh4           sid          sh4           sh4-linux-gnu            zero
-  riscv64       sid          riscv64       riscv64-linux-gnu        (all)
+| Target       | Debian tree  | Debian arch   | `--openjdk-target=...`   | `--with-jvm-variants=...` |
+| ------------ | ------------ | ------------- | ------------------------ | ------------------------- |
+| x86          | buster       | i386          | i386-linux-gnu           | (all)                     |
+| arm          | buster       | armhf         | arm-linux-gnueabihf      | (all)                     |
+| aarch64      | buster       | arm64         | aarch64-linux-gnu        | (all)                     |
+| ppc64le      | buster       | ppc64el       | powerpc64le-linux-gnu    | (all)                     |
+| s390x        | buster       | s390x         | s390x-linux-gnu          | (all)                     |
+| mipsle       | buster       | mipsel        | mipsel-linux-gnu         | zero                      |
+| mips64le     | buster       | mips64el      | mips64el-linux-gnueabi64 | zero                      |
+| armel        | buster       | arm           | arm-linux-gnueabi        | zero                      |
+| ppc          | sid          | powerpc       | powerpc-linux-gnu        | zero                      |
+| ppc64be      | sid          | ppc64         | powerpc64-linux-gnu      | (all)                     |
+| m68k         | sid          | m68k          | m68k-linux-gnu           | zero                      |
+| alpha        | sid          | alpha         | alpha-linux-gnu          | zero                      |
+| sh4          | sid          | sh4           | sh4-linux-gnu            | zero                      |
+| riscv64      | sid          | riscv64       | riscv64-linux-gnu        | (all)                     |
 
 ### Building for ARM/aarch64
 


### PR DESCRIPTION
Hi all,

Currently, the format of several tables in building.md looks a little 
problematic and will incorrectly display the split line. In contrast, the 
corresponding building.html will display the tables correctly.

This patch will only change building.md and the format of the tables 
will display correctly.

Please take a look and have some reviews. Thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306408](https://bugs.openjdk.org/browse/JDK-8306408): Fix the format of several tables in building.md


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13523/head:pull/13523` \
`$ git checkout pull/13523`

Update a local copy of the PR: \
`$ git checkout pull/13523` \
`$ git pull https://git.openjdk.org/jdk.git pull/13523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13523`

View PR using the GUI difftool: \
`$ git pr show -t 13523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13523.diff">https://git.openjdk.org/jdk/pull/13523.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13523#issuecomment-1514065009)