### PR TITLE
8305943: Open source few AWT Focus related tests

### DIFF
--- a/test/jdk/java/awt/Focus/NoFocusOwnerAWTTest.java
+++ b/test/jdk/java/awt/Focus/NoFocusOwnerAWTTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4390019
+  @summary REGRESSION: Alt-F4 keybinding no longer shuts down java application on Windows
+  @key headful
+  @requires (os.family == "windows")
+  @run main NoFocusOwnerAWTTest
+*/
+import java.awt.Frame;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Label;
+import java.awt.MenuBar;
+import java.awt.Menu;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowAdapter;
+
+public class NoFocusOwnerAWTTest {
+
+    static boolean actionFired = false;
+    static boolean closingWindowCalled = false;
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            if (!System.getProperty("os.name").startsWith("Windows")) {
+                // this test is Win32 test only
+                return;
+            }
+            EventQueue.invokeAndWait(() -> {
+
+                frame = new Frame("No Focus Owner AWT Test");
+                frame.addWindowListener(new WindowAdapter() {
+                    public void windowClosing(WindowEvent e) {
+                        System.out.println("windowClosing() is called.");
+                        closingWindowCalled = true;
+                    }
+                });
+                frame.addFocusListener(new FocusListener() {
+                    public void focusGained(FocusEvent fe) {
+                        System.out.println("focus gained on frame");
+                    }
+                    public void focusLost(FocusEvent fe) {
+                        System.out.println("focus lost on frame");
+                    }
+                });
+                MenuBar mb = new MenuBar();
+                Menu m = new Menu("This is Menu");
+                MenuItem mi = new MenuItem("Menu Item");
+                mi.setShortcut(new MenuShortcut(KeyEvent.VK_A));
+                mi.addActionListener( new ActionListener() {
+                    public void actionPerformed(ActionEvent ae) {
+                        System.out.println("action");
+                        actionFired = true;
+                    }
+                });
+                m.add(mi);
+                mb.add(m);
+                frame.setMenuBar(mb);
+                Label lb;
+                frame.add(lb = new Label("press"));
+                lb.addFocusListener(new FocusListener() {
+                    public void focusGained(FocusEvent fe) {
+                        System.out.println("focus gained on label");
+                    }
+                    public void focusLost(FocusEvent fe) {
+                        System.out.println("focus lost on label");
+                    }
+                });
+                frame.pack();
+                frame.toFront();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_A);
+            robot.waitForIdle();
+            robot.keyRelease(KeyEvent.VK_A);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_F4);
+            robot.waitForIdle();
+            robot.keyRelease(KeyEvent.VK_F4);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            if (!actionFired || !closingWindowCalled) {
+                throw new RuntimeException("Test FAILED(actionFired="+actionFired+
+                                       ";closingWindowCalled="+closingWindowCalled+")");
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+ }// class NoFocusOwnerAWTTest

--- a/test/jdk/java/awt/Focus/NoFocusOwnerSwingTest.java
+++ b/test/jdk/java/awt/Focus/NoFocusOwnerSwingTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4390019
+  @summary REGRESSION: Alt-F4 keybinding no longer shuts down java application on Windows
+  @key headful
+  @requires (os.family == "windows")
+  @run main NoFocusOwnerSwingTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Label;
+import java.awt.MenuBar;
+import java.awt.Menu;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowAdapter;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class NoFocusOwnerSwingTest {
+    static boolean closingWindowCalled = false;
+    static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            if (!System.getProperty("os.name").startsWith("Windows")) {
+                // this test is Win32 test only
+                return;
+            }
+
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("No Focus Owner Swing Test");
+                JButton btn;
+                frame.getContentPane().add(btn = new JButton("press"));
+                frame.addWindowListener(new WindowAdapter() {
+                    public void windowClosing(WindowEvent e) {
+                        System.out.println("windowClosing is called");
+                        closingWindowCalled = true;
+                    }
+                });
+                frame.pack();
+                frame.toFront();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_F4);
+            robot.waitForIdle();
+            robot.keyRelease(KeyEvent.VK_F4);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.waitForIdle();
+
+            if (!closingWindowCalled) {
+                throw new RuntimeException("Test FAILED(closingWindowCalled=" +
+                                         closingWindowCalled + ")");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}// class NoFocusOwnerSwingTest

--- a/test/jdk/java/awt/Focus/RestoreFocusInfiniteLoopTest.java
+++ b/test/jdk/java/awt/Focus/RestoreFocusInfiniteLoopTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4504665
+  @summary MerlinBeta2 - vetoing a focus change causes infinite loop
+  @key headful
+  @run main RestoreFocusInfiniteLoopTest
+*/
+
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.beans.VetoableChangeListener;
+
+public class RestoreFocusInfiniteLoopTest {
+    static final int TEST_TIMEOUT = 1000;
+    static final int DELAY = 100;
+    static Button b1;
+    static Frame frame;
+    static Object b1Monitor;
+    static Point origin;
+    static Dimension dim;
+    static MonitoredFocusListener monitorer;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+
+                b1Monitor = new Object();
+                frame = new Frame();
+                b1 = new Button("1");
+                Button b2 = new Button("2");
+                b1.setName("b1");
+                b2.setName("b2");
+
+                frame.setLayout(new FlowLayout());
+                frame.add(b1);
+                frame.add(b2);
+                frame.pack();
+                frame.setSize(100, 100);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                FocusVetoableChangeListener vetoer = new FocusVetoableChangeListener(b2);
+                KeyboardFocusManager.getCurrentKeyboardFocusManager().
+                    addVetoableChangeListener("focusOwner", vetoer);
+
+            });
+            Robot robot = new Robot();
+            robot.setAutoDelay(DELAY);
+            robot.setAutoWaitForIdle(true);
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                monitorer = new MonitoredFocusListener(b1Monitor);
+                b1.addFocusListener(monitorer);
+                origin = b1.getLocationOnScreen();
+                dim = b1.getSize();
+            });
+            robot.mouseMove((int)origin.getX() + (int)dim.getWidth()/2,
+                            (int)origin.getY() + (int)dim.getHeight()/2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (!b1.isFocusOwner()) {
+                synchronized (b1Monitor) {
+                    b1Monitor.wait(TEST_TIMEOUT);
+                }
+            }
+
+            monitorer.resetFocusLost();
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+
+            if (!monitorer.isFocusLostReceived() || !b1.isFocusOwner()) {
+               synchronized (b1Monitor) {
+                    b1Monitor.wait(TEST_TIMEOUT);
+                }
+            }
+            if (!b1.isFocusOwner()) {
+                throw new RuntimeException("Test is FAILED");
+            } else {
+                System.out.println("Test is PASSED");
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+ }// class RestoreFocusInfiniteLoopTest
+
+class FocusVetoableChangeListener implements VetoableChangeListener {
+    Component vetoedComponent;
+    public FocusVetoableChangeListener(Component vetoedComponent) {
+        this.vetoedComponent = vetoedComponent;
+    }
+    public void vetoableChange(PropertyChangeEvent evt)
+        throws PropertyVetoException
+    {
+        Component oldComp = (Component)evt.getOldValue();
+        Component newComp = (Component)evt.getNewValue();
+
+        boolean vetoFocusChange = (newComp == vetoedComponent);
+        process(evt.getPropertyName(), oldComp, newComp);
+
+        if (vetoFocusChange) {
+            throw new PropertyVetoException("message", evt);
+        }
+    }
+    boolean process(String propName, Component o1, Component o2) {
+        System.out.println(propName +
+                           " old=" + (o1 != null ? o1.getName() : "null") +
+                           " new=" + (o2 != null ? o2.getName() : "null"));
+            return true;
+        }
+    }
+
+class MonitoredFocusListener extends FocusAdapter {
+    Object monitor;
+    boolean focuslost = false;
+
+    public void resetFocusLost() {
+        focuslost = false;
+    }
+    public boolean isFocusLostReceived() {
+        return focuslost;
+    }
+    public MonitoredFocusListener(Object monitor) {
+        this.monitor = monitor;
+    }
+
+    public void focusLost(FocusEvent fe) {
+        System.out.println(fe.toString());
+        focuslost = true;
+    }
+    public void focusGained(FocusEvent fe) {
+        System.out.println(fe.toString());
+        synchronized (monitor) {
+            monitor.notify();
+        }
+    }
+}

--- a/test/jdk/java/awt/Focus/SequencedLightweightRequestsTest.java
+++ b/test/jdk/java/awt/Focus/SequencedLightweightRequestsTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4648816
+  @summary Sometimes focus requests on LW components are delayed
+  @key headful
+  @run main SequencedLightweightRequestsTest
+*/
+
+import java.awt.AWTException;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class SequencedLightweightRequestsTest implements FocusListener {
+    final int WAIT_TIME = 5000;
+
+    JFrame testFrame;
+    JButton testButton1;
+    JButton testButton2;
+    JTextField testField;
+
+    public void focusGained(FocusEvent fe) {
+        System.err.println("FocusGained on " + fe.getComponent().getName());
+    }
+
+    public void focusLost(FocusEvent fe) {
+        System.err.println("FocusLost on " + fe.getComponent().getName());
+    }
+
+    public static void main(String[] args) throws Exception {
+        SequencedLightweightRequestsTest test =
+            new SequencedLightweightRequestsTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+
+            SwingUtilities.invokeAndWait(() -> {
+                testFrame = new JFrame("See my components!");
+                testButton1 = new JButton("Click me!");
+                testButton2 = new JButton("Do I have focus?");
+                testField = new JTextField("Do I have focus?");
+                testFrame.getContentPane().setLayout(new FlowLayout());
+                testFrame.getContentPane().add(testButton1);
+                testFrame.getContentPane().add(testField);
+                testFrame.getContentPane().add(testButton2);
+
+                testButton1.setName("Button1");
+                testButton2.setName("Button2");
+                testField.setName("textField");
+                testButton1.addFocusListener(this);
+                testButton2.addFocusListener(this);
+                testField.addFocusListener(this);
+                testFrame.addFocusListener(this);
+
+                testFrame.setSize(300, 100);
+                testFrame.setLocationRelativeTo(null);
+                testFrame.setVisible(true);
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
+
+            // wait to give to frame time for showing
+            robot.delay(1000);
+
+            // make sure that first button has focus
+            Object monitor = new Object();
+            MonitoredFocusListener monitorer =
+                          new MonitoredFocusListener(monitor);
+            Point origin = testButton1.getLocationOnScreen();
+            Dimension dim = testButton1.getSize();
+            robot.mouseMove((int)origin.getX() + (int)dim.getWidth()/2,
+                            (int)origin.getY() + (int)dim.getHeight()/2);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+
+            if (!testButton1.isFocusOwner()) {
+                synchronized (monitor) {
+                    testButton1.addFocusListener(monitorer);
+                    monitor.wait(WAIT_TIME);
+                    testButton1.removeFocusListener(monitorer);
+                }
+            }
+
+            // if first button still doesn't have focus, test fails
+            if (!testButton1.isFocusOwner()) {
+                throw new RuntimeException("First button doesn't receive focus");
+            }
+
+            // two lightweight requests
+            java.awt.EventQueue.invokeAndWait(new Runnable() {
+                public void run() {
+                    testButton2.requestFocus();
+                    testField.requestFocus();
+                }
+            });
+
+            // make sure third button receives focus
+            if (!testField.isFocusOwner()) {
+                synchronized (monitor) {
+                    testField.addFocusListener(monitorer);
+                    monitor.wait(WAIT_TIME);
+                    testField.removeFocusListener(monitorer);
+                }
+            }
+
+            // if the text field still doesn't have focus, test fails
+            if (!testField.isFocusOwner()) {
+                throw new RuntimeException("Text field doesn't receive focus");
+            }
+            System.out.println("Test PASSED");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (testFrame != null) {
+                    testFrame.dispose();
+                }
+            });
+        }
+    }
+}// class SequencedLightweightRequestsTest
+
+class MonitoredFocusListener extends FocusAdapter {
+    Object monitor;
+
+    public MonitoredFocusListener(Object monitor) {
+        this.monitor = monitor;
+    }
+
+    public void focusGained(FocusEvent fe) {
+        synchronized (monitor) {
+            monitor.notify();
+        }
+    }
+}

--- a/test/jdk/java/awt/Focus/SetFocusableTest.java
+++ b/test/jdk/java/awt/Focus/SetFocusableTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4597455
+  @summary setFocusable(false) is not moving the focus to next Focusable Component
+  @key headful
+  @run main SetFocusableTest
+*/
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.TextField;
+
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+public class SetFocusableTest implements KeyListener {
+    static Object buttonMonitor;
+    Object tfMonitor;
+    static final int TEST_TIMEOUT = 5000;
+    Button button;
+    Frame frame;
+    TextField textfield;
+
+    public static void main(String[] args) throws Exception {
+        SetFocusableTest test = new SetFocusableTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                buttonMonitor = new Object();
+                tfMonitor = new Object();
+                frame = new Frame();
+                frame.setTitle("Test Frame");
+                frame.setLocation(100, 100);
+                frame.setLayout(new FlowLayout());
+
+                button = new Button("BUTTON");
+                textfield = new TextField("First");
+
+                button.addKeyListener(this);
+                textfield.addKeyListener(this);
+
+                frame.add(button);
+                frame.add(textfield);
+
+                frame.setBackground(Color.red);
+                frame.setSize(500,200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                frame.toFront();
+                button.addFocusListener(new MonitoredFocusListener(buttonMonitor));
+                textfield.addFocusListener(new MonitoredFocusListener(tfMonitor));
+            });
+
+            Robot robot;
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
+            robot.delay(1000);
+
+            Point buttonOrigin = button.getLocationOnScreen();
+            Dimension buttonSize = button.getSize();
+            robot.mouseMove(
+                (int)buttonOrigin.getX() + (int)buttonSize.getWidth() / 2,
+                (int)buttonOrigin.getY() + (int)buttonSize.getHeight() / 2);
+
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (!button.isFocusOwner()) {
+                synchronized (buttonMonitor) {
+                    buttonMonitor.wait(TEST_TIMEOUT);
+                }
+            }
+            System.out.println("\n\nBefore calling the method button.setFocusable(false)");
+            System.out.println("====================================================");
+            System.out.println("Button is Focusable(button.isFocusable()) :"+button.isFocusable());
+            System.out.println("Button is Focus owner(button.isFocusOwner()) :"+button.isFocusOwner());
+            System.out.println("Button has Focus (button.hasFocus) :"+button.hasFocus());
+            System.out.println("====================================================");
+
+            button.setFocusable(false);
+
+            if (!textfield.isFocusOwner()) {
+                synchronized (tfMonitor) {
+                    tfMonitor.wait(TEST_TIMEOUT);
+                }
+            }
+
+            System.out.println("\nAfter Calling button.setFocusable(false)");
+            System.out.println("====================================================");
+            System.out.println("Button is Focusable(button.isFocusable()) :"+button.isFocusable());
+            System.out.println("Button is Focus owner(button.isFocusOwner()) :"+button.isFocusOwner());
+            System.out.println("Button has Focus (button.hasFocus()) :"+button.hasFocus());
+            System.out.println("TextField is Focusable(textfield.isFocusable()) :"+textfield.isFocusable());
+            System.out.println("TextField is Focus owner(textfield.isFocusOwner()) :"+textfield.isFocusOwner());
+            System.out.println("TextField has Focus (textfield.hasFocus()) :"+textfield.hasFocus());
+            System.out.println("====================================================n\n\n\n");
+
+            if (!button.hasFocus() && !button.isFocusOwner() &&
+                textfield.hasFocus() && textfield.isFocusOwner()){
+                System.out.println("\n\n\nASSERTION :PASSED");
+                System.out.println("=========================");
+                System.out.println("Textfield is having the Focus.Transfer of Focus has happend.");
+            } else {
+                System.out.println("\n\n\nASSERTION :FAILED");
+                System.out.println("==========================");
+                System.out.println("Button is still having the Focus instead of TextField");
+                throw new RuntimeException("Test FIALED");
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }// start()
+
+    public void keyPressed(KeyEvent e) {
+        System.out.println("Key Pressed ");
+    }
+    public void keyReleased(KeyEvent ke) {
+        System.out.println("keyReleased called ");
+    }
+    public void keyTyped(KeyEvent ke) {
+        System.out.println("keyTyped called ");
+    }
+}// class SetFocusableTest
+
+class MonitoredFocusListener extends FocusAdapter {
+    Object monitor;
+    public MonitoredFocusListener(Object monitor) {
+        this.monitor = monitor;
+    }
+
+    public void focusGained(FocusEvent fe) {
+        System.out.println(fe.toString());
+        synchronized (monitor) {
+            monitor.notify();
+        }
+    }
+}


### PR DESCRIPTION
This opensources few AWT Focus related tests.
CI runs are ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305943](https://bugs.openjdk.org/browse/JDK-8305943): Open source few AWT Focus related tests


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13525/head:pull/13525` \
`$ git checkout pull/13525`

Update a local copy of the PR: \
`$ git checkout pull/13525` \
`$ git pull https://git.openjdk.org/jdk.git pull/13525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13525`

View PR using the GUI difftool: \
`$ git pr show -t 13525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13525.diff">https://git.openjdk.org/jdk/pull/13525.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13525#issuecomment-1514269351)