### PR TITLE
JDK-8304291: [AIX] Broken build after JDK-8301998

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-algs.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-algs.hh
@@ -875,7 +875,8 @@ hb_in_ranges (T u, T lo1, T hi1, Ts... ds)
 static inline bool
 hb_unsigned_mul_overflows (unsigned int count, unsigned int size, unsigned *result = nullptr)
 {
-#if (defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && (__clang_major__ >= 8))
+/* avoid with xlc16 clang on AIX; it sets the gcc macros */
+#if (defined(__GNUC__) && !defined(AIX) && (__GNUC__ >= 4)) || (defined(__clang__) && (__clang_major__ >= 8))
   unsigned stack_result;
   if (!result)
     result = &stack_result;

--- a/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
+++ b/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
@@ -43,7 +43,11 @@
 #include "OT/Color/sbix/sbix.hh"
 #include "hb-ot-os2-table.hh"
 #include "hb-ot-post-table.hh"
+
+#if !defined(AIX)
 #include "hb-ot-post-table-v2subset.hh"
+#endif
+
 #include "hb-ot-cff1-table.hh"
 #include "hb-ot-cff2-table.hh"
 #include "hb-ot-vorg-table.hh"


### PR DESCRIPTION
After the latest harfbuzz update, the AIX build is broken.  The old clang compiler from xlc16 does not compile harfbuzz correctly.
First issue in hb-algs.hh is that xlc16 clang still sets some GNUC-related macros, so we do not run into the  `__clang_major__ >= 8`  check that should prevent to try to compile  `__builtin_mul_overflow`   with ancient clang.
The other issue in  `hb-subset.cc`  is a bit tricky and has been observed as well on macOS when very old clang versions were used.

Probably we can get rid of those 2 workarounds in some months after switching to xlc17 which includes a rather new clang version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304291](https://bugs.openjdk.org/browse/JDK-8304291): [AIX] Broken build after JDK-8301998


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13529/head:pull/13529` \
`$ git checkout pull/13529`

Update a local copy of the PR: \
`$ git checkout pull/13529` \
`$ git pull https://git.openjdk.org/jdk.git pull/13529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13529`

View PR using the GUI difftool: \
`$ git pr show -t 13529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13529.diff">https://git.openjdk.org/jdk/pull/13529.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13529#issuecomment-1514519270)