### PR TITLE
8306440: Rename PSS:_num_optional_regions to _max_num_optional_regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -83,7 +83,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _partial_objarray_chunk_size(ParGCArrayScanChunk),
     _partial_array_stepper(num_workers),
     _string_dedup_requests(),
-    _num_optional_regions(optional_cset_length),
+    _num_initial_optional_regions(optional_cset_length),
     _numa(g1h->numa()),
     _obj_alloc_stat(NULL),
     EVAC_FAILURE_INJECTOR_ONLY(_evac_failure_inject_counter(0) COMMA)
@@ -106,7 +106,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
 
   _closures = G1EvacuationRootClosures::create_root_closures(this, _g1h);
 
-  _oops_into_optional_regions = new G1OopStarChunkedList[_num_optional_regions];
+  _oops_into_optional_regions = new G1OopStarChunkedList[_num_initial_optional_regions];
 
   initialize_numa_stats();
 }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -83,7 +83,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _partial_objarray_chunk_size(ParGCArrayScanChunk),
     _partial_array_stepper(num_workers),
     _string_dedup_requests(),
-    _num_initial_optional_regions(optional_cset_length),
+    _max_num_optional_regions(optional_cset_length),
     _numa(g1h->numa()),
     _obj_alloc_stat(NULL),
     EVAC_FAILURE_INJECTOR_ONLY(_evac_failure_inject_counter(0) COMMA)
@@ -106,7 +106,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
 
   _closures = G1EvacuationRootClosures::create_root_closures(this, _g1h);
 
-  _oops_into_optional_regions = new G1OopStarChunkedList[_num_initial_optional_regions];
+  _oops_into_optional_regions = new G1OopStarChunkedList[_max_num_optional_regions];
 
   initialize_numa_stats();
 }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -92,8 +92,8 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
 
   G1CardTable* ct() { return _ct; }
 
-  // Number of optional regions at start of gc.
-  size_t _num_initial_optional_regions;
+  // Maximum number of optional regions at start of gc.
+  size_t _max_num_optional_regions;
   G1OopStarChunkedList* _oops_into_optional_regions;
 
   G1NUMA* _numa;

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -92,7 +92,8 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
 
   G1CardTable* ct() { return _ct; }
 
-  size_t _num_optional_regions;
+  // Number of optional regions at start of gc.
+  size_t _num_initial_optional_regions;
   G1OopStarChunkedList* _oops_into_optional_regions;
 
   G1NUMA* _numa;

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -74,8 +74,8 @@ template <typename T>
 inline void G1ParScanThreadState::remember_root_into_optional_region(T* p) {
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
-  assert(index < _num_initial_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _num_initial_optional_regions);
+  assert(index < _max_num_optional_regions,
+         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _max_num_optional_regions);
   _oops_into_optional_regions[index].push_root(p);
 }
 
@@ -83,16 +83,16 @@ template <typename T>
 inline void G1ParScanThreadState::remember_reference_into_optional_region(T* p) {
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
-  assert(index < _num_initial_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _num_initial_optional_regions);
+  assert(index < _max_num_optional_regions,
+         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _max_num_optional_regions);
   _oops_into_optional_regions[index].push_oop(p);
   verify_task(p);
 }
 
 G1OopStarChunkedList* G1ParScanThreadState::oops_into_optional_region(const HeapRegion* hr) {
-  assert(hr->index_in_opt_cset() < _num_initial_optional_regions,
+  assert(hr->index_in_opt_cset() < _max_num_optional_regions,
          "Trying to access optional region idx %u beyond " SIZE_FORMAT " " HR_FORMAT,
-         hr->index_in_opt_cset(), _num_initial_optional_regions, HR_FORMAT_PARAMS(hr));
+         hr->index_in_opt_cset(), _max_num_optional_regions, HR_FORMAT_PARAMS(hr));
   return &_oops_into_optional_regions[hr->index_in_opt_cset()];
 }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -74,8 +74,8 @@ template <typename T>
 inline void G1ParScanThreadState::remember_root_into_optional_region(T* p) {
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
-  assert(index < _num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _num_optional_regions);
+  assert(index < _num_initial_optional_regions,
+         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _num_initial_optional_regions);
   _oops_into_optional_regions[index].push_root(p);
 }
 
@@ -83,16 +83,16 @@ template <typename T>
 inline void G1ParScanThreadState::remember_reference_into_optional_region(T* p) {
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
-  assert(index < _num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _num_optional_regions);
+  assert(index < _num_initial_optional_regions,
+         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _num_initial_optional_regions);
   _oops_into_optional_regions[index].push_oop(p);
   verify_task(p);
 }
 
 G1OopStarChunkedList* G1ParScanThreadState::oops_into_optional_region(const HeapRegion* hr) {
-  assert(hr->index_in_opt_cset() < _num_optional_regions,
+  assert(hr->index_in_opt_cset() < _num_initial_optional_regions,
          "Trying to access optional region idx %u beyond " SIZE_FORMAT " " HR_FORMAT,
-         hr->index_in_opt_cset(), _num_optional_regions, HR_FORMAT_PARAMS(hr));
+         hr->index_in_opt_cset(), _num_initial_optional_regions, HR_FORMAT_PARAMS(hr));
   return &_oops_into_optional_regions[hr->index_in_opt_cset()];
 }
 


### PR DESCRIPTION
Hi all,

   please review this small change that clarifies the use of `PSS::_num_optional_regions` to be the initial amount of optional regions, not the current amount of optional regions.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306440](https://bugs.openjdk.org/browse/JDK-8306440): Rename PSS:_num_optional_regions to _max_num_optional_regions


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [aa346ef9](https://git.openjdk.org/jdk/pull/13532/files/aa346ef9ecb97524d66f165a3aa9a75d09185654)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13532/head:pull/13532` \
`$ git checkout pull/13532`

Update a local copy of the PR: \
`$ git checkout pull/13532` \
`$ git pull https://git.openjdk.org/jdk.git pull/13532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13532`

View PR using the GUI difftool: \
`$ git pr show -t 13532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13532.diff">https://git.openjdk.org/jdk/pull/13532.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13532#issuecomment-1514561171)