### PR TITLE
8306452: Fix Amazon copyright in JDK-8305425 test

### DIFF
--- a/test/jdk/java/lang/Thread/IsAlive.java
+++ b/test/jdk/java/lang/Thread/IsAlive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Someone^W I did commit a test in the OpenJDK repo that has Amazon copyright notice in the form that is not inline with the preferred one (intentionally without copyright year):

"Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."

These should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306452](https://bugs.openjdk.org/browse/JDK-8306452): Fix Amazon copyright in JDK-8305425 test


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13534/head:pull/13534` \
`$ git checkout pull/13534`

Update a local copy of the PR: \
`$ git checkout pull/13534` \
`$ git pull https://git.openjdk.org/jdk.git pull/13534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13534`

View PR using the GUI difftool: \
`$ git pr show -t 13534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13534.diff">https://git.openjdk.org/jdk/pull/13534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13534#issuecomment-1514799281)