### PR TITLE
8306459: s390x: Replace NULL to nullptr

### DIFF
--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -3155,7 +3155,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // nmethod entry barriers for concurrent class unloading
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-    if (bs_nm != NULL) {
+    if (bs_nm != nullptr) {
       StubRoutines::zarch::_nmethod_entry_barrier = generate_nmethod_entry_barrier();
     }
 

--- a/src/hotspot/cpu/s390/templateTable_s390.cpp
+++ b/src/hotspot/cpu/s390/templateTable_s390.cpp
@@ -2425,7 +2425,7 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   __ load_resolved_indy_entry(cache, index);
   __ z_lg(method, Address(cache, in_bytes(ResolvedIndyEntry::method_offset())));
 
-  // The invokedynamic is unresolved iff method is NULL
+  // The invokedynamic is unresolved iff method is null
   __ z_clgij(method, (unsigned long)nullptr, Assembler::bcondNotEqual, resolved); // method != 0, jump to resolved
   Bytecodes::Code code = bytecode();
   // Call to the interpreter runtime to resolve invokedynamic


### PR DESCRIPTION
This PR changes two occurrences of NULL to null & nullptr. It is a trivial change OR probably we can say some left out from #12325.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306459](https://bugs.openjdk.org/browse/JDK-8306459): s390x: Replace NULL to nullptr


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13538/head:pull/13538` \
`$ git checkout pull/13538`

Update a local copy of the PR: \
`$ git checkout pull/13538` \
`$ git pull https://git.openjdk.org/jdk.git pull/13538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13538`

View PR using the GUI difftool: \
`$ git pr show -t 13538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13538.diff">https://git.openjdk.org/jdk/pull/13538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13538#issuecomment-1514998802)