### PR TITLE
JDK-8306462: Remove NMT gtests that test dead-block-printing

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -64,32 +64,6 @@ static void test_for_live_c_heap_block(size_t sz, ssize_t offset) {
   FREE_C_HEAP_ARRAY(char, c);
 }
 
-static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
-  if (!MemTracker::enabled()) {
-    return;
-  }
-  char* c = NEW_C_HEAP_ARRAY(char, sz, mtTest);
-  LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), sz);
-  memset(c, 0, sz);
-  // We cannot just free the allocation to try dead block printing, since the memory
-  // may be immediately reused by concurrent code. Instead, we mark the block as dead
-  // manually, and revert that before freeing it.
-  MallocHeader* const hdr = MallocHeader::resolve_checked(c);
-  hdr->mark_block_as_dead();
-
-  const char* expected_string = "into dead malloced block";
-  if (offset < 0) {
-    expected_string = "into header of dead malloced block";
-  } else if ((size_t)offset >= sz) {
-    expected_string = "just outside of dead malloced block";
-  }
-
-  test_pointer(c + offset, true, expected_string);
-
-  hdr->revive();
-  FREE_C_HEAP_ARRAY(char, c);
-}
-
 TEST_VM(NMT, location_printing_cheap_live_1) { test_for_live_c_heap_block(2 * K, 0); }              // start of payload
 TEST_VM(NMT, location_printing_cheap_live_2) { test_for_live_c_heap_block(2 * K, -7); }             // into header
 TEST_VM(NMT, location_printing_cheap_live_3) { test_for_live_c_heap_block(2 * K, K + 1); }          // into payload
@@ -97,16 +71,6 @@ TEST_VM(NMT, location_printing_cheap_live_4) { test_for_live_c_heap_block(2 * K,
 TEST_VM(NMT, location_printing_cheap_live_5) { test_for_live_c_heap_block(2 * K + 1, 2 * K + 2); }  // just outside payload
 TEST_VM(NMT, location_printing_cheap_live_6) { test_for_live_c_heap_block(4, 0); }                  // into a very small block
 TEST_VM(NMT, location_printing_cheap_live_7) { test_for_live_c_heap_block(4, 4); }                  // just outside a very small block
-
-#ifdef LINUX
-TEST_VM(NMT, location_printing_cheap_dead_1) { test_for_dead_c_heap_block(2 * K, 0); }              // start of payload
-TEST_VM(NMT, location_printing_cheap_dead_2) { test_for_dead_c_heap_block(2 * K, -7); }             // into header
-TEST_VM(NMT, location_printing_cheap_dead_3) { test_for_dead_c_heap_block(2 * K, K + 1); }          // into payload
-TEST_VM(NMT, location_printing_cheap_dead_4) { test_for_dead_c_heap_block(2 * K, K + 2); }          // into payload (check for even/odd errors)
-TEST_VM(NMT, location_printing_cheap_dead_5) { test_for_dead_c_heap_block(2 * K + 1, 2 * K + 2); }  // just outside payload
-TEST_VM(NMT, location_printing_cheap_dead_6) { test_for_dead_c_heap_block(4, 0); }                  // into a very small block
-TEST_VM(NMT, location_printing_cheap_dead_7) { test_for_dead_c_heap_block(4, 4); }                  // just outside a very small block
-#endif
 
 static void test_for_mmap(size_t sz, ssize_t offset) {
   char* addr = os::reserve_memory(sz, false, mtTest);


### PR DESCRIPTION
[JDK-8304815](https://bugs.openjdk.org/browse/JDK-8304815) introduced using NMT for more precise hs_err file printing. It came with gtests that test correct live- and dead-block printing.

Live/dead-block printing: given a pointer into or very nearby live/dead malloced block, it tests that the printout identifies that block correctly.

Unfortunately, the dead-block-printing tests are prone to intermittent errors, typically on platforms I don't own and cannot test. These tests are not worth the maintenance burden and should just be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306462](https://bugs.openjdk.org/browse/JDK-8306462): Remove NMT gtests that test dead-block-printing


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13539/head:pull/13539` \
`$ git checkout pull/13539`

Update a local copy of the PR: \
`$ git checkout pull/13539` \
`$ git pull https://git.openjdk.org/jdk.git pull/13539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13539`

View PR using the GUI difftool: \
`$ git pr show -t 13539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13539.diff">https://git.openjdk.org/jdk/pull/13539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13539#issuecomment-1515726297)