### PR TITLE
8306461: ObjectInputStream::readObject() should handle negative array sizes without throwing NegativeArraySizeExceptions

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2138,7 +2138,9 @@ public class ObjectInputStream
 
         ObjectStreamClass desc = readClassDesc(false);
         int len = bin.readInt();
-
+        if (len < 0) {
+            throw new InvalidClassException(desc.getName(), "Array length < 0 (" + len + ")");
+        }
         filterCheck(desc.forClass(), len);
 
         Object array = null;

--- a/test/jdk/java/io/ObjectInputStream/NegativeArraySizeTest.java
+++ b/test/jdk/java/io/ObjectInputStream/NegativeArraySizeTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8306461
+ * @summary ObjectInputStream::readObject() should handle negative array sizes without throwing NegativeArraySizeExceptions
+ * @run main/othervm NegativeArraySizeTest
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidClassException;
+import java.io.IOException;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputFilter.Status;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+
+public class NegativeArraySizeTest {
+
+    private static byte[] _buildPayload() throws IOException {
+        String[] simpleArray = new String[1];
+
+        // Serialize to bytes
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(simpleArray);
+        oos.close();
+        byte[] serializedData = baos.toByteArray();
+
+        // Find the right location to modify, looking for the first instance of TC_ENDBLOCKDATA
+        int firstPos = 0;
+        for (int i=0; i<serializedData.length-1; i++) {
+            // 0x78 = TC_ENDBLOCKDATA
+            if (serializedData[i] == 0x78) {
+                firstPos = i;
+                break;
+            }
+        }
+
+        // Replace array length with -2
+        serializedData[firstPos+2] = (byte) 0xff;
+        serializedData[firstPos+3] = (byte) 0xff;
+        serializedData[firstPos+4] = (byte) 0xff;
+        serializedData[firstPos+5] = (byte) 0xfe;
+
+        return  serializedData;
+    }
+
+    public static void test_simpleArray_negative() throws IOException, ClassNotFoundException {
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(_buildPayload()));
+        ois.readObject();
+    }
+
+    public static void test_simpleArray_negative_with_filter() throws IOException, ClassNotFoundException {
+        class CustomFilter implements ObjectInputFilter {
+            @Override
+            public Status checkInput(FilterInfo filterInfo) {
+                Class<?> cl = filterInfo.serialClass();
+                if (cl != null && cl.isArray() && filterInfo.arrayLength() < -1) {
+                    throw new RuntimeException("FilterInfo.arrayLength() must be >= -1 for arrays (was " + filterInfo.arrayLength() + ")");
+                }
+                return Status.ALLOWED;
+            }
+        }
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(_buildPayload()));
+        ois.setObjectInputFilter(new CustomFilter());
+        ois.readObject();
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            test_simpleArray_negative();
+        } catch (NegativeArraySizeException nase) {
+            throw new Exception("ObjectInputStream::readObject() shouldn't throw a NegativeArraySizeException", nase);
+        } catch (ObjectStreamException ose) {
+            // OK, because a NegativeArraySizeException should be converted into a ObjectStreamException
+        }
+        try {
+            test_simpleArray_negative_with_filter();
+        } catch (NegativeArraySizeException nase) {
+            throw new Exception("ObjectInputStream::readObject() shouldn't throw a NegativeArraySizeException", nase);
+        } catch (ObjectStreamException ose) {
+            if (ose instanceof InvalidClassException ice && ice.getMessage().contains("filter status: REJECTED")) {
+                throw new Exception("ObjectInputStream::readObject() should catch NegativeArraySizeExceptions before filtering", ice);
+            }
+            // OK, because a NegativeArraySizeException should be converted into a ObjectStreamException *before* filtering
+        }
+    }
+}


### PR DESCRIPTION
This issue was reported by: Yakov Shafranovich ([yakovsh@amazon.com](mailto:yakovsh@amazon.com))

Currently, `ObjectInputStream::readObject()` doesn't explicitly checks for a negative array length in the deserialization stream. Instead it calls `j.l.r.Array::newInstance(..)` with the negative length which results in a `NegativeArraySizeException`. NegativeArraySizeException is an unchecked exception which is neither declared in the signature of `ObjectInputStream::readObject()` nor mentioned in its API specification. It is therefore not obvious for users of `ObjectInputStream::readObject()` that they may have to handle `NegativeArraySizeException`s. It would therefor be better if a negative array length in the deserialization stream would be automatically wrapped in an `InvalidClassException` which is a checked exception (derived from `IOException` via `ObjectStreamException`) and declared in the signature of `ObjectInputStream::readObject()`.

If we do the negative array length check in `ObjectInputStream::readObject()` before filtering, this will then also fix `ObjectInputFilter.FilterInfo::arrayLength()` which is defined as:
```
Returns:
the non-negative number of array elements when deserializing an array of the class, otherwise -1
```
but currently returns a negative value if the array length is negative.