### PR TITLE
8306482: Remove unused Method AccessFlags

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2089,8 +2089,6 @@
   declare_constant(JVM_ACC_LOOPS_FLAG_INIT)                               \
   declare_constant(JVM_ACC_QUEUED)                                        \
   declare_constant(JVM_ACC_NOT_C2_OSR_COMPILABLE)                         \
-  declare_constant(JVM_ACC_HAS_LINE_NUMBER_TABLE)                         \
-  declare_constant(JVM_ACC_HAS_CHECKED_EXCEPTIONS)                        \
   declare_constant(JVM_ACC_HAS_JSRS)                                      \
   declare_constant(JVM_ACC_IS_OLD)                                        \
   declare_constant(JVM_ACC_IS_OBSOLETE)                                   \
@@ -2099,7 +2097,6 @@
   declare_constant(JVM_ACC_HAS_VANILLA_CONSTRUCTOR)                       \
   declare_constant(JVM_ACC_HAS_FINALIZER)                                 \
   declare_constant(JVM_ACC_IS_CLONEABLE_FAST)                             \
-  declare_constant(JVM_ACC_HAS_LOCAL_VARIABLE_TABLE)                      \
                                                                           \
   declare_constant(JVM_CONSTANT_Utf8)                                     \
   declare_constant(JVM_CONSTANT_Unicode)                                  \

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -51,8 +51,6 @@ enum {
   JVM_ACC_NOT_C2_COMPILABLE       = 0x02000000,
   JVM_ACC_NOT_C1_COMPILABLE       = 0x04000000,
   JVM_ACC_NOT_C2_OSR_COMPILABLE   = 0x08000000,
-  JVM_ACC_HAS_LINE_NUMBER_TABLE   = 0x00100000,
-  JVM_ACC_HAS_CHECKED_EXCEPTIONS  = 0x00400000,
   JVM_ACC_HAS_JSRS                = 0x00800000,
   JVM_ACC_IS_OLD                  = 0x00010000,     // RedefineClasses() has replaced this method
   JVM_ACC_IS_OBSOLETE             = 0x00020000,     // RedefineClasses() has made method obsolete
@@ -68,9 +66,6 @@ enum {
   JVM_ACC_HAS_FINAL_METHOD        = 0x01000000,     // True if klass has final method
   JVM_ACC_IS_HIDDEN_CLASS         = 0x04000000,     // True if klass is hidden
   JVM_ACC_IS_VALUE_BASED_CLASS    = 0x08000000,     // True if klass is marked as a ValueBased class
-
-  // Method* flags
-  JVM_ACC_HAS_LOCAL_VARIABLE_TABLE= 0x00400000,
 };
 
 
@@ -109,8 +104,6 @@ class AccessFlags {
   bool is_not_c1_compilable    () const { return (_flags & JVM_ACC_NOT_C1_COMPILABLE      ) != 0; }
   bool is_not_c2_compilable    () const { return (_flags & JVM_ACC_NOT_C2_COMPILABLE      ) != 0; }
   bool is_not_c2_osr_compilable() const { return (_flags & JVM_ACC_NOT_C2_OSR_COMPILABLE  ) != 0; }
-  bool has_linenumber_table    () const { return (_flags & JVM_ACC_HAS_LINE_NUMBER_TABLE  ) != 0; }
-  bool has_checked_exceptions  () const { return (_flags & JVM_ACC_HAS_CHECKED_EXCEPTIONS ) != 0; }
   bool has_jsrs                () const { return (_flags & JVM_ACC_HAS_JSRS               ) != 0; }
   bool is_old                  () const { return (_flags & JVM_ACC_IS_OLD                 ) != 0; }
   bool is_obsolete             () const { return (_flags & JVM_ACC_IS_OBSOLETE            ) != 0; }
@@ -125,11 +118,6 @@ class AccessFlags {
   bool is_cloneable_fast       () const { return (_flags & JVM_ACC_IS_CLONEABLE_FAST      ) != 0; }
   bool is_hidden_class         () const { return (_flags & JVM_ACC_IS_HIDDEN_CLASS        ) != 0; }
   bool is_value_based_class    () const { return (_flags & JVM_ACC_IS_VALUE_BASED_CLASS   ) != 0; }
-
-  // Method* flags
-  bool has_localvariable_table () const { return (_flags & JVM_ACC_HAS_LOCAL_VARIABLE_TABLE) != 0; }
-  void set_has_localvariable_table()    { atomic_set_bits(JVM_ACC_HAS_LOCAL_VARIABLE_TABLE); }
-  void clear_has_localvariable_table()  { atomic_clear_bits(JVM_ACC_HAS_LOCAL_VARIABLE_TABLE); }
 
   bool on_stack() const                 { return (_flags & JVM_ACC_ON_STACK) != 0; }
 
@@ -168,8 +156,6 @@ class AccessFlags {
   void set_not_c1_compilable()         { atomic_set_bits(JVM_ACC_NOT_C1_COMPILABLE);       }
   void set_not_c2_compilable()         { atomic_set_bits(JVM_ACC_NOT_C2_COMPILABLE);       }
   void set_not_c2_osr_compilable()     { atomic_set_bits(JVM_ACC_NOT_C2_OSR_COMPILABLE);   }
-  void set_has_linenumber_table()      { atomic_set_bits(JVM_ACC_HAS_LINE_NUMBER_TABLE);   }
-  void set_has_checked_exceptions()    { atomic_set_bits(JVM_ACC_HAS_CHECKED_EXCEPTIONS);  }
   void set_has_jsrs()                  { atomic_set_bits(JVM_ACC_HAS_JSRS);                }
   void set_is_old()                    { atomic_set_bits(JVM_ACC_IS_OLD);                  }
   void set_is_obsolete()               { atomic_set_bits(JVM_ACC_IS_OBSOLETE);             }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/AccessFlags.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/AccessFlags.java
@@ -64,8 +64,6 @@ public class AccessFlags implements /* imports */ ClassConstants {
   public boolean loopsFlagInit       () { return (flags & JVM_ACC_LOOPS_FLAG_INIT        ) != 0; }
   public boolean queuedForCompilation() { return (flags & JVM_ACC_QUEUED                 ) != 0; }
   public boolean isNotOsrCompilable  () { return (flags & JVM_ACC_NOT_OSR_COMPILABLE     ) != 0; }
-  public boolean hasLineNumberTable  () { return (flags & JVM_ACC_HAS_LINE_NUMBER_TABLE  ) != 0; }
-  public boolean hasCheckedExceptions() { return (flags & JVM_ACC_HAS_CHECKED_EXCEPTIONS ) != 0; }
   public boolean hasJsrs             () { return (flags & JVM_ACC_HAS_JSRS               ) != 0; }
   public boolean isObsolete          () { return (flags & JVM_ACC_IS_OBSOLETE            ) != 0; }
 
@@ -74,9 +72,6 @@ public class AccessFlags implements /* imports */ ClassConstants {
   public boolean hasVanillaConstructor() { return (flags & JVM_ACC_HAS_VANILLA_CONSTRUCTOR) != 0; }
   public boolean hasFinalizer         () { return (flags & JVM_ACC_HAS_FINALIZER          ) != 0; }
   public boolean isCloneable          () { return (flags & JVM_ACC_IS_CLONEABLE           ) != 0; }
-
-  // Klass* and Method* flags
-  public boolean hasLocalVariableTable() { return (flags & JVM_ACC_HAS_LOCAL_VARIABLE_TABLE ) != 0; }
 
   public void printOn(PrintStream tty) {
     // prints only .class flags and not the hotspot internal flags

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ClassConstants.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ClassConstants.java
@@ -118,8 +118,6 @@ public interface ClassConstants
     // invocation counter machinery.  Until it is, we will keep track of methods which
     // cannot be on stack replaced in the access flags.
     public static final long JVM_ACC_NOT_OSR_COMPILABLE     = 0x08000000;
-    public static final long JVM_ACC_HAS_LINE_NUMBER_TABLE  = 0x00100000;
-    public static final long JVM_ACC_HAS_CHECKED_EXCEPTIONS = 0x00400000;
     public static final long JVM_ACC_HAS_JSRS               = 0x00800000;
     // RedefineClasses() has made method obsolete
     public static final long JVM_ACC_IS_OBSOLETE            = 0x00010000;
@@ -133,9 +131,6 @@ public interface ClassConstants
     public static final long JVM_ACC_HAS_FINALIZER            = 0x40000000;
     // True if klass supports the Clonable interface
     public static final long JVM_ACC_IS_CLONEABLE             = 0x80000000;
-
-    // Method* flags
-    public static final long JVM_ACC_HAS_LOCAL_VARIABLE_TABLE = 0x00200000;
 
     // flags accepted by set_field_flags
     public static final long JVM_ACC_FIELD_FLAGS = 0x00008000 | JVM_ACC_WRITTEN_FLAGS;


### PR DESCRIPTION
Please review this small change to remove Method AccessFlags that are unused.  These flags were moved to ConstMethod a long time ago.
Tested with tier1-4, SA tests locally

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306482](https://bugs.openjdk.org/browse/JDK-8306482): Remove unused Method AccessFlags


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13549/head:pull/13549` \
`$ git checkout pull/13549`

Update a local copy of the PR: \
`$ git checkout pull/13549` \
`$ git pull https://git.openjdk.org/jdk.git pull/13549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13549`

View PR using the GUI difftool: \
`$ git pr show -t 13549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13549.diff">https://git.openjdk.org/jdk/pull/13549.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13549#issuecomment-1515553731)