### PR TITLE
8306331: assert((cnt > 0.0f) && (prob > 0.0f)) failed: Bad frequency assignment in if

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1197,7 +1197,7 @@ static bool has_injected_profile(BoolTest::mask btest, Node* test, int& taken, i
 // We also check that individual counters are positive first, otherwise the sum can become positive.
 // (check for saturation, integer overflow, and immature counts)
 static bool counters_are_meaningful(int counter1, int counter2, int min) {
-  // check for saturation, inluding "uint" values too big to fit it "int"
+  // check for saturation, including "uint" values too big to fit in "int"
   if (counter1 < 0 || counter2 < 0) {
     return false;
   }

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1208,7 +1208,7 @@ static bool counters_are_meaningful(int counter1, int counter2, int min) {
     return false;
   }
   // check if mature
-  return counter1 + counter2 >= min;
+  return (counter1 + counter2) >= min;
 }
 
 //--------------------------dynamic_branch_prediction--------------------------

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1192,6 +1192,25 @@ static bool has_injected_profile(BoolTest::mask btest, Node* test, int& taken, i
   }
   return false;
 }
+
+// Give up if too few (or too many, in which case the sum will overflow) counts to be meaningful.
+// We also check that individual counters are positive first, otherwise the sum can become positive.
+// (check for saturation, integer overflow, and immature counts)
+static bool counters_are_meaningful(int counter1, int counter2, int min) {
+  // check for saturation, inluding "uint" values too big to fit it "int"
+  if (counter1 < 0 || counter2 < 0) {
+    return false;
+  }
+  // check for integer overflow of the sum
+  int64_t sum = (int64_t)counter1 + (int64_t)counter2;
+  STATIC_ASSERT(sizeof(counter1) < sizeof(sum));
+  if (sum > INT_MAX) {
+    return false;
+  }
+  // check if mature
+  return counter1 + counter2 >= min;
+}
+
 //--------------------------dynamic_branch_prediction--------------------------
 // Try to gather dynamic branch prediction behavior.  Return a probability
 // of the branch being taken and set the "cnt" field.  Returns a -1.0
@@ -1218,6 +1237,8 @@ float Parse::dynamic_branch_prediction(float &cnt, BoolTest::mask btest, Node* t
     if (!data->is_JumpData())  return PROB_UNKNOWN;
 
     // get taken and not taken values
+    // NOTE: saturated UINT_MAX values become negative,
+    // as do counts above INT_MAX.
     taken = data->as_JumpData()->taken();
     not_taken = 0;
     if (data->is_BranchData()) {
@@ -1225,13 +1246,16 @@ float Parse::dynamic_branch_prediction(float &cnt, BoolTest::mask btest, Node* t
     }
 
     // scale the counts to be commensurate with invocation counts:
+    // NOTE: overflow for positive values is clamped at INT_MAX
     taken = method()->scale_count(taken);
     not_taken = method()->scale_count(not_taken);
   }
+  // At this point, saturation or overflow is indicated by INT_MAX
+  // or a negative value.
 
   // Give up if too few (or too many, in which case the sum will overflow) counts to be meaningful.
   // We also check that individual counters are positive first, otherwise the sum can become positive.
-  if (taken < 0 || not_taken < 0 || taken + not_taken < 40) {
+  if (!counters_are_meaningful(taken, not_taken, 40)) {
     if (C->log() != nullptr) {
       C->log()->elem("branch target_bci='%d' taken='%d' not_taken='%d'", iter().get_dest(), taken, not_taken);
     }
@@ -1260,7 +1284,7 @@ float Parse::dynamic_branch_prediction(float &cnt, BoolTest::mask btest, Node* t
   }
 
   assert((cnt > 0.0f) && (prob > 0.0f),
-         "Bad frequency assignment in if");
+         "Bad frequency assignment in if cnt=%g prob=%g taken=%d not_taken=%d", cnt, prob, taken, not_taken);
 
   if (C->log() != nullptr) {
     const char* prob_str = nullptr;


### PR DESCRIPTION
This change removes undefined behavior caused by signed overflow, which triggered an assert with Xcode14.3+1.0-beta1 on macos aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306331](https://bugs.openjdk.org/browse/JDK-8306331): assert((cnt &gt; 0.0f) &amp;&amp; (prob &gt; 0.0f)) failed: Bad frequency assignment in if


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [9e7b087b](https://git.openjdk.org/jdk/pull/13551/files/9e7b087b1b02234181f3f3397d51a0bc552a1263)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13551/head:pull/13551` \
`$ git checkout pull/13551`

Update a local copy of the PR: \
`$ git checkout pull/13551` \
`$ git pull https://git.openjdk.org/jdk.git pull/13551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13551`

View PR using the GUI difftool: \
`$ git pr show -t 13551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13551.diff">https://git.openjdk.org/jdk/pull/13551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13551#issuecomment-1515636973)