### PR TITLE
8306060: Open source few AWT Insets related tests

### DIFF
--- a/test/jdk/java/awt/Insets/ClobberSharedInsetsObjectTest.java
+++ b/test/jdk/java/awt/Insets/ClobberSharedInsetsObjectTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4198994
+  @summary getInsets should return Insets object that is safe to modify
+  @key headful
+  @run main ClobberSharedInsetsObjectTest
+*/
+
+/**
+ * ClobberSharedInsetsObjectTest.java
+ *
+ * summary: The bug is that getInsets directly returns Insets object
+ * obtained from peer getInsets.  The latter always return the
+ * reference to the same object, so modifying this object will affect
+ * other code that calls getInsets.  The test checks that it's safe to
+ * modify the Insets object returned by getInsets.  If the change to
+ * this object is not visible on the next invocation, the bug is
+ * considered to be fixed.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Panel;
+
+public class ClobberSharedInsetsObjectTest {
+    static Panel p;
+
+    // Impossible inset value to use for the test
+    final static int SENTINEL_INSET_VALUE = -10;
+    static Frame f;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                // Need a peer anyway, so let the bug manifest visuially, even
+                // though we can detect it automatically.
+                f = new Frame();
+                p = new Panel();
+                p.setBackground(Color.red);
+                f.setLayout (new BorderLayout ());
+                f.add(p, "Center");
+
+                Insets insetsBefore = p.getInsets();
+                insetsBefore.top = SENTINEL_INSET_VALUE;
+
+                Insets insetsAfter = p.getInsets();
+                if (insetsAfter.top == SENTINEL_INSET_VALUE) { // OOPS!
+                    throw new Error("4198994: getInsets returns the same object on subsequent invocations");
+                }
+
+                f.setSize (200,200);
+                f.setLocationRelativeTo(null);
+                f.setVisible(true);
+
+                System.out.println("getInsets is ok.  The object it returns is safe to modify.");
+            } finally {
+                if (f != null) {
+                    f.dispose();
+                }
+            }
+        });
+    }
+}

--- a/test/jdk/java/awt/Insets/RemoveMenuBarTest.java
+++ b/test/jdk/java/awt/Insets/RemoveMenuBarTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 6353381
+  @summary REG: Container.getInsets() returns an incorrect value after removal of menubar, Win32
+  @key headful
+  @run main RemoveMenuBarTest
+*/
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Menu;
+import java.awt.MenuBar;
+
+public class RemoveMenuBarTest {
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                // old insets: top>0 | left>0
+                // new insets: top=0 & left=0
+                // the bug is that updating doesn't happen
+                frame = new Frame();
+                MenuBar menubar = new MenuBar();
+                frame.setBounds(100,100,100,100);
+                frame.setUndecorated(true);
+                frame.pack();
+                menubar.add(new Menu());
+                frame.setMenuBar(menubar);
+                System.out.println(frame.getInsets());
+
+                frame.setMenuBar(null);
+                Insets insets = frame.getInsets();
+                System.out.println(insets);
+                if (insets.top != 0 || insets.left != 0 ||
+                    insets.bottom !=0 || insets.right != 0) {
+                    throw new RuntimeException("Test failed: the incorrect insets");
+                }
+            } finally {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            }
+        });
+    }
+}

--- a/test/jdk/java/awt/Insets/SetInsetsTest.java
+++ b/test/jdk/java/awt/Insets/SetInsetsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4704042
+  @summary Unit tests for Insets.set()
+  @run main SetInsetsTest
+*/
+import java.awt.Insets;
+import java.awt.EventQueue;
+
+public class SetInsetsTest {
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            Insets insets = new Insets(0,0,0,0);
+            insets.set(100,100,100,100);
+            if (insets.top != 100 ||
+                insets.bottom != 100 ||
+                insets.left != 100 ||
+                insets.right != 100) {
+                throw new RuntimeException("Test Failed!  Insets=" + insets);
+            }
+        });
+    }
+}// class SetInsetsTest

--- a/test/jdk/java/awt/Insets/WindowInsetsTest.java
+++ b/test/jdk/java/awt/Insets/WindowInsetsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 5089312
+  @summary Bottom inset must not change after a second pack call.
+  @key headful
+  @run main WindowInsetsTest
+*/
+import java.awt.EventQueue;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JWindow;
+
+public class WindowInsetsTest {
+    static JFrame frame;
+    static JWindow window;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                frame = new JFrame("Window Test");
+                frame.setBounds(100, 100, 400, 300);
+                frame.setVisible(true);
+
+                JButton button = new JButton("A Button");
+                window = new JWindow(frame);
+                window.getContentPane().add(button);
+                window.pack();
+                window.setLocation(200, 200);
+                window.show();
+                double h0 = window.getSize().getHeight();
+                window.pack();
+                double h1 = window.getSize().getHeight();
+                if( Math.abs(h1 - h0) > 0.5 ) {
+                    throw new RuntimeException("Test failed: Bad insets.");
+                }
+                System.out.println("Test Passed.");
+            } finally {
+                if (window != null) {
+                    window.dispose();
+                }
+                if (frame != null) {
+                    frame.dispose();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR opensources few AWT Insets tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306060](https://bugs.openjdk.org/browse/JDK-8306060): Open source few AWT Insets related tests


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13552/head:pull/13552` \
`$ git checkout pull/13552`

Update a local copy of the PR: \
`$ git checkout pull/13552` \
`$ git pull https://git.openjdk.org/jdk.git pull/13552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13552`

View PR using the GUI difftool: \
`$ git pr show -t 13552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13552.diff">https://git.openjdk.org/jdk/pull/13552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13552#issuecomment-1515640435)