### PR TITLE
JDK-8306538: Zero variant build failure after JDK-8257967

### DIFF
--- a/src/hotspot/share/prims/jvmtiAgent.hpp
+++ b/src/hotspot/share/prims/jvmtiAgent.hpp
@@ -62,7 +62,7 @@ class JvmtiAgent : public CHeapObj<mtServiceability> {
   const char* options() const;
   bool is_absolute_path() const NOT_JVMTI_RETURN_(false);
   void* os_lib() const NOT_JVMTI_RETURN_(nullptr);
-  void set_os_lib(void* os_lib);
+  void set_os_lib(void* os_lib) NOT_JVMTI_RETURN;
   const char* os_lib_path() const;
   void set_os_lib_path(const char* path) NOT_JVMTI_RETURN;
   bool is_static_lib() const NOT_JVMTI_RETURN_(false);


### PR DESCRIPTION
This follows the same style of fix applied in #13512. I noticed this issue when cross-compiling zero slowdebug for riscv64. I confirmed locally that this PR fixes the linking errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306538](https://bugs.openjdk.org/browse/JDK-8306538): Zero variant build failure after JDK-8257967


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13557/head:pull/13557` \
`$ git checkout pull/13557`

Update a local copy of the PR: \
`$ git checkout pull/13557` \
`$ git pull https://git.openjdk.org/jdk.git pull/13557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13557`

View PR using the GUI difftool: \
`$ git pr show -t 13557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13557.diff">https://git.openjdk.org/jdk/pull/13557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13557#issuecomment-1516082058)