### PR TITLE
8306543: GHA: MSVC installation is failing when component is already installed

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -104,6 +104,11 @@ jobs:
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
             modify --quiet --installPath 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
+        # Runner images can provide the component already, and the attempt to install it would
+        # fail this step. Configure script below would look for the specific MSVC version
+        # anyway, and would fail there if the component installation failed for a different
+        # reason. Do not treat failures at this step as fatal.
+        continue-on-error: true
 
       - name: 'Configure'
         run: >


### PR DESCRIPTION
Currrent GHA fails on MSVC installation. Looks like the required versions are already installed in the runner image, and this is why the command fails. Our configure scripts look for the specific minor version, and the builds still pass if I drop the VC installation block completely. This tells me the appropriate minor version is already installed. 

For safety, I think we can just ignore the errors from the MSVC installation. In case the runner images moves on to another minor version later, the dependencies would start to install successfully again.

See the GHA run. Both Windows x86_64 and Windows AArch64 select `1429~1.301`:

```
* Toolchain:      microsoft (Microsoft Visual Studio 2019)
* C Compiler:     Version 19.29.30148 (at /c/progra~2/micros~2/2019/enterp~1/vc/tools/msvc/1429~1.301/bin/hostx64/x64/cl.exe)
* C++ Compiler:   Version 19.29.30148 (at /c/progra~2/micros~2/2019/enterp~1/vc/tools/msvc/1429~1.301/bin/hostx64/x64/cl.exe)
```

The last successful GHA run I had selected the same versions:

```
Tools summary:
* Toolchain:      microsoft (Microsoft Visual Studio 2019)
* C Compiler:     Version 19.29.30148 (at /c/progra~2/micros~2/2019/enterp~1/vc/tools/msvc/1429~1.301/bin/hostx64/x64/cl.exe)
* C++ Compiler:   Version 19.29.30148 (at /c/progra~2/micros~2/2019/enterp~1/vc/tools/msvc/1429~1.301/bin/hostx64/x64/cl.exe)
```

Additional testing:
 - [x] Ad-hoc GHA runs pass the configure/initial-build
 - [x] Full GHA runs pass (this PR)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306543](https://bugs.openjdk.org/browse/JDK-8306543): GHA: MSVC installation is failing when component is already installed


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13558/head:pull/13558` \
`$ git checkout pull/13558`

Update a local copy of the PR: \
`$ git checkout pull/13558` \
`$ git pull https://git.openjdk.org/jdk.git pull/13558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13558`

View PR using the GUI difftool: \
`$ git pr show -t 13558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13558.diff">https://git.openjdk.org/jdk/pull/13558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13558#issuecomment-1516234278)