### PR TITLE
8306430: Open source some AWT tests related to TextComponent and Toolkit

### DIFF
--- a/test/jdk/java/awt/TextComponent/PeerlessSetCaret/PeerlessSetCaret.java
+++ b/test/jdk/java/awt/TextComponent/PeerlessSetCaret/PeerlessSetCaret.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4257143
+  @summary RFE: Cannot set some AWT properties until peer has been created
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.TextArea;
+import java.awt.TextField;
+
+public class PeerlessSetCaret {
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            TextField tf = new TextField("Hello, World!");
+            TextArea ta = new TextArea("Hello, World!");
+
+            // without the fix these will throw IllegalComponentStateException
+            tf.setCaretPosition(1);
+            ta.setCaretPosition(1);
+        });
+    }
+}

--- a/test/jdk/java/awt/TextComponent/SelectionBounds/SelectionBounds.java
+++ b/test/jdk/java/awt/TextComponent/SelectionBounds/SelectionBounds.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4118247
+  @summary Make sure bounds are enforced correctly on
+           TextComponent.Select(int, int)
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.TextArea;
+import java.awt.TextComponent;
+
+public class SelectionBounds {
+    public static TextComponent tc;
+
+    public static int[][] index = {
+        {0, 0},     // 0 = selectionStart = selectionEnd
+        {5, 5},     // selectionStart = selectionEnd
+        {5, 7},     // 0 < selectionStart < selectionEnd < textLength
+        {-50, 7},   // selectionStart < 0 < selectionEnd < textLength
+        {-50, 50},  // selectionStart < 0 < textLength < selectionEnd
+        {5, 50},    // 0 < selectionStart < textLength < selectionEnd
+        {40, 50},   // 0 < textLength < selectionStart < selectionEnd
+        {-50, -40}, // selectionStart < selectionEnd < 0 < textLength
+        {7, 5},     // 0 < selectionEnd < selectionStart < textLength
+        {7, -50},   // selectionEnd < 0 < selectionStart < textLength
+        {50, -50},  // selectionEnd < 0 < textLength < selectionStart
+        {50, 5},    // 0 < selectionEnd < textLength < selectionStart
+        {50, 40},   // 0 < textLength < selectionEnd < selectionStart
+        {-40, -50}  // selectionEnd < selectionStart < 0 < textLength
+    };
+
+    public static String[] selections = {
+        "",
+        "",
+        "56",
+        "0123456",
+        "0123456789",
+        "56789",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+    };
+
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            tc = new TextArea("0123456789");
+            runTheTest();
+        });
+    }
+
+    private static void runTheTest() {
+        int i;
+        String str1;
+
+        for (i=0; i<index.length; i++) {
+            tc.select(index[i][0], index[i][1]);
+            str1 = tc.getSelectedText();
+
+            if (!str1.equals(selections[i])) {
+                System.out.println("Test " + i + " FAILED:  " + str1 +
+                    " != " + selections[i]);
+                System.out.println("Test " + i + " FAILED:  " + str1 +
+                    " != " + selections[i]);
+                throw new RuntimeException("Test " + i + " FAILED:  " + str1 +
+                    " != " + selections[i]);
+            }
+            else {
+                System.out.println("Test " + i + " PASSED:  " + str1 +
+                    " = " + selections[i]);
+                System.out.println("Test " + i + " PASSED:  " + str1 +
+                    " = " + selections[i]);
+            }
+        }
+
+        System.out.println("\nAll tests PASSED.");
+        System.out.println("\nAll tests PASSED.");
+    }
+}

--- a/test/jdk/java/awt/TextComponent/SelectionBounds/SelectionBounds.java
+++ b/test/jdk/java/awt/TextComponent/SelectionBounds/SelectionBounds.java
@@ -103,6 +103,5 @@ public class SelectionBounds {
         }
 
         System.out.println("\nAll tests PASSED.");
-        System.out.println("\nAll tests PASSED.");
     }
 }

--- a/test/jdk/java/awt/TextComponent/TextAreaCRLFTest/TextAreaCRLFTest.java
+++ b/test/jdk/java/awt/TextComponent/TextAreaCRLFTest/TextAreaCRLFTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4701398 4652358 4659958 4697796 4666876
+  @summary REGRESSION: TextArea.append does not work consistently with \r.
+  @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.TextArea;
+
+public class TextAreaCRLFTest {
+    private static final char[] DIGITS = {
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+
+    public static Dialog aDialog;
+    public static TextArea area;
+    public static boolean passed = true;
+    public static boolean res;
+    public static String atext = "";
+
+    public static void main(String[] args) throws Exception {
+        String atextCRLF = "row1\r\nrow2\r\nrow3";
+
+        try {
+            EventQueue.invokeAndWait(() -> {
+                aDialog = new Dialog(new Frame());
+                aDialog.setTitle("ADialog");
+                aDialog.setBackground(Color.lightGray);
+                aDialog.setLayout(new BorderLayout());
+                Panel mainPanel = new Panel();
+                mainPanel.setLayout(new BorderLayout(6, 6));
+                area = new TextArea(atextCRLF, 25, 68,
+                    TextArea.SCROLLBARS_VERTICAL_ONLY);
+                area.setFont(new Font("Monospaced", Font.PLAIN, 11));
+                mainPanel.add(area, "Center");
+                aDialog.add(mainPanel, "Center");
+                aDialog.pack();
+                System.out.println("before: "+hexEncode(atextCRLF));
+                System.out.println(" after: "+hexEncode(area.getText()));
+                res = area.getText().equals(atextCRLF);
+                System.out.println("01: " + res + "\n");
+                passed = passed && res;
+                area.setText(atextCRLF);
+                System.out.println("before: "+hexEncode(atextCRLF));
+                System.out.println(" after: "+hexEncode(area.getText()));
+                res = area.getText().equals(atextCRLF);
+                System.out.println("02: " + res + "\n");
+                passed = passed && res;
+
+                area.setText("");
+                atext = "row1";
+                area.append(atext+"\r");
+                area.append(atext+"\r");
+                System.out.println("before: "
+                    +hexEncode(atext+"\r" + atext+"\r"));
+                System.out.println(" after: "+hexEncode(area.getText()));
+                res = area.getText().equals(atext + atext);
+                System.out.println("03: " + res + "\n");
+                passed = passed && res;
+
+                area.setText("");
+                String atext1 = "fine.";
+                String atext2 = "messed up.";
+                atext = atext1 +"\r\n"+ atext2;
+                for (int i = 0; i < atext.length(); i++) {
+                    area.append(atext.substring(i, i+1));
+                }
+                System.out.println("before: "
+                    +hexEncode(atext1 +"\r\n"+ atext2));
+                System.out.println(" after: "+hexEncode(area.getText()));
+                String s = area.getText();
+                String t = s.substring(s.length()-atext2.length());
+                res = t.equals(atext2);
+                System.out.println("04: " + res);
+                passed = passed && res;
+
+                area.setText("");
+                atext = "\r";
+                area.append(atext);
+                System.out.println("before: "+hexEncode(atext));
+                System.out.println(" after: "+hexEncode(area.getText()));
+                res = area.getText().equals("");
+                System.out.println("05: " + res + "\n");
+                passed = passed && res;
+
+                if (System.getProperty("os.name").toUpperCase().
+                    startsWith("WIN")) {
+                    if (!passed) {
+                        throw new RuntimeException("TextAreaCRLFTest FAILED.");
+                    } else {
+                        System.out.println("TextAreaCRLFTest PASSED");
+                    }
+                } else {
+                    System.out.println("This is a Windows oriented testcase.");
+                }
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (aDialog != null) {
+                    aDialog.dispose();
+                }
+            });
+        }
+    }
+
+    private static String hexEncode(String str) {
+        return hexEncode(str.getBytes());
+    }
+
+    private static String hexEncode(byte[] bytes) {
+        StringBuffer buffer = new StringBuffer(bytes.length * 2);
+        for (int i = 0; i < bytes.length; i++) {
+            byte b = bytes[i];
+            buffer.append(DIGITS[(b & 0xF0) >> 4]);
+            buffer.append(DIGITS[b & 0x0F]);
+        }
+        return buffer.toString();
+    }
+}

--- a/test/jdk/java/awt/Toolkit/AWTEventListenerProxyTest/AWTEventListenerProxyTest.java
+++ b/test/jdk/java/awt/Toolkit/AWTEventListenerProxyTest/AWTEventListenerProxyTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4290704
+  @summary Test use of AWTEventListenerProxyTest class
+*/
+
+import java.awt.AWTEvent;
+import java.awt.EventQueue;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.AWTEventListenerProxy;
+import java.util.EventListener;
+
+public class AWTEventListenerProxyTest {
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            Toolkit tk = Toolkit.getDefaultToolkit();
+            if ("sun.awt.X11.XToolkit".equals(tk.getClass().getName())) {
+                System.out.println("Do not test for XAWT Toolkit.");
+                System.out.println("Passing automatically.");
+                return;
+            }
+
+            // check that if no listeners added, returns a 0-length array,
+            // not null
+            AWTEventListener[] array1 = tk.getAWTEventListeners();
+            if (array1 == null || array1.length != 0) {
+                System.out.println("[Empty array test failed!!]");
+                throw new RuntimeException("Test failed -" +
+                    " didn't return 0-sized array");
+            }
+            System.out.println("[Empty array test passed]");
+
+            // simple add/get test
+            DumbListener dl1 = new DumbListener();
+            final long dl1MASK = AWTEvent.ACTION_EVENT_MASK;
+            tk.addAWTEventListener(dl1, dl1MASK);
+
+            array1 = tk.getAWTEventListeners();
+            if (array1 == null || array1.length != 1) {
+                System.out.println("[Simple add/get test failed!!]");
+                throw new RuntimeException("Test failed - didn't " +
+                    "return array of 1");
+            }
+            AWTEventListenerProxy dp1 = (AWTEventListenerProxy) array1[0];
+            EventListener getdl1 = dp1.getListener();
+            if (getdl1 != dl1) {
+                System.out.println("[Simple add/get test failed - " +
+                    "wrong listener!!]");
+                throw new RuntimeException("Test failed - wrong " +
+                    "listener in proxy");
+            }
+
+            long getmask = dp1.getEventMask();
+            if (getmask != dl1MASK) {
+                System.out.println("[Simple add/get test failed - " +
+                    "wrong mask!!]");
+                throw new RuntimeException("Test failed - wrong mask in proxy");
+            }
+            System.out.println("[Simple add/get test passed]");
+
+            // add the same listener inside a proxy, with a different mask
+            // should get back one listener, with the ORed mask
+            final long dl2MASK = AWTEvent.CONTAINER_EVENT_MASK;
+            AWTEventListenerProxy newp = new AWTEventListenerProxy(dl2MASK,
+                dl1);
+            tk.addAWTEventListener(newp, dl2MASK);
+            array1 = tk.getAWTEventListeners();
+            if (array1.length != 1) {
+                System.out.println("[Proxy add/get test failed!!]");
+                throw new RuntimeException("Test failed - added proxy, " +
+                    "but didn't return array of 1");
+            }
+            dp1 = (AWTEventListenerProxy) array1[0];
+            getdl1 = dp1.getListener();
+            if (getdl1 != dl1) {
+                System.out.println("[Proxy add/get test " +
+                    "failed - wrong listener!!]");
+                throw new RuntimeException("Test failed - added proxy, " +
+                    "wrong listener in proxy");
+            }
+            getmask = dp1.getEventMask();
+            if (getmask != (dl1MASK | dl2MASK)) {
+                System.out.println("[Proxy add/get test failed - " +
+                    "wrong mask!!]");
+                throw new RuntimeException("Test failed - added proxy, " +
+                    "wrong mask in proxy");
+            }
+            System.out.println("[Proxy add/get test passed]");
+
+            // add some other listener
+            DumbListener dl3 = new DumbListener();
+            final long dl3MASK = AWTEvent.FOCUS_EVENT_MASK;
+            tk.addAWTEventListener(dl3, dl3MASK);
+
+            // test getting with a mask for a listener already added
+            array1 = tk.getAWTEventListeners(dl1MASK);
+            if (array1.length != 1) {
+                System.out.println("[Get w/ mask test failed!! - " +
+                    "not 1 listener!]");
+                throw new RuntimeException("Test failed - tried to " +
+                    "get w/ mask");
+            }
+            dp1 = (AWTEventListenerProxy) array1[0];
+            getdl1 = dp1.getListener();
+            if (getdl1 != dl1) {
+                System.out.println("[Get w/ mask test failed!! - " +
+                    "wrong listener]");
+                throw new RuntimeException("Test failed - tried to get " +
+                    "w/ mask, wrong listener in proxy");
+            }
+            System.out.println("[Get w/ mask test passed]");
+
+            // test getting with a mask for a listener not added
+            array1 = tk.getAWTEventListeners(AWTEvent.MOUSE_EVENT_MASK);
+            if (array1.length != 0) {
+                System.out.println("[Get w/ mask test 2 failed!! - " +
+                    "not 0 listeners!]");
+                throw new RuntimeException("Test failed - tried to get " +
+                    "w/ mask 2");
+            }
+            System.out.println("[Get w/ mask test 2 passed]");
+
+
+            // test getting with a compound mask for a listener already added
+            array1 = tk.getAWTEventListeners(dl1MASK | dl2MASK);
+            if (array1.length != 1) {
+                System.out.println("[Get w/ compound mask test failed!! - " +
+                    "not 1 listeners!]");
+                throw new RuntimeException("Test failed - tried to get w/ 2 " +
+                    "ORed masks");
+            }
+            dp1 = (AWTEventListenerProxy) array1[0];
+            getdl1 = dp1.getListener();
+            if (getdl1 != dl1) {
+                System.out.println("[Get w/ compound mask test failed!! - " +
+                    "wrong listener]");
+                throw new RuntimeException("Test failed - tried to get w/ " +
+                    "compound mask, wrong listener in proxy");
+            }
+            System.out.println("[Get w/ compound mask test passed]");
+        });
+    }
+
+    public static class DumbListener implements AWTEventListener {
+        public DumbListener() {}
+        public void eventDispatched(AWTEvent e) {}
+    }
+}

--- a/test/jdk/java/awt/Toolkit/ListenersDeadlockTest/ListenerDeadlockTest.java
+++ b/test/jdk/java/awt/Toolkit/ListenersDeadlockTest/ListenerDeadlockTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4338463
+  @summary excessive synchronization in notifyAWTEventListeners leads to
+  deadlock
+*/
+
+import java.awt.AWTEvent;
+import java.awt.EventQueue;
+import java.awt.Panel;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ActionEvent;
+
+public class ListenerDeadlockTest {
+    public static final Object lock = new Object();
+
+    public static final Toolkit toolkit = Toolkit.getDefaultToolkit();
+
+    public static Panel panel = new Panel();
+
+    public static final AWTEventListener listener = new AWTEventListener() {
+        public void eventDispatched(AWTEvent e) {
+            if (e.getSource() == panel) {
+                System.out.println(e);
+                System.out.println("No deadlock");
+                synchronized(lock) {
+                    lock.notifyAll();
+                }
+            }
+        }
+    };
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            toolkit.addAWTEventListener(listener, -1);
+
+            Thread thread = new Thread(new Runnable() {
+                public void run() {
+                    synchronized (toolkit) {
+                        synchronized (lock) {
+                            try {
+                                lock.notifyAll();
+                                lock.wait();
+                            } catch (InterruptedException ex) {
+                            }
+                        }
+                    }
+                }
+            });
+
+            synchronized (lock) {
+                thread.start();
+                try {
+                    lock.wait();
+                } catch (InterruptedException ex) {
+                }
+            }
+
+            panel.dispatchEvent(new ActionEvent(panel,
+                ActionEvent.ACTION_PERFORMED, "Try"));
+        });
+    }
+}


### PR DESCRIPTION
This PR open sources few AWT tests related to TextComponent and Toolkit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306430](https://bugs.openjdk.org/browse/JDK-8306430): Open source some AWT tests related to TextComponent and Toolkit


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [ae9bada3](https://git.openjdk.org/jdk/pull/13561/files/ae9bada32b7b4110873814634f439da291185ed2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13561/head:pull/13561` \
`$ git checkout pull/13561`

Update a local copy of the PR: \
`$ git checkout pull/13561` \
`$ git pull https://git.openjdk.org/jdk.git pull/13561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13561`

View PR using the GUI difftool: \
`$ git pr show -t 13561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13561.diff">https://git.openjdk.org/jdk/pull/13561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13561#issuecomment-1516630862)