### PR TITLE
8304836: Make MALLOC_MIN4 macro more robust

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -39,7 +39,7 @@
  * negative, or the size is INT_MAX as the macro adds 1
  * that overflows into negative value.
  */
-#define MALLOC_MIN4(len) ((unsigned)(len) >= INT_MAX ? \
+#define MALLOC_MIN4(len) (len >= INT_MAX || len < 0 ? \
     NULL : \
     ((char *)malloc((len) + 1 < 4 ? 4 : (len) + 1)))
 


### PR DESCRIPTION
The current macro assumes the argument is `jint` because all locations pass `jint`. However, this would not work if a wider type such as `jlong` is passed. Removing the `unsigned` cast and make the condition explicit would make the macro more robust.