### PR TITLE
8306581: JVMCI tests failed when run with -XX:TypeProfileLevel=222 after JDK-8303431

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2716,7 +2716,7 @@ static jbyteArray get_encoded_annotation_data(InstanceKlass* holder, AnnotationA
   InstanceKlass** filter = filter_length == 1 ?
       (InstanceKlass**) &filter_klass_pointers:
       (InstanceKlass**) filter_klass_pointers;
-  objArrayOop filter_oop = oopFactory::new_objectArray(filter_length, CHECK_NULL);
+  objArrayOop filter_oop = oopFactory::new_objArray(vmClasses::Class_klass(), filter_length, CHECK_NULL);
   objArrayHandle filter_classes(THREAD, filter_oop);
   for (int i = 0; i < filter_length; i++) {
     filter_classes->obj_at_put(i, filter[i]->java_mirror());


### PR DESCRIPTION
This PR fixes an issue where an `Object[]` value is allocated in the VM and passed to a parameter of type `Class[]`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306581](https://bugs.openjdk.org/browse/JDK-8306581): JVMCI tests failed when run with -XX:TypeProfileLevel=222 after JDK-8303431


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13566/head:pull/13566` \
`$ git checkout pull/13566`

Update a local copy of the PR: \
`$ git checkout pull/13566` \
`$ git pull https://git.openjdk.org/jdk.git pull/13566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13566`

View PR using the GUI difftool: \
`$ git pr show -t 13566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13566.diff">https://git.openjdk.org/jdk/pull/13566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13566#issuecomment-1516854345)