### PR TITLE
8229147: Linux os::create_thread() overcounts guardpage size with newer glibc (>=2.27)

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -840,7 +840,6 @@ static void init_adjust_stack_for_guard_pages() {
     // If the minimum stack size changed when we added the guard pages
     // then we need to perform the adjustment.
     os::Linux::AdjustStackSizeForGuardPages = (min_stack2 - min_stack > 0);
-    log_debug(os)("OS: minstack changed by " SIZE_FORMAT, min_stack2 - min_stack);
     log_info(os)("- glibc stack size guard page adjustment is %sneeded",
                  os::Linux::AdjustStackSizeForGuardPages ? "" : "not ");
   }

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -149,6 +149,8 @@ class os::Linux {
   // Return default guard size for the specified thread type
   static size_t default_guard_size(os::ThreadType thr_type);
 
+  static bool AdjustStackSizeForGuardPages; // See comments in os_linux.cpp
+
   static void capture_initial_stack(size_t max_size);
 
   // Stack overflow handling

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -149,7 +149,7 @@ class os::Linux {
   // Return default guard size for the specified thread type
   static size_t default_guard_size(os::ThreadType thr_type);
 
-  static bool AdjustStackSizeForGuardPages; // See comments in os_linux.cpp
+  static bool adjustStackSizeForGuardPages(); // See comments in os_linux.cpp
 
   static void capture_initial_stack(size_t max_size);
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -905,8 +905,8 @@ char* os::Posix::describe_pthread_attr(char* buf, size_t buflen, const pthread_a
   int detachstate = 0;
   pthread_attr_getstacksize(attr, &stack_size);
   pthread_attr_getguardsize(attr, &guard_size);
-  // Work around linux NPTL implementation error, see also os::create_thread() in os_linux.cpp.
-  LINUX_ONLY(stack_size -= guard_size);
+  // Work around glibc stack guard issue, see os::create_thread() in os_linux.cpp.
+  LINUX_ONLY(if (os::Linux::AdjustStackSizeForGuardPages) stack_size -= guard_size;)
   pthread_attr_getdetachstate(attr, &detachstate);
   jio_snprintf(buf, buflen, "stacksize: " SIZE_FORMAT "k, guardsize: " SIZE_FORMAT "k, %s",
     stack_size / K, guard_size / K,

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -906,7 +906,7 @@ char* os::Posix::describe_pthread_attr(char* buf, size_t buflen, const pthread_a
   pthread_attr_getstacksize(attr, &stack_size);
   pthread_attr_getguardsize(attr, &guard_size);
   // Work around glibc stack guard issue, see os::create_thread() in os_linux.cpp.
-  LINUX_ONLY(if (os::Linux::AdjustStackSizeForGuardPages) stack_size -= guard_size;)
+  LINUX_ONLY(if (os::Linux::adjustStackSizeForGuardPages()) stack_size -= guard_size;)
   pthread_attr_getdetachstate(attr, &detachstate);
   jio_snprintf(buf, buflen, "stacksize: " SIZE_FORMAT "k, guardsize: " SIZE_FORMAT "k, %s",
     stack_size / K, guard_size / K,


### PR DESCRIPTION
We can now detect whether glibc includes the guard pages as part of the requested stack size or not, and so only need to make adjustments when glibc requires it.

The intent was to use a local variable as the "flag" but unfortunately it is also needed in os_posix.cpp so I had to make it part of the os::Linux API.

See bug report (and related) for details.

Testing:
  - Manually checked log output for stack sizes and boundaries on systems with and without the glibc fix. (Again see JBS issue)
  -  Tiers 1-3 sanity
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229147](https://bugs.openjdk.org/browse/JDK-8229147): Linux os::create_thread() overcounts guardpage size with newer glibc (&gt;=2.27)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [abcf253a](https://git.openjdk.org/jdk/pull/13571/files/abcf253ac7d3fe1b7fabe318c50ae7020f1c0e95)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13571/head:pull/13571` \
`$ git checkout pull/13571`

Update a local copy of the PR: \
`$ git checkout pull/13571` \
`$ git pull https://git.openjdk.org/jdk.git pull/13571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13571`

View PR using the GUI difftool: \
`$ git pr show -t 13571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13571.diff">https://git.openjdk.org/jdk/pull/13571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13571#issuecomment-1517264077)