### PR TITLE
8306072: Open source several AWT MouseInfo related tests

### DIFF
--- a/test/jdk/java/awt/MouseInfo/ButtonsNumber.java
+++ b/test/jdk/java/awt/MouseInfo/ButtonsNumber.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4908137
+  @summary tests that non-zero number of mouse buttons is returned
+  @key headful
+*/
+
+import java.awt.MouseInfo;
+
+public class ButtonsNumber {
+
+    public static void main(String[] args) {
+
+        if (MouseInfo.getNumberOfButtons() == 0) {
+            throw new RuntimeException("Zero returned by getNumberOfButtons(). Test failed.");
+        }
+    }
+}

--- a/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
+++ b/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
@@ -48,8 +48,8 @@ public class ContainerMousePositionTest {
     private static Point FIRST_BUTTON_LOCATION = new Point(20, 20);
     private static int DELAY = 1000;
     Robot robot;
-    transient int xPos = 0;
-    transient int yPos = 0;
+    volatile int xPos = 0;
+    volatile int yPos = 0;
     Point pMousePosition;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
+++ b/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @summary unit test for a new method in Container class: getMousePosition(boolean)
+  @bug 4009555
+  @key headful
+*/
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class ContainerMousePositionTest {
+    private Button button;
+    private Frame frame;
+    private Panel panel;
+    private static Dimension BUTTON_DIMENSION = new Dimension(100, 100);
+    private static Dimension FRAME_DIMENSION = new Dimension(200, 200);
+    private static Point POINT_WITHOUT_COMPONENTS = new Point(10, 10);
+    private static Point FIRST_BUTTON_LOCATION = new Point(20, 20);
+    private static int DELAY = 1000;
+    Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        ContainerMousePositionTest containerObj = new ContainerMousePositionTest();
+        containerObj.init();
+        containerObj.start();
+    }
+
+    public void init() throws Exception {
+        robot = new Robot();
+        EventQueue.invokeAndWait(() -> {
+            button = new Button("Button");
+            frame = new Frame("Testing Component.getMousePosition()");
+            panel = new Panel();
+
+            button.setSize(BUTTON_DIMENSION);
+            button.setLocation(FIRST_BUTTON_LOCATION);
+
+            panel.setLayout(null);
+
+            panel.add(button);
+            frame.add(panel);
+            frame.setSize(FRAME_DIMENSION);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+    }
+
+    public void start() {
+        try {
+            robot.delay(DELAY);
+            robot.waitForIdle();
+
+            Point p = button.getLocationOnScreen();
+            robot.mouseMove(p.x + button.getWidth() / 2, p.y + button.getHeight() / 2);
+
+            robot.delay(DELAY);
+
+            Point pMousePosition = frame.getMousePosition(false);
+            if (pMousePosition != null) {
+                throw new RuntimeException("Test failed: Container is overlapped by " + " child and it should be taken into account");
+            }
+            System.out.println("Test stage completed: Container is overlapped by " + " child and it was taken into account");
+
+            pMousePosition = frame.getMousePosition(true);
+            if (pMousePosition == null) {
+                throw new RuntimeException("Test failed: Container is overlapped by " + " child and it should not be taken into account");
+            }
+            System.out.println("Test stage completed: Container is overlapped by " + " child and it should not be taken into account");
+
+            robot.mouseMove(panel.getLocationOnScreen().x + POINT_WITHOUT_COMPONENTS.x, panel.getLocationOnScreen().y + POINT_WITHOUT_COMPONENTS.y);
+
+            robot.delay(DELAY);
+
+            pMousePosition = panel.getMousePosition(true);
+            if (pMousePosition == null) {
+                throw new RuntimeException("Test failed: Pointer was outside of " + "the component so getMousePosition() should not return null");
+            }
+            System.out.println("Test stage completed: Pointer was outside of " + "the component and getMousePosition() has not returned null");
+
+            pMousePosition = panel.getMousePosition(false);
+            if (pMousePosition == null) {
+                throw new RuntimeException("Test failed: Pointer was outside of " + "the component so getMousePosition() should not return null");
+            }
+            System.out.println("Test stage completed: Pointer was outside of " + "the component and getMousePosition() has not returned null");
+
+            robot.mouseMove(frame.getLocationOnScreen().x + frame.getWidth() + POINT_WITHOUT_COMPONENTS.x, frame.getLocationOnScreen().y + frame.getHeight() + POINT_WITHOUT_COMPONENTS.y);
+
+            robot.delay(DELAY);
+
+            pMousePosition = frame.getMousePosition(true);
+            if (pMousePosition != null) {
+                throw new RuntimeException("Test failed: Pointer was outside of " + "the Frame widow and getMousePosition() should return null");
+            }
+            System.out.println("Test stage completed: Pointer was outside of " + "the Frame widow and getMousePosition() returned null");
+
+            pMousePosition = frame.getMousePosition(false);
+            if (pMousePosition != null) {
+                throw new RuntimeException("Test failed: Pointer was outside of " + "the Frame widow and getMousePosition() should return null");
+            }
+            System.out.println("Test stage completed: Pointer was outside of " + "the Frame widow and getMousePosition() returned null");
+
+            robot.delay(DELAY);
+
+            System.out.println("ComponentMousePositionTest PASSED.");
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
+++ b/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
@@ -48,6 +48,9 @@ public class ContainerMousePositionTest {
     private static Point FIRST_BUTTON_LOCATION = new Point(20, 20);
     private static int DELAY = 1000;
     Robot robot;
+    int xPos = 0;
+    int yPos = 0;
+    Point pMousePosition;
 
     public static void main(String[] args) throws Exception {
         ContainerMousePositionTest containerObj = new ContainerMousePositionTest();
@@ -75,67 +78,97 @@ public class ContainerMousePositionTest {
         });
     }
 
-    public void start() {
+    public void start() throws Exception {
         try {
             robot.delay(DELAY);
             robot.waitForIdle();
 
-            Point p = button.getLocationOnScreen();
-            robot.mouseMove(p.x + button.getWidth() / 2, p.y + button.getHeight() / 2);
+            EventQueue.invokeAndWait(() -> {
+                Point p = button.getLocationOnScreen();
+                xPos = p.x + button.getWidth() / 2;
+                yPos = p.y + button.getHeight() / 2
+            });
+            robot.mouseMove(xPos,yPos);
+            robot.delay(DELAY);
+
+            EventQueue.invokeAndWait(() -> {
+                pMousePosition = frame.getMousePosition(false);
+                if (pMousePosition != null) {
+                    throw new RuntimeException("Test failed: Container is " +
+                            "overlapped by " + " child and it should be taken " +
+                            "into account");
+                }
+                System.out.println("Test stage completed: Container is " +
+                        "overlapped by " + " child and it was taken into " +
+                        "account");
+
+                pMousePosition = frame.getMousePosition(true);
+                if (pMousePosition == null) {
+                    throw new RuntimeException("Test failed: Container is " +
+                            "overlapped by " + " child and it should not be " +
+                            "taken into account");
+                }
+                System.out.println("Test stage completed: Container is " +
+                        "overlapped by " + " child and it should not be " +
+                        "taken into account");
+                xPos = panel.getLocationOnScreen().x + POINT_WITHOUT_COMPONENTS.x;
+                yPos = panel.getLocationOnScreen().y + POINT_WITHOUT_COMPONENTS.y;
+            });
+
+            robot.mouseMove(xPos, yPos);
 
             robot.delay(DELAY);
 
-            Point pMousePosition = frame.getMousePosition(false);
-            if (pMousePosition != null) {
-                throw new RuntimeException("Test failed: Container is overlapped by " + " child and it should be taken into account");
-            }
-            System.out.println("Test stage completed: Container is overlapped by " + " child and it was taken into account");
+            EventQueue.invokeAndWait(() -> {
+                pMousePosition = panel.getMousePosition(true);
+                if (pMousePosition == null) {
+                    throw new RuntimeException("Test failed: Pointer was " +
+                            "outside of " + "the component so getMousePosition()" +
+                            " should not return null");
+                }
+                System.out.println("Test stage completed: Pointer was outside of " +
+                        "the component and getMousePosition() has not returned null");
 
-            pMousePosition = frame.getMousePosition(true);
-            if (pMousePosition == null) {
-                throw new RuntimeException("Test failed: Container is overlapped by " + " child and it should not be taken into account");
-            }
-            System.out.println("Test stage completed: Container is overlapped by " + " child and it should not be taken into account");
-
-            robot.mouseMove(panel.getLocationOnScreen().x + POINT_WITHOUT_COMPONENTS.x, panel.getLocationOnScreen().y + POINT_WITHOUT_COMPONENTS.y);
-
-            robot.delay(DELAY);
-
-            pMousePosition = panel.getMousePosition(true);
-            if (pMousePosition == null) {
-                throw new RuntimeException("Test failed: Pointer was outside of " + "the component so getMousePosition() should not return null");
-            }
-            System.out.println("Test stage completed: Pointer was outside of " + "the component and getMousePosition() has not returned null");
-
-            pMousePosition = panel.getMousePosition(false);
-            if (pMousePosition == null) {
-                throw new RuntimeException("Test failed: Pointer was outside of " + "the component so getMousePosition() should not return null");
-            }
-            System.out.println("Test stage completed: Pointer was outside of " + "the component and getMousePosition() has not returned null");
-
-            robot.mouseMove(frame.getLocationOnScreen().x + frame.getWidth() + POINT_WITHOUT_COMPONENTS.x, frame.getLocationOnScreen().y + frame.getHeight() + POINT_WITHOUT_COMPONENTS.y);
+                pMousePosition = panel.getMousePosition(false);
+                if (pMousePosition == null) {
+                    throw new RuntimeException("Test failed: Pointer was outside of " +
+                            "the component so getMousePosition() should not return null");
+                }
+                System.out.println("Test stage completed: Pointer was outside of " +
+                        "the component and getMousePosition() has not returned null");
+                xPos = frame.getLocationOnScreen().x + frame.getWidth() + POINT_WITHOUT_COMPONENTS.x;
+                yPos = frame.getLocationOnScreen().y + frame.getHeight() + POINT_WITHOUT_COMPONENTS.y;
+            });
+            robot.mouseMove(xPos, yPos);
 
             robot.delay(DELAY);
 
-            pMousePosition = frame.getMousePosition(true);
-            if (pMousePosition != null) {
-                throw new RuntimeException("Test failed: Pointer was outside of " + "the Frame widow and getMousePosition() should return null");
-            }
-            System.out.println("Test stage completed: Pointer was outside of " + "the Frame widow and getMousePosition() returned null");
+            EventQueue.invokeAndWait(() -> {
+                pMousePosition = frame.getMousePosition(true);
+                if (pMousePosition != null) {
+                    throw new RuntimeException("Test failed: Pointer was outside of " +
+                            "the Frame widow and getMousePosition() should return null");
+                }
+                System.out.println("Test stage completed: Pointer was outside of " +
+                        "the Frame widow and getMousePosition() returned null");
 
-            pMousePosition = frame.getMousePosition(false);
-            if (pMousePosition != null) {
-                throw new RuntimeException("Test failed: Pointer was outside of " + "the Frame widow and getMousePosition() should return null");
-            }
-            System.out.println("Test stage completed: Pointer was outside of " + "the Frame widow and getMousePosition() returned null");
-
+                pMousePosition = frame.getMousePosition(false);
+                if (pMousePosition != null) {
+                    throw new RuntimeException("Test failed: Pointer was outside of " +
+                            "the Frame widow and getMousePosition() should return null");
+                }
+                System.out.println("Test stage completed: Pointer was outside of " +
+                        "the Frame widow and getMousePosition() returned null");
+            });
             robot.delay(DELAY);
 
             System.out.println("ComponentMousePositionTest PASSED.");
         } finally {
-            if (frame != null) {
-                frame.dispose();
-            }
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 }

--- a/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
+++ b/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
@@ -36,8 +36,6 @@ import java.awt.Panel;
 import java.awt.Point;
 import java.awt.Robot;
 
-import java.lang.reflect.InvocationTargetException;
-
 public class ContainerMousePositionTest {
     private Button button;
     private Frame frame;

--- a/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
+++ b/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
@@ -86,7 +86,7 @@ public class ContainerMousePositionTest {
             EventQueue.invokeAndWait(() -> {
                 Point p = button.getLocationOnScreen();
                 xPos = p.x + button.getWidth() / 2;
-                yPos = p.y + button.getHeight() / 2
+                yPos = p.y + button.getHeight() / 2;
             });
             robot.mouseMove(xPos,yPos);
             robot.delay(DELAY);

--- a/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
+++ b/test/jdk/java/awt/MouseInfo/ContainerMousePositionTest.java
@@ -48,8 +48,8 @@ public class ContainerMousePositionTest {
     private static Point FIRST_BUTTON_LOCATION = new Point(20, 20);
     private static int DELAY = 1000;
     Robot robot;
-    int xPos = 0;
-    int yPos = 0;
+    transient int xPos = 0;
+    transient int yPos = 0;
     Point pMousePosition;
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
This open source AWT Mouse Info related tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306072](https://bugs.openjdk.org/browse/JDK-8306072): Open source several AWT MouseInfo related tests


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [86ba000c](https://git.openjdk.org/jdk/pull/13573/files/86ba000ced1befcc2a404e1ffa5e07b79d3ba522)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [86ba000c](https://git.openjdk.org/jdk/pull/13573/files/86ba000ced1befcc2a404e1ffa5e07b79d3ba522)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13573/head:pull/13573` \
`$ git checkout pull/13573`

Update a local copy of the PR: \
`$ git checkout pull/13573` \
`$ git pull https://git.openjdk.org/jdk.git pull/13573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13573`

View PR using the GUI difftool: \
`$ git pr show -t 13573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13573.diff">https://git.openjdk.org/jdk/pull/13573.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13573#issuecomment-1517280421)