### PR TITLE
8306658: GHA: MSVC installation could be optional since it might already be pre-installed

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -104,10 +104,10 @@ jobs:
           set +e
           '/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
-            echo "Toolchain already installed"
+            echo "Toolchain is already installed"
             echo "toolchain-installed=true" >> $GITHUB_OUTPUT
           else
-            echo "Toolchain not yet installed"
+            echo "Toolchain is not yet installed"
             echo "toolchain-installed=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
We figured that seemingly the correct toolchain could be (and is) already installed by default on Github runners and it makes sense to skip the expensive installation operation which takes some 10+ minutes.

I also tested the scenario with an older toolchain version which would really need installing, e.g. 14.28.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306658](https://bugs.openjdk.org/browse/JDK-8306658): GHA: MSVC installation could be optional since it might already be pre-installed


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [2cb14408](https://git.openjdk.org/jdk/pull/13574/files/2cb14408adb8dca7e53b145919a100ec324e9774)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13574/head:pull/13574` \
`$ git checkout pull/13574`

Update a local copy of the PR: \
`$ git checkout pull/13574` \
`$ git pull https://git.openjdk.org/jdk.git pull/13574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13574`

View PR using the GUI difftool: \
`$ git pr show -t 13574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13574.diff">https://git.openjdk.org/jdk/pull/13574.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13574#issuecomment-1517364156)