### PR TITLE
8306636: Disable compiler/c2/Test6905845.java with -XX:TieredStopAtLevel=3

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test6905845.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6905845.java
@@ -26,6 +26,7 @@
  * @bug 6905845
  * @summary Server VM improperly optimizing away loop.
  *
+ * @requires vm.opt.TieredStopAtLevel != 3
  * @run main/timeout=480 compiler.c2.Test6905845
  */
 


### PR DESCRIPTION
Disable the c2 test for TieredStopAtLevel=3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306636](https://bugs.openjdk.org/browse/JDK-8306636): Disable compiler/c2/Test6905845.java with -XX:TieredStopAtLevel=3


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13579/head:pull/13579` \
`$ git checkout pull/13579`

Update a local copy of the PR: \
`$ git checkout pull/13579` \
`$ git pull https://git.openjdk.org/jdk.git pull/13579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13579`

View PR using the GUI difftool: \
`$ git pr show -t 13579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13579.diff">https://git.openjdk.org/jdk/pull/13579.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13579#issuecomment-1517824888)