### PR TITLE
8306435: Juggle04/TestDescription.java should be a booleanArr test and not a byteArr one

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
@@ -35,7 +35,7 @@
  *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
- *      -gp byteArr
+ *      -gp booleanArr
  *      -ms low
  */
 


### PR DESCRIPTION
Each garbage producer should have three test description each with different `-ms` flags. A mistake was made when this file was created (probably because the first byteArr test is named differently).