### PR TITLE
8306476: CDS ArchiveHeapTestClass.java test asserts when vm_exit is called on VM thread

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -922,7 +922,7 @@ void MetaspaceShared::unrecoverable_writing_error(const char* message) {
   if (message != nullptr) {
     log_error(cds)("%s", message);
   }
-  vm_exit(1);
+  vm_direct_exit(1);
 }
 
 // We have finished dumping the static archive. At this point, there may be pending VM


### PR DESCRIPTION
The change in [JDK-8303422](https://bugs.openjdk.org/browse/JDK-8303422) consolidated the different ways to exit the VM during CDS errors, but it included a small mistake. The use of `vm_exit()` is unsafe in some cases, so the method was updated to use `vm_direct_exit()` instead. Verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306476](https://bugs.openjdk.org/browse/JDK-8306476): CDS ArchiveHeapTestClass.java test asserts when vm_exit is called on VM thread


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13583/head:pull/13583` \
`$ git checkout pull/13583`

Update a local copy of the PR: \
`$ git checkout pull/13583` \
`$ git pull https://git.openjdk.org/jdk.git pull/13583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13583`

View PR using the GUI difftool: \
`$ git pr show -t 13583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13583.diff">https://git.openjdk.org/jdk/pull/13583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13583#issuecomment-1518056367)