### PR TITLE
8304986: Upcall stubs should support capureCallState

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -76,6 +76,7 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerModule := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLoaderLookupInvoker := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := -I$(TEST_LIB_NATIVE_SRC)
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libCaptureCallState := Ws2_32.lib
 
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libTracePinnedThreads := jvm.lib
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libNewDirectByteBuffer := $(WIN_LIB_JAVA)

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -178,6 +178,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   if (captured_state_mask != 0) {
     captured_state_offset = frame_bottom_offset;
     frame_bottom_offset += (sizeof(int32_t) * 3);
+    locs.set(StubLocations::CAPTURED_STATE_BUFFER, abi._scratch2);
   }
 
   int frame_size = frame_bottom_offset;
@@ -241,7 +242,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   }
   if (captured_state_mask != 0) {
     assert(captured_state_offset != -1, "no capture state allocated");
-    __ lea(as_Register(locs.get(StubLocations::CAPTURED_STATE_BUFFER)), Address(rsp, captured_state_offset));
+    __ lea(as_Register(locs.get(StubLocations::CAPTURED_STATE_BUFFER)), Address(sp, captured_state_offset));
   }
   arg_shuffle.generate(_masm, as_VMStorage(shuffle_reg), abi._shadow_space_bytes, 0, locs);
   __ block_comment("} argument shuffle");
@@ -307,9 +308,9 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ block_comment("{ on_exit");
   __ lea(c_rarg0, Address(sp, frame_data_offset));
     if (captured_state_mask != 0) {
-    __ lea(c_rarg1, Address(rsp, captured_state_offset));
+    __ lea(c_rarg1, Address(sp, captured_state_offset));
   } else {
-    __ ldr(c_rarg1, NULL_WORD);
+    __ mov(c_rarg1, NULL_WORD);
   }
   __ movw(c_rarg2, captured_state_mask);
   // stack already aligned

--- a/src/hotspot/cpu/arm/upcallLinker_arm.cpp
+++ b/src/hotspot/cpu/arm/upcallLinker_arm.cpp
@@ -30,7 +30,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
-                                       bool needs_return_buffer, int ret_buf_size) {
+                                       bool needs_return_buffer, int ret_buf_size,
+                                       int captured_state_mask) {
   ShouldNotCallThis();
   return nullptr;
 }

--- a/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
@@ -31,7 +31,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
-                                       bool needs_return_buffer, int ret_buf_size) {
+                                       bool needs_return_buffer, int ret_buf_size,
+                                       int captured_state_mask) {
   ShouldNotCallThis();
   return nullptr;
 }

--- a/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
@@ -122,7 +122,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
-                                       bool needs_return_buffer, int ret_buf_size) {
+                                       bool needs_return_buffer, int ret_buf_size,
+                                       int captured_state_mask) {
 
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);

--- a/src/hotspot/cpu/s390/upcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/upcallLinker_s390.cpp
@@ -30,7 +30,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
-                                       bool needs_return_buffer, int ret_buf_size) {
+                                       bool needs_return_buffer, int ret_buf_size,
+                                       int captured_state_mask) {
   ShouldNotCallThis();
   return nullptr;
 }

--- a/src/hotspot/cpu/x86/upcallLinker_x86_32.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_32.cpp
@@ -29,7 +29,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
-                                       bool needs_return_buffer, int ret_buf_size) {
+                                       bool needs_return_buffer, int ret_buf_size,
+                                       int captured_state_mask) {
   ShouldNotCallThis();
   return nullptr;
 }

--- a/src/hotspot/cpu/zero/upcallLinker_zero.cpp
+++ b/src/hotspot/cpu/zero/upcallLinker_zero.cpp
@@ -29,7 +29,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
-                                       bool needs_return_buffer, int ret_buf_size) {
+                                       bool needs_return_buffer, int ret_buf_size,
+                                       int captured_state_mask) {
   ShouldNotCallThis();
   return nullptr;
 }

--- a/src/hotspot/share/prims/downcallLinker.cpp
+++ b/src/hotspot/share/prims/downcallLinker.cpp
@@ -32,7 +32,6 @@
 #endif
 
 void DowncallLinker::capture_state(int32_t* value_ptr, int captured_state_mask) {
-  // keep in synch with jdk.internal.foreign.abi.PreservableValues
 #ifdef _WIN64
   if (captured_state_mask & CapturableState::LAST_ERROR) {
     *value_ptr = GetLastError();

--- a/src/hotspot/share/prims/downcallLinker.cpp
+++ b/src/hotspot/share/prims/downcallLinker.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "downcallLinker.hpp"
+#include "prims/foreignGlobals.hpp"
 
 #include <cerrno>
 #ifdef _WIN64
@@ -32,23 +33,17 @@
 
 void DowncallLinker::capture_state(int32_t* value_ptr, int captured_state_mask) {
   // keep in synch with jdk.internal.foreign.abi.PreservableValues
-  enum PreservableValues {
-    NONE = 0,
-    GET_LAST_ERROR = 1,
-    WSA_GET_LAST_ERROR = 1 << 1,
-    ERRNO = 1 << 2
-  };
 #ifdef _WIN64
-  if (captured_state_mask & GET_LAST_ERROR) {
+  if (captured_state_mask & CapturableState::LAST_ERROR) {
     *value_ptr = GetLastError();
   }
   value_ptr++;
-  if (captured_state_mask & WSA_GET_LAST_ERROR) {
+  if (captured_state_mask & CapturableState::WSA_LAST_ERROR) {
     *value_ptr = WSAGetLastError();
   }
   value_ptr++;
 #endif
-  if (captured_state_mask & ERRNO) {
+  if (captured_state_mask & CapturableState::ERRNO) {
     *value_ptr = errno;
   }
 }

--- a/src/hotspot/share/prims/foreignGlobals.hpp
+++ b/src/hotspot/share/prims/foreignGlobals.hpp
@@ -56,6 +56,7 @@ public:
   int data_offset(uint32_t loc) const;
 };
 
+// keep in sync with jdk.internal.foreign.abi.CapturableState
 struct CapturableState {
   enum {
     NONE = 0,

--- a/src/hotspot/share/prims/foreignGlobals.hpp
+++ b/src/hotspot/share/prims/foreignGlobals.hpp
@@ -56,6 +56,15 @@ public:
   int data_offset(uint32_t loc) const;
 };
 
+struct CapturableState {
+  enum {
+    NONE = 0,
+    LAST_ERROR = 1,
+    WSA_LAST_ERROR = 1 << 1,
+    ERRNO = 1 << 2
+  };
+};
+
 class CallingConventionClosure {
 public:
   virtual int calling_convention(const BasicType* sig_bt, VMStorage* regs, int num_args) const = 0;

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -155,7 +155,6 @@ void UpcallLinker::handle_uncaught_exception(oop exception) {
 
 void UpcallLinker::capture_state(int32_t* value_ptr, int captured_state_mask) {
   assert(value_ptr != nullptr || captured_state_mask == 0, "value ptr null when capturing state");
-  // keep in synch with jdk.internal.foreign.abi.PreservableValues
 #ifdef _WIN64
   if (captured_state_mask & CapturableState::LAST_ERROR) {
     SetLastError(*value_ptr);

--- a/src/hotspot/share/prims/upcallLinker.hpp
+++ b/src/hotspot/share/prims/upcallLinker.hpp
@@ -36,14 +36,17 @@ private:
   static JavaThread* maybe_attach_and_get_thread();
 
   static JavaThread* on_entry(UpcallStub::FrameData* context);
-  static void on_exit(UpcallStub::FrameData* context);
+  static void on_exit(UpcallStub::FrameData* context,
+                      int32_t* captured_state_ptr, int captured_state_mask);
+  static void capture_state(int32_t* value_ptr, int captured_state_mask);
 public:
   static address make_upcall_stub(jobject mh, Method* entry,
                                   BasicType* in_sig_bt, int total_in_args,
                                   BasicType* out_sig_bt, int total_out_args,
                                   BasicType ret_type,
                                   jobject jabi, jobject jconv,
-                                  bool needs_return_buffer, int ret_buf_size);
+                                  bool needs_return_buffer, int ret_buf_size,
+                                  int captured_state_mask);
 };
 
 #endif // SHARE_VM_PRIMS_UPCALLLINKER_HPP

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -85,7 +85,11 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         LinkerOptions optionSet = LinkerOptions.forUpcall(function, options);
 
         MethodType type = function.toMethodType();
-        if (!type.equals(target.type())) {
+        MethodType expectedType = type;
+        if (optionSet.hasCapturedCallState()) {
+            expectedType = expectedType.insertParameterTypes(0, MemorySegment.class); // capture state segment
+        }
+        if (!expectedType.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -84,21 +84,21 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         SharedUtils.checkExceptions(target);
         LinkerOptions optionSet = LinkerOptions.forUpcall(function, options);
 
-        MethodType type = function.toMethodType();
-        MethodType expectedType = type;
+        MethodType nativeType = function.toMethodType();
+        MethodType expectedJavaType = nativeType;
         if (optionSet.hasCapturedCallState()) {
-            expectedType = expectedType.insertParameterTypes(0, MemorySegment.class); // capture state segment
+            expectedJavaType = expectedJavaType.insertParameterTypes(0, MemorySegment.class); // capture state segment
         }
-        if (!expectedType.equals(target.type())) {
+        if (!expectedJavaType.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }
 
         UpcallStubFactory factory = UPCALL_CACHE.get(new LinkRequest(function, optionSet), linkRequest ->
-            arrangeUpcall(type, linkRequest.descriptor(), linkRequest.options()));
+            arrangeUpcall(nativeType, linkRequest.descriptor(), linkRequest.options()));
         return factory.makeStub(target, arena);
     }
 
-    protected abstract UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options);
+    protected abstract UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options);
 
     @Override
     public SystemLookup defaultLookup() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -38,6 +38,7 @@ import jdk.internal.foreign.abi.Binding.VMStore;
 import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -121,6 +122,11 @@ public class CallingSequenceBuilder {
             callerMethodType = mt;
             calleeMethodType = computeCalleeTypeForDowncall();
         } else { // forUpcall == true
+            if (linkerOptions.hasCapturedCallState()) {
+                addArgumentBinding(0, MemorySegment.class, ValueLayout.ADDRESS, List.of(
+                        Binding.vmLoad(abi.capturedStateStorage(), long.class),
+                        Binding.boxAddress(Linker.Option.captureStateLayout())));
+            }
             if (needsReturnBuffer) {
                 addArgumentBinding(0, MemorySegment.class, ValueLayout.ADDRESS, List.of(
                         Binding.vmLoad(abi.retBufAddrStorage(), long.class),

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
@@ -36,8 +36,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 public enum CapturableState {
-    GET_LAST_ERROR    ("GetLastError",    JAVA_INT, 1 << 0, Utils.IS_WINDOWS),
-    WSA_GET_LAST_ERROR("WSAGetLastError", JAVA_INT, 1 << 1, Utils.IS_WINDOWS),
+    GET_LAST_ERROR    ("LastError",    JAVA_INT, 1 << 0, Utils.IS_WINDOWS),
+    WSA_GET_LAST_ERROR("WSALastError", JAVA_INT, 1 << 1, Utils.IS_WINDOWS),
     ERRNO             ("errno",           JAVA_INT, 1 << 2, true);
 
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
@@ -36,9 +36,9 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 public enum CapturableState {
-    GET_LAST_ERROR    ("LastError",    JAVA_INT, 1 << 0, Utils.IS_WINDOWS),
-    WSA_GET_LAST_ERROR("WSALastError", JAVA_INT, 1 << 1, Utils.IS_WINDOWS),
-    ERRNO             ("errno",           JAVA_INT, 1 << 2, true);
+    LAST_ERROR    ("LastError",    JAVA_INT, 1 << 0, Utils.IS_WINDOWS),
+    WSA_LAST_ERROR("WSALastError", JAVA_INT, 1 << 1, Utils.IS_WINDOWS),
+    ERRNO         ("errno",        JAVA_INT, 1 << 2, true);
 
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(
         supportedStates().map(CapturableState::layout).toArray(MemoryLayout[]::new));

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
@@ -135,6 +135,10 @@ public class LinkerOptions {
         public void validateForDowncall(FunctionDescriptor descriptor) {
             // done during construction
         }
+        @Override
+        public void validateForUpcall(FunctionDescriptor descriptor) {
+            // done during construction
+        }
     }
 
     public record IsTrivial() implements LinkerOptionImpl {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -171,7 +171,8 @@ public final class SharedUtils {
         if (hasCaptureCallState) {
             assert target.type().parameterType(1) == MemorySegment.class;
             // IMR is an ABI figment, so the capture state segment which
-            // is inserted artificially by CallingSequenceBuilder should appear before it
+            // is inserted by CallingSequenceBuilder as leading parameter
+            // should appear before the IMR segment parameter
             target = swapArguments(target, 0, 1);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -105,7 +105,8 @@ public class UpcallLinker {
             checkPrimitive(doBindings.type());
             doBindings = insertArguments(exactInvoker(doBindings.type()), 0, doBindings);
             long entryPoint = makeUpcallStub(doBindings, abi, conv,
-                    callingSequence.needsReturnBuffer(), callingSequence.returnBufferSize());
+                    callingSequence.needsReturnBuffer(), callingSequence.returnBufferSize(),
+                    callingSequence.capturedStateMask());
             return UpcallStubs.makeUpcall(entryPoint, scope);
         };
     }
@@ -212,7 +213,8 @@ public class UpcallLinker {
     private record CallRegs(VMStorage[] argRegs, VMStorage[] retRegs) {}
 
     static native long makeUpcallStub(MethodHandle mh, ABIDescriptor abi, CallRegs conv,
-                                      boolean needsReturnBuffer, long returnBufferSize);
+                                      boolean needsReturnBuffer, long returnBufferSize,
+                                      int capturedStateMask);
 
     private static native void registerNatives();
     static {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -193,7 +193,7 @@ public abstract class CallArranger {
                                                           LinkerOptions options) {
         Bindings bindings = getBindings(mt, cDesc, true, options);
         final boolean dropReturn = true; /* drop return, since we don't have bindings for it */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, abiDescriptor(),
+        return SharedUtils.arrangeUpcallHelper(bindings.isInMemoryReturn, dropReturn, abiDescriptor(),
                 bindings.callingSequence);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -57,7 +57,7 @@ public final class LinuxAArch64Linker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        return CallArranger.LINUX.arrangeUpcall(targetType, function, options);
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.LINUX.arrangeUpcall(nativeType, function, options);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -57,7 +57,7 @@ public final class MacOsAArch64Linker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        return CallArranger.MACOS.arrangeUpcall(targetType, function, options);
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.MACOS.arrangeUpcall(nativeType, function, options);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/windows/WindowsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/windows/WindowsAArch64Linker.java
@@ -54,7 +54,7 @@ public final class WindowsAArch64Linker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        return CallArranger.WINDOWS.arrangeUpcall(targetType, function, options);
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.WINDOWS.arrangeUpcall(nativeType, function, options);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -106,8 +106,8 @@ public final class FallbackLinker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        MemorySegment cif = makeCif(targetType, function, FFIABI.DEFAULT, Arena.ofAuto());
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        MemorySegment cif = makeCif(nativeType, function, FFIABI.DEFAULT, Arena.ofAuto());
 
         int captureStateMask = options.capturedCallState()
                 .mapToInt(CapturableState::mask)

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -124,7 +124,7 @@ public class LinuxRISCV64CallArranger {
     public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
         Bindings bindings = getBindings(mt, cDesc, true, options);
         final boolean dropReturn = true; /* drop return, since we don't have bindings for it */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, CLinux,
+        return SharedUtils.arrangeUpcallHelper(bindings.isInMemoryReturn, dropReturn, CLinux,
                 bindings.callingSequence);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64Linker.java
@@ -53,7 +53,7 @@ public final class LinuxRISCV64Linker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        return LinuxRISCV64CallArranger.arrangeUpcall(targetType, function, options);
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        return LinuxRISCV64CallArranger.arrangeUpcall(nativeType, function, options);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -141,7 +141,7 @@ public class CallArranger {
     public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
         Bindings bindings = getBindings(mt, cDesc, true, options);
         final boolean dropReturn = true; /* drop return, since we don't have bindings for it */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, CSysV,
+        return SharedUtils.arrangeUpcallHelper(bindings.isInMemoryReturn, dropReturn, CSysV,
                 bindings.callingSequence);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -55,7 +55,7 @@ public final class SysVx64Linker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        return CallArranger.arrangeUpcall(targetType, function, options);
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.arrangeUpcall(nativeType, function, options);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -135,7 +135,7 @@ public class CallArranger {
     public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
         Bindings bindings = getBindings(mt, cDesc, true, options);
         final boolean dropReturn = false; /* need the return value as well */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, CWindows,
+        return SharedUtils.arrangeUpcallHelper(bindings.isInMemoryReturn, dropReturn, CWindows,
                 bindings.callingSequence);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -54,7 +54,7 @@ public final class Windowsx64Linker extends AbstractLinker {
     }
 
     @Override
-    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
-        return CallArranger.arrangeUpcall(targetType, function, options);
+    protected UpcallStubFactory arrangeUpcall(MethodType nativeType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.arrangeUpcall(nativeType, function, options);
     }
 }

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -150,9 +150,8 @@ Java_jdk_internal_foreign_abi_fallback_LibFallback_createClosure(JNIEnv* env, jc
   void* code;
   void* closure = ffi_closure_alloc(sizeof(ffi_closure), &code);
 
-  jobject global_target = (*env)->NewGlobalRef(env, target);
   struct UpcallUserData* upcall_data = malloc(sizeof *upcall_data);
-  upcall_data->target = global_target;
+  upcall_data->target = (*env)->NewGlobalRef(env, target);
   upcall_data->captured_state_mask = captured_state_mask;
 
   ffi_status status = ffi_prep_closure_loc(closure, jlong_to_ptr(cif), &do_upcall, (void*) upcall_data, code);

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -63,6 +63,7 @@ Java_jdk_internal_foreign_abi_fallback_LibFallback_ffi_1get_1struct_1offsets(JNI
   return ffi_get_struct_offsets((ffi_abi) abi, jlong_to_ptr(type), jlong_to_ptr(offsets));
 }
 
+// keep in synch with jdk.internal.foreign.abi.CapturableState
 enum CapturableState {
   CCS_NONE = 0,
   CCS_LAST_ERROR = 1,
@@ -70,8 +71,8 @@ enum CapturableState {
   CCS_ERRNO = 1 << 2
 };
 
+// keep in sync with DowncallLinker::capture_state in hotspot
 static void do_capture_state_downcall(int32_t* value_ptr, int captured_state_mask) {
-    // keep in synch with jdk.internal.foreign.abi.CapturableState
 #ifdef _WIN64
   if (captured_state_mask & CCS_LAST_ERROR) {
     *value_ptr = GetLastError();
@@ -104,7 +105,6 @@ struct UpcallUserData {
 
 // keep in sync with UpcallLinker::capture_state in hotspot
 static void do_capture_state_upcall(int32_t* value_ptr, int captured_state_mask) {
-  // keep in synch with jdk.internal.foreign.abi.CapturableState
 #ifdef _WIN64
   if (captured_state_mask & CCS_LAST_ERROR) {
     SetLastError(*value_ptr);

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -83,8 +83,8 @@ public class TestIllegalLink extends NativeTestHelper {
     public static Object[][] illegalCaptureState() {
         if (!IS_WINDOWS) {
             return new Object[][]{
-                { "GetLastError" },
-                { "WSAGetLastError" },
+                { "LastError" },
+                { "WSALastError" },
             };
         }
         return new Object[][]{};
@@ -94,7 +94,6 @@ public class TestIllegalLink extends NativeTestHelper {
     public static Object[][] downcallOnlyOptions() {
         return new Object[][]{
             { Linker.Option.firstVariadicArg(0) },
-            { Linker.Option.captureCallState("errno") },
             { Linker.Option.isTrivial() },
         };
     }

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -86,7 +86,7 @@ public class TestCaptureCallState extends NativeTestHelper {
         Linker.Option stl = Linker.Option.captureCallState(testCase.threadLocalName());
         FunctionDescriptor downcallDesc = testCase.retValueLayout()
                 .map(rl -> FunctionDescriptor.of(rl, JAVA_INT, rl))
-                .orElse(FunctionDescriptor.ofVoid(JAVA_INT));
+                .orElseGet(() -> FunctionDescriptor.ofVoid(JAVA_INT));
         MethodHandle handle = downcallHandle("set_" + testCase.nativeTarget(), downcallDesc, stl);
 
         StructLayout capturedStateLayout = Linker.Option.captureStateLayout();

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -34,11 +34,15 @@ import org.testng.annotations.Test;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.GroupLayout;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,8 +59,17 @@ import static org.testng.Assert.assertEquals;
 
 public class TestCaptureCallState extends NativeTestHelper {
 
+    static final MethodHandle MH_UPCALL_TARGET;
+
     static {
         System.loadLibrary("CaptureCallState");
+
+        try {
+            MH_UPCALL_TARGET = MethodHandles.lookup().findStatic(TestCaptureCallState.class, "upcallTarget",
+                    MethodType.methodType(Object.class, MemorySegment.class, VarHandle.class, int.class, Object.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
     }
 
     private record SaveValuesCase(String nativeTarget, String threadLocalName, Optional<MemoryLayout> retValueLayout) {
@@ -81,52 +94,87 @@ public class TestCaptureCallState extends NativeTestHelper {
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment saveSeg = arena.allocate(capturedStateLayout);
-            int captureStateValue = 42;
-            TestValue testValue = null;
-            if (testCase.retValueLayout().isPresent()) {
-                testValue = genTestValue(testCase.retValueLayout().get(), arena);
-            }
+            TestValue captureStateValue = genTestValue(JAVA_INT, arena);
+            TestValue testValue = testCase.retValueLayout().map(rl -> genTestValue(rl, arena)).orElse(null);
+
             boolean needsAllocator = testCase.retValueLayout().map(StructLayout.class::isInstance).orElse(false);
             Object result = needsAllocator
-                ? handle.invoke(arena, saveSeg, captureStateValue, testValue.value())
+                ? handle.invoke(arena, saveSeg, captureStateValue.value(), testValue.value())
                 : testValue != null
-                    ? handle.invoke(saveSeg, captureStateValue, testValue.value())
-                    : handle.invoke(saveSeg, captureStateValue);
+                    ? handle.invoke(saveSeg, captureStateValue.value(), testValue.value())
+                    : handle.invoke(saveSeg, captureStateValue.value());
 
             if (testValue != null) {
                 testValue.check().accept(result);
             }
 
             int savedErrno = (int) errnoHandle.get(saveSeg);
-            assertEquals(savedErrno, captureStateValue);
+            captureStateValue.check().accept(savedErrno);
         }
     }
 
-//    @Test(dataProvider = "cases")
-//    public void testUpcalls(SaveValuesCase testCase) throws Throwable {
-//        Linker.Option stl = Linker.Option.captureCallState(testCase.threadLocalName());
-//        FunctionDescriptor downcallDesc = testCase.nativeDescBase().appendArgumentLayouts(ADDRESS, ADDRESS);
-//        FunctionDescriptor upcallDesc = testCase.nativeDescBase();
-//        MethodHandle handle = downcallHandle("get_" + testCase.nativeTarget(), downcallDesc, stl);
-//
-//        StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
-//        VarHandle errnoHandle = capturedStateLayout.varHandle(groupElement(testCase.threadLocalName()));
-//
-//        try (Arena arena = Arena.ofConfined()) {
-//            int testValue = 42;
-//            MemorySegment callback = upcallStub();
-//
-//            MemorySegment writeBack = arena.allocate(JAVA_INT);
-//            boolean needsAllocator = downcallDesc.returnLayout().map(StructLayout.class::isInstance).orElse(false);
-//            Object result = needsAllocator
-//                ? handle.invoke(arena, writeBack, callback)
-//                : handle.invoke(writeBack, callback);
-//            testCase.resultCheck().accept(result);
-//
-//            int savedErrno = writeBack.get(JAVA_INT, 0);
-//            assertEquals(savedErrno, testValue);
-//        }
-//    }
+    @Test(dataProvider = "cases")
+    public void testUpcalls(SaveValuesCase testCase) throws Throwable {
+        FunctionDescriptor downcallDesc = testCase.retValueLayout()
+                .map(rl -> FunctionDescriptor.of(rl, ADDRESS, ADDRESS))
+                .orElse(FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+        MethodHandle handle = downcallHandle("get_" + testCase.nativeTarget(), downcallDesc);
+
+        try (Arena arena = Arena.ofConfined()) {
+            TestValue captureStateValue = genTestValue(JAVA_INT, arena);
+            TestValue testValue = testCase.retValueLayout().map(rl -> genTestValue(rl, arena)).orElse(null);
+
+            MemorySegment callback = makeCaptureStateCallback(arena, testCase.threadLocalName(),
+                    testCase.retValueLayout(), (int) captureStateValue.value(),
+                    testValue == null ? null : testValue.value());
+
+            MemorySegment writeBack = arena.allocate(JAVA_INT);
+            boolean needsAllocator = downcallDesc.returnLayout().map(StructLayout.class::isInstance).orElse(false);
+            Object result = needsAllocator
+                ? handle.invoke(arena, writeBack, callback)
+                : handle.invoke(writeBack, callback);
+
+            if (testValue != null) {
+                testValue.check().accept(result);
+            }
+
+            int savedErrno = writeBack.get(JAVA_INT, 0);
+            captureStateValue.check().accept(savedErrno);
+        }
+    }
+
+    private MemorySegment makeCaptureStateCallback(Arena arena, String threadLocalName, Optional<MemoryLayout> retLayout,
+                                                   int captureStateValue, Object testValue) {
+        FunctionDescriptor upcallDesc = retLayout
+            .map(FunctionDescriptor::of)
+            .orElse(FunctionDescriptor.ofVoid());
+        StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
+        VarHandle errnoHandle = capturedStateLayout.varHandle(groupElement(threadLocalName));
+        MethodHandle target = MethodHandles.insertArguments(MH_UPCALL_TARGET, 1, errnoHandle, captureStateValue, testValue);
+        if (retLayout.isEmpty()) {
+            target = MethodHandles.dropReturn(target);
+        } else {
+            target = target.asType(target.type().changeReturnType(carrierFor(retLayout.get())));
+        }
+        return LINKER.upcallStub(target, upcallDesc, arena,
+                Linker.Option.captureCallState(threadLocalName));
+    }
+
+    private Class<?> carrierFor(MemoryLayout layout) {
+        if (layout instanceof ValueLayout valueLayout) {
+            return valueLayout.carrier();
+        } else if (layout instanceof GroupLayout) {
+            return MemorySegment.class;
+        } else {
+            throw new IllegalArgumentException("Unsupported layout: " + layout);
+        }
+    }
+
+    public static Object upcallTarget(MemorySegment writeback, VarHandle writebackHandle, int captureStateValue,
+                                      Object returnValue) {
+        writebackHandle.set(writeback, captureStateValue);
+        return returnValue;
+    }
 
     @DataProvider
     public static Object[][] cases() {

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -107,8 +107,8 @@ public class TestCaptureCallState extends NativeTestHelper {
                                             JAVA_DOUBLE.withName("z"), 42D)));
 
         if (IS_WINDOWS) {
-            cases.add(new SaveValuesCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "GetLastError", o -> {}));
-            cases.add(new SaveValuesCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSAGetLastError", o -> {}));
+            cases.add(new SaveValuesCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "LastError", o -> {}));
+            cases.add(new SaveValuesCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSALastError", o -> {}));
         }
 
         return cases.stream().map(tc -> new Object[] {tc}).toArray(Object[][]::new);
@@ -129,4 +129,3 @@ public class TestCaptureCallState extends NativeTestHelper {
     }
 
 }
-

--- a/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
+++ b/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
@@ -163,8 +163,16 @@ EXPORT struct SDDD get_errno_SDDD(int* value_out, struct SDDD (*cb)(void)) {
 EXPORT void set_last_error(int capture_state_value) {
     SetLastError(capture_state_value);
 }
+EXPORT void get_last_error(int* value_out, void (*cb)(void)) {
+    cb();
+    *value_out = GetLastError();
+}
 
 EXPORT void set_wsa_last_error(int capture_state_value) {
     WSASetLastError(capture_state_value);
+}
+EXPORT void get_wsa_last_error(int* value_out, void (*cb)(void)) {
+    cb();
+    *value_out = WSAGetLastError();
 }
 #endif

--- a/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
+++ b/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
@@ -24,33 +24,57 @@
 #include <errno.h>
 
 #ifdef _WIN64
+#include <Windows.h>
+#include <Winsock2.h>
+
 #define EXPORT __declspec(dllexport)
 #else
 #define EXPORT
 #endif
 
-EXPORT void set_errno_V(int value) {
-    errno = value;
+EXPORT void set_errno_V(int capture_state_value) {
+    errno = capture_state_value;
 }
 
-EXPORT int set_errno_I(int value) {
-    errno = value;
-    return 42;
+EXPORT void get_errno_V(int* value_out, void (*cb)(void)) {
+    cb();
+    *value_out = errno;
 }
 
-EXPORT double set_errno_D(int value) {
-    errno = value;
-    return 42.0;
+EXPORT int set_errno_I(int capture_state_value, int test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT int get_errno_I(int* value_out, int (*cb)(void)) {
+    int i = cb();
+    *value_out = errno;
+    return i;
+}
+
+EXPORT double set_errno_D(int capture_state_value, double test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT double get_errno_D(int* value_out, double (*cb)(void)) {
+    double d = cb();
+    *value_out = errno;
+    return d;
 }
 
 struct SL {
     long long x;
 };
 
-EXPORT struct SL set_errno_SL(int value) {
-    errno = value;
-    struct SL s;
-    s.x = 42;
+EXPORT struct SL set_errno_SL(int capture_state_value, struct SL test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT struct SL get_errno_SL(int* value_out, struct SL (*cb)(void)) {
+    struct SL s = cb();
+    *value_out = errno;
     return s;
 }
 
@@ -59,11 +83,14 @@ struct SLL {
     long long y;
 };
 
-EXPORT struct SLL set_errno_SLL(int value) {
-    errno = value;
-    struct SLL s;
-    s.x = 42;
-    s.y = 42;
+EXPORT struct SLL set_errno_SLL(int capture_state_value, struct SLL test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT struct SLL get_errno_SLL(int* value_out, struct SLL (*cb)(void)) {
+    struct SLL s = cb();
+    *value_out = errno;
     return s;
 }
 
@@ -73,12 +100,14 @@ struct SLLL {
     long long z;
 };
 
-EXPORT struct SLLL set_errno_SLLL(int value) {
-    errno = value;
-    struct SLLL s;
-    s.x = 42;
-    s.y = 42;
-    s.z = 42;
+EXPORT struct SLLL set_errno_SLLL(int capture_state_value, struct SLLL test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT struct SLLL get_errno_SLLL(int* value_out, struct SLLL (*cb)(void)) {
+    struct SLLL s = cb();
+    *value_out = errno;
     return s;
 }
 
@@ -86,10 +115,14 @@ struct SD {
     double x;
 };
 
-EXPORT struct SD set_errno_SD(int value) {
-    errno = value;
-    struct SD s;
-    s.x = 42.0;
+EXPORT struct SD set_errno_SD(int capture_state_value, struct SD test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT struct SD get_errno_SD(int* value_out, struct SD (*cb)(void)) {
+    struct SD s = cb();
+    *value_out = errno;
     return s;
 }
 
@@ -98,11 +131,14 @@ struct SDD {
     double y;
 };
 
-EXPORT struct SDD set_errno_SDD(int value) {
-    errno = value;
-    struct SDD s;
-    s.x = 42.0;
-    s.y = 42.0;
+EXPORT struct SDD set_errno_SDD(int capture_state_value, struct SDD test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT struct SDD get_errno_SDD(int* value_out, struct SDD (*cb)(void)) {
+    struct SDD s = cb();
+    *value_out = errno;
     return s;
 }
 
@@ -112,11 +148,23 @@ struct SDDD {
     double z;
 };
 
-EXPORT struct SDDD set_errno_SDDD(int value) {
-    errno = value;
-    struct SDDD s;
-    s.x = 42.0;
-    s.y = 42.0;
-    s.z = 42.0;
+EXPORT struct SDDD set_errno_SDDD(int capture_state_value, struct SDDD test_value) {
+    errno = capture_state_value;
+    return test_value;
+}
+
+EXPORT struct SDDD get_errno_SDDD(int* value_out, struct SDDD (*cb)(void)) {
+    struct SDDD s = cb();
+    *value_out = errno;
     return s;
 }
+
+#ifdef _WIN64
+EXPORT void set_last_error(int capture_state_value) {
+    SetLastError(capture_state_value);
+}
+
+EXPORT void set_wsa_last_error(int capture_state_value) {
+    WSASetLastError(capture_state_value);
+}
+#endif


### PR DESCRIPTION
Implement captureCallState support for upcall stubs.

The method handle of an upcall stub linked with this linker option has an additional leading memory segment parameter into which the capture state (e.g. errno) should be written. After returning from Java, this value is then actually written to the corresponding execution state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 21 to be approved (needs to be created)

### Integration blocker
&nbsp;⚠️ Dependency #13079 must be integrated first

### Issue
 * [JDK-8304986](https://bugs.openjdk.org/browse/JDK-8304986): Upcall stubs should support capureCallState


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13588/head:pull/13588` \
`$ git checkout pull/13588`

Update a local copy of the PR: \
`$ git checkout pull/13588` \
`$ git pull https://git.openjdk.org/jdk.git pull/13588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13588`

View PR using the GUI difftool: \
`$ git pr show -t 13588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13588.diff">https://git.openjdk.org/jdk/pull/13588.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13588#issuecomment-1519489016)