### PR TITLE
8233725: ProcessTools.startProcess() has output issues when using an OutputAnalyzer at the same time

### DIFF
--- a/test/jdk/sun/tools/jhsdb/JStackStressTest.java
+++ b/test/jdk/sun/tools/jhsdb/JStackStressTest.java
@@ -46,6 +46,8 @@ public class JStackStressTest {
     public static void testjstack() throws IOException {
         launchJshell();
         long jShellPID = jShellProcess.pid();
+        OutputAnalyzer jshellOutput = new OutputAnalyzer(jShellProcess);
+
         try {
             // Do 4 jstacks on the jshell process as it starts up
             for (int i = 1; i <= 4; i++) {
@@ -83,7 +85,6 @@ public class JStackStressTest {
                 jShellProcess.waitFor(); // jshell should exit quickly
             } catch (InterruptedException e) {
             }
-            OutputAnalyzer jshellOutput = new OutputAnalyzer(jShellProcess);
             System.out.println("jshell Output: " + jshellOutput.getOutput());
         }
     }

--- a/test/jdk/sun/tools/jhsdb/JStackStressTest.java
+++ b/test/jdk/sun/tools/jhsdb/JStackStressTest.java
@@ -46,8 +46,6 @@ public class JStackStressTest {
     public static void testjstack() throws IOException {
         launchJshell();
         long jShellPID = jShellProcess.pid();
-        OutputAnalyzer jshellOutput = new OutputAnalyzer(jShellProcess);
-
         try {
             // Do 4 jstacks on the jshell process as it starts up
             for (int i = 1; i <= 4; i++) {
@@ -85,6 +83,7 @@ public class JStackStressTest {
                 jShellProcess.waitFor(); // jshell should exit quickly
             } catch (InterruptedException e) {
             }
+            OutputAnalyzer jshellOutput = new OutputAnalyzer(jShellProcess);
             System.out.println("jshell Output: " + jshellOutput.getOutput());
         }
     }

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,7 +350,10 @@ public final class JstatdTest {
 
         // Verify output from jstatd
         OutputAnalyzer output = jstatdThread.getOutput();
-        output.shouldBeEmptyIgnoreVMWarnings();
+        List<String> stdout = output.asLinesWithoutVMWarnings();
+        output.reportDiagnosticSummary();
+        assertEquals(stdout.size(), 1, "Output should contain one line");
+        assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");
         assertNotEquals(output.getExitValue(), 0,
                 "jstatd process exited with unexpected exit code");
     }

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Unit test for ProcessTools.startProcess()
+ * @library /test/lib
+ * @compile ProcessToolsStartProcessTest.java
+ * @run main ProcessToolsStartProcessTest
+ */
+
+import java.util.function.Consumer;
+import java.io.File;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class ProcessToolsStartProcessTest {
+    static final int NUM_LINES = 50;
+    static String output = "";
+
+    private static Consumer<String> outputConsumer = s -> {
+        output += s + "\n";
+    };
+
+    static boolean testStartProcess(boolean withConsumer) throws Exception {
+        boolean success = true;
+        Process p;
+        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
+        launcher.addToolArg("-cp");
+        launcher.addToolArg(Utils.TEST_CLASSES);
+        launcher.addToolArg("ProcessToolsStartProcessTest");
+        launcher.addToolArg("test"); // This one argument triggers producing the output
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.command(launcher.getCommand());
+
+        System.out.println("DEBUG: Test with withConsumer=" + withConsumer);
+        System.out.println("DEBUG: about to start process.");
+        if (withConsumer) {
+            p = ProcessTools.startProcess("java", pb, outputConsumer);
+        } else {
+            p = ProcessTools.startProcess("java", pb);
+        }
+        OutputAnalyzer out = new OutputAnalyzer(p);
+
+        System.out.println("DEBUG: process started.");
+        p.waitFor();
+        if (p.exitValue() != 0) {
+            throw new RuntimeException("Bad exit value: " + p.exitValue());
+        }
+
+        if (withConsumer) {
+            int numLines = output.split("\n").length;
+            if (numLines != NUM_LINES ) {
+                System.out.print("FAILED: wrong number of lines in Consumer output\n");
+                success = false;
+            }
+            System.out.println("DEBUG: Consumer output: got " + numLines + " lines , expected "
+                               + NUM_LINES  + ". Output follow:");
+            System.out.print(output);
+            System.out.println("DEBUG: done with Consumer output.");
+        }
+
+        int numLinesOut = out.getStdout().split("\n").length;
+        if (numLinesOut != NUM_LINES) {
+            System.out.print("FAILED: wrong number of lines in OutputAnalyzer output\n");
+            success = false;
+        }
+        System.out.println("DEBUG: OutputAnalyzer output: got " + numLinesOut + " lines, expected "
+                           + NUM_LINES  + ". Output follows:");
+        System.out.print(out.getStdout());
+        System.out.println("DEBUG: done with OutputAnalyzer stdout.");
+
+        return success;
+    }
+
+    public static void main(String[] args) {
+        if (args.length > 0) {
+            for (int i = 0; i < NUM_LINES; i++) {
+                System.out.println("A line on stdout " + i);
+            }
+        } else {
+            try {
+                boolean test1Result = testStartProcess(false);
+                boolean test2Result = testStartProcess(true);
+                if (!test1Result || !test2Result) {
+                    throw new RuntimeException("One or more tests failed. See output for details.");
+                }
+            } catch (RuntimeException re) {
+                re.printStackTrace();
+                System.out.println("Test ERROR");
+                throw re;
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                System.out.println("Test ERROR");
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -210,7 +210,7 @@ public final class ProcessTools {
      * <p>
      * It is possible to wait for the process to get to a warmed-up state
      * via {@linkplain Predicate} condition on the STDOUT/STDERR and monitor the
-     * in-streams via the provided {@linkplain Consumer}*
+     * in-streams via the provided {@linkplain Consumer}
      * </p>
      *
      * @param name           The process name

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -167,9 +167,10 @@ public final class ProcessTools {
             this.p = p;
         }
 
-        synchronized  int readNext() {
+        synchronized int readNext() {
             if (current > count) {
-                throw new RuntimeException("Shouldn't ever happen.  start: " + current + " count: " + count + " buffer: " + this);
+                throw new RuntimeException("Shouldn't ever happen.  start: "
+                        + current + " count: " + count + " buffer: " + this);
             }
             while (current == count) {
                 if (!p.isAlive()) {
@@ -210,7 +211,7 @@ public final class ProcessTools {
      * <p>
      * It is possible to wait for the process to get to a warmed-up state
      * via {@linkplain Predicate} condition on the STDOUT/STDERR and monitor the
-     * in-streams via the provided {@linkplain Consumer}
+     * in-streams via the provided {@linkplain Consumer}*
      * </p>
      *
      * @param name           The process name
@@ -241,11 +242,11 @@ public final class ProcessTools {
 
         stdout.addPump(new LineForwarder(name, System.out));
         stderr.addPump(new LineForwarder(name, System.err));
-        BufferInputStream out = new BufferInputStream(p);
-        BufferInputStream err = new BufferInputStream(p);
+        BufferInputStream stdOut = new BufferInputStream(p);
+        BufferInputStream stdErr = new BufferInputStream(p);
 
-        stdout.addOutputStream(out.getOutputStream());
-        stderr.addOutputStream(err.getOutputStream());
+        stdout.addOutputStream(stdOut.getOutputStream());
+        stderr.addOutputStream(stdErr.getOutputStream());
 
         if (lineConsumer != null) {
             StreamPumper.LinePump pump = new StreamPumper.LinePump() {
@@ -316,7 +317,7 @@ public final class ProcessTools {
             throw e;
         }
 
-        return new ProcessImpl(p, stdoutTask, stderrTask, out, err);
+        return new ProcessImpl(p, stdoutTask, stderrTask, stdOut, stdErr);
     }
 
     /**
@@ -767,19 +768,19 @@ public final class ProcessTools {
 
     private static class ProcessImpl extends Process {
 
-        private final InputStream out;
-        private final InputStream err;
+        private final InputStream stdOut;
+        private final InputStream stdErr;
         private final Process p;
         private final Future<Void> stdoutTask;
         private final Future<Void> stderrTask;
 
         public ProcessImpl(Process p, Future<Void> stdoutTask, Future<Void> stderrTask,
-                           InputStream out, InputStream err) {
+                           InputStream stdOut, InputStream etdErr) {
             this.p = p;
             this.stdoutTask = stdoutTask;
             this.stderrTask = stderrTask;
-            this.out = out;
-            this.err = err;
+            this.stdOut = stdOut;
+            this.stdErr = etdErr;
         }
 
         @Override
@@ -789,12 +790,12 @@ public final class ProcessTools {
 
         @Override
         public InputStream getInputStream() {
-            return out;
+            return stdOut;
         }
 
         @Override
         public InputStream getErrorStream() {
-            return err;
+            return stdErr;
         }
 
         @Override

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -211,7 +211,7 @@ public final class ProcessTools {
      * <p>
      * It is possible to wait for the process to get to a warmed-up state
      * via {@linkplain Predicate} condition on the STDOUT/STDERR and monitor the
-     * in-streams via the provided {@linkplain Consumer}*
+     * in-streams via the provided {@linkplain Consumer}
      * </p>
      *
      * @param name           The process name


### PR DESCRIPTION
ProcessTools.startProcess() creates process and read it's output error streams. So the any other using of corresponding Process.getInputStream() and Process.getErrorStream() doesn't get process streams.

This fix preserve process streams content and allow to read reuse the date. The ByteArrayOutputStream is used as a buffer. 
It stores all process output, never trying to clean date which has been read. 

The regression test has been provided with issue.

I closed previous PR https://github.com/openjdk/jdk/pull/13560 by mistake instead of updating it.

I run all tests to ensure that no failures are introduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233725](https://bugs.openjdk.org/browse/JDK-8233725): ProcessTools.startProcess() has output issues when using an OutputAnalyzer at the same time


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [782e9cd6](https://git.openjdk.org/jdk/pull/13594/files/782e9cd672545b0a586af64f01b21d3e22d67ff5)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [782e9cd6](https://git.openjdk.org/jdk/pull/13594/files/782e9cd672545b0a586af64f01b21d3e22d67ff5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13594/head:pull/13594` \
`$ git checkout pull/13594`

Update a local copy of the PR: \
`$ git checkout pull/13594` \
`$ git pull https://git.openjdk.org/jdk.git pull/13594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13594`

View PR using the GUI difftool: \
`$ git pr show -t 13594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13594.diff">https://git.openjdk.org/jdk/pull/13594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13594#issuecomment-1519185160)