### PR TITLE
8306566: Open source several clipboard AWT tests

### DIFF
--- a/test/jdk/java/awt/Clipboard/FlavorChangeNotificationTest/Common.java
+++ b/test/jdk/java/awt/Clipboard/FlavorChangeNotificationTest/Common.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Image;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.FlavorEvent;
+import java.awt.datatransfer.FlavorListener;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+
+public class Common {}
+
+class FlavorListenerImpl implements FlavorListener {
+    public boolean notified1, notified2;
+    private int count;
+    public void flavorsChanged(FlavorEvent evt) {
+        switch (count) {
+            case 0:
+                notified1 = true;
+                break;
+            case 1:
+                notified2 = true;
+                break;
+        }
+        count++;
+        System.err.println("listener's " + this +
+                " flavorChanged() called " + count + " time");
+    }
+    public String toString() {
+        return "notified1=" + notified1 + " notified2=" + notified2 +
+                " count=" + count;
+    }
+};
+
+ class Util {
+    public static void setClipboardContents(Clipboard cb,
+                                            Transferable contents,
+                                            ClipboardOwner owner) {
+        while (true) {
+            try {
+                cb.setContents(contents, owner);
+                return;
+            } catch (IllegalStateException ise) {
+                ise.printStackTrace();
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                    ie.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            ie.printStackTrace();
+        }
+    }
+
+    public static Image createImage() {
+        int w = 100;
+        int h = 100;
+        int[] pix = new int[w * h];
+
+        int index = 0;
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int red = 127;
+                int green = 127;
+                int blue = y > h / 2 ? 127 : 0;
+                int alpha = 255;
+                if (x < w / 4 && y < h / 4) {
+                    alpha = 0;
+                    red = 0;
+                }
+                pix[index++] = (alpha << 24) | (red << 16) | (green << 8) | blue;
+            }
+        }
+
+        return Toolkit
+                .getDefaultToolkit().
+                        createImage(new java.awt.image.MemoryImageSource(
+                                w, h, pix, 0, w
+                        ));
+    }
+
+}
+
+
+class TransferableUnion implements Transferable {
+
+    private static final DataFlavor[] ZERO_LENGTH_ARRAY = new DataFlavor[0];
+
+    private final Transferable TRANSF1, TRANSF2;
+
+    private final DataFlavor[] FLAVORS;
+
+
+    public TransferableUnion(Transferable t1, Transferable t2) {
+        if (t1 == null) {
+            throw new NullPointerException("t1");
+        }
+        if (t2 == null) {
+            throw new NullPointerException("t2");
+        }
+
+        this.TRANSF1 = t1;
+        this.TRANSF2 = t2;
+
+        java.util.Set<DataFlavor> flavorSet = new java.util.HashSet<>();
+        flavorSet.addAll(java.util.Arrays.asList(t1.getTransferDataFlavors()));
+        flavorSet.addAll(java.util.Arrays.asList(t2.getTransferDataFlavors()));
+
+        FLAVORS = flavorSet.toArray(ZERO_LENGTH_ARRAY);
+    }
+
+    /**
+     * Returns an array of flavors in which this <code>Transferable</code>
+     * can provide the data.
+     */
+    public DataFlavor[] getTransferDataFlavors() {
+        return FLAVORS.clone();
+    }
+
+    /**
+     * Returns whether the requested flavor is supported by this
+     * <code>Transferable</code>.
+     *
+     * @param flavor the requested flavor for the data
+     * @throws NullPointerException if flavor is <code>null</code>
+     */
+    public boolean isDataFlavorSupported(DataFlavor flavor) {
+        if (flavor == null) {
+            throw new NullPointerException("flavor");
+        }
+
+        return TRANSF1.isDataFlavorSupported(flavor)
+                || TRANSF2.isDataFlavorSupported(flavor);
+    }
+
+    /**
+     * Returns the <code>Transferable</code>'s data in the requested
+     * <code>DataFlavor</code> if possible.
+     *
+     * @param flavor the requested flavor for the data
+     * @return the data in the requested flavor
+     * @throws UnsupportedFlavorException if the requested data flavor is
+     *         not supported by this Transferable
+     * @throws IOException if an <code>IOException</code> occurs while
+     *         retrieving the data.
+     * @throws NullPointerException if flavor is <code>null</code>
+     */
+    public Object getTransferData(DataFlavor flavor)
+            throws UnsupportedFlavorException, java.io.IOException {
+
+        if (!isDataFlavorSupported(flavor)) {
+            throw new UnsupportedFlavorException(flavor);
+        }
+
+        java.io.IOException ioexc = null;
+
+        if (TRANSF1.isDataFlavorSupported(flavor)) {
+            try {
+                return TRANSF1.getTransferData(flavor);
+            } catch (java.io.IOException exc) {
+                ioexc = exc;
+            }
+        }
+
+        if (TRANSF2.isDataFlavorSupported(flavor)) {
+            return TRANSF2.getTransferData(flavor);
+        }
+
+        if (ioexc != null) {
+            throw ioexc;
+        }
+
+        // unreachable
+        return null;
+    }
+
+}
+
+/**
+ * A <code>Transferable</code> that implements the capability required
+ * to transfer an <code>Image</code>.
+ *
+ * This <code>Transferable</code> properly supports
+ * <code>DataFlavor.imageFlavor</code>
+ * and all equivalent flavors.
+ * No other <code>DataFlavor</code>s are supported.
+ *
+ * @see java.awt.datatransfer.DataFlavor.imageFlavor
+ */
+class ImageSelection implements Transferable {
+
+    private static final DataFlavor[] flavors = { DataFlavor.imageFlavor };
+
+    private Image data;
+
+    /**
+     * Creates a <code>Transferable</code> capable of transferring
+     * the specified <code>Image</code>.
+     */
+    public ImageSelection(Image data) {
+        this.data = data;
+    }
+
+    /**
+     * Returns an array of flavors in which this <code>Transferable</code>
+     * can provide the data. <code>DataFlavor.stringFlavor</code>
+     * is supported.
+     *
+     * @return an array of length one, whose element is <code>DataFlavor.
+     *         imageFlavor</code>
+     */
+    public DataFlavor[] getTransferDataFlavors() {
+        return flavors.clone();
+    }
+
+    /**
+     * Returns whether the requested flavor is supported by this
+     * <code>Transferable</code>.
+     *
+     * @param flavor the requested flavor for the data
+     * @return true if <code>flavor</code> is equal to
+     *   <code>DataFlavor.imageFlavor</code>;
+     *   false otherwise
+     * @throws NullPointerException if flavor is <code>null</code>
+     */
+    public boolean isDataFlavorSupported(DataFlavor flavor) {
+        for (int i = 0; i < flavors.length; i++) {
+            if (flavor.equals(flavors[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the <code>Transferable</code>'s data in the requested
+     * <code>DataFlavor</code> if possible. If the desired flavor is
+     * <code>DataFlavor.imageFlavor</code>, or an equivalent flavor,
+     * the <code>Image</code> representing the selection is
+     * returned.
+     *
+     * @param flavor the requested flavor for the data
+     * @return the data in the requested flavor, as outlined above
+     * @throws UnsupportedFlavorException if the requested data flavor is
+     *         not equivalent to <code>DataFlavor.imageFlavor</code>
+     * @throws IOException if an <code>IOException</code> occurs while
+     *         retrieving the data. By default, <code>ImageSelection</code>
+     *         never throws this exception, but a subclass may.
+     * @throws NullPointerException if flavor is <code>null</code>
+     */
+    public Object getTransferData(DataFlavor flavor)
+            throws UnsupportedFlavorException, java.io.IOException {
+        if (flavor.equals(DataFlavor.imageFlavor)) {
+            return data;
+        } else {
+            throw new UnsupportedFlavorException(flavor);
+        }
+    }
+
+} // class ImageSelection
+

--- a/test/jdk/java/awt/Clipboard/FlavorChangeNotificationTest/PrivateClipboardTest.java
+++ b/test/jdk/java/awt/Clipboard/FlavorChangeNotificationTest/PrivateClipboardTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4259272
+  @summary tests that notifications on changes to the set of DataFlavors
+           available on a private clipboard are delivered properly
+  @build Common
+  @run main PrivateClipboardTest
+*/
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+
+public class PrivateClipboardTest {
+
+    public static void main(String[] args) {
+        new PrivateClipboardTest().start();
+    }
+
+    public void start() {
+        final Clipboard clipboard = new Clipboard("local");
+
+        final FlavorListenerImpl listener1 = new FlavorListenerImpl();
+        clipboard.addFlavorListener(listener1);
+
+        final FlavorListenerImpl listener2 = new FlavorListenerImpl();
+        clipboard.addFlavorListener(listener2);
+
+        Util.setClipboardContents(clipboard,
+                new StringSelection("text1"), null);
+        Util.sleep(3000);
+
+        clipboard.removeFlavorListener(listener1);
+
+        Util.setClipboardContents(clipboard,
+                new TransferableUnion(new StringSelection("text2"),
+                        new ImageSelection(Util.createImage())), null);
+        Util.sleep(3000);
+
+        System.err.println("listener1: " + listener1 + "\nlistener2: " + listener2);
+
+        if (!(listener1.notified1 && listener2.notified1 && !listener1.notified2
+                && listener2.notified2)) {
+            throw new RuntimeException("notifications about flavor " +
+                                       "changes delivered incorrectly!");
+        }
+     }
+}

--- a/test/jdk/java/awt/Clipboard/FlavorChangeNotificationTest/SystemClipboardTest.java
+++ b/test/jdk/java/awt/Clipboard/FlavorChangeNotificationTest/SystemClipboardTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4259272
+  @summary tests that notifications on changes to the set of DataFlavors
+           available on the system clipboard are delivered properly
+  @key headful
+  @modules java.desktop/sun.awt
+  @build Common
+  @run main SystemClipboardTest
+*/
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+
+import sun.awt.SunToolkit;
+
+public class SystemClipboardTest {
+
+    private final Clipboard clipboard =
+            Toolkit.getDefaultToolkit().getSystemClipboard();
+
+    private final FlavorListenerImpl listener1 = new FlavorListenerImpl();
+
+    private final FlavorListenerImpl listener2 = new FlavorListenerImpl();
+
+    private boolean isListener2Added;
+
+
+    public static void main(String[] args) {
+        new SystemClipboardTest().start();
+    }
+
+    public void start() {
+        Util.setClipboardContents(clipboard,
+                new StringSelection("text3"), null);
+
+        clipboard.addFlavorListener(listener1);
+
+        final ThreadGroup threadGroup = new ThreadGroup("Test thread group");
+        final Object lock = new Object();
+        final Runnable runnable = new Runnable() {
+                public void run() {
+                    SunToolkit.createNewAppContext();
+                    clipboard.addFlavorListener(listener2);
+                    synchronized (lock) {
+                        isListener2Added = true;
+                        lock.notifyAll();
+                    }
+                }
+        };
+        final Thread thread = new Thread(threadGroup, runnable, "Test thread");
+        synchronized (lock) {
+            thread.start();
+            while (!isListener2Added) {
+                try {
+                    lock.wait();
+                } catch (InterruptedException ie) {
+                    ie.printStackTrace();
+                }
+            }
+        }
+
+        Util.setClipboardContents(clipboard,
+                new TransferableUnion(new StringSelection("text2"),
+                        new ImageSelection(Util.createImage())),
+                null);
+        Util.sleep(3000);
+
+        clipboard.removeFlavorListener(listener1);
+        // must not remove listener2 from this AppContext
+
+        Util.setClipboardContents(clipboard,
+                new StringSelection("text3"), null);
+        Util.sleep(3000);
+
+        System.err.println("listener1: " + listener1
+                + "\nlistener2: " + listener2);
+
+        if (!(listener1.notified1
+                && listener2.notified1
+                && !listener1.notified2
+                && listener2.notified2)) {
+            throw new RuntimeException("notifications about flavor " +
+                                       "changes delivered incorrectly!");
+        }
+     }
+}

--- a/test/jdk/java/awt/Clipboard/GetAltContentsTest/PrivateClipboardTest.java
+++ b/test/jdk/java/awt/Clipboard/GetAltContentsTest/PrivateClipboardTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4287795 4790833
+  @summary tests new Clipboard methods: getAvailableDataFlavors,
+           isDataFlavorAvailable, getData
+  @run main PrivateClipboardTest
+*/
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class PrivateClipboardTest {
+
+    public static void main(String[] args) {
+        boolean failed = false;
+        final Clipboard clipboard = new Clipboard("local");
+
+        if (clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
+            failed = true;
+            System.err.println("FAILURE: isDataFlavorAvailable() returns " +
+                               "true for empty clipboard");
+        }
+
+        try {
+            clipboard.getData(DataFlavor.stringFlavor);
+            failed = true;
+            System.err.println("FAILURE: getData() does not throw " +
+                    "UnsupportedFlavorException for empty clipboard");
+        } catch (UnsupportedFlavorException exc) {
+            System.err.println("getData() for empty clipboard throw " +
+                               "UnsupportedFlavorException correctly: " + exc);
+        } catch (IOException exc) {
+            failed = true;
+            exc.printStackTrace();
+        }
+
+        if (clipboard.getAvailableDataFlavors() == null ||
+                clipboard.getAvailableDataFlavors().length != 0) {
+            failed = true;
+            System.err.println("FAILURE: getAvailableDataFlavors() does not " +
+                    "return zero-length array for empty clipboard: " +
+                    Arrays.toString(clipboard.getAvailableDataFlavors()));
+        }
+
+        final String contentsText = "contents text";
+
+        clipboard.setContents(new StringSelection(contentsText), null);
+
+        Transferable contents = clipboard.getContents(null);
+        Set<DataFlavor> flavorsT = new HashSet<>(
+                Arrays.asList(contents.getTransferDataFlavors()));
+        Set<DataFlavor> flavorsA = new HashSet<>(
+                Arrays.asList(clipboard.getAvailableDataFlavors()));
+        System.err.println("getAvailableDataFlavors(): " + flavorsA);
+        if (!flavorsA.equals(flavorsT)) {
+            failed = true;
+            System.err.println(
+                    "FAILURE: getAvailableDataFlavors() returns incorrect " +
+                    "DataFlavors: " + flavorsA + "\nwhile getContents()." +
+                    "getTransferDataFlavors() return: " + flavorsT);
+        }
+
+        if (!clipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
+            failed = true;
+            System.err.println(
+                    "FAILURE: isDataFlavorAvailable(DataFlavor.stringFlavor) " +
+                               "returns false");
+        }
+
+        Object data = null;
+        try {
+            data = clipboard.getData(DataFlavor.stringFlavor);
+        } catch (UnsupportedFlavorException exc) {
+            failed = true;
+            exc.printStackTrace();
+        } catch (IOException exc) {
+            failed = true;
+            exc.printStackTrace();
+        }
+        System.err.println("getData(): " + data);
+        if (!contentsText.equals(data)) {
+            failed = true;
+            System.err.println("FAILURE: getData() returns: " + data +
+                               ", that is not equal to: \"" + contentsText + "\"");
+        }
+
+        if (failed) {
+            throw new RuntimeException("test failed, for details see output above");
+        }
+     }
+}

--- a/test/jdk/java/awt/Clipboard/LostOwnershipChainTest/PrivateClipboardTest.java
+++ b/test/jdk/java/awt/Clipboard/LostOwnershipChainTest/PrivateClipboardTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4683804
+  @summary Tests that in ClipboardOwner.lostOwnership() Clipboard.getContents()
+           returns actual contents of the clipboard and Clipboard.setContents()
+           can set contents of the clipboard and its owner. The clipboard is
+           a private clipboard.
+*/
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+
+public class PrivateClipboardTest  {
+
+    public static void main(String[] args) {
+        PrivateClipboardOwner.run();
+
+        if (PrivateClipboardOwner.failed) {
+            throw new RuntimeException("test failed: can not get actual " +
+            "contents of the clipboard or set owner of the clipboard");
+        } else {
+            System.err.println("test passed");
+        }
+    }
+}
+
+class PrivateClipboardOwner implements ClipboardOwner {
+    static boolean failed;
+
+    private static final Object LOCK = new Object();
+
+    private static final int CHAIN_LENGTH = 5;
+    private final static Clipboard clipboard =
+            new Clipboard("PrivateClipboard");
+
+    private int m, id;
+
+    public PrivateClipboardOwner(int m) { this.m = m; id = m; }
+
+    public void lostOwnership(Clipboard cb, Transferable contents) {
+        System.err.println(id + " lost clipboard ownership");
+
+        Transferable t = cb.getContents(null);
+        String msg = null;
+        try {
+            msg = (String)t.getTransferData(DataFlavor.stringFlavor);
+        } catch (Exception e) {
+             System.err.println(id + " can't getTransferData: " + e);
+        }
+        System.err.println(id + " Clipboard.getContents(): " + msg);
+        if ( ! msg.equals( "" + (m+1) ) ) {
+            failed = true;
+            System.err.println(
+                    "Clipboard.getContents() returned incorrect contents!");
+        }
+
+        m += 2;
+        if (m <= CHAIN_LENGTH) {
+            System.err.println(id + " Clipboard.setContents(): " + m);
+            cb.setContents(new StringSelection(m + ""), this);
+        }
+
+        synchronized (LOCK) {
+            if (m > CHAIN_LENGTH) {
+                LOCK.notifyAll();
+            }
+        }
+    }
+
+    public static void run() {
+        PrivateClipboardOwner cbo1 = new PrivateClipboardOwner(0);
+        System.err.println(cbo1.m + " Clipboard.setContents(): " + cbo1.m);
+        clipboard.setContents(new StringSelection(cbo1.m + ""), cbo1);
+
+        PrivateClipboardOwner cbo2 = new PrivateClipboardOwner(1);
+
+        synchronized (LOCK) {
+            System.err.println(cbo2.m + " Clipboard.setContents(): " + cbo2.m);
+            clipboard.setContents(new StringSelection(cbo2.m + ""), cbo2);
+            try {
+                LOCK.wait();
+            } catch (InterruptedException exc) {
+                exc.printStackTrace();
+            }
+        }
+
+        if (cbo1.m < CHAIN_LENGTH) {
+            failed = true;
+            System.err.println("chain of calls of lostOwnership() broken!");
+        }
+    }
+}

--- a/test/jdk/java/awt/Clipboard/LostOwnershipChainTest/SystemClipboardTest.java
+++ b/test/jdk/java/awt/Clipboard/LostOwnershipChainTest/SystemClipboardTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4683804
+  @summary Tests that in ClipboardOwner.lostOwnership() Clipboard.getContents()
+           returns actual contents of the clipboard and Clipboard.setContents()
+           can set contents of the clipboard and its owner. The clipboard is
+           the system clipboard.
+  @key headful
+*/
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+
+public class SystemClipboardTest {
+
+    public static void main(String[] args) {
+        SystemClipboardOwner.run();
+
+        if (SystemClipboardOwner.failed) {
+            throw new RuntimeException("test failed: can not get actual " +
+            "contents of the clipboard or set owner of the clipboard");
+        } else {
+            System.err.println("test passed");
+        }
+    }
+}
+
+
+class SystemClipboardOwner implements ClipboardOwner {
+    static boolean failed;
+
+    private static final Object LOCK = new Object();
+
+    private static final int CHAIN_LENGTH = 5;
+    private final static Clipboard clipboard =
+        Toolkit.getDefaultToolkit().getSystemClipboard();
+
+    private int m, id;
+
+    public SystemClipboardOwner(int m) { this.m = m; id = m; }
+
+    public void lostOwnership(Clipboard cb, Transferable contents) {
+        System.err.println(id + " lost clipboard ownership");
+
+        Transferable t = getClipboardContents(cb, null);
+        String msg = null;
+        try {
+            msg = (String)t.getTransferData(DataFlavor.stringFlavor);
+        } catch (Exception e) {
+             System.err.println(id + " can't getTransferData: " + e);
+        }
+        System.err.println(id + " Clipboard.getContents(): " + msg);
+        if ( ! msg.equals( "" + (m+1) ) ) {
+            failed = true;
+            System.err.println(
+                    "Clipboard.getContents() returned incorrect contents!");
+        }
+
+        m += 2;
+        if (m <= CHAIN_LENGTH) {
+            System.err.println(id + " Clipboard.setContents(): " + m);
+            setClipboardContents(cb, new StringSelection(m + ""), this);
+        }
+
+        synchronized (LOCK) {
+            if (m > CHAIN_LENGTH) {
+                LOCK.notifyAll();
+            }
+        }
+    }
+
+    public static void run() {
+        SystemClipboardOwner cbo1 = new SystemClipboardOwner(0);
+        System.err.println(cbo1.m + " Clipboard.setContents(): " + cbo1.m);
+        setClipboardContents(clipboard,
+                new StringSelection(cbo1.m + ""), cbo1);
+
+        SystemClipboardOwner cbo2 = new SystemClipboardOwner(1);
+        synchronized (LOCK) {
+            System.err.println(cbo2.m + " Clipboard.setContents(): " + cbo2.m);
+            setClipboardContents(clipboard,
+                    new StringSelection(cbo2.m + ""), cbo2);
+            try {
+                LOCK.wait();
+            } catch (InterruptedException exc) {
+                exc.printStackTrace();
+            }
+        }
+
+        if (cbo1.m < CHAIN_LENGTH) {
+            failed = true;
+            System.err.println("chain of calls of lostOwnership() broken!");
+        }
+    }
+
+    private static void setClipboardContents(Clipboard cb,
+                                             Transferable contents,
+                                             ClipboardOwner owner) {
+        synchronized (cb) {
+            while (true) {
+                try {
+                    cb.setContents(contents, owner);
+                    return;
+                } catch (IllegalStateException ise) {
+                    try { Thread.sleep(100); }
+                    catch (InterruptedException e) { e.printStackTrace(); }
+                }
+            }
+        }
+    }
+
+    private static Transferable getClipboardContents(Clipboard cb,
+                                                     Object requestor) {
+        synchronized (cb) {
+            while (true) {
+                try {
+                    return cb.getContents(requestor);
+                } catch (IllegalStateException ise) {
+                    try { Thread.sleep(100); }
+                    catch (InterruptedException e) { e.printStackTrace(); }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Open sourcing few AWT clipboard tests.

Testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306566](https://bugs.openjdk.org/browse/JDK-8306566): Open source several clipboard AWT tests


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13595/head:pull/13595` \
`$ git checkout pull/13595`

Update a local copy of the PR: \
`$ git checkout pull/13595` \
`$ git pull https://git.openjdk.org/jdk.git pull/13595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13595`

View PR using the GUI difftool: \
`$ git pr show -t 13595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13595.diff">https://git.openjdk.org/jdk/pull/13595.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13595#issuecomment-1518418610)