### PR TITLE
JDK-8305387: JDK-8301995 breaks arm 32-bit

### DIFF
--- a/src/hotspot/cpu/arm/interp_masm_arm.hpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.hpp
@@ -69,7 +69,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   inline void check_extended_sp(Register tmp) {}
   inline void check_no_cached_stack_top(Register tmp) {}
 
-
   void save_bcp()                                          { str(Rbcp, Address(FP, frame::interpreter_frame_bcp_offset * wordSize)); }
   void restore_bcp()                                       { ldr(Rbcp, Address(FP, frame::interpreter_frame_bcp_offset * wordSize)); }
   void restore_locals() {
@@ -102,6 +101,8 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   // load cpool->resolved_klass_at(index); Rtemp is corrupted upon return
   void load_resolved_klass_at_offset(Register Rcpool, Register Rindex, Register Rklass);
+
+  void load_resolved_indy_entry(Register cache, Register index);
 
   void pop_ptr(Register r);
   void pop_i(Register r = R0_tos);

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -2662,8 +2662,6 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   // compute return type
   __ ldrb(index, Address(cache, in_bytes(ResolvedIndyEntry::result_type_offset())));
   // load return address
-  // Return address is loaded into link register(lr) and not pushed to the stack
-  // like x86
   {
     const address table_addr = (address) Interpreter::invoke_return_entry_table_for(code);
     __ mov_address(Rtemp, table_addr);

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -2608,6 +2608,68 @@ void TemplateTable::load_field_cp_cache_entry(Register Rcache,
   }
 }
 
+// The rmethod register is input and overwritten to be the adapter method for the
+// indy call. Link Register (lr) is set to the return address for the adapter and
+// an appendix may be pushed to the stack. Registers r0-r3 are clobbered
+void TemplateTable::load_invokedynamic_entry(Register method) {
+  // setup registers
+  const Register appendix = R1;
+  const Register cache = R2_tmp;
+  const Register index = R3_tmp;
+  assert_different_registers(method, appendix, cache, index);
+
+  __ save_bcp();
+
+  Label resolved;
+  __ load_resolved_indy_entry(cache, index);
+  // Load-acquire the adapter method to match store-release in ResolvedIndyEntry::fill_in()
+  __ ldr(method, Address(cache, in_bytes(ResolvedIndyEntry::method_offset())));
+  TemplateTable::volatile_barrier(MacroAssembler::LoadLoad, noreg, true);
+  // Compare the method to zero
+  __ cbnz(method, resolved);
+
+  Bytecodes::Code code = bytecode();
+
+  // Call to the interpreter runtime to resolve invokedynamic
+  address entry = CAST_FROM_FN_PTR(address, InterpreterRuntime::resolve_from_cache);
+  __ mov(R1, code); // this is essentially Bytecodes::_invokedynamic, call_VM requires R1
+  __ call_VM(noreg, entry, R1);
+  // Update registers with resolved info
+  __ load_resolved_indy_entry(cache, index);
+  // Load-acquire the adapter method to match store-release in ResolvedIndyEntry::fill_in()
+  __ ldr(method, Address(cache, in_bytes(ResolvedIndyEntry::method_offset())));
+  TemplateTable::volatile_barrier(MacroAssembler::LoadLoad, noreg, true);
+
+#ifdef ASSERT
+  __ cbnz(method, resolved);
+  __ stop("Should be resolved by now");
+#endif // ASSERT
+  __ bind(resolved);
+
+  Label L_no_push;
+  // Check if there is an appendix
+  __ ldrb(index, Address(cache, in_bytes(ResolvedIndyEntry::flags_offset())));
+  __ tbz(index, ResolvedIndyEntry::has_appendix_shift, L_no_push);
+  // Get appendix
+  __ ldrh(index, Address(cache, in_bytes(ResolvedIndyEntry::resolved_references_index_offset())));
+  // Push the appendix as a trailing parameter
+  // since the parameter_size includes it.
+  __ load_resolved_reference_at_index(appendix, index);
+  __ verify_oop(appendix);
+  __ push(appendix);  // push appendix (MethodType, CallSite, etc.)
+  __ bind(L_no_push);
+
+  // compute return type
+  __ ldrb(index, Address(cache, in_bytes(ResolvedIndyEntry::result_type_offset())));
+  // load return address
+  // Return address is loaded into link register(lr) and not pushed to the stack
+  // like x86
+  {
+    const address table_addr = (address) Interpreter::invoke_return_entry_table_for(code);
+    __ mov_address(Rtemp, table_addr);
+    __ ldr(LR, Address(Rtemp, index, lsl, Interpreter::logStackElementSize));
+  }
+}
 
 // Blows all volatile registers: R0-R3, Rtemp, LR.
 void TemplateTable::load_invoke_cp_cache_entry(int byte_no,
@@ -2616,7 +2678,7 @@ void TemplateTable::load_invoke_cp_cache_entry(int byte_no,
                                                Register flags,
                                                bool is_invokevirtual,
                                                bool is_invokevfinal/*unused*/,
-                                               bool is_invokedynamic) {
+                                               bool is_invokedynamic /*unused*/) {
   // setup registers
   const Register cache = R2_tmp;
   const Register index = R3_tmp;
@@ -2639,7 +2701,7 @@ void TemplateTable::load_invoke_cp_cache_entry(int byte_no,
   const int index_offset = in_bytes(ConstantPoolCache::base_offset() +
                                     ConstantPoolCacheEntry::f2_offset());
 
-  size_t index_size = (is_invokedynamic ? sizeof(u4) : sizeof(u2));
+  size_t index_size = sizeof(u2);
   resolve_cache_and_index(byte_no, cache, index, index_size);
     __ add(temp_reg, cache, AsmOperand(index, lsl, LogBytesPerWord));
     __ ldr(method, Address(temp_reg, method_offset));
@@ -3565,7 +3627,7 @@ void TemplateTable::prepare_invoke(int byte_no,
   load_invoke_cp_cache_entry(byte_no, method, index, flags, is_invokevirtual, false, is_invokedynamic);
 
   // maybe push extra argument
-  if (is_invokedynamic || is_invokehandle) {
+  if (is_invokehandle) {
     Label L_no_push;
     __ tbz(flags, ConstantPoolCacheEntry::has_appendix_shift, L_no_push);
     __ mov(temp, index);
@@ -3810,7 +3872,7 @@ void TemplateTable::invokedynamic(int byte_no) {
   const Register Rcallsite = R4_tmp;
   const Register R5_method = R5_tmp;  // can't reuse Rmethod!
 
-  prepare_invoke(byte_no, R5_method, Rcallsite);
+  load_invokedynamic_entry(R5_method);
 
   // Rcallsite: CallSite object (from cpool->resolved_references[f1])
   // Rmethod:   MH.linkToCallSite method (from f2)

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -2624,7 +2624,7 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   __ load_resolved_indy_entry(cache, index);
   // Load-acquire the adapter method to match store-release in ResolvedIndyEntry::fill_in()
   __ ldr(method, Address(cache, in_bytes(ResolvedIndyEntry::method_offset())));
-  TemplateTable::volatile_barrier(MacroAssembler::LoadLoad, noreg, true);
+  TemplateTable::volatile_barrier(MacroAssembler::Membar_mask_bits(MacroAssembler::LoadLoad | MacroAssembler::LoadStore), noreg, true);
   // Compare the method to zero
   __ cbnz(method, resolved);
 
@@ -2638,7 +2638,7 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   __ load_resolved_indy_entry(cache, index);
   // Load-acquire the adapter method to match store-release in ResolvedIndyEntry::fill_in()
   __ ldr(method, Address(cache, in_bytes(ResolvedIndyEntry::method_offset())));
-  TemplateTable::volatile_barrier(MacroAssembler::LoadLoad, noreg, true);
+  TemplateTable::volatile_barrier(MacroAssembler::Membar_mask_bits(MacroAssembler::LoadLoad | MacroAssembler::LoadStore), noreg, true);
 
 #ifdef ASSERT
   __ cbnz(method, resolved);

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -2610,7 +2610,7 @@ void TemplateTable::load_field_cp_cache_entry(Register Rcache,
 
 // The rmethod register is input and overwritten to be the adapter method for the
 // indy call. Link Register (lr) is set to the return address for the adapter and
-// an appendix may be pushed to the stack. Registers r0-r3 are clobbered
+// an appendix may be pushed to the stack. Registers R1-R3, Rtemp (R12) are clobbered
 void TemplateTable::load_invokedynamic_entry(Register method) {
   // setup registers
   const Register appendix = R1;


### PR DESCRIPTION
Provides missing implementation for arm32.

Testing: hotspot/jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305387](https://bugs.openjdk.org/browse/JDK-8305387): JDK-8301995 breaks arm 32-bit


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [ebcaeb97](https://git.openjdk.org/jdk/pull/13596/files/ebcaeb9724402475f89319b42b3d1d6bf5995186)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13596/head:pull/13596` \
`$ git checkout pull/13596`

Update a local copy of the PR: \
`$ git checkout pull/13596` \
`$ git pull https://git.openjdk.org/jdk.git pull/13596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13596`

View PR using the GUI difftool: \
`$ git pr show -t 13596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13596.diff">https://git.openjdk.org/jdk/pull/13596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13596#issuecomment-1518539072)