### PR TITLE
8306697: Add method to obtain String for CONSTANT_Class_info in ClassDesc

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -356,6 +356,24 @@ public sealed interface ClassDesc
     }
 
     /**
+     * {@return the string representation of this {@linkplain ClassDesc} in a
+     * {@code CONSTANT_Class_info} ({@jvms 4.4.1})} This is the binary name
+     * in internal form for classes and interfaces, and descriptors for arrays.
+     * Primitive types cannot be represented by {@code CONSTANT_Class_info}
+     * structures.
+     *
+     * @apiNote
+     * Unlike {@link #ofInternalName ofInternalName} that rejects array descriptors,
+     * this method returns the array descriptor string if this {@linkplain ClassDesc}
+     * represents an array.
+     *
+     * @throws IllegalStateException if this {@linkplain ClassDesc} describes a type
+     * that cannot be represented by a {@code CONSTANT_Class_info}, such as primitive types
+     * @since 21
+     */
+    String internalName();
+
+    /**
      * Returns a field type descriptor string for this type
      *
      * @return the descriptor string

--- a/src/java.base/share/classes/java/lang/constant/PrimitiveClassDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/PrimitiveClassDescImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,11 @@ final class PrimitiveClassDescImpl
             || "VIJCSBFDZ".indexOf(descriptor.charAt(0)) < 0)
             throw new IllegalArgumentException(String.format("not a valid primitive type descriptor: %s", descriptor));
         this.descriptor = descriptor;
+    }
+
+    @Override
+    public String internalName() {
+        throw new IllegalStateException("primitive type " + displayName() + " cannot be encoded in CONSTANT_Class_info");
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/constant/ReferenceClassDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ReferenceClassDescImpl.java
@@ -56,6 +56,11 @@ final class ReferenceClassDescImpl implements ClassDesc {
     }
 
     @Override
+    public String internalName() {
+        return isArray() ? descriptorString() : descriptorString().substring(1, descriptorString().length() - 1);
+    }
+
+    @Override
     public String descriptorString() {
         return descriptor;
     }

--- a/test/jdk/java/lang/constant/ClassDescTest.java
+++ b/test/jdk/java/lang/constant/ClassDescTest.java
@@ -33,12 +33,7 @@ import java.util.Map;
 
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 /**
  * @test
@@ -64,10 +59,15 @@ public class ClassDescTest extends SymbolicDescTest {
             assertEquals(r, Array.newInstance(r.resolveConstantDesc(LOOKUP), 0).getClass().describeConstable().orElseThrow().componentType());
         }
 
+        if (r.isClassOrInterface()) {
+            assertEquals(r.descriptorString(), "L" + r.internalName() + ";");
+        }
+
         if (r.isArray()) {
             assertEquals(r, r.componentType().arrayType());
             assertEquals(r, r.resolveConstantDesc(LOOKUP).getComponentType().describeConstable().orElseThrow().arrayType());
             assertEquals(r, Array.newInstance(r.componentType().resolveConstantDesc(LOOKUP), 0).getClass().describeConstable().orElseThrow());
+            assertEquals(r.descriptorString(), r.internalName());
         }
     }
 
@@ -77,6 +77,10 @@ public class ClassDescTest extends SymbolicDescTest {
         assertEquals(r.resolveConstantDesc(LOOKUP), c);
         assertEquals(c.describeConstable().orElseThrow(), r);
         assertEquals(ClassDesc.ofDescriptor(c.descriptorString()), r);
+
+        if (!c.isPrimitive()) {
+            assertEquals(c.getName(), r.internalName().replace('/', '.'));
+        }
     }
 
     public void testSymbolicDescsConstants() throws ReflectiveOperationException {
@@ -118,6 +122,8 @@ public class ClassDescTest extends SymbolicDescTest {
                     assertEquals(c, p.arrayClass.describeConstable().orElseThrow().componentType());
                     assertEquals(c, p.classDesc.arrayType().componentType());
                 }
+
+                assertThrows(IllegalStateException.class, c::internalName);
             }
 
             for (Primitives other : Primitives.values()) {

--- a/test/jdk/java/lang/constant/ClassDescTest.java
+++ b/test/jdk/java/lang/constant/ClassDescTest.java
@@ -50,6 +50,9 @@ public class ClassDescTest extends SymbolicDescTest {
 
         // Test descriptor accessor, factory, equals
         assertEquals(r, ClassDesc.ofDescriptor(r.descriptorString()));
+        if (!r.isPrimitive()) {
+            assertEquals(r, ClassDesc.ofInternalName(r.internalName()));
+        }
 
         if (!r.descriptorString().equals("V")) {
             assertEquals(r, r.arrayType().componentType());
@@ -79,7 +82,8 @@ public class ClassDescTest extends SymbolicDescTest {
         assertEquals(ClassDesc.ofDescriptor(c.descriptorString()), r);
 
         if (!c.isPrimitive()) {
-            assertEquals(c.getName(), r.internalName().replace('/', '.'));
+            assertEquals(c.getName(), r.internalName().replace('/', '.')); // may be invalid in valhalla
+            assertEquals(r, ClassDesc.ofInternalName(c.getName().replace('.', '/')));
         }
     }
 
@@ -271,7 +275,7 @@ public class ClassDescTest extends SymbolicDescTest {
             }
         }
 
-        List<String> badInternalNames = List.of("I;", "[]", "[Ljava/lang/String;",
+        List<String> badInternalNames = List.of("I;", "[]", "[Ljava.lang.String;",
                 "Ljava.lang.String;", "java.lang.String");
         for (String d : badInternalNames) {
             try {


### PR DESCRIPTION
Add a method `internalName` to `ClassDesc`, and unifies handling of string representation of a class constant in CONSTANT_Class_info via `ofInternalName` and `internalName` APIs, documented in `ClassDesc` itself. In particular, `ofInternalName` now accepts arrays.

The motivation of this API is that avoiding frequent String creations via caching (enabled by this new API, will be in a separate patch) would speed up Classfile API's [writing of simple class files](https://github.com/openjdk/jdk/blob/master/test/micro/org/openjdk/bench/jdk/classfile/Write.java) by 1/3. See https://mail.openjdk.org/pipermail/classfile-api-dev/2023-April/000296.html for more context.

This API is futureproof: for Valhalla's Q-types, it will return their string representation in CONSTANT_Class_info, which is most likely their full descriptor string.

Javadoc: https://cr.openjdk.org/~liach/8306697/java.base/java/lang/constant/ClassDesc.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8306700](https://bugs.openjdk.org/browse/JDK-8306700) to be approved

### Issues
 * [JDK-8306697](https://bugs.openjdk.org/browse/JDK-8306697): Add method to obtain String for CONSTANT_Class_info in ClassDesc
 * [JDK-8306700](https://bugs.openjdk.org/browse/JDK-8306700): Add method to obtain String for CONSTANT_Class_info in ClassDesc (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13598/head:pull/13598` \
`$ git checkout pull/13598`

Update a local copy of the PR: \
`$ git checkout pull/13598` \
`$ git pull https://git.openjdk.org/jdk.git pull/13598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13598`

View PR using the GUI difftool: \
`$ git pr show -t 13598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13598.diff">https://git.openjdk.org/jdk/pull/13598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13598#issuecomment-1518685157)