### PR TITLE
8301455: comments in TestTypeAnnotations still refer to resolved JDK-8068737

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
@@ -137,7 +137,6 @@ public class TestTypeAnnotations extends JavadocTester {
                     ="FldB.html" title="annotation interface in typeannos">@FldB</a> [][]</span>&nbs\
                     p;<span class="element-name">array2SecondOld</span></div>""",
 
-                // When JDK-8068737, we should change the order
                 """
                     <div class="member-signature"><span class="return-type"><a href="FldD.html" titl\
                     e="annotation interface in typeannos">@FldD</a> java.lang.String <a href="FldC.h\
@@ -173,7 +172,6 @@ public class TestTypeAnnotations extends JavadocTester {
                     MRtnA.html" title="annotation interface in typeannos">@MRtnA</a> java.lang.Strin\
                     g</span>&nbsp;<span class="element-name">method</span>()</div>""",
 
-                // When JDK-8068737 is fixed, we should change the order
                 """
                     <div class="member-signature"><span class="return-type"><a href="MRtnA.html" tit\
                     le="annotation interface in typeannos">@MRtnA</a> java.lang.String <a href="MRtn\
@@ -251,7 +249,6 @@ public class TestTypeAnnotations extends JavadocTester {
                     tation interface in typeannos">@ParamB</a> java.lang.String&gt;&nbsp;a)</span></\
                     div>""",
 
-                // When JDK-8068737 is fixed, we should change the order
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
                     lass="element-name">array2Deep</span><wbr><span class="parameters">(<a href="Par\


### PR DESCRIPTION
Simple patch removing comment references to an already fixed bug in test TestTypeAnnotations.java

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301455](https://bugs.openjdk.org/browse/JDK-8301455): comments in TestTypeAnnotations still refer to resolved JDK-8068737


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13600/head:pull/13600` \
`$ git checkout pull/13600`

Update a local copy of the PR: \
`$ git checkout pull/13600` \
`$ git pull https://git.openjdk.org/jdk.git pull/13600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13600`

View PR using the GUI difftool: \
`$ git pr show -t 13600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13600.diff">https://git.openjdk.org/jdk/pull/13600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13600#issuecomment-1518825659)