### PR TITLE
8298189: Regression in SPECjvm2008-MonteCarlo for pre-Cascade Lake Intel processors

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2079,10 +2079,13 @@ bool VM_Version::is_default_intel_cascade_lake() {
   return FLAG_IS_DEFAULT(UseAVX) &&
          FLAG_IS_DEFAULT(MaxVectorSize) &&
          UseAVX > 2 &&
-         is_intel_skylake() &&
-         _stepping >= 5;
+         is_intel_cascade_lake();
 }
 #endif
+
+bool VM_Version::is_intel_cascade_lake() {
+  return is_intel_skylake() && _stepping >= 5;
+}
 
 // avx3_threshold() sets the threshold at which 64-byte instructions are used
 // for implementing the array copy and clear operations.

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -716,6 +716,8 @@ public:
   static bool is_default_intel_cascade_lake();
 #endif
 
+  static bool is_intel_cascade_lake();
+
   static int avx3_threshold();
 
   static bool is_intel_tsc_synched_at_init();

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -13742,6 +13742,13 @@ instruct leaL_rReg_immI2_peep(rRegL dst, rRegL src, immI2 shift)
   ins_pipe(ialu_reg_reg);
 %}
 
+// These peephole rules replace mov + I pairs (where I is one of {add, inc, dec,
+// sal}) with lea instructions. The {add, sal} rules are beneficial in
+// processors with at least partial ALU support for lea
+// (supports_fast_2op_lea()), whereas the {inc, dec} rules are only generally
+// beneficial for processors with full ALU support
+// (VM_Version::supports_fast_3op_lea()) and Intel Cascade Lake.
+
 peephole
 %{
   peeppredicate(VM_Version::supports_fast_2op_lea());
@@ -13760,7 +13767,8 @@ peephole
 
 peephole
 %{
-  peeppredicate(VM_Version::supports_fast_2op_lea());
+  peeppredicate(VM_Version::supports_fast_3op_lea() ||
+                VM_Version::is_intel_cascade_lake());
   peepmatch (incI_rReg);
   peepprocedure (lea_coalesce_imm);
   peepreplace (leaI_rReg_immI_peep());
@@ -13768,7 +13776,8 @@ peephole
 
 peephole
 %{
-  peeppredicate(VM_Version::supports_fast_2op_lea());
+  peeppredicate(VM_Version::supports_fast_3op_lea() ||
+                VM_Version::is_intel_cascade_lake());
   peepmatch (decI_rReg);
   peepprocedure (lea_coalesce_imm);
   peepreplace (leaI_rReg_immI_peep());
@@ -13800,7 +13809,8 @@ peephole
 
 peephole
 %{
-  peeppredicate(VM_Version::supports_fast_2op_lea());
+  peeppredicate(VM_Version::supports_fast_3op_lea() ||
+                VM_Version::is_intel_cascade_lake());
   peepmatch (incL_rReg);
   peepprocedure (lea_coalesce_imm);
   peepreplace (leaL_rReg_immL32_peep());
@@ -13808,7 +13818,8 @@ peephole
 
 peephole
 %{
-  peeppredicate(VM_Version::supports_fast_2op_lea());
+  peeppredicate(VM_Version::supports_fast_3op_lea() ||
+                VM_Version::is_intel_cascade_lake());
   peepmatch (decL_rReg);
   peepprocedure (lea_coalesce_imm);
   peepreplace (leaL_rReg_immL32_peep());


### PR DESCRIPTION
The `mov + inc/dec -> lea` subset of the peephole rules introduced by [JDK-8283699](https://bugs.openjdk.org/browse/JDK-8283699) has been found to cause minor regressions for some common benchmarks on Intel microarchitectures earlier than Cascade Lake. This changeset limits their application to Intel Cascade Lake and microarchitectures with full ALU support for lea (`VM_Version::supports_fast_3op_lea()`), where these peephole rules have been confirmed to be beneficial. The adjustment speeds up SPECjvm2008's MonteCarlo benchmark by between 0.1% and 2.7% on pre-Cascade Lake microarchitectures (Haswell-DT, Coffee Lake-B) across different garbage collectors (G1, ZGC). It additionally yields a speedup of 2.1% on SPECjvm2008's Derby benchmark when using G1 on Coffee Lake-B.

Thanks to @ericcaspole for discussions and helping out with benchmarking.

#### Testing

##### Functionality

- tier1-5 (windows-x64, linux-x64, macosx-x64; release and debug mode).
- Checked that the expected combination of peephole rules is enabled for all microarchitectures supported by Intel's Software Development Emulator 9.0.

##### Performance

- Tested performance on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008), different Intel microarchitectures (Haswell-DT, Coffee Lake-B, Cascade Lake, Ice Lake-SP) and operating systems (linux-x64, windows-x64, and macosx-x64). No significant change was observed besides the improvements mentioned above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298189](https://bugs.openjdk.org/browse/JDK-8298189): Regression in SPECjvm2008-MonteCarlo for pre-Cascade Lake Intel processors


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * Quan Anh Mai `<qamai@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13605/head:pull/13605` \
`$ git checkout pull/13605`

Update a local copy of the PR: \
`$ git checkout pull/13605` \
`$ git pull https://git.openjdk.org/jdk.git pull/13605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13605`

View PR using the GUI difftool: \
`$ git pr show -t 13605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13605.diff">https://git.openjdk.org/jdk/pull/13605.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13605#issuecomment-1519519226)