### PR TITLE
8306733: Remove template parameter of G1DetermineCompactionQueueClosure::free_pinned_region

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -42,8 +42,7 @@ class G1DetermineCompactionQueueClosure : public HeapRegionClosure {
   G1FullCollector* _collector;
   uint _cur_worker;
 
-  template<bool is_humongous>
-  inline void free_pinned_region(HeapRegion* hr);
+  inline void free_empty_humongous_region(HeapRegion* hr);
 
   inline bool should_compact(HeapRegion* hr) const;
 

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -33,13 +33,8 @@
 #include "gc/g1/g1FullGCScope.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
 
-template<bool is_humongous>
-void G1DetermineCompactionQueueClosure::free_pinned_region(HeapRegion* hr) {
-  if (is_humongous) {
-    _g1h->free_humongous_region(hr, nullptr);
-  } else {
-    _g1h->free_region(hr, nullptr);
-  }
+void G1DetermineCompactionQueueClosure::free_empty_humongous_region(HeapRegion* hr) {
+  _g1h->free_humongous_region(hr, nullptr);
   _collector->set_free(hr->hrm_index());
   add_to_compaction_queue(hr);
 }
@@ -88,7 +83,7 @@ inline bool G1DetermineCompactionQueueClosure::do_heap_region(HeapRegion* hr) {
       oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
       bool is_empty = !_collector->mark_bitmap()->is_marked(obj);
       if (is_empty) {
-        free_pinned_region<true>(hr);
+        free_empty_humongous_region(hr);
       } else {
         _collector->set_has_humongous();
       }


### PR DESCRIPTION
Hi all,

  after [JDK-8298048](https://bugs.openjdk.org/browse/JDK-8298048) G1DetermineCompactionQueueClosure::free_pinned_region() may only be called with humongous regions, so the template parameter is unnecessary. This PR removes it.
I kept the method itself (not inlined) because I believe its name acts as a good documentation what is done here at the place it is called, even if it's only 3 LOC.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306733](https://bugs.openjdk.org/browse/JDK-8306733): Remove template parameter of G1DetermineCompactionQueueClosure::free_pinned_region


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13610/head:pull/13610` \
`$ git checkout pull/13610`

Update a local copy of the PR: \
`$ git checkout pull/13610` \
`$ git pull https://git.openjdk.org/jdk.git pull/13610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13610`

View PR using the GUI difftool: \
`$ git pr show -t 13610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13610.diff">https://git.openjdk.org/jdk/pull/13610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13610#issuecomment-1519891109)