### PR TITLE
8306732: TruncatedSeq::predict_next() attempts linear regression with only one data point

### DIFF
--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -206,8 +206,15 @@ double TruncatedSeq::oldest() const {
 }
 
 double TruncatedSeq::predict_next() const {
-  if (_num == 0)
+  if (_num == 0) {
+    // No data points, pick function: y = 0 + 0*x
     return 0.0;
+  }
+
+  if (_num == 1) {
+    // Only one point P, pick function: y = P_y + 0*x
+    return _sequence[0];
+  }
 
   double num           = (double) _num;
   double x_squared_sum = 0.0;


### PR DESCRIPTION
TruncatedSeq::predict_next() attempts linear regression with only one data point, this leads to a division by zero. (There are infinit many linear functions that fit equally well for a single point).

I suggest we do what we do for the zero points case, namely pick one of the linear functions.

For zero points the current version picks `y = 0 + 0*x` and the suggestion is that for one point `P` the function `y = P_y + 0*x` is picked.

Tested for ZGC tier1-7 on Oracle supported platforms. Only ZGC use TruncatedSeq::predict_next()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306732](https://bugs.openjdk.org/browse/JDK-8306732): TruncatedSeq::predict_next() attempts linear regression with only one data point


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13614/head:pull/13614` \
`$ git checkout pull/13614`

Update a local copy of the PR: \
`$ git checkout pull/13614` \
`$ git pull https://git.openjdk.org/jdk.git pull/13614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13614`

View PR using the GUI difftool: \
`$ git pr show -t 13614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13614.diff">https://git.openjdk.org/jdk/pull/13614.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13614#issuecomment-1520017181)