### PR TITLE
8306729: Add nominal descriptors of modules and packages to Constants API

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
@@ -76,6 +76,60 @@ class ConstantUtils {
      }
 
     /**
+     * Validates the correctness of a binary package name. In particular checks for the presence of
+     * invalid characters in the name.
+     *
+     * @param name the package name
+     * @return the package name passed if valid
+     * @throws IllegalArgumentException if the package name is invalid
+     */
+    public static String validateBinaryPackageName(String name) {
+        for (int i=0; i<name.length(); i++) {
+            char ch = name.charAt(i);
+            if (ch == ';' || ch == '[' || ch == '/')
+                throw new IllegalArgumentException("Invalid package name: " + name);
+        }
+        return name;
+    }
+
+    /**
+     * Validates the correctness of an internal package name.
+     * In particular checks for the presence of invalid characters in the name.
+     *
+     * @param name the package name
+     * @return the package name passed if valid
+     * @throws IllegalArgumentException if the package name is invalid
+     */
+    public static String validateInternalPackageName(String name) {
+        for (int i=0; i<name.length(); i++) {
+            char ch = name.charAt(i);
+            if (ch == ';' || ch == '[' || ch == '.')
+                throw new IllegalArgumentException("Invalid package name: " + name);
+        }
+        return name;
+    }
+
+    /**
+     * Validates the correctness of a module name. In particular checks for the presence of
+     * invalid characters in the name.
+     *
+     * {@jvms 4.2.3} Module and Package Names
+     *
+     * @param name the module name
+     * @return the module name passed if valid
+     * @throws IllegalArgumentException if the module name is invalid
+     */
+    public static String validateModuleName(String name) {
+        for (int i=name.length() - 1; i >= 0; i--) {
+            char ch = name.charAt(i);
+            if ((ch >= '\u0000' && ch <= '\u001F')
+            || ((ch == '\\' || ch == ':' || ch =='@') && (i == 0 || name.charAt(--i) != '\\')))
+                throw new IllegalArgumentException("Invalid module name: " + name);
+        }
+        return name;
+    }
+
+    /**
      * Validates a member name
      *
      * @param name the name of the member

--- a/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantUtils.java
@@ -76,12 +76,14 @@ class ConstantUtils {
      }
 
     /**
-     * Validates the correctness of a binary package name. In particular checks for the presence of
-     * invalid characters in the name.
+     * Validates the correctness of a binary package name.
+     * In particular checks for the presence of invalid characters in the name.
+     * Empty package name is allowed.
      *
      * @param name the package name
      * @return the package name passed if valid
      * @throws IllegalArgumentException if the package name is invalid
+     * @throws NullPointerException if the package name is {@code null}
      */
     public static String validateBinaryPackageName(String name) {
         for (int i=0; i<name.length(); i++) {
@@ -95,10 +97,12 @@ class ConstantUtils {
     /**
      * Validates the correctness of an internal package name.
      * In particular checks for the presence of invalid characters in the name.
+     * Empty package name is allowed.
      *
      * @param name the package name
      * @return the package name passed if valid
      * @throws IllegalArgumentException if the package name is invalid
+     * @throws NullPointerException if the package name is {@code null}
      */
     public static String validateInternalPackageName(String name) {
         for (int i=0; i<name.length(); i++) {
@@ -110,14 +114,16 @@ class ConstantUtils {
     }
 
     /**
-     * Validates the correctness of a module name. In particular checks for the presence of
-     * invalid characters in the name.
+     * Validates the correctness of a module name.
+     * In particular checks for the presence of invalid characters in the name.
+     * Empty module name is allowed.
      *
      * {@jvms 4.2.3} Module and Package Names
      *
      * @param name the module name
      * @return the module name passed if valid
      * @throws IllegalArgumentException if the module name is invalid
+     * @throws NullPointerException if the module name is {@code null}
      */
     public static String validateModuleName(String name) {
         for (int i=name.length() - 1; i >= 0; i--) {

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.constant;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A nominal descriptor for a {@code Module} constant.
+ *
+ * <p>To create a {@linkplain ModuleDesc} for a module, use {@link #of}.
+ *
+ * @since 21
+ */
+public sealed interface ModuleDesc
+        permits ModuleDescImpl {
+
+    /**
+     * Returns a {@linkplain ModuleDesc} for a module,
+     * given the name of the module.
+     *
+     * <p>{@jvms 4.2.3} Module names are not encoded in "internal form" like
+     * class and interface names, that is, the ASCII periods (.) that separate
+     * the identifiers in a module name are not replaced by ASCII forward
+     * slashes (/).
+     *
+     * <p>Module names may be drawn from the entire Unicode codespace, subject
+     * to the following constraints:
+     * <ul>
+     * <li>A module name must not contain any code point in the range
+     * '&#92;u0000' to '&#92;u001F' inclusive.
+     * <li>The ASCII backslash (\) is reserved for use as an escape character in
+     * module names. It must not appear in a module name unless it is followed
+     * by an ASCII backslash, an ASCII colon (:), or an ASCII at-sign (@).
+     * The ASCII character sequence \\ may be used to encode a backslash in a
+     * module name.
+     * <li>The ASCII colon (:) and at-sign (@) are reserved for future use in
+     * module names.
+     * They must not appear in module names unless they are escaped.
+     * The ASCII character sequences \: and \@ may be used to encode a colon and
+     * an at-sign in a module name.
+     * </ul>
+     * @param name module name
+     * @return a {@linkplain ModuleDesc} describing the desired module
+     * @throws NullPointerException if the argument is {@code null}
+     * @throws IllegalArgumentException if the name string is not in the
+     * correct format
+     */
+    static ModuleDesc of(String name) {
+        ModuleDescImpl.validateModuleName(requireNonNull(name));
+        return new ModuleDescImpl(name);
+    }
+
+    /**
+     * Returns the module name of this {@linkplain ModuleDesc}.
+     *
+     * @return the module name
+     */
+    String moduleName();
+
+    /**
+     * Compare the specified object with this descriptor for equality.  Returns
+     * {@code true} if and only if the specified object is also a
+     * {@linkplain ModuleDesc} and both describe the same module.
+     *
+     * @param o the other object
+     * @return whether this descriptor is equal to the other object
+     */
+    @Override
+    boolean equals(Object o);
+}

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -60,7 +60,7 @@ public sealed interface ModuleDesc
      *
      * @return the module name
      */
-    String moduleName();
+    String name();
 
     /**
      * Compare the specified object with this descriptor for equality.

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -56,7 +56,7 @@ public sealed interface ModuleDesc
     }
 
     /**
-     * Returns the module name of this {@linkplain ModuleDesc}.
+     * Returns the module name of this {@link ModuleDesc}.
      *
      * @return the module name
      */

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A nominal descriptor for a {@code Module} constant.
  *
- * @apiNote
+ * <p>
  * To create a {@link ModuleDesc} for a module, use the {@link #of(String)}
  * method.
  *

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -29,7 +29,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * A nominal descriptor for a {@code Module} constant.
  *
- * <p>To create a {@link ModuleDesc} for a module, use the {@link #of} method.
+ * @apiNote
+ * To create a {@link ModuleDesc} for a module, use the {@link #of(String)}
+ * method.
  *
  * @jvms 4.4.11 The CONSTANT_Module_info Structure
  * @since 21
@@ -61,9 +63,9 @@ public sealed interface ModuleDesc
     String moduleName();
 
     /**
-     * Compare the specified object with this descriptor for equality.  Returns
-     * {@code true} if and only if the specified object is also a
-     * {@link ModuleDesc} and both describe the same module.
+     * Compare the specified object with this descriptor for equality.
+     * Returns {@code true} if and only if the specified object is
+     * also a {@link ModuleDesc} and both describe the same module.
      *
      * @param o the other object
      * @return whether this descriptor is equal to the other object

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -27,9 +27,9 @@ package java.lang.constant;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A nominal descriptor for a {@code Module} constant {@jvms 4.4.11}.
+ * A nominal descriptor for a {@code Module} constant.
  *
- * <p>To create a {@linkplain ModuleDesc} for a module, use the {@link #of} method.
+ * <p>To create a {@link ModuleDesc} for a module, use the {@link #of} method.
  *
  * @jvms 4.4.11 The CONSTANT_Module_info Structure
  * @since 21
@@ -38,35 +38,15 @@ public sealed interface ModuleDesc
         permits ModuleDescImpl {
 
     /**
-     * Returns a {@linkplain ModuleDesc} for a module,
+     * Returns a {@link ModuleDesc} for a module,
      * given the name of the module.
      *
-     * <p>{@jvms 4.2.3} Module names are not encoded in "internal form" like
-     * class and interface names, that is, the ASCII periods (.) that separate
-     * the identifiers in a module name are not replaced by ASCII forward
-     * slashes (/).
-     *
-     * <p>Module names may be drawn from the entire Unicode codespace, subject
-     * to the following constraints:
-     * <ul>
-     * <li>A module name must not contain any code point in the range
-     * '&#92;u0000' to '&#92;u001F' inclusive.
-     * <li>The ASCII backslash (\) is reserved for use as an escape character in
-     * module names. It must not appear in a module name unless it is followed
-     * by an ASCII backslash, an ASCII colon (:), or an ASCII at-sign (@).
-     * The ASCII character sequence \\ may be used to encode a backslash in a
-     * module name.
-     * <li>The ASCII colon (:) and at-sign (@) are reserved for future use in
-     * module names.
-     * They must not appear in module names unless they are escaped.
-     * The ASCII character sequences \: and \@ may be used to encode a colon and
-     * an at-sign in a module name.
-     * </ul>
      * @param name the module name
-     * @return a {@linkplain ModuleDesc} describing the desired module
+     * @return a {@link ModuleDesc} describing the desired module
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the
      * correct format
+     * @jvms 4.2.3 Module and Package Names
      */
     static ModuleDesc of(String name) {
         ConstantUtils.validateModuleName(requireNonNull(name));
@@ -83,7 +63,7 @@ public sealed interface ModuleDesc
     /**
      * Compare the specified object with this descriptor for equality.  Returns
      * {@code true} if and only if the specified object is also a
-     * {@linkplain ModuleDesc} and both describe the same module.
+     * {@link ModuleDesc} and both describe the same module.
      *
      * @param o the other object
      * @return whether this descriptor is equal to the other object

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -29,8 +29,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * A nominal descriptor for a {@code Module} constant {@jvms 4.4.11}.
  *
- * <p>To create a {@linkplain ModuleDesc} for a module, use {@link #of}.
+ * <p>To create a {@linkplain ModuleDesc} for a module, use the {@link #of} method.
  *
+ * @jvms 4.4.11 The CONSTANT_Module_info Structure
  * @since 21
  */
 public sealed interface ModuleDesc
@@ -61,7 +62,7 @@ public sealed interface ModuleDesc
      * The ASCII character sequences \: and \@ may be used to encode a colon and
      * an at-sign in a module name.
      * </ul>
-     * @param name module name
+     * @param name the module name
      * @return a {@linkplain ModuleDesc} describing the desired module
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the

--- a/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDesc.java
@@ -27,7 +27,7 @@ package java.lang.constant;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A nominal descriptor for a {@code Module} constant.
+ * A nominal descriptor for a {@code Module} constant {@jvms 4.4.11}.
  *
  * <p>To create a {@linkplain ModuleDesc} for a module, use {@link #of}.
  *
@@ -68,7 +68,7 @@ public sealed interface ModuleDesc
      * correct format
      */
     static ModuleDesc of(String name) {
-        ModuleDescImpl.validateModuleName(requireNonNull(name));
+        ConstantUtils.validateModuleName(requireNonNull(name));
         return new ModuleDescImpl(name);
     }
 

--- a/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
@@ -25,24 +25,4 @@
 package java.lang.constant;
 
 record ModuleDescImpl(String moduleName) implements ModuleDesc {
-
-    /**
-     * Validates the correctness of a module name. In particular checks for the presence of
-     * invalid characters in the name.
-     *
-     * {@jvms 4.2.3} Module and Package Names
-     *
-     * @param name the module name
-     * @return the module name passed if valid
-     * @throws IllegalArgumentException if the module name is invalid
-     */
-    public static String validateModuleName(String name) {
-        for (int i=name.length() - 1; i >= 0; i--) {
-            char ch = name.charAt(i);
-            if ((ch >= '\u0000' && ch <= '\u001F')
-            || ((ch == '\\' || ch == ':' || ch =='@') && (i == 0 || name.charAt(--i) != '\\')))
-                throw new IllegalArgumentException("Invalid module name: " + name);
-        }
-        return name;
-    }
 }

--- a/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
@@ -24,5 +24,9 @@
  */
 package java.lang.constant;
 
+/*
+ * Implementation of {@code ModuleDesc}
+ * @param moduleName must have been validated
+ */
 record ModuleDescImpl(String moduleName) implements ModuleDesc {
 }

--- a/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
@@ -26,12 +26,12 @@ package java.lang.constant;
 
 /*
  * Implementation of {@code ModuleDesc}
- * @param moduleName must have been validated
+ * @param name must have been validated
  */
-record ModuleDescImpl(String moduleName) implements ModuleDesc {
+record ModuleDescImpl(String name) implements ModuleDesc {
 
     @Override
     public String toString() {
-        return String.format("ModuleDesc[%s]", moduleName());
+        return String.format("ModuleDesc[%s]", name());
     }
 }

--- a/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
@@ -29,4 +29,9 @@ package java.lang.constant;
  * @param moduleName must have been validated
  */
 record ModuleDescImpl(String moduleName) implements ModuleDesc {
+
+    @Override
+    public String toString() {
+        return String.format("ModuleDesc[%s]", moduleName());
+    }
 }

--- a/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ModuleDescImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.constant;
+
+record ModuleDescImpl(String moduleName) implements ModuleDesc {
+
+    /**
+     * Validates the correctness of a module name. In particular checks for the presence of
+     * invalid characters in the name.
+     *
+     * {@jvms 4.2.3} Module and Package Names
+     *
+     * @param name the module name
+     * @return the module name passed if valid
+     * @throws IllegalArgumentException if the module name is invalid
+     */
+    public static String validateModuleName(String name) {
+        for (int i=name.length() - 1; i >= 0; i--) {
+            char ch = name.charAt(i);
+            if ((ch >= '\u0000' && ch <= '\u001F')
+            || ((ch == '\\' || ch == ':' || ch =='@') && (i == 0 || name.charAt(--i) != '\\')))
+                throw new IllegalArgumentException("Invalid module name: " + name);
+        }
+        return name;
+    }
+}

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -29,9 +29,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A nominal descriptor for a {@code Package} constant {@jvms 4.4.12}.
  *
- * <p>To create a {@linkplain PackageDesc} for a package, use {@link #of} or
- * {@link #ofInternalName(String)}.
+ * <p>To create a {@linkplain PackageDesc} for a package, use the {@link #of} or
+ * {@link #ofInternalName(String)} method.
  *
+ *  * @jvms 4.4.11 The CONSTANT_Module_info Structure
  * @since 21
  */
 public sealed interface PackageDesc
@@ -43,7 +44,7 @@ public sealed interface PackageDesc
      * <p>
      * {@jls 13.1}
      *
-     * @param name the fully qualified (dot-separated) binary package name
+     * @param name the fully qualified (dot-separated) package name
      * @return a {@linkplain PackageDesc} describing the desired package
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the
@@ -62,7 +63,7 @@ public sealed interface PackageDesc
      * {@jvms 4.2.1} In this internal form, the ASCII periods (.) that normally
      * separate the identifiers
      * which make up the binary name are replaced by ASCII forward slashes (/).
-     * @param name the fully qualified class name, in internal (slash-separated)
+     * @param name the fully qualified package name, in internal (slash-separated) form
      * form
      * @return a {@linkplain PackageDesc} describing the desired package
      * @throws NullPointerException if the argument is {@code null}
@@ -79,7 +80,7 @@ public sealed interface PackageDesc
      * of this {@linkplain PackageDesc}.
      *
      * @return the package name, or the empty string for the
-     * default package
+     * unnamed package
      */
     String packageInternalName();
 
@@ -88,7 +89,7 @@ public sealed interface PackageDesc
      * of this {@linkplain PackageDesc}.
      *
      * @return the package name, or the empty string for the
-     * default package
+     * unnamed package
      */
     default String packageName() {
         return ConstantUtils.internalToBinary(packageInternalName());

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A nominal descriptor for a {@code Package} constant.
  *
- * @apiNote
+ * <p>
  * To create a {@link PackageDesc} for a package,
  * use the {@link #of(String)} or {@link #ofInternalName(String)} method.
  *
@@ -68,6 +68,7 @@ public sealed interface PackageDesc
      * @throws IllegalArgumentException if the name string is not in the
      * correct format
      * @jvms 4.2.1 Binary Class and Interface Names
+     * @jvm 4.2.3 Module and Package Names
      * @see PackageDesc#of(String)
      */
     static PackageDesc ofInternalName(String name) {

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -82,9 +82,9 @@ public sealed interface PackageDesc
      *
      * @return the package name in internal form, or the empty string for the
      * unnamed package
-     * @see PackageDesc#packageName()
+     * @see PackageDesc#name()
      */
-    String packageInternalName();
+    String internalName();
 
     /**
      * Returns the fully qualified (dot-separated) package name
@@ -92,10 +92,10 @@ public sealed interface PackageDesc
      *
      * @return the package name, or the empty string for the
      * unnamed package
-     * @see PackageDesc#packageInternalName()
+     * @see PackageDesc#internalName()
      */
-    default String packageName() {
-        return ConstantUtils.internalToBinary(packageInternalName());
+    default String name() {
+        return ConstantUtils.internalToBinary(internalName());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -68,7 +68,7 @@ public sealed interface PackageDesc
      * @throws IllegalArgumentException if the name string is not in the
      * correct format
      * @jvms 4.2.1 Binary Class and Interface Names
-     * @jvm 4.2.3 Module and Package Names
+     * @jvms 4.2.3 Module and Package Names
      * @see PackageDesc#of(String)
      */
     static PackageDesc ofInternalName(String name) {
@@ -101,7 +101,7 @@ public sealed interface PackageDesc
     /**
      * Compare the specified object with this descriptor for equality.
      * Returns {@code true} if and only if the specified object is
-     * also a {@linkp PackageDesc} and both describe the same package.
+     * also a {@link PackageDesc} and both describe the same package.
      *
      * @param o the other object
      * @return whether this descriptor is equal to the other object

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -27,7 +27,7 @@ package java.lang.constant;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A nominal descriptor for a {@code Package} constant.
+ * A nominal descriptor for a {@code Package} constant {@jvms 4.4.12}.
  *
  * <p>To create a {@linkplain PackageDesc} for a package, use {@link #of} or
  * {@link #ofInternalName(String)}.
@@ -50,8 +50,8 @@ public sealed interface PackageDesc
      * correct format
      */
     static PackageDesc of(String name) {
-        PackageDescImpl.validateBinaryPackageName(requireNonNull(name));
-        return new PackageDescImpl(PackageDescImpl.binaryToInternal(name));
+        ConstantUtils.validateBinaryPackageName(requireNonNull(name));
+        return new PackageDescImpl(ConstantUtils.binaryToInternal(name));
     }
 
     /**
@@ -70,7 +70,7 @@ public sealed interface PackageDesc
      * correct format
      */
     static PackageDesc ofInternalName(String name) {
-        PackageDescImpl.validateInternalPackageName(requireNonNull(name));
+        ConstantUtils.validateInternalPackageName(requireNonNull(name));
         return new PackageDescImpl(name);
     }
 
@@ -91,7 +91,7 @@ public sealed interface PackageDesc
      * default package
      */
     default String packageName() {
-        return PackageDescImpl.internalToBinary(packageInternalName());
+        return ConstantUtils.internalToBinary(packageInternalName());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
  * <p>To create a {@linkplain PackageDesc} for a package, use the {@link #of} or
  * {@link #ofInternalName(String)} method.
  *
- *  * @jvms 4.4.11 The CONSTANT_Module_info Structure
+ * @jvms 4.4.11 The CONSTANT_Module_info Structure
  * @since 21
  */
 public sealed interface PackageDesc

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -48,7 +48,7 @@ public sealed interface PackageDesc
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the
      * correct format
-     * @jls 6.7 Fully Qualified Names and Canonical Names
+     * @jls 6.5.3 Module Names and Package Names
      * @see PackageDesc#ofInternalName(String)
      */
     static PackageDesc of(String name) {
@@ -76,17 +76,17 @@ public sealed interface PackageDesc
     }
 
     /**
-     * Returns the fully qualified (slash-separated) internal package name
+     * Returns the fully qualified (slash-separated) package name in internal form
      * of this {@link PackageDesc}.
      *
-     * @return the package name, or the empty string for the
+     * @return the package name in internal form, or the empty string for the
      * unnamed package
      * @see PackageDesc#packageName()
      */
     String packageInternalName();
 
     /**
-     * Returns the fully qualified (dot-separated) binary package name
+     * Returns the fully qualified (dot-separated) package name
      * of this {@link PackageDesc}.
      *
      * @return the package name, or the empty string for the

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -29,26 +29,26 @@ import static java.util.Objects.requireNonNull;
 /**
  * A nominal descriptor for a {@code Package} constant {@jvms 4.4.12}.
  *
- * <p>To create a {@linkplain PackageDesc} for a package, use the {@link #of} or
+ * <p>To create a {@link PackageDesc} for a package, use the {@link #of} or
  * {@link #ofInternalName(String)} method.
  *
- * @jvms 4.4.11 The CONSTANT_Module_info Structure
+ * @jvms 4.4.12 The CONSTANT_Package_info Structure
  * @since 21
  */
 public sealed interface PackageDesc
         permits PackageDescImpl {
 
     /**
-     * Returns a {@linkplain PackageDesc} for a package,
+     * Returns a {@link PackageDesc} for a package,
      * given the name of the package, such as {@code "java.lang"}.
-     * <p>
-     * {@jls 13.1}
      *
      * @param name the fully qualified (dot-separated) package name
-     * @return a {@linkplain PackageDesc} describing the desired package
+     * @return a {@link PackageDesc} describing the desired package
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the
      * correct format
+     * @jls 6.7 Fully Qualified Names and Canonical Names
+     * @see PackageDesc#ofInternalName(String)
      */
     static PackageDesc of(String name) {
         ConstantUtils.validateBinaryPackageName(requireNonNull(name));
@@ -56,19 +56,18 @@ public sealed interface PackageDesc
     }
 
     /**
-     * Returns a {@linkplain PackageDesc} for a package,
+     * Returns a {@link PackageDesc} for a package,
      * given the name of the package in internal form,
      * such as {@code "java/lang"}.
-     * <p>
-     * {@jvms 4.2.1} In this internal form, the ASCII periods (.) that normally
-     * separate the identifiers
-     * which make up the binary name are replaced by ASCII forward slashes (/).
+     *
      * @param name the fully qualified package name, in internal (slash-separated) form
      * form
-     * @return a {@linkplain PackageDesc} describing the desired package
+     * @return a {@link PackageDesc} describing the desired package
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the
      * correct format
+     * @jvms 4.2.1 Binary Class and Interface Names
+     * @see PackageDesc#of(String)
      */
     static PackageDesc ofInternalName(String name) {
         ConstantUtils.validateInternalPackageName(requireNonNull(name));
@@ -77,19 +76,21 @@ public sealed interface PackageDesc
 
     /**
      * Returns the fully qualified (slash-separated) internal package name
-     * of this {@linkplain PackageDesc}.
+     * of this {@link PackageDesc}.
      *
      * @return the package name, or the empty string for the
      * unnamed package
+     * @see PackageDesc#packageName()
      */
     String packageInternalName();
 
     /**
      * Returns the fully qualified (dot-separated) binary package name
-     * of this {@linkplain PackageDesc}.
+     * of this {@link PackageDesc}.
      *
      * @return the package name, or the empty string for the
      * unnamed package
+     * @see PackageDesc#packageInternalName()
      */
     default String packageName() {
         return ConstantUtils.internalToBinary(packageInternalName());

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.constant;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A nominal descriptor for a {@code Package} constant.
+ *
+ * <p>To create a {@linkplain PackageDesc} for a package, use {@link #of} or
+ * {@link #ofInternalName(String)}.
+ *
+ * @since 21
+ */
+public sealed interface PackageDesc
+        permits PackageDescImpl {
+
+    /**
+     * Returns a {@linkplain PackageDesc} for a package,
+     * given the name of the package, such as {@code "java.lang"}.
+     * <p>
+     * {@jls 13.1}
+     *
+     * @param name the fully qualified (dot-separated) binary package name
+     * @return a {@linkplain PackageDesc} describing the desired package
+     * @throws NullPointerException if the argument is {@code null}
+     * @throws IllegalArgumentException if the name string is not in the
+     * correct format
+     */
+    static PackageDesc of(String name) {
+        PackageDescImpl.validateBinaryPackageName(requireNonNull(name));
+        return new PackageDescImpl(PackageDescImpl.binaryToInternal(name));
+    }
+
+    /**
+     * Returns a {@linkplain PackageDesc} for a package,
+     * given the name of the package in internal form,
+     * such as {@code "java/lang"}.
+     * <p>
+     * {@jvms 4.2.1} In this internal form, the ASCII periods (.) that normally
+     * separate the identifiers
+     * which make up the binary name are replaced by ASCII forward slashes (/).
+     * @param name the fully qualified class name, in internal (slash-separated)
+     * form
+     * @return a {@linkplain PackageDesc} describing the desired package
+     * @throws NullPointerException if the argument is {@code null}
+     * @throws IllegalArgumentException if the name string is not in the
+     * correct format
+     */
+    static PackageDesc ofInternalName(String name) {
+        PackageDescImpl.validateInternalPackageName(requireNonNull(name));
+        return new PackageDescImpl(name);
+    }
+
+    /**
+     * Returns the fully qualified (slash-separated) internal package name
+     * of this {@linkplain PackageDesc}.
+     *
+     * @return the package name, or the empty string for the
+     * default package
+     */
+    String packageInternalName();
+
+    /**
+     * Returns the fully qualified (dot-separated) binary package name
+     * of this {@linkplain PackageDesc}.
+     *
+     * @return the package name, or the empty string for the
+     * default package
+     */
+    default String packageName() {
+        return PackageDescImpl.internalToBinary(packageInternalName());
+    }
+
+    /**
+     * Compare the specified object with this descriptor for equality.  Returns
+     * {@code true} if and only if the specified object is also a
+     * {@linkplain PackageDesc} and both describe the same package.
+     *
+     * @param o the other object
+     * @return whether this descriptor is equal to the other object
+     */
+    @Override
+    boolean equals(Object o);
+}

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -27,10 +27,11 @@ package java.lang.constant;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A nominal descriptor for a {@code Package} constant {@jvms 4.4.12}.
+ * A nominal descriptor for a {@code Package} constant.
  *
- * <p>To create a {@link PackageDesc} for a package, use the {@link #of} or
- * {@link #ofInternalName(String)} method.
+ * @apiNote
+ * To create a {@link PackageDesc} for a package,
+ * use the {@link #of(String)} or {@link #ofInternalName(String)} method.
  *
  * @jvms 4.4.12 The CONSTANT_Package_info Structure
  * @since 21
@@ -60,8 +61,8 @@ public sealed interface PackageDesc
      * given the name of the package in internal form,
      * such as {@code "java/lang"}.
      *
-     * @param name the fully qualified package name, in internal (slash-separated) form
-     * form
+     * @param name the fully qualified package name, in internal
+     * (slash-separated) form
      * @return a {@link PackageDesc} describing the desired package
      * @throws NullPointerException if the argument is {@code null}
      * @throws IllegalArgumentException if the name string is not in the

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -98,9 +98,9 @@ public sealed interface PackageDesc
     }
 
     /**
-     * Compare the specified object with this descriptor for equality.  Returns
-     * {@code true} if and only if the specified object is also a
-     * {@linkplain PackageDesc} and both describe the same package.
+     * Compare the specified object with this descriptor for equality.
+     * Returns {@code true} if and only if the specified object is
+     * also a {@linkp PackageDesc} and both describe the same package.
      *
      * @param o the other object
      * @return whether this descriptor is equal to the other object

--- a/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.constant;
+
+record PackageDescImpl(String packageInternalName) implements PackageDesc {
+
+    /**
+     * Validates the correctness of a binary package name. In particular checks for the presence of
+     * invalid characters in the name.
+     *
+     * @param name the package name
+     * @return the package name passed if valid
+     * @throws IllegalArgumentException if the package name is invalid
+     */
+    public static String validateBinaryPackageName(String name) {
+        for (int i=0; i<name.length(); i++) {
+            char ch = name.charAt(i);
+            if (ch == ';' || ch == '[' || ch == '/')
+                throw new IllegalArgumentException("Invalid package name: " + name);
+        }
+        return name;
+    }
+
+    /**
+     * Validates the correctness of an internal package name.
+     * In particular checks for the presence of invalid characters in the name.
+     *
+     * @param name the package name
+     * @return the package name passed if valid
+     * @throws IllegalArgumentException if the package name is invalid
+     */
+    public static String validateInternalPackageName(String name) {
+        for (int i=0; i<name.length(); i++) {
+            char ch = name.charAt(i);
+            if (ch == ';' || ch == '[' || ch == '.')
+                throw new IllegalArgumentException("Invalid package name: " + name);
+        }
+        return name;
+    }
+
+    public static String internalToBinary(String name) {
+        return name.replace('/', '.');
+    }
+
+    public static String binaryToInternal(String name) {
+        return name.replace('.', '/');
+    }
+}

--- a/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
@@ -25,46 +25,4 @@
 package java.lang.constant;
 
 record PackageDescImpl(String packageInternalName) implements PackageDesc {
-
-    /**
-     * Validates the correctness of a binary package name. In particular checks for the presence of
-     * invalid characters in the name.
-     *
-     * @param name the package name
-     * @return the package name passed if valid
-     * @throws IllegalArgumentException if the package name is invalid
-     */
-    public static String validateBinaryPackageName(String name) {
-        for (int i=0; i<name.length(); i++) {
-            char ch = name.charAt(i);
-            if (ch == ';' || ch == '[' || ch == '/')
-                throw new IllegalArgumentException("Invalid package name: " + name);
-        }
-        return name;
-    }
-
-    /**
-     * Validates the correctness of an internal package name.
-     * In particular checks for the presence of invalid characters in the name.
-     *
-     * @param name the package name
-     * @return the package name passed if valid
-     * @throws IllegalArgumentException if the package name is invalid
-     */
-    public static String validateInternalPackageName(String name) {
-        for (int i=0; i<name.length(); i++) {
-            char ch = name.charAt(i);
-            if (ch == ';' || ch == '[' || ch == '.')
-                throw new IllegalArgumentException("Invalid package name: " + name);
-        }
-        return name;
-    }
-
-    public static String internalToBinary(String name) {
-        return name.replace('/', '.');
-    }
-
-    public static String binaryToInternal(String name) {
-        return name.replace('.', '/');
-    }
 }

--- a/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
@@ -26,12 +26,12 @@ package java.lang.constant;
 
 /*
  * Implementation of {@code PackageDesc}
- * @param packageInternalName must have been validated
+ * @param internalName must have been validated
  */
-record PackageDescImpl(String packageInternalName) implements PackageDesc {
+record PackageDescImpl(String internalName) implements PackageDesc {
 
     @Override
     public String toString() {
-        return String.format("PackageDesc[%s]", packageName());
+        return String.format("PackageDesc[%s]", name());
     }
 }

--- a/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
@@ -29,4 +29,9 @@ package java.lang.constant;
  * @param packageInternalName must have been validated
  */
 record PackageDescImpl(String packageInternalName) implements PackageDesc {
+
+    @Override
+    public String toString() {
+        return String.format("PackageDesc[%s]", packageName());
+    }
 }

--- a/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDescImpl.java
@@ -24,5 +24,9 @@
  */
 package java.lang.constant;
 
+/*
+ * Implementation of {@code PackageDesc}
+ * @param packageInternalName must have been validated
+ */
 record PackageDescImpl(String packageInternalName) implements PackageDesc {
 }

--- a/src/java.base/share/classes/java/lang/constant/package-info.java
+++ b/src/java.base/share/classes/java/lang/constant/package-info.java
@@ -89,7 +89,7 @@
  * It is also suitable for describing {@code invokedynamic} call sites in bytecode
  * reading and writing APIs.
  *
- * <p>Another members of this package are {@link java.lang.constant.ModuleDesc}
+ * <p>Other members of this package are {@link java.lang.constant.ModuleDesc}
  * and  {@link java.lang.constant.PackageDesc}. They represent module and package
  * info structures, suitable for describing modules and their content in bytecode
  * reading and writing APIs.

--- a/src/java.base/share/classes/java/lang/constant/package-info.java
+++ b/src/java.base/share/classes/java/lang/constant/package-info.java
@@ -89,6 +89,11 @@
  * It is also suitable for describing {@code invokedynamic} call sites in bytecode
  * reading and writing APIs.
  *
+ * <p>Another members of this package are {@link java.lang.constant.ModuleDesc}
+ * and  {@link java.lang.constant.PackageDesc}. They represent module and package
+ * info structures, suitable for describing modules and their content in bytecode
+ * reading and writing APIs.
+ *
  * @jvms 4.4 The Constant Pool
  *
  * @since 12

--- a/src/java.base/share/classes/java/lang/constant/package-info.java
+++ b/src/java.base/share/classes/java/lang/constant/package-info.java
@@ -89,8 +89,8 @@
  * It is also suitable for describing {@code invokedynamic} call sites in bytecode
  * reading and writing APIs.
  *
- * <p>Other members of this package are {@link java.lang.constant.ModuleDesc}
- * and  {@link java.lang.constant.PackageDesc}. They represent module and package
+ * <p>Other members of this package are {@link ModuleDesc}
+ * and  {@link PackageDesc}. They represent module and package
  * info structures, suitable for describing modules and their content in bytecode
  * reading and writing APIs.
  *

--- a/test/jdk/java/lang/constant/ModuleDescTest.java
+++ b/test/jdk/java/lang/constant/ModuleDescTest.java
@@ -37,7 +37,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class ModuleDescTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"abc\\", "ab\\c", "\u0000", "\u0001", "\u001e", "\u001f"})
+    @ValueSource(strings = {
+        "abc\\", "ab\\c", "\u0001", "\u001e",
+        ":", ":foo", "foo:", "foo:bar",
+        "@", "@foo", "foo@", "foo@bar",
+        "\\", "\\foo", "foo\\", "foo\\bar",
+        "\u0000", "\u0000foo", "foo\u0000", "foo\u0000bar",
+        "\u001f", "\u001ffoo", "foo\u001f", "foo\u001fbar"})
     public void testInvalidModuleNames(String mdl) {
         assertThrows(IllegalArgumentException.class, () -> ModuleDesc.of(mdl));
     }
@@ -48,9 +54,20 @@ class ModuleDescTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"a\\\\b", "a.b/c", "a\\@b\\: c", ""})
+    @ValueSource(strings = {
+        "", "a\\\\b", "a.b/c", "a\\@b\\: c",
+        ".", ".foo", "foo.", "foo.bar",
+        "..", "..foo", "foo..", "foo..bar",
+        "[", "[foo", "foo[", "foo[bar",
+        ";", ";foo", "foo;", "foo;bar",
+        "\\\\", "\\\\foo", "foo\\\\", "foo\\\\bar",
+        "\\\\\\\\", "\\\\\\\\foo", "foo\\\\\\\\", "foo\\\\\\\\bar",
+        "\\:", "\\:foo", "foo\\:", "foo\\:bar",
+        "\\:\\:", "\\:\\:foo", "foo\\:\\:", "foo\\:\\:bar",
+        "\\@", "\\@foo", "foo\\@", "foo\\@bar",
+        "\\@\\@", "\\@\\@foo", "foo\\@\\@", "foo\\@\\@bar"})
     public void testValidModuleNames(String mdl) {
         assertEquals(ModuleDesc.of(mdl), ModuleDesc.of(mdl));
-        assertEquals(ModuleDesc.of(mdl).moduleName(), mdl);
+        assertEquals(ModuleDesc.of(mdl).name(), mdl);
     }
 }

--- a/test/jdk/java/lang/constant/ModuleDescTest.java
+++ b/test/jdk/java/lang/constant/ModuleDescTest.java
@@ -29,6 +29,7 @@
  * @run junit ModuleDescTest
  */
 import java.lang.constant.ModuleDesc;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,8 +42,13 @@ class ModuleDescTest {
         assertThrows(IllegalArgumentException.class, () -> ModuleDesc.of(mdl));
     }
 
+    @Test
+    public void testNullModuleName() {
+        assertThrows(NullPointerException.class, () -> ModuleDesc.of(null));
+    }
+
     @ParameterizedTest
-    @ValueSource(strings = {"a\\\\b", "a.b/c", "a\\@b\\: c"})
+    @ValueSource(strings = {"a\\\\b", "a.b/c", "a\\@b\\: c", ""})
     public void testValidModuleNames(String mdl) {
         assertEquals(ModuleDesc.of(mdl), ModuleDesc.of(mdl));
         assertEquals(ModuleDesc.of(mdl).moduleName(), mdl);

--- a/test/jdk/java/lang/constant/ModuleDescTest.java
+++ b/test/jdk/java/lang/constant/ModuleDescTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing ModuleDesc.
+ * @run junit ModuleDescTest
+ */
+import java.lang.constant.ModuleDesc;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModuleDescTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"abc\\", "ab\\c", "\u0000", "\u0001", "\u001e", "\u001f"})
+    public void testInvalidModuleNames(String mdl) {
+        assertThrows(IllegalArgumentException.class, () -> ModuleDesc.of(mdl));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a\\\\b", "a.b/c", "a\\@b\\: c"})
+    public void testValidModuleNames(String mdl) {
+        assertEquals(ModuleDesc.of(mdl), ModuleDesc.of(mdl));
+        assertEquals(ModuleDesc.of(mdl).moduleName(), mdl);
+    }
+}

--- a/test/jdk/java/lang/constant/PackageDescTest.java
+++ b/test/jdk/java/lang/constant/PackageDescTest.java
@@ -59,11 +59,11 @@ class PackageDescTest {
         assertEquals(PackageDesc.of("a"), PackageDesc.ofInternalName("a"));
         assertEquals(PackageDesc.of("a.b"), PackageDesc.ofInternalName("a/b"));
         assertEquals(PackageDesc.of("a.b.c"), PackageDesc.ofInternalName("a/b/c"));
-        assertEquals(PackageDesc.of("a").packageName(), PackageDesc.ofInternalName("a").packageName());
-        assertEquals(PackageDesc.of("a.b").packageName(), PackageDesc.ofInternalName("a/b").packageName());
-        assertEquals(PackageDesc.of("a.b.c").packageName(), PackageDesc.ofInternalName("a/b/c").packageName());
-        assertEquals(PackageDesc.of("a").packageInternalName(), PackageDesc.ofInternalName("a").packageInternalName());
-        assertEquals(PackageDesc.of("a.b").packageInternalName(), PackageDesc.ofInternalName("a/b").packageInternalName());
-        assertEquals(PackageDesc.of("a.b.c").packageInternalName(), PackageDesc.ofInternalName("a/b/c").packageInternalName());
+        assertEquals(PackageDesc.of("a").name(), PackageDesc.ofInternalName("a").name());
+        assertEquals(PackageDesc.of("a.b").name(), PackageDesc.ofInternalName("a/b").name());
+        assertEquals(PackageDesc.of("a.b.c").name(), PackageDesc.ofInternalName("a/b/c").name());
+        assertEquals(PackageDesc.of("a").internalName(), PackageDesc.ofInternalName("a").internalName());
+        assertEquals(PackageDesc.of("a.b").internalName(), PackageDesc.ofInternalName("a/b").internalName());
+        assertEquals(PackageDesc.of("a.b.c").internalName(), PackageDesc.ofInternalName("a/b/c").internalName());
     }
 }

--- a/test/jdk/java/lang/constant/PackageDescTest.java
+++ b/test/jdk/java/lang/constant/PackageDescTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing PackageDesc.
+ * @run junit PackageDescTest
+ */
+import java.lang.constant.PackageDesc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PackageDescTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"a/b.d", "a[]", "a;"})
+    void testInvalidPackageNames(String pkg) {
+        assertThrows(IllegalArgumentException.class, () -> PackageDesc.of(pkg));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a/b.d", "a[]", "a;"})
+    void testInvalidInternalPackageNames(String pkg) {
+        assertThrows(IllegalArgumentException.class, () -> PackageDesc.ofInternalName(pkg));
+    }
+
+    @Test
+    void testValidPackageNames() {
+        assertEquals(PackageDesc.of("a"), PackageDesc.ofInternalName("a"));
+        assertEquals(PackageDesc.of("a.b"), PackageDesc.ofInternalName("a/b"));
+        assertEquals(PackageDesc.of("a.b.c"), PackageDesc.ofInternalName("a/b/c"));
+        assertEquals(PackageDesc.of("a").packageName(), PackageDesc.ofInternalName("a").packageName());
+        assertEquals(PackageDesc.of("a.b").packageName(), PackageDesc.ofInternalName("a/b").packageName());
+        assertEquals(PackageDesc.of("a.b.c").packageName(), PackageDesc.ofInternalName("a/b/c").packageName());
+        assertEquals(PackageDesc.of("a").packageInternalName(), PackageDesc.ofInternalName("a").packageInternalName());
+        assertEquals(PackageDesc.of("a.b").packageInternalName(), PackageDesc.ofInternalName("a/b").packageInternalName());
+        assertEquals(PackageDesc.of("a.b.c").packageInternalName(), PackageDesc.ofInternalName("a/b/c").packageInternalName());
+    }
+}

--- a/test/jdk/java/lang/constant/PackageDescTest.java
+++ b/test/jdk/java/lang/constant/PackageDescTest.java
@@ -49,7 +49,13 @@ class PackageDescTest {
     }
 
     @Test
+    void testNullInternalPackageNames() {
+        assertThrows(NullPointerException.class, () -> PackageDesc.ofInternalName(null));
+    }
+
+    @Test
     void testValidPackageNames() {
+        assertEquals(PackageDesc.of(""), PackageDesc.ofInternalName(""));
         assertEquals(PackageDesc.of("a"), PackageDesc.ofInternalName("a"));
         assertEquals(PackageDesc.of("a.b"), PackageDesc.ofInternalName("a/b"));
         assertEquals(PackageDesc.of("a.b.c"), PackageDesc.ofInternalName("a/b/c"));


### PR DESCRIPTION
Constants API already provides models for all loadable constants to help programs manipulating class files and modelling bytecode instructions. However no models of module and package constants are provided by Constants API. Every program manipulating class files must implement own models and validation of modules and packages constants.

This pul request adds `java.lang.constant.ModuleDesc` and `java.lang.constant.PackageDesc` to the Constants API. 

Classfile API will follow up and remove its internal implementations of `PackageDesc` and `ModuleDesc`. 

Please review this pull request and attached CSR.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8306730](https://bugs.openjdk.org/browse/JDK-8306730) to be approved

### Issues
 * [JDK-8306729](https://bugs.openjdk.org/browse/JDK-8306729): Add nominal descriptors of modules and packages to Constants API
 * [JDK-8306730](https://bugs.openjdk.org/browse/JDK-8306730): Add nominal descriptors of modules and packages to Constants API (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [efab745b](https://git.openjdk.org/jdk/pull/13615/files/efab745bb9eba8a26f4ffec16dd3d01b6c9e1608)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13615/head:pull/13615` \
`$ git checkout pull/13615`

Update a local copy of the PR: \
`$ git checkout pull/13615` \
`$ git pull https://git.openjdk.org/jdk.git pull/13615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13615`

View PR using the GUI difftool: \
`$ git pr show -t 13615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13615.diff">https://git.openjdk.org/jdk/pull/13615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13615#issuecomment-1520034320)