### PR TITLE
8306738: Select num workers for safepoint ParallelCleanupTask

### DIFF
--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -603,7 +603,8 @@ void SafepointSynchronize::do_cleanup_tasks() {
   WorkerThreads* cleanup_workers = heap->safepoint_workers();
   if (cleanup_workers != nullptr) {
     // Parallel cleanup using GC provided thread pool.
-    cleanup_workers->run_task(&cleanup);
+    const uint num_workers = MIN2<uint>(SAFEPOINT_CLEANUP_NUM_TASKS, cleanup_workers->max_workers());
+    cleanup_workers->run_task(&cleanup, num_workers);
   } else {
     // Serial cleanup using VMThread.
     cleanup.work(0);


### PR DESCRIPTION
Select num workers for safepoint ParallelCleanupTask to be at most the number of parallel cleanup tasks `SAFEPOINT_CLEANUP_NUM_TASKS`

Unsure if `WorkerThreads::max_workers()` is more correct than `WorkerThreads::created_workers()` or `WorkerThreads::active_workers()`. 

Tested tier1-3 Oracle platforms.