### PR TITLE
8306749: Make CardTable::invalidate non-virtual

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -133,7 +133,7 @@ public:
     return byte_for(p) + 1;
   }
 
-  virtual void invalidate(MemRegion mr);
+  void invalidate(MemRegion mr);
 
   // Provide read-only access to the card table array.
   const CardValue* byte_for_const(const void* p) const {


### PR DESCRIPTION
Trivial removing unused `virtual` specifier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306749](https://bugs.openjdk.org/browse/JDK-8306749): Make CardTable::invalidate non-virtual


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13617/head:pull/13617` \
`$ git checkout pull/13617`

Update a local copy of the PR: \
`$ git checkout pull/13617` \
`$ git pull https://git.openjdk.org/jdk.git pull/13617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13617`

View PR using the GUI difftool: \
`$ git pr show -t 13617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13617.diff">https://git.openjdk.org/jdk/pull/13617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13617#issuecomment-1520143988)