### PR TITLE
8306687: Relax memory ordering constraints on metaspace atomic counters

### DIFF
--- a/src/hotspot/share/memory/metaspace/counters.hpp
+++ b/src/hotspot/share/memory/metaspace/counters.hpp
@@ -93,22 +93,22 @@ public:
 
   AbstractAtomicCounter() : _c(0) {}
 
-  T get() const               { return _c; }
+  T get() const               { return Atomic::load(&_c); }
 
   void increment() {
-    Atomic::inc(&_c);
+    Atomic::inc(&_c, memory_order_relaxed);
   }
 
   void decrement() {
-    Atomic::dec(&_c);
+    Atomic::dec(&_c, memory_order_relaxed);
   }
 
   void increment_by(T v) {
-    Atomic::add(&_c, v);
+    Atomic::add(&_c, v, memory_order_relaxed);
   }
 
   void decrement_by(T v) {
-    Atomic::sub(&_c, v);
+    Atomic::sub(&_c, v, memory_order_relaxed);
   }
 
 #ifdef ASSERT


### PR DESCRIPTION
Metaspace atomic counter (`SizeAtomicCounter`) is used to track used `class` and `nonclass` metaspace sizes, they are pure counters and only need atomic guarantee.

Test:
- [x] hotspot_metaspace MacOSX M1
- [x] hotspot_metaspace Linux x86_64
- [x] hotspot_metaspace Linux x86_32

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306687](https://bugs.openjdk.org/browse/JDK-8306687): Relax memory ordering constraints on metaspace atomic counters


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Yumin Qi](https://openjdk.org/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13618/head:pull/13618` \
`$ git checkout pull/13618`

Update a local copy of the PR: \
`$ git checkout pull/13618` \
`$ git pull https://git.openjdk.org/jdk.git pull/13618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13618`

View PR using the GUI difftool: \
`$ git pr show -t 13618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13618.diff">https://git.openjdk.org/jdk/pull/13618.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13618#issuecomment-1520154632)