### PR TITLE
8306766: Reduce heap size for TestJNICriticalStressTest

### DIFF
--- a/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
+++ b/test/hotspot/jtreg/gc/TestJNICriticalStressTest.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 4 G1
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms1g -Xmx1g -Xlog:gc TestJNICriticalStressTest 30 4 4 G1
  */
 
  /*
@@ -41,7 +41,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseParallelGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 4 Parallel
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseParallelGC -Xms1g -Xmx1g -Xlog:gc TestJNICriticalStressTest 30 4 4 Parallel
  */
 
 /*
@@ -52,7 +52,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseSerialGC -Xms3g -Xmx3g -Xmn2g -Xlog:gc TestJNICriticalStressTest 30 4 4 Serial
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseSerialGC -Xms1g -Xmx1g -Xlog:gc TestJNICriticalStressTest 30 4 4 Serial
  */
 
 import jdk.test.lib.Asserts;


### PR DESCRIPTION
Hi all,

Please review this change to reduce the heap size for the test TestJNICriticalStressTest. The test fails in GHA where 32-bit machines fail to reserve the current heap size (3g).

Testing: locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306766](https://bugs.openjdk.org/browse/JDK-8306766): Reduce heap size for TestJNICriticalStressTest


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13619/head:pull/13619` \
`$ git checkout pull/13619`

Update a local copy of the PR: \
`$ git checkout pull/13619` \
`$ git pull https://git.openjdk.org/jdk.git pull/13619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13619`

View PR using the GUI difftool: \
`$ git pr show -t 13619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13619.diff">https://git.openjdk.org/jdk/pull/13619.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13619#issuecomment-1520537249)