### PR TITLE
8306773: Problemlist jdk/incubator/vector/ShortMaxVectorTests.java on x86_32

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -737,6 +737,8 @@ javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-
 
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java   8303498 linux-s390x
 
+jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
+
 ############################################################################
 
 # jdk_jfr


### PR DESCRIPTION
There is a product bug, see the parent bug. Problemlisting to get cleaner GHA runs. 

Additional testing: 
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306773](https://bugs.openjdk.org/browse/JDK-8306773): Problemlist jdk/incubator/vector/ShortMaxVectorTests.java on x86_32


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13623/head:pull/13623` \
`$ git checkout pull/13623`

Update a local copy of the PR: \
`$ git checkout pull/13623` \
`$ git pull https://git.openjdk.org/jdk.git pull/13623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13623`

View PR using the GUI difftool: \
`$ git pr show -t 13623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13623.diff">https://git.openjdk.org/jdk/pull/13623.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13623#issuecomment-1520677376)