### PR TITLE
8306780: ProblemList java/lang/Thread/virtual/HoldsLock.java#id0 in Xcomp

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,4 +28,4 @@
 #############################################################################
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
-
+java/lang/Thread/virtual/HoldsLock.java 8305919 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList java/lang/Thread/virtual/HoldsLock.java#id0 in Xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306780](https://bugs.openjdk.org/browse/JDK-8306780): ProblemList java/lang/Thread/virtual/HoldsLock.java#id0 in Xcomp


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13627/head:pull/13627` \
`$ git checkout pull/13627`

Update a local copy of the PR: \
`$ git checkout pull/13627` \
`$ git pull https://git.openjdk.org/jdk.git pull/13627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13627`

View PR using the GUI difftool: \
`$ git pr show -t 13627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13627.diff">https://git.openjdk.org/jdk/pull/13627.diff</a>

</details>
