### PR TITLE
8306770: (fs) Remove obsolete os.version check from sun.nio.fs.BsdFileStore.supportsFileAttributeView

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.io.IOException;
 import java.util.Arrays;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Bsd implementation of FileStore
@@ -93,11 +92,8 @@ class BsdFileStore
 
             // typical macOS file system types that are known to support xattr
             String fstype = entry().fstype();
-            if ("hfs".equals(fstype))
+            if ("hfs".equals(fstype) || "apfs".equals(fstype)) {
                 return true;
-            if ("apfs".equals(fstype)) {
-                // fgetxattr broken on APFS prior to 10.14
-                return isOsVersionGte(10, 14);
             }
 
             // probe file system capabilities
@@ -112,18 +108,5 @@ class BsdFileStore
         if (name.equals("user"))
             return supportsFileAttributeView(UserDefinedFileAttributeView.class);
         return super.supportsFileAttributeView(name);
-    }
-
-    /**
-     * Returns true if the OS major/minor version is greater than, or equal, to the
-     * given major/minor version.
-     */
-    private static boolean isOsVersionGte(int requiredMajor, int requiredMinor) {
-        String osVersion = GetPropertyAction.privilegedGetProperty("os.version");
-        String[] vers = Util.split(osVersion, '.');
-        int majorVersion = Integer.parseInt(vers[0]);
-        int minorVersion = Integer.parseInt(vers[1]);
-        return (majorVersion > requiredMajor)
-                || (majorVersion == requiredMajor && minorVersion >= requiredMinor);
     }
 }


### PR DESCRIPTION
BsdFileStore no longer needs to check the os.version, it is true on supported versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306770](https://bugs.openjdk.org/browse/JDK-8306770): (fs) Remove obsolete os.version check from sun.nio.fs.BsdFileStore.supportsFileAttributeView


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13628/head:pull/13628` \
`$ git checkout pull/13628`

Update a local copy of the PR: \
`$ git checkout pull/13628` \
`$ git pull https://git.openjdk.org/jdk.git pull/13628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13628`

View PR using the GUI difftool: \
`$ git pr show -t 13628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13628.diff">https://git.openjdk.org/jdk/pull/13628.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13628#issuecomment-1520731857)