### PR TITLE
8289735: UTIL_LOOKUP_PROGS fails on pathes with space

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -29,8 +29,8 @@
 RECOMMENDED_PANDOC_VERSION=2.19.2
 
 ###############################################################################
-# Setup the most fundamental tools that relies on not much else to set up,
-# but is used by much of the early bootstrap code.
+# Setup the most fundamental tools which rely on not much else to set up,
+# but are used by much of the early bootstrap code.
 AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
 [
   # Bootstrapping: These tools are needed by UTIL_LOOKUP_PROGS
@@ -42,7 +42,27 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_CHECK_NONEMPTY(FILE)
   AC_PATH_PROGS(LDD, ldd)
 
-  # First are all the fundamental required tools.
+  # Required tools
+  UTIL_REQUIRE_PROGS(ECHO, echo)
+  UTIL_REQUIRE_PROGS(TR, tr)
+  UTIL_REQUIRE_PROGS(UNAME, uname)
+  UTIL_REQUIRE_PROGS(WC, wc)
+
+  # Required tools with some special treatment
+  UTIL_REQUIRE_SPECIAL(EGREP, [AC_PROG_EGREP])
+  UTIL_REQUIRE_SPECIAL(SED, [AC_PROG_SED])
+
+  # Tools only needed on some platforms
+  UTIL_LOOKUP_PROGS(PATHTOOL, cygpath wslpath)
+  UTIL_LOOKUP_PROGS(CMD, cmd.exe, $PATH:/cygdrive/c/windows/system32:/mnt/c/windows/system32:/c/windows/system32)
+])
+
+###############################################################################
+# Setup further tools that should be resolved early but after setting up
+# build platform and path handling.
+AC_DEFUN_ONCE([BASIC_SETUP_TOOLS],
+[
+  # Required tools
   UTIL_REQUIRE_PROGS(BASH, bash)
   UTIL_REQUIRE_PROGS(CAT, cat)
   UTIL_REQUIRE_PROGS(CHMOD, chmod)
@@ -50,7 +70,6 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_REQUIRE_PROGS(CUT, cut)
   UTIL_REQUIRE_PROGS(DATE, date)
   UTIL_REQUIRE_PROGS(DIFF, gdiff diff)
-  UTIL_REQUIRE_PROGS(ECHO, echo)
   UTIL_REQUIRE_PROGS(EXPR, expr)
   UTIL_REQUIRE_PROGS(FIND, find)
   UTIL_REQUIRE_PROGS(GUNZIP, gunzip)
@@ -72,16 +91,11 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_REQUIRE_PROGS(TAR, gtar tar)
   UTIL_REQUIRE_PROGS(TEE, tee)
   UTIL_REQUIRE_PROGS(TOUCH, touch)
-  UTIL_REQUIRE_PROGS(TR, tr)
-  UTIL_REQUIRE_PROGS(UNAME, uname)
-  UTIL_REQUIRE_PROGS(WC, wc)
   UTIL_REQUIRE_PROGS(XARGS, xargs)
 
-  # Then required tools that require some special treatment.
+  # Required tools with some special treatment
   UTIL_REQUIRE_SPECIAL(GREP, [AC_PROG_GREP])
-  UTIL_REQUIRE_SPECIAL(EGREP, [AC_PROG_EGREP])
   UTIL_REQUIRE_SPECIAL(FGREP, [AC_PROG_FGREP])
-  UTIL_REQUIRE_SPECIAL(SED, [AC_PROG_SED])
 
   # Optional tools, we can do without them
   UTIL_LOOKUP_PROGS(DF, df)
@@ -90,10 +104,8 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_LOOKUP_PROGS(READLINK, greadlink readlink)
   UTIL_LOOKUP_PROGS(WHOAMI, whoami)
 
-  # These are only needed on some platforms
-  UTIL_LOOKUP_PROGS(PATHTOOL, cygpath wslpath)
+  # Tools only needed on some platforms
   UTIL_LOOKUP_PROGS(LSB_RELEASE, lsb_release)
-  UTIL_LOOKUP_PROGS(CMD, cmd.exe, $PATH:/cygdrive/c/windows/system32:/mnt/c/windows/system32:/c/windows/system32)
 
   # For compare.sh only
   UTIL_LOOKUP_PROGS(CMP, cmp)

--- a/make/autoconf/configure.ac
+++ b/make/autoconf/configure.ac
@@ -86,6 +86,7 @@ PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET
 
 # Continue setting up basic stuff. Most remaining code require fundamental tools.
 BASIC_SETUP_PATHS
+BASIC_SETUP_TOOLS
 BASIC_SETUP_BUILD_ENV
 
 # Check if it's a pure open build or if custom sources are to be used.


### PR DESCRIPTION
This is an attempt to fix the issue on Windows when no cygwin Git is installed or the Git for Windows installation has precedence in PATH lookup.
The path to the Windows GIT installation usually resides in `C:\Program Files` which contains a space and thus needs some special handling.

There exists code in `UTIL_LOOKUP_PROGS`/`UTIL_FIXUP_EXECUTABLE` that would handle this. However, it relies on initializations made in `PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET` and `BASIC_SETUP_PATHS`.
Currently, `UTIL_LOOKUP_PROGS(GIT, git)` is called too early in configure and hence the problematic Windows path is not handled correctly.
My fix makes sure that only the barely necessary tool lookups required for `PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET` and `BASIC_SETUP_PATHS` are made in `BASIC_SETUP_FUNDAMENTAL_TOOLS` and everything else is moved into another macro called `BASIC_SETUP_TOOLS` that is invoked after path handling is set up correctly.
