### PR TITLE
8305853: java/text/Format/DateFormat/DateFormatRegression.java fails with "Uncaught exception thrown in test method Test4089106"

### DIFF
--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -357,11 +357,11 @@ public class DateFormatRegression extends IntlTest {
     public void Test4089106() {
         TimeZone def = TimeZone.getDefault();
         try {
-            TimeZone z = new SimpleTimeZone((int)(8.25 * 3600000), "GMT-08:15");
-            TimeZone.setDefault(z);
+            TimeZone customTz = TimeZone.getTimeZone("GMT-08:15");
+            TimeZone.setDefault(customTz);
             SimpleDateFormat f = new SimpleDateFormat();
-            if (!f.getTimeZone().equals(z))
-                errln("Fail: SimpleTimeZone should use TimeZone.getDefault()");
+            if (!f.getTimeZone().equals(customTz))
+                errln("Fail: SimpleDateFormat should use TimeZone.getDefault()");
         }
         finally {
             TimeZone.setDefault(def);

--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.io.*;
  * @bug 4029195 4052408 4056591 4059917 4060212 4061287 4065240 4071441 4073003
  * 4089106 4100302 4101483 4103340 4103341 4104136 4104522 4106807 4108407
  * 4134203 4138203 4148168 4151631 4151706 4153860 4162071 4182066 4209272 4210209
- * 4213086 4250359 4253490 4266432 4406615 4413980 8008577
+ * 4213086 4250359 4253490 4266432 4406615 4413980 8008577 8305853
  * @library /java/text/testlib
  * @run main/othervm -Djava.locale.providers=COMPAT,SPI DateFormatRegression
  */

--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -357,7 +357,7 @@ public class DateFormatRegression extends IntlTest {
     public void Test4089106() {
         TimeZone def = TimeZone.getDefault();
         try {
-            TimeZone z = new SimpleTimeZone((int)(1.25 * 3600000), "FAKEZONE");
+            TimeZone z = new SimpleTimeZone((int)(8.25 * 3600000), "GMT-08:15");
             TimeZone.setDefault(z);
             SimpleDateFormat f = new SimpleDateFormat();
             if (!f.getTimeZone().equals(z))


### PR DESCRIPTION
This PR fixes an intermittent failure (that only occurs on Windows) in _DateFormatRegression.java_.

With the integration of [JDK-8304982](https://bugs.openjdk.org/browse/JDK-8304982), _LocaleProviderAdapter.java_ now emits a compat warning when the class is loaded. This warning calls `ZonedDateTime.now()` during formatting. This call depends on the `TimeZone.ID` of the TimeZone returned from `TimeZone.getDefault()`.

On Windows, the test class which DateFormatRegression extends will run the tests at random, (as opposed to running in the same order every time). When Test4089106() happens to be the first test ran, the static block of LocaleProviderAdapter will be executed with `TimeZone.setDefault()` set to a `SimpleTimeZone` with `id` as _FAKEZONE_. When LocaleProviderAdapter formats the compat warning ... and many calls later calls `ZoneRulesProvider getProvider(String zoneId)` with `zoneId` as _FAKEZONE_ the test fails with _java.time.zone.ZoneRulesException: Unknown time-zone ID: FAKEZONE_.

In order to still test that `SimpleDateFormat.getTimeZone()` defaults to `TimeZone.getDefault()` we can create a `SimpleTimeZone` with a custom id rather than an invalid id. This way ZoneRulesProvider will not fail on the ID, but the `SimpleTimeZone` being tested is still not a "default" `TimeZone`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305853](https://bugs.openjdk.org/browse/JDK-8305853): java/text/Format/DateFormat/DateFormatRegression.java fails with "Uncaught exception thrown in test method Test4089106"


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13630/head:pull/13630` \
`$ git checkout pull/13630`

Update a local copy of the PR: \
`$ git checkout pull/13630` \
`$ git pull https://git.openjdk.org/jdk.git pull/13630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13630`

View PR using the GUI difftool: \
`$ git pr show -t 13630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13630.diff">https://git.openjdk.org/jdk/pull/13630.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13630#issuecomment-1520830103)