### PR TITLE
8306623: (bf) CharBuffer::allocate throws unexpected exception type with some CharSequences

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -2045,8 +2045,17 @@ public abstract sealed class $Type$Buffer
      */
     public $Type$Buffer append(CharSequence csq, int start, int end) {
         if (csq instanceof CharBuffer cb) {
-            int pos = position();
+            //
+            // pre-emptively check for overflow as put(int,CharBuffer,int,int)
+            // would throw IndexOutOfBoundsException instead
+            //
             int length = end - start;
+            int pos = position();
+            int lim = limit();
+            int rem = (pos <= lim) ? lim - pos : 0;
+            if (length > rem)
+                throw new BufferOverflowException();
+
             put(pos, cb, start, length);
             position(pos + length);
             return this;

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -2046,8 +2046,8 @@ public abstract sealed class $Type$Buffer
     public $Type$Buffer append(CharSequence csq, int start, int end) {
         if (csq instanceof CharBuffer cb) {
             //
-            // pre-emptively check for overflow as put(int,CharBuffer,int,int)
-            // would throw IndexOutOfBoundsException instead
+            // the append method throws BufferOverflowException when
+            // there is insufficient space in the buffer
             //
             int length = end - start;
             int pos = position();

--- a/test/jdk/java/lang/Appendable/Basic.java
+++ b/test/jdk/java/lang/Appendable/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 5067405 8306623
+ * @bug 5067405
  * @summary Basic test for classes which implement Appendable.
  */
 
@@ -39,12 +39,11 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 
 interface BasicRunnable extends Runnable {
-    void init(Appendable a, CharSequence csq, String exp);
+    void init(Appendable a, String csq, String exp);
     Appendable reset(Appendable csq);
 }
 
@@ -108,13 +107,13 @@ public class Basic {
     private static BasicRunnable testBufferedWriter =
         new BasicRunnable() {
             private String csn, exp;
-            public void init(Appendable bw, CharSequence csq, String exp) {
+            public void init(Appendable bw, String csn, String exp) {
                 try {
                     ((BufferedWriter)bw).flush();
                 } catch (IOException x) {
                     fail(x);
                 }
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -129,9 +128,9 @@ public class Basic {
         new BasicRunnable() {
             private String csn, exp;
             private CharArrayWriter cw;
-            public void init(Appendable cw, CharSequence csq, String exp) {
+            public void init(Appendable cw, String csn, String exp) {
                 this.cw = (CharArrayWriter)cw;
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -145,13 +144,13 @@ public class Basic {
     private static BasicRunnable testFileWriter =
         new BasicRunnable() {
             private String csn, exp;
-            public void init(Appendable fw, CharSequence csq, String exp) {
+            public void init(Appendable fw, String csn, String exp) {
                 try {
                     ((FileWriter)fw).flush();
                 } catch (IOException x) {
                     fail(x);
                 }
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -181,13 +180,13 @@ public class Basic {
     private static BasicRunnable testOutputStreamWriter =
         new BasicRunnable() {
             private String csn, exp;
-            public void init(Appendable osw, CharSequence csq, String exp) {
+            public void init(Appendable osw, String csn, String exp) {
                 try {
                     ((OutputStreamWriter)osw).flush();
                 } catch (IOException x) {
                     fail(x);
                 }
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -201,9 +200,9 @@ public class Basic {
     private static BasicRunnable testPrintWriter =
         new BasicRunnable() {
             private String csn, exp;
-            public void init(Appendable pw, CharSequence csq, String exp) {
+            public void init(Appendable pw, String csn, String exp) {
                 ((PrintWriter)pw).flush();
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -218,9 +217,9 @@ public class Basic {
         new BasicRunnable() {
             private String csn, exp;
             private StringWriter sw;
-            public void init(Appendable sw, CharSequence csq, String exp) {
+            public void init(Appendable sw, String csn, String exp) {
                 this.sw = (StringWriter)sw;
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -233,9 +232,9 @@ public class Basic {
     private static BasicRunnable testPrintStream =
         new BasicRunnable() {
             private String csn, exp;
-            public void init(Appendable ps, CharSequence csq, String exp) {
+            public void init(Appendable ps, String csn, String exp) {
                 ((PrintStream)ps).flush();
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -250,43 +249,14 @@ public class Basic {
         new BasicRunnable() {
             private String csn, exp;
             private CharBuffer cb;
-            private CharSequence csq;
-            public void init(Appendable cb, CharSequence csq, String exp) {
+            public void init(Appendable cb, String csn, String exp) {
                 this.cb = (CharBuffer)cb;
-                this.csq = csq;
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
                 cb.limit(cb.position()).rewind();
                 ck("CharBuffer.append(" + csn + ")", exp, cb.toString());
-
-                // append() should throw BufferOverflowException
-                int alen = csq != null ? csq.length() : 0;
-                try {
-                    CharBuffer.allocate(alen/8).append(csq, alen/4, alen/2);
-                } catch (BufferOverflowException expected) {
-                    // ignore the BufferOverflowException
-                } catch (Throwable ex) {
-                    fail(ex);
-                }
-
-                // append() should throw IndexOutOfBoundsException
-                int[][] bounds = new int[][] {
-                    {-1, alen},         // negative start
-                    {0, -1},            // negative end
-                    {1, 0},             // start > end
-                    {alen/2, alen + 1}  // end > alen
-                };
-                for (int[] b : bounds) {
-                    try {
-                        CharBuffer.allocate(alen + 1).append(csq, b[0], b[1]);
-                    } catch (IndexOutOfBoundsException expected) {
-                        // ignore the IndexOutOfBoundsException
-                    } catch (Throwable ex) {
-                        fail(ex);
-                    }
-                }
             }
             public Appendable reset(Appendable cb) {
                 ((CharBuffer)cb).clear();
@@ -297,9 +267,9 @@ public class Basic {
         new BasicRunnable() {
             private String csn, exp;
             private StringBuffer sb;
-            public void init(Appendable sb, CharSequence csq, String exp) {
+            public void init(Appendable sb, String csn, String exp) {
                 this.sb = (StringBuffer)sb;
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -313,9 +283,9 @@ public class Basic {
         new BasicRunnable() {
             private String csn, exp;
             private StringBuilder sb;
-            public void init(Appendable sb, CharSequence csq, String exp) {
+            public void init(Appendable sb, String csn, String exp) {
                 this.sb = (StringBuilder)sb;
-                this.csn = csq != null ? csq.getClass().getName() : "null";
+                this.csn = csn;
                 this.exp = exp;
             }
             public void run() {
@@ -335,7 +305,7 @@ public class Basic {
             int end = sp[j][1];
             try {
                 thunk.init(a.append(csq, start, end),
-                           csq,
+                           csq.getClass().getName(),
                            s.subSequence(start, end).toString());
                 thunk.run();
                 a = thunk.reset(a);
@@ -367,7 +337,7 @@ public class Basic {
         int start = 1;
         int end = 2;
         try {
-            thunk.init(a.append(null, start, end), (CharSequence)null,
+            thunk.init(a.append(null, start, end), "null",
                        "null".subSequence(start, end).toString());
             thunk.run();
             a = thunk.reset(a);

--- a/test/jdk/java/nio/Buffer/Basic-X.java.template
+++ b/test/jdk/java/nio/Buffer/Basic-X.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -627,6 +627,36 @@ public class Basic$Type$
         absBulkGet(b);
 
 #if[char]
+        // 8306623
+        String str = "in violet night walking beneath a reign of uncouth stars";
+        char[] chars = str.toCharArray();
+        int cslen = chars.length;
+        CharSequence[] csqs = new CharSequence[] {
+            str,
+            new StringBuffer(str),
+            new StringBuilder(str),
+            CharBuffer.wrap(chars),
+            ByteBuffer.allocateDirect(2*chars.length).asCharBuffer()
+        };
+
+        int[][] bounds = new int[][] {
+            {-1, cslen},         // negative start
+            {0, -1},             // negative end
+            {1, 0},              // start > end
+            {cslen/2, cslen + 1} // end > cslen
+        };
+
+        for (CharSequence csq : csqs) {
+            // append() should throw BufferOverflowException
+            tryCatch(b, BufferOverflowException.class, () ->
+                CharBuffer.allocate(cslen/8).append(csq, cslen/4, cslen/2));
+
+            // append() should throw IndexOutOfBoundsException
+            for (int[] bds : bounds)
+                tryCatch(b, IndexOutOfBoundsException.class, () ->
+                    CharBuffer.allocate(cslen + 1).append(csq, bds[0], bds[1]));
+        }
+        // end 8306623
 
         bulkPutString(b);
         relGet(b);

--- a/test/jdk/java/nio/Buffer/Basic.java
+++ b/test/jdk/java/nio/Buffer/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 4413135 4414911 4416536 4416562 4418782 4471053 4472779 4490253 4523725
  *      4526177 4463011 4660660 4661219 4663521 4782970 4804304 4938424 5029431
  *      5071718 6231529 6221101 6234263 6535542 6591971 6593946 6795561 7190219
- *      7199551 8065556 8149469 8230665 8237514
+ *      7199551 8065556 8149469 8230665 8237514 8306623
  * @modules java.base/java.nio:open
  *          java.base/jdk.internal.misc
  * @author Mark Reinhold

--- a/test/jdk/java/nio/Buffer/BasicChar.java
+++ b/test/jdk/java/nio/Buffer/BasicChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -627,6 +627,36 @@ public class BasicChar
         absBulkGet(b);
 
 
+        // 8306623
+        String str = "in violet night walking beneath a reign of uncouth stars";
+        char[] chars = str.toCharArray();
+        int cslen = chars.length;
+        CharSequence[] csqs = new CharSequence[] {
+            str,
+            new StringBuffer(str),
+            new StringBuilder(str),
+            CharBuffer.wrap(chars),
+            ByteBuffer.allocateDirect(2*chars.length).asCharBuffer()
+        };
+
+        int[][] bounds = new int[][] {
+            {-1, cslen},         // negative start
+            {0, -1},             // negative end
+            {1, 0},              // start > end
+            {cslen/2, cslen + 1} // end > cslen
+        };
+
+        for (CharSequence csq : csqs) {
+            // append() should throw BufferOverflowException
+            tryCatch(b, BufferOverflowException.class, () ->
+                CharBuffer.allocate(cslen/8).append(csq, cslen/4, cslen/2));
+
+            // append() should throw IndexOutOfBoundsException
+            for (int[] bds : bounds)
+                tryCatch(b, IndexOutOfBoundsException.class, () ->
+                    CharBuffer.allocate(cslen + 1).append(csq, bds[0], bds[1]));
+        }
+        // end 8306623
 
         bulkPutString(b);
         relGet(b);


### PR DESCRIPTION
When appending a `CharBuffer`, perform a specific check for buffer overflow before invoking `put()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306623](https://bugs.openjdk.org/browse/JDK-8306623): (bf) CharBuffer::allocate throws unexpected exception type with some CharSequences


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [118076c9](https://git.openjdk.org/jdk/pull/13632/files/118076c94ae74d2a4967b8b6ec12e83365f196c6)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13632/head:pull/13632` \
`$ git checkout pull/13632`

Update a local copy of the PR: \
`$ git checkout pull/13632` \
`$ git pull https://git.openjdk.org/jdk.git pull/13632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13632`

View PR using the GUI difftool: \
`$ git pr show -t 13632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13632.diff">https://git.openjdk.org/jdk/pull/13632.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13632#issuecomment-1521042262)