### PR TITLE
8306735: G1: G1FullGCScope remove unnecessary member _explicit_gc

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -841,8 +841,7 @@ void G1CollectedHeap::prepare_heap_for_full_collection() {
   _hrm.remove_all_free_regions();
 }
 
-void G1CollectedHeap::verify_before_full_collection(bool explicit_gc) {
-  assert(!GCCause::is_user_requested_gc(gc_cause()) || explicit_gc, "invariant");
+void G1CollectedHeap::verify_before_full_collection() {
   assert_used_and_recalculate_used_equal(this);
   if (!VerifyBeforeGC) {
     return;
@@ -913,8 +912,7 @@ void G1CollectedHeap::verify_after_full_collection() {
   _ref_processor_cm->verify_no_references_recorded();
 }
 
-bool G1CollectedHeap::do_full_collection(bool explicit_gc,
-                                         bool clear_all_soft_refs,
+bool G1CollectedHeap::do_full_collection(bool clear_all_soft_refs,
                                          bool do_maximal_compaction) {
   assert_at_safepoint_on_vm_thread();
 
@@ -928,7 +926,7 @@ bool G1CollectedHeap::do_full_collection(bool explicit_gc,
 
   G1FullGCMark gc_mark;
   GCTraceTime(Info, gc) tm("Pause Full", NULL, gc_cause(), true);
-  G1FullCollector collector(this, explicit_gc, do_clear_all_soft_refs, do_maximal_compaction, gc_mark.tracer());
+  G1FullCollector collector(this, do_clear_all_soft_refs, do_maximal_compaction, gc_mark.tracer());
 
   collector.prepare_collection();
   collector.collect();
@@ -943,16 +941,14 @@ void G1CollectedHeap::do_full_collection(bool clear_all_soft_refs) {
   // the caller that the collection did not succeed (e.g., because it was locked
   // out by the GC locker). So, right now, we'll ignore the return value.
 
-  do_full_collection(false,                /* explicit_gc */
-                     clear_all_soft_refs,
+  do_full_collection(clear_all_soft_refs,
                      false /* do_maximal_compaction */);
 }
 
 bool G1CollectedHeap::upgrade_to_full_collection() {
   GCCauseSetter compaction(this, GCCause::_g1_compaction_pause);
   log_info(gc, ergo)("Attempting full compaction clearing soft references");
-  bool success = do_full_collection(false /* explicit gc */,
-                                    true  /* clear_all_soft_refs */,
+  bool success = do_full_collection(true  /* clear_all_soft_refs */,
                                     false /* do_maximal_compaction */);
   // do_full_collection only fails if blocked by GC locker and that can't
   // be the case here since we only call this when already completed one gc.
@@ -1008,8 +1004,7 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
     } else {
       log_info(gc, ergo)("Attempting full compaction");
     }
-    *gc_succeeded = do_full_collection(false, /* explicit_gc */
-                                       maximal_compaction /* clear_all_soft_refs */ ,
+    *gc_succeeded = do_full_collection(maximal_compaction /* clear_all_soft_refs */ ,
                                        maximal_compaction /* do_maximal_compaction */);
   }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -479,16 +479,13 @@ private:
   void retire_gc_alloc_region(HeapRegion* alloc_region,
                               size_t allocated_bytes, G1HeapRegionAttr dest);
 
-  // - if explicit_gc is true, the GC is for a System.gc() etc,
-  //   otherwise it's for a failed allocation.
   // - if clear_all_soft_refs is true, all soft references should be
   //   cleared during the GC.
   // - if do_maximal_compaction is true, full gc will do a maximally
   //   compacting collection, leaving no dead wood.
   // - it returns false if it is unable to do the collection due to the
   //   GC locker being active, true otherwise.
-  bool do_full_collection(bool explicit_gc,
-                          bool clear_all_soft_refs,
+  bool do_full_collection(bool clear_all_soft_refs,
                           bool do_maximal_compaction);
 
   // Callback from VM_G1CollectFull operation, or collect_as_vm_thread.
@@ -505,7 +502,7 @@ private:
   // Internal helpers used during full GC to split it up to
   // increase readability.
   bool abort_concurrent_cycle();
-  void verify_before_full_collection(bool explicit_gc);
+  void verify_before_full_collection();
   void prepare_heap_for_full_collection();
   void prepare_for_mutator_after_full_collection();
   void abort_refinement();

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -111,12 +111,11 @@ uint G1FullCollector::calc_active_workers() {
 }
 
 G1FullCollector::G1FullCollector(G1CollectedHeap* heap,
-                                 bool explicit_gc,
                                  bool clear_soft_refs,
                                  bool do_maximal_compaction,
                                  G1FullGCTracer* tracer) :
     _heap(heap),
-    _scope(heap->monitoring_support(), explicit_gc, clear_soft_refs, do_maximal_compaction, tracer),
+    _scope(heap->monitoring_support(), clear_soft_refs, do_maximal_compaction, tracer),
     _num_workers(calc_active_workers()),
     _has_compaction_targets(false),
     _has_humongous(false),
@@ -183,7 +182,7 @@ void G1FullCollector::prepare_collection() {
 
   // Verification needs the bitmap, so we should clear the bitmap only later.
   bool in_concurrent_cycle = _heap->abort_concurrent_cycle();
-  _heap->verify_before_full_collection(scope()->is_explicit_gc());
+  _heap->verify_before_full_collection();
   if (in_concurrent_cycle) {
     GCTraceTime(Debug, gc) debug("Clear Bitmap");
     _heap->concurrent_mark()->clear_bitmap(_heap->workers());

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -100,7 +100,6 @@ class G1FullCollector : StackObj {
 
 public:
   G1FullCollector(G1CollectedHeap* heap,
-                  bool explicit_gc,
                   bool clear_soft_refs,
                   bool do_maximal_compaction,
                   G1FullGCTracer* tracer);

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -37,12 +37,10 @@ G1FullGCJFRTracerMark::~G1FullGCJFRTracerMark() {
 }
 
 G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
-                             bool explicit_gc,
                              bool clear_soft,
                              bool do_maximal_compaction,
                              G1FullGCTracer* tracer) :
     _rm(),
-    _explicit_gc(explicit_gc),
     _do_maximal_compaction(do_maximal_compaction),
     _g1h(G1CollectedHeap::heap()),
     _svc_marker(SvcGCMarker::FULL),
@@ -56,10 +54,6 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
     _region_compaction_threshold(do_maximal_compaction ?
                                  HeapRegion::GrainWords :
                                  (1 - MarkSweepDeadRatio / 100.0) * HeapRegion::GrainWords) { }
-
-bool G1FullGCScope::is_explicit_gc() {
-  return _explicit_gc;
-}
 
 bool G1FullGCScope::should_clear_soft_refs() {
   return _soft_refs.should_clear();

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -47,7 +47,6 @@ public:
 // Class used to group scoped objects used in the Full GC together.
 class G1FullGCScope : public StackObj {
   ResourceMark            _rm;
-  bool                    _explicit_gc;
   bool                    _do_maximal_compaction;
   G1CollectedHeap*        _g1h;
   SvcGCMarker             _svc_marker;
@@ -62,12 +61,10 @@ class G1FullGCScope : public StackObj {
 
 public:
   G1FullGCScope(G1MonitoringSupport* monitoring_support,
-                bool explicit_gc,
                 bool clear_soft,
                 bool do_maximal_compaction,
                 G1FullGCTracer* tracer);
 
-  bool is_explicit_gc();
   bool should_clear_soft_refs();
   bool do_maximal_compaction() { return _do_maximal_compaction; }
 

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -51,8 +51,7 @@ bool VM_G1CollectFull::skip_operation() const {
 void VM_G1CollectFull::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   GCCauseSetter x(g1h, _gc_cause);
-  _gc_succeeded = g1h->do_full_collection(true  /* explicit_gc */,
-                                          false /* clear_all_soft_refs */,
+  _gc_succeeded = g1h->do_full_collection(false /* clear_all_soft_refs */,
                                           false /* do_maximal_compaction */);
 }
 


### PR DESCRIPTION
Hi All,

Please review this change to remove the unnecessary `explicit_gc` member from G1FullGCScope. We can rely on gc_cause() to determine whether the explicit_gc is true where required. 

Testing: tier1_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306735](https://bugs.openjdk.org/browse/JDK-8306735): G1: G1FullGCScope remove unnecessary member _explicit_gc


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13638/head:pull/13638` \
`$ git checkout pull/13638`

Update a local copy of the PR: \
`$ git checkout pull/13638` \
`$ git pull https://git.openjdk.org/jdk.git pull/13638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13638`

View PR using the GUI difftool: \
`$ git pr show -t 13638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13638.diff">https://git.openjdk.org/jdk/pull/13638.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13638#issuecomment-1521611647)