### PR TITLE
8306838: GetGraphicsTest needs to be headful

### DIFF
--- a/test/jdk/java/awt/Graphics/GetGraphicsTest.java
+++ b/test/jdk/java/awt/Graphics/GetGraphicsTest.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 4746122
+ * @key headful
  * @summary Checks getGraphics doesn't throw NullPointerExcepton for invalid colors and font.
  * @run main GetGraphicsTest
 */


### PR DESCRIPTION
Newly added GetGraphicsTest should be headful as it uses a Frame

```
java.awt.HeadlessException:
No X11 DISPLAY variable was set,
or no headful library support was found,
but this program performed an operation which requires it,

at java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:166)
at java.desktop/java.awt.Window.<init>(Window.java:553)
at java.desktop/java.awt.Frame.<init>(Frame.java:428)
at java.desktop/java.awt.Frame.<init>(Frame.java:393)
at GetGraphicsTest.<init>(GetGraphicsTest.java:35)
at GetGraphicsTest.main(GetGraphicsTest.java:47) 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306838](https://bugs.openjdk.org/browse/JDK-8306838): GetGraphicsTest needs to be headful


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13639/head:pull/13639` \
`$ git checkout pull/13639`

Update a local copy of the PR: \
`$ git checkout pull/13639` \
`$ git pull https://git.openjdk.org/jdk.git pull/13639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13639`

View PR using the GUI difftool: \
`$ git pr show -t 13639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13639.diff">https://git.openjdk.org/jdk/pull/13639.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13639#issuecomment-1521737017)