### PR TITLE
8306849: Missing headful in java/awt/Graphics/GetGraphicsTest.java

### DIFF
--- a/test/jdk/java/awt/Graphics/GetGraphicsTest.java
+++ b/test/jdk/java/awt/Graphics/GetGraphicsTest.java
@@ -24,6 +24,7 @@
  * @test
  * @bug 4746122
  * @summary Checks getGraphics doesn't throw NullPointerExcepton for invalid colors and font.
+ * @key headful
  * @run main GetGraphicsTest
 */
 


### PR DESCRIPTION
Add `@key headful` in the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306849](https://bugs.openjdk.org/browse/JDK-8306849): Missing headful in java/awt/Graphics/GetGraphicsTest.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13640/head:pull/13640` \
`$ git checkout pull/13640`

Update a local copy of the PR: \
`$ git checkout pull/13640` \
`$ git pull https://git.openjdk.org/jdk.git pull/13640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13640`

View PR using the GUI difftool: \
`$ git pr show -t 13640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13640.diff">https://git.openjdk.org/jdk/pull/13640.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13640#issuecomment-1521785788)