### PR TITLE
8306823: Native memory leak in SharedRuntime::notify_jvmti_unmount/mount.

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -64,7 +64,7 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/javaCalls.hpp"
-#include "runtime/jniHandles.hpp"
+#include "runtime/jniHandles.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -644,6 +644,8 @@ JRT_ENTRY(void, SharedRuntime::notify_jvmti_mount(oopDesc* vt, jboolean hide, jb
   } else {
     JvmtiVTMSTransitionDisabler::VTMS_mount_end(vthread, first_mount);
   }
+
+  JNIHandles::destroy_local(vthread);
 JRT_END
 
 JRT_ENTRY(void, SharedRuntime::notify_jvmti_unmount(oopDesc* vt, jboolean hide, jboolean last_unmount, JavaThread* current))
@@ -654,6 +656,8 @@ JRT_ENTRY(void, SharedRuntime::notify_jvmti_unmount(oopDesc* vt, jboolean hide, 
   } else {
     JvmtiVTMSTransitionDisabler::VTMS_unmount_end(vthread, last_unmount);
   }
+
+  JNIHandles::destroy_local(vthread);
 JRT_END
 #endif // INCLUDE_JVMTI
 


### PR DESCRIPTION
The code introduced by [JDK-8304303](https://bugs.openjdk.org/browse/JDK-8304303) uses `JNIHandles::make_local` which requires `JNIHandles::destroy_local` which is currently missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306823](https://bugs.openjdk.org/browse/JDK-8306823): Native memory leak in SharedRuntime::notify_jvmti_unmount/mount.


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13641/head:pull/13641` \
`$ git checkout pull/13641`

Update a local copy of the PR: \
`$ git checkout pull/13641` \
`$ git pull https://git.openjdk.org/jdk.git pull/13641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13641`

View PR using the GUI difftool: \
`$ git pr show -t 13641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13641.diff">https://git.openjdk.org/jdk/pull/13641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13641#issuecomment-1521790308)