### PR TITLE
8301169: java/net/httpclient/ThrowingSubscribersAsInputStream.java,ThrowingSubscribersAsInputStreamAsync.java, and other httpclient tests failing on windows: Unable to establish loopback connection

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
@@ -388,6 +388,17 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
 
             String body = response.join().body();
             assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                System.gc();
+                System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                var error = TRACKER.check(tracker, 10000);
+                if (error != null) throw error;
+                System.out.println(now() + "client shutdown normally: " + tracker.getName());
+                System.err.println(now() + "client shutdown normally: " + tracker.getName());
+            }
         }
     }
 
@@ -469,6 +480,17 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
             }
             if (response != null) {
                 finisher.finish(where, response, thrower);
+            }
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                System.gc();
+                System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                var error = TRACKER.check(tracker, 10000);
+                if (error != null) throw error;
+                System.out.println(now() + "client shutdown normally: " + tracker.getName());
+                System.err.println(now() + "client shutdown normally: " + tracker.getName());
             }
         }
     }

--- a/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
@@ -389,6 +389,13 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
             String body = response.join().body();
             assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
             if (!sameClient) {
+                // Wait for the client to be garbage collected.
+                // we use the ReferenceTracker API rather than HttpClient::close here,
+                // because these tests inject faults by throwing inside callbacks, which
+                // is more likely to get HttpClient::close wedged until jtreg times out.
+                // By using the ReferenceTracker, we will get some diagnosis about what
+                // is keeping the client alive if it doesn't get GC'ed within the
+                // expected time frame.
                 var tracker = TRACKER.getTracker(client);
                 client = null;
                 System.gc();
@@ -482,6 +489,13 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
                 finisher.finish(where, response, thrower);
             }
             if (!sameClient) {
+                // Wait for the client to be garbage collected.
+                // we use the ReferenceTracker API rather than HttpClient::close here,
+                // because these tests inject faults by throwing inside callbacks, which
+                // is more likely to get HttpClient::close wedged until jtreg times out.
+                // By using the ReferenceTracker, we will get some diagnosis about what
+                // is keeping the client alive if it doesn't get GC'ed within the
+                // expected time frame.
                 var tracker = TRACKER.getTracker(client);
                 client = null;
                 System.gc();

--- a/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
@@ -340,6 +340,17 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
                 assertEquals(promisedBody, promised.uri().toASCIIString());
             }
             assertEquals(3, pushPromises.size());
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                System.gc();
+                System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                var error = TRACKER.check(tracker, 10000);
+                if (error != null) throw error;
+                System.out.println(now() + "client shutdown normally: " + tracker.getName());
+                System.err.println(now() + "client shutdown normally: " + tracker.getName());
+            }
         }
     }
 
@@ -424,6 +435,17 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
             }
             if (response != null) {
                 finisher.finish(where, req.uri(), response, thrower, promiseMap);
+            }
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                System.gc();
+                System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                var error = TRACKER.check(tracker, 10000);
+                if (error != null) throw error;
+                System.out.println(now() + "client shutdown normally: " + tracker.getName());
+                System.err.println(now() + "client shutdown normally: " + tracker.getName());
             }
         }
     }

--- a/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
@@ -341,6 +341,13 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
             }
             assertEquals(3, pushPromises.size());
             if (!sameClient) {
+                // Wait for the client to be garbage collected.
+                // we use the ReferenceTracker API rather than HttpClient::close here,
+                // because these tests inject faults by throwing inside callbacks, which
+                // is more likely to get HttpClient::close wedged until jtreg times out.
+                // By using the ReferenceTracker, we will get some diagnosis about what
+                // is keeping the client alive if it doesn't get GC'ed within the
+                // expected time frame.
                 var tracker = TRACKER.getTracker(client);
                 client = null;
                 System.gc();
@@ -437,6 +444,13 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
                 finisher.finish(where, req.uri(), response, thrower, promiseMap);
             }
             if (!sameClient) {
+                // Wait for the client to be garbage collected.
+                // we use the ReferenceTracker API rather than HttpClient::close here,
+                // because these tests inject faults by throwing inside callbacks, which
+                // is more likely to get HttpClient::close wedged until jtreg times out.
+                // By using the ReferenceTracker, we will get some diagnosis about what
+                // is keeping the client alive if it doesn't get GC'ed within the
+                // expected time frame.
                 var tracker = TRACKER.getTracker(client);
                 client = null;
                 System.gc();

--- a/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
@@ -314,6 +314,17 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
             HttpResponse<String> response = client.send(req, handler);
             String body = response.body();
             assertEquals(URI.create(body).getPath(), URI.create(uri2).getPath());
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                System.gc();
+                System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                var error = TRACKER.check(tracker, 10000);
+                if (error != null) throw error;
+                System.out.println(now() + "client shutdown normally: " + tracker.getName());
+                System.err.println(now() + "client shutdown normally: " + tracker.getName());
+            }
         }
     }
 
@@ -460,6 +471,17 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
             }
             if (response != null) {
                 finisher.finish(where, response, thrower);
+            }
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                System.gc();
+                System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+                var error = TRACKER.check(tracker, 10000);
+                if (error != null) throw error;
+                System.out.println(now() + "client shutdown normally: " + tracker.getName());
+                System.err.println(now() + "client shutdown normally: " + tracker.getName());
             }
         }
     }

--- a/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
@@ -315,6 +315,13 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
             String body = response.body();
             assertEquals(URI.create(body).getPath(), URI.create(uri2).getPath());
             if (!sameClient) {
+                // Wait for the client to be garbage collected.
+                // we use the ReferenceTracker API rather than HttpClient::close here,
+                // because these tests inject faults by throwing inside callbacks, which
+                // is more likely to get HttpClient::close wedged until jtreg times out.
+                // By using the ReferenceTracker, we will get some diagnosis about what
+                // is keeping the client alive if it doesn't get GC'ed within the
+                // expected time frame.
                 var tracker = TRACKER.getTracker(client);
                 client = null;
                 System.gc();
@@ -473,6 +480,13 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
                 finisher.finish(where, response, thrower);
             }
             if (!sameClient) {
+                // Wait for the client to be garbage collected.
+                // we use the ReferenceTracker API rather than HttpClient::close here,
+                // because these tests inject faults by throwing inside callbacks, which
+                // is more likely to get HttpClient::close wedged until jtreg times out.
+                // By using the ReferenceTracker, we will get some diagnosis about what
+                // is keeping the client alive if it doesn't get GC'ed within the
+                // expected time frame.
                 var tracker = TRACKER.getTracker(client);
                 client = null;
                 System.gc();


### PR DESCRIPTION
The HttpClient Throwing* tests are creating a lot of HttpClient instances and have been observed failing on Windows from time to time with the error:  Unable to establish loopback connection.

To try and mitigate the issue here is a change that will wait for the previous client to be GC'ed before creating the new one. Hopefully that should reduce the cases where these tests fail due to resource exhaustion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301169](https://bugs.openjdk.org/browse/JDK-8301169): java/net/httpclient/ThrowingSubscribersAsInputStream.java,ThrowingSubscribersAsInputStreamAsync.java, and other httpclient tests failing on windows: Unable to establish loopback connection


### Reviewers
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**) ⚠️ Review applies to [62792d05](https://git.openjdk.org/jdk/pull/13644/files/62792d0510099e6eb4c85494f48daea051c7dfba)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13644/head:pull/13644` \
`$ git checkout pull/13644`

Update a local copy of the PR: \
`$ git checkout pull/13644` \
`$ git pull https://git.openjdk.org/jdk.git pull/13644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13644`

View PR using the GUI difftool: \
`$ git pr show -t 13644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13644.diff">https://git.openjdk.org/jdk/pull/13644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13644#issuecomment-1521858377)