### PR TITLE
8306855: [s390x] fix difference in abi sizes

### DIFF
--- a/src/hotspot/cpu/s390/c1_FrameMap_s390.hpp
+++ b/src/hotspot/cpu/s390/c1_FrameMap_s390.hpp
@@ -30,7 +30,7 @@
 
   enum {
     nof_reg_args = 5,   // Registers Z_ARG1 - Z_ARG5 are available for parameter passing.
-    first_available_sp_in_frame = frame::z_abi_16_size,
+    first_available_sp_in_frame = frame::z_common_abi_size,
     frame_pad_in_bytes = 0
   };
 

--- a/src/hotspot/cpu/s390/c1_FrameMap_s390.hpp
+++ b/src/hotspot/cpu/s390/c1_FrameMap_s390.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -238,7 +238,7 @@ int LIR_Assembler::emit_unwind_handler() {
 
   // Remove the activation and dispatch to the unwind handler.
   __ pop_frame();
-  __ z_lg(Z_EXC_PC, _z_abi16(return_pc), Z_SP);
+  __ z_lg(Z_EXC_PC, _z_common_abi(return_pc), Z_SP);
 
   // Z_EXC_OOP: exception oop
   // Z_EXC_PC: exception pc

--- a/src/hotspot/cpu/s390/c1_Runtime1_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_Runtime1_s390.cpp
@@ -807,7 +807,7 @@ OopMapSet* Runtime1::generate_handle_exception(StubID id, StubAssembler *sasm) {
 
       // Load issuing PC (the return address for this stub).
       const int frame_size_in_bytes = sasm->frame_size() * VMRegImpl::slots_per_word * VMRegImpl::stack_slot_size;
-      __ z_lg(Z_EXC_PC, Address(Z_SP, frame_size_in_bytes + _z_abi16(return_pc)));
+      __ z_lg(Z_EXC_PC, Address(Z_SP, frame_size_in_bytes + _z_common_abi(return_pc)));
       DEBUG_ONLY(__ z_lay(reg_fp, Address(Z_SP, frame_size_in_bytes));)
 
       // Make sure that the vm_results are cleared (may be unnecessary).
@@ -850,7 +850,7 @@ OopMapSet* Runtime1::generate_handle_exception(StubID id, StubAssembler *sasm) {
 
 #ifdef ASSERT
   { NearLabel ok;
-    __ z_cg(Z_EXC_PC, Address(reg_fp, _z_abi16(return_pc)));
+    __ z_cg(Z_EXC_PC, Address(reg_fp, _z_common_abi(return_pc)));
     __ branch_optimized(Assembler::bcondEqual, ok);
     __ stop("use throwing pc as return address (has bci & oop map)");
     __ bind(ok);

--- a/src/hotspot/cpu/s390/c1_Runtime1_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_Runtime1_s390.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -117,7 +117,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    z_abi_16* sender_abi = (z_abi_16*)fp;
+    z_common_abi* sender_abi = (z_common_abi*)fp;
     intptr_t* sender_sp = (intptr_t*) fp;
     address   sender_pc = (address)   sender_abi->return_pc;
 
@@ -278,7 +278,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (sp() == 0 || (intptr_t(sp()) & (wordSize-1)) != 0) {
     return false;
   }
-  int min_frame_slots = (z_abi_16_size + z_ijava_state_size) / sizeof(intptr_t);
+  int min_frame_slots = (z_common_abi_size + z_ijava_state_size) / sizeof(intptr_t);
   if (fp() - min_frame_slots < sp()) {
     return false;
   }

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -47,7 +47,7 @@
   //    0       [ABI_160]
   //
   //  ABI_160:
-  //    0       [ABI_16]
+  //    0       [Z_COMMON_ABI]
   //    16      CARG_1: spill slot for outgoing arg 1. used by next callee.
   //    24      CARG_2: spill slot for outgoing arg 2. used by next callee.
   //    32      CARG_3: spill slot for outgoing arg 3. used by next callee.
@@ -61,7 +61,7 @@
   //    152     CFARG_4: spill slot for outgoing fp arg 4. used by next callee.
   //    160     [REMAINING CARGS]
   //
-  //  ABI_16:
+  //  Z_COMMON_ABI:
   //    0       callers_sp
   //    8       return_pc
 
@@ -76,17 +76,23 @@
      log_2_of_alignment_in_bits = 6
   } frame_constants;
 
-  struct z_abi_16 {
+  // Common ABI. On top of all frames, C and Java
+  struct z_common_abi {
     uint64_t callers_sp;
     uint64_t return_pc;
   };
 
   enum {
-    z_abi_16_size = sizeof(z_abi_16)
+    z_common_abi_size = sizeof(z_common_abi)
   };
 
-  #define _z_abi16(_component) \
-          (offset_of(frame::z_abi_16, _component))
+  #define _z_common_abi(_component) \
+          (offset_of(frame::z_common_abi, _component))
+
+  // Z_NATIVE_ABI for native C frames.
+  struct z_native_abi: z_common_abi {
+    // Nothing to add here!
+  };
 
   // ABI_160:
 
@@ -98,9 +104,7 @@
   // long as we do not provide extra infrastructure, one should use
   // either z_abi_160_size, or _z_abi(remaining_cargs) instead of
   // sizeof(...).
-  struct z_abi_160 {
-    uint64_t callers_sp;
-    uint64_t return_pc;
+  struct z_abi_160 : z_native_abi {
     uint64_t carg_1;
     uint64_t carg_2;
     uint64_t carg_3;
@@ -123,6 +127,7 @@
   };
 
   enum {
+    z_native_abi_size = sizeof(z_native_abi),
     z_abi_160_size = 160
   };
 
@@ -157,6 +162,10 @@
           (-frame::z_spill_nonvolatiles_size + offset_of(frame::z_spill_nonvolatiles, _component))
 
   // Frame layout for the Java template interpreter on z/Architecture.
+  //
+  // We differentiate between TOP and PARENT frames.
+  // TOP frames allow for calling native C code.
+  // A TOP frame is trimmed to a PARENT frame when calling a Java method.
   //
   // In these figures the stack grows upwards, while memory grows
   // downwards. Square brackets denote regions possibly larger than
@@ -250,13 +259,14 @@
 
  public:
 
-  // PARENT_IJAVA_FRAME_ABI
+  // ABI for every Java frame, compiled and interpreted
 
-  struct z_parent_ijava_frame_abi : z_abi_16 {
+  struct z_java_abi : z_common_abi {
+    // Nothing to add here!
   };
 
-  enum {
-    z_parent_ijava_frame_abi_size = sizeof(z_parent_ijava_frame_abi)
+  struct z_parent_ijava_frame_abi : z_java_abi {
+    // Nothing to add here!
   };
 
   #define _z_parent_ijava_frame_abi(_component) \
@@ -268,6 +278,8 @@
   };
 
   enum {
+    z_java_abi_size = sizeof(z_java_abi),
+    z_parent_ijava_frame_abi_size = sizeof(z_parent_ijava_frame_abi),
     z_top_ijava_frame_abi_size = sizeof(z_top_ijava_frame_abi)
   };
 
@@ -357,17 +369,8 @@
   //          [monitor] (optional)
   //          [in_preserve] added / removed by prolog / epilog
 
- public:
-
-   struct z_top_jit_abi_32 {
-     uint64_t callers_sp;
-     uint64_t return_pc;
-     uint64_t toc;
-     uint64_t tmp;
-   };
-
-  #define _z_top_jit_abi(_component) \
-          (offset_of(frame::z_top_jit_abi_32, _component))
+  // For JIT frames we don't differentiate between TOP and PARENT frames.
+  // Runtime calls go through stubs which push a new frame.
 
   struct jit_monitor {
         uint64_t monitor[1];
@@ -378,7 +381,7 @@
     // nothing to add here!
   };
 
-  struct jit_out_preserve : z_top_jit_abi_32 {
+  struct jit_out_preserve : z_java_abi {
     // Nothing to add here!
   };
 
@@ -473,7 +476,7 @@
   inline intptr_t  sp_at(     int index) const  { return *sp_addr_at(index); }
 
   // Access ABIs.
-  inline z_abi_16*  own_abi()     const { return (z_abi_16*) sp(); }
+  inline z_common_abi*  own_abi()     const { return (z_common_abi*) sp(); }
   inline z_abi_160* callers_abi() const { return (z_abi_160*) fp(); }
 
  private:

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -2125,7 +2125,7 @@ void MacroAssembler::pop_frame() {
 // Pop current C frame and restore return PC register (Z_R14).
 void MacroAssembler::pop_frame_restore_retPC(int frame_size_in_bytes) {
   BLOCK_COMMENT("pop_frame_restore_retPC:");
-  int retPC_offset = _z_abi16(return_pc) + frame_size_in_bytes;
+  int retPC_offset = _z_common_abi(return_pc) + frame_size_in_bytes;
   // If possible, pop frame by add instead of load (a penny saved is a penny got :-).
   if (Displacement::is_validDisp(retPC_offset)) {
     z_lg(Z_R14, retPC_offset, Z_SP);

--- a/src/hotspot/cpu/s390/macroAssembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.inline.hpp
@@ -250,11 +250,11 @@ inline bool MacroAssembler::is_load_addr_pcrel(address a) {
 // Save the return pc in the register that should be stored as the return pc
 // in the current frame (default is R14).
 inline void MacroAssembler::save_return_pc(Register pc) {
-  z_stg(pc, _z_abi16(return_pc), Z_SP);
+  z_stg(pc, _z_common_abi(return_pc), Z_SP);
 }
 
 inline void MacroAssembler::restore_return_pc() {
-  z_lg(Z_R14, _z_abi16(return_pc), Z_SP);
+  z_lg(Z_R14, _z_common_abi(return_pc), Z_SP);
 }
 
 // Call a function with given entry.

--- a/src/hotspot/cpu/s390/macroAssembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.inline.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -329,7 +329,7 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, RegisterSet reg
   // We have to restore return_pc right away.
   // Nobody else will. Furthermore, return_pc isn't necessarily the default (Z_R14).
   // Nobody else knows which register we saved.
-  __ z_lg(return_pc, _z_abi16(return_pc) + frame_size_in_bytes, Z_SP);
+  __ z_lg(return_pc, _z_common_abi(return_pc) + frame_size_in_bytes, Z_SP);
 
   // Register save area in new frame starts above z_abi_160 area.
   int offset = register_save_offset;
@@ -2921,7 +2921,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
   if (!cause_return) {
     Label no_adjust;
      // If our stashed return pc was modified by the runtime we avoid touching it
-    const int offset_of_return_pc = _z_abi16(return_pc) + RegisterSaver::live_reg_frame_size(RegisterSaver::all_registers);
+    const int offset_of_return_pc = _z_common_abi(return_pc) + RegisterSaver::live_reg_frame_size(RegisterSaver::all_registers);
     __ z_cg(Z_R6, offset_of_return_pc, Z_SP);
     __ z_brne(no_adjust);
 

--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -1087,7 +1087,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   }
 
   // asm_assert* is a nop in product builds
-  NOT_PRODUCT(__ z_cg(Z_R14, _z_abi16(return_pc), Z_SP));
+  NOT_PRODUCT(__ z_cg(Z_R14, _z_common_abi(return_pc), Z_SP));
   NOT_PRODUCT(__ asm_assert_eq("killed Z_R14", 0));
   __ resize_frame_absolute(sp_after_resize, fp, true);
   __ save_return_pc(Z_R14);


### PR DESCRIPTION
This PR equals the interpreter, native abi sizes. JIT abi is completely removed as it was not being used anywhere in s390x code base. Apart form it, `z_abi_16` was replaced by `z_common_abi` and some other renaming followed this ladder.

Builds `slowdebug, fastdebug, release, optimized` are okay. `tier1-tests on fastdebug-build` are not affected as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306855](https://bugs.openjdk.org/browse/JDK-8306855): [s390x] fix difference in abi sizes


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13650/head:pull/13650` \
`$ git checkout pull/13650`

Update a local copy of the PR: \
`$ git checkout pull/13650` \
`$ git pull https://git.openjdk.org/jdk.git pull/13650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13650`

View PR using the GUI difftool: \
`$ git pr show -t 13650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13650.diff">https://git.openjdk.org/jdk/pull/13650.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13650#issuecomment-1522154580)