### PR TITLE
8306711: Improve diagnosis of `IntlTest` framework

### DIFF
--- a/test/jdk/java/text/Normalizer/ICUBasicTest.java
+++ b/test/jdk/java/text/Normalizer/ICUBasicTest.java
@@ -41,6 +41,8 @@
 import sun.text.Normalizer;
 import jdk.internal.icu.text.NormalizerBase;
 
+import java.util.HexFormat;
+
 import static java.text.Normalizer.Form.*;
 
 public class ICUBasicTest extends IntlTest {
@@ -149,7 +151,8 @@ public class ICUBasicTest extends IntlTest {
 
         if (!expected.equals(result)) {
             errln("Reordering of combining marks failed. Expected: " +
-                  toHexString(expected) + " Got: "+ toHexString(result));
+                  HexFormat.of().withDelimiter(" ").formatHex(expected.getBytes())
+                    + " Got: "+ HexFormat.of().withDelimiter(" ").formatHex(result.getBytes()));
         }
     }
 
@@ -191,16 +194,22 @@ public class ICUBasicTest extends IntlTest {
 
             String result = NormalizerBase.normalize(input, NFD);
             if (!result.equals(output)) {
-                errln("FAIL input: " + toHexString(input) + "\n" +
-                      " decompose: " + toHexString(result) + "\n" +
-                      "  expected: " + toHexString(output));
+                errln("FAIL input: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(input.getBytes()) + "\n" +
+                      " decompose: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(result.getBytes()) + "\n" +
+                      "  expected: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(output.getBytes()));
             }
 
             result = NormalizerBase.normalize(input, NFC);
             if (!result.equals(output)) {
-                errln("FAIL input: " + toHexString(input) + "\n" +
-                      "   compose: " + toHexString(result) + "\n" +
-                      "  expected: " + toHexString(output));
+                errln("FAIL input: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(input.getBytes()) + "\n" +
+                      "   compose: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(output.getBytes()) + "\n" +
+                      "  expected: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(output.getBytes()));
             }
         }
     }
@@ -231,21 +240,27 @@ public class ICUBasicTest extends IntlTest {
             String exp = DATA[i+1];
 
             if (b.equals(exp)) {
-                logln("Ok: " + toHexString(a) + " x COMPOSE_COMPAT => " +
-                      toHexString(b));
+                logln("Ok: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(a.getBytes()) + " x COMPOSE_COMPAT => " +
+                      HexFormat.of().withDelimiter(" ")
+                              .formatHex(b.getBytes()));
             } else {
-                errln("FAIL: " + toHexString(a) + " x COMPOSE_COMPAT => " +
-                      toHexString(b) + ", expect " + toHexString(exp));
+                errln("FAIL: " + HexFormat.of().withDelimiter(" ")
+                        .formatHex(b.getBytes()) + " x COMPOSE_COMPAT => " +
+                      HexFormat.of().withDelimiter(" ")
+                              .formatHex(a.getBytes()) + ", expect " +
+                        HexFormat.of().withDelimiter(" ")
+                                .formatHex(exp.getBytes()));
             }
 
             a = NormalizerBase.normalize(b, NFD);
             exp = DATA[i+2];
             if (a.equals(exp)) {
-                logln("Ok: " + toHexString(b) + " x DECOMP => " +
-                      toHexString(a));
+                logln("Ok: " + HexFormat.of().withDelimiter(" ").formatHex(b.getBytes()) + " x DECOMP => " +
+                      HexFormat.of().withDelimiter(" ").formatHex(a.getBytes()));
             } else {
-                errln("FAIL: " + toHexString(b) + " x DECOMP => " +
-                      toHexString(a) + ", expect " + toHexString(exp));
+                errln("FAIL: " + HexFormat.of().withDelimiter(" ").formatHex(b.getBytes()) + " x DECOMP => " +
+                      HexFormat.of().withDelimiter(" ").formatHex(a.getBytes()) + ", expect " + HexFormat.of().withDelimiter(" ").formatHex(exp.getBytes()));
             }
         }
     }
@@ -382,25 +397,33 @@ public class ICUBasicTest extends IntlTest {
         String c = NormalizerBase.normalize(b, NFC);
 
         if (c.equals(a)) {
-            errln("FAIL: " + toHexString(a) + " x DECOMP_COMPAT => " +
-                  toHexString(b) + " x COMPOSE => " +
-                  toHexString(c) + " for the latest Unicode");
+            errln("FAIL: " + HexFormat.of().withDelimiter(" ")
+                    .formatHex(a.getBytes()) + " x DECOMP_COMPAT => " +
+                  HexFormat.of().withDelimiter(" ")
+                          .formatHex(b.getBytes()) + " x COMPOSE => " +
+                  HexFormat.of().withDelimiter(" ")
+                          .formatHex(c.getBytes()) + " for the latest Unicode");
         } else if (verbose) {
-            logln("Ok: " + toHexString(a) + " x DECOMP_COMPAT => " +
-                  toHexString(b) + " x COMPOSE => " +
-                  toHexString(c) + " for the latest Unicode");
+            logln("Ok: " + HexFormat.of().withDelimiter(" ")
+                    .formatHex(a.getBytes()) + " x DECOMP_COMPAT => " +
+                  HexFormat.of().withDelimiter(" ")
+                          .formatHex(b.getBytes()) + " x COMPOSE => " +
+                  HexFormat.of().withDelimiter(" ")
+                          .formatHex(c.getBytes()) + " for the latest Unicode");
         }
 
         b = NormalizerBase.normalize(a, NFKD, Normalizer.UNICODE_3_2);
         c = NormalizerBase.normalize(b, NFC, Normalizer.UNICODE_3_2);
         if (c.equals(a)) {
-            errln("FAIL: " + toHexString(a) + " x DECOMP_COMPAT => " +
-                  toHexString(b) + " x COMPOSE => " +
-                  toHexString(c) + " for Unicode 3.2.0");
+            errln("FAIL: " + HexFormat.of().withDelimiter(" ")
+                    .formatHex(a.getBytes()) + " x DECOMP_COMPAT => " +
+                  HexFormat.of().withDelimiter(" ").formatHex(b.getBytes()) + " x COMPOSE => " +
+                  HexFormat.of().withDelimiter(" ").formatHex(c.getBytes()) + " for Unicode 3.2.0");
         } else if (verbose) {
-            logln("Ok: " + toHexString(a) + " x DECOMP_COMPAT => " +
-                  toHexString(b) + " x COMPOSE => " +
-                  toHexString(c) + " for Unicode 3.2.0");
+            logln("Ok: " + HexFormat.of().withDelimiter(" ")
+                    .formatHex(a.getBytes()) + " x DECOMP_COMPAT => " +
+                  HexFormat.of().withDelimiter(" ").formatHex(b.getBytes()) + " x COMPOSE => " +
+                  HexFormat.of().withDelimiter(" ").formatHex(c.getBytes()) + " for Unicode 3.2.0");
         }
     }
 
@@ -572,15 +595,18 @@ public class ICUBasicTest extends IntlTest {
                             int outCol) throws Exception {
         for (int i = 0; i < tests.length; i++) {
             String input = tests[i][0];
-            logln("Normalizing '" + input + "' (" + toHexString(input) + ")" );
+            logln("Normalizing '" + input + "' (" + HexFormat.of()
+                    .withDelimiter(" ").formatHex(input.getBytes()) + ")" );
 
             String expect =tests[i][outCol];
             String output = java.text.Normalizer.normalize(input, form);
 
             if (!output.equals(expect)) {
                 errln("FAIL: case " + i
-                    + " expected '" + expect + "' (" + toHexString(expect) + ")"
-                    + " but got '" + output + "' (" + toHexString(output) + ")"
+                    + " expected '" + expect + "' (" + HexFormat.of()
+                        .withDelimiter(" ").formatHex(expect.getBytes()) + ")"
+                    + " but got '" + output + "' (" + HexFormat.of()
+                        .withDelimiter(" ").formatHex(output.getBytes()) + ")"
 );
             }
         }

--- a/test/jdk/java/text/testlib/IntlTest.java
+++ b/test/jdk/java/text/testlib/IntlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,10 +50,11 @@ public abstract class IntlTest {
     // Everything below here is boilerplate code that makes it possible
     // to add a new test by simply adding a method to an existing class.
     //------------------------------------------------------------------------
-
     protected IntlTest() {
+        Class<? extends IntlTest> testClass = getClass();
+        testName = testClass.getCanonicalName();
         // Populate testMethods with all the test methods.
-        Method[] methods = getClass().getDeclaredMethods();
+        Method[] methods = testClass.getDeclaredMethods();
         for (Method method : methods) {
             if (Modifier.isPublic(method.getModifiers())
                 && method.getReturnType() == void.class
@@ -67,71 +69,33 @@ public abstract class IntlTest {
         }
     }
 
-    protected void run(String[] args) throws Exception
-    {
+    protected void run(String[] args) throws Exception {
         // Set up the log and reference streams.  We use PrintWriters in order to
         // take advantage of character conversion.  The JavaEsc converter will
         // convert Unicode outside the ASCII range to Java's \\uxxxx notation.
         log = new PrintWriter(System.out, true);
-
-        // Parse the test arguments.  They can be either the flag
-        // "-verbose" or names of test methods. Create a list of
-        // tests to be run.
-        List<Method> testsToRun = new ArrayList<>(args.length);
-        for (String arg : args) {
-            switch (arg) {
-            case "-verbose":
-                verbose = true;
-                break;
-            case "-prompt":
-                prompt = true;
-                break;
-            case "-nothrow":
-                nothrow = true;
-                break;
-            case "-exitcode":
-                exitCode = true;
-                break;
-            default:
-                Method m = testMethods.get(arg);
-                if (m == null) {
-                    System.out.println("Method " + arg + ": not found");
-                    usage();
-                    return;
-                }
-                testsToRun.add(m);
-                break;
-            }
-        }
-
-        // If no test method names were given explicitly, run them all.
-        if (testsToRun.isEmpty()) {
-            testsToRun.addAll(testMethods.values());
-        }
-
-        System.out.println(getClass().getName() + " {");
+        List<Method> testsToRun = configureTestsAndArgs(args);
+        System.out.println(testName + " {");
         indentLevel++;
 
         // Run the list of tests given in the test arguments
         for (Method testMethod : testsToRun) {
             int oldCount = errorCount;
-
             writeTestName(testMethod.getName());
-
             try {
-                testMethod.invoke(this, new Object[0]);
+                testMethod.invoke(this);
             } catch (IllegalAccessException e) {
-                errln("Can't acces test method " + testMethod.getName());
+                errln("Can't access test method " + testMethod.getName());
             } catch (InvocationTargetException e) {
-                errln("Uncaught exception thrown in test method "
-                        + testMethod.getName());
-                e.getTargetException().printStackTrace(this.log);
+                // Log exception first, that way if -nothrow is
+                // not an arg, the original exception is still logged
+                logExc(e);
+                errln(String.format("$$$ Uncaught exception thrown in %s," +
+                        " see above for cause", testMethod.getName()));
             }
             writeTestResult(errorCount - oldCount);
         }
         indentLevel--;
-        writeTestResult(errorCount);
-
         if (prompt) {
             System.out.println("Hit RETURN to exit...");
             try {
@@ -140,14 +104,48 @@ public abstract class IntlTest {
                 System.out.println("Exception: " + e.toString() + e.getMessage());
             }
         }
-        if (nothrow) {
+        if (noThrow) {
             if (exitCode) {
                 System.exit(errorCount);
             }
             if (errorCount > 0) {
-                throw new IllegalArgumentException("encountered " + errorCount + " errors");
+                throw new RuntimeException(String.format(
+                        "$$$ %s FAILED with %s failures%n", testName, errorCount));
+            } else {
+                log.println(String.format("\t$$$ %s PASSED%n", testName));
             }
         }
+    }
+
+    private List<Method> configureTestsAndArgs(String[] args) {
+        // Parse the test arguments. They can be either the flag
+        // "-verbose" or names of test methods. Create a list of
+        // tests to be run.
+        List<Method> testsToRun = new ArrayList<>(args.length);
+        for (String arg : args) {
+            switch (arg) {
+                case "-verbose" -> verbose = true;
+                case "-prompt" -> prompt = true;
+                case "-nothrow" -> noThrow = true;
+                case "-exitcode" -> exitCode = true;
+                default -> {
+                    Method m = testMethods.get(arg);
+                    if (m == null) {
+                        System.out.println("Method " + arg + ": not found");
+                        usage();
+                        return testsToRun;
+                    }
+                    testsToRun.add(m);
+                }
+            }
+        }
+        // If no test method names were given explicitly, run them all.
+        if (testsToRun.isEmpty()) {
+            testsToRun.addAll(testMethods.values());
+        }
+        // Arbitrarily sort the tests, so that they are run in the same order every time
+        testsToRun.sort(Comparator.comparing(Method::getName));
+        return testsToRun;
     }
 
     /**
@@ -177,6 +175,11 @@ public abstract class IntlTest {
         }
     }
 
+    private void logExc(InvocationTargetException ite) {
+        indent(indentLevel);
+        ite.getTargetException().printStackTrace(this.log);
+    }
+
     protected void err(String message) {
         errImpl(message, false);
     }
@@ -194,13 +197,9 @@ public abstract class IntlTest {
         }
         log.flush();
 
-        if (!nothrow) {
+        if (!noThrow) {
             throw new RuntimeException(message);
         }
-    }
-
-    protected int getErrorCount() {
-        return errorCount;
     }
 
     protected void writeTestName(String testName) {
@@ -224,20 +223,6 @@ public abstract class IntlTest {
         }
     }
 
-    /*
-     * Returns a spece-delimited hex String.
-     */
-    protected static String toHexString(String s) {
-        StringBuilder sb = new StringBuilder(" ");
-
-        for (int i = 0; i < s.length(); i++) {
-            sb.append(Integer.toHexString(s.charAt(i)));
-            sb.append(' ');
-        }
-
-        return sb.toString();
-    }
-
     private void indent(int distance) {
         if (needLineFeed) {
             log.println(" {");
@@ -258,9 +243,9 @@ public abstract class IntlTest {
             System.out.println("\t" + methodName);
         }
     }
-
+    private final String testName;
     private boolean     prompt;
-    private boolean     nothrow;
+    private boolean     noThrow;
     protected boolean   verbose;
     private boolean     exitCode;
     private PrintWriter log;

--- a/test/jdk/java/text/testlib/IntlTest.java
+++ b/test/jdk/java/text/testlib/IntlTest.java
@@ -201,15 +201,15 @@ public abstract class IntlTest {
         }
     }
 
+    protected int getErrorCount() {
+        return errorCount;
+    }
+
     protected void writeTestName(String testName) {
         indent(indentLevel);
         log.print(testName);
         log.flush();
         needLineFeed = true;
-    }
-
-    protected int getErrorCount() {
-        return errorCount;
     }
 
     protected void writeTestResult(int count) {

--- a/test/jdk/java/text/testlib/IntlTest.java
+++ b/test/jdk/java/text/testlib/IntlTest.java
@@ -226,20 +226,6 @@ public abstract class IntlTest {
         }
     }
 
-    /*
-     * Returns a space-delimited hex String.
-     */
-    protected static String toHexString(String s) {
-        StringBuilder sb = new StringBuilder(" ");
-
-        for (int i = 0; i < s.length(); i++) {
-            sb.append(Integer.toHexString(s.charAt(i)));
-            sb.append(' ');
-        }
-
-        return sb.toString();
-    }
-
     private void indent(int distance) {
         if (needLineFeed) {
             log.println(" {");

--- a/test/jdk/java/text/testlib/IntlTest.java
+++ b/test/jdk/java/text/testlib/IntlTest.java
@@ -81,17 +81,18 @@ public abstract class IntlTest {
         // Run the list of tests given in the test arguments
         for (Method testMethod : testsToRun) {
             int oldCount = errorCount;
-            writeTestName(testMethod.getName());
+            String testName = testMethod.getName();
+            writeTestName(testName);
             try {
                 testMethod.invoke(this);
             } catch (IllegalAccessException e) {
-                errln("Can't access test method " + testMethod.getName());
+                errln("Can't access test method " + testName);
             } catch (InvocationTargetException e) {
                 // Log exception first, that way if -nothrow is
                 // not an arg, the original exception is still logged
                 logExc(e);
                 errln(String.format("$$$ Uncaught exception thrown in %s," +
-                        " see above for cause", testMethod.getName()));
+                        " see above for cause", testName));
             }
             writeTestResult(errorCount - oldCount);
         }
@@ -104,16 +105,14 @@ public abstract class IntlTest {
                 System.out.println("Exception: " + e.toString() + e.getMessage());
             }
         }
-        if (nothrow) {
-            if (exitCode) {
-                System.exit(errorCount);
-            }
-            if (errorCount > 0) {
-                throw new RuntimeException(String.format(
-                        "$$$ %s FAILED with %s failures%n", testName, errorCount));
-            } else {
-                log.println(String.format("\t$$$ %s PASSED%n", testName));
-            }
+        if (exitCode) {
+            System.exit(errorCount);
+        }
+        if (errorCount > 0) {
+            throw new RuntimeException(String.format(
+                    "$$$ %s FAILED with %s failures%n", testName, errorCount));
+        } else {
+            log.println(String.format("\t$$$ %s PASSED%n", testName));
         }
     }
 
@@ -209,6 +208,10 @@ public abstract class IntlTest {
         needLineFeed = true;
     }
 
+    protected int getErrorCount() {
+        return errorCount;
+    }
+
     protected void writeTestResult(int count) {
         if (!needLineFeed) {
             indent(indentLevel);
@@ -221,10 +224,6 @@ public abstract class IntlTest {
         } else {
             log.println(" Passed");
         }
-    }
-
-    protected int getErrorCount() {
-        return errorCount;
     }
 
     /*

--- a/test/jdk/java/text/testlib/IntlTest.java
+++ b/test/jdk/java/text/testlib/IntlTest.java
@@ -104,7 +104,7 @@ public abstract class IntlTest {
                 System.out.println("Exception: " + e.toString() + e.getMessage());
             }
         }
-        if (noThrow) {
+        if (nothrow) {
             if (exitCode) {
                 System.exit(errorCount);
             }
@@ -126,7 +126,7 @@ public abstract class IntlTest {
             switch (arg) {
                 case "-verbose" -> verbose = true;
                 case "-prompt" -> prompt = true;
-                case "-nothrow" -> noThrow = true;
+                case "-nothrow" -> nothrow = true;
                 case "-exitcode" -> exitCode = true;
                 default -> {
                     Method m = testMethods.get(arg);
@@ -197,7 +197,7 @@ public abstract class IntlTest {
         }
         log.flush();
 
-        if (!noThrow) {
+        if (!nothrow) {
             throw new RuntimeException(message);
         }
     }
@@ -221,6 +221,10 @@ public abstract class IntlTest {
         } else {
             log.println(" Passed");
         }
+    }
+
+    protected int getErrorCount() {
+        return errorCount;
     }
 
     /*
@@ -259,7 +263,7 @@ public abstract class IntlTest {
     }
     private final String testName;
     private boolean     prompt;
-    private boolean     noThrow;
+    private boolean     nothrow;
     protected boolean   verbose;
     private boolean     exitCode;
     private PrintWriter log;

--- a/test/jdk/java/text/testlib/IntlTest.java
+++ b/test/jdk/java/text/testlib/IntlTest.java
@@ -223,6 +223,20 @@ public abstract class IntlTest {
         }
     }
 
+    /*
+     * Returns a space-delimited hex String.
+     */
+    protected static String toHexString(String s) {
+        StringBuilder sb = new StringBuilder(" ");
+
+        for (int i = 0; i < s.length(); i++) {
+            sb.append(Integer.toHexString(s.charAt(i)));
+            sb.append(' ');
+        }
+
+        return sb.toString();
+    }
+
     private void indent(int distance) {
         if (needLineFeed) {
             log.println(" {");


### PR DESCRIPTION
Please review changes to the IntlTest (test framework) class. 

These changes include
- Logging the actual exception + stack trace. Previously, the test framework would throw `InvocationTargetException` but hide the actual underlying exception of the failing test unless the test class was ran with -nothrow.
- Sorting the tests, ensuring for any given run, the tests are ran in the same order. (In [JDK-8305853](https://bugs.openjdk.org/browse/JDK-8305853) it was discovered that on Windows, the test framework would execute tests in a random order each time).
- Improving output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306711](https://bugs.openjdk.org/browse/JDK-8306711): Improve diagnosis of `IntlTest` framework


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [a395ba67](https://git.openjdk.org/jdk/pull/13655/files/a395ba67ff870c7f8acdcdc3d05795a0de7749d3)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [a395ba67](https://git.openjdk.org/jdk/pull/13655/files/a395ba67ff870c7f8acdcdc3d05795a0de7749d3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13655/head:pull/13655` \
`$ git checkout pull/13655`

Update a local copy of the PR: \
`$ git checkout pull/13655` \
`$ git pull https://git.openjdk.org/jdk.git pull/13655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13655`

View PR using the GUI difftool: \
`$ git pr show -t 13655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13655.diff">https://git.openjdk.org/jdk/pull/13655.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13655#issuecomment-1522383782)