### PR TITLE
8306705: com/sun/jdi/PopAndInvokeTest.java fails with NativeMethodException

### DIFF
--- a/test/jdk/com/sun/jdi/PopAndInvokeTest.java
+++ b/test/jdk/com/sun/jdi/PopAndInvokeTest.java
@@ -50,8 +50,9 @@ class PopAndInvokeTarg {
         if (waiting) {
             return;
         }
-        waiting = true;
         System.out.println("    debuggee: in waiter");
+        // No printlns or other calls allowed after this point.
+        waiting = true;
         while (true) {
         }
     }


### PR DESCRIPTION
Recently [JDK-8305511](https://bugs.openjdk.org/browse/JDK-8305511) removed the "@ignore 6951287 ", allowing this test to run, which is why this failure mode is now turning up.

There is a race condition, leading to the `popFrames()` call being done while a native method is in the set of frames to be popped. This results in a `NativeMethodException` instead of the frames being popped. The debuggee has:

```
    public static void waiter() {
        if (waiting) {
            return;
        }
        waiting = true;
        System.out.println(" debuggee: in waiter");
        while (true) {
        }
    }
```

And the debugger waits for `waiting == true` (checked via JDI calls) before suspending and doing the `popFrames()`. The problem is the println() after setting `waiting = true`. The debugger side can detect that `waiting == true` before the println() is complete, and the println() involves native code. Once `waiting` is set true, we need to make sure no other method calls are made so we can be sure that only the `waiter()` method is on the stack.

Note there is a lot of interesting history to this CR, including [JDK-6417053](https://bugs.openjdk.org/browse/JDK-6417053), which actually reproduced this issue long ago (but got closed as CNR), although it failed with a different error message (even though it was the same issue), and the different error message was itself the result of another bug that was inadvertently fixed when virtual threads support was added to JDI. See the CR for details if you are interested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306705](https://bugs.openjdk.org/browse/JDK-8306705): com/sun/jdi/PopAndInvokeTest.java fails with NativeMethodException


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13657/head:pull/13657` \
`$ git checkout pull/13657`

Update a local copy of the PR: \
`$ git checkout pull/13657` \
`$ git pull https://git.openjdk.org/jdk.git pull/13657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13657`

View PR using the GUI difftool: \
`$ git pr show -t 13657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13657.diff">https://git.openjdk.org/jdk/pull/13657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13657#issuecomment-1522426903)