### PR TITLE
8168469: Memory leak in JceSecurity

### DIFF
--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,10 @@ package javax.crypto;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.io.*;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.nio.file.*;
 import java.security.*;
@@ -86,12 +89,15 @@ final class JceSecurity {
     // Map of the providers we already have verified.
     // If verified ok, value == PROVIDER_VERIFIED, otherwise
     // the cause of verification failure is stored as value.
-    private static final Map<IdentityWrapper, Object>
+    private static final Map<WeakIdentityWrapper, Object>
         verificationResults = new ConcurrentHashMap<>();
 
     // Map<Provider,?> of the providers currently being verified
     private static final Map<Provider, Object> verifyingProviders =
             new IdentityHashMap<>();
+
+    // weak references queued by GC
+    private static final ReferenceQueue<Object> queue = new ReferenceQueue<>();
 
     private static final boolean isRestricted;
 
@@ -199,38 +205,52 @@ final class JceSecurity {
      * Return null if ok, failure Exception if verification failed.
      */
     static Exception getVerificationResult(Provider p) {
-        IdentityWrapper pKey = new IdentityWrapper(p);
-        Object o = verificationResults.get(pKey);
-        // no mapping found
-        if (o == null) {
-            synchronized (JceSecurity.class) {
-                // check cache again in case the result is now available
-                o = verificationResults.get(pKey);
-                if (o == null) {
+        expungeStaleWrappers();
+        WeakIdentityWrapper pKey = new WeakIdentityWrapper(p, queue);
+        try {
+            Object o = verificationResults.computeIfAbsent(pKey, new Function<>() {
+                public Object apply(WeakIdentityWrapper key) {
+                    // no mapping found
                     if (verifyingProviders.get(p) != null) {
                         // recursion; return failure now
-                        return new NoSuchProviderException
+                        throw new IllegalStateException
                                 ("Recursion during verification");
                     }
+                    Object result;
                     try {
                         verifyingProviders.put(p, Boolean.FALSE);
                         URL providerURL = getCodeBase(p.getClass());
                         verifyProvider(providerURL, p);
-                        o = PROVIDER_VERIFIED;
+                        result = PROVIDER_VERIFIED;
                     } catch (Exception e) {
-                        o = e;
+                        result = e;
                     } finally {
                         verifyingProviders.remove(p);
                     }
-                    verificationResults.put(pKey, o);
                     if (debug != null) {
                         debug.println("Provider " + p.getName() +
-                                " verification result: " + o);
+                                " verification result: " + result);
                     }
+                    return result;
                 }
-            }
+            });
+            return (o == PROVIDER_VERIFIED? null : (Exception) o);
+
+        } catch (IllegalStateException ise) {
+            // recursive update detected
+            return new NoSuchProviderException
+                    ("Recursion during verification");
         }
-        return (o == PROVIDER_VERIFIED? null : (Exception) o);
+    }
+
+    /**
+     * Removes weakly reachable keys from history.
+     */
+    static void expungeStaleWrappers() {
+        WeakIdentityWrapper key;
+        while ((key = (WeakIdentityWrapper) queue.poll()) != null) {
+            verificationResults.remove(key);
+        }
     }
 
     // return whether this provider is properly signed and can be used by JCE
@@ -404,12 +424,13 @@ final class JceSecurity {
         return isRestricted;
     }
 
-    private static final class IdentityWrapper {
+    private static final class WeakIdentityWrapper extends WeakReference<Object> {
 
-        final Provider obj;
+        final int hash;
 
-        IdentityWrapper(Provider obj) {
-            this.obj = obj;
+        WeakIdentityWrapper(Provider obj, ReferenceQueue<Object> queue) {
+            super(obj, queue);
+            hash = System.identityHashCode(obj);
         }
 
         @Override
@@ -417,15 +438,12 @@ final class JceSecurity {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof IdentityWrapper)) {
-                return false;
-            }
-            return this.obj == ((IdentityWrapper)o).obj;
+            return o instanceof WeakIdentityWrapper w && get() == w.get();
         }
 
         @Override
         public int hashCode() {
-            return System.identityHashCode(obj);
+            return hash;
         }
     }
 }

--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -213,8 +213,7 @@ final class JceSecurity {
                     // no mapping found
                     if (verifyingProviders.get(p) != null) {
                         // recursion; return failure now
-                        throw new IllegalStateException
-                                ("Recursion during verification");
+                        throw new IllegalStateException();
                     }
                     Object result;
                     try {

--- a/test/jdk/javax/crypto/JceSecurity/VerificationResults.java
+++ b/test/jdk/javax/crypto/JceSecurity/VerificationResults.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8168469
+ * @summary Memory leak in JceSecurity
+ * @compile --add-exports java.base/com.sun.crypto.provider=ALL-UNNAMED VerificationResults.java
+ * @run main/othervm -Xmx128m --add-exports java.base/com.sun.crypto.provider=ALL-UNNAMED VerificationResults
+ */
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+import com.sun.crypto.provider.SunJCE;
+
+public class VerificationResults {
+
+    // approximate double the number of providers that fits in -Xmx128m heap
+    private static final int PROVIDERS_COUNT = 2000;
+    // the heap buffer size that triggers the OOME when the providers heap cannot be reclaimed
+    private static final int OOM_TRIGGER_SIZE = 10 * 1024 * 1024;
+    public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchPaddingException {
+        int i = 0;
+        try {
+            for (; i < PROVIDERS_COUNT; i++) {
+                SunJCE jceProvider = new SunJCE();
+                Cipher c = Cipher.getInstance("AES", jceProvider);
+                char[] arr = new char[OOM_TRIGGER_SIZE];
+            }
+        } catch (OutOfMemoryError e) {
+            System.out.println("Caught OOME - less than 10M heap left.\nCreated " + i + " SunJCE providers");
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

I would like to propose a patch for an issue discussed in [1][2] that fixes an OOME in the current code base. The issue appears when a SunJCE provider object reference is stored in a non-static variable, which eventually leads to a Java heap OOME.

The solution proposed earlier [1] raised a concern that the identity of provider objects may be somehow broken when using `WeakHashMap<Class<? extends Provider>, Object>` instead of `IdentityHashMap<Provider, Object>`. The solution hasn't been integrated that time. Later in 2019 a performance improvement was introduced with [3][4] that changed `IdentityHashMap` to `ConcurrentHashMap` of `IdentityWrapper<Provider> `objects that maintained the object identity while improved performance.

The solution being proposed keeps up with performance improvement in [3], further narrowing the synchronization down to the hash table node, avoids lambdas that may cause startup time regressions and maintains providers identity using `WeakIdentityWrapper` that extends `WeakReference<Object>` while avoiding depletion of Java heap by using weak pointers as the mapping key. Once a provider object becomes weakly reachable it is queued along with its reference object to the `ReferenceQueue` (a new static member in `JceSecurity`). The `equals()` method of the `WeakIdentityWrapper` will never match a new wrapper object to anything inside the hash table after the corresponding element's `WeakReference.get()` returned null. This leads to accumulating "empty" elements in the hash table. The new static function `expungeStaleWrappers()` drops the "empty" elements queued by GC each time the `getVerificationResult()` method is called.

`ConcurrentHashMap`'s `computeIfAbsent()` does (partially) detect recursive updates for keys that are being added to empty bins. For such keys an `IllegalStateException` is thrown prior to recursive execution of the `mappingFunction`. For nodes that are added to existing TreeBins or linked lists, in which case no recursion detection is done prior to calling `mappingFunction`, the recursion detection relies on old method with `IdentityMap` of Providers.

I include a test that runs under memory constrained conditions (128M) that hits the heap limit in current VMs where it is impossible to reclaim providers' memory (unless they've been cached under weak references). The updated jdk versions pass the test.

Testing: jtreg + JCK on a downport of the patch to JDK 17 with no regressions

[1] https://mail.openjdk.org/pipermail/security-dev/2016-October/015024.html
[2] https://bugs.openjdk.org/browse/JDK-8168469
[3] https://bugs.openjdk.org/browse/JDK-7107615
[4] https://github.com/openjdk/jdk/commit/74d45e481d1ad6aa5d7c6315ea86681e1a978ce0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8168469](https://bugs.openjdk.org/browse/JDK-8168469): Memory leak in JceSecurity


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13658/head:pull/13658` \
`$ git checkout pull/13658`

Update a local copy of the PR: \
`$ git checkout pull/13658` \
`$ git pull https://git.openjdk.org/jdk.git pull/13658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13658`

View PR using the GUI difftool: \
`$ git pr show -t 13658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13658.diff">https://git.openjdk.org/jdk/pull/13658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13658#issuecomment-1522436780)