### PR TITLE
8306872: Rename Node_Array::Size()

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4468,7 +4468,7 @@ void PhaseIdealLoop::build_and_optimize() {
           AutoNodeBudget node_budget(this);
           if (lpt->_head->as_CountedLoop()->is_normal_loop() &&
               lpt->policy_maximally_unroll(this)) {
-            memset( worklist.adr(), 0, worklist.Size()*sizeof(Node*) );
+            memset( worklist.adr(), 0, worklist.max()*sizeof(Node*) );
             do_maximally_unroll(lpt, worklist);
           }
         }
@@ -4543,7 +4543,7 @@ void PhaseIdealLoop::build_and_optimize() {
   // If split-if's didn't hack the graph too bad (no CFG changes)
   // then do loop opts.
   if (C->has_loops() && !C->major_progress()) {
-    memset( worklist.adr(), 0, worklist.Size()*sizeof(Node*) );
+    memset( worklist.adr(), 0, worklist.max()*sizeof(Node*) );
     _ltree_root->_child->iteration_split( this, worklist );
     // No verify after peeling!  GCM has hoisted code out of the loop.
     // After peeling, the hoisted code could sink inside the peeled area.
@@ -6356,7 +6356,7 @@ void PhaseIdealLoop::dump(IdealLoopTree* loop, uint idx, Node_List &rpo_list) co
       }
     }
     // Dump nodes it controls
-    for (uint k = 0; k < _nodes.Size(); k++) {
+    for (uint k = 0; k < _nodes.max(); k++) {
       // (k < C->unique() && get_ctrl(find(k)) == n)
       if (k < C->unique() && _nodes[k] == (Node*)((intptr_t)n + 1)) {
         Node* m = C->root()->find(k);

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1735,7 +1735,7 @@ MachNode* Matcher::find_shared_node(Node* leaf, uint rule) {
   if (!leaf->is_Con() && !leaf->is_DecodeNarrowPtr()) return nullptr;
 
   // See if this Con has already been reduced using this rule.
-  if (_shared_nodes.Size() <= leaf->_idx) return nullptr;
+  if (_shared_nodes.max() <= leaf->_idx) return nullptr;
   MachNode* last = (MachNode*)_shared_nodes.at(leaf->_idx);
   if (last != nullptr && rule == last->rule()) {
     // Don't expect control change for DecodeN

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1548,7 +1548,7 @@ public:
     Copy::zero_to_bytes(_nodes, _max * sizeof(Node*));
   }
 
-  uint Size() const { return _max; }
+  uint max() const { return _max; }
   void dump() const;
 };
 

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3072,7 +3072,7 @@ void Scheduling::garbage_collect_pinch_nodes() {
   if (_cfg->C->trace_opto_output()) tty->print("Reclaimed pinch nodes:");
 #endif
   int trace_cnt = 0;
-  for (uint k = 0; k < _reg_node.Size(); k++) {
+  for (uint k = 0; k < _reg_node.max(); k++) {
     Node* pinch = _reg_node[k];
     if ((pinch != nullptr) && pinch->Opcode() == Op_Node &&
         // no predecence input edges

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -664,7 +664,7 @@ void PhaseTransform::dump_old2new_map() const {
 }
 
 void PhaseTransform::dump_new( uint nidx ) const {
-  for( uint i=0; i<_nodes.Size(); i++ )
+  for( uint i=0; i<_nodes.max(); i++ )
     if( _nodes[i] && _nodes[i]->_idx == nidx ) {
       _nodes[i]->dump();
       tty->cr();


### PR DESCRIPTION
Node_List inherits Node_Array, so it inherits Size(). To resolve naming conflict,
Node_List uses size() (with little s) and keeps Size() as capacity. I don't think 
it's a good practice to distinct two function using capital initial. In particular
they have different meanings. A true story is that it took me 2 days to find a bug
that I chose wrong one between them.

This patch just renames Node_Array::Size to max. By using different names, this will
avoid from misusing. We need to changes 6 places. 4 are for Node_List::Size() intentionally.
2 of them are for Node_Array::Size().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306872](https://bugs.openjdk.org/browse/JDK-8306872): Rename Node_Array::Size()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13659/head:pull/13659` \
`$ git checkout pull/13659`

Update a local copy of the PR: \
`$ git checkout pull/13659` \
`$ git pull https://git.openjdk.org/jdk.git pull/13659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13659`

View PR using the GUI difftool: \
`$ git pr show -t 13659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13659.diff">https://git.openjdk.org/jdk/pull/13659.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13659#issuecomment-1522452854)