### PR TITLE
8298993: (process) java/lang/ProcessBuilder/UnblockSignals.java fails

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
+++ b/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
@@ -28,6 +28,8 @@ import java.io.IOException;
  * @summary Verify Signal mask is cleared by ProcessBuilder start
  * @bug 8234262
  * @requires (os.family == "linux" | os.family == "mac")
+ * @comment Don't allow -Xcomp, it disturbs the relative timing of the sleep and kill commands
+ * @requires (vm.compMode == "Xmixed")
  * @run main/othervm UnblockSignals
  * @run main/othervm -Xrs UnblockSignals
  */

--- a/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
+++ b/test/jdk/java/lang/ProcessBuilder/UnblockSignals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.io.IOException;
  * @bug 8234262
  * @requires (os.family == "linux" | os.family == "mac")
  * @comment Don't allow -Xcomp, it disturbs the relative timing of the sleep and kill commands
- * @requires (vm.compMode == "Xmixed")
+ * @requires (vm.compMode != "Xcomp")
  * @run main/othervm UnblockSignals
  * @run main/othervm -Xrs UnblockSignals
  */


### PR DESCRIPTION
It appears that -Xcomp causes the relative timing of the commands to be disturbed enough to prevent the correct operation of the test. The test should not be run with -Xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298993](https://bugs.openjdk.org/browse/JDK-8298993): (process) java/lang/ProcessBuilder/UnblockSignals.java fails


### Reviewers
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13660/head:pull/13660` \
`$ git checkout pull/13660`

Update a local copy of the PR: \
`$ git checkout pull/13660` \
`$ git pull https://git.openjdk.org/jdk.git pull/13660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13660`

View PR using the GUI difftool: \
`$ git pr show -t 13660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13660.diff">https://git.openjdk.org/jdk/pull/13660.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13660#issuecomment-1522465935)