### PR TITLE
8306027: Clarify JVMTI heap functions spec about virtual thread stack.

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3517,10 +3517,10 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
             Heap root reference: monitor.
           </constant>
           <constant id="JVMTI_HEAP_REFERENCE_STACK_LOCAL" num="24">
-            Heap root reference: local variable on the stack.
+            Local variable on a thread stack.
           </constant>
           <constant id="JVMTI_HEAP_REFERENCE_JNI_LOCAL" num="25">
-            Heap root reference: JNI local reference.
+            JNI local reference on a thread stack.
           </constant>
           <constant id="JVMTI_HEAP_REFERENCE_THREAD" num="26">
             Heap root reference: Thread.
@@ -4535,7 +4535,7 @@ class C2 extends C1 implements I2 {
         if <code>initial_object</code> is not specified, all objects
         reachable from the heap roots.
         The heap root are the set of system classes,
-        JNI globals, references from thread stacks, and other objects used as roots
+        JNI globals, references from platform thread stacks, and other objects used as roots
         for the purposes of garbage collection.
         <p/>
         This function operates by traversing the reference graph.
@@ -5579,7 +5579,7 @@ class C2 extends C1 implements I2 {
         This function iterates over the root objects and all objects that
         are directly and indirectly reachable from the root objects.
         The root objects comprise the set of system classes,
-        JNI globals, references from thread stacks, and other objects used as roots
+        JNI globals, references from platform thread stacks, and other objects used as roots
         for the purposes of garbage collection.
         <p/>
         For each root the <paramlink id="heap_root_callback"></paramlink>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3520,7 +3520,7 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
             Local variable on a thread stack.
           </constant>
           <constant id="JVMTI_HEAP_REFERENCE_JNI_LOCAL" num="25">
-            JNI local reference on a thread stack.
+            JNI local reference.
           </constant>
           <constant id="JVMTI_HEAP_REFERENCE_THREAD" num="26">
             Heap root reference: Thread.


### PR DESCRIPTION
The fix updates JVMTI spec updates description of heap functions to support virtual threads.
Virtual threads are not heap roots by design, so FollowReference/IterateOverReachableObjects specs are updated to note only platform threads.
References from thread stacks (including virtual threads) are reported as JVMTI_HEAP_REFERENCE_STACK_LOCAL/JVMTI_HEAP_REFERENCE_JNI_LOCAL, so description of the values is relaxed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8306781](https://bugs.openjdk.org/browse/JDK-8306781) to be approved

### Issues
 * [JDK-8306027](https://bugs.openjdk.org/browse/JDK-8306027): Clarify JVMTI heap functions spec about virtual thread stack.
 * [JDK-8306781](https://bugs.openjdk.org/browse/JDK-8306781): Clarify JVMTI heap functions spec about virtual thread stack. (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13661/head:pull/13661` \
`$ git checkout pull/13661`

Update a local copy of the PR: \
`$ git checkout pull/13661` \
`$ git pull https://git.openjdk.org/jdk.git pull/13661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13661`

View PR using the GUI difftool: \
`$ git pr show -t 13661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13661.diff">https://git.openjdk.org/jdk/pull/13661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13661#issuecomment-1522502702)