### PR TITLE
8306901: Macro offset_of confuses Eclipse CDT

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -140,12 +140,12 @@ inline int g_isfinite(jdouble f)                 { return isfinite(f); }
 // use offsetof() instead, with the invalid-offsetof warning
 // temporarily disabled.
 #define offset_of(klass,field)                          \
-[]() {                                                  \
+([]() {                                                 \
   char space[sizeof (klass)] ATTRIBUTE_ALIGNED(16);     \
   klass* dummyObj = (klass*)space;                      \
   char* c = (char*)(void*)&dummyObj->field;             \
   return (size_t)(c - space);                           \
-}()
+}())
 
 
 #if defined(_LP64) && defined(__APPLE__)


### PR DESCRIPTION
With this pr I would like to wrap the body of the macro `offset_of` as defined for gcc in parentheses to fix the described issues with Eclipse CDT.
As an alternative the [`(int)` cast in `byte_offset_of`](https://github.com/openjdk/jdk/blob/44d9f55d0b3c469988be6f1c47f0cfbc433c4490/src/hotspot/share/utilities/sizes.hpp#L59) could be removed. I preferred adding the parentheses to the gcc version of `offset_of` because the impact is smaller.

Of course I'd rather have a local solution for the issue but I couldn't find one that didn't require changes in the source code.

Testing: GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306901](https://bugs.openjdk.org/browse/JDK-8306901): Macro offset_of confuses Eclipse CDT


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13668/head:pull/13668` \
`$ git checkout pull/13668`

Update a local copy of the PR: \
`$ git checkout pull/13668` \
`$ git pull https://git.openjdk.org/jdk.git pull/13668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13668`

View PR using the GUI difftool: \
`$ git pr show -t 13668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13668.diff">https://git.openjdk.org/jdk/pull/13668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13668#issuecomment-1523693248)