### PR TITLE
8306933: C2: "assert(false) failed: infinite loop" failure

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4019,9 +4019,6 @@ bool Compile::final_graph_reshaping() {
     // must be infinite loops.
     for (DUIterator_Fast jmax, j = n->fast_outs(jmax); j < jmax; j++)
       if (!frc._visited.test(n->fast_out(j)->_idx)) {
-        DEBUG_ONLY( n->fast_out(j)->dump(); );
-        DEBUG_ONLY( n->dump_bfs(1, 0, "-"); );
-        assert(false, "infinite loop");
         record_method_not_compilable("infinite loop");
         return true;            // Found unvisited kid; must be unreach
       }

--- a/test/hotspot/jtreg/compiler/c2/TestInfiniteLoopCompilationFailure.java
+++ b/test/hotspot/jtreg/compiler/c2/TestInfiniteLoopCompilationFailure.java
@@ -26,9 +26,9 @@
  * @bug 8306933
  * @summary C2: "assert(false) failed: infinite loop" failure
  * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
- *                   -XX:+StressIGVN -XX:StressSeed=675320863 TestInfiniteLoopCompilationFailure
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=675320863 TestInfiniteLoopCompilationFailure
  * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
- *                   -XX:+StressIGVN TestInfiniteLoopCompilationFailure
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestInfiniteLoopCompilationFailure
  */
 
 public class TestInfiniteLoopCompilationFailure {

--- a/test/hotspot/jtreg/compiler/c2/TestInfiniteLoopCompilationFailure.java
+++ b/test/hotspot/jtreg/compiler/c2/TestInfiniteLoopCompilationFailure.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8306933
+ * @summary C2: "assert(false) failed: infinite loop" failure
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
+ *                   -XX:+StressIGVN -XX:StressSeed=675320863 TestInfiniteLoopCompilationFailure
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
+ *                   -XX:+StressIGVN TestInfiniteLoopCompilationFailure
+ */
+
+public class TestInfiniteLoopCompilationFailure {
+    public static void main(String[] args) {
+        int[][] array = { new int[100] };
+        test(false, 0, array);
+    }
+
+    private static void test(boolean flag, int i, int[][] array) {
+        if (flag) {
+            int[] array2;
+
+            array2 = array[i];
+            int j;
+            for (j = 0; j < 10; j++) {
+            }
+            int k;
+            if (j == 10) {
+                k = i;
+            } else {
+                k = 0;
+            }
+            int v = array2[k];
+            for (;;) {
+                v += array[i][i];
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The assert fires because an infinite loop appears in the graph after
loop opts are over.

After loop opts, the `for(;;)` loop contains a null check and a range
check for `array[i]`. So it's not considered an infinite loop (it has
exits to uncommon traps). The null check and range check are redundant
with the one right before the loop: `int v = array2[k];` IGVN can
optimize it but it doesn't happen until after loop opts when a
`ConvI2L` for the `array[i]` access is processed as part of post loop
opts IGVN. The `for(;;)` loop is then emptied and only contains a
`Loop` and a `Safepoint` nodes.

I propose removing the assert (at least for now) as I don't see a way
to guarantee no infinite loop can appear after loop opts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306933](https://bugs.openjdk.org/browse/JDK-8306933): C2: "assert(false) failed: infinite loop" failure


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [f943db9d](https://git.openjdk.org/jdk/pull/13672/files/f943db9d2269cb2cf7c95e4e04f650a08b4768de)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13672/head:pull/13672` \
`$ git checkout pull/13672`

Update a local copy of the PR: \
`$ git checkout pull/13672` \
`$ git pull https://git.openjdk.org/jdk.git pull/13672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13672`

View PR using the GUI difftool: \
`$ git pr show -t 13672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13672.diff">https://git.openjdk.org/jdk/pull/13672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13672#issuecomment-1523657745)