### PR TITLE
8306927: Collator treats "v" and "w" as the same letter for Swedish language locale.

### DIFF
--- a/src/jdk.localedata/share/classes/sun/text/resources/ext/CollationData_sv.java
+++ b/src/jdk.localedata/share/classes/sun/text/resources/ext/CollationData_sv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.localedata/share/classes/sun/text/resources/ext/CollationData_sv.java
+++ b/src/jdk.localedata/share/classes/sun/text/resources/ext/CollationData_sv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,6 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- */
-
-/*
  */
 
 /*
@@ -55,7 +52,6 @@ public class CollationData_sv extends ListResourceBundle {
                 "< \u00e6 , \u00c6 " +                   //  ae ligature
                 "< o\u0308 , O\u0308 " +   // o-umlaut
                 "< o\u030b , O\u030b ; \u00f8 , \u00d8 " +   // o-double-acute < o-stroke
-                "& V ; w , W" +
                 "& Y, u\u0308 , U\u0308" + // u-double-acute
                 "; u\u030b, U\u030b "
             }

--- a/test/jdk/sun/text/resources/Collator/SwedishTest.java
+++ b/test/jdk/sun/text/resources/Collator/SwedishTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8306927
+ * @modules jdk.localedata
+ * @summary Tests Swedish collation involving 'v' and 'w'.
+ */
+
+import java.text.Collator;
+import java.util.Arrays;
+import java.util.Locale;
+
+public class SwedishTest {
+    private static final String[] src = {"wb", "va", "vc"};
+    private static final String[] expected = {"va", "vc", "wb"};
+
+    public static void main (String[] args) {
+        Arrays.sort(src, Collator.getInstance(Locale.of("sv")));
+        if (!Arrays.equals(src, expected)) {
+            throw new RuntimeException("Swedish collation failed");
+        }
+    }
+}


### PR DESCRIPTION
Updating the collation rules for Swedish to the modern one, which is aligned with the CLDR's default collation rules. Since it is changing the existing behavior, a release note has also been drafted: https://bugs.openjdk.org/browse/JDK-8306948

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306927](https://bugs.openjdk.org/browse/JDK-8306927): Collator treats "v" and "w" as the same letter for Swedish language locale.


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13677/head:pull/13677` \
`$ git checkout pull/13677`

Update a local copy of the PR: \
`$ git checkout pull/13677` \
`$ git pull https://git.openjdk.org/jdk.git pull/13677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13677`

View PR using the GUI difftool: \
`$ git pr show -t 13677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13677.diff">https://git.openjdk.org/jdk/pull/13677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13677#issuecomment-1524034225)