### PR TITLE
JDK-8306952: improve generic signature of internal DCInlineTag class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DCTree.java
@@ -400,7 +400,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public abstract static class DCInlineTag extends DCEndPosTree<DCInlineTag> implements InlineTagTree {
+    public abstract static class DCInlineTag<T extends DCEndPosTree<T>> extends DCEndPosTree<T> implements InlineTagTree {
         @Override @DefinedBy(Api.COMPILER_TREE)
         public String getTagName() {
             return getKind().tagName;
@@ -514,7 +514,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCDocRoot extends DCInlineTag implements DocRootTree {
+    public static class DCDocRoot extends DCInlineTag<DCDocRoot> implements DocRootTree {
 
         @Override @DefinedBy(Api.COMPILER_TREE)
         public Kind getKind() {
@@ -717,7 +717,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCIndex extends DCInlineTag implements IndexTree {
+    public static class DCIndex extends DCInlineTag<DCIndex> implements IndexTree {
         public final DCTree term;
         public final List<DCTree> description;
 
@@ -747,7 +747,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCInheritDoc extends DCInlineTag implements InheritDocTree {
+    public static class DCInheritDoc extends DCInlineTag<DCInheritDoc> implements InheritDocTree {
         @Override @DefinedBy(Api.COMPILER_TREE)
         public Kind getKind() {
             return Kind.INHERIT_DOC;
@@ -759,7 +759,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCLink extends DCInlineTag implements LinkTree {
+    public static class DCLink extends DCInlineTag<DCLink> implements LinkTree {
         public final Kind kind;
         public final DCReference ref;
         public final List<DCTree> label;
@@ -792,7 +792,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCLiteral extends DCInlineTag implements LiteralTree {
+    public static class DCLiteral extends DCInlineTag<DCLiteral> implements LiteralTree {
         public final Kind kind;
         public final DCText body;
 
@@ -1084,7 +1084,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCSnippet extends DCInlineTag implements SnippetTree {
+    public static class DCSnippet extends DCInlineTag<DCSnippet> implements SnippetTree {
         public final List<? extends DocTree> attributes;
         public final DCText body;
 
@@ -1186,7 +1186,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCSummary extends DCInlineTag implements SummaryTree {
+    public static class DCSummary extends DCInlineTag<DCSummary> implements SummaryTree {
         public final List<DCTree> summary;
 
         DCSummary(List<DCTree> summary) {
@@ -1209,7 +1209,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCSystemProperty extends DCInlineTag implements SystemPropertyTree {
+    public static class DCSystemProperty extends DCInlineTag<DCSystemProperty> implements SystemPropertyTree {
         public final Name propertyName;
 
         DCSystemProperty(Name propertyName) {
@@ -1323,7 +1323,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCUnknownInlineTag extends DCInlineTag implements UnknownInlineTagTree {
+    public static class DCUnknownInlineTag extends DCInlineTag<DCUnknownInlineTag> implements UnknownInlineTagTree {
         public final Name name;
         public final List<DCTree> content;
 
@@ -1383,7 +1383,7 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static class DCValue extends DCInlineTag implements ValueTree {
+    public static class DCValue extends DCInlineTag<DCValue> implements ValueTree {
         public final DCText format;
         public final DCReference ref;
 


### PR DESCRIPTION
Please review a small update to the generic signature of the internal `DCInlineTag` class, to improve its use in chained method calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306952](https://bugs.openjdk.org/browse/JDK-8306952): improve generic signature of internal DCInlineTag class


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13678/head:pull/13678` \
`$ git checkout pull/13678`

Update a local copy of the PR: \
`$ git checkout pull/13678` \
`$ git pull https://git.openjdk.org/jdk.git pull/13678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13678`

View PR using the GUI difftool: \
`$ git pr show -t 13678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13678.diff">https://git.openjdk.org/jdk/pull/13678.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13678#issuecomment-1524058191)