### PR TITLE
8306946: jdk/test/lib/process/ProcessToolsStartProcessTest.java fails with "wrong number of lines in OutputAnalyzer output"

### DIFF
--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -96,7 +96,7 @@ public class ProcessToolsStartProcessTest {
                 System.out.println("A line on stdout: " + i + " " + ".".repeat(i));
             }
         } else {
-            for (int i = 1; i < 10; i++) {
+            for (int i = 1; i < 5; i++) {
                 System.out.println("ITERATION " + i);
                 boolean test1Result = testStartProcess(i * 10 + i, false);
                 if (!test1Result) {

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -76,7 +76,7 @@ public class ProcessToolsStartProcessTest {
             if (numLines != numOfLines) {
                 System.out.print("FAILED: wrong number of lines in Consumer output\n");
                 success = false;
-                System.out.print(out.getStdout());
+                System.out.print(output);
             }
         }
 
@@ -92,7 +92,8 @@ public class ProcessToolsStartProcessTest {
 
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            for (int i = 0; i < Integer.parseInt(args[0]); i++) {
+            int iter = Integer.parseInt(args[0]);
+            for (int i = 0; i < iter; i++) {
                 System.out.println("A line on stdout: " + i + " " + ".".repeat(i));
             }
         } else {

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -38,21 +38,21 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class ProcessToolsStartProcessTest {
-    static final int NUM_LINES = 50;
     static String output = "";
 
     private static Consumer<String> outputConsumer = s -> {
         output += s + "\n";
     };
 
-    static boolean testStartProcess(boolean withConsumer) throws Exception {
+    static boolean testStartProcess(int numOfLines, boolean withConsumer) throws Exception {
         boolean success = true;
+        output = "";
         Process p;
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
         launcher.addToolArg("-cp");
         launcher.addToolArg(Utils.TEST_CLASSES);
         launcher.addToolArg("ProcessToolsStartProcessTest");
-        launcher.addToolArg("test"); // This one argument triggers producing the output
+        launcher.addToolArg(Integer.toString(numOfLines));
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(launcher.getCommand());
 
@@ -73,49 +73,39 @@ public class ProcessToolsStartProcessTest {
 
         if (withConsumer) {
             int numLines = output.split("\n").length;
-            if (numLines != NUM_LINES ) {
+            if (numLines != numOfLines) {
                 System.out.print("FAILED: wrong number of lines in Consumer output\n");
                 success = false;
+                System.out.print(out.getStdout());
             }
-            System.out.println("DEBUG: Consumer output: got " + numLines + " lines , expected "
-                               + NUM_LINES  + ". Output follow:");
-            System.out.print(output);
-            System.out.println("DEBUG: done with Consumer output.");
         }
 
         int numLinesOut = out.getStdout().split("\n").length;
-        if (numLinesOut != NUM_LINES) {
+        if (numLinesOut != numOfLines) {
             System.out.print("FAILED: wrong number of lines in OutputAnalyzer output\n");
+            System.out.print(out.getStdout());
             success = false;
         }
-        System.out.println("DEBUG: OutputAnalyzer output: got " + numLinesOut + " lines, expected "
-                           + NUM_LINES  + ". Output follows:");
-        System.out.print(out.getStdout());
-        System.out.println("DEBUG: done with OutputAnalyzer stdout.");
 
         return success;
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            for (int i = 0; i < NUM_LINES; i++) {
-                System.out.println("A line on stdout " + i);
+            for (int i = 0; i < Integer.parseInt(args[0]); i++) {
+                System.out.println("A line on stdout: " + i + " " + ".".repeat(i));
             }
         } else {
-            try {
-                boolean test1Result = testStartProcess(false);
-                boolean test2Result = testStartProcess(true);
-                if (!test1Result || !test2Result) {
-                    throw new RuntimeException("One or more tests failed. See output for details.");
+            for (int i = 1; i < 10; i++) {
+                System.out.println("ITERATION " + i);
+                boolean test1Result = testStartProcess(i * 10 + i, false);
+                if (!test1Result) {
+                    throw new RuntimeException("First test (no consumer) failed. See output for details.");
                 }
-            } catch (RuntimeException re) {
-                re.printStackTrace();
-                System.out.println("Test ERROR");
-                throw re;
-            } catch (Exception ex) {
-                ex.printStackTrace();
-                System.out.println("Test ERROR");
-                throw new RuntimeException(ex);
+                boolean test2Result = testStartProcess(i * 10 + i, true);
+                if (!test2Result) {
+                    throw new RuntimeException("Second test (with consumer) failed. See output for details.");
+                }
             }
         }
     }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -178,13 +178,16 @@ public final class ProcessTools {
             while (current == count) {
                 if (!p.isAlive()) {
                     try {
-                        // It is needed to wait until stream is flushed after
+                        // It is needed to  ensure that stream is flushed after
                         // process is completed.
-                        task.get();
+                        task.get(10, TimeUnit.MILLISECONDS);
                         if (current == count) {
                             return -1;
                         }
-                    } catch (Exception e) {
+                    } catch (TimeoutException e) {
+                        // continue execution, so wait(1) give a chance to write
+                        // in this buffer by unlocking this synchronized method
+                    } catch (InterruptedException | ExecutionException e) {
                         return -1;
                     }
                 }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -116,7 +117,7 @@ public final class ProcessTools {
             throws IOException {
         try {
             return startProcess(name, processBuilder, consumer, null, -1, TimeUnit.NANOSECONDS);
-        } catch (InterruptedException | TimeoutException e) {
+        } catch (InterruptedException | TimeoutException | CancellationException e) {
             // will never happen
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The ProcessTools.startProcess (...) has been updated to completely read streams after process has been completed.
The test was updated to run 5 times with different number of lines and line sizes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306946](https://bugs.openjdk.org/browse/JDK-8306946): jdk/test/lib/process/ProcessToolsStartProcessTest.java fails with "wrong number of lines in OutputAnalyzer output"


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d02b889a](https://git.openjdk.org/jdk/pull/13683/files/d02b889af81cc6f081f5249fe171479a90c2b533)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13683/head:pull/13683` \
`$ git checkout pull/13683`

Update a local copy of the PR: \
`$ git checkout pull/13683` \
`$ git pull https://git.openjdk.org/jdk.git pull/13683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13683`

View PR using the GUI difftool: \
`$ git pr show -t 13683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13683.diff">https://git.openjdk.org/jdk/pull/13683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13683#issuecomment-1524380790)