### PR TITLE
8306976: UTIL_REQUIRE_SPECIAL warning on grep

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -49,6 +49,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_REQUIRE_PROGS(WC, wc)
 
   # Required tools with some special treatment
+  UTIL_REQUIRE_SPECIAL(GREP, [AC_PROG_GREP])
   UTIL_REQUIRE_SPECIAL(EGREP, [AC_PROG_EGREP])
   UTIL_REQUIRE_SPECIAL(SED, [AC_PROG_SED])
 
@@ -94,7 +95,6 @@ AC_DEFUN_ONCE([BASIC_SETUP_TOOLS],
   UTIL_REQUIRE_PROGS(XARGS, xargs)
 
   # Required tools with some special treatment
-  UTIL_REQUIRE_SPECIAL(GREP, [AC_PROG_GREP])
   UTIL_REQUIRE_SPECIAL(FGREP, [AC_PROG_FGREP])
 
   # Optional tools, we can do without them


### PR DESCRIPTION
hi
```
bash configure
```
There is an warning message
```
The following warnings were produced. Repeated here for convenience:
WARNING: Ignoring value of GREP from the environment. Use command line variables instead. 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306976](https://bugs.openjdk.org/browse/JDK-8306976): UTIL_REQUIRE_SPECIAL warning on grep


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13685/head:pull/13685` \
`$ git checkout pull/13685`

Update a local copy of the PR: \
`$ git checkout pull/13685` \
`$ git pull https://git.openjdk.org/jdk.git pull/13685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13685`

View PR using the GUI difftool: \
`$ git pr show -t 13685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13685.diff">https://git.openjdk.org/jdk/pull/13685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13685#issuecomment-1524944450)