### PR TITLE
8306997: C2: "malformed control flow" assert due to missing safepoint on backedge with a switch

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -435,7 +435,7 @@ void Parse::do_tableswitch() {
 
   // generate decision tree, using trichotomy when possible
   int rnum = len+2;
-  bool makes_backward_branch = false;
+  bool makes_backward_branch = (default_dest <= bci());
   SwitchRange* ranges = NEW_RESOURCE_ARRAY(SwitchRange, rnum);
   int rp = -1;
   if (lo_index != min_jint) {
@@ -526,7 +526,7 @@ void Parse::do_lookupswitch() {
   }
 
   int rnum = len*2+1;
-  bool makes_backward_branch = false;
+  bool makes_backward_branch = (default_dest <= bci());
   SwitchRange* ranges = NEW_RESOURCE_ARRAY(SwitchRange, rnum);
   int rp = -1;
   for (int j = 0; j < len; j++) {

--- a/test/hotspot/jtreg/compiler/parsing/MissingSafepointOnSwitch.jasm
+++ b/test/hotspot/jtreg/compiler/parsing/MissingSafepointOnSwitch.jasm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class MissingSafepointOnSwitch
+	version 52:0
+{
+  public Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+  /* Same as:
+    public static void test(boolean flag, int v) {
+        if (flag) {
+            loop:
+            for (; ; ) {
+                switch(v) {
+                    case 0:
+                    case 1:
+                    case 2:
+                        break loop;
+                    default:
+                }
+            }
+        }
+    }
+    but with the default: set to the loop entry
+  */
+  public static Method test:"(ZI)V"
+	stack 1 locals 2
+  {
+		iload_0;
+		ifeq	L32;
+	L4:	stack_frame_type same;
+		iload_1;
+		tableswitch{ //0 to 2
+		0: L32;
+		1: L32;
+		2: L32;
+		default: L4 };
+	L32:	stack_frame_type same;
+		return;
+  }
+
+} // end Class TestMissingSafepointOnSwitch

--- a/test/hotspot/jtreg/compiler/parsing/TestMissingSafepointOnSwitch.java
+++ b/test/hotspot/jtreg/compiler/parsing/TestMissingSafepointOnSwitch.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8306997
+ * @summary C2: "malformed control flow" assert due to missing safepoint on backedge with a switch
+ * @compile MissingSafepointOnSwitch.jasm
+ * @run main/othervm -Xcomp -XX:CompileOnly=MissingSafepointOnSwitch::test TestMissingSafepointOnSwitch
+ */
+
+public class TestMissingSafepointOnSwitch {
+    public static void main(String[] args) {
+        MissingSafepointOnSwitch.test(false, 0);
+    }
+
+}


### PR DESCRIPTION
The assert fires because a self loop (a `Loop` whose second input is
itself) is removed by loop opts. That loop comes from a switch where
the default case is a loop head (a code shape I couldn't get javac to
produce). That `Loop` should at the very least have a `Safepoint` but
the logic at parse time only looks for backedges in the non default
cases. With that fixed, the `Loop` is no longer considered dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306997](https://bugs.openjdk.org/browse/JDK-8306997): C2: "malformed control flow" assert due to missing safepoint on backedge with a switch


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13688/head:pull/13688` \
`$ git checkout pull/13688`

Update a local copy of the PR: \
`$ git checkout pull/13688` \
`$ git pull https://git.openjdk.org/jdk.git pull/13688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13688`

View PR using the GUI difftool: \
`$ git pr show -t 13688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13688.diff">https://git.openjdk.org/jdk/pull/13688.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13688#issuecomment-1525547343)