### PR TITLE
8282384: [LOOM] Need test for ThreadReference.interrupt() on a vthread

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
@@ -47,11 +47,9 @@ import java.io.*;
  * The test is passed if both 'interrupted status" are equal,           <BR>
  * otherwise the test failed.                                           <BR>
  *                                                                      <BR>
- * The test consists of two cases as follows:                           <BR>
+ * The test consists of one test case as follows:                       <BR>
  * - both debuggee's threads are locked up at synchronized block and    <BR>
  *   are not suspended;                                                 <BR>
- * - both debuggee's threads are locked up at synchronized block and    <BR>
- *   are suspended by java.lang.Thread.suspend() method;                <BR>
  */
 
 public class interrupt001 {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,7 +211,9 @@ public class interrupt001 {
             throw new TestBug("ERROR: Not found ThreadReference for name :" + threadName2);
         }
 
-        log2("......interrupting the thread2");
+        log2("......thread2 is " + (thread2.isVirtual() ? "" : "not ") + "a virtual thread");
+
+        log2("......interrupting thread2");
         thread2.interrupt();
 
         log2("......instructing main thread to check up threads' interrupted statuses");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001a.java
@@ -206,13 +206,11 @@ public class interrupt001a {
     }
 }
 
-class interrupt001aTask implements Runnable {
+class interrupt001aTask extends NamedTask {
 
     public interrupt001aTask(String taskName) {
-        this.taskName = taskName;
+        super(taskName);
     }
-
-    public String taskName;
 
     public boolean ready;
 
@@ -238,6 +236,6 @@ class interrupt001aTask implements Runnable {
     }
 
     void log(String str) {
-        interrupt001a.log2(taskName + " : " + str);
+        interrupt001a.log2(getName() + " : " + str);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001a.java
@@ -102,7 +102,7 @@ public class interrupt001a {
 
             } else if (instruction.equals("newcheck")) {
 
-                synchronized (interrupt001aThread.lockingObject) {
+                synchronized (interrupt001aTask.lockingObject) {
                     thread2 = threadStart("Thread02");
                     thread3 = threadStart("Thread03");
 
@@ -143,7 +143,7 @@ public class interrupt001a {
     }
 
     private static Thread threadStart(String threadName) {
-        interrupt001aThread resultRunnable = new interrupt001aThread(threadName);
+        interrupt001aTask resultRunnable = new interrupt001aTask(threadName);
         Thread resultThread = JDIThreadFactory.newThread(resultRunnable, threadName);
         synchronized (resultRunnable.waitnotifyObj) {
             resultThread.start();
@@ -206,13 +206,13 @@ public class interrupt001a {
     }
 }
 
-class interrupt001aThread implements Runnable {
+class interrupt001aTask implements Runnable {
 
-    public interrupt001aThread(String threadName) {
-        this.threadName = threadName;
+    public interrupt001aTask(String taskName) {
+        this.taskName = taskName;
     }
 
-    public String threadName;
+    public String taskName;
 
     public boolean ready;
 
@@ -238,6 +238,6 @@ class interrupt001aThread implements Runnable {
     }
 
     void log(String str) {
-        interrupt001a.log2(threadName + " : " + str);
+        interrupt001a.log2(taskName + " : " + str);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/interrupt/interrupt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,9 +65,9 @@ public class interrupt001a {
     // scaffold objects
     private static volatile ArgumentHandler argumentHandler = null;
 
-    private static interrupt001aThread thread2 = null;
+    private static Thread thread2 = null;
 
-    private static interrupt001aThread thread3 = null;
+    private static Thread thread3 = null;
 
     private static IOPipe pipe;
 
@@ -142,14 +142,15 @@ public class interrupt001a {
         System.exit(exitCode + PASS_BASE);
     }
 
-    private static interrupt001aThread threadStart(String threadName) {
-        interrupt001aThread resultThread = new interrupt001aThread(threadName);
-        synchronized (resultThread.waitnotifyObj) {
+    private static Thread threadStart(String threadName) {
+        interrupt001aThread resultRunnable = new interrupt001aThread(threadName);
+        Thread resultThread = JDIThreadFactory.newThread(resultRunnable, threadName);
+        synchronized (resultRunnable.waitnotifyObj) {
             resultThread.start();
             try {
                 log1("       before:   waitnotifyObj.wait();");
-                while (!resultThread.ready)
-                    resultThread.waitnotifyObj.wait();
+                while (!resultRunnable.ready)
+                    resultRunnable.waitnotifyObj.wait();
                 log1("       after:    waitnotifyObj.wait();");
             } catch (InterruptedException e) {
                 logErr("Unexpected InterruptedException while waiting for start of : " + threadName);
@@ -205,11 +206,13 @@ public class interrupt001a {
     }
 }
 
-class interrupt001aThread extends Thread {
+class interrupt001aThread implements Runnable {
 
     public interrupt001aThread(String threadName) {
-        super(threadName);
+        this.threadName = threadName;
     }
+
+    public String threadName;
 
     public boolean ready;
 
@@ -235,6 +238,6 @@ class interrupt001aThread extends Thread {
     }
 
     void log(String str) {
-        interrupt001a.log2(Thread.currentThread().getName() + " : " + str);
+        interrupt001a.log2(threadName + " : " + str);
     }
 }


### PR DESCRIPTION
Convert this ThreadReference.interrupt() test to support virtual threads. I believe this is the only test for ThreadReference.interrupt() that we have.

Tested by running with and without -Dmain.wrapper=Virtual on all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282384](https://bugs.openjdk.org/browse/JDK-8282384): [LOOM] Need test for ThreadReference.interrupt() on a vthread


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [a7f277a9](https://git.openjdk.org/jdk/pull/13696/files/a7f277a9df8518567011e3dbf9d42efbcd0cfadb)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [a7f277a9](https://git.openjdk.org/jdk/pull/13696/files/a7f277a9df8518567011e3dbf9d42efbcd0cfadb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13696/head:pull/13696` \
`$ git checkout pull/13696`

Update a local copy of the PR: \
`$ git checkout pull/13696` \
`$ git pull https://git.openjdk.org/jdk.git pull/13696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13696`

View PR using the GUI difftool: \
`$ git pr show -t 13696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13696.diff">https://git.openjdk.org/jdk/pull/13696.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13696#issuecomment-1526105495)