### PR TITLE
8296935: Arrays.asList() can return a List that throws undocumented ArrayStoreException

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4186,6 +4186,10 @@ public final class Arrays {
      * those that would change the size of the returned list. Those methods leave
      * the list unchanged and throw {@link UnsupportedOperationException}.
      *
+     * <p>If the specified array's actual component type differs from the type
+     * parameter T, this can result in operations on the returned list throwing an
+     * {@code ArrayStoreException}.
+     *
      * @apiNote
      * This method acts as bridge between array-based and collection-based
      * APIs, in combination with {@link Collection#toArray}.


### PR DESCRIPTION
…

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8307074](https://bugs.openjdk.org/browse/JDK-8307074) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8296935](https://bugs.openjdk.org/browse/JDK-8296935): Arrays.asList() can return a List that throws undocumented ArrayStoreException
 * [JDK-8307074](https://bugs.openjdk.org/browse/JDK-8307074): Arrays.asList() can return a List that throws undocumented ArrayStoreException (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13698/head:pull/13698` \
`$ git checkout pull/13698`

Update a local copy of the PR: \
`$ git checkout pull/13698` \
`$ git pull https://git.openjdk.org/jdk.git pull/13698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13698`

View PR using the GUI difftool: \
`$ git pr show -t 13698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13698.diff">https://git.openjdk.org/jdk/pull/13698.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13698#issuecomment-1526177359)