### PR TITLE
8302496: Runtime.exit incorrectly says it never throws an exception

### DIFF
--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -283,8 +283,7 @@ public class Runtime {
 
     /**
      * Immediately {@linkplain ##termination terminates} the Java Virtual Machine.
-     * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
-     * method disallows exiting with the specified status, throws {@link SecurityException}.
+     * If the security manager denies exiting, throws {@link SecurityException}.
      * Otherwise, termination of the Java Virtual Machine is unconditional and immediate.
      * This method does not initiate the {@linkplain ##shutdown shutdown sequence}, nor does
      * it wait for the shutdown sequence to finish if it is already in progress. An

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -141,18 +141,19 @@ public class Runtime {
 
     /**
      * Initiates the <a href="#shutdown">shutdown sequence</a> of the Java Virtual Machine.
-     * This method blocks indefinitely; it never returns or throws an exception (that is, it
-     * does not complete either normally or abruptly). The argument serves as a status code;
-     * by convention, a nonzero status code indicates abnormal termination.
+     * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
+     * method disallows exiting with the specified status, throws {@link SecurityException}.
+     * Otherwise, this method blocks indefinitely; it neither returns nor throws an exception
+     * (that is, it does not complete either normally or abruptly). The argument serves as a
+     * status code. By convention, a nonzero status code indicates abnormal termination.
      *
-     * <p> Invocations of this method are serialized such that only one
-     * invocation will actually proceed with the shutdown sequence and
-     * terminate the VM with the given status code. All other invocations
-     * simply block indefinitely.
+     * <p> Successful invocations of this method are serialized such that only one invocation
+     * will proceed with the shutdown sequence and terminate the VM with the given status code.
+     * All other invocations will perform no action and block indefinitely.
      *
-     * <p> Because this method always blocks indefinitely, if it is invoked from
-     * a shutdown hook, it will prevent that shutdown hook from terminating.
-     * Consequently, this will prevent the shutdown sequence from finishing.
+     * <p> Because a successful invocation of this method blocks indefinitely, if it is invoked
+     * from a shutdown hook, it will prevent that shutdown hook from terminating. Consequently,
+     * this will prevent the shutdown sequence from finishing.
      *
      * <p> The {@link System#exit(int) System.exit} method is the
      * conventional and convenient means of invoking this method.
@@ -280,10 +281,13 @@ public class Runtime {
     }
 
     /**
-     * Immediately <a href="#termination">terminates</a> the Java Virtual Machine. Termination
-     * is unconditional and immediate. This method does not initiate the
-     * <a href="#shutdown">shutdown sequence</a>, nor does it wait for the shutdown sequence
-     * to finish if it is already in progress. This method never returns normally.
+     * Immediately <a href="#termination">terminates</a> the Java Virtual Machine.
+     * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
+     * method disallows exiting with the specified status, throws {@link SecurityException}.
+     * Otherwise, termination of the Java Virtual Machine is unconditional and immediate.
+     * This method does not initiate the <a href="#shutdown">shutdown sequence</a>, nor does
+     * it wait for the shutdown sequence to finish if it is already in progress. An
+     * invocation of this method never returns normally.
      *
      * @apiNote
      * This method should be used with extreme caution. Using it may circumvent or disrupt

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -140,7 +140,7 @@ public class Runtime {
     private Runtime() {}
 
     /**
-     * Initiates the <a href="#shutdown">shutdown sequence</a> of the Java Virtual Machine.
+     * Initiates the {@linkplain ##shutdown shutdown sequence} of the Java Virtual Machine.
      * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
      * method disallows exiting with the specified status, throws {@link SecurityException}.
      * Otherwise, this method blocks indefinitely; it neither returns nor throws an exception
@@ -191,7 +191,7 @@ public class Runtime {
      * Registers a new virtual-machine shutdown hook.
      *
      * <p> A <i>shutdown hook</i> is simply an initialized but unstarted thread. Shutdown hooks
-     * are started at the beginning of the <a href="#shutdown">shutdown sequence</a>.
+     * are started at the beginning of the {@linkplain ##shutdown shutdown sequence}.
      * Registration and de-registration of shutdown hooks is disallowed once the shutdown
      * sequence has begun.
      * <p>
@@ -281,18 +281,18 @@ public class Runtime {
     }
 
     /**
-     * Immediately <a href="#termination">terminates</a> the Java Virtual Machine.
+     * Immediately {@linkplain ##termination terminates} the Java Virtual Machine.
      * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
      * method disallows exiting with the specified status, throws {@link SecurityException}.
      * Otherwise, termination of the Java Virtual Machine is unconditional and immediate.
-     * This method does not initiate the <a href="#shutdown">shutdown sequence</a>, nor does
+     * This method does not initiate the {@linkplain ##shutdown shutdown sequence}, nor does
      * it wait for the shutdown sequence to finish if it is already in progress. An
      * invocation of this method never returns normally.
      *
      * @apiNote
      * This method should be used with extreme caution. Using it may circumvent or disrupt
      * any cleanup actions intended to be performed by shutdown hooks, possibly leading to
-     * data corruption. See the <a href="#termination">termination</a> section above
+     * data corruption. See the {@linkplain ##termination termination} section above
      * for other possible consequences of halting the Java Virtual Machine.
      *
      * @param  status

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -141,14 +141,15 @@ public class Runtime {
 
     /**
      * Initiates the {@linkplain ##shutdown shutdown sequence} of the Java Virtual Machine.
-     * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
-     * method disallows exiting with the specified status, throws {@link SecurityException}.
-     * Otherwise, this method blocks indefinitely; it neither returns nor throws an exception
-     * (that is, it does not complete either normally or abruptly). The argument serves as a
-     * status code. By convention, a nonzero status code indicates abnormal termination.
+     * Unless the security manager denies exiting, this method initiates the shutdown sequence
+     * (if it is not already initiated) and then blocks indefinitely. This method neither returns
+     * nor throws an exception; that is, it does not complete either normally or abruptly.
+     *
+     * <p> The argument serves as a status code. By convention, a nonzero status code
+     * indicates abnormal termination.
      *
      * <p> Successful invocations of this method are serialized such that only one invocation
-     * will proceed with the shutdown sequence and terminate the VM with the given status code.
+     * initiates the shutdown sequence and terminates the VM with the given status code.
      * All other invocations will perform no action and block indefinitely.
      *
      * <p> Because a successful invocation of this method blocks indefinitely, if it is invoked

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1886,18 +1886,17 @@ public final class System {
     }
 
     /**
-     * Initiates the <a href="Runtime.html#shutdown">shutdown sequence</a> of the
-     * Java Virtual Machine. This method always blocks indefinitely. The argument
-     * serves as a status code; by convention, a nonzero status code indicates
-     * abnormal termination.
-     * <p>
-     * This method calls the {@code exit} method in class {@code Runtime}. This
-     * method never returns normally.
+     * Initiates the <a href="#shutdown">shutdown sequence</a> of the Java Virtual Machine.
+     * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
+     * method disallows exiting with the specified status, throws {@link SecurityException}.
+     * Otherwise, this method blocks indefinitely; it neither returns nor throws an exception
+     * (that is, it does not complete either normally or abruptly). The argument serves as a
+     * status code. By convention, a nonzero status code indicates abnormal termination.
      * <p>
      * The call {@code System.exit(n)} is effectively equivalent to the call:
-     * <blockquote><pre>
-     * Runtime.getRuntime().exit(n)
-     * </pre></blockquote>
+     * {@snippet :
+     *     Runtime.getRuntime().exit(n)
+     * }
      *
      * @implNote
      * The initiation of the shutdown sequence is logged by {@link Runtime#exit(int)}.

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1887,11 +1887,12 @@ public final class System {
 
     /**
      * Initiates the {@linkplain Runtime##shutdown shutdown sequence} of the Java Virtual Machine.
-     * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
-     * method disallows exiting with the specified status, throws {@link SecurityException}.
-     * Otherwise, this method blocks indefinitely; it neither returns nor throws an exception
-     * (that is, it does not complete either normally or abruptly). The argument serves as a
-     * status code. By convention, a nonzero status code indicates abnormal termination.
+     * Unless the security manager denies exiting, this method initiates the shutdown sequence
+     * (if it is not already initiated) and then blocks indefinitely. This method neither returns
+     * nor throws an exception; that is, it does not complete either normally or abruptly.
+     * <p>
+     * The argument serves as a status code. By convention, a nonzero status code
+     * indicates abnormal termination.
      * <p>
      * The call {@code System.exit(n)} is effectively equivalent to the call:
      * {@snippet :

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1886,7 +1886,7 @@ public final class System {
     }
 
     /**
-     * Initiates the <a href="#shutdown">shutdown sequence</a> of the Java Virtual Machine.
+     * Initiates the {@linkplain Runtime##shutdown shutdown sequence} of the Java Virtual Machine.
      * If a security manager is present and its {@link SecurityManager#checkExit checkExit}
      * method disallows exiting with the specified status, throws {@link SecurityException}.
      * Otherwise, this method blocks indefinitely; it neither returns nor throws an exception


### PR DESCRIPTION
Textual specification clarifications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8307081](https://bugs.openjdk.org/browse/JDK-8307081) to be approved

### Issues
 * [JDK-8302496](https://bugs.openjdk.org/browse/JDK-8302496): Runtime.exit incorrectly says it never throws an exception
 * [JDK-8307081](https://bugs.openjdk.org/browse/JDK-8307081): Runtime.exit incorrectly says it never throws an exception (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13706/head:pull/13706` \
`$ git checkout pull/13706`

Update a local copy of the PR: \
`$ git checkout pull/13706` \
`$ git pull https://git.openjdk.org/jdk.git pull/13706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13706`

View PR using the GUI difftool: \
`$ git pr show -t 13706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13706.diff">https://git.openjdk.org/jdk/pull/13706.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13706#issuecomment-1526753185)