### PR TITLE
8303475: potential null pointer dereference in filemap.cpp

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -361,6 +361,7 @@ void SharedClassPathEntry::set_name(const char* name, TRAPS) {
 }
 
 void SharedClassPathEntry::copy_from(SharedClassPathEntry* ent, ClassLoaderData* loader_data, TRAPS) {
+  assert(ent != NULL, "sanity");
   _type = ent->_type;
   _is_module_path = ent->_is_module_path;
   _timestamp = ent->_timestamp;


### PR DESCRIPTION
Please review this small patch which adds an assert in `SharedClassPathEntry::copy_from()` to ensure the input arg `SharedClassPathEntry* ent` is non null. This suppresses a warning from an internal static analysis tool.

Passed tiers 1 and 3 testing.