### PR TITLE
8307005: Make CardTableBarrierSet::initialize non-virtual

### DIFF
--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp
@@ -66,7 +66,7 @@ protected:
 
   CardTable* card_table() const { return _card_table; }
 
-  virtual void initialize();
+  void initialize();
 
   void write_region(JavaThread* thread, MemRegion mr) {
     invalidate(mr);


### PR DESCRIPTION
Trivial removing `virtual` specifier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307005](https://bugs.openjdk.org/browse/JDK-8307005): Make CardTableBarrierSet::initialize non-virtual


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13713/head:pull/13713` \
`$ git checkout pull/13713`

Update a local copy of the PR: \
`$ git checkout pull/13713` \
`$ git pull https://git.openjdk.org/jdk.git pull/13713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13713`

View PR using the GUI difftool: \
`$ git pr show -t 13713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13713.diff">https://git.openjdk.org/jdk/pull/13713.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13713#issuecomment-1527223464)