### PR TITLE
8307103: Two TestMetaspaceAllocationMT tests fail after JDK-8306696

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
@@ -113,7 +113,6 @@ public class TestMetaspaceAllocationMT1 {
             System.out.println("#### seconds: " + seconds);
             System.out.println("#### commitLimit: " + commitLimit);
             System.out.println("#### reserveLimit: " + reserveLimit);
-            System.out.println("#### ReclaimPolicy: " + Settings.settings().reclaimPolicy);
             System.out.println("#### guards: " + Settings.settings().usesAllocationGuards);
 
             MetaspaceTestContext context = new MetaspaceTestContext(commitLimit, reserveLimit);

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
@@ -112,7 +112,6 @@ public class TestMetaspaceAllocationMT2 {
             System.out.println("#### seconds: " + seconds);
             System.out.println("#### commitLimit: " + commitLimit);
             System.out.println("#### reserveLimit: " + reserveLimit);
-            System.out.println("#### ReclaimPolicy: " + Settings.settings().reclaimPolicy);
             System.out.println("#### guards: " + Settings.settings().usesAllocationGuards);
 
             MetaspaceTestContext context = new MetaspaceTestContext(commitLimit, reserveLimit);


### PR DESCRIPTION
This is because `Settings.settings().reclaimPolicy` had been removed in JDK-8306696.
So we can just remove the prints in the tests.