### PR TITLE
8307104: [AIX] VM crashes with UseRTMLocking on Power10

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -380,7 +380,7 @@ void VM_Version::initialize() {
   // Adjust RTM (Restricted Transactional Memory) flags.
   if (UseRTMLocking) {
     // If CPU or OS do not support RTM:
-    if (PowerArchitecturePPC64 < 8) {
+    if (PowerArchitecturePPC64 < 8 || PowerArchitecturePPC64 > 9) {
       vm_exit_during_initialization("RTM instructions are not available on this CPU.");
     }
 
@@ -673,7 +673,7 @@ void VM_Version::determine_features() {
   // We don't want to change this property, as user code might depend on it.
   // So the tests can not check on subversion 3.30, and we only enable RTM
   // with AIX 7.2.
-  if (has_lqarx()) { // POWER8 or above
+  if (has_lqarx() && !has_brw()) { // POWER8 or POWER9
     if (os::Aix::os_version() >= 0x07020000) { // At least AIX 7.2.
       _features |= rtm_m;
     }


### PR DESCRIPTION
We need to prevent usage of transactional memory (UseRTMLocking) on Power10 which doesn't support it. The VM crashes with SIGILL on AIX when trying to use it.

I'm also changing the AIX specific check for the case in which somebody uses Power10 with -XX:PowerArchitecturePPC64=8 (or 9).
The Linux specific code is fine as it is.

This change is small and should get considered for backports. We may remove the RTM code completely for future JDKs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307104](https://bugs.openjdk.org/browse/JDK-8307104): [AIX] VM crashes with UseRTMLocking on Power10


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13717/head:pull/13717` \
`$ git checkout pull/13717`

Update a local copy of the PR: \
`$ git checkout pull/13717` \
`$ git pull https://git.openjdk.org/jdk.git pull/13717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13717`

View PR using the GUI difftool: \
`$ git pr show -t 13717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13717.diff">https://git.openjdk.org/jdk/pull/13717.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13717#issuecomment-1527571759)