### PR TITLE
8307106: Allow concurrent GCs to walk CLDG without ClassLoaderDataGraph_lock

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -160,7 +160,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   Symbol* _name_and_id;
   JFR_ONLY(DEFINE_TRACE_ID_FIELD;)
 
-  void set_next(ClassLoaderData* next) { _next = next; }
+  void set_next(ClassLoaderData* next) { Atomic::store(&_next, next); }
   ClassLoaderData* next() const        { return Atomic::load(&_next); }
 
   ClassLoaderData(Handle h_class_loader, bool has_class_mirror_holder);

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -261,8 +261,15 @@ ClassLoaderData* ClassLoaderDataGraph::add(Handle loader, bool has_class_mirror_
   return loader_data;
 }
 
+inline void assert_is_safepoint_or_gc() {
+  assert(SafepointSynchronize::is_at_safepoint() ||
+         Thread::current()->is_ConcurrentGC_thread() ||
+         Thread::current()->is_Worker_thread(),
+         "Must be called by safepoint or GC");
+}
+
 void ClassLoaderDataGraph::cld_unloading_do(CLDClosure* cl) {
-  assert_locked_or_safepoint_weak(ClassLoaderDataGraph_lock);
+  assert_is_safepoint_or_gc();
   for (ClassLoaderData* cld = _unloading; cld != nullptr; cld = cld->next()) {
     assert(cld->is_unloading(), "invariant");
     cl->do_cld(cld);
@@ -272,15 +279,15 @@ void ClassLoaderDataGraph::cld_unloading_do(CLDClosure* cl) {
 // These are functions called by the GC, which require all of the CLDs, including the
 // unloading ones.
 void ClassLoaderDataGraph::cld_do(CLDClosure* cl) {
-  assert_locked_or_safepoint_weak(ClassLoaderDataGraph_lock);
-  for (ClassLoaderData* cld = _head;  cld != nullptr; cld = cld->_next) {
+  assert_is_safepoint_or_gc();
+  for (ClassLoaderData* cld = Atomic::load_acquire(&_head);  cld != nullptr; cld = cld->next()) {
     cl->do_cld(cld);
   }
 }
 
 void ClassLoaderDataGraph::roots_cld_do(CLDClosure* strong, CLDClosure* weak) {
-  assert_locked_or_safepoint_weak(ClassLoaderDataGraph_lock);
-  for (ClassLoaderData* cld = _head;  cld != nullptr; cld = cld->_next) {
+  assert_is_safepoint_or_gc();
+  for (ClassLoaderData* cld = Atomic::load_acquire(&_head);  cld != nullptr; cld = cld->next()) {
     CLDClosure* closure = cld->keep_alive() ? strong : weak;
     if (closure != nullptr) {
       closure->do_cld(cld);
@@ -289,7 +296,7 @@ void ClassLoaderDataGraph::roots_cld_do(CLDClosure* strong, CLDClosure* weak) {
 }
 
 void ClassLoaderDataGraph::always_strong_cld_do(CLDClosure* cl) {
-  assert_locked_or_safepoint_weak(ClassLoaderDataGraph_lock);
+  assert_is_safepoint_or_gc();
   if (ClassUnloading) {
     roots_cld_do(cl, nullptr);
   } else {
@@ -520,7 +527,8 @@ bool ClassLoaderDataGraph::do_unloading() {
       prev->set_next(data);
     } else {
       assert(dead == _head, "sanity check");
-      _head = data;
+      // The GC might be walking this concurrently
+      Atomic::store(&_head, data);
     }
     dead->set_next(_unloading);
     _unloading = dead;

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -174,16 +174,6 @@ void assert_locked_or_safepoint(const Mutex* lock) {
   fatal("must own lock %s", lock->name());
 }
 
-// a weaker assertion than the above
-void assert_locked_or_safepoint_weak(const Mutex* lock) {
-  if (DebuggingContext::is_enabled() || VMError::is_error_reported()) return;
-  assert(lock != nullptr, "Need non-null lock");
-  if (lock->is_locked()) return;
-  if (SafepointSynchronize::is_at_safepoint()) return;
-  if (!Universe::is_fully_initialized()) return;
-  fatal("must own lock %s", lock->name());
-}
-
 // a stronger assertion than the above
 void assert_lock_strong(const Mutex* lock) {
   if (DebuggingContext::is_enabled() || VMError::is_error_reported()) return;

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -180,11 +180,9 @@ void print_lock_ranks(outputStream* st);
 // for debugging: check that we're already owning this lock (or are at a safepoint / handshake)
 #ifdef ASSERT
 void assert_locked_or_safepoint(const Mutex* lock);
-void assert_locked_or_safepoint_weak(const Mutex* lock);
 void assert_lock_strong(const Mutex* lock);
 #else
 #define assert_locked_or_safepoint(lock)
-#define assert_locked_or_safepoint_weak(lock)
 #define assert_lock_strong(lock)
 #endif
 


### PR DESCRIPTION
A concurrent GC with concurrent class unloading can't currently walk the CLDG without the CLDG_lock today. We should add some synchronization code so it can do that safely. This patch adds the missing bits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307106](https://bugs.openjdk.org/browse/JDK-8307106): Allow concurrent GCs to walk CLDG without ClassLoaderDataGraph_lock


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13718/head:pull/13718` \
`$ git checkout pull/13718`

Update a local copy of the PR: \
`$ git checkout pull/13718` \
`$ git pull https://git.openjdk.org/jdk.git pull/13718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13718`

View PR using the GUI difftool: \
`$ git pr show -t 13718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13718.diff">https://git.openjdk.org/jdk/pull/13718.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13718#issuecomment-1527572346)