### PR TITLE
8305714 : Add an extra test for JDK-8292755

### DIFF
--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8305714
+ * @bug 8292755
  * @summary make sure JShell not crashing while throwing undefined exception
  * @modules
  *     jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8305714
+ * @summary make sure JShell not crashing while throwing undefined exception
+ * @modules
+ *     jdk.compiler/com.sun.tools.javac.api
+ *     jdk.compiler/com.sun.tools.javac.main
+ *     jdk.jshell/jdk.internal.jshell.tool:open
+ *     jdk.jshell/jdk.internal.jshell.tool.resources:open
+ *     jdk.jshell/jdk.jshell:open
+ * @library /tools/lib
+ * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
+ * @build Compiler UITesting
+ * @build UndefinedClassTest
+ * @run testng UndefinedClassTest
+ */
+
+import org.testng.annotations.Test;
+
+@Test
+public class UndefinedClassTest extends UITesting {
+
+    public UndefinedClassTest() {
+        super(true);
+    }
+
+    public void testUndefinedClass() throws Exception{
+        String code = "@FunctionalInterface\n" +
+                "interface RunnableWithThrowable {\n" +
+                " void run() throws Throwable;\n" +
+                "\n" +
+                " // You can also replace `static` with `default` and test again\n" +
+                " static RunnableWithThrowable getInstance() {\n" +
+                " return () -> { throw new NotExist(); };\n" +
+                " }\n" +
+                "}";
+        // set terminal height so that help output won't hit page breaks
+        System.setProperty("test.terminal.height", "1000000");
+        doRunTest((inputSink, out) -> {
+            inputSink.write(code + "\n");
+            waitOutput(out, "NotExist");
+        });
+    }
+}

--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -47,13 +47,27 @@ public class UndefinedClassTest extends UITesting {
         super(true);
     }
 
-    public void testUndefinedClass() throws Exception{
+    public void testUndefinedClassWithStaticAccess() throws Exception{
         String code = "@FunctionalInterface\n" +
                 "interface RunnableWithThrowable {\n" +
                 " void run() throws Throwable;\n" +
                 "\n" +
-                " // You can also replace `static` with `default` and test again\n" +
                 " static RunnableWithThrowable getInstance() {\n" +
+                " return () -> { throw new NotExist(); };\n" +
+                " }\n" +
+                "}";
+        doRunTest((inputSink, out) -> {
+            inputSink.write(code + "\n");
+            waitOutput(out, "NotExist");
+        });
+    }
+
+    public void testUndefinedClassWithDefaultAccess() throws Exception{
+        String code = "@FunctionalInterface\n" +
+                "interface RunnableWithThrowable {\n" +
+                " void run() throws Throwable;\n" +
+                "\n" +
+                " default RunnableWithThrowable getInstance() {\n" +
                 " return () -> { throw new NotExist(); };\n" +
                 " }\n" +
                 "}";

--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -57,7 +57,6 @@ public class UndefinedClassTest extends UITesting {
                 " return () -> { throw new NotExist(); };\n" +
                 " }\n" +
                 "}";
-        
         doRunTest((inputSink, out) -> {
             inputSink.write(code + "\n");
             waitOutput(out, "NotExist");

--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -57,6 +57,7 @@ public class UndefinedClassTest extends UITesting {
                 " return () -> { throw new NotExist(); };\n" +
                 " }\n" +
                 "}";
+        
         doRunTest((inputSink, out) -> {
             inputSink.write(code + "\n");
             waitOutput(out, "NotExist");

--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8292755
- * @summary make sure JShell not crashing while throwing undefined exception
+ * @summary InternalError seen while throwing undefined exception
  * @modules
  *     jdk.compiler/com.sun.tools.javac.api
  *     jdk.compiler/com.sun.tools.javac.main
@@ -57,8 +57,6 @@ public class UndefinedClassTest extends UITesting {
                 " return () -> { throw new NotExist(); };\n" +
                 " }\n" +
                 "}";
-        // set terminal height so that help output won't hit page breaks
-        System.setProperty("test.terminal.height", "1000000");
         doRunTest((inputSink, out) -> {
             inputSink.write(code + "\n");
             waitOutput(out, "NotExist");


### PR DESCRIPTION
Add a testing case for undefined classes in Java JShell to make sure JShell does not crash when an undefined class is used.

This test was passed for Linux, MacOS, and Windows by mach5 build and test in Oracle.

Reviewer: @coffeys @lahodaj

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305714](https://bugs.openjdk.org/browse/JDK-8305714): Add an extra test for JDK-8292755


### Reviewers
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13719/head:pull/13719` \
`$ git checkout pull/13719`

Update a local copy of the PR: \
`$ git checkout pull/13719` \
`$ git pull https://git.openjdk.org/jdk.git pull/13719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13719`

View PR using the GUI difftool: \
`$ git pr show -t 13719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13719.diff">https://git.openjdk.org/jdk/pull/13719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13719#issuecomment-1527644599)