### PR TITLE
8307088: Allow the jdbc.drivers system property to be searchable

### DIFF
--- a/src/java.sql/share/classes/java/sql/DriverManager.java
+++ b/src/java.sql/share/classes/java/sql/DriverManager.java
@@ -52,7 +52,7 @@ import jdk.internal.reflect.Reflection;
  * As part of its initialization, the {@code DriverManager} class will
  * attempt to load available JDBC drivers by using:
  * <ul>
- * <li>The {@code jdbc.drivers} system property which contains a
+ * <li>The {@systemProperty jdbc.drivers} system property which contains a
  * colon separated list of fully qualified class names of JDBC drivers. Each
  * driver is loaded using the {@linkplain ClassLoader#getSystemClassLoader
  * system class loader}:

--- a/src/java.sql/share/classes/java/sql/DriverManager.java
+++ b/src/java.sql/share/classes/java/sql/DriverManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 20213, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/DriverManager.java
+++ b/src/java.sql/share/classes/java/sql/DriverManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 20213, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

Please review this trivial change which allows the` jdbc.drivers` system property to be searchable.

Best.
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307088](https://bugs.openjdk.org/browse/JDK-8307088): Allow the jdbc.drivers system property to be searchable


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13724/head:pull/13724` \
`$ git checkout pull/13724`

Update a local copy of the PR: \
`$ git checkout pull/13724` \
`$ git pull https://git.openjdk.org/jdk.git pull/13724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13724`

View PR using the GUI difftool: \
`$ git pr show -t 13724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13724.diff">https://git.openjdk.org/jdk/pull/13724.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13724#issuecomment-1527891652)