### PR TITLE
8307110: zero build broken after JDK-8304265

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -599,10 +599,11 @@ var getJibProfilesProfiles = function (input, common, data) {
         "linux-aarch64-zero": {
             target_os: "linux",
             target_cpu: "aarch64",
-            dependencies: ["devkit", "gtest"],
+            dependencies: ["devkit", "gtest", "libffi"],
             configure_args: concat(common.configure_args_64bit, [
                 "--with-zlib=system",
                 "--with-jvm-variants=zero",
+                "--with-libffi=" + input.get("libffi", "home_path"),
                 "--enable-libffi-bundling"
             ])
         },
@@ -611,10 +612,11 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: "linux",
             target_cpu: "x86",
             build_cpu: "x64",
-            dependencies: ["devkit", "gtest"],
+            dependencies: ["devkit", "gtest", "libffi"],
             configure_args:  concat(common.configure_args_32bit, [
                 "--with-zlib=system",
                 "--with-jvm-variants=zero",
+                "--with-libffi=" + input.get("libffi", "home_path"),
                 "--enable-libffi-bundling"
             ])
         }
@@ -1272,7 +1274,7 @@ var getJibProfilesDependencies = function (input, common) {
 
         libffi: {
             organization: common.organization,
-            module: "libffi-" + input.build_platform,
+            module: "libffi-" + input.target_platform,
             ext: "tar.gz",
             revision: "3.4.2+1.0"
         },

--- a/make/devkit/createLibffiBundle.sh
+++ b/make/devkit/createLibffiBundle.sh
@@ -81,6 +81,7 @@ cd $LIBFFI_DIR
 if [ ! -e $LIBFFI_DIR/configure ]; then
   bash ./autogen.sh
 fi
+# For Linux/x86, add --build=i686-pc-linux-gnu CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32
 bash ./configure --prefix=$INSTALL_DIR CC=$DEVKIT_DIR/bin/gcc CXX=$DEVKIT_DIR/bin/g++
 
 # Run with nice to keep system usable during build.
@@ -91,6 +92,7 @@ mkdir -p $IMAGE_DIR
 if [ ! -e $IMAGE_DIR/lib/libffi.so ]; then
   echo "Copying libffi.so* to image"
   mkdir -p $IMAGE_DIR/lib
+  # For Linux/x86 it's under /lib/ instead of /lib64/
   cp -a $INSTALL_DIR/lib64/libffi.so* $IMAGE_DIR/lib/
 fi
 if [ ! -e $IMAGE_DIR/include/ ]; then


### PR DESCRIPTION
These changes were accidentally omitted from https://github.com/openjdk/jdk/pull/13079

When building the zero VM on aarch64 and linux-x86 in our CI, compilation of `libFallbackLinker.c` can fail because the function `ffi_get_struct_offsets` can not be found.

The issue is that the libffi version found on some of our build systems is too old, and doesn't contain the required function. This patch switches away from using the libffi found on the system, and to using a pre-built libffi 3.4.2 package (as we already do for linux-x64-zero)

I tried getting the linux-x86-zero build working as well, but it's broken for other reasons. I've at least verified that it compiles `libFallbackLinker.c` when using libffi 3.4.2

Testing: building linux-aarrch64-zero & linux-aarrch64-zero-debug, as well as linux-x86-zero and linux-x86-zero-debug (the x86 builds failed for other reasons)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307110](https://bugs.openjdk.org/browse/JDK-8307110): zero build broken after JDK-8304265


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13728/head:pull/13728` \
`$ git checkout pull/13728`

Update a local copy of the PR: \
`$ git checkout pull/13728` \
`$ git pull https://git.openjdk.org/jdk.git pull/13728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13728`

View PR using the GUI difftool: \
`$ git pr show -t 13728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13728.diff">https://git.openjdk.org/jdk/pull/13728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13728#issuecomment-1528076893)