### PR TITLE
8305963: Typo in java.security.Security.getProperty

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -702,14 +702,15 @@ public final class Security {
      *
      * @param key the key of the property being retrieved.
      *
-     * @return the value of the security property corresponding to key.
+     * @return the string value of the security property, or null if there
+     *          is no property with that key.
      *
      * @throws  SecurityException
      *          if a security manager exists and its {@link
      *          java.lang.SecurityManager#checkPermission} method
      *          denies
      *          access to retrieve the specified security property value
-     * @throws  NullPointerException is key is {@code null}
+     * @throws  NullPointerException if key is {@code null}
      *
      * @see #setProperty
      * @see java.security.SecurityPermission

--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -702,7 +702,7 @@ public final class Security {
      *
      * @param key the key of the property being retrieved.
      *
-     * @return the string value of the security property, or null if there
+     * @return the value of the security property, or {@code null} if there
      *          is no property with that key.
      *
      * @throws  SecurityException


### PR DESCRIPTION
Fix type-o and update returns message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305963](https://bugs.openjdk.org/browse/JDK-8305963): Typo in java.security.Security.getProperty


### Reviewers
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**) ⚠️ Review applies to [e7046330](https://git.openjdk.org/jdk/pull/13729/files/e704633056e329fccb21704e7574a410b715eebc)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to [e7046330](https://git.openjdk.org/jdk/pull/13729/files/e704633056e329fccb21704e7574a410b715eebc)


### Contributors
 * Sean Coffey `<coffeys@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13729/head:pull/13729` \
`$ git checkout pull/13729`

Update a local copy of the PR: \
`$ git checkout pull/13729` \
`$ git pull https://git.openjdk.org/jdk.git pull/13729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13729`

View PR using the GUI difftool: \
`$ git pr show -t 13729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13729.diff">https://git.openjdk.org/jdk/pull/13729.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13729#issuecomment-1528103947)