### PR TITLE
8307135: java/awt/dnd/NotReallySerializableTest/NotReallySerializableTest.java failed

### DIFF
--- a/test/jdk/java/awt/dnd/NotReallySerializableTest/NotReallySerializableTest.java
+++ b/test/jdk/java/awt/dnd/NotReallySerializableTest/NotReallySerializableTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4187912
   @summary Test that some incorrectly written DnD code cannot hang the app
   @run main NotReallySerializableTest


### PR DESCRIPTION
The test uses the `DragSource.getDefaultDragSource()` which throws HeadlessException. The test should be marked as headful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307135](https://bugs.openjdk.org/browse/JDK-8307135): java/awt/dnd/NotReallySerializableTest/NotReallySerializableTest.java failed


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13733/head:pull/13733` \
`$ git checkout pull/13733`

Update a local copy of the PR: \
`$ git checkout pull/13733` \
`$ git pull https://git.openjdk.org/jdk.git pull/13733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13733`

View PR using the GUI difftool: \
`$ git pr show -t 13733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13733.diff">https://git.openjdk.org/jdk/pull/13733.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13733#issuecomment-1528280288)