### PR TITLE
8156916: intrinsify MethodHandles.arrayConstructor()

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -841,6 +841,9 @@ class InvokerBytecodeGenerator {
                 case ARRAY_LENGTH:
                     emitArrayLength(name);
                     continue;
+                case ARRAY_CONSTRUCTOR:
+                    emitArrayConstructor(name);
+                    continue;
                 case IDENTITY:
                     assert(name.arguments.length == 1);
                     emitPushArguments(name, 0);
@@ -889,6 +892,17 @@ class InvokerBytecodeGenerator {
     static final class BytecodeGenerationException extends RuntimeException {
         BytecodeGenerationException(Exception cause) {
             super(cause);
+        }
+    }
+
+    void emitArrayConstructor(Name name) {
+        var componentType = name.function.methodType().returnType().componentType();
+        var wrapper = Wrapper.forBasicType(componentType);
+        if (wrapper != Wrapper.OBJECT) {
+            mv.visitIntInsn(Opcodes.NEWARRAY, arrayTypeCode(wrapper));
+        } else {
+            assert isStaticallyNameable(componentType);
+            mv.visitTypeInsn(Opcodes.ANEWARRAY, getInternalName(componentType));
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4326,12 +4326,7 @@ return mh1;
      * @since 9
      */
     public static MethodHandle arrayConstructor(Class<?> arrayClass) throws IllegalArgumentException {
-        if (!arrayClass.isArray()) {
-            throw newIllegalArgumentException("not an array class: " + arrayClass.getName());
-        }
-        MethodHandle ani = MethodHandleImpl.getConstantHandle(MethodHandleImpl.MH_Array_newInstance).
-                bindTo(arrayClass.getComponentType());
-        return ani.asType(ani.type().changeReturnType(arrayClass));
+        return MethodHandleImpl.makeArrayElementAccessor(arrayClass, MethodHandleImpl.ArrayAccess.CONSTRUCT);
     }
 
     /**

--- a/test/jdk/java/lang/invoke/ArrayConstructorTest.java
+++ b/test/jdk/java/lang/invoke/ArrayConstructorTest.java
@@ -60,7 +60,7 @@ public class ArrayConstructorTest {
     @DataProvider
     static Object[][] arrayConstructorNegative() {
         return new Object[][]{
-                {String.class, IllegalArgumentException.class, "not an array class: java.lang.String"},
+                {String.class, IllegalArgumentException.class, "not an array: java.lang.String"},
                 {null, NullPointerException.class, null}
         };
     }

--- a/test/jdk/java/lang/invoke/ArrayConstructorTest.java
+++ b/test/jdk/java/lang/invoke/ArrayConstructorTest.java
@@ -60,7 +60,7 @@ public class ArrayConstructorTest {
     @DataProvider
     static Object[][] arrayConstructorNegative() {
         return new Object[][]{
-                {String.class, IllegalArgumentException.class, "not an array: java.lang.String"},
+                {String.class, IllegalArgumentException.class, "not an array: class java.lang.String"},
                 {null, NullPointerException.class, null}
         };
     }

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructor.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.invoke;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark assessing the performance of {@link MethodHandles#arrayConstructor}
+ * return value's invocation.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class MethodHandlesArrayConstructor {
+
+    /*
+     * Implementation notes:
+     *   - tests
+     *   - create arrays of different sizes, to emulate collector scenarios
+     *   - there are 4 kinds of code paths: primitive arrays, Object[], statically
+     *     invocable, non-statically invocable, and they may present different
+     */
+
+    private static final MethodHandle MH;
+    private static MethodHandle mh;
+
+    static {
+        MH = MethodHandles.arrayConstructor(String[].class);
+    }
+
+    @Setup
+    public void setup() {
+        mh = MethodHandles.arrayConstructor(String[].class);
+    }
+
+    @Benchmark
+    public Object baselineConstruct() {
+        return new String[8];
+    }
+
+    @Benchmark
+    public Object constantFoldConstruct() throws Throwable {
+        return (String[]) MH.invoke(8);
+    }
+
+    @Benchmark
+    public Object instanceConstruct() throws Throwable {
+        return (String[]) mh.invoke(8);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorCall.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorCall.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -47,8 +46,8 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(3)
-public class MethodHandlesArrayConstructor {
+@Fork(1)
+public class MethodHandlesArrayConstructorCall {
 
     /*
      * Implementation notes:
@@ -58,16 +57,20 @@ public class MethodHandlesArrayConstructor {
      *     invocable, non-statically invocable, and they may present different
      */
 
-    private static final MethodHandle MH;
-    private static MethodHandle mh;
+    private static final MethodHandle MH_STRING;
+    private static final MethodHandle MH_NON_INVOCABLE;
+    private MethodHandle mh;
+    private MethodHandle mhNonInvocable;
 
     static {
-        MH = MethodHandles.arrayConstructor(String[].class);
+        MH_STRING = MethodHandles.arrayConstructor(String[].class);
+        MH_NON_INVOCABLE = MethodHandles.arrayConstructor(MethodHandlesArrayConstructorCall[].class);
     }
 
     @Setup
     public void setup() {
         mh = MethodHandles.arrayConstructor(String[].class);
+        mhNonInvocable = MethodHandles.arrayConstructor(MethodHandlesArrayConstructorCall[].class);
     }
 
     @Benchmark
@@ -77,11 +80,21 @@ public class MethodHandlesArrayConstructor {
 
     @Benchmark
     public Object constantFoldConstruct() throws Throwable {
-        return (String[]) MH.invoke(8);
+        return (String[]) MH_STRING.invoke(8);
     }
 
     @Benchmark
     public Object instanceConstruct() throws Throwable {
         return (String[]) mh.invoke(8);
+    }
+
+    @Benchmark
+    public Object constantFoldNonInvocableConstruct() throws Throwable {
+        return (String[]) MH_NON_INVOCABLE.invoke(8);
+    }
+
+    @Benchmark
+    public Object instanceNonInvocableConstruct() throws Throwable {
+        return (String[]) mhNonInvocable.invoke(8);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorCall.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorCall.java
@@ -90,11 +90,11 @@ public class MethodHandlesArrayConstructorCall {
 
     @Benchmark
     public Object constantFoldNonInvocableConstruct() throws Throwable {
-        return (String[]) MH_NON_INVOCABLE.invoke(8);
+        return (MethodHandlesArrayConstructorCall[]) MH_NON_INVOCABLE.invoke(8);
     }
 
     @Benchmark
     public Object instanceNonInvocableConstruct() throws Throwable {
-        return (String[]) mhNonInvocable.invoke(8);
+        return (MethodHandlesArrayConstructorCall[]) mhNonInvocable.invoke(8);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorColdStart.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorColdStart.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.invoke;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark assessing the creation performance of {@link MethodHandles#arrayConstructor}
+ * on first invocation.
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 10, warmups = 0)
+public class MethodHandlesArrayConstructorColdStart {
+
+    @Benchmark
+    public MethodHandle testCreatePrimitive() {
+        return MethodHandles.arrayConstructor(int[].class);
+    }
+
+    @Benchmark
+    public MethodHandle testCreateObject() {
+        return MethodHandles.arrayConstructor(Object[].class);
+    }
+
+    @Benchmark
+    public MethodHandle testCreateInvocable() {
+        return MethodHandles.arrayConstructor(String[].class);
+    }
+
+    @Benchmark
+    public MethodHandle testCreateNonInvocable() {
+        return MethodHandles.arrayConstructor(MethodHandlesArrayConstructor[].class);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorColdStart.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructorColdStart.java
@@ -25,13 +25,10 @@ package org.openjdk.bench.java.lang.invoke;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -64,6 +61,6 @@ public class MethodHandlesArrayConstructorColdStart {
 
     @Benchmark
     public MethodHandle testCreateNonInvocable() {
-        return MethodHandles.arrayConstructor(MethodHandlesArrayConstructor[].class);
+        return MethodHandles.arrayConstructor(MethodHandlesArrayConstructorColdStart[].class);
     }
 }


### PR DESCRIPTION
Try to intrinsify MethodHandles.arrayConstructor for java.lang, java.lang.invoke, and java.util types, which InvokerBytecodeGenerator can refer to directly in a class constant.

In fact, the performance difference of Array.newInstance and anewarray is quite negligible per benchmark:
```
Benchmark                                                            Mode  Cnt     Score     Error  Units
MethodHandlesArrayConstructorCall.baselineConstruct                  avgt    5     3.467 ±   0.163  ns/op
MethodHandlesArrayConstructorCall.constantFoldConstruct              avgt    5     3.403 ±   0.070  ns/op
MethodHandlesArrayConstructorCall.constantFoldNonInvocableConstruct  avgt    5     3.445 ±   0.231  ns/op
MethodHandlesArrayConstructorCall.instanceConstruct                  avgt    5     4.034 ±   0.168  ns/op
MethodHandlesArrayConstructorCall.instanceNonInvocableConstruct      avgt    5     4.038 ±   0.104  ns/op
MethodHandlesArrayConstructorColdStart.testCreateInvocable             ss   10  1425.991 ± 308.216  us/op
MethodHandlesArrayConstructorColdStart.testCreateNonInvocable          ss   10  1401.480 ± 258.402  us/op
MethodHandlesArrayConstructorColdStart.testCreateObject                ss   10  1213.018 ± 166.522  us/op
MethodHandlesArrayConstructorColdStart.testCreatePrimitive             ss   10  1163.461 ± 178.549  us/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8156916](https://bugs.openjdk.org/browse/JDK-8156916): intrinsify MethodHandles.arrayConstructor()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13735/head:pull/13735` \
`$ git checkout pull/13735`

Update a local copy of the PR: \
`$ git checkout pull/13735` \
`$ git pull https://git.openjdk.org/jdk.git pull/13735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13735`

View PR using the GUI difftool: \
`$ git pr show -t 13735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13735.diff">https://git.openjdk.org/jdk/pull/13735.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13735#issuecomment-1528951733)