### PR TITLE
8307148: Incorrect Javadoc Tags in JDK

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -1162,7 +1162,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
      * @param dLen the length of the application data.
      * @param buf the buffer to write the two lengths into.
      *
-     * @note it is the caller's responsibility to provide an array large
+     * @implNote it is the caller's responsibility to provide an array large
      *      enough to hold the two longs.
      */
     private void authWriteLengths(long aLen, long dLen, byte[] buf) {

--- a/src/java.base/share/classes/java/text/CharacterIteratorFieldDelegate.java
+++ b/src/java.base/share/classes/java/text/CharacterIteratorFieldDelegate.java
@@ -101,7 +101,7 @@ class CharacterIteratorFieldDelegate implements Format.FieldDelegate {
      * Returns an {@code AttributedCharacterIterator} that can be used
      * to iterate over the resulting formatted String.
      *
-     * @pararm string Result of formatting.
+     * @param string Result of formatting.
      */
     public AttributedCharacterIterator getIterator(String string) {
         // Add the last AttributedCharacterIterator if necessary

--- a/src/java.base/share/classes/java/util/jar/Manifest.java
+++ b/src/java.base/share/classes/java/util/jar/Manifest.java
@@ -217,7 +217,7 @@ public class Manifest implements Cloneable {
     /**
      * Adds line breaks to enforce a maximum of 72 bytes per line.
      *
-     * @deprecation Replaced with {@link #println72}.
+     * @deprecated Replaced with {@link #println72}.
      */
     @Deprecated(since = "13")
     static void make72Safe(StringBuffer line) {

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1359,7 +1359,7 @@ public final class Unsafe {
      * by writing it to a <em>volatile</em> field, or storing it into a <em>final</em> field in constructor,
      * or issuing a {@link #storeFence} before publishing the reference.
      * <p>
-     * @implnote This method can only allocate primitive arrays, to avoid garbage reference
+     * @implNote This method can only allocate primitive arrays, to avoid garbage reference
      * elements that could break heap integrity.
      *
      * @param componentType array component type to allocate

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -829,7 +829,7 @@ public final class ModuleBootstrap {
      * --patch-modules options that are encoded in system properties.
      *
      * @param prefix the system property prefix
-     * @praam regex the regex for splitting the RHS of the option value
+     * @param regex the regex for splitting the RHS of the option value
      */
     private static Map<String, List<String>> decode(String prefix,
                                                     String regex,

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -940,7 +940,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
     }
 
     /**
-     * @deprecated.  Use java.net.Authenticator.setDefault() instead.
+     * @deprecated  Use java.net.Authenticator.setDefault() instead.
      */
     @Deprecated
     public static void setDefaultAuthenticator(HttpAuthenticator a) {

--- a/src/java.base/share/classes/sun/security/util/ManifestDigester.java
+++ b/src/java.base/share/classes/sun/security/util/ManifestDigester.java
@@ -79,7 +79,7 @@ public class ManifestDigester {
      * @param offset should point to the starting offset with in the
      * raw bytes of the next section.
      *
-     * @pos set by
+     * @param pos set by
      *
      * @return false if end of bytes has been reached, otherwise returns
      *          true

--- a/src/java.base/share/classes/sun/text/RuleBasedBreakIterator.java
+++ b/src/java.base/share/classes/sun/text/RuleBasedBreakIterator.java
@@ -734,7 +734,7 @@ public class RuleBasedBreakIterator extends BreakIterator {
     /**
      * Sets the iterator to refer to the first boundary position following
      * the specified position.
-     * @offset The position from which to begin searching for a break position.
+     * @param offset The position from which to begin searching for a break position.
      * @return The position of the first break after the current position.
      */
     @Override
@@ -778,7 +778,7 @@ public class RuleBasedBreakIterator extends BreakIterator {
     /**
      * Sets the iterator to refer to the last boundary position before the
      * specified position.
-     * @offset The position to begin searching for a break from.
+     * @param offset The position to begin searching for a break from.
      * @return The position of the last boundary before the starting position.
      */
     @Override

--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
@@ -119,7 +119,7 @@ abstract class AbstractMidiDevice implements MidiDevice, ReferenceCountingDevice
      * these objects is necessary to be able to decide later (when it comes to closing) if
      * R/T's are ones that opened the device implicitly.
      *
-     * @object The Receiver or Transmitter instance that triggered this implicit open.
+     * @param object The Receiver or Transmitter instance that triggered this implicit open.
      */
     private void openInternal(Object object) throws MidiUnavailableException {
         synchronized(this) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/AiffFileReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AiffFileReader.java
@@ -170,7 +170,7 @@ public final class AiffFileReader extends SunFileReader {
     /**
      * read_ieee_extended
      * Extended precision IEEE floating-point conversion routine.
-     * @argument DataInputStream
+     * @param dis
      * @return double
      * @throws IOException
      */

--- a/src/java.desktop/share/classes/com/sun/media/sound/AiffFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AiffFileWriter.java
@@ -390,8 +390,8 @@ public final class AiffFileWriter extends SunFileWriter {
 
     /**
      * Extended precision IEEE floating-point conversion routine.
-     * @argument DataOutputStream
-     * @argument double
+     * @param dos 
+     * @param f
      * @throws IOException
      */
     private void write_ieee_extended(DataOutputStream dos, float f) throws IOException {

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -562,7 +562,7 @@ public class Container extends Component {
      * index without calling removeNotify.
      * Note: Should be called while holding treeLock
      * Returns whether removeNotify was invoked
-     * @since: 1.5
+     * @since 1.5
      */
     private boolean removeDelicately(Component comp, Container newParent, int newIndex) {
         checkTreeLock();
@@ -687,7 +687,7 @@ public class Container extends Component {
      * removeNotify on the component. Since removeNotify destroys native window this might (not)
      * be required. For example, if new container and old containers are the same we don't need to
      * destroy native window.
-     * @since: 1.5
+     * @since 1.5
      */
     private static boolean isRemoveNotifyNeeded(Component comp, Container oldContainer, Container newContainer) {
         if (oldContainer == null) { // Component didn't have parent - no removeNotify

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -1009,7 +1009,7 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
          * the specified component differ between focused and unfocused states.
          * If the color differ the component will then repaint itself.
          *
-         * @comp the component to check
+         * @param comp the component to check
          */
         private void repaintIfBackgroundsDiffer(JComponent comp) {
             ComponentUI ui = comp.getUI();

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -1654,7 +1654,7 @@ class AccessibleHTML implements Accessible {
              *
              * @see #getAccessibleParent
              * @see #getAccessibleChildrenCount
-             * @gsee #getAccessibleChild
+             * @see #getAccessibleChild
              */
             public int getAccessibleIndexInParent() {
                 return elementInfo.getIndexInParent();

--- a/src/java.desktop/share/classes/sun/awt/LightweightFrame.java
+++ b/src/java.desktop/share/classes/sun/awt/LightweightFrame.java
@@ -141,7 +141,7 @@ public abstract class LightweightFrame extends Frame {
      *
      * @return the scale factor
      * @see #notifyDisplayChanged(int)
-     * @Deprecated replaced by {@link #getScaleFactorX()} and
+     * @deprecated replaced by {@link #getScaleFactorX()} and
      * {@link #getScaleFactorY}
      */
     @Deprecated(since = "9")
@@ -171,7 +171,7 @@ public abstract class LightweightFrame extends Frame {
      * Called when display of the hosted frame is changed.
      *
      * @param scaleFactor the scale factor
-     * @Deprecated replaced by {@link #notifyDisplayChanged(double, double)}
+     * @deprecated replaced by {@link #notifyDisplayChanged(double, double)}
      */
     @Deprecated(since = "9")
     public abstract void notifyDisplayChanged(int scaleFactor);

--- a/src/java.desktop/share/classes/sun/awt/im/InputContext.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputContext.java
@@ -444,7 +444,7 @@ public class InputContext extends java.awt.im.InputContext
      * input method window.
      *
      * @param source the component losing the focus
-     * @isTemporary whether the focus change is temporary
+     * @param isTemporary whether the focus change is temporary
      */
     private void focusLost(Component source, boolean isTemporary) {
 

--- a/src/java.desktop/share/classes/sun/swing/LightweightContent.java
+++ b/src/java.desktop/share/classes/sun/swing/LightweightContent.java
@@ -117,7 +117,7 @@ public interface LightweightContent {
      * @param height the logical height of the image
      * @param linestride the line stride of the pixel buffer
      * @param scale the scale factor of the pixel buffer
-     * @Deprecated replaced by
+     * @deprecated replaced by
      * {@link #imageBufferReset(int[],int,int,int,int,int,double,double)}
      */
     @Deprecated(since = "9")

--- a/src/java.rmi/share/classes/java/rmi/server/LogStream.java
+++ b/src/java.rmi/share/classes/java/rmi/server/LogStream.java
@@ -63,7 +63,7 @@ public class LogStream extends PrintStream {
      * private, users must have a LogStream created through the "log"
      * method.
      * @param name string identifying messages from this log
-     * @out output stream that log messages will be sent to
+     * @param out output stream that log messages will be sent to
      * @since 1.1
      * @deprecated no replacement
      */

--- a/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
@@ -466,8 +466,8 @@ public class ReliableLog {
      * Generates a version filename prepended with the stable storage
      * directory path with the version number as a suffix.
      *
-     * @param name version file name
-     * @thisversion a version number
+     * @param prefix version file name prefix
+     * @param ver a version number
      */
     private String versionName(String prefix, int ver) {
         ver = (ver == 0) ? version : ver;

--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -259,7 +259,7 @@ public final class ProviderList {
      * implementation.
      * @param p the provider whose classloader must be used for
      * instantiating the desired MechanismFactory
-     * @ param className the name of the MechanismFactory class
+     * @param className the name of the MechanismFactory class
      * @throws GSSException If some error occurs when trying to
      * instantiate this MechanismFactory.
      */

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MultiHashtable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MultiHashtable.java
@@ -46,7 +46,7 @@ public final class MultiHashtable<K,V> {
      * @param key key with which the specified value is to be associated
      * @param value value to be added to a set that is associated with the specified key
      * @return the set that is associated with the specified key.
-     * @throw UnsupportedOperationException is the MultiHashtable is not modifiable.
+     * @throws UnsupportedOperationException is the MultiHashtable is not modifiable.
      */
     public Set<V> put(K key, V value) {
         if (modifiable) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/PropertyManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/PropertyManager.java
@@ -111,7 +111,7 @@ public class PropertyManager {
     /**
      * Initializes reader properties.
      *
-     * @implNote: StAX defined namespace rather than Xerces' should be used.
+     * @implNote StAX defined namespace rather than Xerces' should be used.
      */
     private void initConfigurableReaderProperties() {
         //spec default values

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
@@ -1675,7 +1675,7 @@ public class XMLEntityScanner implements XMLLocator  {
      * @param notify       Determine whether to notify listeners of
      *                     the event
      *
-     * @returns Returns true if the entity changed as a result of this
+     * @return Returns true if the entity changed as a result of this
      *          load operation.
      */
     final boolean load(int offset, boolean changeEntity, boolean notify)
@@ -2124,7 +2124,7 @@ public class XMLEntityScanner implements XMLLocator  {
      * Further, it may put them in a cache for later process as needed, for example
      * as specified in 3.3.3 Attribute-Value Normalization.
      *
-     * @ImplNote this method does not limit to processing external parsed entities
+     * @implNote this method does not limit to processing external parsed entities
      * as 2.11 required. It handles all cases where newlines need to be processed.
      *
      * @param buffer the current content buffer

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/XSSimpleType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/XSSimpleType.java
@@ -176,7 +176,7 @@ public interface XSSimpleType extends XSSimpleTypeDefinition {
      *          But Andy thinks XPATH potentially needs this compare() method.
      *
      * @param value1  the first value
-     * @prarm value2  the second value
+     * @param value2  the second value
      * @return        > 0 if value1 > value2
      *                = 0 if value1 == value2
      *                < = if value1 < value2

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM2.java
@@ -3238,7 +3238,7 @@ public class SAX2DTM2 extends SAX2DTM
     /**
      * Return the next namespace node following the given base node.
      *
-     * @baseID The node identity of the base node, which can be an
+     * @param baseID The node identity of the base node, which can be an
      * element, attribute or namespace node.
      * @return The namespace node immediately following the base node.
      */

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/XSLOutputAttributes.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/XSLOutputAttributes.java
@@ -226,7 +226,7 @@ interface XSLOutputAttributes {
      * <li> "{http://xml.apache.org/xalan}indent-amount"
      * <li> "{http://xml.apache.org/xalan}line-separator"
      * </ul>
-     * @val The non-default value of the parameter
+     * @param val The non-default value of the parameter
      */
     public void setOutputProperty(String name, String val);
 
@@ -241,7 +241,7 @@ interface XSLOutputAttributes {
      * <li> "{http://xml.apache.org/xalan}indent-amount"
      * <li> "{http://xml.apache.org/xalan}line-separator"
      * </ul>
-     * @val The default value of the parameter
+     * @param val The default value of the parameter
      */
     public void setOutputPropertyDefault(String name, String val);
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
@@ -1614,7 +1614,7 @@ final class DOM3TreeWalker {
      * appropriate well-formedness error.
      *
      * @param data The contents of the comment node
-     * @parent The parent of the EntityReference Node
+     * @param parent The parent of the EntityReference Node
      */
     protected void isEntityReferneceWellFormed(EntityReference node) {
         // Is the EntityReference name a valid XML name

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
@@ -834,8 +834,7 @@ public class XPathParser
   }
 
   /**
-   *
-   * @returns an Object which is either a String, a Number, a Boolean, or a vector
+   * Returns an Object which is either a String, a Number, a Boolean, or a vector
    * of nodes.
    *
    * EqualityExpr  ::=  RelationalExpr
@@ -891,8 +890,7 @@ public class XPathParser
   }
 
   /**
-   * .
-   * @returns an Object which is either a String, a Number, a Boolean, or a vector
+   * Returns an Object which is either a String, a Number, a Boolean, or a vector
    * of nodes.
    *
    * RelationalExpr  ::=  AdditiveExpr
@@ -1614,7 +1612,7 @@ public class XPathParser
    * | RelativeLocationPath '/' Step
    * | AbbreviatedRelativeLocationPath
    *
-   * @returns true if, and only if, a RelativeLocationPath was matched
+   * @return true if, and only if, a RelativeLocationPath was matched
    *
    * @throws TransformerException
    */
@@ -1646,7 +1644,7 @@ public class XPathParser
    * Step    ::=    Basis Predicate
    * | AbbreviatedStep
    *
-   * @returns false if step was empty (or only a '/'); true, otherwise
+   * @return false if step was empty (or only a '/'); true, otherwise
    *
    * @throws TransformerException
    */

--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/XMLEntityStorage.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/XMLEntityStorage.java
@@ -249,7 +249,7 @@ public class XMLEntityStorage {
      * Checks whether an entity given by name is external.
      *
      * @param entityName The name of the entity to check.
-     * @returns True if the entity is external, false otherwise
+     * @return true if the entity is external; false otherwise
      *           (including when the entity is not declared).
      */
     public boolean isExternalEntity(String entityName) {
@@ -266,7 +266,7 @@ public class XMLEntityStorage {
      * // in the external subset.
      *
      * @param entityName The name of the entity to check.
-     * @returns True if the entity was declared in the external subset, false otherwise
+     * @return true if the entity was declared in the external subset; false otherwise
      *           (including when the entity is not declared).
      */
     public boolean isEntityDeclInExternalSubset(String entityName) {
@@ -319,7 +319,7 @@ public class XMLEntityStorage {
      * Checks whether an entity given by name is unparsed.
      *
      * @param entityName The name of the entity to check.
-     * @returns True if the entity is unparsed, false otherwise
+     * @return true if the entity is unparsed; false otherwise
      *          (including when the entity is not declared).
      */
     public boolean isUnparsedEntity(String entityName) {
@@ -335,7 +335,7 @@ public class XMLEntityStorage {
      * Checks whether an entity given by name is declared.
      *
      * @param entityName The name of the entity to check.
-     * @returns True if the entity is declared, false otherwise.
+     * @return true if the entity is declared; false otherwise.
      */
     public boolean isDeclaredEntity(String entityName) {
 

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogImpl.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogImpl.java
@@ -227,7 +227,7 @@ class CatalogImpl extends GroupEntry implements Catalog {
     /**
      * Gets the parent of this catalog.
      *
-     * @returns The parent catalog
+     * @return The parent catalog
      */
     public Catalog getParent() {
         return this.parent;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/BytecodeFrame.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/BytecodeFrame.java
@@ -286,7 +286,7 @@ public final class BytecodeFrame extends BytecodePosition {
      *
      * @param i the local variable to query
      * @return the kind of local variable {@code i}
-     * @throw {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numLocals}
+     * @throws {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numLocals}
      */
     public JavaKind getLocalValueKind(int i) {
         Objects.checkIndex(i, numLocals);
@@ -298,7 +298,7 @@ public final class BytecodeFrame extends BytecodePosition {
      *
      * @param i the local variable to query
      * @return the kind of stack slot {@code i}
-     * @throw {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numStack}
+     * @throws {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numStack}
      */
     public JavaKind getStackValueKind(int i) {
         Objects.checkIndex(i, numStack);
@@ -310,7 +310,7 @@ public final class BytecodeFrame extends BytecodePosition {
      *
      * @param i the local variable index
      * @return the value that can be used to reconstruct the local's current value
-     * @throw {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numLocals}
+     * @throws {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numLocals}
      */
     public JavaValue getLocalValue(int i) {
         Objects.checkIndex(i, numLocals);
@@ -322,7 +322,7 @@ public final class BytecodeFrame extends BytecodePosition {
      *
      * @param i the stack index
      * @return the value that can be used to reconstruct the stack slot's current value
-     * @throw {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numStack}
+     * @throws {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numStack}
      */
     public JavaValue getStackValue(int i) {
         Objects.checkIndex(i, numStack);
@@ -334,7 +334,7 @@ public final class BytecodeFrame extends BytecodePosition {
      *
      * @param i the lock index
      * @return the value that can be used to reconstruct the lock's current value
-     * @throw {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numLocks}
+     * @throws {@link IndexOutOfBoundsException} if {@code i < 0 || i >= this.numLocks}
      */
     public JavaValue getLockValue(int i) {
         Objects.checkIndex(i, numLocks);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Graph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Graph.java
@@ -85,7 +85,7 @@ public final class Graph<T> {
      * Returns a new Graph after transitive reduction.  All edges in
      * the given g takes precedence over this graph.
      *
-     * @throw IllegalArgumentException g must be a subgraph this graph
+     * @throws IllegalArgumentException g must be a subgraph this graph
      */
     public Graph<T> reduce(Graph<T> g) {
         boolean subgraph = nodes.containsAll(g.nodes) &&


### PR DESCRIPTION
The JDK has several Javadoc comments with incorrect tags. For example, in several classes, the @param tag was omitted or misspelled, such as "@object ..." instead of "@param object".

In other cases, @implNote is misspelled as @note or @ImplNote or @implnote.

We also found cases of @returns instead of @return and @throw instead of @throws.

Lastly, there are tags using @deprecation and @Deprecation instead of @deprecated.

This issue might be related in part to https://bugs.openjdk.org/browse/JDK-8210241

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307148](https://bugs.openjdk.org/browse/JDK-8307148): Incorrect Javadoc Tags in JDK (**Bug** - P5)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13736/head:pull/13736` \
`$ git checkout pull/13736`

Update a local copy of the PR: \
`$ git checkout pull/13736` \
`$ git pull https://git.openjdk.org/jdk.git pull/13736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13736`

View PR using the GUI difftool: \
`$ git pr show -t 13736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13736.diff">https://git.openjdk.org/jdk/pull/13736.diff</a>

</details>
