### PR TITLE
8307150: RISC-V: Remove remaining StoreLoad barrier with UseCondCardMark for Serial/Parallel GC

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shared/cardTableBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/cardTableBarrierSetAssembler_riscv.cpp
@@ -49,7 +49,6 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
 
   if (UseCondCardMark) {
     Label L_already_dirty;
-    __ membar(MacroAssembler::StoreLoad);
     __ lbu(t1,  Address(tmp));
     __ beqz(t1, L_already_dirty);
     __ sb(zr, Address(tmp));


### PR DESCRIPTION
Hi, 

can I have reviews for this change that removes the remaining StoreLoad barrier for RISC-V port in `CardTableBarrierSetAssembler::store_check` just like [JDK-8261309](https://bugs.openjdk.org/browse/JDK-8261309) did?

After the removal of CMS, this barrier is no longer needed.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307150](https://bugs.openjdk.org/browse/JDK-8307150): RISC-V: Remove remaining StoreLoad barrier with UseCondCardMark for Serial/Parallel GC


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13739/head:pull/13739` \
`$ git checkout pull/13739`

Update a local copy of the PR: \
`$ git checkout pull/13739` \
`$ git pull https://git.openjdk.org/jdk.git pull/13739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13739`

View PR using the GUI difftool: \
`$ git pr show -t 13739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13739.diff">https://git.openjdk.org/jdk/pull/13739.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13739#issuecomment-1529374189)