### PR TITLE
8307163: JLONG_FORMAT_SPECIFIER should be updated on Windows

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -102,7 +102,7 @@ inline int g_isfinite(jfloat  f)                 { return _finite(f); }
 inline int g_isfinite(jdouble f)                 { return _finite(f); }
 
 // Formatting.
-#define FORMAT64_MODIFIER "I64"
+#define FORMAT64_MODIFIER "ll"
 
 #define offset_of(klass,field) offsetof(klass,field)
 

--- a/src/java.base/windows/native/libjli/java_md.h
+++ b/src/java.base/windows/native/libjli/java_md.h
@@ -39,7 +39,7 @@
 #define MAXPATHLEN      MAX_PATH
 #define MAXNAMELEN      MAX_PATH
 
-#define JLONG_FORMAT_SPECIFIER "%I64d"
+#define JLONG_FORMAT_SPECIFIER "%lld"
 
 /*
  * Function prototypes.


### PR DESCRIPTION
Windows no longer uses I64d anywhere in their newer compilers, instead using the conforming lld specifiers. Minor cleanup here in JLI code to reflect that

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307163](https://bugs.openjdk.org/browse/JDK-8307163): JLONG_FORMAT_SPECIFIER should be updated on Windows


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13740/head:pull/13740` \
`$ git checkout pull/13740`

Update a local copy of the PR: \
`$ git checkout pull/13740` \
`$ git pull https://git.openjdk.org/jdk.git pull/13740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13740`

View PR using the GUI difftool: \
`$ git pr show -t 13740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13740.diff">https://git.openjdk.org/jdk/pull/13740.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13740#issuecomment-1529938108)