### PR TITLE
JDK-8307123: Fix deprecation warnings in DPrinter

### DIFF
--- a/test/langtools/tools/javac/lib/DPrinter.java
+++ b/test/langtools/tools/javac/lib/DPrinter.java
@@ -601,6 +601,7 @@ public class DPrinter {
     protected Object getField(Object o, Class<?> clazz, String name) {
         try {
             Field f = clazz.getDeclaredField(name);
+            @SuppressWarnings("deprecation")
             boolean prev = f.isAccessible();
             f.setAccessible(true);
             try {
@@ -618,6 +619,7 @@ public class DPrinter {
     protected Object callMethod(Object o, Class<?> clazz, String name) {
         try {
             Method m = clazz.getDeclaredMethod(name);
+            @SuppressWarnings("deprecation")
             boolean prev = m.isAccessible();
             m.setAccessible(true);
             try {


### PR DESCRIPTION
Please review a trivial test clean to fix some deprecation warnings in the test/langtools DPrinter class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307123](https://bugs.openjdk.org/browse/JDK-8307123): Fix deprecation warnings in DPrinter


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13747/head:pull/13747` \
`$ git checkout pull/13747`

Update a local copy of the PR: \
`$ git checkout pull/13747` \
`$ git pull https://git.openjdk.org/jdk.git pull/13747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13747`

View PR using the GUI difftool: \
`$ git pr show -t 13747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13747.diff">https://git.openjdk.org/jdk/pull/13747.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13747#issuecomment-1530511612)