### PR TITLE
8303942: FileMapInfo::write_bytes aborts on a short os::write

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -771,9 +771,9 @@ FILE* os::fdopen(int fd, const char* mode) {
   return ::fdopen(fd, mode);
 }
 
-ssize_t os::write(int fd, const void *buf, unsigned int nBytes) {
+ssize_t os::pd_write(int fd, const void *buf, unsigned int nBytes) {
   ssize_t res;
-  RESTARTABLE(::write(fd, buf, (size_t) nBytes), res);
+  RESTARTABLE(::write(fd, buf, (size_t)nBytes), res);
   return res;
 }
 

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -104,20 +104,14 @@ static void save_memory_to_file(char* addr, size_t size) {
   } else {
     ssize_t result;
 
-    for (size_t remaining = size; remaining > 0;) {
-
-      result = os::write(fd, addr, remaining);
-      if (result == OS_ERR) {
-        if (PrintMiscellaneous && Verbose) {
-          warning("Could not write Perfdata save file: %s: %s\n",
-                  destfile, os::strerror(errno));
-        }
-        break;
+    result = os::write(fd, addr, size);
+    if (result == OS_ERR) {
+      if (PrintMiscellaneous && Verbose) {
+        warning("Could not write Perfdata save file: %s: %s\n",
+                destfile, os::strerror(errno));
       }
-
-      remaining -= (size_t)result;
-      addr += result;
     }
+
 
     result = ::close(fd);
     if (PrintMiscellaneous && Verbose) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4771,8 +4771,8 @@ FILE* os::fdopen(int fd, const char* mode) {
   return ::_fdopen(fd, mode);
 }
 
-ssize_t os::write(int fd, const void *buf, unsigned int nBytes) {
-  return ::write(fd, buf, nBytes);
+ssize_t os::pd_write(int fd, const void *buf, unsigned int nBytes) {
+  return ::write(fd, buf, (size_t)nBytes);
 }
 
 void os::exit(int num) {

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -361,7 +361,6 @@ void SharedClassPathEntry::set_name(const char* name, TRAPS) {
 }
 
 void SharedClassPathEntry::copy_from(SharedClassPathEntry* ent, ClassLoaderData* loader_data, TRAPS) {
-  assert(ent != NULL, "sanity");
   _type = ent->_type;
   _is_module_path = ent->_is_module_path;
   _timestamp = ent->_timestamp;
@@ -1686,7 +1685,7 @@ size_t FileMapInfo::write_heap_region(ArchiveHeapInfo* heap_info) {
 void FileMapInfo::write_bytes(const void* buffer, size_t nbytes) {
   assert(_file_open, "must be");
   ssize_t n = os::write(_fd, buffer, (unsigned int)nbytes);
-  if (n < 0 || (size_t)n != nbytes) {
+  if (n < 0) {
     // If the shared archive is corrupted, close it and remove it.
     close();
     remove(_full_path);

--- a/src/hotspot/share/jfr/writers/jfrStreamWriterHost.inline.hpp
+++ b/src/hotspot/share/jfr/writers/jfrStreamWriterHost.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,17 +74,13 @@ inline void StreamWriterHost<Adapter, AP>::write_bytes(void* dest, const void* b
 template <typename Adapter, typename AP>
 inline void StreamWriterHost<Adapter, AP>::write_bytes(const u1* buf, intptr_t len) {
   assert(len >= 0, "invariant");
-  while (len > 0) {
-    const unsigned int nBytes = len > INT_MAX ? INT_MAX : (unsigned int)len;
-    const ssize_t num_written = os::write(_fd, buf, nBytes);
-    if (errno == ENOSPC) {
-      JfrJavaSupport::abort("Failed to write to jfr stream because no space left on device", false);
-    }
-    guarantee(num_written > 0, "Nothing got written, or os::write() failed");
-    _stream_pos += num_written;
-    len -= num_written;
-    buf += num_written;
+  const unsigned int nBytes = len > INT_MAX ? INT_MAX : (unsigned int)len;
+  const ssize_t num_written = os::write(_fd, buf, nBytes);
+  if (errno == ENOSPC) {
+    JfrJavaSupport::abort("Failed to write to jfr stream because no space left on device", false);
   }
+  guarantee(num_written > 0, "Nothing got written, or os::write() failed");
+  _stream_pos += num_written;
 }
 
 template <typename Adapter, typename AP>

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1378,6 +1378,22 @@ bool os::file_exists(const char* filename) {
   return os::stat(filename, &statbuf) == 0;
 }
 
+ssize_t os::write(int fd, const void *buf, unsigned int nBytes) {
+  ssize_t res;
+  size_t len = nBytes;
+  while (len > 0) {
+    res = pd_write(fd, buf, (unsigned int)len);
+    if (res < 0) {
+      return res;
+    }
+    buf = (void *)((char *)buf + len);
+    len -= res;
+  }
+
+  return res;
+}
+
+
 // Splits a path, based on its separator, the number of
 // elements is returned back in "elements".
 // file_name_length is used as a modifier for each path's

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -229,6 +229,7 @@ class os: AllStatic {
   // Get summary strings for system information in buffer provided
   static void  get_summary_cpu_info(char* buf, size_t buflen);
   static void  get_summary_os_info(char* buf, size_t buflen);
+  static ssize_t pd_write(int fd, const void *buf, unsigned int nBytes);
 
   static void initialize_initial_active_processor_count();
 

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -55,14 +55,9 @@ char const* FileWriter::write_buf(char* buf, ssize_t size) {
   assert(_fd >= 0, "Must be open");
   assert(size > 0, "Must write at least one byte");
 
-  while (size > 0) {
-    ssize_t n = os::write(_fd, buf, (uint) size);
-    if (n <= 0) {
-      return os::strerror(errno);
-    }
-
-    buf += n;
-    size -= n;
+  ssize_t n = os::write(_fd, buf, (uint)size);
+  if (n <= 0) {
+    return os::strerror(errno);
   }
 
   return nullptr;


### PR DESCRIPTION
`os::write` is implemented using loops until the whole bytes are written. All uses of `os::write` in a loop are changed to single call. 
Platform dependent versions of the `os::write` are also renamed and moved to private sections accordingly.
