### PR TITLE
JDK-8068925: Add @Override in javax.tools classes

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/DiagnosticCollector.java
+++ b/src/java.compiler/share/classes/javax/tools/DiagnosticCollector.java
@@ -47,6 +47,7 @@ public final class DiagnosticCollector<S> implements DiagnosticListener<S> {
      */
     public DiagnosticCollector() {}
 
+    @Override
     public void report(Diagnostic<? extends S> diagnostic) {
         Objects.requireNonNull(diagnostic);
         diagnostics.add(diagnostic);

--- a/src/java.compiler/share/classes/javax/tools/DocumentationTool.java
+++ b/src/java.compiler/share/classes/javax/tools/DocumentationTool.java
@@ -191,8 +191,10 @@ public interface DocumentationTool extends Tool, OptionChecker {
          */
         SNIPPET_PATH;
 
+        @Override
         public String getName() { return name(); }
 
+        @Override
         public boolean isOutputLocation() {
             switch (this) {
                 case DOCUMENTATION_OUTPUT:

--- a/src/java.compiler/share/classes/javax/tools/JavaCompiler.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaCompiler.java
@@ -168,6 +168,7 @@ import javax.annotation.processing.Processor;
  *       JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
  *       StandardJavaFileManager stdFileManager = compiler.getStandardFileManager(null, null, null);
  *       JavaFileManager fileManager = new ForwardingJavaFileManager(stdFileManager) {
+ *           @Override
  *           public void flush() throws IOException {
  *               logger.entering(StandardJavaFileManager.class.getName(), "flush");
  *               super.flush();

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -68,10 +68,12 @@ public class SimpleJavaFileObject implements JavaFileObject {
         this.kind = kind;
     }
 
+    @Override
     public URI toUri() {
         return uri;
     }
 
+    @Override
     public String getName() {
         return toUri().getPath();
     }
@@ -82,6 +84,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * behavior as long as the contract of {@link FileObject} is
      * obeyed.
      */
+    @Override
     public InputStream openInputStream() throws IOException {
         throw new UnsupportedOperationException();
     }
@@ -92,6 +95,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * behavior as long as the contract of {@link FileObject} is
      * obeyed.
      */
+    @Override
     public OutputStream openOutputStream() throws IOException {
         throw new UnsupportedOperationException();
     }
@@ -107,14 +111,13 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * @throws UnsupportedOperationException {@inheritDoc}
      * @throws IOException {@inheritDoc}
      */
+    @Override
     public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
         CharSequence charContent = getCharContent(ignoreEncodingErrors);
         if (charContent == null)
             throw new UnsupportedOperationException();
-        if (charContent instanceof CharBuffer) {
-            CharBuffer buffer = (CharBuffer)charContent;
-            if (buffer.hasArray())
-                return new CharArrayReader(buffer.array());
+        if (charContent instanceof CharBuffer buffer && buffer.hasArray()) {
+            return new CharArrayReader(buffer.array());
         }
         return new StringReader(charContent.toString());
     }
@@ -125,6 +128,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * behavior as long as the contract of {@link FileObject} is
      * obeyed.
      */
+    @Override
     public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
         throw new UnsupportedOperationException();
     }
@@ -139,6 +143,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * @throws UnsupportedOperationException {@inheritDoc}
      * @throws IOException {@inheritDoc}
      */
+    @Override
     public Writer openWriter() throws IOException {
         return new OutputStreamWriter(openOutputStream());
     }
@@ -150,6 +155,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      *
      * @return {@code 0L}
      */
+    @Override
     public long getLastModified() {
         return 0L;
     }
@@ -161,6 +167,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      *
      * @return {@code false}
      */
+    @Override
     public boolean delete() {
         return false;
     }
@@ -168,6 +175,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
     /**
      * @return {@code this.kind}
      */
+    @Override
     public Kind getKind() {
         return kind;
     }
@@ -186,6 +194,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * <p>Subclasses can change this behavior as long as the contract
      * of {@link JavaFileObject} is obeyed.
      */
+    @Override
     public boolean isNameCompatible(String simpleName, Kind kind) {
         String baseName = simpleName + kind.extension;
         return kind.equals(getKind())
@@ -198,6 +207,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * change this behavior as long as the contract of
      * {@link JavaFileObject} is obeyed.
      */
+    @Override
     public NestingKind getNestingKind() { return null; }
 
     /**
@@ -205,6 +215,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * change this behavior as long as the contract of
      * {@link JavaFileObject} is obeyed.
      */
+    @Override
     public Modifier getAccessLevel()  { return null; }
 
     @Override


### PR DESCRIPTION
Please review a simple update to add `@Override` annotations where appropriate in the `javax.tools` API, and one other minor opportunistic cleanup to use an `instanceof` pattern.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8068925](https://bugs.openjdk.org/browse/JDK-8068925): Add @Override in javax.tools classes


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13766/head:pull/13766` \
`$ git checkout pull/13766`

Update a local copy of the PR: \
`$ git checkout pull/13766` \
`$ git pull https://git.openjdk.org/jdk.git pull/13766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13766`

View PR using the GUI difftool: \
`$ git pr show -t 13766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13766.diff">https://git.openjdk.org/jdk/pull/13766.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13766#issuecomment-1532293911)