### PR TITLE
8307181: MemoryLayout.structLayout uses undocumented strict alignment constraints

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -739,6 +739,28 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @return a struct layout with the given member layouts.
      * @throws IllegalArgumentException if the sum of the {@linkplain #bitSize() bit sizes} of the member layouts
      * overflows.
+     * @throws IllegalArgumentException if a member layouts in {@code elements} occurs at an offset (relative to the start
+     * of the struct layout) which is not compatible with its alignment constraint.
+     *
+     * @apiNote This factory does not automatically align element layouts, by inserting additional {@linkplain PaddingLayout
+     * padding layout} elements. As such, the following struct layout creation will fail with an exception:
+     *
+     * {@snippet lang = java:
+     * structLayout(JAVA_SHORT, JAVA_INT)
+     * }
+     *
+     * To avoid the exception, clients can either insert additional padding layout elements:
+     *
+     * {@snippet lang = java:
+     * structLayout(JAVA_SHORT, MemoryLayout.ofPadding(16), JAVA_INT)
+     * }
+     *
+     * Or, alternatively, they can use a member layout which features a smaller alignment constraint. This will result
+     * in a <em>packed</em> struct layout:
+     *
+     * {@snippet lang = java:
+     * structLayout(JAVA_SHORT, JAVA_INT.withBitAlignment(16))
+     * }
      */
     static StructLayout structLayout(MemoryLayout... elements) {
         Objects.requireNonNull(elements);

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -739,7 +739,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @return a struct layout with the given member layouts.
      * @throws IllegalArgumentException if the sum of the {@linkplain #bitSize() bit sizes} of the member layouts
      * overflows.
-     * @throws IllegalArgumentException if a member layouts in {@code elements} occurs at an offset (relative to the start
+     * @throws IllegalArgumentException if a member layout in {@code elements} occurs at an offset (relative to the start
      * of the struct layout) which is not compatible with its alignment constraint.
      *
      * @apiNote This factory does not automatically align element layouts, by inserting additional {@linkplain PaddingLayout


### PR DESCRIPTION
This patch adds documentation for the behavior of the `MemoryLayout::structLayout` factory.

This factory throws an `IllegalArgumentException` if one of the member layouts passed to it occurs at an offset within the struct that is not aligned.

As part of this patch, I've also added some api notes on how to use this factory when unaligned elements are present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8307335](https://bugs.openjdk.org/browse/JDK-8307335) to be approved

### Issues
 * [JDK-8307181](https://bugs.openjdk.org/browse/JDK-8307181): MemoryLayout.structLayout uses undocumented strict alignment constraints
 * [JDK-8307335](https://bugs.openjdk.org/browse/JDK-8307335): MemoryLayout.structLayout uses undocumented strict alignment constraints (**CSR**)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [592a3db6](https://git.openjdk.org/jdk/pull/13770/files/592a3db63b21cece89421dc673796b9cff84c472)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13770/head:pull/13770` \
`$ git checkout pull/13770`

Update a local copy of the PR: \
`$ git checkout pull/13770` \
`$ git pull https://git.openjdk.org/jdk.git pull/13770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13770`

View PR using the GUI difftool: \
`$ git pr show -t 13770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13770.diff">https://git.openjdk.org/jdk/pull/13770.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13770#issuecomment-1532651691)