### PR TITLE
8307346 - Add missing gc+phases logging for ObjectCount(AfterGC) JFR event collection code

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -323,7 +323,10 @@ void G1FullCollector::phase1_mark_live_objects() {
     _heap->complete_cleaning(purged_class);
   }
 
-  scope()->tracer()->report_object_count_after_gc(&_is_alive);
+  {
+    GCTraceTime(Debug, gc, phases) debug("Report Object Count", scope()->timer());
+    scope()->tracer()->report_object_count_after_gc(&_is_alive);
+  }
 #if TASKQUEUE_STATS
   oop_queue_set()->print_and_reset_taskqueue_stats("Oop Queue");
   array_queue_set()->print_and_reset_taskqueue_stats("ObjArrayOop Queue");

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2068,7 +2068,7 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
   }
 
   {
-    GCTraceTime(Debug, gc, phases) debug("Report Object Count", &_gc_timer);
+    GCTraceTime(Debug, gc, phases) tm("Report Object Count", &_gc_timer);
     _gc_tracer.report_object_count_after_gc(is_alive_closure());
   }
 #if TASKQUEUE_STATS

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2067,7 +2067,10 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
     JVMCI_ONLY(JVMCI::do_unloading(purged_class));
   }
 
-  _gc_tracer.report_object_count_after_gc(is_alive_closure());
+  {
+    GCTraceTime(Debug, gc, phases) debug("Report Object Count", &_gc_timer);
+    _gc_tracer.report_object_count_after_gc(is_alive_closure());
+  }
 #if TASKQUEUE_STATS
   ParCompactionManager::oop_task_queues()->print_and_reset_taskqueue_stats("Oop Queue");
   ParCompactionManager::_objarray_task_queues->print_and_reset_taskqueue_stats("ObjArrayOop Queue");

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -210,7 +210,10 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
     JVMCI_ONLY(JVMCI::do_unloading(purged_class));
   }
 
-  gc_tracer()->report_object_count_after_gc(&is_alive);
+  {
+    GCTraceTime(Debug, gc, phases) debug("Report Object Count", gc_timer());
+    gc_tracer()->report_object_count_after_gc(&is_alive);
+  }
 }
 
 

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -211,7 +211,7 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
   }
 
   {
-    GCTraceTime(Debug, gc, phases) debug("Report Object Count", gc_timer());
+    GCTraceTime(Debug, gc, phases) tm_m("Report Object Count", gc_timer());
     gc_tracer()->report_object_count_after_gc(&is_alive);
   }
 }


### PR DESCRIPTION
Add logging for the time taken to collect/report ObjectCount(AfterGC) event to Serial, Parallel and G1 full collectors, for parity with the G1 concurrent collector. This event can be *very* expensive to collect (single threaded STW full heap scan), so it's very important to show it clearly to the user.

Added output:
```
Serial

[7.976s][debug][gc,phases      ] GC(7) Trigger cleanups 0.002ms
[7.977s][debug][gc,phases      ] GC(7) Class Unloading 0.556ms
++ [7.977s][debug][gc,phases,start] GC(7) Report Object Count
++ [8.529s][debug][gc,phases      ] GC(7) Report Object Count 552.065ms
[8.529s][info ][gc,phases      ] GC(7) Phase 1: Mark live objects 1066.882ms
[8.529s][info ][gc,phases,start] GC(7) Phase 2: Compute new object addresses

Parallel

[5.786s][debug][gc,phases      ] GC(12) Trigger cleanups 0.002ms
[5.786s][debug][gc,phases      ] GC(12) Class Unloading 0.556ms
++ [5.786s][debug][gc,phases,start] GC(12) Report Object Count
++ [6.313s][debug][gc,phases      ] GC(12) Report Object Count 526.307ms
[6.313s][info ][gc,phases      ] GC(12) Marking Phase 889.900ms
[6.313s][info ][gc,phases,start] GC(12) Summary Phase

G1 Full

[3.922s][debug][gc,phases         ] GC(24) Trigger cleanups 0.002ms
[3.922s][debug][gc,phases         ] GC(24) Phase 1: Class Unloading and Cleanup 0.159ms
++ [3.922s][debug][gc,phases,start   ] GC(24) Report Object Count
++ [4.442s][debug][gc,phases         ] GC(24) Report Object Count 519.292ms
[4.442s][info ][gc,phases         ] GC(24) Phase 1: Mark live objects 653.209ms
[4.442s][info ][gc,phases,start   ] GC(24) Phase 2: Prepare compaction
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307346](https://bugs.openjdk.org/browse/JDK-8307346): Add missing gc+phases logging for ObjectCount(AfterGC) JFR event collection code


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [3ef4f4cc](https://git.openjdk.org/jdk/pull/13772/files/3ef4f4cc36112f4d224a9eb61c53874da6124d93)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13772/head:pull/13772` \
`$ git checkout pull/13772`

Update a local copy of the PR: \
`$ git checkout pull/13772` \
`$ git pull https://git.openjdk.org/jdk.git pull/13772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13772`

View PR using the GUI difftool: \
`$ git pr show -t 13772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13772.diff">https://git.openjdk.org/jdk/pull/13772.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13772#issuecomment-1532770562)