### PR TITLE
8307348 - Parallelize heap walk for ObjectCount(AfterGC) JFR event collection

### DIFF
--- a/src/hotspot/share/gc/shared/gcTrace.cpp
+++ b/src/hotspot/share/gc/shared/gcTrace.cpp
@@ -109,7 +109,12 @@ void GCTracer::report_object_count_after_gc(BoolObjectClosure* is_alive_cl) {
     KlassInfoTable cit(false);
     if (!cit.allocation_failed()) {
       HeapInspection hi;
-      hi.populate_table(&cit, is_alive_cl);
+      uint parallel_threads = 1;
+      WorkerThreads* workers = Universe::heap()->safepoint_workers();
+      if (workers != nullptr) {
+        parallel_threads = workers->active_workers();
+      }
+      hi.populate_table(&cit, is_alive_cl, parallel_threads);
       ObjectCountEventSenderClosure event_sender(cit.size_of_instances_in_words(), Ticks::now());
       cit.iterate(&event_sender);
     }


### PR DESCRIPTION
ObjectCount(AfterGC) event does a full single-threaded heap scan at a safepoint. After https://bugs.openjdk.org/browse/JDK-8215624, it is trivial to use the parallel version of the heap scan, reducing the time spent at the safepoint, and thus reducing the overhead of this event.

The performance improvement is obvious, but just for confirmation, on my 16-core host, at around 1GB occupancy:

```
Before: 770ms ( [3.059s][debug][gc,phases         ] GC(13) Report Object Count 770.317ms )
 After:  92ms ( [2.335s][debug][gc,phases         ] GC(13) Report Object Count  91.742ms )
```

Question 1: Should this be the default behaviour for populate_table (use the number active workers as the parallelism, if nothing else specified)?

Question 2: Is active_workers the correct value to use here? Or is max_workers more appropriate?