### PR TITLE
8303669: SelectVersion indexes past the end of the argv array

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1007,7 +1007,7 @@ SelectVersion(int argc, char **argv, char **main_class)
 
     argc--;
     argv++;
-    while ((arg = *argv) != 0 && *arg == '-') {
+    while (argc > 0 && *(arg = *argv) == '-') {
         has_arg = IsOptionWithArgument(argc, argv);
         if (JLI_StrCCmp(arg, "-version:") == 0) {
             JLI_ReportErrorMessage(SPC_ERROR1);
@@ -1209,7 +1209,7 @@ ParseArguments(int *pargc, char ***pargv,
 
     *pret = 0;
 
-    while ((arg = *argv) != 0 && *arg == '-') {
+    while (argc > 0 && *(arg = *argv) == '-') {
         char *option = NULL;
         char *value = NULL;
         int kind = GetOpt(&argc, &argv, &option, &value);

--- a/test/jdk/tools/launcher/JliLaunchTest.java
+++ b/test/jdk/tools/launcher/JliLaunchTest.java
@@ -24,7 +24,7 @@
 
 /**
  * @test
- * @bug 8213362 8238225
+ * @bug 8213362 8238225 8303669
  * @comment Test JLI_Launch for tools distributed outside JDK
  * @library /test/lib
  * @run main/native JliLaunchTest

--- a/test/jdk/tools/launcher/exeJliLaunchTest.c
+++ b/test/jdk/tools/launcher/exeJliLaunchTest.c
@@ -33,8 +33,14 @@
 #include "java.h"
 
 int
-main(int argc, char **argv)
+main(int argc, char **args)
 {
+    //avoid null-terminated array of arguments to test JDK-8303669
+    char *argv[argc];
+    for (int i = 0; i < argc; i++) {
+        argv[i] = args[i];
+    }
+
     return JLI_Launch(argc, argv,
                    0, NULL,
                    0, NULL,


### PR DESCRIPTION
libjli/java.c's SelectVersion method receives argc and argv but ignores argc in some circumstances an instead checks if *argv == 0 in its while loop, which results in a segmentation fault if the provided array is not NULL terminated. 

This patch counts down argc in the while loops instead of looking for zero termination.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303669](https://bugs.openjdk.org/browse/JDK-8303669): SelectVersion indexes past the end of the argv array


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13775/head:pull/13775` \
`$ git checkout pull/13775`

Update a local copy of the PR: \
`$ git checkout pull/13775` \
`$ git pull https://git.openjdk.org/jdk.git pull/13775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13775`

View PR using the GUI difftool: \
`$ git pr show -t 13775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13775.diff">https://git.openjdk.org/jdk/pull/13775.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13775#issuecomment-1532915581)