### PR TITLE
8305082: Remove finalize() from test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObj.jasm
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObj.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObj.jasm
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObj.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObj.jasm
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObj.jasm
@@ -26,12 +26,6 @@
 interface I { }
 
 public class InterfaceObj implements I {
-    static void f(I intf) throws Throwable {
-        I.finalize();
-    }
-    public static void testFinalize() throws Throwable {
-        f(new InterfaceObj());
-    }
     static void c(I intf) throws Throwable {
         I.clone();
     }
@@ -50,20 +44,6 @@ super public class InterfaceObj implements I version 60:0 {
     public Method "<init>":"()V" stack 1 locals 1 {
         aload_0;
         invokespecial    Method java/lang/Object."<init>":"()V";
-        return;
-    }
-
-    static Method f:"(LI;)V" throws java/lang/Throwable stack 1 locals 1 {
-        aload_0;
-        invokeinterface    InterfaceMethod I.finalize:"()V", 1;
-        return;
-    }
-
-    public static Method testFinalize:"()V" throws java/lang/Throwable stack 2 locals 1 {
-        new    class InterfaceObj;
-        dup;
-        invokespecial   Method "<init>":"()V";
-        invokestatic    Method f:"(LI;)V";
         return;
     }
 

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
@@ -42,19 +42,11 @@ public class InterfaceObjectTest implements ICloneExtend {
         System.out.println("In InterfaceObjectTest's clone() method\n");
         return null;
     }
-    public String toString() {
-        try {
-            System.out.println("In InterfaceObjectTest's toString() method\n");
-        } catch (Throwable t) {
-            throw new AssertionError(t);
-        }
-        return "InterfaceObjectTest";
-    }
 
     public static void tryIt(ICloneExtend o1) {
         try {
             Object o2 = o1.clone();
-            o1.toString();
+            o1.clone();
         } catch (Throwable t) {
             throw new AssertionError(t);
         }
@@ -62,12 +54,12 @@ public class InterfaceObjectTest implements ICloneExtend {
 
 
     public static void main(String[] args) throws Exception {
-        // Test with abstract public clone() and finalize() methods.
+        // Test with abstract public clone() method.
         InterfaceObjectTest o1 = new InterfaceObjectTest();
         tryIt(o1);
 
 
-        // Test with reflection without abstract public clone() and finalize() methods.
+        // Test with reflection without abstract public clone() and method.
         Class cls = Class.forName("InterfaceObj");
 
         try {

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
@@ -46,7 +46,6 @@ public class InterfaceObjectTest implements ICloneExtend {
     public static void tryIt(ICloneExtend o1) {
         try {
             Object o2 = o1.clone();
-            o1.clone();
         } catch (Throwable t) {
             throw new AssertionError(t);
         }
@@ -59,7 +58,7 @@ public class InterfaceObjectTest implements ICloneExtend {
         tryIt(o1);
 
 
-        // Test with reflection without abstract public clone() and method.
+        // Test with reflection without abstract public clone() method.
         Class cls = Class.forName("InterfaceObj");
 
         try {

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
@@ -24,13 +24,13 @@
 /*
  * @test
  * @bug 8026394 8251414
- * @summary test interface resolution when clone and finalize are declared abstract within
+ * @summary test interface resolution when clone and toString are declared abstract within
  *          an interface and when they are not
  * @compile InterfaceObj.jasm
  * @run main InterfaceObjectTest
  */
 interface IClone extends Cloneable {
-    void finalize() throws Throwable;
+    String toString();
     Object clone();
 }
 
@@ -42,19 +42,19 @@ public class InterfaceObjectTest implements ICloneExtend {
         System.out.println("In InterfaceObjectTest's clone() method\n");
         return null;
     }
-    @SuppressWarnings("removal")
-    public void finalize() throws Throwable {
+    public String toString() {
         try {
-            System.out.println("In InterfaceObjectTest's finalize() method\n");
+            System.out.println("In InterfaceObjectTest's toString() method\n");
         } catch (Throwable t) {
             throw new AssertionError(t);
         }
+        return "InterfaceObjectTest";
     }
 
     public static void tryIt(ICloneExtend o1) {
         try {
             Object o2 = o1.clone();
-            o1.finalize();
+            o1.toString();
         } catch (Throwable t) {
             throw new AssertionError(t);
         }
@@ -69,15 +69,6 @@ public class InterfaceObjectTest implements ICloneExtend {
 
         // Test with reflection without abstract public clone() and finalize() methods.
         Class cls = Class.forName("InterfaceObj");
-        try {
-            java.lang.reflect.Method m = cls.getMethod("testFinalize");
-            m.invoke(cls);
-            throw new RuntimeException("Failed to throw NoSuchMethodError for finalize()");
-        } catch (java.lang.reflect.InvocationTargetException e) {
-            if (!e.getCause().toString().contains("NoSuchMethodError")) {
-                throw new RuntimeException("wrong ITE: " + e.getCause().toString());
-            }
-        }
 
         try {
             java.lang.reflect.Method m = cls.getMethod("testClone");

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class InterfaceObjectTest implements ICloneExtend {
         System.out.println("In InterfaceObjectTest's clone() method\n");
         return null;
     }
-
+    @SuppressWarnings("removal")
     public void finalize() throws Throwable {
         try {
             System.out.println("In InterfaceObjectTest's finalize() method\n");

--- a/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java
@@ -24,13 +24,12 @@
 /*
  * @test
  * @bug 8026394 8251414
- * @summary test interface resolution when clone and toString are declared abstract within
+ * @summary test interface resolution when clone is declared abstract within
  *          an interface and when they are not
  * @compile InterfaceObj.jasm
  * @run main InterfaceObjectTest
  */
 interface IClone extends Cloneable {
-    String toString();
     Object clone();
 }
 


### PR DESCRIPTION
The warning is suppressed. The `finalize()` method is used intentionally as a method inherited from `Object`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305082](https://bugs.openjdk.org/browse/JDK-8305082): Remove finalize() from test/hotspot/jtreg/runtime/linkResolver/InterfaceObjectTest.java


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [23ac0d8b](https://git.openjdk.org/jdk/pull/13778/files/23ac0d8b0a53f379ddefa94aff8f94b08828004a)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [23ac0d8b](https://git.openjdk.org/jdk/pull/13778/files/23ac0d8b0a53f379ddefa94aff8f94b08828004a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13778/head:pull/13778` \
`$ git checkout pull/13778`

Update a local copy of the PR: \
`$ git checkout pull/13778` \
`$ git pull https://git.openjdk.org/jdk.git pull/13778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13778`

View PR using the GUI difftool: \
`$ git pr show -t 13778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13778.diff">https://git.openjdk.org/jdk/pull/13778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13778#issuecomment-1533004881)