### PR TITLE
8307156: native_thread not protected by TLH

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -664,8 +664,7 @@ bool JfrJavaSupport::is_jdk_jfr_module_available(outputStream* stream, TRAPS) {
 
 typedef JfrOopTraceId<ThreadIdAccess> AccessThreadTraceId;
 
-static JavaThread* get_native(jobject thread) {
-  ThreadsListHandle tlh;
+static JavaThread* get_native(ThreadsListHandle& tlh, jobject thread) {
   JavaThread* native_thread = NULL;
   (void)tlh.cv_internal_thread_to_JavaThread(thread, &native_thread, NULL);
   return native_thread;
@@ -704,7 +703,8 @@ void JfrJavaSupport::exclude(JavaThread* jt, oop ref, jobject thread) {
       return;
     }
   }
-  jt = get_native(thread);
+  ThreadsListHandle tlh;
+  jt = get_native(tlh, thread);
   if (jt != nullptr) {
     JfrThreadLocal::exclude_jvm_thread(jt);
   }
@@ -720,7 +720,8 @@ void JfrJavaSupport::include(JavaThread* jt, oop ref, jobject thread) {
       return;
     }
   }
-  jt = get_native(thread);
+  ThreadsListHandle tlh;
+  jt = get_native(tlh, thread);
   if (jt != nullptr) {
     JfrThreadLocal::include_jvm_thread(jt);
   }


### PR DESCRIPTION
Greetings,

this is a small adjustment to correct and extend the scope of the TLH.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307156](https://bugs.openjdk.org/browse/JDK-8307156): native_thread not protected by TLH


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13780/head:pull/13780` \
`$ git checkout pull/13780`

Update a local copy of the PR: \
`$ git checkout pull/13780` \
`$ git pull https://git.openjdk.org/jdk.git pull/13780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13780`

View PR using the GUI difftool: \
`$ git pr show -t 13780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13780.diff">https://git.openjdk.org/jdk/pull/13780.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13780#issuecomment-1533080283)