### PR TITLE
8307308: Add serviceability_ttf_virtual group to exclude jvmti tests developed for virtual threads

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -125,6 +125,13 @@ tier1_loom_serviceability = \
 hotspot_loom = \
   :tier1_loom
 
+serviceability_ttf_virtual = \
+  serviceability/ \
+  -serviceability/jvmti/vthread \
+  -serviceability/jvmti/thread  \
+  -serviceability/jvmti/events  \
+  -serviceability/jvmti/negative
+
 tier1_common = \
   sanity/BasicVMTest.java \
   gtest/GTestWrapper.java \


### PR DESCRIPTION
Please review following trivial fix which add serviceability_ttf_virtual test group.
There are several directories with jvmti tests developed for testing virtual threads. It does't make sense to run them with virtual test thread factory. So the group serviceability_ttf_virtual is introduced to run all other svc test in this mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307308](https://bugs.openjdk.org/browse/JDK-8307308): Add serviceability_ttf_virtual group to exclude jvmti tests developed for virtual threads


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13782/head:pull/13782` \
`$ git checkout pull/13782`

Update a local copy of the PR: \
`$ git checkout pull/13782` \
`$ git pull https://git.openjdk.org/jdk.git pull/13782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13782`

View PR using the GUI difftool: \
`$ git pr show -t 13782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13782.diff">https://git.openjdk.org/jdk/pull/13782.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13782#issuecomment-1533286750)