### PR TITLE
8307091: A few client tests intermittently throw ConcurrentModificationException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -360,12 +360,15 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
                                 break;
                             }
                         }
-                        if (start >= 0 && end > start
-                            && newFileCache.subList(end, newSize).equals(fileCache.subList(start, oldSize))) {
-                            if (loadThread.isInterrupted()) {
-                                return null;
+
+                        if (start >= 0 && end > start) {
+                            List<File> listStart_OldSize = new Vector<>(fileCache.subList(start, oldSize));
+                            if (newFileCache.subList(end, newSize).equals(listStart_OldSize)) {
+                                if (loadThread.isInterrupted()) {
+                                    return null;
+                                }
+                                return new DoChangeContents(newFileCache.subList(start, end), start, null, 0, fid);
                             }
-                            return new DoChangeContents(newFileCache.subList(start, end), start, null, 0, fid);
                         }
                     } else if (newSize < oldSize) {
                         //see if interval is removed
@@ -378,12 +381,15 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
                                 break;
                             }
                         }
-                        if (start >= 0 && end > start
-                            && fileCache.subList(end, oldSize).equals(newFileCache.subList(start, newSize))) {
-                            if (loadThread.isInterrupted()) {
-                                return null;
+
+                        if (start >= 0 && end > start) {
+                            List<File> listEnd_OldSize = new Vector<>(fileCache.subList(end, oldSize));
+                            if(listEnd_OldSize.equals(newFileCache.subList(start, newSize))) {
+                                if (loadThread.isInterrupted()) {
+                                    return null;
+                                }
+                                return new DoChangeContents(null, 0, new Vector<>(fileCache.subList(start, end)), start, fid);
                             }
-                            return new DoChangeContents(null, 0, new Vector<>(fileCache.subList(start, end)), start, fid);
                         }
                     }
                     if (!fileCache.equals(newFileCache)) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -384,7 +384,7 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
 
                         if (start >= 0 && end > start) {
                             List<File> listEnd_OldSize = new Vector<>(fileCache.subList(end, oldSize));
-                            if(listEnd_OldSize.equals(newFileCache.subList(start, newSize))) {
+                            if (listEnd_OldSize.equals(newFileCache.subList(start, newSize))) {
                                 if (loadThread.isInterrupted()) {
                                     return null;
                                 }


### PR DESCRIPTION
Few test are throwing Concurrent Modification Exception Intermittently. Since the issue is intermittent and from the log and code review, It is found that the shared variable `fileCache` is used in comparison with the `newFileCache` where the comparison invokes the iterator method in AbstractList class. Since based on vector documentation it was evident that listIterator are fail-fast iterators and hence it would be better to make a separate local copy of vectors for comparing operations. 
The same is implemented and tested in CI system which shows green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307091](https://bugs.openjdk.org/browse/JDK-8307091): A few client tests intermittently throw ConcurrentModificationException


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [5829aade](https://git.openjdk.org/jdk/pull/13783/files/5829aade05f0d15d63c733256fb524483b454545)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [5829aade](https://git.openjdk.org/jdk/pull/13783/files/5829aade05f0d15d63c733256fb524483b454545)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13783/head:pull/13783` \
`$ git checkout pull/13783`

Update a local copy of the PR: \
`$ git checkout pull/13783` \
`$ git pull https://git.openjdk.org/jdk.git pull/13783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13783`

View PR using the GUI difftool: \
`$ git pr show -t 13783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13783.diff">https://git.openjdk.org/jdk/pull/13783.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13783#issuecomment-1533336829)