### PR TITLE
8307375: Alignment check on layouts used as sequence element is not correct

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -704,12 +704,12 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @param elementLayout the sequence element layout.
      * @return the new sequence layout with the given element layout and size.
      * @throws IllegalArgumentException if {@code elementCount } is negative.
-     * @throws IllegalArgumentException if {@code elementLayout.bitAlignment() > elementLayout.bitSize()}.
+     * @throws IllegalArgumentException if {@code elementLayout.bitSize() % elementLayout.bitAlignment() != 0}.
      */
     static SequenceLayout sequenceLayout(long elementCount, MemoryLayout elementLayout) {
         MemoryLayoutUtil.requireNonNegative(elementCount);
         Objects.requireNonNull(elementLayout);
-        Utils.checkElementAlignment(elementLayout, "Element layout alignment greater than its size");
+        Utils.checkElementAlignment(elementLayout, "Element layout size is not multiple of alignment");
         return wrapOverflow(() ->
                 SequenceLayoutImpl.of(elementCount, elementLayout));
     }
@@ -725,7 +725,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      *
      * @param elementLayout the sequence element layout.
      * @return a new sequence layout with the given element layout and maximum element count.
-     * @throws IllegalArgumentException if {@code elementLayout.bitAlignment() > elementLayout.bitSize()}.
+     * @throws IllegalArgumentException if {@code elementLayout.bitSize() % elementLayout.bitAlignment() != 0}.
      */
     static SequenceLayout sequenceLayout(MemoryLayout elementLayout) {
         Objects.requireNonNull(elementLayout);

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -476,10 +476,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *
      * @param elementLayout the layout to be used for splitting.
      * @return a sequential {@code Stream} over disjoint slices in this segment.
-     * @throws IllegalArgumentException if the {@code elementLayout} size is zero, or the segment size modulo the
-     * {@code elementLayout} size is greater than zero, if this segment is
-     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the provided layout,
-     * or if the {@code elementLayout} alignment is greater than its size.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize() == 0}.
+     * @throws IllegalArgumentException if {@code byteSize() % elementLayout.byteSize() != 0}.
+     * @throws IllegalArgumentException if {@code elementLayout.bitSize() % elementLayout.bitAlignment() != 0}.
+     * @throws IllegalArgumentException if this segment is <a href="MemorySegment.html#segment-alignment">incompatible
+     * with the alignment constraint</a> in the provided layout.
      */
     Stream<MemorySegment> elements(MemoryLayout elementLayout);
 

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -459,10 +459,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *
      * @param elementLayout the layout to be used for splitting.
      * @return the element spliterator for this segment
-     * @throws IllegalArgumentException if the {@code elementLayout} size is zero, or the segment size modulo the
-     * {@code elementLayout} size is greater than zero, if this segment is
-     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the provided layout,
-     * or if the {@code elementLayout} alignment is greater than its size.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize() == 0}.
+     * @throws IllegalArgumentException if {@code byteSize() % elementLayout.byteSize() != 0}.
+     * @throws IllegalArgumentException if {@code elementLayout.bitSize() % elementLayout.bitAlignment() != 0}.
+     * @throws IllegalArgumentException if this segment is <a href="MemorySegment.html#segment-alignment">incompatible
+     * with the alignment constraint</a> in the provided layout.
      */
     Spliterator<MemorySegment> spliterator(MemoryLayout elementLayout);
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -165,7 +165,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         if (elementLayout.byteSize() == 0) {
             throw new IllegalArgumentException("Element layout size cannot be zero");
         }
-        Utils.checkElementAlignment(elementLayout, "Element layout alignment greater than its size");
+        Utils.checkElementAlignment(elementLayout, "Element layout size is not multiple of alignment");
         if (!isAlignedForElement(0, elementLayout)) {
             throw new IllegalArgumentException("Incompatible alignment constraints");
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -177,6 +177,7 @@ public final class Utils {
     public static void checkElementAlignment(ValueLayout layout, String msg) {
         // Fast-path: if both size and alignment are powers of two, we can just
         // check if one is greater than the other.
+        assert isPowerOfTwo(layout.bitSize());
         if (layout.byteAlignment() > layout.byteSize()) {
             throw new IllegalArgumentException(msg);
         }
@@ -253,5 +254,9 @@ public final class Utils {
 
     public static int byteWidthOfPrimitive(Class<?> primitive) {
         return Wrapper.forPrimitiveType(primitive).bitWidth() / 8;
+    }
+
+    public static boolean isPowerOfTwo(long value) {
+        return (value & (value - 1)) == 0L;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -174,8 +174,17 @@ public final class Utils {
     }
 
     @ForceInline
-    public static void checkElementAlignment(MemoryLayout layout, String msg) {
+    public static void checkElementAlignment(ValueLayout layout, String msg) {
+        // Fast-path: if both size and alignment are powers of two, we can just
+        // check if one is greater than the other.
         if (layout.byteAlignment() > layout.byteSize()) {
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    @ForceInline
+    public static void checkElementAlignment(MemoryLayout layout, String msg) {
+        if (layout.byteSize() % layout.byteAlignment() != 0) {
             throw new IllegalArgumentException(msg);
         }
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -25,6 +25,8 @@
  */
 package jdk.internal.foreign.layout;
 
+import jdk.internal.foreign.Utils;
+
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.SequenceLayout;
@@ -138,8 +140,8 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
     }
 
     private static long requirePowerOfTwoAndGreaterOrEqualToEight(long value) {
-        if (((value & (value - 1)) != 0L) || // value must be a power of two
-                (value < 8)) { // value must be greater or equal to 8
+        if (!Utils.isPowerOfTwo(value) || // value must be a power of two
+                value < 8) { // value must be greater or equal to 8
             throw new IllegalArgumentException("Invalid alignment: " + value);
         }
         return value;

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -31,6 +31,7 @@ import java.lang.foreign.*;
 
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
@@ -292,9 +293,32 @@ public class TestLayouts {
     }
 
     @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
-    public void testBadSequence(MemoryLayout layout, long bitAlign) {
+    public void testBadSequenceElementAlignmentTooBig(MemoryLayout layout, long bitAlign) {
         layout = layout.withBitAlignment(layout.bitSize() * 2); // hyper-align
         MemoryLayout.sequenceLayout(layout);
+    }
+
+    @Test(dataProvider="layoutsAndAlignments")
+    public void testBadSequenceElementSizeNotMultipleOfAlignment(MemoryLayout layout, long bitAlign) {
+        boolean shouldFail = layout.byteSize() % layout.byteAlignment() != 0;
+        try {
+            MemoryLayout.sequenceLayout(layout);
+            assertFalse(shouldFail);
+        } catch (IllegalArgumentException ex) {
+            assertTrue(shouldFail);
+        }
+    }
+
+    @Test(dataProvider="layoutsAndAlignments")
+    public void testBadSpliteratorElementSizeNotMultipleOfAlignment(MemoryLayout layout, long bitAlign) {
+        boolean shouldFail = layout.byteSize() % layout.byteAlignment() != 0;
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(layout);
+            segment.spliterator(layout);
+            assertFalse(shouldFail);
+        } catch (IllegalArgumentException ex) {
+            assertTrue(shouldFail);
+        }
     }
 
     @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
@@ -392,25 +416,32 @@ public class TestLayouts {
 
     @DataProvider(name = "layoutsAndAlignments")
     public Object[][] layoutsAndAlignments() {
-        Object[][] layoutsAndAlignments = new Object[basicLayouts.length * 4][];
+        List<Object[]> layoutsAndAlignments = new ArrayList<>();
         int i = 0;
         //add basic layouts
         for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { l, l.bitAlignment() };
+            layoutsAndAlignments.add(new Object[] { l, l.bitAlignment() });
         }
         //add basic layouts wrapped in a sequence with given size
         for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.sequenceLayout(4, l), l.bitAlignment() };
+            layoutsAndAlignments.add(new Object[] { MemoryLayout.sequenceLayout(4, l), l.bitAlignment() });
         }
         //add basic layouts wrapped in a struct
-        for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.structLayout(l), l.bitAlignment() };
+        for (MemoryLayout l1 : basicLayouts) {
+            for (MemoryLayout l2 : basicLayouts) {
+                if (l1.byteSize() % l2.byteAlignment() != 0) continue; // second element is not aligned, skip
+                long align = Math.max(l1.bitAlignment(), l2.bitAlignment());
+                layoutsAndAlignments.add(new Object[]{MemoryLayout.structLayout(l1, l2), align});
+            }
         }
         //add basic layouts wrapped in a union
-        for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.unionLayout(l), l.bitAlignment() };
+        for (MemoryLayout l1 : basicLayouts) {
+            for (MemoryLayout l2 : basicLayouts) {
+                long align = Math.max(l1.bitAlignment(), l2.bitAlignment());
+                layoutsAndAlignments.add(new Object[]{MemoryLayout.unionLayout(l1, l2), align});
+            }
         }
-        return layoutsAndAlignments;
+        return layoutsAndAlignments.toArray(Object[][]::new);
     }
 
     @DataProvider(name = "groupLayouts")

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -321,6 +321,18 @@ public class TestLayouts {
         }
     }
 
+    @Test(dataProvider="layoutsAndAlignments")
+    public void testBadElementsElementSizeNotMultipleOfAlignment(MemoryLayout layout, long bitAlign) {
+        boolean shouldFail = layout.byteSize() % layout.byteAlignment() != 0;
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(layout);
+            segment.elements(layout);
+            assertFalse(shouldFail);
+        } catch (IllegalArgumentException ex) {
+            assertTrue(shouldFail);
+        }
+    }
+
     @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
     public void testBadStruct(MemoryLayout layout, long bitAlign) {
         layout = layout.withBitAlignment(layout.bitSize() * 2); // hyper-align


### PR DESCRIPTION
This patch fixes `Utils::checkElementAlignment` to do the right thing for _all_ layouts.

The current implementation is broken, as it only works correctly when the input layout is a value layout.
Since value layouts have a size that is a power of two (and size all layouts have alignment that is also a power of two), then verifying that `size > alignment` works well.

But if the input layout is some other layout (e.g. a `StructLayout`), this "power of two" assumption no longer holds. E.g. we can have a layout whose size is 48, and whose alignment is 32. While 48 is clearly bigger than 32, such a layout is still not suitable to be used as an element layout in a sequence.

The fix is to provide two overloads for `Utils::checkElementAlignment` - one which works on `ValueLayout` and another which works on any `MemoryLayout`. The `ValueLayout` version works as before (so performance is not affected).
The `MemoryLayout` variant would perform a full check using the `%` operator. Currently we only use this when creating a new sequence layout and when creating a stream out of a memory segment, so I'm not worried about potential performance regressions.

I've fixed the javadoc so that the various `@throws` clauses in the affected methods reflect the correct behavior.

Finally, I've made the existing alignment/layout tests a bit more robust, by also adding pair-wise combinations of layouts, wrapped in a struct/union. This does generate illegal layout cases which would not have been detected w/o this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8307376](https://bugs.openjdk.org/browse/JDK-8307376) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8307375](https://bugs.openjdk.org/browse/JDK-8307375): Alignment check on layouts used as sequence element is not correct
 * [JDK-8307376](https://bugs.openjdk.org/browse/JDK-8307376): Alignment check on layouts used as sequence element is not correct (**CSR**)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [1f2fd4b0](https://git.openjdk.org/jdk/pull/13784/files/1f2fd4b0dc04907fba9c1efc1d88bd976dca4547)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13784/head:pull/13784` \
`$ git checkout pull/13784`

Update a local copy of the PR: \
`$ git checkout pull/13784` \
`$ git pull https://git.openjdk.org/jdk.git pull/13784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13784`

View PR using the GUI difftool: \
`$ git pr show -t 13784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13784.diff">https://git.openjdk.org/jdk/pull/13784.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13784#issuecomment-1533467994)