### PR TITLE
8307306: Change some ConstantPool::name_ref_at calls to uncached_name_ref_at

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -452,8 +452,8 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
         // fall through
       case JVM_CONSTANT_InterfaceMethodref: {
         if (!_need_verify) break;
-        const int klass_ref_index = cp->klass_ref_index_at(index);
-        const int name_and_type_ref_index = cp->name_and_type_ref_index_at(index);
+        const int klass_ref_index = cp->uncached_klass_ref_index_at(index);
+        const int name_and_type_ref_index = cp->uncached_name_and_type_ref_index_at(index);
         check_property(valid_klass_reference_at(klass_ref_index),
                        "Invalid constant pool index %u in class file %s",
                        klass_ref_index, CHECK);
@@ -655,7 +655,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
       }
       case JVM_CONSTANT_Dynamic: {
         const int name_and_type_ref_index =
-          cp->name_and_type_ref_index_at(index);
+          cp->uncached_name_and_type_ref_index_at(index);
         // already verified to be utf8
         const int name_ref_index =
           cp->name_ref_index_at(name_and_type_ref_index);
@@ -678,7 +678,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
       case JVM_CONSTANT_Methodref:
       case JVM_CONSTANT_InterfaceMethodref: {
         const int name_and_type_ref_index =
-          cp->name_and_type_ref_index_at(index);
+          cp->uncached_name_and_type_ref_index_at(index);
         // already verified to be utf8
         const int name_ref_index =
           cp->name_ref_index_at(name_and_type_ref_index);
@@ -729,7 +729,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
           case JVM_REF_invokeSpecial:
           case JVM_REF_newInvokeSpecial: {
             const int name_and_type_ref_index =
-              cp->name_and_type_ref_index_at(ref_index);
+              cp->uncached_name_and_type_ref_index_at(ref_index);
             const int name_ref_index =
               cp->name_ref_index_at(name_and_type_ref_index);
             const Symbol* const name = cp->symbol_at(name_ref_index);

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -2310,8 +2310,8 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
       1 << JVM_CONSTANT_Fieldref, CHECK_VERIFY(this));
 
   // Get field name and signature
-  Symbol* field_name = cp->name_ref_at(index);
-  Symbol* field_sig = cp->signature_ref_at(index);
+  Symbol* field_name = cp->uncached_name_ref_at(index);
+  Symbol* field_sig = cp->uncached_signature_ref_at(index);
   bool is_getfield = false;
 
   // Field signature was checked in ClassFileParser.
@@ -2401,7 +2401,7 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
         return;
       }
       Symbol* ref_class_name =
-        cp->klass_name_at(cp->klass_ref_index_at(index));
+        cp->klass_name_at(cp->uncached_klass_ref_index_at(index));
       if (!name_in_supers(ref_class_name, current_class()))
         // stack_object_type must be assignable to _current_class_type since:
         // 1. stack_object_type must be assignable to ref_class.
@@ -2725,7 +2725,7 @@ void ClassVerifier::verify_invoke_init(
       if (was_recursively_verified()) return;
       Method* m = InstanceKlass::cast(ref_klass)->uncached_lookup_method(
         vmSymbols::object_initializer_name(),
-        cp->signature_ref_at(bcs->get_index_u2()),
+        cp->uncached_signature_ref_at(bcs->get_index_u2()),
         Klass::OverpassLookupMode::find);
       // Do nothing if method is not found.  Let resolution detect the error.
       if (m != nullptr) {
@@ -2804,8 +2804,8 @@ void ClassVerifier::verify_invoke_instructions(
   verify_cp_type(bcs->bci(), index, cp, types, CHECK_VERIFY(this));
 
   // Get method name and signature
-  Symbol* method_name = cp->name_ref_at(index);
-  Symbol* method_sig = cp->signature_ref_at(index);
+  Symbol* method_name = cp->uncached_name_ref_at(index);
+  Symbol* method_sig = cp->uncached_signature_ref_at(index);
 
   // Method signature was checked in ClassFileParser.
   assert(SignatureVerifier::is_valid_method_signature(method_sig),
@@ -2828,7 +2828,7 @@ void ClassVerifier::verify_invoke_instructions(
         "buffer type must match VerificationType size");
 
   // Get the UTF8 index for this signature.
-  int sig_index = cp->signature_ref_index_at(cp->name_and_type_ref_index_at(index));
+  int sig_index = cp->signature_ref_index_at(cp->uncached_name_and_type_ref_index_at(index));
 
   // Get the signature's verification types.
   sig_as_verification_types* mth_sig_verif_types;
@@ -2934,7 +2934,7 @@ void ClassVerifier::verify_invoke_instructions(
           if (was_recursively_verified()) return;
           assert(cp->cache() == nullptr, "not rewritten yet");
           Symbol* ref_class_name =
-            cp->klass_name_at(cp->klass_ref_index_at(index));
+            cp->klass_name_at(cp->uncached_klass_ref_index_at(index));
           // See the comments in verify_field_instructions() for
           // the rationale behind this.
           if (name_in_supers(ref_class_name, current_class())) {

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -297,7 +297,7 @@ class ClassVerifier : public StackObj {
 
   VerificationType cp_ref_index_to_type(
       int index, const constantPoolHandle& cp, TRAPS) {
-    return cp_index_to_type(cp->klass_ref_index_at(index), cp, THREAD);
+    return cp_index_to_type(cp->uncached_klass_ref_index_at(index), cp, THREAD);
   }
 
   bool is_protected_access(

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -226,15 +226,15 @@ void Rewriter::maybe_rewrite_invokehandle(address opc, int cp_index, int cache_i
       int status = _method_handle_invokers.at(cp_index);
       assert(status >= -1 && status <= 1, "oob tri-state");
       if (status == 0) {
-        if (_pool->klass_ref_at_noresolve(cp_index) == vmSymbols::java_lang_invoke_MethodHandle() &&
+        if (_pool->uncached_klass_ref_at_noresolve(cp_index) == vmSymbols::java_lang_invoke_MethodHandle() &&
             MethodHandles::is_signature_polymorphic_name(vmClasses::MethodHandle_klass(),
-                                                         _pool->name_ref_at(cp_index))) {
+                                                         _pool->uncached_name_ref_at(cp_index))) {
           // we may need a resolved_refs entry for the appendix
           add_invokedynamic_resolved_references_entry(cp_index, cache_index);
           status = +1;
-        } else if (_pool->klass_ref_at_noresolve(cp_index) == vmSymbols::java_lang_invoke_VarHandle() &&
+        } else if (_pool->uncached_klass_ref_at_noresolve(cp_index) == vmSymbols::java_lang_invoke_VarHandle() &&
                    MethodHandles::is_signature_polymorphic_name(vmClasses::VarHandle_klass(),
-                                                                _pool->name_ref_at(cp_index))) {
+                                                                _pool->uncached_name_ref_at(cp_index))) {
           // we may need a resolved_refs entry for the appendix
           add_invokedynamic_resolved_references_entry(cp_index, cache_index);
           status = +1;
@@ -421,11 +421,11 @@ void Rewriter::scan_method(Thread* thread, Method* method, bool reverse, bool* i
           InstanceKlass* klass = method->method_holder();
           u2 bc_index = Bytes::get_Java_u2(bcp + prefix_length + 1);
           constantPoolHandle cp(thread, method->constants());
-          Symbol* ref_class_name = cp->klass_name_at(cp->klass_ref_index_at(bc_index));
+          Symbol* ref_class_name = cp->klass_name_at(cp->uncached_klass_ref_index_at(bc_index));
 
           if (klass->name() == ref_class_name) {
-            Symbol* field_name = cp->name_ref_at(bc_index);
-            Symbol* field_sig = cp->signature_ref_at(bc_index);
+            Symbol* field_name = cp->uncached_name_ref_at(bc_index);
+            Symbol* field_sig = cp->uncached_signature_ref_at(bc_index);
 
             fieldDescriptor fd;
             if (klass->find_field(field_name, field_sig, &fd) != nullptr) {

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -688,7 +688,8 @@ Symbol* ConstantPool::impl_signature_ref_at(int which, bool uncached) {
 
 int ConstantPool::impl_name_and_type_ref_index_at(int which, bool uncached) {
   int i = which;
-  if (!uncached && cache() != nullptr) {
+  if (!uncached) {
+    assert(cache() != nullptr, "'which' is a rewritten index so this class must have been rewritten");
     if (ConstantPool::is_invokedynamic_index(which)) {
       // Invokedynamic index is index into the resolved indy array in the constant pool cache
       int pool_index = invokedynamic_bootstrap_ref_index_at(which);
@@ -713,7 +714,8 @@ int ConstantPool::impl_name_and_type_ref_index_at(int which, bool uncached) {
 
 constantTag ConstantPool::impl_tag_ref_at(int which, bool uncached) {
   int pool_index = which;
-  if (!uncached && cache() != nullptr) {
+  if (!uncached) {
+    assert(cache() != nullptr, "'which' is a rewritten index so this class must have been rewritten");
     if (ConstantPool::is_invokedynamic_index(which)) {
       // Invokedynamic index is index into resolved_references
       pool_index = invokedynamic_bootstrap_ref_index_at(which);
@@ -729,7 +731,8 @@ int ConstantPool::impl_klass_ref_index_at(int which, bool uncached) {
   guarantee(!ConstantPool::is_invokedynamic_index(which),
             "an invokedynamic instruction does not have a klass");
   int i = which;
-  if (!uncached && cache() != nullptr) {
+  if (!uncached) {
+    assert(cache() != nullptr, "'which' is a rewritten index so this class must have been rewritten");
     // change byte-ordering and go via cache
     i = remap_instruction_operand_from_cache(which);
   }


### PR DESCRIPTION
The set of functions in constantpool.hpp used for grabbing references at a certain index have cached and uncached variants which have different meanings for the index they take as an argument. In the implementation of these functions, the `uncached` boolean is checks alongside whether or not the cache has been created, but this is redundant since, if the cache has been created, the bytecode operands have been rewritten. This change replaces some of the calls with the uncached variant which expects a constant pool index as input so that the "cached" calls can take in rewritten indices. Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307306](https://bugs.openjdk.org/browse/JDK-8307306): Change some ConstantPool::name_ref_at calls to uncached_name_ref_at


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Contributors
 * Ioi Lam `<iklam@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13786/head:pull/13786` \
`$ git checkout pull/13786`

Update a local copy of the PR: \
`$ git checkout pull/13786` \
`$ git pull https://git.openjdk.org/jdk.git pull/13786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13786`

View PR using the GUI difftool: \
`$ git pr show -t 13786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13786.diff">https://git.openjdk.org/jdk/pull/13786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13786#issuecomment-1533727550)