### PR TITLE
8307347: serviceability/sa/ClhsdbDumpclass.java could leave files owned by root on macOS

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -31,6 +31,7 @@ import jdk.test.lib.Utils;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.SA.SATestUtils;
 import jtreg.SkippedException;
 
 /**
@@ -47,6 +48,10 @@ public class ClhsdbDumpclass {
     static final String APP_SLASH_CLASSNAME = APP_DOT_CLASSNAME.replace('.', '/');
 
     public static void main(String[] args) throws Exception {
+        if (SATestUtils.needsPrivileges()) {
+            // This test will create a file as root that cannot be easily deleted, so don't run it.
+            throw new SkippedException("Cannot run this test on OSX if adding privileges is required.");
+        }
         System.out.println("Starting ClhsdbDumpclass test");
 
         LingeredApp theApp = null;


### PR DESCRIPTION
Unless this test is run as root, it needs sudo privileges. If it gets them, the test runs fine, but leaves a file with root ownership.  So jtreg cannot delete it, and you see errors when "make clean" tries to delete it. 
It's best that we just don't run the test on OSX if sudo privileges.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8307347](https://bugs.openjdk.org/browse/JDK-8307347): serviceability/sa/ClhsdbDumpclass.java could leave files owned by root on macOS


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13791/head:pull/13791` \
`$ git checkout pull/13791`

Update a local copy of the PR: \
`$ git checkout pull/13791` \
`$ git pull https://git.openjdk.org/jdk.git pull/13791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13791`

View PR using the GUI difftool: \
`$ git pr show -t 13791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13791.diff">https://git.openjdk.org/jdk/pull/13791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13791#issuecomment-1534229253)