### PR TITLE
8307352: AARCH64: Improve itable_stub

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -573,7 +573,7 @@ class Address {
         if (size == 0) // It's a byte
           i->f(ext().shift() >= 0, 12);
         else {
-          assert(ext().shift() <= 0 || ext().shift() == (int)size, "bad shift");
+          guarantee(ext().shift() <= 0 || ext().shift() == (int)size, "bad shift");
           i->f(ext().shift() > 0, 12);
         }
         i->f(0b10, 11, 10);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1229,7 +1229,7 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   // itableOffsetEntry[] itable = recv_klass + Klass::vtable_start_offset() + sizeof(vtableEntry) * recv_klass->_vtable_len;
   // temp_itbl_klass = itable[0]._interface;
   int vtblEntrySize = vtableEntry::size_in_bytes();
-  guarantee(vtblEntrySize == wordSize, "ldr shift amount must be lsl#3");
+  assert(vtblEntrySize == wordSize, "ldr shift amount must be lsl#3");
   ldr(temp_itbl_klass, Address(recv_klass, scan_temp, Address::lsl(exact_log2(vtblEntrySize))));
   mov(holder_offset, zr);
   // scan_temp = &(itable[0]._interface)

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1215,22 +1215,21 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   assert_different_registers(resolved_klass, recv_klass, holder_klass, temp_itbl_klass, scan_temp, holder_offset);
   assert_different_registers(method_result, recv_klass, holder_klass, temp_itbl_klass, scan_temp, holder_offset);
 
-  int vtable_base = in_bytes(Klass::vtable_start_offset());
-  int itentry_off = in_bytes(itableMethodEntry::method_offset());
-  int scan_step = itableOffsetEntry::size() * wordSize;
-  int vte_size = vtableEntry::size_in_bytes();
+  int vtable_start_offset = in_bytes(Klass::vtable_start_offset());
+  int itable_offset_entry_size = itableOffsetEntry::size() * wordSize;
   int ioffset = in_bytes(itableOffsetEntry::interface_offset());
   int ooffset = in_bytes(itableOffsetEntry::offset_offset());
-  assert(vte_size == wordSize, "else adjust times_vte_scale");
+  assert(vtableEntry::size_in_bytes() == wordSize, "else adjust times_vte_scale");
 
-  Label L_loop_scan_resolved_entry, L_resolved_found, L_holder_found;
+  Label L_loop_search_resolved_entry, L_resolved_found, L_holder_found;
 
-  // temp_itbl_klass = recv_klass.itable[0]
-  // scan_temp = &recv_klass.itable[0]
   ldrw(scan_temp, Address(recv_klass, Klass::vtable_length_offset()));
-  add(recv_klass, recv_klass, vtable_base + ioffset);
+  add(recv_klass, recv_klass, vtable_start_offset + ioffset);
+  // itableOffsetEntry[] itable = recv_klass + Klass::vtable_start_offset() + recv_klass->_vtable_len;
+  // temp_itbl_klass = itable[0]._interface;
   ldr(temp_itbl_klass, Address(recv_klass, scan_temp, Address::lsl(3)));
   mov(holder_offset, zr);
+  // scan_temp = &(itable[0]._interface)
   lea(scan_temp, Address(recv_klass, scan_temp, Address::lsl(3)));
 
   // Initial checks:
@@ -1238,67 +1237,63 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   //   - if (itable[0] == holder_klass), shortcut to "holder found"
   //   - if (itable[0] == 0), no such interface
   cmp(resolved_klass, holder_klass);
-  br(Assembler::NE, L_loop_scan_resolved_entry);
+  br(Assembler::NE, L_loop_search_resolved_entry);
   cmp(holder_klass, temp_itbl_klass);
   br(Assembler::EQ, L_holder_found);
   cbz(temp_itbl_klass, L_no_such_interface);
 
   // Loop: Look for holder_klass record in itable
   //   do {
-  //     temp_itbl_klass = *(scan_temp += scan_step);
+  //     temp_itbl_klass = *(scan_temp += itable_offset_entry_size);
   //     if (temp_itbl_klass == holder_klass) {
   //       goto L_holder_found; // Found!
   //     }
   //   } while (temp_itbl_klass != 0);
   //   goto L_no_such_interface // Not found.
-  Label L_scan_holder;
-  bind(L_scan_holder);
-    ldr(temp_itbl_klass, Address(pre(scan_temp, scan_step)));
+  Label L_search_holder;
+  bind(L_search_holder);
+    ldr(temp_itbl_klass, Address(pre(scan_temp, itable_offset_entry_size)));
     cmp(holder_klass, temp_itbl_klass);
     br(Assembler::EQ, L_holder_found);
-    cbnz(temp_itbl_klass, L_scan_holder);
+    cbnz(temp_itbl_klass, L_search_holder);
 
   b(L_no_such_interface);
 
   // Loop: Look for resolved_class record in itable
-  //   L_save_holder_offset:
-  //     holder_offset = index;
-  //   do {
-  //     temp_itbl_klass = *(scan_temp += scan_step);
-  //     if (temp_itbl_klass == holder_klass) {
-  //        goto L_save_holder_offset;
+  //   while (true) {
+  //     temp_itbl_klass = *(scan_temp += itable_offset_entry_size);
+  //     if (temp_itbl_klass == 0) {
+  //       goto L_no_such_interface;
   //     }
   //     if (temp_itbl_klass == resolved_klass) {
   //        goto L_resolved_found;  // Found!
   //     }
-  //   } while (temp_itbl_klass != 0);
-  //   goto L_no_such_interface // Not found.
+  //     if (temp_itbl_klass == holder_klass) {
+  //        holder_offset = scan_temp;
+  //     }
+  //   }
   //
-  Label L_save_holder_offset;
-  bind(L_save_holder_offset);
-    mov(holder_offset, scan_temp);
-    // continue searching for resolved_found (checked above: resolved found != resolved class)
-  Label L_loop_scan_resolved;
-  bind(L_loop_scan_resolved);
-    ldr(temp_itbl_klass, Address(pre(scan_temp, scan_step)));
-    bind(L_loop_scan_resolved_entry);
-    cmp(holder_klass, temp_itbl_klass);
-    br(Assembler::EQ, L_save_holder_offset);
+  Label L_loop_search_resolved;
+  bind(L_loop_search_resolved);
+    ldr(temp_itbl_klass, Address(pre(scan_temp, itable_offset_entry_size)));
+  bind(L_loop_search_resolved_entry);
+    cbz(temp_itbl_klass, L_no_such_interface);
     cmp(resolved_klass, temp_itbl_klass);
     br(Assembler::EQ, L_resolved_found);
-    cbnz(temp_itbl_klass, L_loop_scan_resolved);
-
-  b(L_no_such_interface);
+    cmp(holder_klass, temp_itbl_klass);
+    br(Assembler::NE, L_loop_search_resolved);
+    mov(holder_offset, scan_temp);
+    b(L_loop_search_resolved);
 
   // See if we already have a holder klass. If not, go and scan for it.
   bind(L_resolved_found);
-  cbz(holder_offset, L_scan_holder);
+  cbz(holder_offset, L_search_holder);
   mov(scan_temp, holder_offset);
 
   // Finally, scan_temp contains holder_klass vtable offset
   bind(L_holder_found);
   ldrw(method_result, Address(scan_temp, ooffset - ioffset));
-  add(recv_klass, recv_klass, (itable_index << 3) + itentry_off - (vtable_base + ioffset));
+  add(recv_klass, recv_klass, (itable_index << 3) + in_bytes(itableMethodEntry::method_offset()) - vtable_start_offset - ioffset);
   ldr(method_result, Address(recv_klass, method_result, Address::uxtw(0)));
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1220,7 +1220,6 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   int itable_offset_entry_size = itableOffsetEntry::size() * wordSize;
   int ioffset = in_bytes(itableOffsetEntry::interface_offset());
   int ooffset = in_bytes(itableOffsetEntry::offset_offset());
-  assert(vtableEntry::size_in_bytes() == wordSize, "else adjust times_vte_scale");
 
   Label L_loop_search_resolved_entry, L_resolved_found, L_holder_found;
 
@@ -1229,7 +1228,7 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   // itableOffsetEntry[] itable = recv_klass + Klass::vtable_start_offset() + sizeof(vtableEntry) * recv_klass->_vtable_len;
   // temp_itbl_klass = itable[0]._interface;
   int vtblEntrySize = vtableEntry::size_in_bytes();
-  assert(vtblEntrySize == wordSize, "ldr shift amount must be lsl#3");
+  assert(vtblEntrySize == wordSize, "ldr lsl shift amount must be 3");
   ldr(temp_itbl_klass, Address(recv_klass, scan_temp, Address::lsl(exact_log2(vtblEntrySize))));
   mov(holder_offset, zr);
   // scan_temp = &(itable[0]._interface)

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -943,6 +943,16 @@ public:
                                Label& no_such_interface,
                    bool return_method = true);
 
+  void lookup_interface_method_stub(Register recv_klass,
+                                    Register holder_klass,
+                                    Register resolved_klass,
+                                    Register method_result,
+                                    Register temp_reg,
+                                    Register temp_reg2,
+                                    Register temp_reg3,
+                                    int itable_index,
+                                    Label& L_no_such_interface);
+
   // virtual method calling
   // n.b. x86 allows RegisterOrConstant for vtable_index
   void lookup_virtual_method(Register recv_klass,

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -949,7 +949,6 @@ public:
                                     Register method_result,
                                     Register temp_reg,
                                     Register temp_reg2,
-                                    Register temp_reg3,
                                     int itable_index,
                                     Label& L_no_such_interface);
 

--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -178,6 +178,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   const Register resolved_klass_reg = rmethod; // resolved interface klass (REFC)
   const Register temp_reg           = r11;
   const Register temp_reg2          = r15;
+  const Register temp_reg3          = r17;
   const Register icholder_reg       = rscratch2;
 
   Label L_no_such_interface;
@@ -192,28 +193,15 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   __ load_klass(recv_klass_reg, j_rarg0);
 
   // Receiver subtype check against REFC.
-  __ lookup_interface_method(// inputs: rec. class, interface
-                             recv_klass_reg, resolved_klass_reg, noreg,
-                             // outputs:  scan temp. reg1, scan temp. reg2
-                             temp_reg2, temp_reg,
-                             L_no_such_interface,
-                             /*return_method=*/false);
-
-  const ptrdiff_t  typecheckSize = __ pc() - start_pc;
-  start_pc = __ pc();
-
   // Get selected method from declaring class and itable index
-  __ lookup_interface_method(// inputs: rec. class, interface, itable index
-                             recv_klass_reg, holder_klass_reg, itable_index,
-                             // outputs: method, scan temp. reg
-                             rmethod, temp_reg,
-                             L_no_such_interface);
+  __ lookup_interface_method_stub(recv_klass_reg, holder_klass_reg, resolved_klass_reg, rmethod,
+                                  temp_reg, temp_reg2, temp_reg3, itable_index, L_no_such_interface);
 
   const ptrdiff_t lookupSize = __ pc() - start_pc;
 
   // Reduce "estimate" such that "padding" does not drop below 8.
   const ptrdiff_t estimate = 124;
-  const ptrdiff_t codesize = typecheckSize + lookupSize;
+  const ptrdiff_t codesize = lookupSize;
   slop_delta  = (int)(estimate - codesize);
   slop_bytes += slop_delta;
   assert(slop_delta >= 0, "itable #%d: Code size estimate (%d) for lookup_interface_method too small, required: %d", itable_index, (int)estimate, (int)codesize);

--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -197,11 +197,9 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   __ lookup_interface_method_stub(recv_klass_reg, holder_klass_reg, resolved_klass_reg, rmethod,
                                   temp_reg, temp_reg2, temp_reg3, itable_index, L_no_such_interface);
 
-  const ptrdiff_t lookupSize = __ pc() - start_pc;
-
   // Reduce "estimate" such that "padding" does not drop below 8.
   const ptrdiff_t estimate = 124;
-  const ptrdiff_t codesize = lookupSize;
+  const ptrdiff_t codesize = __ pc() - start_pc;
   slop_delta  = (int)(estimate - codesize);
   slop_bytes += slop_delta;
   assert(slop_delta >= 0, "itable #%d: Code size estimate (%d) for lookup_interface_method too small, required: %d", itable_index, (int)estimate, (int)codesize);

--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -175,10 +175,9 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // so all registers except arguments are free at this point.
   const Register recv_klass_reg     = r10;
   const Register holder_klass_reg   = r16; // declaring interface klass (DECC)
-  const Register resolved_klass_reg = rmethod; // resolved interface klass (REFC)
+  const Register resolved_klass_reg = r17; // resolved interface klass (REFC)
   const Register temp_reg           = r11;
   const Register temp_reg2          = r15;
-  const Register temp_reg3          = r17;
   const Register icholder_reg       = rscratch2;
 
   Label L_no_such_interface;
@@ -195,7 +194,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // Receiver subtype check against REFC.
   // Get selected method from declaring class and itable index
   __ lookup_interface_method_stub(recv_klass_reg, holder_klass_reg, resolved_klass_reg, rmethod,
-                                  temp_reg, temp_reg2, temp_reg3, itable_index, L_no_such_interface);
+                                  temp_reg, temp_reg2, itable_index, L_no_such_interface);
 
   // Reduce "estimate" such that "padding" does not drop below 8.
   const ptrdiff_t estimate = 124;


### PR DESCRIPTION
This is a change for AARCH similar to https://github.com/openjdk/jdk/pull/13460 

The change replaces two separate iterations over the itable with a new algorithm consisting of two loops. First, we look for a match with resolved_klass, checking for a match with holder_klass along the way. Then we continue iterating (not starting over) the itable using the second loop, checking only for a match with holder_klass.

InterfaceCalls openjdk benchmark performance results on A53, A72, Neoverse N1 and V1 micro-architectures:

```
Cortex-A53 (Pi 3 Model B Rev 1.2)

test1stInt2Types    37.5      37.358     0.38
test1stInt3Types   160.166   148.04      8.19
test1stInt5Types   158.131   147.955     6.88
test2ndInt2Types    52.634    53.291    -1.23
test2ndInt3Types   201.39    181.603    10.90
test2ndInt5Types   195.722   176.707    10.76
testIfaceCall      157.453   140.498    12.07
testIfaceExtCall   175.46    154.351    13.68
testMonomorphic     32.052    32.039     0.04
                                 AVG:    6.85

Cortex-A72 (Pi 4 Model B Rev 1.2)

test1stInt2Types    27.4796   27.4738    0.02
test1stInt3Types    66.0085   64.9374    1.65
test1stInt5Types    67.9812   66.2316    2.64
test2ndInt2Types    32.0581   32.062    -0.01
test2ndInt3Types    68.2715   65.6643    3.97
test2ndInt5Types    68.1012   65.8024    3.49
testIfaceCall       64.0684   64.1811   -0.18
testIfaceExtCall    91.6226   81.5867   12.30
testMonomorphic     26.7161   26.7142    0.01
                                 AVG:    2.66

Neoverse N1 (m6g.metal)

test1stInt2Types     2.9104    2.9086    0.06
test1stInt3Types    10.9642   10.2909    6.54
test1stInt5Types    10.9607   10.2856    6.56
test2ndInt2Types     3.3410    3.3478   -0.20
test2ndInt3Types    12.3291   11.3089    9.02
test2ndInt5Types    12.328    11.2704    9.38
testIfaceCall       11.0598   10.3657    6.70
testIfaceExtCall    13.0692   11.2826   15.84
testMonomorphic      2.2354    2.2341    0.06
                                 AVG:    6.00

Neoverse V1 (c7g.2xlarge)

test1stInt2Types    2.2317     2.2320   -0.01
test1stInt3Types    6.6884     6.1911    8.03
test1stInt5Types    6.7334     6.2193    8.27
test2ndInt2Types    2.4002     2.4013   -0.04
test2ndInt3Types    7.9603     7.0372   13.12
test2ndInt5Types    7.9532     7.0474   12.85
testIfaceCall       6.7028     6.3272    5.94
testIfaceExtCall    8.3253     6.9416   19.93
testMonomorphic     1.2446     1.2544   -0.79
                                 AVG:    7.48 
```

Testing: jtreg tier1-3, release & fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307352](https://bugs.openjdk.org/browse/JDK-8307352): AARCH64: Improve itable_stub (**Enhancement** - P4)


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**) ⚠️ Review applies to [1687c4bd](https://git.openjdk.org/jdk/pull/13792/files/1687c4bd80e44fc6631205fefcdf64e2ac2c4034)
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13792/head:pull/13792` \
`$ git checkout pull/13792`

Update a local copy of the PR: \
`$ git checkout pull/13792` \
`$ git pull https://git.openjdk.org/jdk.git pull/13792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13792`

View PR using the GUI difftool: \
`$ git pr show -t 13792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13792.diff">https://git.openjdk.org/jdk/pull/13792.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13792#issuecomment-1589442109)