### PR TITLE
8307421: Fix comment in g1CollectionSetChooser.hpp after JDK-8306836

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
@@ -54,7 +54,7 @@ public:
 
   // Determine whether to add the given region to the collection set candidates or
   // not. Currently, we skip regions that we will never move during young gc, and
-  // regions which liveness is below the occupancy threshold.
+  // regions which liveness is over the occupancy threshold.
   // Regions also need a complete remembered set to be a candidate.
   static bool should_add(HeapRegion* hr);
 


### PR DESCRIPTION
Hi all,

  please review this trivial comment fix @kimbarrett noticed while reviewing the [JDK-8306836](https://bugs.openjdk.org/browse/JDK-8306836) change after having it pushed.

Testing: local compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307421](https://bugs.openjdk.org/browse/JDK-8307421): Fix comment in g1CollectionSetChooser.hpp after JDK-8306836


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13793/head:pull/13793` \
`$ git checkout pull/13793`

Update a local copy of the PR: \
`$ git checkout pull/13793` \
`$ git pull https://git.openjdk.org/jdk.git pull/13793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13793`

View PR using the GUI difftool: \
`$ git pr show -t 13793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13793.diff">https://git.openjdk.org/jdk/pull/13793.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13793#issuecomment-1534249982)