### PR TITLE
8303153: Native interpreter frame missing mirror

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -884,7 +884,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     // Make sure there is room for the exception oop pushed in case method throws
     // an exception (see TemplateInterpreterGenerator::generate_throw_exception())
     __ sub(rscratch1, sp, 2 * wordSize);
-    __ stp(zr, rscratch1, Address(sp, 4 * wordSize));
+    __ stp(r10, rscratch1, Address(sp, 4 * wordSize));
     __ mov(sp, rscratch1);
   }
 }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -789,7 +789,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     // an exception (see TemplateInterpreterGenerator::generate_throw_exception())
     __ sub(t0, sp, 2 * wordSize);
     __ sd(t0, Address(sp, 5 * wordSize));
-    __ sd(zr, Address(sp, 4 * wordSize));
+    __ sd(t2, Address(sp, 4 * wordSize));
     __ mv(sp, t0);
   }
 }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -770,8 +770,10 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   __ sd(x19_sender_sp, Address(sp, 9 * wordSize));
   __ sd(zr, Address(sp, 8 * wordSize));
 
-  // Get mirror
+  // Get mirror and store it in the frame as GC root for this Method*
   __ load_mirror(t2, xmethod, x15, t1);
+  __ sd(t2, Address(sp, 4 * wordSize));
+
   if (!native_call) {
     __ ld(t0, Address(xmethod, Method::const_offset()));
     __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
@@ -779,9 +781,8 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     __ slli(t0, t0, 3);
     __ sub(t0, sp, t0);
     __ andi(t0, t0, -16);
-    // Store extended SP and mirror
+    // Store extended SP
     __ sd(t0, Address(sp, 5 * wordSize));
-    __ sd(t2, Address(sp, 4 * wordSize));
     // Move SP out of the way
     __ mv(sp, t0);
   } else {
@@ -789,7 +790,6 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     // an exception (see TemplateInterpreterGenerator::generate_throw_exception())
     __ sub(t0, sp, 2 * wordSize);
     __ sd(t0, Address(sp, 5 * wordSize));
-    __ sd(t2, Address(sp, 4 * wordSize));
     __ mv(sp, t0);
   }
 }


### PR DESCRIPTION
The mirror needs to be stored in the frame for native calls also on AArch64 and RISC-V (as it is on other platforms).
See JDK-8303153 for more info.
Passes tier1-5 tests on AArch64. Done basic tests on RISC-V using QEmu.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303153](https://bugs.openjdk.org/browse/JDK-8303153): Native interpreter frame missing mirror


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [3d0a5ff9](https://git.openjdk.org/jdk/pull/13794/files/3d0a5ff931eaef27407bbafbd80cff397f437526)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13794/head:pull/13794` \
`$ git checkout pull/13794`

Update a local copy of the PR: \
`$ git checkout pull/13794` \
`$ git pull https://git.openjdk.org/jdk.git pull/13794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13794`

View PR using the GUI difftool: \
`$ git pr show -t 13794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13794.diff">https://git.openjdk.org/jdk/pull/13794.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13794#issuecomment-1534266649)