### PR TITLE
JDK-8307331: Correctly update line maps when class redefine rewrites bytecodes

### DIFF
--- a/src/hotspot/share/runtime/relocator.cpp
+++ b/src/hotspot/share/runtime/relocator.cpp
@@ -407,11 +407,24 @@ void Relocator::adjust_exception_table(int bci, int delta) {
   }
 }
 
+static void print_linenumber_table(unsigned char* table) {
+  CompressedLineNumberReadStream stream(table);
+  tty->print_cr("-------------------------------------------------");
+  while (stream.read_pair()) {
+    tty->print_cr("   - line %d: %d", stream.line(), stream.bci());
+  }
+  tty->print_cr("-------------------------------------------------");
+}
 
 // The width of instruction at "bci" is changing by "delta".  Adjust the line number table.
 void Relocator::adjust_line_no_table(int bci, int delta) {
   if (method()->has_linenumber_table()) {
-    CompressedLineNumberReadStream  reader(method()->compressed_linenumber_table());
+    // if we already made adjustments then use the updated table
+    unsigned char *table = compressed_line_number_table();
+    if (table == nullptr) {
+      table = method()->compressed_linenumber_table();
+    }
+    CompressedLineNumberReadStream  reader(table);
     CompressedLineNumberWriteStream writer(64);  // plenty big for most line number tables
     while (reader.read_pair()) {
       int adjustment = (reader.bci() > bci) ? delta : 0;
@@ -420,6 +433,10 @@ void Relocator::adjust_line_no_table(int bci, int delta) {
     writer.write_terminator();
     set_compressed_line_number_table(writer.buffer());
     set_compressed_line_number_table_size(writer.position());
+    if (TraceRelocator) {
+      tty->print_cr("Adjusted line number table");
+      print_linenumber_table(compressed_line_number_table());
+    }
   }
 }
 


### PR DESCRIPTION
This small change ensures that repeated bytecode rewrites necessitated by class pool index updates are applied cumulatively when updating the method line number table. The current code applies each change to the original table which means only the last one is applied (and even then with the wrong adjustment).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307331](https://bugs.openjdk.org/browse/JDK-8307331): Correctly update line maps when class redefine rewrites bytecodes


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13795/head:pull/13795` \
`$ git checkout pull/13795`

Update a local copy of the PR: \
`$ git checkout pull/13795` \
`$ git pull https://git.openjdk.org/jdk.git pull/13795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13795`

View PR using the GUI difftool: \
`$ git pr show -t 13795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13795.diff">https://git.openjdk.org/jdk/pull/13795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13795#issuecomment-1534403851)