### PR TITLE
8307428: jstat tests doesn't tolerate dash in the O column

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
+++ b/test/jdk/sun/tools/jstatd/JstatGCUtilParser.java
@@ -46,7 +46,7 @@ public class JstatGCUtilParser {
         S0(GcStatisticsType.PERCENTAGE_OR_DASH),
         S1(GcStatisticsType.PERCENTAGE_OR_DASH),
         E(GcStatisticsType.PERCENTAGE_OR_DASH),
-        O(GcStatisticsType.PERCENTAGE),
+        O(GcStatisticsType.PERCENTAGE_OR_DASH),
         M(GcStatisticsType.PERCENTAGE_OR_DASH),
         CCS(GcStatisticsType.PERCENTAGE_OR_DASH),
         YGC(GcStatisticsType.INTEGER_OR_DASH),


### PR DESCRIPTION
When running jstat tests like the following:
test/jdk/sun/tools/jstatd/TestJstatdServer.java

with Generational ZGC we get a failure because the O (old generation percentage) is reported as `-` and not a number. The reason why it is reported as `-` is that the current capacity of the old generation is zero and that leads to a divide-by-zero in this line:
https://github.com/openjdk/jdk/blob/82a8e91ef7c3b397f9cce3854722cfe4bace6f2e/src/jdk.jcmd/share/classes/sun/tools/jstat/resources/jstat_options#L1029

G1 has some workarounds for this situation where the reported capacity is slightly above 0. I'm a bit reluctant to add such a hack into Generational ZGC. I've talked to the jstat maintainers and they propose that we simply relax the test.

Tested locally by running the jstat/jstad tests in the Generational ZGC branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307428](https://bugs.openjdk.org/browse/JDK-8307428): jstat tests doesn't tolerate dash in the O column


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13796/head:pull/13796` \
`$ git checkout pull/13796`

Update a local copy of the PR: \
`$ git checkout pull/13796` \
`$ git pull https://git.openjdk.org/jdk.git pull/13796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13796`

View PR using the GUI difftool: \
`$ git pr show -t 13796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13796.diff">https://git.openjdk.org/jdk/pull/13796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13796#issuecomment-1534425606)