### PR TITLE
8307425 - Socket input stream read burns CPU cycles with back-to-back poll(0) calls

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -78,6 +78,9 @@ import sun.net.ResourceManager;
 import sun.net.ext.ExtendedSocketOptions;
 import sun.net.util.IPAddressUtil;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 /**
  * An implementation of DatagramChannels.
  */
@@ -497,7 +500,12 @@ class DatagramChannelImpl
             if (nanos == 0) {
                 millis = -1;
             } else {
-                millis = TimeUnit.NANOSECONDS.toMillis(nanos);
+                millis = NANOSECONDS.toMillis(nanos);
+                if (nanos > MILLISECONDS.toNanos(millis)) {
+                    // Round up any excess nanos to the nearest millisecond to
+                    // avoid parking for less than requested.
+                    millis++;
+                }
             }
             Net.poll(getFD(), event, millis);
         }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -183,9 +183,8 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             } else {
                 millis = NANOSECONDS.toMillis(nanos);
                 if (nanos > MILLISECONDS.toNanos(millis)) {
-                    // Round up any excess nanos to the nearest millisecond. Avoids
-                    // parking for less than requested, especially when poll is
-                    // called with zero millis, which would return immediately.
+                    // Round up any excess nanos to the nearest millisecond to
+                    // avoid parking for less than requested.
                     millis++;
                 }
             }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -183,8 +183,9 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             } else {
                 millis = NANOSECONDS.toMillis(nanos);
                 if (nanos > MILLISECONDS.toNanos(millis)) {
-                    // Round *up*, so we never (ask to) wait less than requested.
-                    // Especially important between 0 and 1ms to avoid a tight loop.
+                    // Round up any excess nanos to the nearest millisecond. Avoids
+                    // parking for less than requested, especially when poll is
+                    // called with zero millis, which would return immediately.
                     millis++;
                 }
             }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -182,6 +182,11 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
                 millis = -1;
             } else {
                 millis = NANOSECONDS.toMillis(nanos);
+                if (nanos > MILLISECONDS.toNanos(millis)) {
+                    // Round *up*, so we never (ask to) wait less than requested.
+                    // Especially important between 0 and 1ms to avoid a tight loop.
+                    millis++;
+                }
             }
             Net.poll(fd, event, millis);
         }

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -90,6 +90,11 @@ public interface SelChImpl extends Channel {
                 millis = -1;
             } else {
                 millis = NANOSECONDS.toMillis(nanos);
+                if (nanos > MILLISECONDS.toNanos(millis)) {
+                    // Round *up*, so we never (ask to) wait less than requested.
+                    // Especially important between 0 and 1ms to avoid a tight loop.
+                    millis++;
+                }
             }
             Net.poll(getFD(), event, millis);
         }

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -28,6 +28,7 @@ package sun.nio.ch;
 import java.nio.channels.Channel;
 import java.io.FileDescriptor;
 import java.io.IOException;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -28,6 +28,7 @@ package sun.nio.ch;
 import java.nio.channels.Channel;
 import java.io.FileDescriptor;
 import java.io.IOException;
+
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -92,9 +93,8 @@ public interface SelChImpl extends Channel {
             } else {
                 millis = NANOSECONDS.toMillis(nanos);
                 if (nanos > MILLISECONDS.toNanos(millis)) {
-                    // Round up any excess nanos to the nearest millisecond. Avoids
-                    // parking for less than requested, especially when poll is
-                    // called with zero millis, which would return immediately.
+                    // Round up any excess nanos to the nearest millisecond to
+                    // avoid parking for less than requested.
                     millis++;
                 }
             }

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -93,7 +93,7 @@ public interface SelChImpl extends Channel {
                 millis = NANOSECONDS.toMillis(nanos);
                 if (nanos > MILLISECONDS.toNanos(millis)) {
                     // Round up any excess nanos to the nearest millisecond. Avoids
-                    // parking for less than requested, especially when poll is 
+                    // parking for less than requested, especially when poll is
                     // called with zero millis, which would return immediately.
                     millis++;
                 }

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -92,8 +92,9 @@ public interface SelChImpl extends Channel {
             } else {
                 millis = NANOSECONDS.toMillis(nanos);
                 if (nanos > MILLISECONDS.toNanos(millis)) {
-                    // Round *up*, so we never (ask to) wait less than requested.
-                    // Especially important between 0 and 1ms to avoid a tight loop.
+                    // Round up any excess nanos to the nearest millisecond. Avoids
+                    // parking for less than requested, especially when poll is 
+                    // called with zero millis, which would return immediately.
                     millis++;
                 }
             }


### PR DESCRIPTION
As described in https://bugs.openjdk.org/browse/JDK-8307425, fix two places where nanoseconds are rounded *down* to milliseconds, leading to expensive tight poll/read loops in some scenarios.

```
import java.io.InputStream;
import java.net.Socket;

public class ReadSingle {
    public static void main(String[] args) throws Exception {
        Socket s = new Socket("httpbin.org", 443);
        s.setSoTimeout(2); s.getOutputStream().write(1);
        InputStream is = s.getInputStream();
        System.out.println("Starting single byte read");
        is.read();
        s.close();
    }
}
```

Before (first poll with 1ms timeout, then tight loop of poll/read for the remainder):
```
strace -ftT -e trace=poll,read java ReadSingle
...
Starting single byte read
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000017>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 1) = 0 (Timeout) <0.001071>
                                        1ms timeout --^
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000014>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000013>
                    0ms timeout (tight loop begins) --^
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000013>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000013>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000013>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000013>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000013>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000014>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000013>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000013>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000013>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000013>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000014>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000014>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000014>
[pid 20963] 10:38:04 poll([{fd=5, events=POLLIN}], 1, 0) = 0 (Timeout) <0.000014>
[pid 20963] 10:38:04 read(5, 0x7fd14c191cb0, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000013>
Exception in thread "main" java.net.SocketTimeoutException: Read timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:273)
	at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:299)
	at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:341)
	at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:791)
	at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1099)
	at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1093)
	at ReadSingle.main(ReadSingle.java:10)
```

After (single poll with 2ms timeout):
```
strace -ftT -e trace=poll,read java ReadSingle
...
Starting single byte read
[pid 21831] 10:39:13 read(5, 0x7fae1c199a10, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000014>
[pid 21831] 10:39:13 poll([{fd=5, events=POLLIN}], 1, 2) = 0 (Timeout) <0.002072>
                                        2ms timeout --^
[pid 21831] 10:39:13 read(5, 0x7fae1c199a10, 1) = -1 EAGAIN (Resource temporarily unavailable) <0.000012>
Exception in thread "main" java.net.SocketTimeoutException: Read timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:279)
	at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:305)
	at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:347)
	at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:797)
	at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1099)
	at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1093)
	at ReadSingle.main(ReadSingle.java:10)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307425](https://bugs.openjdk.org/browse/JDK-8307425): Socket input stream read burns CPU cycles with back-to-back poll(0) calls


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [0bbd890d](https://git.openjdk.org/jdk/pull/13798/files/0bbd890dda66987683ae4605ca9bf909a3fc7f65)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13798/head:pull/13798` \
`$ git checkout pull/13798`

Update a local copy of the PR: \
`$ git checkout pull/13798` \
`$ git pull https://git.openjdk.org/jdk.git pull/13798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13798`

View PR using the GUI difftool: \
`$ git pr show -t 13798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13798.diff">https://git.openjdk.org/jdk/pull/13798.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13798#issuecomment-1534600903)