### PR TITLE
8307395: Add missing STS to Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -770,6 +770,7 @@ public:
 
   void work(uint worker_id) {
     ShenandoahConcurrentWorkerSession worker_session(worker_id);
+    ShenandoahSuspendibleThreadSetJoiner sts_join;
     {
       ShenandoahEvacOOMScope oom;
       // jni_roots and weak_roots are OopStorage backed roots, concurrent iteration


### PR DESCRIPTION
Testing in project Lilliput has revealed that Shenandoah GC is lacking one STS. This causes a reliable crash (with Lilliput) when running TestGCBasherWithShenandoah.java with -XX:+UseHeavyMonitors because it touches an already deflated monitor.

Testing (all in Lilliput where it caused the troubles, but applies to upstream as well):
 - [x] TestGCBasherWithShenandoah.java +UseHeavyMonitors
 - [x] hotspot_gc_shenandoah +UseHeavyMonitors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307395](https://bugs.openjdk.org/browse/JDK-8307395): Add missing STS to Shenandoah


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13799/head:pull/13799` \
`$ git checkout pull/13799`

Update a local copy of the PR: \
`$ git checkout pull/13799` \
`$ git pull https://git.openjdk.org/jdk.git pull/13799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13799`

View PR using the GUI difftool: \
`$ git pr show -t 13799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13799.diff">https://git.openjdk.org/jdk/pull/13799.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13799#issuecomment-1534616650)