### PR TITLE
8307446: RISC-V: Improve performance of floating point to integer conversion

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4063,14 +4063,13 @@ void MacroAssembler::zero_dcache_blocks(Register base, Register cnt, Register tm
 
 #define FCVT_SAFE(FLOATCVT, FLOATSIG)                                                     \
 void MacroAssembler::FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {     \
-  Label do_convert, done;                                                                 \
+  Label done;                                                                             \
+  assert_different_registers(dst, tmp);                                                   \
   fclass_##FLOATSIG(tmp, src);                                                            \
+  mv(dst, zr);                                                                            \
   /* check if src is NaN */                                                               \
   andi(tmp, tmp, 0b1100000000);                                                           \
-  beqz(tmp, do_convert);                                                                  \
-  mv(dst, zr);                                                                            \
-  j(done);                                                                                \
-  bind(do_convert);                                                                       \
+  bnez(tmp, done);                                                                        \
   FLOATCVT(dst, src);                                                                     \
   bind(done);                                                                             \
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4061,24 +4061,24 @@ void MacroAssembler::zero_dcache_blocks(Register base, Register cnt, Register tm
   bge(cnt, tmp1, loop);
 }
 
-#define FCVT_SAFE(FLOATCVT, FLOATEQ)                                                             \
-void MacroAssembler:: FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {           \
-  Label L_Okay;                                                                                  \
-  fscsr(zr);                                                                                     \
-  FLOATCVT(dst, src);                                                                            \
-  frcsr(tmp);                                                                                    \
-  andi(tmp, tmp, 0x1E);                                                                          \
-  beqz(tmp, L_Okay);                                                                             \
-  FLOATEQ(tmp, src, src);                                                                        \
-  bnez(tmp, L_Okay);                                                                             \
-  mv(dst, zr);                                                                                   \
-  bind(L_Okay);                                                                                  \
+#define FCVT_SAFE(FLOATCVT, IS_DOUBLE)                                                    \
+void MacroAssembler::FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {     \
+  Label do_convert, done;                                                                 \
+  IS_DOUBLE ? fclass_d(tmp, src) : fclass_s(tmp, src);                                    \
+  /* check if src is NaN */                                                               \
+  andi(tmp, tmp, 0b1100000000);                                                           \
+  beqz(tmp, do_convert);                                                                  \
+  mv(dst, zr);                                                                            \
+  j(done);                                                                                \
+  bind(do_convert);                                                                       \
+  FLOATCVT(dst, src);                                                                     \
+  bind(done);                                                                             \
 }
 
-FCVT_SAFE(fcvt_w_s, feq_s)
-FCVT_SAFE(fcvt_l_s, feq_s)
-FCVT_SAFE(fcvt_w_d, feq_d)
-FCVT_SAFE(fcvt_l_d, feq_d)
+FCVT_SAFE(fcvt_w_s, false);
+FCVT_SAFE(fcvt_l_s, false);
+FCVT_SAFE(fcvt_w_d, true);
+FCVT_SAFE(fcvt_l_d, true);
 
 #undef FCVT_SAFE
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4061,10 +4061,10 @@ void MacroAssembler::zero_dcache_blocks(Register base, Register cnt, Register tm
   bge(cnt, tmp1, loop);
 }
 
-#define FCVT_SAFE(FLOATCVT, IS_DOUBLE)                                                    \
+#define FCVT_SAFE(FLOATCVT, FLOATSIG)                                                     \
 void MacroAssembler::FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {     \
   Label do_convert, done;                                                                 \
-  IS_DOUBLE ? fclass_d(tmp, src) : fclass_s(tmp, src);                                    \
+  fclass_##FLOATSIG(tmp, src);                                                            \
   /* check if src is NaN */                                                               \
   andi(tmp, tmp, 0b1100000000);                                                           \
   beqz(tmp, do_convert);                                                                  \
@@ -4075,10 +4075,10 @@ void MacroAssembler::FLOATCVT##_safe(Register dst, FloatRegister src, Register t
   bind(done);                                                                             \
 }
 
-FCVT_SAFE(fcvt_w_s, false);
-FCVT_SAFE(fcvt_l_s, false);
-FCVT_SAFE(fcvt_w_d, true);
-FCVT_SAFE(fcvt_l_d, true);
+FCVT_SAFE(fcvt_w_s, s);
+FCVT_SAFE(fcvt_l_s, s);
+FCVT_SAFE(fcvt_w_d, d);
+FCVT_SAFE(fcvt_l_d, d);
 
 #undef FCVT_SAFE
 


### PR DESCRIPTION
Hi, 

can I have reviews for this change that improves the performance of floating point to integer conversion?

Currently, risc-v port converts floating point to integer using `FCVT_SAFE` in macroAssembler_riscv.cpp.

The main issue here is Java spec returns 0 when the floating point number is NaN [1].
But for RISC-V ISA, instructions converting a floating-point value to an integer value (`FCVT.W.S`/`FCVT.L.S`/`FCVT.W.D`/`FCVT.L.D`) return the largest/smallest value when the floating point number is NaN [2].
That requires additional logic to handle the case when the src of conversion is NaN, as the following code did:

```
#define FCVT_SAFE(FLOATCVT, FLOATEQ)                                                             \
void MacroAssembler:: FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {           \
  Label L_Okay;                                                                                  \
  fscsr(zr);                                                                                     \
  FLOATCVT(dst, src);                                                                            \
  frcsr(tmp);                                                                                    \
  andi(tmp, tmp, 0x1E);                                                                          \
  beqz(tmp, L_Okay);                                                                             \
  FLOATEQ(tmp, src, src);                                                                        \
  bnez(tmp, L_Okay);                                                                             \
  mv(dst, zr);                                                                                   \
  bind(L_Okay);                                                                                  \
}

FCVT_SAFE(fcvt_w_s, feq_s)
FCVT_SAFE(fcvt_l_s, feq_s)
FCVT_SAFE(fcvt_w_d, feq_d)
FCVT_SAFE(fcvt_l_d, feq_d)
```

We can improve the logic of NaN checking with the `fclass` instruction just as [JDK-8297359](https://bugs.openjdk.org/browse/JDK-8297359) did.

Here are the JMH results, we can got an obvious improvement for `f2i`/`f2l`/`d2i`/`d2l` conversions (source: [FloatConversion.java](https://gist.github.com/feilongjiang/b59bdd8db8460242bafac4a2ee6c2e06#file-floatconversion-java), tests on HiFive Unmatched board):

```
Before:

Benchmark                     (size)   Mode  Cnt   Score   Error   Units
FloatConversion.doubleToInt     2048  thrpt   15  29.311 ± 0.063  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  29.914 ± 0.023  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  30.530 ± 0.011  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  29.657 ± 0.021  ops/ms

Benchmark                     (size)   Mode  Cnt   Score   Error   Units
FloatConversion.doubleToInt     2048  thrpt   15  29.335 ± 0.014  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  29.919 ± 0.022  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  30.523 ± 0.026  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  29.670 ± 0.011  ops/ms

Benchmark                     (size)   Mode  Cnt   Score   Error   Units
FloatConversion.doubleToInt     2048  thrpt   15  29.344 ± 0.017  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  29.908 ± 0.060  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  30.539 ± 0.009  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  29.676 ± 0.013  ops/ms

---------------------------------------------------------------------------

After:

Benchmark                     (size)   Mode  Cnt   Score   Error   Units
FloatConversion.doubleToInt     2048  thrpt   15  65.903 ± 0.385  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  66.491 ± 0.057  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  68.045 ± 0.061  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  68.441 ± 0.077  ops/ms

Benchmark                     (size)   Mode  Cnt   Score   Error   Units
FloatConversion.doubleToInt     2048  thrpt   15  66.015 ± 0.059  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  66.511 ± 0.059  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  68.077 ± 0.051  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  68.467 ± 0.076  ops/ms

Benchmark                     (size)   Mode  Cnt   Score   Error   Units
FloatConversion.doubleToInt     2048  thrpt   15  65.999 ± 0.067  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  66.454 ± 0.090  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  68.048 ± 0.055  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  68.467 ± 0.054  ops/ms
```

1. https://docs.oracle.com/javase/specs/jls/se20/html/jls-5.html#jls-5.1.3
2. https://github.com/riscv/riscv-isa-manual/blob/63aeaada9b2fee7ca15e5c6b6a28f3b710fb7e58/src/f-st-ext.adoc?plain=1#L365-L386

## Testing:
- [x] tier1~3 on Unmatched board (release build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307446](https://bugs.openjdk.org/browse/JDK-8307446): RISC-V: Improve performance of floating point to integer conversion


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [c4de5e77](https://git.openjdk.org/jdk/pull/13800/files/c4de5e775a284a1617ad6513128cadee904e2970)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13800/head:pull/13800` \
`$ git checkout pull/13800`

Update a local copy of the PR: \
`$ git checkout pull/13800` \
`$ git pull https://git.openjdk.org/jdk.git pull/13800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13800`

View PR using the GUI difftool: \
`$ git pr show -t 13800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13800.diff">https://git.openjdk.org/jdk/pull/13800.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13800#issuecomment-1534669085)