### PR TITLE
8307448: Test RedefineSharedClassJFR fail due to wrong assumption

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8306929
- * @summary Verify clean_previous_versions when run with JFR and CDS
+ * @summary Verify should_clean_previous_versions when run with JFR and CDS
  * @requires vm.jvmti
  * @requires vm.cds
  * @requires vm.hasJFR
@@ -69,8 +69,9 @@ public class RedefineSharedClassJFR {
 
             if (args[0].equals("xshare-off")) {
                 // First case is with -Xshare:off. In this case no classes are shared
-                // and we should be able to clean out the retransformed classes. Verify
-                // that the cleaning is done when the GC is triggered.
+                // and we should be able to clean out the retransformed classes. There
+                // is no guarantee that any classes will be in use, so just verify that
+                // no classes are added due to being shared.
                 List<String> offCommand = new ArrayList<>();
                 offCommand.add("-Xshare:off");
                 offCommand.addAll(baseCommand);

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
@@ -76,12 +76,9 @@ public class RedefineSharedClassJFR {
                 offCommand.addAll(baseCommand);
                 ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(offCommand);
                 new OutputAnalyzer(pb.start())
-                    .shouldContain(SHOULD_CLEAN_TRUE)
-                    .shouldNotContain(SHOULD_CLEAN_FALSE)
-                    // We expect at least one of the transformed classes to be in use, if
-                    // not the above check that should_clean_previous should be true will also
-                    // fail. This check is to show what is expected.
-                    .shouldContain(SCRATCH_CLASS_ADDED_ON_STACK)
+                    // We can't expect any of the transformed classes to be in use
+                    // so the only thing we can verify is that no scratch classes
+                    // are added because they are shared.
                     .shouldNotContain(SCRATCH_CLASS_ADDED_SHARED)
                     .shouldHaveExitValue(0);
                 return;


### PR DESCRIPTION
Please review this fix to avoid a tier1 test failure.

**Summary**
The newly added test wrongfully assumed that one of the transformed classes would be in use. This seem to be the case in most runs, but there is no guarantee. This change fixes the test to only verify that nothing is seen as shared when running with -Xshare:off.

**Testing**
Verified that the test still passes locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307448](https://bugs.openjdk.org/browse/JDK-8307448): Test RedefineSharedClassJFR fail due to wrong assumption


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13801/head:pull/13801` \
`$ git checkout pull/13801`

Update a local copy of the PR: \
`$ git checkout pull/13801` \
`$ git pull https://git.openjdk.org/jdk.git pull/13801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13801`

View PR using the GUI difftool: \
`$ git pr show -t 13801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13801.diff">https://git.openjdk.org/jdk/pull/13801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13801#issuecomment-1534670606)