### PR TITLE
8306326: [BACKOUT] 8277573: VmObjectAlloc is not generated by intrinsics methods which allocate objects

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -1031,14 +1031,10 @@ void ConnectionGraph::add_call_node(CallNode* call) {
     ciMethod* meth = call->as_CallJava()->method();
     if (meth == nullptr) {
       const char* name = call->as_CallStaticJava()->_name;
-      if (strncmp(name, "_notify_jvmti_object_alloc", 26) == 0) { // Object escapes to JVMTI
-        add_java_object(call, PointsToNode::GlobalEscape);
-      } else {
-        assert(strncmp(name, "_multianewarray", 15) == 0, "TODO: add failed case check");
-        // Returns a newly allocated non-escaped object.
-        add_java_object(call, PointsToNode::NoEscape);
-        set_not_scalar_replaceable(ptnode_adr(call_idx) NOT_PRODUCT(COMMA "is result of multinewarray"));
-      }
+      assert(strncmp(name, "_multianewarray", 15) == 0, "TODO: add failed case check");
+      // Returns a newly allocated non-escaped object.
+      add_java_object(call, PointsToNode::NoEscape);
+      set_not_scalar_replaceable(ptnode_adr(call_idx) NOT_PRODUCT(COMMA "is result of multinewarray"));
     } else if (meth->is_boxing_method()) {
       // Returns boxing object
       PointsToNode::EscapeState es;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -50,7 +50,6 @@
 #include "opto/runtime.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/subnode.hpp"
-#include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "prims/unsafe.hpp"
 #include "runtime/jniHandles.inline.hpp"
@@ -2829,29 +2828,8 @@ bool LibraryCallKit::inline_unsafe_allocate() {
     test = _gvn.transform(new SubINode(inst, bits));
     // The 'test' is non-zero if we need to take a slow path.
   }
-  Node* obj = new_instance(kls, test);
-#if INCLUDE_JVMTI
-  // Check if JvmtiExport::_should_notify_object_alloc is enabled and post notifications
-  IdealKit ideal(this);
-  IdealVariable result(ideal); ideal.declarations_done();
-  Node* ONE = ideal.ConI(1);
-  Node* addr = makecon(TypeRawPtr::make((address) &JvmtiExport::_should_notify_object_alloc));
-  Node* should_post_vm_object_alloc = ideal.load(ideal.ctrl(), addr, TypeInt::BOOL, T_BOOLEAN, Compile::AliasIdxRaw);
 
-  ideal.sync_kit(this);
-  ideal.if_then(should_post_vm_object_alloc, BoolTest::eq, ONE); {
-    const TypeFunc *tf = OptoRuntime::notify_jvmti_object_alloc_Type();
-    address funcAddr = OptoRuntime::notify_jvmti_object_alloc();
-    sync_kit(ideal);
-    Node* call = make_runtime_call(RC_NO_LEAF, tf, funcAddr, "_notify_jvmti_object_alloc", TypePtr::BOTTOM, obj);
-    ideal.sync_kit(this);
-    ideal.set(result,_gvn.transform(new ProjNode(call, TypeFunc::Parms+0)));
-  } ideal.else_(); {
-    ideal.set(result,obj);
-  } ideal.end_if();
-  final_sync(ideal);
-  obj = ideal.value(result);
-#endif //INCLUDE_JVMTI
+  Node* obj = new_instance(kls, test);
   set_result(obj);
   return true;
 }

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -110,7 +110,6 @@ address OptoRuntime::_rethrow_Java                                = nullptr;
 address OptoRuntime::_slow_arraycopy_Java                         = nullptr;
 address OptoRuntime::_register_finalizer_Java                     = nullptr;
 #if INCLUDE_JVMTI
-address OptoRuntime::_notify_jvmti_object_alloc                   = nullptr;
 address OptoRuntime::_notify_jvmti_vthread_start                  = nullptr;
 address OptoRuntime::_notify_jvmti_vthread_end                    = nullptr;
 address OptoRuntime::_notify_jvmti_vthread_mount                  = nullptr;
@@ -156,7 +155,6 @@ bool OptoRuntime::generate(ciEnv* env) {
   gen(env, _multianewarray5_Java           , multianewarray5_Type         , multianewarray5_C               ,    0 , true, false);
   gen(env, _multianewarrayN_Java           , multianewarrayN_Type         , multianewarrayN_C               ,    0 , true, false);
 #if INCLUDE_JVMTI
-  gen(env, _notify_jvmti_object_alloc      , notify_jvmti_object_alloc_Type, SharedRuntime::notify_jvmti_object_alloc, 0, true, false);
   gen(env, _notify_jvmti_vthread_start     , notify_jvmti_vthread_Type    , SharedRuntime::notify_jvmti_vthread_start, 0, true, false);
   gen(env, _notify_jvmti_vthread_end       , notify_jvmti_vthread_Type    , SharedRuntime::notify_jvmti_vthread_end,   0, true, false);
   gen(env, _notify_jvmti_vthread_mount     , notify_jvmti_vthread_Type    , SharedRuntime::notify_jvmti_vthread_mount, 0, true, false);
@@ -481,21 +479,6 @@ const TypeFunc *OptoRuntime::new_instance_Type() {
 }
 
 #if INCLUDE_JVMTI
-const TypeFunc *OptoRuntime::notify_jvmti_object_alloc_Type() {
-  // create input type (domain)
-  const Type **fields = TypeTuple::fields(1);
-  fields[TypeFunc::Parms+0] = TypeInstPtr::NOTNULL;
-  const TypeTuple *domain = TypeTuple::make(TypeFunc::Parms+1, fields);
-
-   // create result type (range)
-   fields = TypeTuple::fields(1);
-   fields[TypeFunc::Parms+0] = TypeInstPtr::NOTNULL; // Returned oop
-
-   const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+1, fields);
-
-   return TypeFunc::make(domain, range);
-}
-
 const TypeFunc *OptoRuntime::notify_jvmti_vthread_Type() {
   // create input type (domain)
   const Type **fields = TypeTuple::fields(2);

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -136,7 +136,6 @@ class OptoRuntime : public AllStatic {
   static address _slow_arraycopy_Java;
   static address _register_finalizer_Java;
 #if INCLUDE_JVMTI
-  static address _notify_jvmti_object_alloc;
   static address _notify_jvmti_vthread_start;
   static address _notify_jvmti_vthread_end;
   static address _notify_jvmti_vthread_mount;
@@ -216,7 +215,6 @@ private:
   static address slow_arraycopy_Java()                   { return _slow_arraycopy_Java; }
   static address register_finalizer_Java()               { return _register_finalizer_Java; }
 #if INCLUDE_JVMTI
-  static address notify_jvmti_object_alloc()             { return _notify_jvmti_object_alloc; }
   static address notify_jvmti_vthread_start()            { return _notify_jvmti_vthread_start; }
   static address notify_jvmti_vthread_end()              { return _notify_jvmti_vthread_end; }
   static address notify_jvmti_vthread_mount()            { return _notify_jvmti_vthread_mount; }

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -724,7 +724,6 @@ JvmtiEventControllerPrivate::recompute_enabled() {
     // set global should_post_on_exceptions
     JvmtiExport::set_should_post_on_exceptions((any_env_thread_enabled & SHOULD_POST_ON_EXCEPTIONS_BITS) != 0);
 
-    JvmtiExport::_should_notify_object_alloc = JvmtiExport::should_post_vm_object_alloc();
   }
 
   EC_TRACE(("[-] # recompute enabled - after " JULONG_FORMAT_X, any_env_thread_enabled));

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1067,10 +1067,6 @@ bool JvmtiExport::has_early_class_hook_env() {
 
 bool JvmtiExport::_should_post_class_file_load_hook = false;
 
-// This flag is read by C2 during VM internal objects allocation
-bool JvmtiExport::_should_notify_object_alloc = false;
-
-
 // this entry is for class file load hook on class load, redefine and retransform
 bool JvmtiExport::post_class_file_load_hook(Symbol* h_name,
                                             Handle class_loader,

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -396,9 +396,6 @@ class JvmtiExport : public AllStatic {
     }
   }
 
-  // Used by C2 to post vm_object_alloc
-  static bool _should_notify_object_alloc;
-
   static void record_sampled_internal_object_allocation(oop object) NOT_JVMTI_RETURN;
   // Post objects collected by sampled_object_alloc_event_collector.
   static void post_sampled_object_alloc(JavaThread *thread, oop object) NOT_JVMTI_RETURN;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -628,14 +628,6 @@ void SharedRuntime::throw_and_post_jvmti_exception(JavaThread* current, Symbol* 
 }
 
 #if INCLUDE_JVMTI
-JRT_ENTRY(void, SharedRuntime::notify_jvmti_object_alloc(oopDesc* o, JavaThread* current))
-  Handle h = Handle(current, o);
-  if (JvmtiExport::should_post_vm_object_alloc()) {
-    JvmtiExport::post_vm_object_alloc(current, o);
-  }
-  current->set_vm_result(h());
-JRT_END
-
 JRT_ENTRY(void, SharedRuntime::notify_jvmti_vthread_start(oopDesc* vt, jboolean hide, JavaThread* current))
   assert(hide == JNI_FALSE, "must be VTMS transition finish");
   jobject vthread = JNIHandles::make_local(const_cast<oopDesc*>(vt));

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -265,7 +265,6 @@ class SharedRuntime: AllStatic {
   static void throw_and_post_jvmti_exception(JavaThread* current, Symbol* name, const char *message = nullptr);
 
 #if INCLUDE_JVMTI
-  static void notify_jvmti_object_alloc(oopDesc* o, JavaThread* current);
   // Functions for JVMTI notifications
   static void notify_jvmti_vthread_start(oopDesc* vt, jboolean hide, JavaThread* current);
   static void notify_jvmti_vthread_end(oopDesc* vt, jboolean hide, JavaThread* current);

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,6 +27,7 @@
 #
 #############################################################################
 
+vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
@@ -36,6 +37,8 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-x64
 
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
+
+serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8307462 generic-all
 
 gc/cslocker/TestCSLocker.java 8293289 generic-x64
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -148,6 +148,7 @@ vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
+vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 generic-all
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64


### PR DESCRIPTION
8277573: VmObjectAlloc is not generated by intrinsics methods which allocate objects

caused significant regressions in some benchmarks and should be reverted.

This fix backout changes and update problemlist bugs to new issue.
Tier1 passed
Running also tier5 to check other builds and more svc testing
