### PR TITLE
8250596: Update remaining manpage references from "OS X" to "macOS"

### DIFF
--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -2354,7 +2354,7 @@ file.
 The security properties file is called \f[V]java.security\f[R], and
 resides in the security properties directory:
 .IP \[bu] 2
-\f[B]Linux and OS X:\f[R] \f[V]java.home/lib/security\f[R]
+\f[B]Linux and macOS:\f[R] \f[V]java.home/lib/security\f[R]
 .IP \[bu] 2
 \f[B]Windows:\f[R] \f[V]java.home\[rs]lib\[rs]security\f[R]
 .PP
@@ -2632,7 +2632,7 @@ A certificates file named \f[V]cacerts\f[R] resides in the security
 properties directory:
 .RS
 .IP \[bu] 2
-\f[B]Linux and OS X:\f[R] \f[I]JAVA_HOME\f[R]\f[V]/lib/security\f[R]
+\f[B]Linux and macOS:\f[R] \f[I]JAVA_HOME\f[R]\f[V]/lib/security\f[R]
 .IP \[bu] 2
 \f[B]Windows:\f[R] \f[I]JAVA_HOME\f[R]\f[V]\[rs]lib\[rs]security\f[R]
 .PP
@@ -2643,8 +2643,8 @@ System administrators can configure and manage that file with the
 type.
 The \f[V]cacerts\f[R] keystore file ships with a default set of root CA
 certificates.
-For Linux, OS X, and Windows, you can list the default certificates with
-the following command:
+For Linux, macOS, and Windows, you can list the default certificates
+with the following command:
 .RS
 .PP
 \f[V]keytool -list -cacerts\f[R]

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -197,8 +197,8 @@ The keystore is by default stored in a file named \f[V].keystore\f[R] in
 the user\[aq]s home directory, as determined by the \f[V]user.home\f[R]
 system property.
 .PP
-\f[B]Linux and OS X:\f[R] \f[V]user.home\f[R] defaults to the user\[aq]s
-home directory.
+\f[B]Linux and macOS:\f[R] \f[V]user.home\f[R] defaults to the
+user\[aq]s home directory.
 .PP
 The input stream from the \f[V]-keystore\f[R] option is passed to the
 \f[V]KeyStore.load\f[R] method.
@@ -1159,7 +1159,7 @@ KeyUsage extension that doesn\[aq]t allow it to sign a file, the
 \f[V]-strict\f[R] option is specified.
 .PP
 \f[B]Note:\f[R] Exit codes are reused because only the values from 0 to
-255 are legal on Linux and OS X.
+255 are legal on Linux and macOS.
 .PP
 The following sections describes the names, codes, and descriptions of
 the errors and warnings that the \f[V]jarsigner\f[R] command can issue.

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -548,7 +548,7 @@ The \f[I]lvmid\f[R] is typically, but not necessarily, the operating
 system\[aq]s process identifier for the target JVM process.
 You can use the \f[V]jps\f[R] command to determine the \f[I]lvmid\f[R]
 provided the JVM processes is not running in a separate docker instance.
-You can also determine the \f[I]lvmid\f[R] on Linux and OS X platforms
+You can also determine the \f[I]lvmid\f[R] on Linux and macOS platforms
 with the \f[V]ps\f[R] command, and on Windows with the Windows Task
 Manager.
 .TP

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -116,7 +116,7 @@ Provides a search path for resolution of dependent classes.
 directories separated by the system-specific path separator.
 For example:
 .IP \[bu] 2
-\f[B]Linux and OS X:\f[R]
+\f[B]Linux and macOS:\f[R]
 .RS 2
 .RS
 .PP

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -275,7 +275,7 @@ classes in that containing archive are analyzed.
 The following example demonstrates analyzing the dependencies of the
 \f[V]Notepad.jar\f[R] file.
 .PP
-\f[B]Linux and OS X:\f[R]
+\f[B]Linux and macOS:\f[R]
 .IP
 .nf
 \f[CB]

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -223,7 +223,7 @@ create --class-path mods/com.greetings --module-path mlib
   --cmds commands --config configfiles --header-files src/h
   --libs lib --main-class com.greetings.Main
   --man-pages man --module-version 1.0
-  --os-arch \[dq]x86_x64\[dq] --os-name \[dq]Mac OS X\[dq]
+  --os-arch \[dq]x86_x64\[dq] --os-name \[dq]macOS\[dq]
   --os-version \[dq]10.10.5\[dq] greetingsmod
 \f[R]
 .fi
@@ -248,7 +248,7 @@ The following is an example of creating a JMOD file:
 jmod create --class-path mods/com.greetings --cmds commands
   --config configfiles --header-files src/h --libs lib
   --main-class com.greetings.Main --man-pages man --module-version 1.0
-  --os-arch \[dq]x86_x64\[dq] --os-name \[dq]Mac OS X\[dq]
+  --os-arch \[dq]x86_x64\[dq] --os-name \[dq]macOS\[dq]
   --os-version \[dq]10.10.5\[dq] greetingsmod
 \f[R]
 .fi
@@ -396,7 +396,7 @@ from the directory \f[V]jmodhashex\f[R].
 Run the following command from the \f[V]jmodhashex2\f[R] directory:
 .RS 4
 .IP \[bu] 2
-\f[B]Linux and OS X:\f[R]
+\f[B]Linux and macOS:\f[R]
 .RS 2
 .RS
 .PP

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -107,9 +107,9 @@ The \f[V]jstatd\f[R] server can monitor only JVMs for which it has the
 appropriate native access permissions.
 Therefore, the \f[V]jstatd\f[R] process must be running with the same
 user credentials as the target JVMs.
-Some user credentials, such as the root user in Linux and OS X operating
-systems, have permission to access the instrumentation exported by any
-JVM on the system.
+Some user credentials, such as the root user in Linux and macOS
+operating systems, have permission to access the instrumentation
+exported by any JVM on the system.
 A \f[V]jstatd\f[R] process running with such credentials can monitor any
 JVM on the system, but introduces additional security concerns.
 .PP


### PR DESCRIPTION
Most of the manpages were updated a few years ago but some references remain.
This patch renames remaining references to "macOS".

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8250596](https://bugs.openjdk.org/browse/JDK-8250596): Update remaining manpage references from "OS X" to "macOS"


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to [88c2d42c](https://git.openjdk.org/jdk/pull/13807/files/88c2d42c9d193110530e0499e94a0566f3a3d424)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [88c2d42c](https://git.openjdk.org/jdk/pull/13807/files/88c2d42c9d193110530e0499e94a0566f3a3d424)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [88c2d42c](https://git.openjdk.org/jdk/pull/13807/files/88c2d42c9d193110530e0499e94a0566f3a3d424)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [88c2d42c](https://git.openjdk.org/jdk/pull/13807/files/88c2d42c9d193110530e0499e94a0566f3a3d424)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13807/head:pull/13807` \
`$ git checkout pull/13807`

Update a local copy of the PR: \
`$ git checkout pull/13807` \
`$ git pull https://git.openjdk.org/jdk.git pull/13807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13807`

View PR using the GUI difftool: \
`$ git pr show -t 13807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13807.diff">https://git.openjdk.org/jdk/pull/13807.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13807#issuecomment-1535025112)