### PR TITLE
8307779: Relax the java.awt.Robot specification

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -400,7 +400,7 @@ public class Robot {
      * from a user to capture the screens via system dialog.
      * When selected in this dialog, the permission to capture a set of screens
      * can be saved for later reuse.<br>
-     * Use the {@link #revokeScreenCapturePermission()} to reset the stored
+     * Use the {@link #revokeScreenCapturePermission()} to revoke the stored
      * permission.
      * <br>
      * The pixel color may be black for screens for which no capture permission
@@ -431,7 +431,7 @@ public class Robot {
      * from a user to capture the screens via system dialog.
      * When selected in this dialog, the permission to capture a set of screens
      * can be saved for later reuse.<br>
-     * Use the {@link #revokeScreenCapturePermission()} to reset the stored
+     * Use the {@link #revokeScreenCapturePermission()} to revoke the stored
      * permission.
      * <br>
      * The image may be black for screens for which no capture permission

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,14 @@ import static sun.java2d.SunGraphicsEnvironment.toDeviceSpaceAbs;
  * <p>
  * Applications that use Robot for purposes other than self-testing should
  * handle these error conditions gracefully.
+ *
+ * @implNote on Linux systems using Wayland, the robot runs in
+ * so-called X11 compatibility mode. This means that generated mouse and
+ * keyboard events can only be delivered within the X11 server and between
+ * their clients.<br>
+ * Trying to interact with the Wayland area of responsibility may have no effect
+ * (e.g. interacting with window decorations, trying to change the
+ * window stacking order with the mouse or keyboard shortcuts)
  *
  * @author      Robi Khan
  * @since       1.3
@@ -189,6 +197,10 @@ public class Robot {
 
     /**
      * Moves mouse pointer to given screen coordinates.
+     * @implNote the mouse pointer may not visually move on Linux systems
+     *           using Wayland, while the subsequent mousePress and mouseRelease
+     *           can be delivered to the correct location
+     *
      * @param x         X position
      * @param y         Y position
      */
@@ -383,8 +395,24 @@ public class Robot {
 
     /**
      * Returns the color of a pixel at the given screen coordinates.
+     *
+     * @implNote On Linux systems using Wayland, permission may be requested
+     * from a user to capture the screens via system dialog.
+     * When selected in this dialog, the permission to capture a set of screens
+     * can be saved for later reuse.<br>
+     * Use the {@link #resetScreenCapturePermission()} to reset the stored
+     * permission.
+     * <br>
+     * The pixel color may be black if permission to capture a particular screen
+     * has not been granted.
+     * <br>
+     * It is not recommended to call this method on EDT, as it may block the UI
+     * update until the user confirms his choice in the system dialog.
+     *
      * @param   x       X position of pixel
      * @param   y       Y position of pixel
+     * @throws  SecurityException if {@code readDisplayPixels} permission
+     *          is not granted, or user has denied screen capturing
      * @return  Color of the pixel
      */
     public synchronized Color getPixelColor(int x, int y) {
@@ -397,10 +425,26 @@ public class Robot {
     /**
      * Creates an image containing pixels read from the screen.  This image does
      * not include the mouse cursor.
+     *
+     * @implNote On Linux systems using Wayland, permission may be requested
+     * from a user to capture the screens via system dialog.
+     * When selected in this dialog, the permission to capture a set of screens
+     * can be saved for later reuse.<br>
+     * Use the {@link #resetScreenCapturePermission()} to reset the stored
+     * permission.
+     * <br>
+     * The image may be black if permission to capture a particular screen
+     * has not been granted.
+     * <br>
+     * It is not recommended to call this method on EDT, as it may block the UI
+     * update until the user confirms his choice in the system dialog.
+     *
      * @param   screenRect      Rect to capture in screen coordinates
      * @return  The captured image
-     * @throws  IllegalArgumentException if {@code screenRect} width and height are not greater than zero
-     * @throws  SecurityException if {@code readDisplayPixels} permission is not granted
+     * @throws  IllegalArgumentException if {@code screenRect} width and height
+     *          are not greater than zero
+     * @throws  SecurityException if {@code readDisplayPixels} permission
+     *          is not granted, or user has denied screen capturing
      * @see     SecurityManager#checkPermission
      * @see     AWTPermission
      */
@@ -583,6 +627,14 @@ public class Robot {
         if (security != null) {
             security.checkPermission(AWTPermissions.READ_DISPLAY_PIXELS_PERMISSION);
         }
+    }
+
+    /**
+     * Resets the stored screen data capture permission for a set of screens.
+     * Is a no-op if not supported by the platform.
+     */
+    public void resetScreenCapturePermission() {
+        peer.resetScreenCapturePermission();
     }
 
     /*

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -434,8 +434,8 @@ public class Robot {
      * Use the {@link #revokeScreenCapturePermission()} to reset the stored
      * permission.
      * <br>
-     * The image may be black if permission to capture a particular screen
-     * has not been granted.
+     * The image may be black for screens for which no capture permission
+     * has been granted.
      * <br>
      * It is not recommended to call this method on EDT, as it may block the UI
      * update until the user confirms his choice in the system dialog.
@@ -445,7 +445,8 @@ public class Robot {
      * @throws  IllegalArgumentException if {@code screenRect} width and height
      *          are not greater than zero
      * @throws  SecurityException if {@code readDisplayPixels} permission
-     *          is not granted, or user has denied screen capturing
+     *          is not granted, or user has denied screen capture for all
+     *          screens
      * @see     SecurityManager#checkPermission
      * @see     AWTPermission
      */

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -400,11 +400,11 @@ public class Robot {
      * from a user to capture the screens via system dialog.
      * When selected in this dialog, the permission to capture a set of screens
      * can be saved for later reuse.<br>
-     * Use the {@link #resetScreenCapturePermission()} to reset the stored
+     * Use the {@link #revokeScreenCapturePermission()} to reset the stored
      * permission.
      * <br>
-     * The pixel color may be black if permission to capture a particular screen
-     * has not been granted.
+     * The pixel color may be black for screens for which no capture permission
+     * has been granted.
      * <br>
      * It is not recommended to call this method on EDT, as it may block the UI
      * update until the user confirms his choice in the system dialog.
@@ -412,7 +412,8 @@ public class Robot {
      * @param   x       X position of pixel
      * @param   y       Y position of pixel
      * @throws  SecurityException if {@code readDisplayPixels} permission
-     *          is not granted, or user has denied screen capturing
+     *          is not granted, or user has denied screen capture for all
+     *          screens
      * @return  Color of the pixel
      */
     public synchronized Color getPixelColor(int x, int y) {
@@ -430,7 +431,7 @@ public class Robot {
      * from a user to capture the screens via system dialog.
      * When selected in this dialog, the permission to capture a set of screens
      * can be saved for later reuse.<br>
-     * Use the {@link #resetScreenCapturePermission()} to reset the stored
+     * Use the {@link #revokeScreenCapturePermission()} to reset the stored
      * permission.
      * <br>
      * The image may be black if permission to capture a particular screen
@@ -630,11 +631,13 @@ public class Robot {
     }
 
     /**
-     * Resets the stored screen data capture permission for a set of screens.
-     * Is a no-op if not supported by the platform.
+     * Revokes the stored permission to capture screen data.
+     * Subsequent calls to {@link #getPixelColor(int, int)}
+     * and {@link #createScreenCapture(Rectangle)} may request
+     * a new permission from the user on applicable platforms.
      */
-    public void resetScreenCapturePermission() {
-        peer.resetScreenCapturePermission();
+    public void revokeScreenCapturePermission() {
+        peer.revokeScreenCapturePermission();
     }
 
     /*

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -431,9 +431,6 @@ public class Robot {
      * then a {@code SecurityException} may be thrown,
      * or the content of the returned {@code Color} is undefined.
      * <p>
-     * The {@link #revokeScreenCapturePermission()} can be used to revoke
-     * a previously granted permission.
-     * <p>
      * @apiNote It is recommended to avoid calling this method on
      * the AWT Event Dispatch Thread since screen capture may be a lengthy
      * operation, particularly if acquiring permissions is needed and involves
@@ -460,9 +457,6 @@ public class Robot {
      * to capture screen content, and the required permissions are not granted,
      * then a {@code SecurityException} may be thrown,
      * or the contents of the returned {@code BufferedImage} are undefined.
-     * <p>
-     * The {@link #revokeScreenCapturePermission()} can be used to revoke
-     * a previously granted permission.
      * <p>
      * @apiNote It is recommended to avoid calling this method on
      * the AWT Event Dispatch Thread since screen capture may be a lengthy
@@ -657,19 +651,6 @@ public class Robot {
         if (security != null) {
             security.checkPermission(AWTPermissions.READ_DISPLAY_PIXELS_PERMISSION);
         }
-    }
-
-    /**
-     * Revokes the stored permission to capture screen data,
-     * if the desktop environment requires that permissions be granted
-     * to capture screen content. Does nothing otherwise.
-     * <p>
-     * Subsequent calls to {@link #getPixelColor(int, int)}
-     * and {@link #createScreenCapture(Rectangle)} may request
-     * a new permission from the user.
-     */
-    public void revokeScreenCapturePermission() {
-        peer.revokeScreenCapturePermission();
     }
 
     /*

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -453,8 +453,7 @@ public class Robot {
     }
 
     /**
-     * Creates an image containing pixels read from the screen.  This image does
-     * not include the mouse cursor.
+     * Creates an image containing pixels read from the screen.
      * <p>
      * If the desktop environment requires that permissions be granted
      * to capture screen content, and the required permissions are not granted,
@@ -485,7 +484,6 @@ public class Robot {
 
     /**
      * Creates an image containing pixels read from the screen.
-     * This image does not include the mouse cursor.
      * This method can be used in case there is a scaling transform
      * from user space to screen (device) space.
      * Typically this means that the display is a high resolution screen,

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -439,8 +439,8 @@ public class Robot {
      * @param   x       X position of pixel
      * @param   y       Y position of pixel
      * @throws  SecurityException if {@code readDisplayPixels} permission
-     *          is not granted, or the user has not allowed any of their screens
-     *          to be captured.
+     *          is not granted, or access to the screen is denied
+     *          by the desktop environment
      * @return  Color of the pixel
      */
     public synchronized Color getPixelColor(int x, int y) {
@@ -468,8 +468,8 @@ public class Robot {
      * @throws  IllegalArgumentException if {@code screenRect} width and height
      *          are not greater than zero
      * @throws  SecurityException if {@code readDisplayPixels} permission
-     *          is not granted, or the user has not allowed any of their screens
-     *          to be captured.
+     *          is not granted, or access to the screen is denied
+     *          by the desktop environment
      * @see     SecurityManager#checkPermission
      * @see     AWTPermission
      */

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -511,8 +511,11 @@ public class Robot {
      * }</pre>
      * @param   screenRect     Rect to capture in screen coordinates
      * @return  The captured image
-     * @throws  IllegalArgumentException if {@code screenRect} width and height are not greater than zero
-     * @throws  SecurityException if {@code readDisplayPixels} permission is not granted
+     * @throws  IllegalArgumentException if {@code screenRect} width and height
+     *          are not greater than zero
+     * @throws  SecurityException if {@code readDisplayPixels} permission
+     *          is not granted, or access to the screen is denied
+     *          by the desktop environment
      * @see     SecurityManager#checkPermission
      * @see     AWTPermission
      *

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -226,9 +226,10 @@ public class Robot {
 
     /**
      * Moves mouse pointer to given screen coordinates.
-     * @implNote the mouse pointer may not visually move on Linux systems
-     *           using Wayland, while the subsequent mousePress and mouseRelease
-     *           can be delivered to the correct location
+     * @implNote the mouse pointer may not visually move on some platforms,
+     *           such as Linux systems using Wayland, while the subsequent
+     *           mousePress and mouseRelease can be delivered to
+     *           the correct location
      *
      * @param x         X position
      * @param y         Y position

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -226,10 +226,10 @@ public class Robot {
 
     /**
      * Moves mouse pointer to given screen coordinates.
-     * @implNote the mouse pointer may not visually move on some platforms,
-     *           such as Linux systems using Wayland, while the subsequent
-     *           mousePress and mouseRelease can be delivered to
-     *           the correct location
+     * <p>
+     * The mouse pointer may not visually move on some platforms,
+     * while the subsequent mousePress and mouseRelease can be
+     * delivered to the correct location
      *
      * @param x         X position
      * @param y         Y position
@@ -439,7 +439,7 @@ public class Robot {
      * @param   x       X position of pixel
      * @param   y       Y position of pixel
      * @throws  SecurityException if {@code readDisplayPixels} permission
-     *          is not granted, or user has not allowed any of his screens
+     *          is not granted, or the user has not allowed any of their screens
      *          to be captured.
      * @return  Color of the pixel
      */
@@ -468,7 +468,7 @@ public class Robot {
      * @throws  IllegalArgumentException if {@code screenRect} width and height
      *          are not greater than zero
      * @throws  SecurityException if {@code readDisplayPixels} permission
-     *          is not granted, or user has not allowed any of his screens
+     *          is not granted, or the user has not allowed any of their screens
      *          to be captured.
      * @see     SecurityManager#checkPermission
      * @see     AWTPermission

--- a/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
@@ -129,8 +129,10 @@ public interface RobotPeer
     }
 
     /**
-     * Resets the stored screen data capture permission for a set of screens.
-     * Is a no-op if not supported by the platform.
+     * Revokes the stored permission to capture screen data.
+     * Subsequent calls to {@link Robot#getPixelColor(int, int)}
+     * and {@link Robot#createScreenCapture(Rectangle)} may request
+     * a new permission from the user on applicable platforms.
      */
-    default void resetScreenCapturePermission() {}
+    default void revokeScreenCapturePermission() {}
 }

--- a/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,4 +127,10 @@ public interface RobotPeer
     default boolean useAbsoluteCoordinates() {
         return false;
     }
+
+    /**
+     * Resets the stored screen data capture permission for a set of screens.
+     * Is a no-op if not supported by the platform.
+     */
+    default void resetScreenCapturePermission() {}
 }

--- a/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
@@ -129,10 +129,13 @@ public interface RobotPeer
     }
 
     /**
-     * Revokes the stored permission to capture screen data.
+     * Revokes the stored permission to capture screen data,
+     * if the desktop environment requires that permissions be granted
+     * to capture screen content. Does nothing otherwise.
+     * <p>
      * Subsequent calls to {@link Robot#getPixelColor(int, int)}
      * and {@link Robot#createScreenCapture(Rectangle)} may request
-     * a new permission from the user on applicable platforms.
+     * a new permission from the user.
      */
     default void revokeScreenCapturePermission() {}
 }

--- a/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/RobotPeer.java
@@ -127,15 +127,4 @@ public interface RobotPeer
     default boolean useAbsoluteCoordinates() {
         return false;
     }
-
-    /**
-     * Revokes the stored permission to capture screen data,
-     * if the desktop environment requires that permissions be granted
-     * to capture screen content. Does nothing otherwise.
-     * <p>
-     * Subsequent calls to {@link Robot#getPixelColor(int, int)}
-     * and {@link Robot#createScreenCapture(Rectangle)} may request
-     * a new permission from the user.
-     */
-    default void revokeScreenCapturePermission() {}
 }


### PR DESCRIPTION
We need to relax the java.awt.Robot specification according to the latest operating system trends. 
This should at least cover the case of Wayland, which has changed many familiar concepts in Linux.

https://bugs.openjdk.org/browse/JDK-8280982 [Wayland] [XWayland] java.awt.Robot taking screenshots
https://bugs.openjdk.org/browse/JDK-8280995 [XWayland] Robot.mouseMove does not visually move mouse cursor
https://bugs.openjdk.org/browse/JDK-8280990 [XWayland] XTest emulated mouse click does not bring window to front.
https://bugs.openjdk.org/browse/JDK-8280988 [XWayland] Click on title to request focus test failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308012](https://bugs.openjdk.org/browse/JDK-8308012) to be approved

### Issues
 * [JDK-8307779](https://bugs.openjdk.org/browse/JDK-8307779): Relax the java.awt.Robot specification
 * [JDK-8308012](https://bugs.openjdk.org/browse/JDK-8308012): Relax the java.awt.Robot specification (**CSR**)


### Reviewers
 * [Maxim Kartashev](https://openjdk.org/census#mkartashev) (@mkartashev - no project role) ⚠️ Review applies to [53145ec4](https://git.openjdk.org/jdk/pull/13809/files/53145ec40a30afa9b7f2570db2efa95ca22f2fa7)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13809/head:pull/13809` \
`$ git checkout pull/13809`

Update a local copy of the PR: \
`$ git checkout pull/13809` \
`$ git pull https://git.openjdk.org/jdk.git pull/13809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13809`

View PR using the GUI difftool: \
`$ git pr show -t 13809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13809.diff">https://git.openjdk.org/jdk/pull/13809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13809#issuecomment-1540807717)