### PR TITLE
8306712: CDS DeterministicDump.java test fails with -XX:+UseStringDeduplication

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3048,6 +3048,11 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     // class metadata instead of modifying them in place. The copy is inaccessible to the compiler.
     // TODO: revisit the following for the static archive case.
     set_mode_flags(_int);
+
+    // String deduplication may cause CDS to iterate the strings in different order from one
+    // run to another which resulting in non-determinstic CDS archives.
+    // Disable UseStringDeduplication while dumping CDS archive.
+    UseStringDeduplication = false;
   }
 
   // RecordDynamicDumpInfo is not compatible with ArchiveClassesAtExit

--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -54,11 +54,6 @@ public class DeterministicDump {
         baseArgs.add("-Xmx128M");
 
         if (Platform.is64bit()) {
-            if (!compressed) {
-                System.out.println("CDS archives with uncompressed oops are still non-deterministic");
-                System.out.println("See https://bugs.openjdk.org/browse/JDK-8282828");
-                return;
-            }
             // These options are available only on 64-bit.
             String sign = (compressed) ?  "+" : "-";
             baseArgs.add("-XX:" + sign + "UseCompressedOops");


### PR DESCRIPTION
Please review this change for:

- disabling `UseStringDeduplication` while dumping CDS archive;
- removing the unnecessary `!compressed` check from the test.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306712](https://bugs.openjdk.org/browse/JDK-8306712): CDS DeterministicDump.java test fails with -XX:+UseStringDeduplication


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [1f4389fd](https://git.openjdk.org/jdk/pull/13810/files/1f4389fd35259b1073df3eb5931f85b280abd829)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [1f4389fd](https://git.openjdk.org/jdk/pull/13810/files/1f4389fd35259b1073df3eb5931f85b280abd829)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13810/head:pull/13810` \
`$ git checkout pull/13810`

Update a local copy of the PR: \
`$ git checkout pull/13810` \
`$ git pull https://git.openjdk.org/jdk.git pull/13810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13810`

View PR using the GUI difftool: \
`$ git pr show -t 13810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13810.diff">https://git.openjdk.org/jdk/pull/13810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13810#issuecomment-1535068561)