### PR TITLE
8307483: New micros for j.u.c.LockSupport

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util.concurrent;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Threads(1)
+@Warmup(iterations =  5, time = 5)
+@Measurement(iterations =  5, time = 5)
+public class UnparkBenchSleepersAfter {
+
+    /*
+        This micro creates thousands of sleeper threads after the threads doing the barrier await
+        to see if that has any effect on the barrier performance.
+     */
+
+    @Param({"4000"})
+    int idles;
+
+    @Param({"2"})
+    int workers;
+
+    CyclicBarrier barrier;
+
+    @Benchmark
+    public void barrier() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(workers);
+        for (int i = 0; i < workers; i++) {
+            exec.submit(() ->
+            {
+                try {
+                    barrier.await();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    barrier.reset();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+    }
+
+    IdleThread[] idle_threads;
+
+
+    ExecutorService exec;
+
+    @Setup
+    public void setup() throws InterruptedException {
+        barrier = new CyclicBarrier(workers);
+        exec = Executors.newFixedThreadPool(workers);
+        CountDownLatch latch = new CountDownLatch(workers);
+        for (int i = 0; i < workers; i++) { // warmup exec
+            exec.submit(() ->
+            {
+                try {
+                    Thread.sleep(0);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        idle_threads = new IdleThread[idles];
+        for(int i=0; i < idle_threads.length; i++) {
+            new Thread(idle_threads[i] = new IdleThread()).start();
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        for(IdleThread it : idle_threads) {
+            it.stop();
+        }
+        exec.shutdown();
+    }
+
+    public static class IdleThread implements Runnable {
+        boolean done = false;
+        Thread my_thread;
+
+        @Override
+        public void run() {
+            my_thread = Thread.currentThread();
+            while (!done) {
+                LockSupport.park();
+            }
+        }
+
+        public void stop() {
+            done = true;
+            LockSupport.unpark(my_thread);
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
@@ -115,14 +115,14 @@ public class UnparkBenchSleepersAfter {
 
     @TearDown
     public void tearDown() {
-        for (IdleRunnable it : idleRunnables) {
-            it.stop();
+        for (IdleRunnable r : idleRunnables) {
+            r.stop();
         }
         exec.shutdown();
     }
 
     public static class IdleRunnable implements Runnable {
-        volatile boolean done = false;
+        volatile boolean done;
         Thread myThread;
 
         @Override

--- a/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
@@ -84,7 +84,7 @@ public class UnparkBenchSleepersAfter {
         latch.await();
     }
 
-    IdleThread[] idleThreads;
+    IdleRunnable[] idleRunnables;
 
     ExecutorService exec;
 
@@ -105,27 +105,29 @@ public class UnparkBenchSleepersAfter {
             });
         }
         latch.await();
-        idle_threads = new IdleThread[idles];
-        for(int i=0; i < idle_threads.length; i++) {
-            new Thread(idle_threads[i] = new IdleThread()).start();
+        idleRunnables = new IdleRunnable[idles];
+        for(int i = 0; i < idles; i++) {
+            IdleRunnable r = new IdleRunnable();
+            idleRunnables[i] = r;
+            new Thread(r).start();
         }
     }
 
     @TearDown
     public void tearDown() {
-        for (IdleThread it : idle_threads) {
+        for (IdleRunnable it : idleRunnables) {
             it.stop();
         }
         exec.shutdown();
     }
 
-    public static class IdleThread implements Runnable {
-        boolean done = false;
+    public static class IdleRunnable implements Runnable {
+        volatile boolean done = false;
         Thread myThread;
 
         @Override
         public void run() {
-            my_thread = Thread.currentThread();
+            myThread = Thread.currentThread();
             while (!done) {
                 LockSupport.park();
             }
@@ -133,7 +135,7 @@ public class UnparkBenchSleepersAfter {
 
         public void stop() {
             done = true;
-            LockSupport.unpark(my_thread);
+            LockSupport.unpark(myThread);
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersAfter.java
@@ -84,8 +84,7 @@ public class UnparkBenchSleepersAfter {
         latch.await();
     }
 
-    IdleThread[] idle_threads;
-
+    IdleThread[] idleThreads;
 
     ExecutorService exec;
 
@@ -95,8 +94,7 @@ public class UnparkBenchSleepersAfter {
         exec = Executors.newFixedThreadPool(workers);
         CountDownLatch latch = new CountDownLatch(workers);
         for (int i = 0; i < workers; i++) { // warmup exec
-            exec.submit(() ->
-            {
+            exec.submit(() -> {
                 try {
                     Thread.sleep(0);
                 } catch (InterruptedException e) {
@@ -115,7 +113,7 @@ public class UnparkBenchSleepersAfter {
 
     @TearDown
     public void tearDown() {
-        for(IdleThread it : idle_threads) {
+        for (IdleThread it : idle_threads) {
             it.stop();
         }
         exec.shutdown();
@@ -123,7 +121,7 @@ public class UnparkBenchSleepersAfter {
 
     public static class IdleThread implements Runnable {
         boolean done = false;
-        Thread my_thread;
+        Thread myThread;
 
         @Override
         public void run() {

--- a/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersBefore.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersBefore.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util.concurrent;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Control;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.LockSupport;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Threads(1)
+@Warmup(iterations =  5, time = 5)
+@Measurement(iterations =  5, time = 5)
+public class UnparkBenchSleepersBefore {
+
+    /*
+        This micro creates thousands of sleeper threads before the threads doing the barrier await
+        to see if that has any effect on the barrier performance, as seen with JDK-8305670.
+     */
+
+    @Param({"4000"})
+    int idles;
+
+    @Param({"2"})
+    int workers;
+
+    CyclicBarrier barrier;
+
+    @Benchmark
+    public void barrier() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(workers);
+        for (int i = 0; i < workers; i++) {
+            exec.submit(() ->
+            {
+                try {
+                    barrier.await();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    barrier.reset();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+    }
+
+    IdleThread[] idle_threads;
+
+
+    ExecutorService exec;
+
+    @Setup
+    public void setup() {
+        idle_threads = new IdleThread[idles];
+        for(int i=0; i < idle_threads.length; i++) {
+            new Thread(idle_threads[i] = new IdleThread()).start();
+        }
+        barrier = new CyclicBarrier(workers);
+        exec = Executors.newFixedThreadPool(workers); // order is important, create this executor only after idle threads
+    }
+
+    @TearDown
+    public void tearDown() {
+        for(IdleThread it : idle_threads) {
+            it.stop();
+        }
+        exec.shutdown();
+    }
+
+    public static class IdleThread implements Runnable {
+        boolean done = false;
+        Thread my_thread;
+
+        @Override
+        public void run() {
+            my_thread = Thread.currentThread();
+            while (!done) {
+                LockSupport.park();
+            }
+        }
+
+        public void stop() {
+            done = true;
+            LockSupport.unpark(my_thread);
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersBefore.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/UnparkBenchSleepersBefore.java
@@ -95,7 +95,8 @@ public class UnparkBenchSleepersBefore {
     public void setup() {
         idleRunnables = new IdleRunnable[idles];
         for(int i = 0; i < idleRunnables.length; i++) {
-            new Thread(idleRunnables[i] = new IdleRunnable()).start();
+            idleRunnables[i] = new IdleRunnable();
+            new Thread(idleRunnables[i]).start();
         }
         barrier = new CyclicBarrier(workers);
         exec = Executors.newFixedThreadPool(workers); // order is important, create this executor only after idle threads
@@ -103,14 +104,14 @@ public class UnparkBenchSleepersBefore {
 
     @TearDown
     public void tearDown() {
-        for(IdleRunnable it : idleRunnables) {
-            it.stop();
+        for (IdleRunnable r : idleRunnables) {
+            r.stop();
         }
         exec.shutdown();
     }
 
     public static class IdleRunnable implements Runnable {
-        volatile boolean done = false;
+        volatile boolean done;
         Thread myThread;
 
         @Override


### PR DESCRIPTION
These micros were developed while investigating JDK-8305670 by myself and Sergey Kuksenko. The order of thread creation was important in that bug, so there are 2 JMH for creating sleepers before and after the worker threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307483](https://bugs.openjdk.org/browse/JDK-8307483): New micros for j.u.c.LockSupport


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [4a486cfd](https://git.openjdk.org/jdk/pull/13815/files/4a486cfdbb62cff94dc37394ca3278a14143158a)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [4a486cfd](https://git.openjdk.org/jdk/pull/13815/files/4a486cfdbb62cff94dc37394ca3278a14143158a)


### Contributors
 * Sergey Kuksenko `<skuksenko@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13815/head:pull/13815` \
`$ git checkout pull/13815`

Update a local copy of the PR: \
`$ git checkout pull/13815` \
`$ git pull https://git.openjdk.org/jdk.git pull/13815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13815`

View PR using the GUI difftool: \
`$ git pr show -t 13815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13815.diff">https://git.openjdk.org/jdk/pull/13815.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13815#issuecomment-1535366750)