### PR TITLE
8307489: ProblemList jdk/incubator/vector/LoadJsvmlTest.java on windows-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -667,6 +667,7 @@ java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8288839 wind
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
+sanity/client/SwingSet/src/EditorPaneDemoTest.java 8212240 linux-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -740,7 +740,6 @@ jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java   8303498 linux-s3
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
 jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
 
-
 ############################################################################
 
 # jdk_jfr

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -605,6 +605,7 @@ sun/security/pkcs11/rsa/TestSignatures.java                     8295343 linux-al
 sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-all
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
+sun/security/pkcs11/Cipher/TestKATForGCM.java                   8240611 linux-x64,macosx-x64
 
 
 ############################################################################

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -736,6 +736,8 @@ javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java   8303498 linux-s390x
 
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
+jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
+
 
 ############################################################################
 


### PR DESCRIPTION
Trivial fixes to ProblemList a few tests:
- [JDK-8307489](https://bugs.openjdk.org/browse/JDK-8307489) ProblemList jdk/incubator/vector/LoadJsvmlTest.java on windows-x64
- [JDK-8307490](https://bugs.openjdk.org/browse/JDK-8307490) ProblemList sun/security/pkcs11/Cipher/TestKATForGCM.java on linux-x64 and macosx-x64
- [JDK-8307491](https://bugs.openjdk.org/browse/JDK-8307491) ProblemList sanity/client/SwingSet/src/EditorPaneDemoTest.java on linux-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8307489](https://bugs.openjdk.org/browse/JDK-8307489): ProblemList jdk/incubator/vector/LoadJsvmlTest.java on windows-x64
 * [JDK-8307490](https://bugs.openjdk.org/browse/JDK-8307490): ProblemList sun/security/pkcs11/Cipher/TestKATForGCM.java on linux-x64 and macosx-x64
 * [JDK-8307491](https://bugs.openjdk.org/browse/JDK-8307491): ProblemList sanity/client/SwingSet/src/EditorPaneDemoTest.java on linux-x64


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13816/head:pull/13816` \
`$ git checkout pull/13816`

Update a local copy of the PR: \
`$ git checkout pull/13816` \
`$ git pull https://git.openjdk.org/jdk.git pull/13816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13816`

View PR using the GUI difftool: \
`$ git pr show -t 13816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13816.diff">https://git.openjdk.org/jdk/pull/13816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13816#issuecomment-1535420066)