### PR TITLE
8306583: Add JVM crash check in CDSTestUtils.executeAndLog

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestCDSVMCrash
+ * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver TestCDSVMCrash
+ * @bug 8306583
+ */
+
+ import jdk.test.lib.cds.CDSTestUtils;
+ import jdk.test.lib.process.OutputAnalyzer;
+ import jdk.test.lib.process.ProcessTools;
+
+ public class TestCDSVMCrash {
+
+     public static void main(String[] args) throws Exception {
+         if (args.length == 1) {
+             // This should guarantee to throw:
+             // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
+             try {
+                 Object[] oa = new Object[Integer.MAX_VALUE];
+                 throw new Error("OOME not triggered");
+             } catch (OutOfMemoryError err) {
+                 throw new Error("OOME didn't abort JVM!");
+             }
+         }
+         // else this is the main test
+         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+                  "-XX:-CreateCoredumpOnCrash", "-Xmx128m", "-Xshare:on", TestCDSVMCrash.class.getName(),"throwOOME");
+         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+         // executeAndLog should throw an exception in the VM crashed
+         try {
+            CDSTestUtils.executeAndLog(pb, "cds_vm_crash");
+            throw new Error("Expected VM to crash");
+         } catch(RuntimeException e) {
+            if (!e.getMessage().equals("Hotspot crashed")) {
+              throw new Error("Expected message: Hotspot crashed");
+            }
+         }
+         int exitValue = output.getExitValue();
+         if (0 == exitValue) {
+             //expecting a non zero value
+             throw new Error("Expected to get non zero exit value");
+         }
+        output.shouldContain("A fatal error has been detected by the Java Runtime Environment");
+        System.out.println("PASSED");
+     }
+ }

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -692,6 +692,9 @@ public class CDSTestUtils {
         if (copyChildStdoutToMainStdout)
             System.out.println("[STDOUT]\n" + output.getStdout());
 
+        if (output.getExitValue() != 0 && output.getStdout().contains("A fatal error has been detected")) {
+          throw new RuntimeException("Hotspot crashed");
+        }
         return output;
     }
 


### PR DESCRIPTION
The JVM may sometimes crash when using -Xshare:dump but some CDS tests can pass due to only expecting the error code and a certain output. This adds a check for a VM crash in `executeAndLog()` which is used consistently among CDS tests as well as a new test to verify that this feature works. Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306583](https://bugs.openjdk.org/browse/JDK-8306583): Add JVM crash check in CDSTestUtils.executeAndLog


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [d1152269](https://git.openjdk.org/jdk/pull/13817/files/d115226916ed90b774e02574fbee90c6279a6d92)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13817/head:pull/13817` \
`$ git checkout pull/13817`

Update a local copy of the PR: \
`$ git checkout pull/13817` \
`$ git pull https://git.openjdk.org/jdk.git pull/13817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13817`

View PR using the GUI difftool: \
`$ git pr show -t 13817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13817.diff">https://git.openjdk.org/jdk/pull/13817.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13817#issuecomment-1535648901)