### PR TITLE
8307149: MethodHandles.arrayConstructor can be cached

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -85,7 +85,7 @@ abstract class MethodHandleImpl {
         MethodType correctType = ArrayAccessor.correctType(arrayClass, access);
         if (mh.type() != correctType) {
             // two assertions only applicable to non-construct access
-            assert(access == ArrayAccess.CONSTRUCT || arrayClass.isPrimitive());
+            assert(access == ArrayAccess.CONSTRUCT || !arrayClass.isPrimitive());
             assert(access == ArrayAccess.CONSTRUCT || mh.type().parameterType(0) == Object[].class);
             /* if access == SET */ assert(access != ArrayAccess.SET || mh.type().parameterType(2) == Object.class);
             /* if access == GET */ assert(access != ArrayAccess.GET ||
@@ -172,7 +172,7 @@ abstract class MethodHandleImpl {
         static final int GETTER_INDEX = 0, SETTER_INDEX = 1, LENGTH_INDEX = 2,
                 CONSTRUCTOR_INDEX = 3, INDEX_LIMIT = 4;
         static final ClassValue<MethodHandle[]> TYPED_ACCESSORS
-                = new ClassValue<MethodHandle[]>() {
+                = new ClassValue<>() {
                     @Override
                     protected MethodHandle[] computeValue(Class<?> type) {
                         return new MethodHandle[INDEX_LIMIT];
@@ -255,7 +255,7 @@ abstract class MethodHandleImpl {
         }
         static MethodHandle getAccessor(Class<?> arrayClass, ArrayAccess access) {
             if (access == ArrayAccess.CONSTRUCT)
-                return getConstantHandle(MH_Array_newInstance).bindTo(arrayClass);
+                return getConstantHandle(MH_Array_newInstance).bindTo(arrayClass.componentType());
 
             String     name = name(arrayClass, access);
             MethodType type = type(arrayClass, access);
@@ -1490,7 +1490,7 @@ abstract class MethodHandleImpl {
         if (elemType == Object.class)
             return varargsArray(nargs);
         // other cases:  primitive arrays, subtypes of Object[]
-        MethodHandle cache[] = Makers.TYPED_COLLECTORS.get(elemType);
+        MethodHandle[] cache = Makers.TYPED_COLLECTORS.get(elemType);
         MethodHandle mh = nargs < cache.length ? cache[nargs] : null;
         if (mh != null)  return mh;
         mh = makeCollector(arrayType, nargs);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4326,12 +4326,7 @@ return mh1;
      * @since 9
      */
     public static MethodHandle arrayConstructor(Class<?> arrayClass) throws IllegalArgumentException {
-        if (!arrayClass.isArray()) {
-            throw newIllegalArgumentException("not an array class: " + arrayClass.getName());
-        }
-        MethodHandle ani = MethodHandleImpl.getConstantHandle(MethodHandleImpl.MH_Array_newInstance).
-                bindTo(arrayClass.getComponentType());
-        return ani.asType(ani.type().changeReturnType(arrayClass));
+        return MethodHandleImpl.makeArrayAccessor(arrayClass, MethodHandleImpl.ArrayAccess.CONSTRUCT);
     }
 
     /**
@@ -4351,7 +4346,7 @@ return mh1;
      * @since 9
      */
     public static MethodHandle arrayLength(Class<?> arrayClass) throws IllegalArgumentException {
-        return MethodHandleImpl.makeArrayElementAccessor(arrayClass, MethodHandleImpl.ArrayAccess.LENGTH);
+        return MethodHandleImpl.makeArrayAccessor(arrayClass, MethodHandleImpl.ArrayAccess.LENGTH);
     }
 
     /**
@@ -4375,7 +4370,7 @@ return mh1;
      * @jvms 6.5 {@code aaload} Instruction
      */
     public static MethodHandle arrayElementGetter(Class<?> arrayClass) throws IllegalArgumentException {
-        return MethodHandleImpl.makeArrayElementAccessor(arrayClass, MethodHandleImpl.ArrayAccess.GET);
+        return MethodHandleImpl.makeArrayAccessor(arrayClass, MethodHandleImpl.ArrayAccess.GET);
     }
 
     /**
@@ -4399,7 +4394,7 @@ return mh1;
      * @jvms 6.5 {@code aastore} Instruction
      */
     public static MethodHandle arrayElementSetter(Class<?> arrayClass) throws IllegalArgumentException {
-        return MethodHandleImpl.makeArrayElementAccessor(arrayClass, MethodHandleImpl.ArrayAccess.SET);
+        return MethodHandleImpl.makeArrayAccessor(arrayClass, MethodHandleImpl.ArrayAccess.SET);
     }
 
     /**

--- a/test/jdk/java/lang/invoke/ArrayConstructorTest.java
+++ b/test/jdk/java/lang/invoke/ArrayConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class ArrayConstructorTest {
     @DataProvider
     static Object[][] arrayConstructorNegative() {
         return new Object[][]{
-                {String.class, IllegalArgumentException.class, "not an array class: java.lang.String"},
+                {String.class, IllegalArgumentException.class, "not an array: class java.lang.String"},
                 {null, NullPointerException.class, null}
         };
     }

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructor.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesArrayConstructor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.invoke;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark assesses the performance of MethodHandles.arrayConstructor
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class MethodHandlesArrayConstructor {
+
+    /**
+     * Implementation notes:
+     *   - creating simple array, and accessing the middle element
+     *   - might have done iteration over array, but that will measure pipelining effects instead
+     *   - volatile modifier on array breaks the DCE, which would otherwise eliminate the array store
+     *   - the array is not shared to prevent true sharing
+     *   - the array is large enough to prevent false sharing
+     */
+
+    private static MethodHandle mh;
+
+    @Setup
+    public void setup() throws Throwable {
+        mh = MethodHandles.arrayConstructor(String[].class);
+    }
+
+    @Benchmark
+    public MethodHandle testCreate() {
+        return MethodHandles.arrayConstructor(String[].class);
+    }
+
+    @Benchmark
+    public String[] baselineRaw() {
+        return new String[5];
+    }
+
+    @Benchmark
+    public String[] testConstructor() throws Throwable {
+        return (String[]) mh.invoke(5);
+    }
+
+}


### PR DESCRIPTION
This patch migrates `MethodHandles::arrayConstructor`, added in Java 9 as a hotfix to the incorrect constructor found on arrays via Lookup, to share the array access caching features. The result is that calling `MethodHandles.arrayConstructor` to create method handles is much faster.

Oracle JDK 20:
```
Benchmark                                             Mode  Cnt   Score   Error  Units
MethodHandlesArrayConstructor.createWithAnewarray     avgt   15   2.739 ± 0.058  ns/op
MethodHandlesArrayConstructor.createWithMethodHandle  avgt   15   3.313 ± 0.041  ns/op
MethodHandlesArrayConstructor.methodHandleCreation    avgt   15  61.874 ± 0.397  ns/op
```

This patch:
```
Benchmark                                             Mode  Cnt  Score   Error  Units
MethodHandlesArrayConstructor.createWithAnewarray     avgt   15  3.067 ± 0.026  ns/op
MethodHandlesArrayConstructor.createWithMethodHandle  avgt   15  3.699 ± 0.042  ns/op
MethodHandlesArrayConstructor.methodHandleCreation    avgt   15  1.447 ± 0.004  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307149](https://bugs.openjdk.org/browse/JDK-8307149): MethodHandles.arrayConstructor can be cached (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13819/head:pull/13819` \
`$ git checkout pull/13819`

Update a local copy of the PR: \
`$ git checkout pull/13819` \
`$ git pull https://git.openjdk.org/jdk.git pull/13819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13819`

View PR using the GUI difftool: \
`$ git pr show -t 13819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13819.diff">https://git.openjdk.org/jdk/pull/13819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13819#issuecomment-1535529235)