### PR TITLE
8293547: Add relaxed add_and_fetch for macos aarch64 atomics

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/atomic_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/atomic_bsd_aarch64.hpp
@@ -37,9 +37,13 @@ template<size_t byte_size>
 struct Atomic::PlatformAdd {
   template<typename D, typename I>
   D add_and_fetch(D volatile* dest, I add_value, atomic_memory_order order) const {
-    D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
-    FULL_MEM_BARRIER;
-    return res;
+    if (order == memory_order_relaxed) {
+      return __atomic_add_fetch(dest, add_value, __ATOMIC_RELAXED);
+    } else {
+      D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
+      FULL_MEM_BARRIER;
+      return res;
+    }
   }
 
   template<typename D, typename I>


### PR DESCRIPTION
Atomic::add_and_fetch currently doesn't honor the relaxed memory order hint. I suggest that we change the code to do so. We initially found this issue when looking into why one of our parallel iterators were slower than expected. We have been using this for a while in the Generational ZGC repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293547](https://bugs.openjdk.org/browse/JDK-8293547): Add relaxed add_and_fetch for macos aarch64 atomics


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13823/head:pull/13823` \
`$ git checkout pull/13823`

Update a local copy of the PR: \
`$ git checkout pull/13823` \
`$ git pull https://git.openjdk.org/jdk.git pull/13823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13823`

View PR using the GUI difftool: \
`$ git pr show -t 13823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13823.diff">https://git.openjdk.org/jdk/pull/13823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13823#issuecomment-1535751046)