### PR TITLE
8307521: Introduce check_oop infrastructure to check oops in the oop class

### DIFF
--- a/src/hotspot/share/oops/oopsHierarchy.cpp
+++ b/src/hotspot/share/oops/oopsHierarchy.cpp
@@ -30,6 +30,8 @@
 
 #ifdef CHECK_UNHANDLED_OOPS
 
+CheckOopFunctionPointer check_oop_function = nullptr;
+
 void oop::register_oop() {
   assert (CheckUnhandledOops, "should only call when CheckUnhandledOops");
   if (!Universe::is_fully_initialized()) return;


### PR DESCRIPTION
I'd like to add some extra verification to our C++ usages of oops. The intention is to quickly find when we are passing around an oop that wasn't fetched via a required load barrier. We have found this kind of verification crucial when developing Generational ZGC.

My proposal is to hook into the CHECK_UNHANDLED_OOPS code, which is only compiled when building fastdebug builds. In release and slowdebug builds, `oops` are simple `oopDesc*`, but with CHECK_UNHANDLED_OOPS oop is a class where we can easily hook in verification code.

The actual verification code is not included in the patch, but the required infrastructure is. Then when we deliver Generational ZGC, it will install a verification function pointer during initialization. See: https://github.com/openjdk/zgc/blob/349cf9ae38664991879402a90c5e23e291f1c1c3/src/hotspot/share/gc/z/zAddress.cpp#L92

```
static void initialize_check_oop_function() {
#ifdef CHECK_UNHANDLED_OOPS
  if (ZVerifyOops) {
    // Enable extra verification of usages of oops in oopsHierarchy.hpp
    check_oop_function = [](oopDesc* obj) {
      (void)to_zaddress(obj);
    };
  }
#endif
}
```

We've separated out this code from the larger Generational ZGC PR, so that it can get a proper review without being hidden together with all other changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307521](https://bugs.openjdk.org/browse/JDK-8307521): Introduce check_oop infrastructure to check oops in the oop class


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13825/head:pull/13825` \
`$ git checkout pull/13825`

Update a local copy of the PR: \
`$ git checkout pull/13825` \
`$ git pull https://git.openjdk.org/jdk.git pull/13825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13825`

View PR using the GUI difftool: \
`$ git pr show -t 13825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13825.diff">https://git.openjdk.org/jdk/pull/13825.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13825#issuecomment-1535923858)