### PR TITLE
8307131: C2: assert(false) failed: malformed control flow

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2014,7 +2014,8 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
   bool strip_mine_loop = iv_bt == T_INT &&
                          loop->_child == nullptr &&
                          sfpt != nullptr &&
-                         !loop->_has_call;
+                         !loop->_has_call &&
+                         is_deleteable_safept(sfpt);
   IdealLoopTree* outer_ilt = nullptr;
   if (strip_mine_loop) {
     outer_ilt = create_outer_strip_mined_loop(test, cmp, init_control, loop,

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestNondeleteableSafePoint.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestNondeleteableSafePoint.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8307131
+ * @summary C2: assert(false) failed: malformed control flow
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestNondeleteableSafePoint -XX:-TieredCompilation TestNondeleteableSafePoint
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestNondeleteableSafePoint {
+    static int N;
+
+    public static void main(String[] strArr) throws Exception {
+        Thread thread = new Thread() {
+                public void run() {
+                    test();
+                }
+            };
+        // Give thread some time to trigger compilation
+        thread.setDaemon(true);
+        thread.start();
+        Thread.sleep(Utils.adjustTimeout(500));
+    }
+
+    static void test() {
+        int i19, i21, iArr1[] = new int[N];
+        while (true) {
+            for (i19 = i21 = 2; i21 > i19; --i21) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
The IR graph has a loop nest with 2 loops and 2 safepoints. Both
safepoints are in the inner loop. One is on the backedge of the inner
loop. The inner loop is transformed into a counted loop and that
safepoint is removed. The other safepoint is right above the inner
loop's exit condition. The outer strip mined loop is constructed and
the safepoint is moved to the outer strip mined loop eventhough that
safepoint is marked as non deleteable. The inner loop is later on
removed, the outer strip mined loop is too, so is the safepoint. What
was the outer loop of the 2 loop nest becomes an infinite loop without
a safepoint and is considered dead code which in turn causes the
assert to fire.

The fix I propose is to only build the strip mined loop if the
safepoint that's moved to the outer strip mined loop is deleteable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307131](https://bugs.openjdk.org/browse/JDK-8307131): C2: assert(false) failed: malformed control flow


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13826/head:pull/13826` \
`$ git checkout pull/13826`

Update a local copy of the PR: \
`$ git checkout pull/13826` \
`$ git pull https://git.openjdk.org/jdk.git pull/13826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13826`

View PR using the GUI difftool: \
`$ git pr show -t 13826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13826.diff">https://git.openjdk.org/jdk/pull/13826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13826#issuecomment-1535943406)