### PR TITLE
8307527: MacOS Zero builds fail with undefined FFI_GO_CLOSURES after JDK-8304265

### DIFF
--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -32,7 +32,7 @@
 
 #define SUPPORT_MONITOR_COUNT
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(FFI_GO_CLOSURES)
 #define FFI_GO_CLOSURES 0
 #endif
 

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -25,6 +25,12 @@
 
 #include "jdk_internal_foreign_abi_fallback_LibFallback.h"
 
+// This is similar to globalDefinitions_zero.hpp, which is not accessible
+// from JDK libraries. Copy-paste it here.
+#if defined(__APPLE__) && !defined(FFI_GO_CLOSURES)
+#define FFI_GO_CLOSURES 0
+#endif
+
 #include <ffi.h>
 
 #include <errno.h>


### PR DESCRIPTION
See the bug. Actually, I am not sure why JDK-8304265 changed the `#ifndef FFI_GO_CLOSURES` to `#ifdef _APPLE_`. That seems too intrusive if `FFI_GO_CLOSURES` *is* enabled. So I rewrote the block to something more safe.

Additional testing:
 - [x] macos-aarch64-zero-fastdebug `make images` passes