### PR TITLE
8305169: java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java -- test server didn't start in timely manner

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
@@ -63,15 +63,13 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import sun.security.testlibrary.SimpleOCSPServer;
-import sun.security.testlibrary.SimpleOCSPServer;
-import sun.security.testlibrary.SimpleOCSPServer;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
-import sun.security.testlibrary.SimpleOCSPServer;
 
 public class GetAndPostTests {
     private static final String PASS = "passphrase";
+    private static final int SERVER_WAIT_SECS = 60;
     private static CertificateFactory certFac;
 
     public static void main(String args[]) throws Exception {
@@ -114,13 +112,8 @@ public class GetAndPostTests {
                     endEntCert.getSerialNumber(),
                     new SimpleOCSPServer.CertStatusInfo(
                             SimpleOCSPServer.CertStatus.CERT_STATUS_GOOD)));
-            ocspResponder.start();
-            // Wait 5 seconds for server ready
-            boolean readyStatus =
-                    ocspResponder.awaitServerReady(5, TimeUnit.SECONDS);
-            if (!readyStatus) {
-                throw new RuntimeException("Server not ready");
-            }
+
+            startOcspServer(ocspResponder);
 
             int ocspPort = ocspResponder.getPort();
             URI ocspURI = new URI("http://localhost:" + ocspPort);
@@ -167,6 +160,14 @@ public class GetAndPostTests {
                 ocspResponder.stop();
             }
         }
+    }
+
+    private static void startOcspServer(SimpleOCSPServer ocspResponder) throws InterruptedException, IOException {
+            ocspResponder.start();
+            if (!ocspResponder.awaitServerReady(SERVER_WAIT_SECS, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Server not ready after " + SERVER_WAIT_SECS
+                        + " seconds.");
+            }
     }
 
     /**

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -288,7 +288,15 @@ public class SimpleOCSPServer {
     public synchronized void stop() {
         if (started) {
             receivedShutdown = true;
+            started = false;
             log("Received shutdown notification");
+        }
+    }
+
+    public synchronized void shutdownNow() {
+        stop();
+        if (threadPool != null) {
+            threadPool.shutdownNow();
         }
     }
 
@@ -577,7 +585,7 @@ public class SimpleOCSPServer {
      * @param message the message to log
      */
     private static synchronized void err(String message) {
-        System.out.println("[" + Thread.currentThread().getName() + "]: " +
+        System.err.println("[" + Thread.currentThread().getName() + "]: " +
                 message);
     }
 


### PR DESCRIPTION
Could someone please review this PR? It is a small change to increase the time that the client waits for the server thread to start.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305169](https://bugs.openjdk.org/browse/JDK-8305169): java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java -- test server didn't start in timely manner


### Reviewers
 * [Sibabrata Sahoo](https://openjdk.org/census#ssahoo) (@sisahoo - Committer)
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13829/head:pull/13829` \
`$ git checkout pull/13829`

Update a local copy of the PR: \
`$ git checkout pull/13829` \
`$ git pull https://git.openjdk.org/jdk.git pull/13829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13829`

View PR using the GUI difftool: \
`$ git pr show -t 13829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13829.diff">https://git.openjdk.org/jdk/pull/13829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13829#issuecomment-1536128797)