### PR TITLE
8280993: [XWayland] Popup is not closed on click outside of area controlled by XWayland

### DIFF
--- a/src/java.desktop/share/classes/java/awt/PopupMenu.java
+++ b/src/java.desktop/share/classes/java/awt/PopupMenu.java
@@ -43,6 +43,10 @@ import sun.awt.AWTAccessor;
  * (e.g., you add it to a {@code MenuBar}), then you <b>cannot</b>
  * call {@code show} on that {@code PopupMenu}.
  *
+ * @implNote On Linux systems using Wayland, the popup menu may not be dismissed
+ * by clicking on the decorations of its own parent window
+ * and on some system panels.
+ *
  * @author      Amy Fowler
  */
 public class PopupMenu extends Menu {

--- a/src/java.desktop/share/classes/java/awt/PopupMenu.java
+++ b/src/java.desktop/share/classes/java/awt/PopupMenu.java
@@ -43,10 +43,6 @@ import sun.awt.AWTAccessor;
  * (e.g., you add it to a {@code MenuBar}), then you <b>cannot</b>
  * call {@code show} on that {@code PopupMenu}.
  *
- * @implNote On Linux systems using Wayland, the popup menu may not be dismissed
- * by clicking on the decorations of its own parent window
- * and on some system panels.
- *
  * @author      Amy Fowler
  */
 public class PopupMenu extends Menu {

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -101,6 +101,10 @@ import sun.awt.UngrabEvent;
  * has been added to the <code>java.beans</code> package.
  * Please see {@link java.beans.XMLEncoder}.
  *
+ * @implNote On Linux systems using Wayland, the popup menu may not be dismissed
+ * by clicking on the decorations of its own parent window
+ * and on some system panels.
+ *
  * @author Georges Saab
  * @author David Karlton
  * @author Arnaud Weber

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -101,10 +101,6 @@ import sun.awt.UngrabEvent;
  * has been added to the <code>java.beans</code> package.
  * Please see {@link java.beans.XMLEncoder}.
  *
- * @implNote On Linux systems using Wayland, the popup menu may not be dismissed
- * by clicking on the decorations of its own parent window
- * and on some system panels.
- *
  * @author Georges Saab
  * @author David Karlton
  * @author Arnaud Weber

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1883,6 +1883,10 @@ public abstract class SunToolkit extends Toolkit
         return false;
     }
 
+    public boolean isRunningOnWayland() {
+        return false;
+    }
+
     private static final Object DEACTIVATION_TIMES_MAP_KEY = new Object();
 
     public synchronized void setWindowDeactivationTime(Window w, long time) {

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1886,6 +1886,11 @@ public abstract class SunToolkit extends Toolkit
     public boolean isRunningOnWayland() {
         return false;
     }
+
+    public void dismissPopupOnFocusLostIfNeeded(Window invoker) {}
+
+    public void dismissPopupOnFocusLostIfNeededCleanUp(Window invoker) {}
+
 
     private static final Object DEACTIVATION_TIMES_MAP_KEY = new Object();
 

--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -421,4 +421,35 @@ public abstract class UNIXToolkit extends SunToolkit
         return AccessController.doPrivileged((PrivilegedAction<Boolean>)()
                 -> Boolean.getBoolean("jdk.gtk.verbose"));
     }
+
+    private static volatile Boolean isOnWayland = null;
+
+    @SuppressWarnings("removal")
+    public static boolean isOnWayland() {
+        Boolean result = isOnWayland;
+        if (result == null) {
+            synchronized (GTK_LOCK) {
+                result = isOnWayland;
+                if (result == null) {
+                    isOnWayland
+                            = result
+                            = AccessController.doPrivileged(
+                            (PrivilegedAction<Boolean>) () -> {
+                                final String display =
+                                        System.getenv("WAYLAND_DISPLAY");
+
+                                return display != null
+                                        && !display.trim().isEmpty();
+                            }
+                    );
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isRunningOnWayland() {
+        return isOnWayland();
+    }
 }

--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -25,12 +25,33 @@
 package sun.awt;
 
 import java.awt.RenderingHints;
-import static java.awt.RenderingHints.*;
+
+import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_DEFAULT;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HBGR;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VBGR;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VRGB;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+
 import java.awt.color.ColorSpace;
-import java.awt.image.*;
+
+import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
 
+import sun.awt.X11.XBaseWindow;
 import sun.security.action.GetIntegerAction;
 import com.sun.java.swing.plaf.gtk.GTKConstants.TextDirection;
 import sun.java2d.opengl.OGLRenderQueue;
@@ -451,5 +472,61 @@ public abstract class UNIXToolkit extends SunToolkit
     @Override
     public boolean isRunningOnWayland() {
         return isOnWayland();
+    }
+
+    // We rely on the X11 input grab mechanism, but for the Wayland session
+    // it only works inside the XWayland server, so mouse clicks outside of it
+    // will not be detected.
+    // (window decorations, pure Wayland applications, desktop, etc.)
+    //
+    // As a workaround, we can dismiss menus when the window loses focus.
+    //
+    // However, there are "blind spots" though, which, when clicked, don't
+    // transfer the focus away and don't dismiss the menu
+    // (e.g. the window's own title or the area in the side dock without
+    // application icons).
+    private static final WindowFocusListener waylandWindowFocusListener;
+
+    static {
+        if (isOnWayland()) {
+            waylandWindowFocusListener = new WindowAdapter() {
+                @Override
+                public void windowLostFocus(WindowEvent e) {
+                    Window window = e.getWindow();
+                    window.removeWindowFocusListener(this);
+
+                    // AWT
+                    XBaseWindow.ungrabInput();
+
+                    // Swing
+                    window.dispatchEvent(new UngrabEvent(window));
+                }
+            };
+        } else {
+            waylandWindowFocusListener = null;
+        }
+    }
+
+    @Override
+    public void dismissPopupOnFocusLostIfNeeded(Window invoker) {
+        if (!isOnWayland()
+                || invoker == null
+                || Arrays
+                    .asList(invoker.getWindowFocusListeners())
+                    .contains(waylandWindowFocusListener)
+        ) {
+            return;
+        }
+
+        invoker.addWindowFocusListener(waylandWindowFocusListener);
+    }
+
+    @Override
+    public void dismissPopupOnFocusLostIfNeededCleanUp(Window invoker) {
+        if (!isOnWayland() || invoker == null) {
+            return;
+        }
+
+        invoker.removeWindowFocusListener(waylandWindowFocusListener);
     }
 }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XBaseWindow.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XBaseWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,13 @@
 
 package sun.awt.X11;
 
-import java.awt.*;
-import sun.awt.*;
-import java.util.*;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.HashSet;
+import java.util.Set;
+
+import sun.awt.SunToolkit;
 import sun.util.logging.PlatformLogger;
 
 public class XBaseWindow {
@@ -912,7 +916,7 @@ public class XBaseWindow {
         }
     }
 
-    static void ungrabInput() {
+    public static void ungrabInput() {
         XToolkit.awtLock();
         try {
             XBaseWindow grabWindow = XAwtState.getGrabWindow();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XPopupMenuPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XPopupMenuPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,21 @@
  */
 package sun.awt.X11;
 
-import java.awt.*;
-import java.awt.peer.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Event;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.MenuItem;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.Rectangle;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 
+import java.awt.peer.PopupMenuPeer;
 import java.util.Vector;
 import sun.awt.AWTAccessor;
 import sun.util.logging.PlatformLogger;
@@ -125,6 +136,7 @@ public class XPopupMenuPeer extends XMenuWindow implements PopupMenuPeer {
             //near the periphery of the screen, XToolkit
             Rectangle bounds = getWindowBounds(pt, dim);
             reshape(bounds);
+            waylandDismissOnWindowFocusLostAdd();
             xSetVisible(true);
             toFront();
             selectItem(null, false);

--- a/src/java.desktop/unix/classes/sun/awt/X11/XPopupMenuPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XPopupMenuPeer.java
@@ -35,12 +35,14 @@ import java.awt.MenuItem;
 import java.awt.Point;
 import java.awt.PopupMenu;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 
 import java.awt.peer.PopupMenuPeer;
 import java.util.Vector;
 import sun.awt.AWTAccessor;
+import sun.awt.SunToolkit;
 import sun.util.logging.PlatformLogger;
 
 public class XPopupMenuPeer extends XMenuWindow implements PopupMenuPeer {
@@ -136,7 +138,9 @@ public class XPopupMenuPeer extends XMenuWindow implements PopupMenuPeer {
             //near the periphery of the screen, XToolkit
             Rectangle bounds = getWindowBounds(pt, dim);
             reshape(bounds);
-            waylandDismissOnWindowFocusLostAdd();
+            if (Toolkit.getDefaultToolkit() instanceof SunToolkit sunToolkit) {
+                sunToolkit.dismissPopupOnFocusLostIfNeeded(getMenuTarget());
+            }
             xSetVisible(true);
             toFront();
             selectItem(null, false);


### PR DESCRIPTION
On Linux systems, we rely on XGrabPointer (X11 API) to capture mouse input and dismiss popup menus on mouse clicks outside the popup menu.
Unfortunately, on Linux systems using the [Wayland](https://wayland.freedesktop.org/) session this only works inside [XWayland(Wayland's X11 server implementation)](https://wayland.freedesktop.org/xserver.html).
This means if a user clicks on a part of the screen not controlled by XWayland (e.g. window decorations, other non X11 applications) the popup menu will not be hidden.

As a workaround, we can hide this menu when the parent popup menu window loses focus.
However, it does have its drawbacks, which should be described in the documentation.The focus does not change when clicking on the header of its own parent window or on non-focusable windows, .e.g., empty space in system dock, so in this case the popup menu is not hidden.

Third-party applications use a similar approach.

I also have doubts about the need to change the documentation, as I can't find where it is described that the popup menu should be hidden when clicked outside the menu.

<del>CSR: https://bugs.openjdk.org/browse/JDK-8307529</del>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8280993](https://bugs.openjdk.org/browse/JDK-8280993): [XWayland] Popup is not closed on click outside of area controlled by XWayland
 * [JDK-8307529](https://bugs.openjdk.org/browse/JDK-8307529): [XWayland] Popup is not closed on click outside of area controlled by XWayland (**CSR**) (Withdrawn)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13830/head:pull/13830` \
`$ git checkout pull/13830`

Update a local copy of the PR: \
`$ git checkout pull/13830` \
`$ git pull https://git.openjdk.org/jdk.git pull/13830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13830`

View PR using the GUI difftool: \
`$ git pr show -t 13830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13830.diff">https://git.openjdk.org/jdk/pull/13830.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13830#issuecomment-1536196100)