### PR TITLE
8307535: java.util.logging.Handlers should be more VirtualThread friendly

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/ErrorManager.java
+++ b/src/java.logging/share/classes/java/util/logging/ErrorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,13 +85,15 @@ public class ErrorManager {
      * @param ex     an exception (may be null)
      * @param code   an error code defined in ErrorManager
      */
-    public synchronized void error(String msg, Exception ex, int code) {
-        if (reported) {
-            // We only report the first error, to avoid clogging
-            // the screen.
-            return;
+    public void error(String msg, Exception ex, int code) {
+        synchronized (this) {
+            if (reported) {
+                // We only report the first error, to avoid clogging
+                // the screen.
+                return;
+            }
+            reported = true;
         }
-        reported = true;
         String text = "java.util.logging.ErrorManager: " + code;
         if (msg != null) {
             text = text + ": " + msg;

--- a/src/java.logging/share/classes/java/util/logging/FileHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/FileHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -728,7 +728,21 @@ public class FileHandler extends StreamHandler {
     /**
      * Rotate the set of output files
      */
-    private synchronized void rotate() {
+    private void rotate() {
+        if (tryUseLock()) {
+            try {
+                rotate0();
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                rotate0();
+            }
+        }
+    }
+
+    private void rotate0() {
         Level oldLevel = getLevel();
         setLevel(Level.OFF);
 
@@ -760,9 +774,23 @@ public class FileHandler extends StreamHandler {
      * @param  record  description of the log event. A null record is
      *                 silently ignored and is not published
      */
-    @SuppressWarnings("removal")
     @Override
-    public synchronized void publish(LogRecord record) {
+    public void publish(LogRecord record) {
+        if (tryUseLock()) {
+            try {
+                publish0(record);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                publish0(record);
+            }
+        }
+
+    }
+    @SuppressWarnings("removal")
+    private void publish0(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }
@@ -791,7 +819,21 @@ public class FileHandler extends StreamHandler {
      *             the caller does not have {@code LoggingPermission("control")}.
      */
     @Override
-    public synchronized void close() throws SecurityException {
+    public void close() throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                close0();
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                close0();
+            }
+        }
+    }
+
+    private void close0() throws SecurityException {
         super.close();
         // Unlock any lock file.
         if (lockFileName == null) {

--- a/src/java.logging/share/classes/java/util/logging/Handler.java
+++ b/src/java.logging/share/classes/java/util/logging/Handler.java
@@ -189,7 +189,21 @@ public abstract class Handler {
      * @throws  SecurityException  if a security manager exists and if
      *             the caller does not have {@code LoggingPermission("control")}.
      */
-    public synchronized void setFormatter(Formatter newFormatter) throws SecurityException {
+    public void setFormatter(Formatter newFormatter) throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                setFormatter0(newFormatter);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setFormatter0(newFormatter);
+            }
+        }
+    }
+
+    private void setFormatter0(Formatter newFormatter) throws SecurityException {
         checkPermission();
         formatter = Objects.requireNonNull(newFormatter);
     }
@@ -215,7 +229,22 @@ public abstract class Handler {
      * @throws  UnsupportedEncodingException if the named encoding is
      *          not supported.
      */
-    public synchronized void setEncoding(String encoding)
+    public void setEncoding(String encoding)
+            throws SecurityException, java.io.UnsupportedEncodingException {
+        if (tryUseLock()) {
+            try {
+                setEncoding0(encoding);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setEncoding0(encoding);
+            }
+        }
+    }
+
+    private void setEncoding0(String encoding)
                         throws SecurityException, java.io.UnsupportedEncodingException {
         checkPermission();
         if (encoding != null) {
@@ -251,7 +280,21 @@ public abstract class Handler {
      * @throws  SecurityException  if a security manager exists and if
      *             the caller does not have {@code LoggingPermission("control")}.
      */
-    public synchronized void setFilter(Filter newFilter) throws SecurityException {
+    public void setFilter(Filter newFilter) throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                setFilter0(newFilter);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setFilter0(newFilter);
+            }
+        }
+    }
+
+    private void setFilter0(Filter newFilter) throws SecurityException {
         checkPermission();
         filter = newFilter;
     }
@@ -275,7 +318,21 @@ public abstract class Handler {
      * @throws  SecurityException  if a security manager exists and if
      *             the caller does not have {@code LoggingPermission("control")}.
      */
-    public synchronized void setErrorManager(ErrorManager em) {
+    public void setErrorManager(ErrorManager em) {
+        if (tryUseLock()) {
+            try {
+                setErrorManager0(em);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setErrorManager0(em);
+            }
+        }
+    }
+
+    private void setErrorManager0(ErrorManager em) {
         checkPermission();
         if (em == null) {
            throw new NullPointerException();
@@ -327,13 +384,29 @@ public abstract class Handler {
      * @throws  SecurityException  if a security manager exists and if
      *             the caller does not have {@code LoggingPermission("control")}.
      */
-    public synchronized void setLevel(Level newLevel) throws SecurityException {
+    public void setLevel(Level newLevel) throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                setLevel0(newLevel);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setLevel0(newLevel);
+            }
+        }
+    }
+
+    private void setLevel0(Level newLevel) throws SecurityException {
         if (newLevel == null) {
             throw new NullPointerException();
         }
         checkPermission();
         logLevel = newLevel;
     }
+
+
 
     /**
      * Get the log level specifying which messages will be

--- a/src/java.logging/share/classes/java/util/logging/Handler.java
+++ b/src/java.logging/share/classes/java/util/logging/Handler.java
@@ -30,8 +30,7 @@ import java.util.Objects;
 import java.io.UnsupportedEncodingException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-
-import jdk.internal.misc.InternalLock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * A {@code Handler} object takes log messages from a {@code Logger} and
@@ -67,7 +66,7 @@ public abstract class Handler {
     private volatile Level logLevel = Level.ALL;
     private volatile ErrorManager errorManager = new ErrorManager();
     private volatile String encoding;
-    final InternalLock lock;
+    private final ReentrantLock lock;
 
     /**
      * Default constructor.  The resulting {@code Handler} has a log
@@ -79,13 +78,13 @@ public abstract class Handler {
         lock = initLocking();
     }
 
-    private InternalLock initLocking() {
+    private ReentrantLock initLocking() {
         Class<?> clazz = this.getClass();
         ClassLoader loader = clazz.getClassLoader();
         if (loader != null && loader != ClassLoader.getPlatformClassLoader()) {
             return null;
         } else {
-            return InternalLock.newLockOrNull();
+            return new ReentrantLock();
         }
     }
 

--- a/src/java.logging/share/classes/java/util/logging/MemoryHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/MemoryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,7 +178,21 @@ public class MemoryHandler extends Handler {
      *                 silently ignored and is not published
      */
     @Override
-    public synchronized void publish(LogRecord record) {
+    public void publish(LogRecord record) {
+        if (tryUseLock()) {
+            try {
+                publish0(record);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                publish0(record);
+            }
+        }
+    }
+
+    private void publish0(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }
@@ -200,7 +214,22 @@ public class MemoryHandler extends Handler {
      * <p>
      * The buffer is then cleared.
      */
-    public synchronized void push() {
+    public void push() {
+        if (tryUseLock()) {
+            try {
+                push0();
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                push0();
+            }
+        }
+
+    }
+
+    private void push0() {
         for (int i = 0; i < count; i++) {
             int ix = (start+i)%buffer.length;
             LogRecord record = buffer[ix];

--- a/src/java.logging/share/classes/java/util/logging/MemoryHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/MemoryHandler.java
@@ -226,7 +226,6 @@ public class MemoryHandler extends Handler {
                 push0();
             }
         }
-
     }
 
     private void push0() {
@@ -273,7 +272,21 @@ public class MemoryHandler extends Handler {
      * @throws  SecurityException  if a security manager exists and if
      *             the caller does not have {@code LoggingPermission("control")}.
      */
-    public synchronized void setPushLevel(Level newLevel) throws SecurityException {
+    public void setPushLevel(Level newLevel) throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                setPushLevel0(newLevel);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setPushLevel0(newLevel);
+            }
+        }
+    }
+
+    private void setPushLevel0(Level newLevel) throws SecurityException {
         if (newLevel == null) {
             throw new NullPointerException();
         }

--- a/src/java.logging/share/classes/java/util/logging/SocketHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/SocketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,7 +156,21 @@ public class SocketHandler extends StreamHandler {
      *             the caller does not have {@code LoggingPermission("control")}.
      */
     @Override
-    public synchronized void close() throws SecurityException {
+    public void close() throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                close0();
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                close0();
+            }
+        }
+    }
+
+    private void close0() throws SecurityException {
         super.close();
         if (sock != null) {
             try {
@@ -175,7 +189,21 @@ public class SocketHandler extends StreamHandler {
      *                 silently ignored and is not published
      */
     @Override
-    public synchronized void publish(LogRecord record) {
+    public void publish(LogRecord record) {
+        if (tryUseLock()) {
+            try {
+                publish0(record);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                publish0(record);
+            }
+        }
+    }
+
+    private void publish0(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }

--- a/src/java.logging/share/classes/java/util/logging/StreamHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/StreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,21 @@ public class StreamHandler extends Handler {
      * @throws  SecurityException  if a security manager exists and if
      *             the caller does not have {@code LoggingPermission("control")}.
      */
-    protected synchronized void setOutputStream(OutputStream out) throws SecurityException {
+    protected void setOutputStream(OutputStream out) throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                setOutputStream0(out);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setOutputStream0(out);
+            }
+        }
+    }
+
+    private void setOutputStream0(OutputStream out) throws SecurityException {
         if (out == null) {
             throw new NullPointerException();
         }
@@ -157,7 +171,21 @@ public class StreamHandler extends Handler {
      *          not supported.
      */
     @Override
-    public synchronized void setEncoding(String encoding)
+    public void setEncoding(String encoding)
+                        throws SecurityException, java.io.UnsupportedEncodingException {
+        if (tryUseLock()) {
+            try {
+                setEncoding0(encoding);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                setEncoding0(encoding);
+            }
+        }
+    }
+    private void setEncoding0(String encoding)
                         throws SecurityException, java.io.UnsupportedEncodingException {
         super.setEncoding(encoding);
         if (output == null) {
@@ -190,7 +218,20 @@ public class StreamHandler extends Handler {
      *                 silently ignored and is not published
      */
     @Override
-    public synchronized void publish(LogRecord record) {
+    public void publish(LogRecord record) {
+        if (tryUseLock()) {
+            try {
+                publish0(record);
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                publish0(record);
+            }
+        }
+    }
+    private void publish0(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }
@@ -241,7 +282,20 @@ public class StreamHandler extends Handler {
      * Flush any buffered messages.
      */
     @Override
-    public synchronized void flush() {
+    public void flush() {
+        if (tryUseLock()) {
+            try {
+                flush0();
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                flush0();
+            }
+        }
+    }
+    private void flush0() {
         if (writer != null) {
             try {
                 writer.flush();
@@ -253,7 +307,7 @@ public class StreamHandler extends Handler {
         }
     }
 
-    private synchronized void flushAndClose() throws SecurityException {
+    private void flushAndClose() throws SecurityException {
         checkPermission();
         if (writer != null) {
             try {
@@ -286,8 +340,18 @@ public class StreamHandler extends Handler {
      *             the caller does not have LoggingPermission("control").
      */
     @Override
-    public synchronized void close() throws SecurityException {
-        flushAndClose();
+    public void close() throws SecurityException {
+        if (tryUseLock()) {
+            try {
+                flushAndClose();
+            } finally {
+                unlock();
+            }
+        } else {
+            synchronized (this) {
+                flushAndClose();
+            }
+        }
     }
 
     // Package-private support for setting OutputStream


### PR DESCRIPTION
Several Handlers class use monitors to synchronize when formatting / publishing LogRecords.
When logging within a VirtualThread, holding this monitor can cause the carrier thread to be pinned.
Handlers could use jdk.internal.misc.InternalLock, in a similar way to some java.io classes (such as PrintStream) to avoid pinning the carrier thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307535](https://bugs.openjdk.org/browse/JDK-8307535): java.util.logging.Handlers should be more VirtualThread friendly


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13832/head:pull/13832` \
`$ git checkout pull/13832`

Update a local copy of the PR: \
`$ git checkout pull/13832` \
`$ git pull https://git.openjdk.org/jdk.git pull/13832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13832`

View PR using the GUI difftool: \
`$ git pr show -t 13832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13832.diff">https://git.openjdk.org/jdk/pull/13832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13832#issuecomment-1536294882)