### PR TITLE
8280031: Deprecate GTK2 for removal

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,11 @@ public abstract class UNIXToolkit extends SunToolkit
     private static final int[] BAND_OFFSETS = { 0, 1, 2 };
     private static final int[] BAND_OFFSETS_ALPHA = { 0, 1, 2, 3 };
     private static final int DEFAULT_DATATRANSFER_TIMEOUT = 10000;
+
+    private static final String GTK2_DEPRECATION_MESSAGE =
+            "WARNING: the GTK 2 library is deprecated and " +
+                    "its support will be removed in a future release";
+    private static volatile boolean gtk2WarningIssued = false;
 
     // Allowed GTK versions
     public enum GtkVersions {
@@ -405,6 +410,10 @@ public abstract class UNIXToolkit extends SunToolkit
         if (version == null) {
             return GtkVersions.ANY;
         } else if (version.startsWith("2")) {
+            if (!gtk2WarningIssued) {
+                System.err.println(GTK2_DEPRECATION_MESSAGE);
+                gtk2WarningIssued = true;
+            }
             return GtkVersions.GTK2;
         } else if("3".equals(version) ){
             return GtkVersions.GTK3;


### PR DESCRIPTION
GTK3 has been the default for several years now. GTK2 is now only available by specifying it with the jdk.gtk.version system property. With the announcement of the GTK 4 release in December 2020, the GTK 2 toolkit has reached its end of life.

It is time to deprecate it for removal.

Since there's no associated API, we just print a deprecation message once when trying to load gtk2.

CSR: https://bugs.openjdk.org/browse/JDK-8307481

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8307481](https://bugs.openjdk.org/browse/JDK-8307481) to be approved

### Issues
 * [JDK-8280031](https://bugs.openjdk.org/browse/JDK-8280031): Deprecate GTK2 for removal
 * [JDK-8307481](https://bugs.openjdk.org/browse/JDK-8307481): Deprecate GTK2 for removal (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13834/head:pull/13834` \
`$ git checkout pull/13834`

Update a local copy of the PR: \
`$ git checkout pull/13834` \
`$ git pull https://git.openjdk.org/jdk.git pull/13834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13834`

View PR using the GUI difftool: \
`$ git pr show -t 13834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13834.diff">https://git.openjdk.org/jdk/pull/13834.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13834#issuecomment-1536436106)