### PR TITLE
8306941: Open source several datatransfer and dnd AWT tests

### DIFF
--- a/test/jdk/java/awt/datatransfer/MimeFormatsTest.java
+++ b/test/jdk/java/awt/datatransfer/MimeFormatsTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4859006
+  @summary tests that MIME formats are mapped to flavors properly on X11
+  @requires (os.family == "linux")
+  @key headful
+  @run main MimeFormatsTest
+*/
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.FlavorMap;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.SystemFlavorMap;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+
+public class MimeFormatsTest implements ClipboardOwner {
+    public static final DataFlavor TEST_FLAVOR =
+        new DataFlavor(
+                "text/test;charset=UTF-8;class=java.io.InputStream",
+                null);
+
+    public static class TextTransferable implements Transferable {
+        private final String text;
+
+        public TextTransferable(String text) {
+            this.text = text;
+        }
+
+        public Object getTransferData(DataFlavor flavor)
+          throws UnsupportedFlavorException, IOException {
+            if (!isDataFlavorSupported(TEST_FLAVOR)) {
+                throw new UnsupportedFlavorException(flavor);
+            }
+
+            return new ByteArrayInputStream(
+                    text.getBytes(StandardCharsets.UTF_8));
+        }
+
+        public DataFlavor[] getTransferDataFlavors(){
+            return new DataFlavor[] { TEST_FLAVOR };
+        }
+
+        public boolean isDataFlavorSupported(DataFlavor flavor) {
+            return TEST_FLAVOR.equals(flavor);
+        }
+    }
+
+    public static final String DATA =
+        "\u0440\u0443\u0441\u0441\u043a\u0438\u0439";
+
+    private String testData = null;
+
+    private static final Clipboard clipboard =
+        Toolkit.getDefaultToolkit().getSystemClipboard();
+
+    public void childRun() {
+        Transferable t = clipboard.getContents(null);
+        String data = "";
+        try {
+            data = (String)t.getTransferData(DataFlavor.stringFlavor);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        System.err.println("contents size=" + data.length());
+        for (int i = 0; i < data.length(); i++) {
+            System.err.println("     char[" + i + "]=" + (int) data.charAt(i));
+        }
+        ClipboardOwner owner = new ClipboardOwner() {
+                public void lostOwnership(Clipboard clipboard,
+                                          Transferable contents) {
+                    System.err.println("%d exit".formatted(
+                            System.currentTimeMillis()));
+                    System.err.println("Exiting");
+                    System.exit(0);
+                }
+            };
+        clipboard.setContents(new StringSelection(data + data), owner);
+
+        Object lock = new Object();
+        synchronized (lock) {
+            // Wait to let the parent retrieve the contents.
+            try {
+                System.err.println("%d wait".formatted(
+                        System.currentTimeMillis()));
+                lock.wait();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void start() {
+        FlavorMap fm = SystemFlavorMap.getDefaultFlavorMap();
+        if (fm instanceof SystemFlavorMap) {
+            SystemFlavorMap sfm = (SystemFlavorMap)fm;
+            String mimeNative = "text/plain;charset=UTF-8";
+            sfm.setNativesForFlavor(TEST_FLAVOR,
+                                    new String[] { mimeNative });
+            sfm.setFlavorsForNative(mimeNative,
+                                    new DataFlavor[] { TEST_FLAVOR });
+        } else {
+            System.err.println("WARNING: system flavor map: " + fm);
+            return;
+        }
+
+        clipboard.setContents(new TextTransferable(DATA), this);
+
+        try {
+            String javaPath = System.getProperty("java.home", "");
+            String[] command = {
+                    javaPath + File.separator + "bin" + File.separator + "java",
+                    "-cp",
+                    System.getProperty("test.classes", "."),
+                    "Child"
+            };
+
+            Process process = Runtime.getRuntime().exec(command);
+            ProcessResults pres = ProcessResults.doWaitFor(process);
+
+            int returnCode = pres.exitValue;
+
+            if (pres.stderr != null && pres.stderr.length() > 0) {
+                System.err.println("========= Child VM System.err ========");
+                System.err.print(pres.stderr);
+                System.err.println("======================================");
+            }
+
+            if (pres.stdout != null && pres.stdout.length() > 0) {
+                System.err.println("========= Child VM System.out ========");
+                System.err.print(pres.stdout);
+                System.err.println("======================================");
+            }
+
+            System.err.println("Child return code=" + returnCode);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        System.err.println("Received data size=" + testData.length());
+        for (int i = 0; i < testData.length(); i++) {
+            System.err.println("     char[" + i + "]=" + (int)testData.charAt(i));
+        }
+
+        if (!testData.equals(DATA + DATA)) {
+            throw new RuntimeException();
+        }
+    }
+
+    public void lostOwnership(Clipboard clip, Transferable contents) {
+        Runnable r = new Runnable() {
+                public void run() {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    Transferable t = clipboard.getContents(null);
+                    try {
+                        InputStream is =
+                            (InputStream)t.getTransferData(TEST_FLAVOR);
+                        Reader r = new InputStreamReader(is,
+                                StandardCharsets.UTF_8);
+                        StringBuffer sb = new StringBuffer();
+                        int ch = 0;
+                        while ((ch = r.read()) != -1) {
+                            System.err.println("ch=" + ch);
+                            sb.append((char)ch);
+                        }
+                        testData = sb.toString();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    clipboard.setContents(new TextTransferable(""), null);
+                }
+            };
+        new Thread(r).start();
+    }
+
+    public static void main(String[] args) {
+        if (!System.getProperty("os.name").startsWith("Linux")) {
+            return;
+        }
+
+        MimeFormatsTest mimeFormatsTest = new MimeFormatsTest();
+        mimeFormatsTest.start();
+    }
+}
+
+class Child {
+    public static void main(String[] args) {
+        MimeFormatsTest test = new MimeFormatsTest();
+        test.childRun();
+    }
+}
+
+class ProcessResults {
+    public int exitValue;
+    public String stdout;
+    public String stderr;
+
+    public ProcessResults() {
+        exitValue = -1;
+        stdout = "";
+        stderr = "";
+    }
+
+    /**
+     * Method to perform a "wait" for a process and return its exit value.
+     * This is a workaround for <code>Process.waitFor()</code> never returning.
+     */
+    public static ProcessResults doWaitFor(Process p) {
+        ProcessResults pres = new ProcessResults();
+
+        InputStream in = null;
+        InputStream err = null;
+
+        try {
+            in = p.getInputStream();
+            err = p.getErrorStream();
+
+            boolean finished = false;
+
+            while (!finished) {
+                try {
+                    while (in.available() > 0) {
+                        pres.stdout += (char)in.read();
+                    }
+                    while (err.available() > 0) {
+                        pres.stderr += (char)err.read();
+                    }
+                    // Ask the process for its exitValue. If the process
+                    // is not finished, an IllegalThreadStateException
+                    // is thrown. If it is finished, we fall through and
+                    // the variable finished is set to true.
+                    pres.exitValue = p.exitValue();
+                    finished  = true;
+                }
+                catch (IllegalThreadStateException e) {
+                    // Process is not finished yet;
+                    // Sleep a little to save on CPU cycles
+                    Thread.currentThread().sleep(500);
+                }
+            }
+            if (in != null) in.close();
+            if (err != null) err.close();
+        }
+        catch (Throwable e) {
+            System.err.println("doWaitFor(): unexpected exception");
+            e.printStackTrace();
+        }
+        return pres;
+    }
+}

--- a/test/jdk/java/awt/datatransfer/RemoveFlavorListenerTest.java
+++ b/test/jdk/java/awt/datatransfer/RemoveFlavorListenerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6194489
+  @summary tests that removeFlavorListener does not throw an exception in any case.
+  @key headful
+  @run main RemoveFlavorListenerTest
+*/
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.FlavorEvent;
+import java.awt.datatransfer.FlavorListener;
+
+public class RemoveFlavorListenerTest {
+
+    public static void main(String[] args) {
+        try {
+            FlavorListener fl = new FlavorListener() {
+                public void flavorsChanged(FlavorEvent e) {}
+            };
+            Toolkit.getDefaultToolkit()
+                    .getSystemClipboard().removeFlavorListener(fl);
+        } catch (NullPointerException e) {
+            throw new RuntimeException("NullPointerException, test case failed",
+                    e);
+        }
+    }
+}

--- a/test/jdk/java/awt/dnd/AutoscrollStopTest.java
+++ b/test/jdk/java/awt/dnd/AutoscrollStopTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4516490
+  @summary verifies that autoscroll is stopped when the drop happens
+  @key headful
+  @run main AutoscrollStopTest
+*/
+
+
+import java.awt.AWTException;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.Autoscroll;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragGestureRecognizer;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+
+
+public class AutoscrollStopTest extends Frame implements Autoscroll {
+    static volatile AutoscrollStopTest test = null;
+
+    volatile boolean dropHappened = false;
+
+    final DragSource dragSource = DragSource.getDefaultDragSource();
+    final Transferable transferable = new StringSelection("TEXT");
+    final DragGestureListener dragGestureListener = new DragGestureListener() {
+            public void dragGestureRecognized(DragGestureEvent dge) {
+                dge.startDrag(null, transferable);
+            }
+        };
+    final DragGestureRecognizer dragGestureRecognizer =
+            dragSource.createDefaultDragGestureRecognizer(
+                    this, DnDConstants.ACTION_COPY_OR_MOVE,
+                    dragGestureListener);
+
+    final DropTargetListener dropTargetListener = new DropTargetAdapter() {
+        public void drop(DropTargetDropEvent e) {
+            e.rejectDrop();
+            dropHappened = true;
+        }
+    };
+
+    final DropTarget dropTarget = new DropTarget(this, dropTargetListener);
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            test = new AutoscrollStopTest();
+            test.createUI();
+        });
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(test::dispose);
+        }
+    }
+
+    public static int sign(int n) {
+        return Integer.compare(n, 0);
+    }
+
+    public void createUI() {
+        setTitle("AutoscrollStopTest");
+        setMinimumSize(new Dimension(200, 200));
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    public void start() throws AWTException {
+        final Robot robot = new Robot();
+        try {
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            final Point srcPoint = this.getLocationOnScreen();
+            final Dimension d = this.getSize();
+            srcPoint.translate(d.width / 2, d.height / 2);
+
+            final Point dstPoint = new Point(srcPoint);
+            dstPoint.translate(d.width / 4, d.height / 4);
+
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+
+            for (;!srcPoint.equals(dstPoint);
+                 srcPoint.translate(sign(dstPoint.x - srcPoint.x),
+                                    sign(dstPoint.y - srcPoint.y))) {
+                robot.mouseMove(srcPoint.x, srcPoint.y);
+            }
+        } finally {
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        }
+    }
+
+    public Insets getAutoscrollInsets() {
+        final Dimension d = this.getSize();
+        return new Insets(d.height / 2, d.width / 2,
+                d.height / 2, d.width / 2);
+    }
+
+    public void autoscroll(Point cursorLocation) {
+        if (dropHappened) {
+            throw new RuntimeException("Test failed");
+        }
+    }
+}

--- a/test/jdk/java/awt/dnd/ButtonReleaseTest.java
+++ b/test/jdk/java/awt/dnd/ButtonReleaseTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4215643
+  @summary Tests that the drag source receives mouseReleased event
+  @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+
+public class ButtonReleaseTest {
+
+    static volatile ButtonPanelFrame buttonPanelFrame;
+    static final int FRAME_ACTIVATION_TIMEOUT = 1000;
+    static final int DROP_COMPLETION_TIMEOUT = 4000;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(20);
+
+        try {
+            EventQueue.invokeAndWait(() -> {
+                buttonPanelFrame = new ButtonPanelFrame();
+                buttonPanelFrame.pack();
+                buttonPanelFrame.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+
+            Point p = buttonPanelFrame.getButtonLocation();
+            Dimension d = buttonPanelFrame.getButtonSize();
+            p.translate(d.width / 2, d.height / 2);
+            robot.mouseMove(p.x, p.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int i = 0; i < d.width; i++) {
+                p.translate(0, 1);
+                robot.mouseMove(p.x, p.y);
+            }
+
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            try {
+                Thread.sleep(DROP_COMPLETION_TIMEOUT);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("The test failed.");
+            }
+
+            if (!buttonPanelFrame.passed()) {
+                throw new RuntimeException(
+                        "The test failed - mouse release was not received.");
+            }
+
+        } finally {
+            EventQueue.invokeAndWait(buttonPanelFrame::dispose);
+        }
+    }
+}
+
+class ButtonPanelFrame extends Frame {
+
+    DnDSource dragSource;
+    DnDTarget dropTarget;
+
+    ButtonPanelFrame() {
+        Panel mainPanel;
+
+        setTitle("ButtonReleaseTest - ButtonPanelFrame");
+        setSize(200, 200);
+        setLocationRelativeTo(null);
+        setLayout(new BorderLayout());
+
+        mainPanel = new Panel();
+        mainPanel.setLayout(new BorderLayout());
+
+        mainPanel.setBackground(Color.black);
+
+        dropTarget = new DnDTarget(Color.red, Color.yellow);
+        dragSource = new DnDSource("Drag ME!");
+
+        mainPanel.add(dragSource, "North");
+        mainPanel.add(dropTarget, "Center");
+        add(mainPanel, BorderLayout.CENTER);
+    }
+
+    boolean passed() {
+        return dragSource.passed();
+    }
+
+    Point getButtonLocation() {
+        return dragSource.getLocationOnScreen();
+    }
+
+    Dimension getButtonSize() {
+        return dragSource.getSize();
+    }
+}
+
+class DnDSource extends Button implements Serializable, Transferable,
+                                          DragGestureListener,
+                                          DragSourceListener {
+
+    private transient DataFlavor df;
+    private transient int dropAction;
+    volatile boolean released = false;
+
+    DnDSource(String label) {
+        super(label);
+
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                                              this);
+        addMouseListener(new MouseAdapter() {
+            public void mouseReleased(MouseEvent e) {
+                synchronized(this) {
+                    released = true;
+                    notifyAll();
+                }
+            }
+        });
+        setBackground(Color.yellow);
+        setForeground(Color.blue);
+
+        df = new DataFlavor(DnDSource.class, "DnDSource");
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, this, this);
+    }
+
+
+    public void dragEnter(DragSourceDragEvent dsde) {
+        dsde.getDragSourceContext().setCursor(DragSource.DefaultCopyDrop);
+    }
+
+    public void dragOver(DragSourceDragEvent dsde) {
+    }
+
+    public void dragGestureChanged(DragSourceDragEvent dsde) {
+    }
+
+    public void dragExit(DragSourceEvent dsde) {
+        dsde.getDragSourceContext().setCursor(null);
+    }
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {
+    }
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { df };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor sdf) {
+        return df.equals(sdf);
+    }
+
+    public Object getTransferData(DataFlavor tdf) throws UnsupportedFlavorException , IOException {
+
+        Object copy = null;
+
+        if (!df.equals(tdf)) {
+            throw new UnsupportedFlavorException(tdf);
+        }
+
+        Container parent = getParent();
+        switch (dropAction) {
+            case DnDConstants.ACTION_COPY:
+                try {
+                    copy = this.clone();
+                } catch (CloneNotSupportedException e) {
+
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    ObjectOutputStream    oos  = new ObjectOutputStream(baos);
+                    oos.writeObject(this);
+                    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+                    ObjectInputStream ois = new ObjectInputStream(bais);
+
+                    try {
+                      copy = ois.readObject();
+                    } catch (ClassNotFoundException cnfe) {
+                      // do nothing
+                    }
+                }
+                return copy;
+
+            case DnDConstants.ACTION_MOVE:
+                synchronized(this) {
+                    if (parent != null) parent.remove(this);
+                }
+                return this;
+
+            case DnDConstants.ACTION_LINK:
+                return this;
+
+            default:
+                return this;
+        }
+    }
+
+    boolean passed() {
+        return !released;
+    }
+}
+
+class DnDTarget extends Panel implements DropTargetListener {
+
+    Color bgColor;
+    Color htColor;
+
+    DnDTarget(Color bgColor, Color htColor) {
+        super();
+        this.bgColor = bgColor;
+        this.htColor = htColor;
+        setBackground(bgColor);
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(200, 200);
+    }
+
+    public void dragEnter(DropTargetDragEvent e) {
+        e.acceptDrag(DnDConstants.ACTION_COPY);
+        setBackground(htColor);
+        repaint();
+    }
+
+    public void dragOver(DropTargetDragEvent e) {
+        e.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void dragExit(DropTargetEvent e) {
+        setBackground(bgColor);
+        repaint();
+    }
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+            return;
+        }
+
+        DataFlavor[] dfs = dtde.getCurrentDataFlavors();
+
+        if (dfs != null && dfs.length >= 1) {
+            Transferable transfer = dtde.getTransferable();
+            Object obj = null;
+
+            try {
+                obj = transfer.getTransferData(dfs[0]);
+            } catch (IOException | UnsupportedFlavorException e) {
+                System.err.println(e.getMessage());
+                dtc.dropComplete(false);
+                return;
+            }
+
+            if (obj != null) {
+                Button button   = null;
+
+                try {
+                    button   = (Button)obj;
+                } catch (Exception e) {
+                    System.err.println(e.getMessage());
+                    dtc.dropComplete(false);
+                    return;
+                }
+                add(button);
+                repaint();
+            }
+        }
+
+        setBackground(bgColor);
+        invalidate();
+        validate();
+        repaint();
+        dtc.dropComplete(true);
+    }
+
+    public void dragScroll(DropTargetDragEvent e) {
+    }
+
+    public void dropActionChanged(DropTargetDragEvent e) {
+    }
+}


### PR DESCRIPTION
Open sourcing few more tests:

```
java/awt/datatransfer/MimeFormatsTest/MimeFormatsTest.java
java/awt/datatransfer/RemoveFlavorListenerTest/RemoveFlavorListenerTest.java
java/awt/dnd/AutoscrollStopTest/AutoscrollStopTest.java
java/awt/dnd/ButtonReleaseTest/ButtonReleaseTest.java 
```

Testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306941](https://bugs.openjdk.org/browse/JDK-8306941): Open source several datatransfer and dnd AWT tests


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13836/head:pull/13836` \
`$ git checkout pull/13836`

Update a local copy of the PR: \
`$ git checkout pull/13836` \
`$ git pull https://git.openjdk.org/jdk.git pull/13836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13836`

View PR using the GUI difftool: \
`$ git pr show -t 13836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13836.diff">https://git.openjdk.org/jdk/pull/13836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13836#issuecomment-1536536059)