### PR TITLE
8307553: Remove dead code MetaspaceClosure::push_method_entry

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -122,23 +122,6 @@ public:
   };
 
 private:
-  class SpecialRefInfo {
-    // We have a "special pointer" of the given _type at _field_offset of _src_obj.
-    // See MetaspaceClosure::push_special().
-    MetaspaceClosure::SpecialRef _type;
-    address _src_obj;
-    size_t _field_offset;
-
-  public:
-    SpecialRefInfo() {}
-    SpecialRefInfo(MetaspaceClosure::SpecialRef type, address src_obj, size_t field_offset)
-      : _type(type), _src_obj(src_obj), _field_offset(field_offset) {}
-
-    MetaspaceClosure::SpecialRef type() const { return _type;         }
-    address src_obj()                   const { return _src_obj;      }
-    size_t field_offset()               const { return _field_offset; }
-  };
-
   class SourceObjInfo {
     MetaspaceClosure::Ref* _ref; // The object that's copied into the buffer
     uintx _ptrmap_start;     // The bit-offset of the start of this object (inclusive)
@@ -230,7 +213,6 @@ private:
   ResizeableResourceHashtable<address, address, AnyObj::C_HEAP, mtClassShared> _buffered_to_src_table;
   GrowableArray<Klass*>* _klasses;
   GrowableArray<Symbol*>* _symbols;
-  GrowableArray<SpecialRefInfo>* _special_refs;
 
   // statistics
   DumpAllocStats _alloc_stats;
@@ -268,7 +250,6 @@ private:
   void make_shallow_copies(DumpRegion *dump_region, const SourceObjList* src_objs);
   void make_shallow_copy(DumpRegion *dump_region, SourceObjInfo* src_info);
 
-  void update_special_refs();
   void relocate_embedded_pointers(SourceObjList* src_objs);
 
   bool is_excluded(Klass* k);
@@ -357,7 +338,6 @@ public:
   void gather_source_objs();
   bool gather_klass_and_symbol(MetaspaceClosure::Ref* ref, bool read_only);
   bool gather_one_source_obj(MetaspaceClosure::Ref* enclosing_ref, MetaspaceClosure::Ref* ref, bool read_only);
-  void add_special_ref(MetaspaceClosure::SpecialRef type, address src_obj, size_t field_offset);
   void remember_embedded_pointer_in_copied_obj(MetaspaceClosure::Ref* enclosing_ref, MetaspaceClosure::Ref* ref);
 
   DumpRegion* rw_region() { return &_rw_region; }

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -78,10 +78,6 @@ public:
     _default
   };
 
-  enum SpecialRef {
-    _method_entry_ref
-  };
-
   // class MetaspaceClosure::Ref --
   //
   // MetaspaceClosure can be viewed as a very simple type of copying garbage
@@ -356,19 +352,6 @@ public:
   }
 #endif
 
-  template <class T> void push_method_entry(T** mpp, intptr_t* p) {
-    Ref* ref = new MSORef<T>(mpp, _default);
-    push_special(_method_entry_ref, ref, (intptr_t*)p);
-    if (!ref->keep_after_pushing()) {
-      delete ref;
-    }
-  }
-
-  // This is for tagging special pointers that are not a reference to MetaspaceObj. It's currently
-  // used to mark the method entry points in Method/ConstMethod.
-  virtual void push_special(SpecialRef type, Ref* obj, intptr_t* p) {
-    assert(type == _method_entry_ref, "only special type allowed for now");
-  }
 };
 
 // This is a special MetaspaceClosure that visits each unique MetaspaceObj once.


### PR DESCRIPTION
Please review this trivial change to remove dead code, which is unused since [JDK-8263002](https://bugs.openjdk.org/browse/JDK-8263002), when CDS method trampolines were removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307553](https://bugs.openjdk.org/browse/JDK-8307553): Remove dead code MetaspaceClosure::push_method_entry


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13842/head:pull/13842` \
`$ git checkout pull/13842`

Update a local copy of the PR: \
`$ git checkout pull/13842` \
`$ git pull https://git.openjdk.org/jdk.git pull/13842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13842`

View PR using the GUI difftool: \
`$ git pr show -t 13842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13842.diff">https://git.openjdk.org/jdk/pull/13842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13842#issuecomment-1536668481)