### PR TITLE
8306758: com/sun/jdi/ConnectedVMs.java fails with "Non-zero debuggee exitValue: 143"

### DIFF
--- a/test/jdk/com/sun/jdi/InstTarg.java
+++ b/test/jdk/com/sun/jdi/InstTarg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,16 @@ public class InstTarg {
 
     public static void main(String args[]) {
         start();
+        // Sleep before exiting to allow disconnect efforts done on the JDI side to complete.
+        // Note that not sleeping long enough is for the most part harmless, but might render
+        // the testing insufficient because the debuggee will quickly exit naturally
+        // once the debuggee does the vm.resume(), rather than waiting for disconnect
+        // efforts to complete first.
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     static void start() {

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -722,6 +722,12 @@ abstract public class TestScaffold extends TargetAdapter {
         return vmStartThread;
     }
 
+    //
+    // Tests that expect an exitValue other than 0 will need to override this method.
+    protected boolean allowedExitValue(int exitValue) {
+        return exitValue == 0 || exitValue == 1;
+    }
+
     public synchronized void waitForVMDisconnect() {
         traceln("TS: waitForVMDisconnect");
         while (!vmDisconnected) {
@@ -738,11 +744,9 @@ abstract public class TestScaffold extends TargetAdapter {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        int res = p.exitValue();
-        // Some tests purposefully exit with an exception, which produces exitValue
-        // 1, so we have to allow it also.
-        if (res != 0 && res != 1) {
-            throw new RuntimeException("Non-zero debuggee exitValue: " + res);
+        int exitValue = p.exitValue();
+        if (!allowedExitValue(exitValue)) {
+            throw new RuntimeException("Invalid debuggee exitValue: " + exitValue);
         }
 
         traceln("TS: waitForVMDisconnect: done");

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -722,8 +722,9 @@ abstract public class TestScaffold extends TargetAdapter {
         return vmStartThread;
     }
 
-    //
-    // Tests that expect an exitValue other than 0 will need to override this method.
+    /*
+     * Tests that expect an exitValue other than 0 or 1 will need to override this method.
+     */
     protected boolean allowedExitValue(int exitValue) {
         return exitValue == 0 || exitValue == 1;
     }


### PR DESCRIPTION
This test was very rarely failing with a exitValue 143 from the debuggee. It only happened when the machine was under a lot of stress. After some investigation it was realized that on unix OSes it should *always* expect exitValue 143, but for some reason was normally getting exitValue 0. The reason 143 should be expected is because `Process.destroy()` is used on the debuggee, which results in a SIGTERM, which should produce exitValue 143. The reason we were not normally seeing this is because the `Process.destroy()` was done while the debuggee was suspended at a breakpoint.  Nothing can be done with the SIGTERM while all threads are suspended, but once the debugger does the `vm.resume()` the SIGTERM can be handled. But by that time it is a race between some thread handling SIGTERM and doing the exit(143), and the main debuggee thread resuming and exiting cleanly (producing exitValue 0). In almost all cases the clean exit was winning. By adding a 5 second sleep before exiting, I made it so the SIGTERM exit always wins. Once this was in place, I had to make changes so the test would pass with exitCode 143. This was done by adding a `TestScaffold.allowExitValue()` method, which the test can override. Note I'll have more uses for this in the future, as I plan to no longer by default allow exitValue 1 (exit with an uncaught exception) and requiring tests to override this method if needed. That will be done by [JDK-8307559](https://bugs.openjdk.org/browse/JDK-8307559).

Tested by running all of test/jdk/com/sun/jdi with and without virtual threads, 10x times on each platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306758](https://bugs.openjdk.org/browse/JDK-8306758): com/sun/jdi/ConnectedVMs.java fails with "Non-zero debuggee exitValue: 143"


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [91b40048](https://git.openjdk.org/jdk/pull/13848/files/91b400486ad43fa48120ede589adf31a5cd0033f)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13848/head:pull/13848` \
`$ git checkout pull/13848`

Update a local copy of the PR: \
`$ git checkout pull/13848` \
`$ git pull https://git.openjdk.org/jdk.git pull/13848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13848`

View PR using the GUI difftool: \
`$ git pr show -t 13848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13848.diff">https://git.openjdk.org/jdk/pull/13848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13848#issuecomment-1536962623)