### PR TITLE
8307480: Improve SA "transported core" documentation for windows

### DIFF
--- a/src/jdk.hotspot.agent/doc/transported_core.html
+++ b/src/jdk.hotspot.agent/doc/transported_core.html
@@ -76,15 +76,34 @@ installed on the debugger machine.
  is setup:
  </p>
 
-<p>
+<code>
  set PATH=%JAVA_HOME%\bin;%JAVA_HOME%\bin\server;%PATH%
-</p>
+</code>
 
 <p>
 You can also include user JNI libraries in <b>PATH</b>.
 If the windows libraries are not identical, then they may also need to be copied
 to the debugger machine and included in <b>PATH</b>.
 </p>
+
+<p>
+By default symbols are also located using <b>PATH</b>. However, there are also Java properties that can be used to specify both the location of the binaries, and also separately the location of symbols. Use <b>sun.jvm.hotspot.debugger.windbg.imagePath</b> for the location of binaries, and use <b>sun.jvm.hotspot.debugger.windbg.symbolPath</b> for the location of symbols. <b>imagePath</b> defaults to <b>PATH</b> if not set, and <b>symbolPath</b> defaults to <b>imagePath</b>. The advantage of using these propeties is that you don't need to change your <b>PATH</b> setting, and they allow for binaries to be located separately from symbols.
+</p>
+
+<p>
+How you set these properties will depend on the SA tool being used. The following in an example of when launching the clhsdb tool:
+</p>
+
+<code>
+jhsdb -J-Dsun.jvm.hotspot.debugger.windbg.imagePath="%PATH%;D:/SomePath" clhsdb
+</code>
+
+<p>If you are not seeing symbols for Windows libraries, try adding "<b>srv*https://msdl.microsoft.com/download/symbols</b>" to <b>sun.jvm.hotspot.debugger.windbg.symbolPath</b>. Note doing this means that SA will no longer look in <b>PATH</b> for your JVM and JNI symbols, so make sure those paths also get added. The following is one possible approach:
+</p>
+
+<code>
+jhsdb -J-Dsun.jvm.hotspot.debugger.windbg.symbolPath="%PATH%;srv*https://msdl.microsoft.com/download/symbol" clhsdb
+</code>
 
 <h3>Using transported core dumps on macOS</h3>
 <p>

--- a/src/jdk.hotspot.agent/doc/transported_core.html
+++ b/src/jdk.hotspot.agent/doc/transported_core.html
@@ -91,7 +91,7 @@ By default symbols are also located using <b>PATH</b>. However, there are also J
 </p>
 
 <p>
-How you set these properties will depend on the SA tool being used. The following in an example of when launching the clhsdb tool:
+How you set these properties will depend on the SA tool being used. The following example demonstrates how to set one of the properties when launching the clhsdb tool:
 </p>
 
 <code>

--- a/src/jdk.hotspot.agent/doc/transported_core.html
+++ b/src/jdk.hotspot.agent/doc/transported_core.html
@@ -95,10 +95,10 @@ How you set these properties will depend on the SA tool being used. The followin
 </p>
 
 <code>
-jhsdb -J-Dsun.jvm.hotspot.debugger.windbg.imagePath="%PATH%;D:/SomePath" clhsdb
+jhsdb -J-Dsun.jvm.hotspot.debugger.windbg.imagePath="%PATH%;D:\SomePath" clhsdb
 </code>
 
-<p>If you are not seeing symbols for Windows libraries, try adding "<b>srv*https://msdl.microsoft.com/download/symbols</b>" to <b>sun.jvm.hotspot.debugger.windbg.symbolPath</b>. Note doing this means that SA will no longer look in <b>PATH</b> for your JVM and JNI symbols, so make sure those paths also get added. The following is one possible approach:
+<p>If you are not seeing symbols for Windows libraries, try setting <b>sun.jvm.hotspot.debugger.windbg.symbolPath</b> to include "<b>srv*https://msdl.microsoft.com/download/symbols</b>". Also include <b>PATH</b> so SA will still find your JVM and JNI symbols. For example:
 </p>
 
 <code>


### PR DESCRIPTION
The SA document `transported_core.html` contains some tips on getting core files to work when debugging it on a machine other than the one that produced it. There are a few improvements that can be made based on information provided in [JDK-8306437](https://bugs.openjdk.org/browse/JDK-8306437) and in the #13530 review (which was eventually pulled as not necessary).

Updates to the document include the use of `sun.jvm.hotspot.debugger.windbg.imagePath` and `sun.jvm.hotspot.debugger.windbg.symbolPath` properties, and adding "`srv*https://msdl.microsoft.com/download/symbols`" to symbolPath.

The rendered html file with these changes can be found here:
https://htmlpreview.github.io/?https://raw.githubusercontent.com/openjdk/jdk/75b10f672a461d3742c51db06ec2625605e45cf0/src/jdk.hotspot.agent/doc/transported_core.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307480](https://bugs.openjdk.org/browse/JDK-8307480): Improve SA "transported core" documentation for windows


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [7f6345fd](https://git.openjdk.org/jdk/pull/13849/files/7f6345fdc90ba78e16a630b31e3f2507d685b3fa)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Poonam Bajaj](https://openjdk.org/census#poonam) (@poonamparhar - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13849/head:pull/13849` \
`$ git checkout pull/13849`

Update a local copy of the PR: \
`$ git checkout pull/13849` \
`$ git pull https://git.openjdk.org/jdk.git pull/13849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13849`

View PR using the GUI difftool: \
`$ git pr show -t 13849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13849.diff">https://git.openjdk.org/jdk/pull/13849.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13849#issuecomment-1536961795)