### PR TITLE
8307523: [vectorapi] Optimize MaskFromLongBenchmark.java

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskFromLongBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskFromLongBenchmark.java
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -26,113 +26,187 @@ package org.openjdk.bench.jdk.incubator.vector;
 import jdk.incubator.vector.*;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
 public class MaskFromLongBenchmark {
-    static long val = 0;
+    private static final int ITERATION = 20000;
 
-    @Setup(Level.Invocation)
-    public void BmSetup() {
-        val++;
+    @Benchmark
+    public long microMaskFromLong_Byte64() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_64, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Byte64() {
-        VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_64, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Byte128() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_128, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Byte128() {
-        VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_128, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Byte256() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_256, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Byte256() {
-        VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_256, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Byte512() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_512, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Byte512() {
-        VectorMask mask = VectorMask.fromLong(ByteVector.SPECIES_512, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Short64() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_64, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Short64() {
-        VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_64, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Short128() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_128, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Short128() {
-        VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_128, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Short256() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_256, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Short256() {
-        VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_256, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Short512() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_512, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Short512() {
-        VectorMask mask = VectorMask.fromLong(ShortVector.SPECIES_512, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Integer64() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_64, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Integer64() {
-        VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_64, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Integer128() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_128, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Integer128() {
-        VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_128, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Integer256() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_256, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Integer256() {
-        VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_256, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Integer512() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_512, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Integer512() {
-        VectorMask mask = VectorMask.fromLong(IntVector.SPECIES_512, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Long64() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_64, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Long64() {
-        VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_64, val);
-        return mask.laneIsSet(0) ? 1 : 0;
+    public long microMaskFromLong_Long128() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_128, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Long128() {
-        VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_128, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+    public long microMaskFromLong_Long256() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_256, res);
+            res += mask.trueCount();
+        }
+
+        return res;
     }
 
     @Benchmark
-    public int microMaskFromLong_Long256() {
-        VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_256, val);
-        return mask.laneIsSet(1) ? 1 : 0;
-    }
+    public long microMaskFromLong_Long512() {
+        long res = 0;
+        for (int i = 0; i < ITERATION; i++) {
+            VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_512, res);
+            res += mask.trueCount();
+        }
 
-    @Benchmark
-    public int microMaskFromLong_Long512() {
-        VectorMask mask = VectorMask.fromLong(LongVector.SPECIES_512, val);
-        return mask.laneIsSet(1) ? 1 : 0;
+        return res;
     }
 
 }


### PR DESCRIPTION
To avoid dead code elimination, a use-point laneIsSet() is added in each benchmark method in MaskFromLongBenchmark.java.

However, currently laneIsSet() [1] is implemented by toLong(). So it may generate a fromLong-toLong pair [2], making this benchmark to be noneffective after inlining laneIsSet() into the outer method. The assembly of maskFromLong_byte128 benchmark on SVE2 is shown in [3]. We cannot see the bdep instruction used by fromLong on AArch64 [4]. So, in this case, we cannot measure fromLong()'s performance by using this benchmark.

This patch uses trueCount() [5] instead of toLong() to measure the fromLong()'s performance effectively. After this patch, we can see the bdep instruction in the hot loop [6] of maskFromLong_byte128 benchmark.

Since using Blackhole to consume VectorMask will generate a heavy vector box, we don't use Blackhole to fix this benchmark.

[1]: https://github.com/openjdk/jdk/blob/96fa2751e8bbc05d6d064d80c07720cc9db05c54/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java#L70
[2]: https://github.com/openjdk/jdk/blob/ff368d504e9101e11c7182185f56255f429d31e3/src/hotspot/share/opto/vectornode.cpp#L1736
[3]: https://gist.github.com/changpeng1997/467f6056f78d99c055030fa5888b6baa
[4]: https://github.com/openjdk/jdk/blob/787832a58677205c9a11ae100dd8a2fbddb30a4a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp#L1099
[5]: https://docs.oracle.com/en/java/javase/16/docs/api/jdk.incubator.vector/jdk/incubator/vector/VectorMask.html#trueCount()
[6]: https://gist.github.com/changpeng1997/79bea0a9f80530bec89978950897000d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307523](https://bugs.openjdk.org/browse/JDK-8307523): [vectorapi] Optimize MaskFromLongBenchmark.java


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13851/head:pull/13851` \
`$ git checkout pull/13851`

Update a local copy of the PR: \
`$ git checkout pull/13851` \
`$ git pull https://git.openjdk.org/jdk.git pull/13851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13851`

View PR using the GUI difftool: \
`$ git pr show -t 13851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13851.diff">https://git.openjdk.org/jdk/pull/13851.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13851#issuecomment-1536984510)