### PR TITLE
8307588: [JVMCI] HotSpotConstantPool#lookupBootstrapMethodInvocation broken by JDK-8301995

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestDynamicConstant.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestDynamicConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestDynamicConstant.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestDynamicConstant.java
@@ -333,6 +333,8 @@ public class TestDynamicConstant implements Opcodes {
         Assert.assertTrue((code[bci] & 0xff) == INVOKEDYNAMIC, "unexpected bytecode");
         int cpi = beS4(code, bci + 1);
         method.getConstantPool().loadReferencedType(cpi, INVOKEDYNAMIC, false);
+        BootstrapMethodInvocation bmi = method.getConstantPool().lookupBootstrapMethodInvocation(cpi, INVOKEDYNAMIC);
+        Assert.assertEquals(bmi.getName(), "do_concat");
     }
 
     // @formatter:off


### PR DESCRIPTION
As a result of the changes for [JDK-8301995](https://bugs.openjdk.org/browse/JDK-8301995), `HotSpotConstantPool#lookupBootstrapMethodIntrospection` is broken as it no longer decodes the correct constant pool index for looking up the bootstrap method invocation for invokedynamic.

This fixes the problem and modifies `TestDynamicConstant` to exercise the code in question.

I've manually verified that this solved the native image issues that uncovered the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307588](https://bugs.openjdk.org/browse/JDK-8307588): [JVMCI] HotSpotConstantPool#lookupBootstrapMethodInvocation broken by JDK-8301995


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to [b271e842](https://git.openjdk.org/jdk/pull/13858/files/b271e8429aedcef13db0211c7114c562d97ee3e2)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [b271e842](https://git.openjdk.org/jdk/pull/13858/files/b271e8429aedcef13db0211c7114c562d97ee3e2)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13858/head:pull/13858` \
`$ git checkout pull/13858`

Update a local copy of the PR: \
`$ git checkout pull/13858` \
`$ git pull https://git.openjdk.org/jdk.git pull/13858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13858`

View PR using the GUI difftool: \
`$ git pr show -t 13858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13858.diff">https://git.openjdk.org/jdk/pull/13858.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13858#issuecomment-1537979898)