### PR TITLE
JDK-8307604: gcc12 based Alpine build broken build after JDK-8307301

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -453,7 +453,7 @@ else
    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers strict-aliasing \
-       unused-result
+       unused-result array-bounds
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis


### PR DESCRIPTION
After the harfbuzz 7.2 update we run into

/linuxmuslx86_64/jdk-dev/src/java.desktop/share/native/libharfbuzz/OT/glyf/Glyph.hh:281:8: error: offset '4' outside bounds of constant string [-Werror=array-bounds]
  281 | bool get_points (hb_font_t *font, const accelerator_t &glyf_accelerator,
      | ^~~~~~~~~~
/linuxmuslx86_64/jdk-dev/src/java.desktop/share/native/libharfbuzz/hb-static.cc:45:16: note: '_hb_NullPool' declared here
   45 | uint64_t const _hb_NullPool[(HB_NULL_POOL_SIZE + sizeof (uint64_t) - 1) / sizeof (uint64_t)] = {};
      | ^~~~~~~~~~~~
/linuxmuslx86_64/jdk-dev/src/java.desktop/share/native/libharfbuzz/OT/glyf/Glyph.hh:281:8: error: offset '4' outside bounds of constant string [-Werror=array-bounds]
  281 | bool get_points (hb_font_t *font, const accelerator_t &glyf_accelerator,
      | ^~~~~~~~~~
/linuxmuslx86_64/jdk-dev/src/java.desktop/share/native/libharfbuzz/hb-static.cc:45:16: note: '_hb_NullPool' declared here
   45 | uint64_t const _hb_NullPool[(HB_NULL_POOL_SIZE + sizeof (uint64_t) - 1) / sizeof (uint64_t)] = {};

We use gcc12 on Alpine.
Switching off this  'warning as error' fixes the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307604](https://bugs.openjdk.org/browse/JDK-8307604): gcc12 based Alpine build broken build after JDK-8307301


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13859/head:pull/13859` \
`$ git checkout pull/13859`

Update a local copy of the PR: \
`$ git checkout pull/13859` \
`$ git pull https://git.openjdk.org/jdk.git pull/13859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13859`

View PR using the GUI difftool: \
`$ git pr show -t 13859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13859.diff">https://git.openjdk.org/jdk/pull/13859.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13859#issuecomment-1538153217)