### PR TITLE
JDK-8133773: clarify specification of Spliterator.tryAdvance

### DIFF
--- a/src/java.base/share/classes/java/util/Spliterator.java
+++ b/src/java.base/share/classes/java/util/Spliterator.java
@@ -295,7 +295,7 @@ import java.util.function.LongConsumer;
  */
 public interface Spliterator<T> {
     /**
-     * If a remaining element exists, performs the given action on it,
+     * If a remaining element exists: performs the given action on it,
      * returning {@code true}; else returns {@code false}.  If this
      * Spliterator is {@link #ORDERED} the action is performed on the
      * next element in encounter order.  Exceptions thrown by the
@@ -304,7 +304,7 @@ public interface Spliterator<T> {
      * Subsequent behavior of a spliterator is unspecified if the action throws
      * an exception.
      *
-     * @param action The action
+     * @param action The action which will be invoked at-most once
      * @return {@code false} if no remaining elements existed
      * upon entry to this method, else {@code true}.
      * @throws NullPointerException if the specified action is null

--- a/src/java.base/share/classes/java/util/Spliterator.java
+++ b/src/java.base/share/classes/java/util/Spliterator.java
@@ -304,7 +304,7 @@ public interface Spliterator<T> {
      * Subsequent behavior of a spliterator is unspecified if the action throws
      * an exception.
      *
-     * @param action The action which will be invoked at-most once
+     * @param action The action whose operation is performed at-most once
      * @return {@code false} if no remaining elements existed
      * upon entry to this method, else {@code true}.
      * @throws NullPointerException if the specified action is null


### PR DESCRIPTION
Attempting to make the "at-most once" nature, of invoking the supplied action to tryAdvance, clearer in the JavaDoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8133773](https://bugs.openjdk.org/browse/JDK-8133773): clarify specification of Spliterator.tryAdvance


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Tagir F. Valeev](https://openjdk.org/census#tvaleev) (@amaembo - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13860/head:pull/13860` \
`$ git checkout pull/13860`

Update a local copy of the PR: \
`$ git checkout pull/13860` \
`$ git pull https://git.openjdk.org/jdk.git pull/13860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13860`

View PR using the GUI difftool: \
`$ git pr show -t 13860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13860.diff">https://git.openjdk.org/jdk/pull/13860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13860#issuecomment-1538156663)