### PR TITLE
JDK-8307603: [AIX] Broken build after JDK-8307301

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
+++ b/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
@@ -43,7 +43,11 @@
 #include "OT/Color/sbix/sbix.hh"
 #include "hb-ot-os2-table.hh"
 #include "hb-ot-post-table.hh"
+
+#if !defined(AIX)
 #include "hb-ot-post-table-v2subset.hh"
+#endif
+
 #include "hb-ot-cff1-table.hh"
 #include "hb-ot-cff2-table.hh"
 #include "hb-ot-vorg-table.hh"


### PR DESCRIPTION
The AIX build is broken after [JDK-8307301](https://bugs.openjdk.org/browse/JDK-8307301) which updated harfbuzz to 7.2 .
This was expected because an older AIX workaround was removed.
Bringing back the AIX workaround solves the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307603](https://bugs.openjdk.org/browse/JDK-8307603): [AIX] Broken build after JDK-8307301


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13861/head:pull/13861` \
`$ git checkout pull/13861`

Update a local copy of the PR: \
`$ git checkout pull/13861` \
`$ git pull https://git.openjdk.org/jdk.git pull/13861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13861`

View PR using the GUI difftool: \
`$ git pr show -t 13861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13861.diff">https://git.openjdk.org/jdk/pull/13861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13861#issuecomment-1538169660)