### PR TITLE
8307458: Add periodic heap usage JFR events

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -260,6 +260,19 @@
     <Field type="ulong" contentType="bytes" name="heapUsed" label="Heap Used" description="Bytes allocated by objects in the heap" />
   </Event>
 
+  <Event name="GCHeapMemoryUsage" category="Java Virtual Machine, Heap" label="GC Heap Memory Usage" period="everyChunk">
+    <Field type="ulong" contentType="bytes" name="used" label="Heap Used" description="Bytes allocated for storing objects on the heap" />
+    <Field type="ulong" contentType="bytes" name="committed" label="Heap Committed" description="Bytes committed for storing objects on the heap" />
+    <Field type="ulong" contentType="bytes" name="max" label="Heap Max" description="Max size for the heap" />
+  </Event>
+
+  <Event name="GCHeapMemoryPoolUsage" category="Java Virtual Machine, Heap" label="GC Heap Memory Pool Usage" period="everyChunk">
+    <Field type="string" name="name" label="Name" description="GC Heap Memory Pool Name" />
+    <Field type="ulong" contentType="bytes" name="used" label="GC Heap Memory Pool Used" description="Bytes used for storing objects in this memory pool" />
+    <Field type="ulong" contentType="bytes" name="committed" label="GC Heap Memory Pool Committed" description="Bytes committed for storing objects in this memory pool" />
+    <Field type="ulong" contentType="bytes" name="max" label="GC Heap Memory Pool Max" description="Max size for storing objects in this memory pool" />
+  </Event>
+
   <Type name="MetaspaceSizes">
     <Field type="ulong" contentType="bytes" name="committed" label="Committed" description="Committed memory for this space" />
     <Field type="ulong" contentType="bytes" name="used" label="Used" description="Bytes allocated by objects in the space" />

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -65,6 +65,7 @@
 #include "runtime/vm_version.hpp"
 #include "services/classLoadingService.hpp"
 #include "services/management.hpp"
+#include "services/memoryPool.hpp"
 #include "services/threadService.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -525,6 +526,37 @@ TRACE_REQUEST_FUNC(JavaThreadStatistics) {
   event.set_peakCount(ThreadService::get_peak_thread_count());
   event.commit();
 }
+
+TRACE_REQUEST_FUNC(GCHeapMemoryUsage) {
+  MemoryUsage usage = Universe::heap()->memory_usage();
+  EventGCHeapMemoryUsage event;
+  event.set_used(usage.used());
+  event.set_committed(usage.committed());
+  event.set_max(usage.max_size());
+  event.set_starttime(timestamp());
+  event.set_endtime(timestamp());
+  event.commit();
+}
+
+TRACE_REQUEST_FUNC(GCHeapMemoryPoolUsage) {
+  ResourceMark mark;
+  GrowableArray<MemoryPool*> pools = Universe::heap()->memory_pools();
+  for (int i = 0; i < pools.length(); i++) {
+    MemoryPool* pool = pools.at(i);
+    if (pool->is_heap()) {
+      MemoryUsage usage = pool->get_memory_usage();
+      EventGCHeapMemoryPoolUsage event;
+      event.set_name(pool->name());
+      event.set_used(usage.used());
+      event.set_committed(usage.committed());
+      event.set_max(usage.max_size());
+      event.set_starttime(timestamp());
+      event.set_endtime(timestamp());
+      event.commit();
+    }
+  }
+}
+
 
 TRACE_REQUEST_FUNC(ClassLoadingStatistics) {
 #if INCLUDE_MANAGEMENT

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -529,7 +529,7 @@ TRACE_REQUEST_FUNC(JavaThreadStatistics) {
 
 TRACE_REQUEST_FUNC(GCHeapMemoryUsage) {
   MemoryUsage usage = Universe::heap()->memory_usage();
-  EventGCHeapMemoryUsage event;
+  EventGCHeapMemoryUsage event(UNTIMED);
   event.set_used(usage.used());
   event.set_committed(usage.committed());
   event.set_max(usage.max_size());
@@ -545,7 +545,7 @@ TRACE_REQUEST_FUNC(GCHeapMemoryPoolUsage) {
     MemoryPool* pool = pools.at(i);
     if (pool->is_heap()) {
       MemoryUsage usage = pool->get_memory_usage();
-      EventGCHeapMemoryPoolUsage event;
+      EventGCHeapMemoryPoolUsage event(UNTIMED);
       event.set_name(pool->name());
       event.set_used(usage.used());
       event.set_committed(usage.committed());

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -322,6 +322,16 @@
       <setting name="enabled">false</setting>
     </event>
 
+    <event name="jdk.GCHeapMemoryUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapMemoryPoolUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
     <event name="jdk.GCHeapSummary">
       <setting name="enabled" control="gc-enabled-normal">true</setting>
     </event>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -322,6 +322,16 @@
       <setting name="enabled">false</setting>
     </event>
 
+    <event name="jdk.GCHeapMemoryUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event name="jdk.GCHeapMemoryPoolUsage">
+      <setting name="enabled" control="gc-enabled-normal">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
     <event name="jdk.GCHeapSummary">
       <setting name="enabled" control="gc-enabled-normal">true</setting>
     </event>

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryPoolUsageEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryPoolUsageEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.gc.detailed;
+
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+import static jdk.test.lib.Asserts.assertFalse;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm -XX:-ExplicitGCInvokesConcurrent jdk.jfr.event.gc.detailed.TestGCHeapMemoryPoolUsageEvent
+ */
+public class TestGCHeapMemoryPoolUsageEvent {
+    public static void main(String[] args) throws Exception {
+        try (Recording recording = new Recording()) {
+            recording.enable(EventNames.GCHeapMemoryPoolUsage);
+            recording.start();
+            System.gc();
+            recording.stop();
+
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            System.out.println(events);
+            assertFalse(events.isEmpty());
+
+            RecordedEvent event = events.get(0);
+            Events.assertField(event, "name").notNull();
+            Events.assertField(event, "used").atLeast(0L);
+            Events.assertField(event, "committed").atLeast(0L);
+            Events.assertField(event, "max").atLeast(-1L);
+        }
+    }
+}
+
+

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.gc.detailed;
+
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+import static jdk.test.lib.Asserts.assertFalse;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm -XX:-ExplicitGCInvokesConcurrent jdk.jfr.event.gc.detailed.TestGCHeapMemoryUsageEvent
+ */
+public class TestGCHeapMemoryUsageEvent {
+    public static void main(String[] args) throws Exception {
+        try (Recording recording = new Recording()) {
+            recording.enable(EventNames.GCHeapMemoryUsage);
+            recording.start();
+            System.gc();
+            recording.stop();
+
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            System.out.println(events);
+            assertFalse(events.isEmpty());
+            RecordedEvent event = events.get(0);
+            Events.assertField(event, "used").above(0L);
+            Events.assertField(event, "committed").above(0L);
+            Events.assertField(event, "max").above(0L);
+        }
+    }
+}
+

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -95,6 +95,8 @@ public class EventNames {
     public static final String ReservedStackActivation = PREFIX + "ReservedStackActivation";
 
     // GC
+    public static final String GCHeapMemoryUsage = PREFIX + "GCHeapMemoryUsage";
+    public static final String GCHeapMemoryPoolUsage = PREFIX + "GCHeapMemoryPoolUsage";
     public static final String GCHeapSummary = PREFIX + "GCHeapSummary";
     public static final String MetaspaceSummary = PREFIX + "MetaspaceSummary";
     public static final String MetaspaceGCThreshold = PREFIX + "MetaspaceGCThreshold";


### PR DESCRIPTION
Hi all,

please review this patch that adds two new JFR events:

- `GCHeapMemoryUsage`
- `GCHeapMemoryPoolUsage`

The two new events are periodic (period configurable as usual) and should contain the same information as a call to [`MemoryMXBean.getHeapMemoryUsage`](https://docs.oracle.com/en/java/javase/20/docs/api/java.management/java/lang/management/MemoryMXBean.html#getHeapMemoryUsage()) and/or [`MemoryPoolMXBean.getUsage`](https://docs.oracle.com/en/java/javase/20/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getUsage()). Having this data accessible via JFR (in addition to MXBeans) is useful for tools working primarily with JFR recordings, for example [JMC](https://openjdk.org/projects/jmc/).

### Testing
- [x] Tier 1 - 3 on Linux x64, Linux aarch64, Windows x64, macOS aarch64
- [x] Added two new JTReg tests for the new events
- [x] Local testing on macOS aarch64

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307458](https://bugs.openjdk.org/browse/JDK-8307458): Add periodic heap usage JFR events


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13867/head:pull/13867` \
`$ git checkout pull/13867`

Update a local copy of the PR: \
`$ git checkout pull/13867` \
`$ git pull https://git.openjdk.org/jdk.git pull/13867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13867`

View PR using the GUI difftool: \
`$ git pr show -t 13867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13867.diff">https://git.openjdk.org/jdk/pull/13867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13867#issuecomment-1538444791)