### PR TITLE
8307629: FunctionDescriptor::toMethodType should allow sequence layouts (mainline)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -62,6 +62,7 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * Returns a function descriptor with the given argument layouts appended to the argument layout array
      * of this function descriptor.
      * @param addedLayouts the argument layouts to append.
+     * @throws IllegalArgumentException if one of the layouts in {@code addedLayouts} is a padding layout.
      * @return the new function descriptor.
      */
     FunctionDescriptor appendArgumentLayouts(MemoryLayout... addedLayouts);
@@ -72,6 +73,7 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * @param index the index at which to insert the arguments
      * @param addedLayouts the argument layouts to insert at given index.
      * @return the new function descriptor.
+     * @throws IllegalArgumentException if one of the layouts in {@code addedLayouts} is a padding layout.
      * @throws IllegalArgumentException if {@code index < 0 || index > argumentLayouts().size()}.
      */
     FunctionDescriptor insertArgumentLayouts(int index, MemoryLayout... addedLayouts);
@@ -79,6 +81,7 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
     /**
      * Returns a function descriptor with the given memory layout as the new return layout.
      * @param newReturn the new return layout.
+     * @throws IllegalArgumentException if {@code newReturn} is a padding layout.
      * @return the new function descriptor.
      */
     FunctionDescriptor changeReturnLayout(MemoryLayout newReturn);
@@ -96,9 +99,11 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * The carrier type of a layout is determined as follows:
      * <ul>
      * <li>If the layout is a {@link ValueLayout} the carrier type is determined through {@link ValueLayout#carrier()}.</li>
-     * <li>If the layout is a {@link GroupLayout} the carrier type is {@link MemorySegment}.</li>
-     * <li>If the layout is a {@link PaddingLayout}, or {@link SequenceLayout} an {@link IllegalArgumentException} is thrown.</li>
+     * <li>If the layout is a {@link GroupLayout} or a {@link SequenceLayout}, the carrier type is {@link MemorySegment}.</li>
      * </ul>
+     *
+     * @apiNote A function descriptor cannot, by construction, contain any padding layouts. As such, it is not
+     * necessary to specify how padding layout should be mapped to carrier types.
      *
      * @return the method type consisting of the carrier types of the layouts in this function descriptor
      * @throws IllegalArgumentException if one or more layouts in the function descriptor can not be mapped to carrier
@@ -110,6 +115,8 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * Creates a function descriptor with the given return and argument layouts.
      * @param resLayout the return layout.
      * @param argLayouts the argument layouts.
+     * @throws IllegalArgumentException if {@code resLayout} is a padding layout.
+     * @throws IllegalArgumentException if one of the layouts in {@code argLayouts} is a padding layout.
      * @return the new function descriptor.
      */
     static FunctionDescriptor of(MemoryLayout resLayout, MemoryLayout... argLayouts) {
@@ -121,6 +128,7 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
     /**
      * Creates a function descriptor with the given argument layouts and no return layout.
      * @param argLayouts the argument layouts.
+     * @throws IllegalArgumentException if one of the layouts in {@code argLayouts} is a padding layout.
      * @return the new function descriptor.
      */
     static FunctionDescriptor ofVoid(MemoryLayout... argLayouts) {

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -113,9 +113,10 @@ public class TestFunctionDescriptor extends NativeTestHelper {
     public void testCarrierMethodType() {
         FunctionDescriptor fd = FunctionDescriptor.of(C_INT,
                 C_INT,
-                MemoryLayout.structLayout(C_INT, C_INT));
+                MemoryLayout.structLayout(C_INT, C_INT),
+                MemoryLayout.sequenceLayout(3, C_INT));
         MethodType cmt = fd.toMethodType();
-        assertEquals(cmt, MethodType.methodType(int.class, int.class, MemorySegment.class));
+        assertEquals(cmt, MethodType.methodType(int.class, int.class, MemorySegment.class, MemorySegment.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -138,6 +139,31 @@ public class TestFunctionDescriptor extends NativeTestHelper {
     public void testIllegalInsertArgOutOfBounds() {
         FunctionDescriptor fd = FunctionDescriptor.of(C_INT);
         fd.insertArgumentLayouts(2, C_INT);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPaddingInVoidFunction() {
+        FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(8));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPaddingInNonVoidFunction() {
+        FunctionDescriptor.of(MemoryLayout.paddingLayout(8));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPaddingInAppendArgLayouts() {
+        FunctionDescriptor.ofVoid().appendArgumentLayouts(MemoryLayout.paddingLayout(8));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPaddingInInsertArgLayouts() {
+        FunctionDescriptor.ofVoid().insertArgumentLayouts(0, MemoryLayout.paddingLayout(8));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadPaddingInChangeRetLayout() {
+        FunctionDescriptor.ofVoid().changeReturnLayout(MemoryLayout.paddingLayout(8));
     }
 
 }

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -110,14 +110,6 @@ public class TestIllegalLink extends NativeTestHelper {
     public static Object[][] types() {
         List<Object[]> cases = new ArrayList<>(Arrays.asList(new Object[][]{
             {
-                    FunctionDescriptor.of(MemoryLayout.paddingLayout(64)),
-                    "Unsupported layout: x64"
-            },
-            {
-                    FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(64)),
-                    "Unsupported layout: x64"
-            },
-            {
                     FunctionDescriptor.of(MemoryLayout.sequenceLayout(2, C_INT)),
                     "Unsupported layout: [2:i32]"
             },


### PR DESCRIPTION
This is a port of: https://git.openjdk.org/panama-foreign/pull/830

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8307630](https://bugs.openjdk.org/browse/JDK-8307630) to be approved

### Issues
 * [JDK-8307629](https://bugs.openjdk.org/browse/JDK-8307629): FunctionDescriptor::toMethodType should allow sequence layouts (mainline)
 * [JDK-8307630](https://bugs.openjdk.org/browse/JDK-8307630): FunctionDescriptor::toMethodType should allow sequence layouts (mainline) (**CSR**)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13869/head:pull/13869` \
`$ git checkout pull/13869`

Update a local copy of the PR: \
`$ git checkout pull/13869` \
`$ git pull https://git.openjdk.org/jdk.git pull/13869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13869`

View PR using the GUI difftool: \
`$ git pr show -t 13869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13869.diff">https://git.openjdk.org/jdk/pull/13869.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13869#issuecomment-1538680786)