### PR TITLE
8307486: ProcessTools.java should wait until vthread is completed before checking exceptions

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -895,10 +895,10 @@ public final class ProcessTools {
                         tg.uncaughtThrowable = error;
                     }
                 });
-            if (tg.uncaughtThrowable != null) {
-                throw new RuntimeException(tg.uncaughtThrowable);
-            }
             vthread.join();
+            if (tg.uncaughtThrowable != null) {
+                throw tg.uncaughtThrowable;
+            }
         } else if (wrapper.equals("Kernel")) {
             MainThreadGroup tg = new MainThreadGroup();
             Thread t = new Thread(tg, () -> {
@@ -913,7 +913,7 @@ public final class ProcessTools {
             t.start();
             t.join();
             if (tg.uncaughtThrowable != null) {
-                throw new RuntimeException(tg.uncaughtThrowable);
+                throw tg.uncaughtThrowable;
             }
         } else {
             mainMethod.invoke(null, new Object[] { classArgs });


### PR DESCRIPTION
Updated processtools to check exception after join().

Tested with running CI virtual thread tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307486](https://bugs.openjdk.org/browse/JDK-8307486): ProcessTools.java should wait until vthread is completed before checking exceptions


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13873/head:pull/13873` \
`$ git checkout pull/13873`

Update a local copy of the PR: \
`$ git checkout pull/13873` \
`$ git pull https://git.openjdk.org/jdk.git pull/13873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13873`

View PR using the GUI difftool: \
`$ git pr show -t 13873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13873.diff">https://git.openjdk.org/jdk/pull/13873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13873#issuecomment-1539187140)