### PR TITLE
8300204: Sealed-class hierarchy graph missing nodes

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
+++ b/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
@@ -265,16 +265,17 @@ public final class SealedGraph implements Taglet {
         }
 
         private static boolean isInPublicApi(TypeElement typeElement, Set<String> exports) {
-           return (exports.contains(packageName(typeElement.getQualifiedName().toString())) ||
-                   exports.contains(packageName(typeElement.getSuperclass().toString()))) &&
-                   typeElement.getModifiers().contains(Modifier.PUBLIC);
+            var packageName = packageName(typeElement);
+            return packageName.isPresent() && exports.contains(packageName.get()) &&
+                    typeElement.getModifiers().contains(Modifier.PUBLIC);
         }
 
-        private static String packageName(String name) {
-            int lastDot = name.lastIndexOf('.');
-            return lastDot < 0
-                    ? ""
-                    : name.substring(0, lastDot);
+        private static Optional<String> packageName(TypeElement element) {
+            return switch (element.getNestingKind()) {
+                case TOP_LEVEL -> Optional.of(((PackageElement) element.getEnclosingElement()).getQualifiedName().toString());
+                case ANONYMOUS, LOCAL -> Optional.empty();
+                case MEMBER -> packageName((TypeElement) element.getEnclosingElement());
+            };
         }
     }
 }


### PR DESCRIPTION
Please review this simple patch that fixes the package determination for nested classes in the `@sealedGraph` taglet.

Current JDK 21:
https://download.java.net/java/early_access/jdk21/docs/api/java.base/java/lang/foreign/MemoryLayout.html
https://download.java.net/java/early_access/jdk21/docs/api/java.base/java/lang/foreign/ValueLayout.html
![image](https://user-images.githubusercontent.com/7806504/236984282-f4361510-6208-4469-92d6-b9ce143204c3.png)

This patch:
https://cr.openjdk.org/~liach/8300204/java.base/java/lang/foreign/MemoryLayout.html
https://cr.openjdk.org/~liach/8300204/java.base/java/lang/foreign/ValueLayout.html
![image](https://user-images.githubusercontent.com/7806504/236984331-a877a493-487a-444a-984c-9175393cbb92.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300204](https://bugs.openjdk.org/browse/JDK-8300204): Sealed-class hierarchy graph missing nodes


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13875/head:pull/13875` \
`$ git checkout pull/13875`

Update a local copy of the PR: \
`$ git checkout pull/13875` \
`$ git pull https://git.openjdk.org/jdk.git pull/13875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13875`

View PR using the GUI difftool: \
`$ git pr show -t 13875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13875.diff">https://git.openjdk.org/jdk/pull/13875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13875#issuecomment-1539328431)