### PR TITLE
8307653: Adjust delay time and gc log argument in TestAbortOnVMOperationTimeout

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -26,13 +26,13 @@ import jdk.test.lib.process.*;
 
 /*
  * @test TestAbortOnVMOperationTimeout
- * @bug 8181143 8269523
+ * @bug 8181143 8269523 8307653
  * @summary Check abort on VM timeout is working
  * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestAbortOnVMOperationTimeout
+ * @run driver/timeout=600 TestAbortOnVMOperationTimeout
  */
 
 public class TestAbortOnVMOperationTimeout {
@@ -53,9 +53,7 @@ public class TestAbortOnVMOperationTimeout {
 
         // These should definitely pass: more than 3 minutes is enough for Serial to act.
         // The values are deliberately non-round to trip off periodic task granularity.
-        for (int delay : new int[]{183423}) {
-            testWith(delay, true);
-        }
+        testWith(183423, true);
 
         // These should fail: Serial is not very fast but we have seen the test
         // execute as quickly as 2ms!

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -51,9 +51,9 @@ public class TestAbortOnVMOperationTimeout {
             return;
         }
 
-        // These should definitely pass: more than a minute is enough for Serial to act.
+        // These should definitely pass: more than 3 minutes is enough for Serial to act.
         // The values are deliberately non-round to trip off periodic task granularity.
-        for (int delay : new int[]{63423, 12388131}) {
+        for (int delay : new int[]{183423}) {
             testWith(delay, true);
         }
 
@@ -72,7 +72,7 @@ public class TestAbortOnVMOperationTimeout {
                 "-Xmx256m",
                 "-XX:+UseSerialGC",
                 "-XX:-CreateCoredumpOnCrash",
-                "-Xlog:gc",
+                "-Xlog:gc*=debug",
                 "TestAbortOnVMOperationTimeout",
                 "foo"
         );

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -32,7 +32,7 @@ import jdk.test.lib.process.*;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver/timeout=600 TestAbortOnVMOperationTimeout
+ * @run driver TestAbortOnVMOperationTimeout
  */
 
 public class TestAbortOnVMOperationTimeout {
@@ -51,8 +51,8 @@ public class TestAbortOnVMOperationTimeout {
             return;
         }
 
-        // These should definitely pass: more than 3 minutes is enough for Serial to act.
-        // The values are deliberately non-round to trip off periodic task granularity.
+        // This should definitely pass: more than 3 minutes is enough for Serial to act.
+        // The value is deliberately non-round to trip off periodic task granularity.
         testWith(183423, true);
 
         // These should fail: Serial is not very fast but we have seen the test
@@ -70,7 +70,7 @@ public class TestAbortOnVMOperationTimeout {
                 "-Xmx256m",
                 "-XX:+UseSerialGC",
                 "-XX:-CreateCoredumpOnCrash",
-                "-Xlog:gc*=debug",
+                "-Xlog:gc*=info",
                 "TestAbortOnVMOperationTimeout",
                 "foo"
         );


### PR DESCRIPTION
Hi all,

This patch increases the delay time of the test `TestAbortOnVMOperationTimeout` 
so that it can pass on the low performance devices (such as my local riscv64 dev board).

And I adjust the gc log options to get more gc log message which is useful to
inspect the issue [JDK-8296819](https://bugs.openjdk.org/browse/JDK-8296819).

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307653](https://bugs.openjdk.org/browse/JDK-8307653): Adjust delay time and gc log argument in TestAbortOnVMOperationTimeout


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13878/head:pull/13878` \
`$ git checkout pull/13878`

Update a local copy of the PR: \
`$ git checkout pull/13878` \
`$ git pull https://git.openjdk.org/jdk.git pull/13878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13878`

View PR using the GUI difftool: \
`$ git pr show -t 13878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13878.diff">https://git.openjdk.org/jdk/pull/13878.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13878#issuecomment-1539440887)