### PR TITLE
8307518: Remove G1 workaround in jstat about zero sized generation sizes

### DIFF
--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -48,8 +48,6 @@ public:
 
 class G1YoungGenerationCounters : public G1GenerationCounters {
 public:
-  // We pad the capacity three times given that the young generation
-  // contains three spaces (eden and two survivors).
   G1YoungGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
   : G1GenerationCounters(monitoring_support, name, 0 /* ordinal */, 3 /* spaces */,
                          0 /* min_capacity */, max_size, 0 /* curr_capacity */) {

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -52,17 +52,14 @@ public:
   // contains three spaces (eden and two survivors).
   G1YoungGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
   : G1GenerationCounters(monitoring_support, name, 0 /* ordinal */, 3 /* spaces */,
-                         G1MonitoringSupport::pad_capacity(0, 3) /* min_capacity */,
-                         G1MonitoringSupport::pad_capacity(max_size, 3),
-                         G1MonitoringSupport::pad_capacity(0, 3) /* curr_capacity */) {
+                         0 /* min_capacity */, max_size, 0 /* curr_capacity */) {
     if (UsePerfData) {
       update_all();
     }
   }
 
   virtual void update_all() {
-    size_t committed =
-              G1MonitoringSupport::pad_capacity(_monitoring_support->young_gen_committed(), 3);
+    size_t committed = _monitoring_support->young_gen_committed();
     _current_size->set_value(committed);
   }
 };
@@ -71,17 +68,14 @@ class G1OldGenerationCounters : public G1GenerationCounters {
 public:
   G1OldGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
   : G1GenerationCounters(monitoring_support, name, 1 /* ordinal */, 1 /* spaces */,
-                         G1MonitoringSupport::pad_capacity(0) /* min_capacity */,
-                         G1MonitoringSupport::pad_capacity(max_size),
-                         G1MonitoringSupport::pad_capacity(0) /* curr_capacity */) {
+                         0 /* min_capacity */, max_size, 0 /* curr_capacity */) {
     if (UsePerfData) {
       update_all();
     }
   }
 
   virtual void update_all() {
-    size_t committed =
-              G1MonitoringSupport::pad_capacity(_monitoring_support->old_gen_committed());
+    size_t committed = _monitoring_support->old_gen_committed();
     _current_size->set_value(committed);
   }
 };
@@ -145,8 +139,8 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   // and used.
   _old_space_counters = new HSpaceCounters(_old_gen_counters->name_space(),
     "space", 0 /* ordinal */,
-    pad_capacity(g1h->max_capacity()) /* max_capacity */,
-    pad_capacity(_old_gen_committed) /* init_capacity */);
+    g1h->max_capacity() /* max_capacity */,
+    _old_gen_committed /* init_capacity */);
 
   //   Young collection set
   //  name "generation.0".  This is logically the young generation.
@@ -160,16 +154,16 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   // See _old_space_counters for additional counters
   _eden_space_counters = new HSpaceCounters(young_collection_name_space,
     "eden", 0 /* ordinal */,
-    pad_capacity(g1h->max_capacity()) /* max_capacity */,
-    pad_capacity(_eden_space_committed) /* init_capacity */);
+    g1h->max_capacity() /* max_capacity */,
+    _eden_space_committed /* init_capacity */);
 
   //  name "generation.0.space.1"
   // See _old_space_counters for additional counters
   // Set the arguments to indicate that this survivor space is not used.
   _from_space_counters = new HSpaceCounters(young_collection_name_space,
     "s0", 1 /* ordinal */,
-    pad_capacity(0) /* max_capacity */,
-    pad_capacity(0) /* init_capacity */);
+    0 /* max_capacity */,
+    0 /* init_capacity */);
   // Given that this survivor space is not used, we update it here
   // once to reflect that its used space is 0 so that we don't have to
   // worry about updating it again later.
@@ -181,8 +175,8 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   // See _old_space_counters for additional counters
   _to_space_counters = new HSpaceCounters(young_collection_name_space,
     "s1", 2 /* ordinal */,
-    pad_capacity(g1h->max_capacity()) /* max_capacity */,
-    pad_capacity(_survivor_space_committed) /* init_capacity */);
+    g1h->max_capacity() /* max_capacity */,
+    _survivor_space_committed /* init_capacity */);
 }
 
 G1MonitoringSupport::~G1MonitoringSupport() {
@@ -296,13 +290,13 @@ void G1MonitoringSupport::recalculate_sizes() {
 void G1MonitoringSupport::update_sizes() {
   recalculate_sizes();
   if (UsePerfData) {
-    _eden_space_counters->update_capacity(pad_capacity(_eden_space_committed));
+    _eden_space_counters->update_capacity(_eden_space_committed);
     _eden_space_counters->update_used(_eden_space_used);
     // only the "to" survivor space is active, so we don't need to
     // update the counters for the "from" survivor space
-    _to_space_counters->update_capacity(pad_capacity(_survivor_space_committed));
+    _to_space_counters->update_capacity(_survivor_space_committed);
     _to_space_counters->update_used(_survivor_space_used);
-    _old_space_counters->update_capacity(pad_capacity(_old_gen_committed));
+    _old_space_counters->update_capacity(_old_gen_committed);
     _old_space_counters->update_used(_old_gen_used);
 
     _young_gen_counters->update_all();

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -40,17 +40,22 @@ public:
   G1GenerationCounters(G1MonitoringSupport* monitoring_support,
                        const char* name, int ordinal, int spaces,
                        size_t min_capacity, size_t max_capacity,
-                       size_t curr_capacity)
-  : GenerationCounters(name, ordinal, spaces, min_capacity,
+                       size_t curr_capacity) :
+    GenerationCounters(name, ordinal, spaces, min_capacity,
                        max_capacity, curr_capacity),
     _monitoring_support(monitoring_support) { }
 };
 
 class G1YoungGenerationCounters : public G1GenerationCounters {
 public:
-  G1YoungGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
-  : G1GenerationCounters(monitoring_support, name, 0 /* ordinal */, 3 /* spaces */,
-                         0 /* min_capacity */, max_size, 0 /* curr_capacity */) {
+  G1YoungGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size) :
+    G1GenerationCounters(monitoring_support,
+                         name,
+                         0 /* ordinal */,
+                         3 /* spaces */,
+                         0 /* min_capacity */,
+                         max_size,
+                         0 /* curr_capacity */) {
     if (UsePerfData) {
       update_all();
     }
@@ -64,9 +69,14 @@ public:
 
 class G1OldGenerationCounters : public G1GenerationCounters {
 public:
-  G1OldGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
-  : G1GenerationCounters(monitoring_support, name, 1 /* ordinal */, 1 /* spaces */,
-                         0 /* min_capacity */, max_size, 0 /* curr_capacity */) {
+  G1OldGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size) :
+    G1GenerationCounters(monitoring_support,
+                         name,
+                         1 /* ordinal */,
+                         1 /* spaces */,
+                         0 /* min_capacity */,
+                         max_size,
+                         0 /* curr_capacity */) {
     if (UsePerfData) {
       update_all();
     }
@@ -136,9 +146,9 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   // Counters are created from maxCapacity, capacity, initCapacity,
   // and used.
   _old_space_counters = new HSpaceCounters(_old_gen_counters->name_space(),
-    "space", 0 /* ordinal */,
-    g1h->max_capacity() /* max_capacity */,
-    _old_gen_committed /* init_capacity */);
+                                           "space", 0 /* ordinal */,
+                                           g1h->max_capacity() /* max_capacity */,
+                                           _old_gen_committed /* init_capacity */);
 
   //   Young collection set
   //  name "generation.0".  This is logically the young generation.
@@ -151,17 +161,17 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   //  name "generation.0.space.0"
   // See _old_space_counters for additional counters
   _eden_space_counters = new HSpaceCounters(young_collection_name_space,
-    "eden", 0 /* ordinal */,
-    g1h->max_capacity() /* max_capacity */,
-    _eden_space_committed /* init_capacity */);
+                                            "eden", 0 /* ordinal */,
+                                            g1h->max_capacity() /* max_capacity */,
+                                            _eden_space_committed /* init_capacity */);
 
   //  name "generation.0.space.1"
   // See _old_space_counters for additional counters
   // Set the arguments to indicate that this survivor space is not used.
   _from_space_counters = new HSpaceCounters(young_collection_name_space,
-    "s0", 1 /* ordinal */,
-    0 /* max_capacity */,
-    0 /* init_capacity */);
+                                            "s0", 1 /* ordinal */,
+                                            0 /* max_capacity */,
+                                            0 /* init_capacity */);
   // Given that this survivor space is not used, we update it here
   // once to reflect that its used space is 0 so that we don't have to
   // worry about updating it again later.
@@ -172,9 +182,9 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   //  name "generation.0.space.2"
   // See _old_space_counters for additional counters
   _to_space_counters = new HSpaceCounters(young_collection_name_space,
-    "s1", 2 /* ordinal */,
-    g1h->max_capacity() /* max_capacity */,
-    _survivor_space_committed /* init_capacity */);
+                                          "s1", 2 /* ordinal */,
+                                          g1h->max_capacity() /* max_capacity */,
+                                          _survivor_space_committed /* init_capacity */);
 }
 
 G1MonitoringSupport::~G1MonitoringSupport() {

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -192,21 +192,6 @@ public:
   GrowableArray<GCMemoryManager*> memory_managers();
   GrowableArray<MemoryPool*> memory_pools();
 
-  // Unfortunately, the jstat tool assumes that no space has 0
-  // capacity. In our case, given that each space is logical, it's
-  // possible that no regions will be allocated to it, hence to have 0
-  // capacity (e.g., if there are no survivor regions, the survivor
-  // space has 0 capacity). The way we deal with this is to always pad
-  // each capacity value we report to jstat by a very small amount to
-  // make sure that it's never zero. Given that we sometimes have to
-  // report a capacity of a generation that contains several spaces
-  // (e.g., young gen includes one eden, two survivor spaces), the
-  // mult parameter is provided in order to adding the appropriate
-  // padding multiple times so that the capacities add up correctly.
-  static size_t pad_capacity(size_t size_bytes, size_t mult = 1) {
-    return size_bytes + MinObjAlignmentInBytes * mult;
-  }
-
   // Recalculate all the sizes from scratch and update all the jstat
   // counters accordingly.
   void update_sizes();


### PR DESCRIPTION
Hi all,

  please review removal of some workaround in g1 memory usage monitoring that made sure that there were no 0-sized generations in the output. After [JDK-8307428](https://bugs.openjdk.org/browse/JDK-8307428) this is not necessary any more.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307518](https://bugs.openjdk.org/browse/JDK-8307518): Remove G1 workaround in jstat about zero sized generation sizes


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [6af87816](https://git.openjdk.org/jdk/pull/13880/files/6af878169ccebff5e6a06551f38b184274690e39)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13880/head:pull/13880` \
`$ git checkout pull/13880`

Update a local copy of the PR: \
`$ git checkout pull/13880` \
`$ git pull https://git.openjdk.org/jdk.git pull/13880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13880`

View PR using the GUI difftool: \
`$ git pr show -t 13880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13880.diff">https://git.openjdk.org/jdk/pull/13880.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13880#issuecomment-1539637268)