### PR TITLE
8307758: RISC-V: Improve bit test code introduced by JDK-8291555

### DIFF
--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -135,7 +135,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
 
   if (LockingMode == LM_LIGHTWEIGHT) {
     ld(hdr, Address(obj, oopDesc::mark_offset_in_bytes()));
-    andi(t0, hdr, markWord::monitor_value);
+    test_bit(t0, hdr, exact_log2(markWord::monitor_value));
     bnez(t0, slow_case, /* is_far */ true);
     fast_unlock(obj, hdr, t0, t1, slow_case);
   } else if (LockingMode == LM_LEGACY) {

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -922,7 +922,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
       bne(tmp1, obj_reg, slow_case);
 
       ld(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      andi(t0, header_reg, markWord::monitor_value);
+      test_bit(t0, header_reg, exact_log2(markWord::monitor_value));
       bnez(t0, slow_case);
       fast_unlock(obj_reg, header_reg, swap_reg, t0, slow_case);
       j(count);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2663,7 +2663,7 @@ encode %{
       // If the owner is anonymous, we need to fix it -- in an outline stub.
       Register tmp2 = disp_hdr;
       __ ld(tmp2, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
-      __ andi(t0, tmp2, (int64_t)ObjectMonitor::ANONYMOUS_OWNER);
+      __ test_bit(t0, tmp2, exact_log2(ObjectMonitor::ANONYMOUS_OWNER));
       C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmp, tmp2);
       Compile::current()->output()->add_stub(stub);
       __ bnez(t0, stub->entry(), /* is_far */ true);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1828,7 +1828,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     } else {
       assert(LockingMode == LM_LIGHTWEIGHT, "");
       __ ld(old_hdr, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ andi(t0, old_hdr, markWord::monitor_value);
+      __ test_bit(t0, old_hdr, exact_log2(markWord::monitor_value));
       __ bnez(t0, slow_path_unlock);
       __ fast_unlock(obj_reg, old_hdr, swap_reg, t0, slow_path_unlock);
       __ decrement(Address(xthread, JavaThread::held_monitor_count_offset()));


### PR DESCRIPTION
[JDK-8291555](https://bugs.openjdk.org/browse/JDK-8291555) introduced some single-bit tests that use `andi`, we can replace it with `test_bit` to avoid using the temp register when UseZbs is enabled.

Testing:
- [x] tier1-tier3 on Unmatched board (release build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307758](https://bugs.openjdk.org/browse/JDK-8307758): RISC-V: Improve bit test code introduced by JDK-8291555


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13882/head:pull/13882` \
`$ git checkout pull/13882`

Update a local copy of the PR: \
`$ git checkout pull/13882` \
`$ git pull https://git.openjdk.org/jdk.git pull/13882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13882`

View PR using the GUI difftool: \
`$ git pr show -t 13882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13882.diff">https://git.openjdk.org/jdk/pull/13882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13882#issuecomment-1540245853)