### PR TITLE
8297657: name demangling intermittently fails

### DIFF
--- a/src/hotspot/os/aix/decoder_aix.hpp
+++ b/src/hotspot/os/aix/decoder_aix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,9 +29,7 @@
 // Provide simple AIXDecoder which enables decoding of C frames in VM.
 class AIXDecoder: public AbstractDecoder {
  public:
-  AIXDecoder() {
-    _decoder_status = no_error;
-  }
+  AIXDecoder() : AbstractDecoder(no_error) {}
   virtual ~AIXDecoder() {}
 
   virtual bool demangle(const char* symbol, char* buf, int buflen) { return false; } // use AixSymbols::get_function_name to demangle

--- a/src/hotspot/os/bsd/decoder_machO.hpp
+++ b/src/hotspot/os/bsd/decoder_machO.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,11 @@
 
 #include "utilities/decoder.hpp"
 
-// Just a placehold for now, a real implementation should derive
-// from AbstractDecoder
 class MachODecoder : public AbstractDecoder {
  public:
-  MachODecoder() { }
+  MachODecoder() {
+    _decoder_status = no_error;
+  }
   virtual ~MachODecoder() { }
   virtual bool demangle(const char* symbol, char* buf, int buflen);
   virtual bool decode(address pc, char* buf, int buflen, int* offset,

--- a/src/hotspot/os/bsd/decoder_machO.hpp
+++ b/src/hotspot/os/bsd/decoder_machO.hpp
@@ -31,9 +31,7 @@
 
 class MachODecoder : public AbstractDecoder {
  public:
-  MachODecoder() {
-    _decoder_status = no_error;
-  }
+  MachODecoder() : AbstractDecoder(no_error) { }
   virtual ~MachODecoder() { }
   virtual bool demangle(const char* symbol, char* buf, int buflen);
   virtual bool decode(address pc, char* buf, int buflen, int* offset,

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -48,6 +48,8 @@ protected:
   decoder_status  _decoder_status;
 
 public:
+  AbstractDecoder(decoder_status status) : _decoder_status(status) {}
+
   virtual ~AbstractDecoder() {}
 
   // decode an pc address to corresponding function name and an offset from the beginning of
@@ -84,9 +86,7 @@ public:
 // Do nothing decoder
 class NullDecoder : public AbstractDecoder {
 public:
-  NullDecoder() {
-    _decoder_status = not_available;
-  }
+  NullDecoder() : AbstractDecoder(not_available) {}
 
   virtual ~NullDecoder() {};
 

--- a/src/hotspot/share/utilities/decoder_elf.hpp
+++ b/src/hotspot/share/utilities/decoder_elf.hpp
@@ -33,10 +33,8 @@
 class ElfDecoder : public AbstractDecoder {
 
 public:
-  ElfDecoder() {
-    _opened_elf_files = nullptr;
-    _decoder_status = no_error;
-  }
+  ElfDecoder() : AbstractDecoder(no_error), _opened_elf_files(nullptr) {}
+
   virtual ~ElfDecoder();
 
   bool demangle(const char* symbol, char *buf, int buflen);


### PR DESCRIPTION
Fixes an intermittent name demangling problem (due to the uninitialized AbstractDecoder::_decoder_status field).
The problem affected hs-err stack traces on macosx-aarch64 and macosx-amd64.

I've done manual testing to verify the problem and the solution.
Also run tier1-5 after the fix without seeing any new problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297657](https://bugs.openjdk.org/browse/JDK-8297657): name demangling intermittently fails


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13883/head:pull/13883` \
`$ git checkout pull/13883`

Update a local copy of the PR: \
`$ git checkout pull/13883` \
`$ git pull https://git.openjdk.org/jdk.git pull/13883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13883`

View PR using the GUI difftool: \
`$ git pr show -t 13883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13883.diff">https://git.openjdk.org/jdk/pull/13883.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13883#issuecomment-1540051976)