### PR TITLE
8305083: Remove finalize() from test/hotspot/jtreg/vmTestbase/nsk/share/ and /jpda that are used in serviceability/dcmd/framework tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/FinalizableObject.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/FinalizableObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,28 +23,18 @@
 
 package nsk.share;
 
+
 /**
- * This class is an simple exalmple of finalizable object, that implements interface
- * <code>Finalizable</code> and invokes standard <code>finalize()</code> method
- * as finalization.
+ * This class is an simple exalmple of finalizable object, that
+ * implements interface <code>Finalizable</code>.
  *
  * @see Finalizable
  * @see Finalizer
  */
 public class FinalizableObject implements Finalizable {
-
     /**
-     * This method will be invoked by <tt>Finalizer</tt> when virtual mashine
-     * shuts down.
-     * For <code>FinalizableObject</code> this method just invoke
-     * <code>finalize()</code>.
-     *
-     * @throws Throwable if any throwable exception thrown during finalization
-     *
-     * @see Object#finalize()
-     * @see Finalizer
+     * Subclasses should override this method to provide the specific
+     * cleanup actions that they need.
      */
-    public void finalizeAtExit() throws Throwable {
-        finalize();
-    }
+    public void cleanup() {}
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/FinalizableObject.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/FinalizableObject.java
@@ -25,7 +25,7 @@ package nsk.share;
 
 
 /**
- * This class is an simple example of finalizable object, that
+ * This class is a simple example of finalizable object, that
  * implements interface <code>Finalizable</code>.
  *
  * @see Finalizable

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/FinalizableObject.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/FinalizableObject.java
@@ -25,7 +25,7 @@ package nsk.share;
 
 
 /**
- * This class is an simple exalmple of finalizable object, that
+ * This class is an simple example of finalizable object, that
  * implements interface <code>Finalizable</code>.
  *
  * @see Finalizable

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/LocalProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/LocalProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,8 +60,7 @@ public class LocalProcess extends FinalizableObject {
 
         process = Runtime.getRuntime().exec(args);
 
-        Finalizer finalizer = new Finalizer(this);
-        finalizer.activate();
+        registerCleanup();
     }
 
     public void launch (String cmdLine) throws IOException {
@@ -69,8 +68,7 @@ public class LocalProcess extends FinalizableObject {
 
         process = Runtime.getRuntime().exec(cmdLine);
 
-        Finalizer finalizer = new Finalizer(this);
-        finalizer.activate();
+        registerCleanup();
     }
 
     /** Return exit status. */
@@ -166,12 +164,10 @@ public class LocalProcess extends FinalizableObject {
     }
 
     /**
-     * Finalize mirror by invoking <code>close()</code>.
+     * This method is called at finalization and calls <code>kill()</code>.
      *
-     * @throws Throwable if any throwable exception is thrown during finalization
      */
-    protected void finalize() throws Throwable {
+    public void cleanup() {
         kill();
-        super.finalize();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/LocalProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/LocalProcess.java
@@ -167,6 +167,7 @@ public class LocalProcess extends FinalizableObject {
      * This method is called at finalization and calls <code>kill()</code>.
      *
      */
+    @Override
     public void cleanup() {
         kill();
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,12 +189,11 @@ public class Log extends FinalizableObject {
     @Deprecated
     protected Log() {
         // install finalizer to print errors summary at exit
-        Finalizer finalizer = new Finalizer(this);
-        finalizer.activate();
-
+        registerCleanup();
         // Don't log exceptions from this method. It would just add unnecessary logs.
         loggedExceptions.add("nsk.share.jdi.SerialExecutionDebugger.executeTests");
     }
+
 
     /**
      * Incarnate new Log for the given <code>stream</code> and
@@ -470,7 +469,7 @@ public class Log extends FinalizableObject {
      */
     @Deprecated
     protected synchronized void logTo(PrintStream stream) {
-        finalize(); // flush older log stream
+        cleanup(); // flush older log stream
         out = stream;
         verbose = true;
     }
@@ -605,8 +604,13 @@ public class Log extends FinalizableObject {
 
     /**
      * Print errors summary if mode is verbose, flush and cancel output stream.
+     *
+     * This is replacement of the finalize() method and is called when this
+     * Log instance becomes unreachable.
+     *
      */
-    protected void finalize() {
+    @Override
+    public void cleanup() {
         if (verbose() && isErrorsSummaryEnabled()) {
             printErrorsSummary();
         }
@@ -619,7 +623,7 @@ public class Log extends FinalizableObject {
      * Perform finalization at the exit.
      */
     public void finalizeAtExit() {
-        finalize();
+        cleanup();
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/MainWrapper.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/MainWrapper.java
@@ -43,8 +43,8 @@ public final class MainWrapper {
 
         // It is needed to register finalizer thread in default thread group
         // So FinalizerThread thread can't be in virtual threads group
-        Finalizer finalizer = new Finalizer(new FinalizableObject());
-        finalizer.activate();
+        FinalizableObject finalizableObject = new FinalizableObject();
+        finalizableObject.registerCleanup();
 
         // Some tests use this property to understand if virtual threads are used
         System.setProperty("main.wrapper", wrapperName);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -751,8 +751,6 @@ public class Binder extends DebugeeBinder {
 
         boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
         if (vthreadMode) {
-            /* Need --enable-preview on the debuggee in order to support virtual threads. */
-            vmArgs += " --enable-preview";
             /* Some tests need more carrier threads than the default provided. */
             vmArgs += " -Djdk.virtualThreadScheduler.parallelism=15";
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -129,9 +129,7 @@ public class Binder extends DebugeeBinder {
     public Debugee makeLocalDebugee(Process process) {
         LocalLaunchedDebugee debugee = new LocalLaunchedDebugee(process, this);
 
-        Finalizer finalizer = new Finalizer(debugee);
-        finalizer.activate();
-
+        debugee.registerCleanup();
         return debugee;
     }
 
@@ -753,6 +751,8 @@ public class Binder extends DebugeeBinder {
 
         boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
         if (vthreadMode) {
+            /* Need --enable-preview on the debuggee in order to support virtual threads. */
+            vmArgs += " --enable-preview";
             /* Some tests need more carrier threads than the default provided. */
             vmArgs += " -Djdk.virtualThreadScheduler.parallelism=15";
         }
@@ -942,8 +942,7 @@ public class Binder extends DebugeeBinder {
 
         RemoteLaunchedDebugee debugee = new RemoteLaunchedDebugee(this);
 
-        Finalizer finalizer = new Finalizer(debugee);
-        finalizer.activate();
+        debugee.registerCleanup();
 
         return debugee;
     }
@@ -956,8 +955,7 @@ public class Binder extends DebugeeBinder {
         ManualLaunchedDebugee debugee = new ManualLaunchedDebugee(this);
         debugee.launchDebugee(cmd);
 
-        Finalizer finalizer = new Finalizer(debugee);
-        finalizer.activate();
+        debugee.registerCleanup();
 
         return debugee;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Binder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,8 +106,7 @@ final public class Binder extends DebugeeBinder {
             debugee.redirectOutput(log);
         }
 
-        Finalizer finalizer = new Finalizer(debugee);
-        finalizer.activate();
+        debugee.registerCleanup();
 
         Transport transport = debugee.connect();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,6 @@ public class BindServer implements Finalizable {
     public static int run(String argv[], PrintStream out) {
         return new BindServer().runIt(argv, out);
     }
-
     /**
      * Perform execution of <code>BindServer</code>.
      * This method handles command line arguments, starts seperate
@@ -152,8 +151,8 @@ public class BindServer implements Finalizable {
         log.enableVerboseOnError(false);
         logger = new Log.Logger(log, "");
 
-        Finalizer bindFinalizer = new Finalizer(this);
-        bindFinalizer.activate();
+        registerCleanup();
+
 
         logger.trace(TRACE_LEVEL_THREADS, "BindServer: starting main thread");
 
@@ -217,7 +216,7 @@ public class BindServer implements Finalizable {
 
         logger.trace(TRACE_LEVEL_THREADS, "BindServer: exiting main thread");
         try {
-            finalize();
+            cleanup();
         } catch (Throwable e) {
             e.printStackTrace(log.getOutStream());
             logger.complain("Caught exception while finalization of BindServer:\n\t" + e);
@@ -408,19 +407,17 @@ public class BindServer implements Finalizable {
      *
      * @see #close()
      */
-    protected void finalize() throws Throwable {
+    public void cleanup() {
         close();
-        super.finalize();
     }
 
     /**
      * Make finalization of <code>BindServer</code> object at program exit
-     * by invoking method <code>finalize()</code>.
+     * by invoking method <code>cleanup()</code>.
      *
-     * @see #finalize()
      */
     public void finalizeAtExit() throws Throwable {
-        finalize();
+        cleanup();
         logger.trace(TRACE_LEVEL_THREADS, "BindServer: finalization at exit completed");
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
@@ -153,7 +153,6 @@ public class BindServer implements Finalizable {
 
         registerCleanup();
 
-
         logger.trace(TRACE_LEVEL_THREADS, "BindServer: starting main thread");
 
         logger.display("Listening to port: " + argHandler.getBindPortNumber());
@@ -407,6 +406,7 @@ public class BindServer implements Finalizable {
      *
      * @see #close()
      */
+    @Override
     public void cleanup() {
         close();
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
@@ -313,12 +313,6 @@ public class DebugeeBinder extends Log.Logger implements Finalizable {
 
         args.add(argumentHandler.getLaunchExecPath());
 
-        /* Need --enable-preview on the debuggee in order to support virtual threads. */
-        boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
-        if (vthreadMode) {
-            args.add("--enable-preview");
-        }
-
         String javaOpts = argumentHandler.getLaunchOptions();
         if (javaOpts != null && javaOpts.length() > 0) {
             StringTokenizer st = new StringTokenizer(javaOpts);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,9 @@ abstract public class DebugeeProcess extends FinalizableObject {
     protected DebugeeProcess (DebugeeBinder binder) {
         this.binder = binder;
         this.log = binder.getLog();
+
+        // Register the cleanup() method to be called when this instance becomes unreachable.
+        registerCleanup();
     }
 
     /**
@@ -460,8 +463,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
      *
      * @throws Throwable if any throwable exception is thrown during finalization
      */
-    protected void finalize() throws Throwable {
+    public void cleanup() {
         close();
-        super.finalize();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketIOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketIOPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,6 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
     protected ServerSocket serverSocket;
 
     protected String name;
-
     /**
      * Make general <code>IOPipe</code> object with specified parameters.
      */
@@ -93,6 +92,8 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
         this.timeout = timeout;
         this.listening = listening;
         this.name = name;
+
+        registerCleanup();
     }
 
     /**
@@ -104,6 +105,8 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
         this.port = port;
         this.timeout = timeout;
         this.listening = listening;
+
+        registerCleanup();
     }
 
     /**
@@ -308,18 +311,15 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
 
     /**
      * Perform finalization of the object by invoking close().
+     *
+     * This is replacement of finalize() method and is called
+     * when this instance becomes unreachable.
+     *
      */
-    protected void finalize() throws Throwable {
+    public void cleanup() {
         close();
-        super.finalize();
     }
 
-    /**
-     * Perform finalization of the object at exit by invoking finalize().
-     */
-    public void finalizeAtExit() throws Throwable {
-        finalize();
-    }
 
     /**
      * Field 'pipeCounter' and method 'getNextPipeNumber' are used to construct unique names for SocketIOPipes


### PR DESCRIPTION
This PR is continuation of https://github.com/openjdk/jdk/pull/13420 which was far behind the master.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305083](https://bugs.openjdk.org/browse/JDK-8305083): Remove finalize() from test/hotspot/jtreg/vmTestbase/nsk/share/ and /jpda that are used in serviceability/dcmd/framework tests


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [63e342f6](https://git.openjdk.org/jdk/pull/13884/files/63e342f6cbf1ebcbb6a103c776f9c654673815c3)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [63e342f6](https://git.openjdk.org/jdk/pull/13884/files/63e342f6cbf1ebcbb6a103c776f9c654673815c3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13884/head:pull/13884` \
`$ git checkout pull/13884`

Update a local copy of the PR: \
`$ git checkout pull/13884` \
`$ git pull https://git.openjdk.org/jdk.git pull/13884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13884`

View PR using the GUI difftool: \
`$ git pr show -t 13884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13884.diff">https://git.openjdk.org/jdk/pull/13884.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13884#issuecomment-1539768258)