### PR TITLE
8307732: build-test-lib is broken

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -36,7 +36,7 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
     DISABLED_WARNINGS := deprecation removal preview, \
@@ -53,7 +53,13 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
     DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal preview, \
-    JAVAC_FLAGS := --enable-preview, \
+    JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile.attribute=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile.java.lang.constant=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.module=ALL-UNNAMED \
+        --enable-preview, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)

--- a/test/lib/jdk/test/lib/net/HttpHeaderParser.java
+++ b/test/lib/jdk/test/lib/net/HttpHeaderParser.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-public class HttpHeaderParser {
+public final class HttpHeaderParser {
     private static final char CR = '\r';
     private static final char LF = '\n';
     private static final char HT = '\t';


### PR DESCRIPTION
Fixes the issue by adding `--add-exports` for the required modules and making the `HttpHeaderParser` final (fixing an issue with calling overridable methods in a constructor).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307732](https://bugs.openjdk.org/browse/JDK-8307732): build-test-lib is broken


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13885/head:pull/13885` \
`$ git checkout pull/13885`

Update a local copy of the PR: \
`$ git checkout pull/13885` \
`$ git pull https://git.openjdk.org/jdk.git pull/13885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13885`

View PR using the GUI difftool: \
`$ git pr show -t 13885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13885.diff">https://git.openjdk.org/jdk/pull/13885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13885#issuecomment-1539944216)