### PR TITLE
8305081: Remove finalize() from test/hotspot/jtreg/compiler/runtime/Test8168712

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/Test8168712.java
+++ b/test/hotspot/jtreg/compiler/runtime/Test8168712.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,20 +48,31 @@
  */
 package compiler.runtime;
 
+import java.lang.ref.Cleaner;
 import java.util.*;
 
 public class Test8168712 {
     static HashSet<Test8168712> m = new HashSet<>();
+
+    // One cleaner thread for cleaning all the instances. Otherwise, we get OOME.
+    static Cleaner cleaner = Cleaner.create();
+
+    public Test8168712() {
+        cleaner.register(this, () -> cleanup());
+    }
+
     public static void main(String args[]) {
         int i = 0;
         while (i++<15000) {
             test();
         }
     }
+
     static Test8168712 test() {
         return new Test8168712();
     }
-    protected void finalize() {
+
+    public void cleanup() {
         m.add(this);
     }
 }


### PR DESCRIPTION
- The `finalize()` method is replaced with `cleanup()`. 
- A new constructor is added to register the cleanup method.
- A static `Cleaner` is defined to have only one cleaner thread for all the 15000 instances. Otherwise, we get an `OutOfMemoryException` on cleaner thread creation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305081](https://bugs.openjdk.org/browse/JDK-8305081): Remove finalize() from test/hotspot/jtreg/compiler/runtime/Test8168712


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13886/head:pull/13886` \
`$ git checkout pull/13886`

Update a local copy of the PR: \
`$ git checkout pull/13886` \
`$ git pull https://git.openjdk.org/jdk.git pull/13886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13886`

View PR using the GUI difftool: \
`$ git pr show -t 13886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13886.diff">https://git.openjdk.org/jdk/pull/13886.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13886#issuecomment-1540099410)