### PR TITLE
8288619: Unexpected parsing for @see

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -284,6 +284,7 @@ public class DocCommentParser {
      * Non-standard tags are represented by {@link UnknownBlockTagTree}.
      */
     protected DCTree blockTag() {
+        newline = false;
         int p = bp;
         try {
             nextChar();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -520,6 +520,7 @@ public class DocCommentParser {
      * It is an error if the beginning of the next tag is detected.
      */
     protected DCText quotedString() {
+        newline = false;
         int pos = bp;
         nextChar();
 

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -907,7 +907,10 @@ public class DocCommentTester {
             var annos = (path.getLeaf() instanceof MethodTree m)
                     ? m.getModifiers().getAnnotations().toString()
                     : "";
-            boolean normalizeTags = !annos.equals("@NormalizeTags(false)");
+            if (annos.contains("@PrettyCheck(false)")) {
+                return;
+            }
+            boolean normalizeTags = !annos.contains("@NormalizeTags(false)");
 
             String raw = trees.getDocComment(path);
             String normRaw = normalize(raw, normalizeTags);

--- a/test/langtools/tools/javac/doctree/SeeTest.java
+++ b/test/langtools/tools/javac/doctree/SeeTest.java
@@ -75,6 +75,7 @@ DocComment[DOC_COMMENT, pos:1
      * @see
      *    "{@code}"
      */
+    @PrettyCheck(false)
     void new_line_before_quoted_string() { }
 /*
 DocComment[DOC_COMMENT, pos:1

--- a/test/langtools/tools/javac/doctree/SeeTest.java
+++ b/test/langtools/tools/javac/doctree/SeeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8031212 8273244 8284908 8200337
+ * @bug 7021614 8031212 8273244 8284908 8200337 8288619
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -48,6 +48,24 @@ DocComment[DOC_COMMENT, pos:1
     See[SEE, pos:7
       reference: 1
         Text[TEXT, pos:12, "String"]
+    ]
+]
+*/
+
+    /**
+     * Test '@' in quoted string.
+     * @see "{@code}"
+     */
+    void at_sign_in_quote_string() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 1
+    Text[TEXT, pos:1, Test_'@'_in_quoted_string.]
+  body: empty
+  block tags: 1
+    See[SEE, pos:29
+      reference: 1
+        Text[TEXT, pos:34, "{@code}"]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/SeeTest.java
+++ b/test/langtools/tools/javac/doctree/SeeTest.java
@@ -56,7 +56,7 @@ DocComment[DOC_COMMENT, pos:1
      * Test '@' in quoted string.
      * @see "{@code}"
      */
-    void at_sign_in_quote_string() { }
+    void at_sign_in_quoted_string() { }
 /*
 DocComment[DOC_COMMENT, pos:1
   firstSentence: 1

--- a/test/langtools/tools/javac/doctree/SeeTest.java
+++ b/test/langtools/tools/javac/doctree/SeeTest.java
@@ -71,6 +71,25 @@ DocComment[DOC_COMMENT, pos:1
 */
 
     /**
+     * Test new line before quoted string.
+     * @see
+     *    "{@code}"
+     */
+    void new_line_before_quoted_string() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 1
+    Text[TEXT, pos:1, Test_new_line_before_quoted_string.]
+  body: empty
+  block tags: 1
+    See[SEE, pos:38
+      reference: 1
+        Text[TEXT, pos:47, "{@code}"]
+    ]
+]
+*/
+
+    /**
      * abc.
      * @see <a href="url">url</a>
      */


### PR DESCRIPTION
Hi all,

When invoking the method `DocCommentParser::quotedString` with field `newline` as `true` 
and the quoted string has the character `@`, `quotedString` will break the loop and return `null`.
This patch changes the field `newline` to `false` at the beginning of the method `quotedString`
to solve this issue. And a corresponding test case is added.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288619](https://bugs.openjdk.org/browse/JDK-8288619): Unexpected parsing for @see


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13888/head:pull/13888` \
`$ git checkout pull/13888`

Update a local copy of the PR: \
`$ git checkout pull/13888` \
`$ git pull https://git.openjdk.org/jdk.git pull/13888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13888`

View PR using the GUI difftool: \
`$ git pr show -t 13888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13888.diff">https://git.openjdk.org/jdk/pull/13888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13888#issuecomment-1540206811)