### PR TITLE
JDK-8151531: Add notes to BaseStream.spliterator/iterator docs regarding them being escape hatches

### DIFF
--- a/src/java.base/share/classes/java/util/stream/BaseStream.java
+++ b/src/java.base/share/classes/java/util/stream/BaseStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/BaseStream.java
+++ b/src/java.base/share/classes/java/util/stream/BaseStream.java
@@ -69,6 +69,11 @@ public interface BaseStream<T, S extends BaseStream<T, S>>
      * <p>This is a <a href="package-summary.html#StreamOps">terminal
      * operation</a>.
      *
+     * <p>
+     * This method is provided as an "escape hatch" to enable
+     * arbitrary client-controlled pipeline traversals in the event that the
+     * existing operations are not sufficient to the task.
+     *
      * @return the element iterator for this stream
      */
     Iterator<T> iterator();
@@ -78,6 +83,11 @@ public interface BaseStream<T, S extends BaseStream<T, S>>
      *
      * <p>This is a <a href="package-summary.html#StreamOps">terminal
      * operation</a>.
+     *
+     * <p>
+     * This method is provided as an "escape hatch" to enable
+     * arbitrary client-controlled pipeline traversals in the event that the
+     * existing operations are not sufficient to the task.
      *
      * <p>
      * The returned spliterator should report the set of characteristics derived

--- a/src/java.base/share/classes/java/util/stream/BaseStream.java
+++ b/src/java.base/share/classes/java/util/stream/BaseStream.java
@@ -69,8 +69,8 @@ public interface BaseStream<T, S extends BaseStream<T, S>>
      * <p>This is a <a href="package-summary.html#StreamOps">terminal
      * operation</a>.
      *
-     * <p>
-     * This method is provided as an "escape hatch" to enable
+     * @apiNote
+     * This operation is provided as an "escape hatch" to enable
      * arbitrary client-controlled pipeline traversals in the event that the
      * existing operations are not sufficient to the task.
      *
@@ -84,8 +84,8 @@ public interface BaseStream<T, S extends BaseStream<T, S>>
      * <p>This is a <a href="package-summary.html#StreamOps">terminal
      * operation</a>.
      *
-     * <p>
-     * This method is provided as an "escape hatch" to enable
+     * @apiNote
+     * This operation is provided as an "escape hatch" to enable
      * arbitrary client-controlled pipeline traversals in the event that the
      * existing operations are not sufficient to the task.
      *


### PR DESCRIPTION
Still relevant to address? /cc @PaulSandoz

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8151531](https://bugs.openjdk.org/browse/JDK-8151531): Add notes to BaseStream.spliterator/iterator docs regarding them being escape hatches


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13890/head:pull/13890` \
`$ git checkout pull/13890`

Update a local copy of the PR: \
`$ git checkout pull/13890` \
`$ git pull https://git.openjdk.org/jdk.git pull/13890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13890`

View PR using the GUI difftool: \
`$ git pr show -t 13890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13890.diff">https://git.openjdk.org/jdk/pull/13890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13890#issuecomment-1540468779)