### PR TITLE
8307765: DynamicArchiveHeader contents are missing in CDS mapfile

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -445,3 +445,12 @@ bool DynamicArchive::validate(FileMapInfo* dynamic_info) {
 
   return true;
 }
+
+void DynamicArchiveHeader::print(outputStream* st) {
+  ResourceMark rm;
+
+  st->print_cr("- base_header_crc:                0x%08x", base_header_crc());
+  for (int i = 0; i < NUM_CDS_REGIONS; i++) {
+    st->print_cr("- base_region_crc[%d]:             0x%08x", i, base_region_crc(i));
+  }
+}

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -54,6 +54,7 @@ public:
     assert(is_valid_region(i), "must be");
     _base_region_crc[i] = c;
   }
+  void print(outputStream* st);
 };
 
 class DynamicArchive : AllStatic {

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2394,6 +2394,13 @@ FileMapRegion* FileMapInfo::last_core_region() const {
   return region_at(MetaspaceShared::ro);
 }
 
+void FileMapInfo::print(outputStream* st) const {
+  header()->print(st);
+  if (!is_static()) {
+    dynamic_header()->print(st);
+  }
+}
+
 void FileMapHeader::set_as_offset(char* p, size_t *offset) {
   *offset = ArchiveBuilder::current()->any_to_offset((address)p);
 }

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -530,9 +530,7 @@ public:
     return header()->region_at(i);
   }
 
-  void print(outputStream* st) {
-    header()->print(st);
-  }
+  void print(outputStream* st) const;
 
   const char* vm_version() {
     return header()->jvm_ident();


### PR DESCRIPTION
This change adds DynamicArchiveHeader contents in the mapfile generated for a dynamic CDS archive.
The additional fields that appears in the header section of the cds mapfile are:
```
- base_header_crc:                <value>
- base_region_crc[0]:             <value>
- base_region_crc[1]:             <value>
- base_region_crc[2]:             <value>
- base_region_crc[3]:             <value>
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307765](https://bugs.openjdk.org/browse/JDK-8307765): DynamicArchiveHeader contents are missing in CDS mapfile


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13891/head:pull/13891` \
`$ git checkout pull/13891`

Update a local copy of the PR: \
`$ git checkout pull/13891` \
`$ git pull https://git.openjdk.org/jdk.git pull/13891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13891`

View PR using the GUI difftool: \
`$ git pr show -t 13891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13891.diff">https://git.openjdk.org/jdk/pull/13891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13891#issuecomment-1540577542)