### PR TITLE
8281103: Give example for Locale that is English and follows the ISO standards

### DIFF
--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -294,6 +294,14 @@ public final class WeekFields implements Serializable {
      * those extensions. If both "fw" and "rg" are specified, the value from
      * the "fw" extension supersedes the implicit one from the "rg" extension.
      *
+     * <p>For example, users who are interested in using an English locale,
+     * but want the first day of the week that corresponds with the ISO-8601
+     * standard can call
+     * {@snippet lang=java :
+     * Locale enIsoLoc = Locale.forLanguageTag("en-u-fw-mon");
+     * WeekFields.of(theLoc).getFirstDayOfWeek(); // returns MONDAY
+     * }
+     *
      * @param locale  the locale to use, not null
      * @return the week-definition, not null
      */

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -299,7 +299,7 @@ public final class WeekFields implements Serializable {
      * standard can call
      * {@snippet lang=java :
      * Locale enIsoLoc = Locale.forLanguageTag("en-u-fw-mon");
-     * WeekFields.of(theLoc).getFirstDayOfWeek(); // returns MONDAY
+     * WeekFields.of(enIsoLoc).getFirstDayOfWeek(); // returns MONDAY
      * }
      *
      * @param locale  the locale to use, not null


### PR DESCRIPTION
Please review this PR which adds an example snippet to `java.time.temporal.WeekFields.of(Locale locale)`

The snippet demonstrates how to create a Locale that has English Locale qualities with an ISO-8601 first day of the week. 

This snippet was added as there was a desire for an English/ISO-8601 Locale constant to be added, but the existing methods in the JDK are better suited for accomplishing this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8307546](https://bugs.openjdk.org/browse/JDK-8307546) to be approved

### Issues
 * [JDK-8281103](https://bugs.openjdk.org/browse/JDK-8281103): Give example for Locale that is English and follows the ISO standards
 * [JDK-8307546](https://bugs.openjdk.org/browse/JDK-8307546): Give example for Locale that is English and follows the ISO standards (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13893/head:pull/13893` \
`$ git checkout pull/13893`

Update a local copy of the PR: \
`$ git checkout pull/13893` \
`$ git pull https://git.openjdk.org/jdk.git pull/13893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13893`

View PR using the GUI difftool: \
`$ git pr show -t 13893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13893.diff">https://git.openjdk.org/jdk/pull/13893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13893#issuecomment-1540869750)