### PR TITLE
8299340: CreateProcessW lpCommandLine must be mutable

### DIFF
--- a/src/java.base/windows/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/windows/native/libjava/ProcessImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
 #include "io_util_md.h"
 #include <windows.h>
 #include <io.h>
+#include <wchar.h>
 
 /* We try to make sure that we can read and write 4095 bytes (the
  * fixed limit on Linux) to the pipe on all operating systems without
@@ -379,13 +380,21 @@ Java_java_lang_ProcessImpl_create(JNIEnv *env, jclass ignored,
                 if (!(*env)->ExceptionCheck(env)) {
                     jlong *handles = (*env)->GetLongArrayElements(env, stdHandles, NULL);
                     if (handles != NULL) {
-                        ret = processCreate(
-                            env,
-                            pcmd,
-                            penvBlock,
-                            pdir,
-                            handles,
-                            redirectErrorStream);
+                        // Copy command line to mutable char buffer; CreateProcessW may modify it
+                        jsize cmdLen = (*env)->GetStringLength(env, cmd);
+                        WCHAR *pcmdCopy = (WCHAR*)malloc(cmdLen * sizeof(WCHAR));
+                        if (pcmdCopy != NULL) {
+                            wmemcpy(pcmdCopy, pcmd, cmdLen);
+
+                            ret = processCreate(
+                                env,
+                                pcmd,
+                                penvBlock,
+                                pdir,
+                                handles,
+                                redirectErrorStream);
+                            free(pcmdCopy);   // free mutable command line
+                        }
                         (*env)->ReleaseLongArrayElements(env, stdHandles, handles, 0);
                     }
                     if (pdir != NULL)

--- a/src/java.base/windows/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/windows/native/libjava/ProcessImpl_md.c
@@ -382,9 +382,10 @@ Java_java_lang_ProcessImpl_create(JNIEnv *env, jclass ignored,
                     if (handles != NULL) {
                         // Copy command line to mutable char buffer; CreateProcessW may modify it
                         jsize cmdLen = (*env)->GetStringLength(env, cmd);
-                        WCHAR *pcmdCopy = (WCHAR*)malloc(cmdLen * sizeof(WCHAR));
+                        WCHAR *pcmdCopy = (WCHAR*)malloc((cmdLen + 1) * sizeof(WCHAR));
                         if (pcmdCopy != NULL) {
                             wmemcpy(pcmdCopy, pcmd, cmdLen);
+                            pcmdCopy[cmdLen] = 0;    // null terminate
 
                             ret = processCreate(
                                 env,


### PR DESCRIPTION
Launching of processes on Windows using `ProcessCreateW` with a Unicode character set requires the buffer to be writable. An access violation might occur if `ProcessCreateW` writes to the command line string. The current implementation fetches the command line string using JNI GetStringChars returning a buffer that should not be modified. The code is unchanged since 2015.  There have not been any reported faults in that time.

This change copies the command line to a separately allocation mutable buffer to satisfy the Windows requirement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299340](https://bugs.openjdk.org/browse/JDK-8299340): CreateProcessW lpCommandLine must be mutable


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13894/head:pull/13894` \
`$ git checkout pull/13894`

Update a local copy of the PR: \
`$ git checkout pull/13894` \
`$ git pull https://git.openjdk.org/jdk.git pull/13894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13894`

View PR using the GUI difftool: \
`$ git pr show -t 13894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13894.diff">https://git.openjdk.org/jdk/pull/13894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13894#issuecomment-1546073817)