### PR TITLE
8307808: G1: Remove partial object-count report after gc

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -375,8 +375,6 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
 
   void weak_refs_work();
 
-  void report_object_count(bool mark_completed);
-
   void reclaim_empty_regions();
 
   // After reclaiming empty regions, update heap sizes.


### PR DESCRIPTION
Simple removing object-count event in the case of incomplete-marking.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307808](https://bugs.openjdk.org/browse/JDK-8307808): G1: Remove partial object-count report after gc


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13897/head:pull/13897` \
`$ git checkout pull/13897`

Update a local copy of the PR: \
`$ git checkout pull/13897` \
`$ git pull https://git.openjdk.org/jdk.git pull/13897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13897`

View PR using the GUI difftool: \
`$ git pr show -t 13897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13897.diff">https://git.openjdk.org/jdk/pull/13897.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13897#issuecomment-1541832792)