### PR TITLE
8307813: [JVMCI] Export markWord::lock_mask_in_place to JVMCI compilers.

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -739,6 +739,7 @@
   declare_constant(markWord::hash_shift)                                  \
   declare_constant(markWord::monitor_value)                               \
                                                                           \
+  declare_constant(markWord::lock_mask_in_place)                          \
   declare_constant(markWord::age_mask_in_place)                           \
   declare_constant(markWord::hash_mask)                                   \
   declare_constant(markWord::hash_mask_in_place)                          \


### PR DESCRIPTION
Export markWord::lock_mask_in_place to JVMCI compilers. This field is essential for accessing cached identity hash code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307813](https://bugs.openjdk.org/browse/JDK-8307813): [JVMCI] Export markWord::lock_mask_in_place to JVMCI compilers.


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13902/head:pull/13902` \
`$ git checkout pull/13902`

Update a local copy of the PR: \
`$ git checkout pull/13902` \
`$ git pull https://git.openjdk.org/jdk.git pull/13902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13902`

View PR using the GUI difftool: \
`$ git pr show -t 13902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13902.diff">https://git.openjdk.org/jdk/pull/13902.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13902#issuecomment-1542076897)