### PR TITLE
8307533: Use atomic bitset functions for metadata flags

### DIFF
--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -26,6 +26,7 @@
 #define SHARE_OOPS_FIELDINFO_HPP
 
 #include "memory/allocation.hpp"
+#include "oops/metadataFlags.hpp"
 #include "oops/typeArrayOop.hpp"
 #include "utilities/unsigned5.hpp"
 #include "utilities/vmEnums.hpp"
@@ -281,7 +282,7 @@ class FieldInfoStream : AllStatic {
   static void print_from_fieldinfo_stream(Array<u1>* fis, outputStream* os, ConstantPool* cp);
 };
 
-class FieldStatus {
+class FieldStatus : public MetadataFlags {
   enum FieldStatusBitPosition {
     _fs_access_watched,       // field access is watched by JVMTI
     _fs_modification_watched, // field modification is watched by JVMTI
@@ -294,9 +295,6 @@ class FieldStatus {
   bool test_flag(FieldStatusBitPosition pos) { return (_flags & flag_mask(pos)) != 0; }
   // this performs an atomic update on a live status byte!
   void update_flag(FieldStatusBitPosition pos, bool z);
-  // out-of-line functions do a CAS-loop
-  static void atomic_set_bits(u1& flags, u1 mask);
-  static void atomic_clear_bits(u1& flags, u1 mask);
 
   public:
   FieldStatus() { _flags = 0; }

--- a/src/hotspot/share/oops/fieldInfo.inline.hpp
+++ b/src/hotspot/share/oops/fieldInfo.inline.hpp
@@ -150,26 +150,6 @@ inline FieldInfoReader& FieldInfoReader::set_position_and_next_index(int positio
   return *this;
 }
 
-inline void FieldStatus::atomic_set_bits(u1& flags, u1 mask) {
-  // Atomically update the flags with the bits given
-  u1 old_flags, new_flags, witness;
-  do {
-    old_flags = flags;
-    new_flags = old_flags | mask;
-    witness = Atomic::cmpxchg(&flags, old_flags, new_flags);
-  } while (witness != old_flags);
-}
-
-inline void FieldStatus::atomic_clear_bits(u1& flags, u1 mask) {
-  // Atomically update the flags with the bits given
-  u1 old_flags, new_flags, witness;
-  do {
-    old_flags = flags;
-    new_flags = old_flags & ~mask;
-    witness = Atomic::cmpxchg(&flags, old_flags, new_flags);
-  } while (witness != old_flags);
-}
-
 inline void FieldStatus::update_flag(FieldStatusBitPosition pos, bool z) {
   if (z) atomic_set_bits(_flags, flag_mask(pos));
   else atomic_clear_bits(_flags, flag_mask(pos));

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -31,27 +31,6 @@
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
 
-// This can be removed for the atomic bitset functions, when available.
-void InstanceKlassFlags::atomic_set_bits(u1 bits) {
-  // Atomically update the status with the bits given
-  u1 old_status, new_status, f;
-  do {
-    old_status = _status;
-    new_status = old_status | bits;
-    f = Atomic::cmpxchg(&_status, old_status, new_status);
-  } while(f != old_status);
-}
-
-void InstanceKlassFlags::atomic_clear_bits(u1 bits) {
-  // Atomically update the status with the bits given
-  u1 old_status, new_status, f;
-  do {
-    old_status = _status;
-    new_status = old_status & ~bits;
-    f = Atomic::cmpxchg(&_status, old_status, new_status);
-  } while(f != old_status);
-}
-
 void InstanceKlassFlags::print_on(outputStream* st) const {
 #define IK_FLAGS_PRINT(name, ignore)          \
   if (name()) st->print(" ##name ");

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -25,6 +25,8 @@
 #ifndef SHARE_OOPS_INSTANCEKLASSFLAGS_HPP
 #define SHARE_OOPS_INSTANCEKLASSFLAGS_HPP
 
+#include "oops/metadataFlags.hpp"
+
 class ClassLoaderData;
 
 // The InstanceKlassFlags class contains the parse-time and writeable flags associated with
@@ -33,7 +35,7 @@ class ClassLoaderData;
 // require atomic access.
 // These flags are JVM internal and not part of the AccessFlags classfile specification.
 
-class InstanceKlassFlags {
+class InstanceKlassFlags : public MetadataFlags {
   friend class VMStructs;
   friend class JVMCIVMStructs;
 
@@ -113,16 +115,14 @@ class InstanceKlassFlags {
   bool name() const { return (_status & _misc_##name) != 0; } \
   void set_##name(bool b) {         \
     if (b) { \
-      atomic_set_bits(_misc_##name); \
+      atomic_set_bits(_status, _misc_##name); \
     } else { \
-      atomic_clear_bits(_misc_##name); \
+      atomic_clear_bits(_status, _misc_##name); \
     } \
   }
   IK_STATUS_DO(IK_STATUS_GET_SET)
 #undef IK_STATUS_GET_SET
 
-  void atomic_set_bits(u1 bits);
-  void atomic_clear_bits(u1 bits);
   void print_on(outputStream* st) const;
 };
 

--- a/src/hotspot/share/oops/metadataFlags.hpp
+++ b/src/hotspot/share/oops/metadataFlags.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_OOPS_METADATAFLAGS_HPP
+#define SHARE_OOPS_METADATAFLAGS_HPP
+
+#include "runtime/atomic.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
+
+// Somewhere to put the atomic bit set functions not supported in Atomic for some reason.
+class MetadataFlags {
+
+ protected:
+  inline void atomic_set_bits(u1& flags, u1 mask) {
+    // Atomically update the flags with the bits given
+    u1 old_flags, new_flags, witness;
+    do {
+      old_flags = flags;
+      new_flags = old_flags | mask;
+      witness = Atomic::cmpxchg(&flags, old_flags, new_flags);
+    } while (witness != old_flags);
+  }
+
+  inline void atomic_clear_bits(u1& flags, u1 mask) {
+    // Atomically update the flags with the bits given
+    u1 old_flags, new_flags, witness;
+    do {
+      old_flags = flags;
+      new_flags = old_flags & ~mask;
+      witness = Atomic::cmpxchg(&flags, old_flags, new_flags);
+    } while (witness != old_flags);
+  }
+
+  void atomic_set_bits(u4& status, u4 bits)   { Atomic::fetch_then_or(&status, bits); }
+  void atomic_clear_bits(u4& status, u4 bits) { Atomic::fetch_then_and(&status, ~bits); }
+};
+
+#endif // SHARE_OOPS_METADATAFLAGS_HPP

--- a/src/hotspot/share/oops/methodFlags.cpp
+++ b/src/hotspot/share/oops/methodFlags.cpp
@@ -24,29 +24,7 @@
 
 #include "precompiled.hpp"
 #include "oops/methodFlags.hpp"
-#include "runtime/atomic.hpp"
 #include "utilities/ostream.hpp"
-
-// This can be removed for the atomic bitset functions, when available.
-void MethodFlags::atomic_set_bits(u4 bits) {
-  // Atomically update the status with the bits given
-  u4 old_status, new_status, f;
-  do {
-    old_status = _status;
-    new_status = old_status | bits;
-    f = Atomic::cmpxchg(&_status, old_status, new_status);
-  } while(f != old_status);
-}
-
-void MethodFlags::atomic_clear_bits(u4 bits) {
-  // Atomically update the status with the bits given
-  u4 old_status, new_status, f;
-  do {
-    old_status = _status;
-    new_status = old_status & ~bits;
-    f = Atomic::cmpxchg(&_status, old_status, new_status);
-  } while(f != old_status);
-}
 
 void MethodFlags::print_on(outputStream* st) const {
 #define M_PRINT(name, ignore)          \

--- a/src/hotspot/share/oops/methodFlags.hpp
+++ b/src/hotspot/share/oops/methodFlags.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_OOPS_METHODFLAGS_HPP
 #define SHARE_OOPS_METHODFLAGS_HPP
 
+#include "oops/metadataFlags.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
@@ -35,7 +36,7 @@ class outputStream;
 // _status are set at runtime and require atomic access.
 // These flags are JVM internal and not part of the AccessFlags classfile specification.
 
-class MethodFlags {
+class MethodFlags : public MetadataFlags {
   friend class VMStructs;
   friend class JVMCIVMStructs;
    /* end of list */
@@ -77,17 +78,15 @@ class MethodFlags {
   bool name() const { return (_status & _misc_##name) != 0; } \
   void set_##name(bool b) {         \
     if (b) { \
-      atomic_set_bits(_misc_##name); \
+      atomic_set_bits(_status, _misc_##name); \
     } else { \
-      atomic_clear_bits(_misc_##name); \
+      atomic_clear_bits(_status, _misc_##name); \
     } \
   }
   M_STATUS_DO(M_STATUS_GET_SET)
 #undef M_STATUS_GET_SET
 
   int as_int() const { return _status; }
-  void atomic_set_bits(u4 bits);
-  void atomic_clear_bits(u4 bits);
   void print_on(outputStream* st) const;
 };
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307533](https://bugs.openjdk.org/browse/JDK-8307533): Use atomic bitset functions for metadata flags


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13903/head:pull/13903` \
`$ git checkout pull/13903`

Update a local copy of the PR: \
`$ git checkout pull/13903` \
`$ git pull https://git.openjdk.org/jdk.git pull/13903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13903`

View PR using the GUI difftool: \
`$ git pr show -t 13903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13903.diff">https://git.openjdk.org/jdk/pull/13903.diff</a>

</details>
