### PR TITLE
8307799: Newly added java/awt/dnd/MozillaDnDTest.java has invalid jtreg `@requires` clause

### DIFF
--- a/test/jdk/java/awt/dnd/MozillaDnDTest.java
+++ b/test/jdk/java/awt/dnd/MozillaDnDTest.java
@@ -64,7 +64,7 @@ import java.io.Reader;
   @test
   @bug 4746177
   @summary tests that data types exported by Netscape 6.2 are supported
-  @requires(os != "windows")
+  @requires (os.family == "windows")
   @key headful
   @run main MozillaDnDTest
 */

--- a/test/jdk/java/awt/dnd/MozillaDnDTest.java
+++ b/test/jdk/java/awt/dnd/MozillaDnDTest.java
@@ -64,7 +64,7 @@ import java.io.Reader;
   @test
   @bug 4746177
   @summary tests that data types exported by Netscape 6.2 are supported
-  @requires (os.family == "windows")
+  @requires (os.family != "windows")
   @key headful
   @run main MozillaDnDTest
 */


### PR DESCRIPTION
A trivial fix to adjust an `@requires` tag into the proper format.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307799](https://bugs.openjdk.org/browse/JDK-8307799): Newly added java/awt/dnd/MozillaDnDTest.java has invalid jtreg `@requires` clause


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13906/head:pull/13906` \
`$ git checkout pull/13906`

Update a local copy of the PR: \
`$ git checkout pull/13906` \
`$ git pull https://git.openjdk.org/jdk.git pull/13906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13906`

View PR using the GUI difftool: \
`$ git pr show -t 13906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13906.diff">https://git.openjdk.org/jdk/pull/13906.diff</a>

</details>
