### PR TITLE
8307619: C2 failed: Not monotonic (AndI CastII LShiftI) in TestShiftCastAndNotification.java

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1924,17 +1924,14 @@ bool MulNode::AndIL_shift_and_mask_is_always_zero(PhaseGVN* phase, Node* shift, 
     return false;
   }
   const TypeInteger* mask_t = phase->type(mask)->isa_integer(bt);
-  const TypeInteger* shift_t = phase->type(shift)->isa_integer(bt);
-  if (mask_t == nullptr || shift_t == nullptr) {
+  if (mask_t == nullptr || phase->type(shift)->isa_integer(bt) == nullptr) {
     return false;
   }
   shift = shift->uncast();
   if (shift == nullptr) {
     return false;
   }
-  mask_t = phase->type(mask)->isa_integer(bt);
-  shift_t = phase->type(shift)->isa_integer(bt);
-  if (mask_t == nullptr || shift_t == nullptr) {
+  if (phase->type(shift)->isa_integer(bt) == nullptr) {
     return false;
   }
   BasicType shift_bt = bt;
@@ -1951,6 +1948,9 @@ bool MulNode::AndIL_shift_and_mask_is_always_zero(PhaseGVN* phase, Node* shift, 
     if (val->Opcode() == Op_LShiftI) {
       shift_bt = T_INT;
       shift = val;
+      if (phase->type(shift)->isa_integer(bt) == nullptr) {
+        return false;
+      }
     }
   }
   if (shift->Opcode() != Op_LShift(shift_bt)) {

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1923,12 +1923,17 @@ bool MulNode::AndIL_shift_and_mask_is_always_zero(PhaseGVN* phase, Node* shift, 
   if (mask == nullptr || shift == nullptr) {
     return false;
   }
+  const TypeInteger* mask_t = phase->type(mask)->isa_integer(bt);
+  const TypeInteger* shift_t = phase->type(shift)->isa_integer(bt);
+  if (mask_t == nullptr || shift_t == nullptr) {
+    return false;
+  }
   shift = shift->uncast();
   if (shift == nullptr) {
     return false;
   }
-  const TypeInteger* mask_t = phase->type(mask)->isa_integer(bt);
-  const TypeInteger* shift_t = phase->type(shift)->isa_integer(bt);
+  mask_t = phase->type(mask)->isa_integer(bt);
+  shift_t = phase->type(shift)->isa_integer(bt);
   if (mask_t == nullptr || shift_t == nullptr) {
     return false;
   }


### PR DESCRIPTION
**The Problem**

During CCP, we get to a state like that:
```
x (int:1)   Phi (int:4)
|           |
|     +-----+
|     |
LShiftI (int:16)
  |
CastII (top)       ConI (int:3)
  |                 |
  +----+  +---------+
       |  |
       AndI
```

We call `AddINode::Value` during CCP, and in `MulNode::AndIL_shift_and_mask_is_always_zero` we `uncast` both inputs, which leaves us with `LShiftI` and `ConI` as the "true" inputs. They both have non-top types, and so we determine that this `AndI-LShiftI` combination always leads to `zero`: The `Phi` has a constant type (`int:4`). So this leaves the lowest 4 bits zero after the `LShiftI`. Then and-ing that with `int:3` means we extract the lowest 3 bits that are zero. So the result is provably always zero - that is the idea.

Then, we have some type updates (here of `x` and `Phi` and `LShiftI`), and the graph looks like this:
```
x (int)    Phi (int:0..4)
|           |
|     +-----+
|     |
LShiftI (int)
  |
CastII (top)       ConI (int:3)
  |                 |
  +----+  +---------+
       |  |
       AndI
```

This leads to `shift2` failing to have constant type:
https://github.com/openjdk/jdk/blob/a6b72f56f56b4f33ac163e90b115d79b2b844999/src/hotspot/share/opto/mulnode.cpp#L1964-L1967

And with that, we fall back to `MulNode::Value`:
https://github.com/openjdk/jdk/blob/a6b72f56f56b4f33ac163e90b115d79b2b844999/src/hotspot/share/opto/mulnode.cpp#L559-L566

In `MulNode::Value` we detect that the `CastII` has type `top`, and return `top` for `AndI`.

CCP expects the types to become more wide over time, so going from `int:0` to `top` is the wrong direction.

**Solution**

The problem is with the relatively rare `CastII` still being `top` - this seems to be very rare. But the new regression test `TestShiftCastAndNotification.java` seems to create exactly that case, in combination with `-XX:StressCCP`.

We should guard against `top` in one of the `AndI` inputs inside `MulNode::AndIL_shift_and_mask_is_always_zero`. This will prevent it from detecting the zero-case, untill `MulNode::Value` would get a chance to compute a non-top type.

**Argument for Solution**

Is there still a threat from `MulNode::AndIL_shift_and_mask_is_always_zero` computing a zero first, and `MulNode::Value` a type that does not include zero after ward?
As types only widen during CCP, having a zero first means that all inputs now are non-top - in fact they are all `T_INT`. Since types only widen in the inputs, and a `zero` combination was possible first, it must also be possible later.

**Testing**

It used to reproduce with `-XX:RepeatCompilation=1000` very quickly, by restricting to that single failing method.
This seems fixed now, I verified it locally.

Passes up to tier5 and stress testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307619](https://bugs.openjdk.org/browse/JDK-8307619): C2 failed: Not monotonic (AndI CastII LShiftI) in TestShiftCastAndNotification.java


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13908/head:pull/13908` \
`$ git checkout pull/13908`

Update a local copy of the PR: \
`$ git checkout pull/13908` \
`$ git pull https://git.openjdk.org/jdk.git pull/13908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13908`

View PR using the GUI difftool: \
`$ git pr show -t 13908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13908.diff">https://git.openjdk.org/jdk/pull/13908.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13908#issuecomment-1544169606)