### PR TITLE
8307626: java/net/httpclient/FlowAdapter* tests should close the HttpClient instances

### DIFF
--- a/test/jdk/java/net/httpclient/FlowAdapterPublisherTest.java
+++ b/test/jdk/java/net/httpclient/FlowAdapterPublisherTest.java
@@ -24,9 +24,9 @@
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.http.HttpClient.Builder;
+import java.net.http.HttpClient.Version;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.util.Arrays;
@@ -35,18 +35,11 @@ import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
-import jdk.httpclient.test.lib.http2.Http2TestExchange;
-import jdk.httpclient.test.lib.http2.Http2Handler;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -66,18 +59,18 @@ import static org.testng.Assert.fail;
  * @test
  * @summary Basic tests for Flow adapter Publishers
  * @library /test/lib /test/jdk/java/net/httpclient/lib
- * @build jdk.httpclient.test.lib.http2.Http2TestServer
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm FlowAdapterPublisherTest
  */
 
-public class FlowAdapterPublisherTest {
+public class FlowAdapterPublisherTest implements HttpServerAdapters {
 
     SSLContext sslContext;
-    HttpServer httpTestServer;         // HTTP/1.1    [ 4 servers ]
-    HttpsServer httpsTestServer;       // HTTPS/1.1
-    Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
-    Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
+    HttpTestServer httpTestServer;     // HTTP/1.1    [ 4 servers ]
+    HttpTestServer httpsTestServer;    // HTTPS/1.1
+    HttpTestServer http2TestServer;    // HTTP/2 ( h2c )
+    HttpTestServer https2TestServer;   // HTTP/2 ( h2  )
     String httpURI;
     String httpsURI;
     String http2URI;
@@ -96,6 +89,23 @@ public class FlowAdapterPublisherTest {
     static final Class<NullPointerException> NPE = NullPointerException.class;
     static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
 
+    private static Version version(String uri) {
+        if (uri.contains("/http1/")) return Version.HTTP_1_1;
+        if (uri.contains("/https1/")) return Version.HTTP_1_1;
+        if (uri.contains("/http2/")) return Version.HTTP_2;
+        if (uri.contains("/https2/")) return Version.HTTP_2;
+        return null;
+    }
+
+    private HttpClient newHttpClient(String uri) {
+        var builder = HttpClient.newBuilder();
+        return builder.sslContext(sslContext).proxy(Builder.NO_PROXY).build();
+    }
+
+    private HttpRequest.Builder newRequestBuilder(String uri) {
+        return HttpRequest.newBuilder(URI.create(uri));
+    }
+
     @Test
     public void testAPIExceptions() {
         assertThrows(NPE, () -> fromPublisher(null));
@@ -111,67 +121,75 @@ public class FlowAdapterPublisherTest {
     //  Flow.Publisher<ByteBuffer>
 
     @Test(dataProvider = "uris")
-    void testByteBufferPublisherUnknownLength(String url) {
+    void testByteBufferPublisherUnknownLength(String uri) {
         String[] body = new String[] { "You know ", "it's summer ", "in Ireland ",
                 "when the ", "rain gets ", "warmer." };
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(fromPublisher(new BBPublisher(body))).build();
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(fromPublisher(new BBPublisher(body))).build();
 
-        HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, Arrays.stream(body).collect(joining()));
+            HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, Arrays.stream(body).collect(joining()));
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testByteBufferPublisherFixedLength(String url) {
+    void testByteBufferPublisherFixedLength(String uri) {
         String[] body = new String[] { "You know ", "it's summer ", "in Ireland ",
                 "when the ", "rain gets ", "warmer." };
         int cl = Arrays.stream(body).mapToInt(String::length).sum();
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(fromPublisher(new BBPublisher(body), cl)).build();
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(fromPublisher(new BBPublisher(body), cl)).build();
 
-        HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, Arrays.stream(body).collect(joining()));
+            HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, Arrays.stream(body).collect(joining()));
+        }
     }
 
     // Flow.Publisher<MappedByteBuffer>
 
     @Test(dataProvider = "uris")
-    void testMappedByteBufferPublisherUnknownLength(String url) {
+    void testMappedByteBufferPublisherUnknownLength(String uri) {
         String[] body = new String[] { "God invented ", "whiskey to ", "keep the ",
                 "Irish from ", "ruling the ", "world." };
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(fromPublisher(new MBBPublisher(body))).build();
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(fromPublisher(new MBBPublisher(body))).build();
 
-        HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, Arrays.stream(body).collect(joining()));
+            HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, Arrays.stream(body).collect(joining()));
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testMappedByteBufferPublisherFixedLength(String url) {
+    void testMappedByteBufferPublisherFixedLength(String uri) {
         String[] body = new String[] { "God invented ", "whiskey to ", "keep the ",
                 "Irish from ", "ruling the ", "world." };
         int cl = Arrays.stream(body).mapToInt(String::length).sum();
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(fromPublisher(new MBBPublisher(body), cl)).build();
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(fromPublisher(new MBBPublisher(body), cl)).build();
 
-        HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, Arrays.stream(body).collect(joining()));
+            HttpResponse<String> response = client.sendAsync(request, ofString(UTF_8)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, Arrays.stream(body).collect(joining()));
+        }
     }
 
     // The following two tests depend on Exception detail messages, which is
@@ -179,36 +197,38 @@ public class FlowAdapterPublisherTest {
     // updated if the exception message is updated.
 
     @Test(dataProvider = "uris")
-    void testPublishTooFew(String url) throws InterruptedException {
+    void testPublishTooFew(String uri) throws InterruptedException {
         String[] body = new String[] { "You know ", "it's summer ", "in Ireland ",
                 "when the ", "rain gets ", "warmer." };
         int cl = Arrays.stream(body).mapToInt(String::length).sum() + 1; // length + 1
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(fromPublisher(new BBPublisher(body), cl)).build();
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(fromPublisher(new BBPublisher(body), cl)).build();
 
-        try {
-            HttpResponse<String> response = client.send(request, ofString(UTF_8));
-            fail("Unexpected response: " + response);
-        } catch (IOException expected) {
-            assertMessage(expected, "Too few bytes returned");
+            try {
+                HttpResponse<String> response = client.send(request, ofString(UTF_8));
+                fail("Unexpected response: " + response);
+            } catch (IOException expected) {
+                assertMessage(expected, "Too few bytes returned");
+            }
         }
     }
 
     @Test(dataProvider = "uris")
-    void testPublishTooMany(String url) throws InterruptedException {
+    void testPublishTooMany(String uri) throws InterruptedException {
         String[] body = new String[] { "You know ", "it's summer ", "in Ireland ",
                 "when the ", "rain gets ", "warmer." };
         int cl = Arrays.stream(body).mapToInt(String::length).sum() - 1; // length - 1
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(fromPublisher(new BBPublisher(body), cl)).build();
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(fromPublisher(new BBPublisher(body), cl)).build();
 
-        try {
-            HttpResponse<String> response = client.send(request, ofString(UTF_8));
-            fail("Unexpected response: " + response);
-        } catch (IOException expected) {
-            assertMessage(expected, "Too many bytes in request body");
+            try {
+                HttpResponse<String> response = client.send(request, ofString(UTF_8));
+                fail("Unexpected response: " + response);
+            } catch (IOException expected) {
+                assertMessage(expected, "Too many bytes in request body");
+            }
         }
     }
 
@@ -332,33 +352,26 @@ public class FlowAdapterPublisherTest {
         }
     }
 
-    static String serverAuthority(HttpServer server) {
-        return InetAddress.getLoopbackAddress().getHostName() + ":"
-                + server.getAddress().getPort();
-    }
-
     @BeforeTest
     public void setup() throws Exception {
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(),0);
-        httpTestServer = HttpServer.create(sa, 0);
-        httpTestServer.createContext("/http1/echo", new Http1EchoHandler());
-        httpURI = "http://" + serverAuthority(httpTestServer) + "/http1/echo";
+        httpTestServer = HttpTestServer.create(Version.HTTP_1_1);
+        httpTestServer.addHandler(new HttpEchoHandler(), "/http1/echo");
+        httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer.createContext("/https1/echo", new Http1EchoHandler());
-        httpsURI = "https://" + serverAuthority(httpsTestServer) + "/https1/echo";
+        httpsTestServer = HttpTestServer.create(Version.HTTP_1_1, sslContext);
+        httpsTestServer.addHandler(new HttpEchoHandler(), "/https1/echo");
+        httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = new Http2TestServer("localhost", false, 0);
-        http2TestServer.addHandler(new Http2EchoHandler(), "/http2/echo");
+        http2TestServer = HttpTestServer.create(Version.HTTP_2);
+        http2TestServer.addHandler(new HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = new Http2TestServer("localhost", true, sslContext);
-        https2TestServer.addHandler(new Http2EchoHandler(), "/https2/echo");
+        https2TestServer = HttpTestServer.create(Version.HTTP_2, sslContext);
+        https2TestServer.addHandler(new HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 
         httpTestServer.start();
@@ -369,27 +382,15 @@ public class FlowAdapterPublisherTest {
 
     @AfterTest
     public void teardown() throws Exception {
-        httpTestServer.stop(0);
-        httpsTestServer.stop(0);
+        httpTestServer.stop();
+        httpsTestServer.stop();
         http2TestServer.stop();
         https2TestServer.stop();
     }
 
-    static class Http1EchoHandler implements HttpHandler {
+    static class HttpEchoHandler implements HttpTestHandler {
         @Override
-        public void handle(HttpExchange t) throws IOException {
-            try (InputStream is = t.getRequestBody();
-                 OutputStream os = t.getResponseBody()) {
-                byte[] bytes = is.readAllBytes();
-                t.sendResponseHeaders(200, bytes.length);
-                os.write(bytes);
-            }
-        }
-    }
-
-    static class Http2EchoHandler implements Http2Handler {
-        @Override
-        public void handle(Http2TestExchange t) throws IOException {
+        public void handle(HttpTestExchange t) throws IOException {
             try (InputStream is = t.getRequestBody();
                  OutputStream os = t.getResponseBody()) {
                 byte[] bytes = is.readAllBytes();

--- a/test/jdk/java/net/httpclient/FlowAdapterSubscriberTest.java
+++ b/test/jdk/java/net/httpclient/FlowAdapterSubscriberTest.java
@@ -26,32 +26,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.http.HttpClient.Builder;
+import java.net.http.HttpClient.Version;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscribers;
+
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
-import jdk.httpclient.test.lib.http2.Http2TestExchange;
-import jdk.httpclient.test.lib.http2.Http2Handler;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -67,21 +59,23 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @summary Basic tests for Flow adapter Subscribers
  * @library /test/lib /test/jdk/java/net/httpclient/lib
- * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm -Djdk.internal.httpclient.debug=true FlowAdapterSubscriberTest
  */
 
-public class FlowAdapterSubscriberTest {
+public class FlowAdapterSubscriberTest implements HttpServerAdapters {
 
     SSLContext sslContext;
-    HttpServer httpTestServer;         // HTTP/1.1    [ 4 servers ]
-    HttpsServer httpsTestServer;       // HTTPS/1.1
-    Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
-    Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
+    HttpTestServer httpTestServer;     // HTTP/1.1    [ 4 servers ]
+    HttpTestServer httpsTestServer;    // HTTPS/1.1
+    HttpTestServer http2TestServer;    // HTTP/2 ( h2c )
+    HttpTestServer https2TestServer;   // HTTP/2 ( h2  )
     String httpURI;
     String httpsURI;
     String http2URI;
     String https2URI;
+
     static final long start = System.nanoTime();
     public static String now() {
         long now = System.nanoTime() - start;
@@ -102,6 +96,23 @@ public class FlowAdapterSubscriberTest {
     }
 
     static final Class<NullPointerException> NPE = NullPointerException.class;
+
+    private static Version version(String uri) {
+        if (uri.contains("/http1/")) return Version.HTTP_1_1;
+        if (uri.contains("/https1/")) return Version.HTTP_1_1;
+        if (uri.contains("/http2/")) return Version.HTTP_2;
+        if (uri.contains("/https2/")) return Version.HTTP_2;
+        return null;
+    }
+
+    private HttpClient newHttpClient(String uri) {
+        var builder = HttpClient.newBuilder();
+        return builder.sslContext(sslContext).proxy(Builder.NO_PROXY).build();
+    }
+
+    private HttpRequest.Builder newRequestBuilder(String uri) {
+        return HttpRequest.newBuilder(URI.create(uri));
+    }
 
     @Test
     public void testNull() {
@@ -125,300 +136,335 @@ public class FlowAdapterSubscriberTest {
     // List<ByteBuffer>
 
     @Test(dataProvider = "uris")
-    void testListWithFinisher(String url) {
-        System.out.printf(now() + "testListWithFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
+    void testListWithFinisher(String uri) {
+        System.out.printf(now() + "testListWithFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
 
-        ListSubscriber subscriber = new ListSubscriber();
-        HttpResponse<String> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber, Supplier::get)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "May the luck of the Irish be with you!");
+            ListSubscriber subscriber = new ListSubscriber();
+            HttpResponse<String> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber, Supplier::get)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "May the luck of the Irish be with you!");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testListWithoutFinisher(String url) {
-        System.out.printf(now() + "testListWithoutFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
+    void testListWithoutFinisher(String uri) {
+        System.out.printf(now() + "testListWithoutFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
 
-        ListSubscriber subscriber = new ListSubscriber();
-        HttpResponse<Void> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber)).join();
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "May the luck of the Irish be with you!");
+            ListSubscriber subscriber = new ListSubscriber();
+            HttpResponse<Void> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber)).join();
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "May the luck of the Irish be with you!");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testListWithFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testListWithFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
+    void testListWithFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testListWithFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
 
-        ListSubscriber subscriber = new ListSubscriber();
-        HttpResponse<String> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber, Supplier::get));
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "May the luck of the Irish be with you!");
+            ListSubscriber subscriber = new ListSubscriber();
+            HttpResponse<String> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber, Supplier::get));
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "May the luck of the Irish be with you!");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testListWithoutFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testListWithoutFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
+    void testListWithoutFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testListWithoutFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the luck of the Irish be with you!")).build();
 
-        ListSubscriber subscriber = new ListSubscriber();
-        HttpResponse<Void> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber));
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "May the luck of the Irish be with you!");
+            ListSubscriber subscriber = new ListSubscriber();
+            HttpResponse<Void> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber));
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "May the luck of the Irish be with you!");
+        }
     }
 
     // Collection<ByteBuffer>
 
     @Test(dataProvider = "uris")
-    void testCollectionWithFinisher(String url) {
-        System.out.printf(now() + "testCollectionWithFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("What's the craic?")).build();
+    void testCollectionWithFinisher(String uri) {
+        System.out.printf(now() + "testCollectionWithFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("What's the craic?")).build();
 
-        CollectionSubscriber subscriber = new CollectionSubscriber();
-        HttpResponse<String> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber, CollectionSubscriber::get)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "What's the craic?");
+            CollectionSubscriber subscriber = new CollectionSubscriber();
+            HttpResponse<String> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber, CollectionSubscriber::get)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "What's the craic?");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testCollectionWithoutFinisher(String url) {
-        System.out.printf(now() + "testCollectionWithoutFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("What's the craic?")).build();
+    void testCollectionWithoutFinisher(String uri) {
+        System.out.printf(now() + "testCollectionWithoutFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("What's the craic?")).build();
 
-        CollectionSubscriber subscriber = new CollectionSubscriber();
-        HttpResponse<Void> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber)).join();
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "What's the craic?");
+            CollectionSubscriber subscriber = new CollectionSubscriber();
+            HttpResponse<Void> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber)).join();
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "What's the craic?");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testCollectionWithFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testCollectionWithFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("What's the craic?")).build();
+    void testCollectionWithFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testCollectionWithFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("What's the craic?")).build();
 
-        CollectionSubscriber subscriber = new CollectionSubscriber();
-        HttpResponse<String> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber, CollectionSubscriber::get));
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "What's the craic?");
+            CollectionSubscriber subscriber = new CollectionSubscriber();
+            HttpResponse<String> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber, CollectionSubscriber::get));
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "What's the craic?");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testCollectionWithoutFinisheBlocking(String url) throws Exception {
-        System.out.printf(now() + "testCollectionWithoutFinisheBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("What's the craic?")).build();
+    void testCollectionWithoutFinisheBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testCollectionWithoutFinisheBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("What's the craic?")).build();
 
-        CollectionSubscriber subscriber = new CollectionSubscriber();
-        HttpResponse<Void> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber));
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "What's the craic?");
+            CollectionSubscriber subscriber = new CollectionSubscriber();
+            HttpResponse<Void> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber));
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "What's the craic?");
+        }
     }
 
     // Iterable<ByteBuffer>
 
     @Test(dataProvider = "uris")
-    void testIterableWithFinisher(String url) {
-        System.out.printf(now() + "testIterableWithFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
+    void testIterableWithFinisher(String uri) {
+        System.out.printf(now() + "testIterableWithFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
 
-        IterableSubscriber subscriber = new IterableSubscriber();
-        HttpResponse<String> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber, Supplier::get)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "We're sucking diesel now!");
+            IterableSubscriber subscriber = new IterableSubscriber();
+            HttpResponse<String> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber, Supplier::get)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "We're sucking diesel now!");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testIterableWithoutFinisher(String url) {
-        System.out.printf(now() + "testIterableWithoutFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
+    void testIterableWithoutFinisher(String uri) {
+        System.out.printf(now() + "testIterableWithoutFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
 
-        IterableSubscriber subscriber = new IterableSubscriber();
-        HttpResponse<Void> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber)).join();
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "We're sucking diesel now!");
+            IterableSubscriber subscriber = new IterableSubscriber();
+            HttpResponse<Void> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber)).join();
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "We're sucking diesel now!");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testIterableWithFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testIterableWithFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
+    void testIterableWithFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testIterableWithFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
 
-        IterableSubscriber subscriber = new IterableSubscriber();
-        HttpResponse<String> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber, Supplier::get));
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "We're sucking diesel now!");
+            IterableSubscriber subscriber = new IterableSubscriber();
+            HttpResponse<String> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber, Supplier::get));
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "We're sucking diesel now!");
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testIterableWithoutFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testIterableWithoutFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
+    void testIterableWithoutFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testIterableWithoutFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
 
-        IterableSubscriber subscriber = new IterableSubscriber();
-        HttpResponse<Void> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber));
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertEquals(text, "We're sucking diesel now!");
+            IterableSubscriber subscriber = new IterableSubscriber();
+            HttpResponse<Void> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber));
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertEquals(text, "We're sucking diesel now!");
+        }
     }
 
     // Subscriber<Object>
 
     @Test(dataProvider = "uris")
-    void testObjectWithFinisher(String url) {
-        System.out.printf(now() + "testObjectWithFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
+    void testObjectWithFinisher(String uri) {
+        System.out.printf(now() + "testObjectWithFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
 
-        ObjectSubscriber subscriber = new ObjectSubscriber();
-        HttpResponse<String> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber, ObjectSubscriber::get)).join();
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertTrue(text.length() != 0);  // what else can be asserted!
+            ObjectSubscriber subscriber = new ObjectSubscriber();
+            HttpResponse<String> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber, ObjectSubscriber::get)).join();
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertTrue(text.length() != 0);  // what else can be asserted!
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testObjectWithoutFinisher(String url) {
-        System.out.printf(now() + "testObjectWithoutFinisher(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
+    void testObjectWithoutFinisher(String uri) {
+        System.out.printf(now() + "testObjectWithoutFinisher(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
 
-        ObjectSubscriber subscriber = new ObjectSubscriber();
-        HttpResponse<Void> response = client.sendAsync(request,
-                BodyHandlers.fromSubscriber(subscriber)).join();
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertTrue(text.length() != 0);  // what else can be asserted!
+            ObjectSubscriber subscriber = new ObjectSubscriber();
+            HttpResponse<Void> response = client.sendAsync(request,
+                    BodyHandlers.fromSubscriber(subscriber)).join();
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertTrue(text.length() != 0);  // what else can be asserted!
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testObjectWithFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testObjectWithFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
+    void testObjectWithFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testObjectWithFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
 
-        ObjectSubscriber subscriber = new ObjectSubscriber();
-        HttpResponse<String> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber, ObjectSubscriber::get));
-        String text = response.body();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertTrue(text.length() != 0);  // what else can be asserted!
+            ObjectSubscriber subscriber = new ObjectSubscriber();
+            HttpResponse<String> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber, ObjectSubscriber::get));
+            String text = response.body();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertTrue(text.length() != 0);  // what else can be asserted!
+        }
     }
 
     @Test(dataProvider = "uris")
-    void testObjectWithoutFinisherBlocking(String url) throws Exception {
-        System.out.printf(now() + "testObjectWithoutFinisherBlocking(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
+    void testObjectWithoutFinisherBlocking(String uri) throws Exception {
+        System.out.printf(now() + "testObjectWithoutFinisherBlocking(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
 
-        ObjectSubscriber subscriber = new ObjectSubscriber();
-        HttpResponse<Void> response = client.send(request,
-                BodyHandlers.fromSubscriber(subscriber));
-        String text = subscriber.get();
-        System.out.println(text);
-        assertEquals(response.statusCode(), 200);
-        assertTrue(text.length() != 0);  // what else can be asserted!
+            ObjectSubscriber subscriber = new ObjectSubscriber();
+            HttpResponse<Void> response = client.send(request,
+                    BodyHandlers.fromSubscriber(subscriber));
+            String text = subscriber.get();
+            System.out.println(text);
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.version(), version(uri));
+            assertTrue(text.length() != 0);  // what else can be asserted!
+        }
     }
 
 
     // -- mapping using convenience handlers
 
     @Test(dataProvider = "uris")
-    void mappingFromByteArray(String url) throws Exception {
-        System.out.printf(now() + "mappingFromByteArray(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
+    void mappingFromByteArray(String uri) throws Exception {
+        System.out.printf(now() + "mappingFromByteArray(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("We're sucking diesel now!")).build();
 
-        client.sendAsync(request, BodyHandlers.fromSubscriber(BodySubscribers.ofByteArray(),
-                    bas -> new String(bas.getBody().toCompletableFuture().join(), UTF_8)))
-                .thenApply(FlowAdapterSubscriberTest::assert200ResponseCode)
-                .thenApply(HttpResponse::body)
-                .thenAccept(body -> assertEquals(body, "We're sucking diesel now!"))
-                .join();
+            client.sendAsync(request, BodyHandlers.fromSubscriber(BodySubscribers.ofByteArray(),
+                            bas -> new String(bas.getBody().toCompletableFuture().join(), UTF_8)))
+                    .thenApply(FlowAdapterSubscriberTest::assert200ResponseCode)
+                    .thenApply(HttpResponse::body)
+                    .thenAccept(body -> assertEquals(body, "We're sucking diesel now!"))
+                    .join();
+        }
     }
 
     @Test(dataProvider = "uris")
-    void mappingFromInputStream(String url) throws Exception {
-        System.out.printf(now() + "mappingFromInputStream(%s) starting%n", url);
-        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
+    void mappingFromInputStream(String uri) throws Exception {
+        System.out.printf(now() + "mappingFromInputStream(%s) starting%n", uri);
+        try (HttpClient client = newHttpClient(uri)) {
+            HttpRequest request = newRequestBuilder(uri)
+                    .POST(BodyPublishers.ofString("May the wind always be at your back.")).build();
 
-        client.sendAsync(request, BodyHandlers.fromSubscriber(BodySubscribers.ofInputStream(),
-                    ins -> {
-                        InputStream is = ins.getBody().toCompletableFuture().join();
-                        return new String(uncheckedReadAllBytes(is), UTF_8); } ))
-                .thenApply(FlowAdapterSubscriberTest::assert200ResponseCode)
-                .thenApply(HttpResponse::body)
-                .thenAccept(body -> assertEquals(body, "May the wind always be at your back."))
-                .join();
+            client.sendAsync(request, BodyHandlers.fromSubscriber(BodySubscribers.ofInputStream(),
+                            ins -> {
+                                InputStream is = ins.getBody().toCompletableFuture().join();
+                                return new String(uncheckedReadAllBytes(is), UTF_8);
+                            }))
+                    .thenApply(FlowAdapterSubscriberTest::assert200ResponseCode)
+                    .thenApply(HttpResponse::body)
+                    .thenAccept(body -> assertEquals(body, "May the wind always be at your back."))
+                    .join();
+        }
     }
 
     /** An abstract Subscriber that converts all received data into a String. */
@@ -503,12 +549,8 @@ public class FlowAdapterSubscriberTest {
 
     static final <T> HttpResponse<T> assert200ResponseCode(HttpResponse<T> response) {
         assertEquals(response.statusCode(), 200);
+        assertEquals(response.version(), version(response.request().uri().toString()));
         return response;
-    }
-
-    static String serverAuthority(HttpServer server) {
-        return InetAddress.getLoopbackAddress().getHostName() + ":"
-                + server.getAddress().getPort();
     }
 
     @BeforeTest
@@ -517,22 +559,20 @@ public class FlowAdapterSubscriberTest {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpServer.create(sa, 0);
-        httpTestServer.createContext("/http1/echo", new Http1EchoHandler());
-        httpURI = "http://" + serverAuthority(httpTestServer) + "/http1/echo";
+        httpTestServer = HttpTestServer.create(Version.HTTP_1_1);
+        httpTestServer.addHandler(new HttpEchoHandler(), "/http1/echo");
+        httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer.createContext("/https1/echo", new Http1EchoHandler());
-        httpsURI = "https://" + serverAuthority(httpsTestServer) + "/https1/echo";
+        httpsTestServer = HttpTestServer.create(Version.HTTP_1_1, sslContext);
+        httpsTestServer.addHandler(new HttpEchoHandler(), "/https1/echo");
+        httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = new Http2TestServer("localhost", false, 0);
-        http2TestServer.addHandler(new Http2EchoHandler(), "/http2/echo");
+        http2TestServer = HttpTestServer.create(Version.HTTP_2);
+        http2TestServer.addHandler(new HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = new Http2TestServer("localhost", true, sslContext);
-        https2TestServer.addHandler(new Http2EchoHandler(), "/https2/echo");
+        https2TestServer = HttpTestServer.create(Version.HTTP_2, sslContext);
+        https2TestServer.addHandler(new HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 
         httpTestServer.start();
@@ -543,27 +583,15 @@ public class FlowAdapterSubscriberTest {
 
     @AfterTest
     public void teardown() throws Exception {
-        httpTestServer.stop(0);
-        httpsTestServer.stop(0);
+        httpTestServer.stop();
+        httpsTestServer.stop();
         http2TestServer.stop();
         https2TestServer.stop();
     }
 
-    static class Http1EchoHandler implements HttpHandler {
+    static class HttpEchoHandler implements HttpTestHandler {
         @Override
-        public void handle(HttpExchange t) throws IOException {
-            try (InputStream is = t.getRequestBody();
-                 OutputStream os = t.getResponseBody()) {
-                byte[] bytes = is.readAllBytes();
-                t.sendResponseHeaders(200, bytes.length);
-                os.write(bytes);
-            }
-        }
-    }
-
-    static class Http2EchoHandler implements Http2Handler {
-        @Override
-        public void handle(Http2TestExchange t) throws IOException {
+        public void handle(HttpTestExchange t) throws IOException {
             try (InputStream is = t.getRequestBody();
                  OutputStream os = t.getResponseBody()) {
                 byte[] bytes = is.readAllBytes();


### PR DESCRIPTION
java/net/httpclient/FlowAdapterPublisherTest.java and java/net/httpclient/FlowAdapterSubscriberTest.java create one HttpClient instance per test method. The test should use try-with-resources to close the client instances.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307626](https://bugs.openjdk.org/browse/JDK-8307626): java/net/httpclient/FlowAdapter* tests should close the HttpClient instances


### Reviewers
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13909/head:pull/13909` \
`$ git checkout pull/13909`

Update a local copy of the PR: \
`$ git checkout pull/13909` \
`$ git pull https://git.openjdk.org/jdk.git pull/13909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13909`

View PR using the GUI difftool: \
`$ git pr show -t 13909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13909.diff">https://git.openjdk.org/jdk/pull/13909.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13909#issuecomment-1542497200)