### PR TITLE
8281715: Move "base CDS archive not loaded" tests to SharedArchiveFileOption.java

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -218,32 +218,5 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         runTwo(nonExistBase, nonExistTop,
                appJar, mainClass, isAuto ? 0 : 1,
                "Specified shared archive not found (" + nonExistBase + ")");
-
-        // following two tests:
-        //   -Xshare:auto -XX:SharedArchiveFile=top.jsa, but base does not exist.
-
-      if (!isUseSharedSpacesDisabled()) {
-        new File(baseArchiveName).delete();
-
-        startTest("11. -XX:+AutoCreateSharedArchive -XX:SharedArchiveFile=" + topArchiveName);
-        run(topArchiveName,
-            "-Xshare:auto",
-            "-XX:+AutoCreateSharedArchive",
-            "-cp",
-            appJar, mainClass)
-            .assertNormalExit(output -> {
-                output.shouldContain("warning: -XX:+AutoCreateSharedArchive is unsupported when base CDS archive is not loaded");
-            });
-
-        startTest("12. -XX:SharedArchiveFile=" + topArchiveName + " -XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"));
-        run(topArchiveName,
-            "-Xshare:auto",
-            "-XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"),
-            "-cp",
-            appJar, mainClass)
-            .assertNormalExit(output -> {
-                output.shouldContain("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
-            });
-      }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
@@ -228,6 +228,30 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
                   "-Xlog:cds",
                   "-cp", appJar, mainClass)
                  .assertAbnormalExit("Cannot use the following option when dumping the shared archive: --patch-module");
+
+            // following two tests:
+            //   -Xshare:auto -XX:SharedArchiveFile=top.jsa, but base does not exist.
+            if (!isUseSharedSpacesDisabled()) {
+                new File(baseArchiveName).delete();
+                testcase("Archive not loaded -XX:+AutoCreateSharedArchive -XX:SharedArchiveFile=" + topArchiveName);
+                run(topArchiveName,
+                    "-Xshare:auto",
+                    "-XX:+AutoCreateSharedArchive",
+                    "-cp",
+                    appJar, mainClass)
+                    .assertNormalExit(output -> {
+                        output.shouldContain("warning: -XX:+AutoCreateSharedArchive is unsupported when base CDS archive is not loaded");
+                    });
+                testcase("Archive not loaded -XX:SharedArchiveFile=" + topArchiveName + " -XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"));
+                run(topArchiveName,
+                    "-Xshare:auto",
+                    "-XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"),
+                    "-cp",
+                    appJar, mainClass)
+                    .assertNormalExit(output -> {
+                        output.shouldContain(ERROR);
+                    });
+            }
         }
 
         {


### PR DESCRIPTION
ArchiveConsistency.java is meant to check for the corruption of a CDS archive file, yet it checks for "warning: -XX:+AutoCreateSharedArchive is unsupported when base CDS archive is not loaded." These test cases should be moved to SharedArchiveFileOption.java instead. Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281715](https://bugs.openjdk.org/browse/JDK-8281715): Move "base CDS archive not loaded" tests to SharedArchiveFileOption.java


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13911/head:pull/13911` \
`$ git checkout pull/13911`

Update a local copy of the PR: \
`$ git checkout pull/13911` \
`$ git pull https://git.openjdk.org/jdk.git pull/13911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13911`

View PR using the GUI difftool: \
`$ git pr show -t 13911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13911.diff">https://git.openjdk.org/jdk/pull/13911.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13911#issuecomment-1542786210)