### PR TITLE
8307850: update for deprecated sprintf for jdk.jdi

### DIFF
--- a/src/jdk.jdi/share/native/libdt_shmem/SharedMemoryTransport.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/SharedMemoryTransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,9 +64,9 @@ throwShmemException(JNIEnv *env, char *message, jint errorCode)
     char buf[255];
 
     if (shmemBase_getlasterror(msg, sizeof(msg)) == SYS_OK) {
-        sprintf(buf, "%s: %s\n", message, msg);
+        snprintf(buf, sizeof(buf), "%s: %s\n", message, msg);
     } else {
-        sprintf(buf, "%s, error code = %d", message, errorCode);
+        snprintf(buf, sizeof(buf), "%s, error code = %d", message, errorCode);
     }
     throwException(env, "java/io/IOException", buf);
 }

--- a/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
@@ -241,7 +241,7 @@ createWithGeneratedName(char *prefix, char *nameBuffer, CreateFunc func, void *a
         strcpy(nameBuffer, prefix);
         if (i > 0) {
             char buf[10];
-            sprintf(buf, ".%d", i+1);
+            snprintf(buf, sizeof(buf), ".%d", i+1);
             strcat(nameBuffer, buf);
         }
         error = func(nameBuffer, arg);
@@ -430,14 +430,14 @@ createStream(char *name, Stream *stream)
     jint error;
     char objectName[MAX_IPC_NAME];
 
-    sprintf(objectName, "%s.mutex", name);
+    snprintf(objectName, sizeof(objectName), "%s.mutex", name);
     error = createWithGeneratedName(objectName, stream->shared->mutexName,
                                     createMutex, &stream->mutex);
     if (error != SYS_OK) {
         return error;
     }
 
-    sprintf(objectName, "%s.hasData", name);
+    snprintf(objectName, sizeof(objectName), "%s.hasData", name);
     error = createWithGeneratedName(objectName, stream->shared->hasDataEventName,
                                     createEvent, &stream->hasData);
     if (error != SYS_OK) {
@@ -445,7 +445,7 @@ createStream(char *name, Stream *stream)
         return error;
     }
 
-    sprintf(objectName, "%s.hasSpace", name);
+    snprintf(objectName, sizeof(objectName), "%s.hasSpace", name);
     error = createWithGeneratedName(objectName, stream->shared->hasSpaceEventName,
                                     createEvent, &stream->hasSpace);
     if (error != SYS_OK) {
@@ -568,7 +568,7 @@ openConnection(SharedMemoryTransport *transport, jlong otherPID,
         return SYS_NOMEM;
     }
 
-    sprintf(connection->name, "%s.%" PRId64, transport->name, sysProcessGetID());
+    snprintf(connection->name, sizeof(connection->name), "%s.%" PRId64, transport->name, sysProcessGetID());
     error = sysSharedMemOpen(connection->name, &connection->sharedMemory,
                              &connection->shared);
     if (error != SYS_OK) {
@@ -636,7 +636,7 @@ createConnection(SharedMemoryTransport *transport, jlong otherPID,
         return SYS_NOMEM;
     }
 
-    sprintf(connection->name, "%s.%" PRId64, transport->name, otherPID);
+    snprintf(connection->name, sizeof(connection->name), "%s.%" PRId64, transport->name, otherPID);
     error = sysSharedMemCreate(connection->name, sizeof(SharedMemory),
                                &connection->sharedMemory, &connection->shared);
     if (error != SYS_OK) {
@@ -735,7 +735,7 @@ openTransport(const char *address, SharedMemoryTransport **transportPtr)
 
     if (strlen(address) >= MAX_IPC_PREFIX) {
         char buf[128];
-        sprintf(buf, "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
+        snprintf(buf, sizeof(buf), "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
         setLastErrorMsg(buf);
         closeTransport(transport);
         return SYS_ERR;
@@ -799,7 +799,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
     } else {
         if (strlen(address) >= MAX_IPC_PREFIX) {
             char buf[128];
-            sprintf(buf, "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
+            snprintf(buf, sizeof(buf), "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
             setLastErrorMsg(buf);
             closeTransport(transport);
             return SYS_ERR;
@@ -817,7 +817,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
     memset(transport->shared, 0, sizeof(SharedListener));
     transport->shared->acceptingPID = sysProcessGetID();
 
-    sprintf(objectName, "%s.mutex", transport->name);
+    snprintf(objectName, sizeof(objectName), "%s.mutex", transport->name);
     error = createWithGeneratedName(objectName, transport->shared->mutexName,
                                     createMutex, &transport->mutex);
     if (error != SYS_OK) {
@@ -825,7 +825,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
         return error;
     }
 
-    sprintf(objectName, "%s.accept", transport->name);
+    snprintf(objectName, sizeof(objectName), "%s.accept", transport->name);
     error = createWithGeneratedName(objectName, transport->shared->acceptEventName,
                                     createEvent, &transport->acceptEvent);
     if (error != SYS_OK) {
@@ -833,7 +833,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
         return error;
     }
 
-    sprintf(objectName, "%s.attach", transport->name);
+    snprintf(objectName, sizeof(objectName), "%s.attach", transport->name);
     error = createWithGeneratedName(objectName, transport->shared->attachEventName,
                                     createEvent, &transport->attachEvent);
     if (error != SYS_OK) {
@@ -1260,7 +1260,7 @@ exitTransportWithError(char *message, char *fileName,
     jint error;
     char buffer[500];
 
-    sprintf(buffer, "Shared Memory Transport \"%s\", line %d: %s\n",
+    snprintf(buffer, sizeof(buffer), "Shared Memory Transport \"%s\", line %d: %s\n",
             fileName, lineNumber, message);
     error = (*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_2);
     if (error != JNI_OK) {


### PR DESCRIPTION
Hi,

May I have this update reviewed?

The sprintf is deprecated in Xcode 14, and Microsoft Virtual Studio, because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) for building failure, and [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378)/[JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635)/[JDK-8301132](https://bugs.openjdk.org/browse/JDK-8301132) for testing issues . This is a break-down update for sprintf uses in the jdk.jdi module.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307850](https://bugs.openjdk.org/browse/JDK-8307850): update for deprecated sprintf for jdk.jdi


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13913/head:pull/13913` \
`$ git checkout pull/13913`

Update a local copy of the PR: \
`$ git checkout pull/13913` \
`$ git pull https://git.openjdk.org/jdk.git pull/13913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13913`

View PR using the GUI difftool: \
`$ git pr show -t 13913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13913.diff">https://git.openjdk.org/jdk/pull/13913.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13913#issuecomment-1543238927)