### PR TITLE
8307857: validate-source fails after JDK-8306758

### DIFF
--- a/test/jdk/com/sun/jdi/InstTarg.java
+++ b/test/jdk/com/sun/jdi/InstTarg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial copyright fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307857](https://bugs.openjdk.org/browse/JDK-8307857): validate-source fails after JDK-8306758


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13916/head:pull/13916` \
`$ git checkout pull/13916`

Update a local copy of the PR: \
`$ git checkout pull/13916` \
`$ git pull https://git.openjdk.org/jdk.git pull/13916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13916`

View PR using the GUI difftool: \
`$ git pr show -t 13916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13916.diff">https://git.openjdk.org/jdk/pull/13916.diff</a>

</details>
