### PR TITLE
JDK-8307869: Remove unnecessary log statements from arm32 fastlocking code

### DIFF
--- a/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
@@ -30,7 +30,6 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "interpreter/interpreter.hpp"
-#include "logging/log.hpp"
 #include "oops/arrayOop.hpp"
 #include "oops/markWord.hpp"
 #include "runtime/basicLock.hpp"
@@ -215,7 +214,6 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   assert(oopDesc::mark_offset_in_bytes() == 0, "Required by atomic instructions");
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    log_trace(fastlock)("C1_MacroAssembler::lock fast");
 
     Register t1 = disp_hdr; // Needs saving, probably
     Register t2 = hdr;      // blow
@@ -277,7 +275,6 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   assert(oopDesc::mark_offset_in_bytes() == 0, "Required by atomic instructions");
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    log_trace(fastlock)("C1_MacroAssembler::unlock fast");
 
     ldr(obj, Address(disp_hdr, obj_offset));
 

--- a/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
@@ -25,7 +25,6 @@
 #include "precompiled.hpp"
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
-#include "logging/log.hpp"
 #include "opto/c2_MacroAssembler.hpp"
 #include "runtime/basicLock.hpp"
 
@@ -93,7 +92,6 @@ void C2_MacroAssembler::fast_lock(Register Roop, Register Rbox, Register Rscratc
   }
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    log_trace(fastlock)("C2_MacroAssembler::lock fast");
 
     fast_lock_2(Roop /* obj */, Rbox /* t1 */, Rscratch /* t2 */, Rscratch2 /* t3 */,
                 1 /* savemask (save t1) */, done);
@@ -144,7 +142,6 @@ void C2_MacroAssembler::fast_unlock(Register Roop, Register Rbox, Register Rscra
   Label done;
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    log_trace(fastlock)("C2_MacroAssembler::unlock fast");
 
     fast_unlock_2(Roop /* obj */, Rbox /* t1 */, Rscratch /* t2 */, Rscratch2 /* t3 */,
                   1 /* savemask (save t1) */, done);

--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -911,7 +911,6 @@ void InterpreterMacroAssembler::lock_object(Register Rlock) {
     }
 
     if (LockingMode == LM_LIGHTWEIGHT) {
-      log_trace(fastlock)("InterpreterMacroAssembler lock fast");
       fast_lock_2(Robj, R0 /* t1 */, Rmark /* t2 */, Rtemp /* t3 */, 0 /* savemask */, slow_case);
       b(done);
     } else if (LockingMode == LM_LEGACY) {
@@ -1025,8 +1024,6 @@ void InterpreterMacroAssembler::unlock_object(Register Rlock) {
     str(Rzero, Address(Rlock, obj_offset));
 
     if (LockingMode == LM_LIGHTWEIGHT) {
-
-      log_trace(fastlock)("InterpreterMacroAssembler unlock fast");
 
       // Check for non-symmetric locking. This is allowed by the spec and the interpreter
       // must handle it.


### PR DESCRIPTION
Trivial patch to remove some logging.

Remnant of [JDK-8291555](https://bugs.openjdk.org/browse/JDK-8291555): During review it was noted by @shipilev that the logging in arm fastlocking code is superfluous and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307869](https://bugs.openjdk.org/browse/JDK-8307869): Remove unnecessary log statements from arm32 fastlocking code


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13922/head:pull/13922` \
`$ git checkout pull/13922`

Update a local copy of the PR: \
`$ git checkout pull/13922` \
`$ git pull https://git.openjdk.org/jdk.git pull/13922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13922`

View PR using the GUI difftool: \
`$ git pr show -t 13922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13922.diff">https://git.openjdk.org/jdk/pull/13922.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13922#issuecomment-1543349799)