### PR TITLE
8307885

### DIFF
--- a/test/jdk/com/sun/jdi/ConnectedVMs.java
+++ b/test/jdk/com/sun/jdi/ConnectedVMs.java
@@ -31,9 +31,6 @@
  * @library /test/lib
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g InstTarg.java
- * @run driver ConnectedVMs Kill
- * @run driver ConnectedVMs Resume-to-exit
- * @run driver ConnectedVMs dispose()
  * @run driver ConnectedVMs exit()
  */
 import com.sun.jdi.*;
@@ -69,15 +66,19 @@ public class ConnectedVMs extends TestScaffold {
     protected boolean allowedExitValue(int exitValue) {
         if (passName.equals("Kill")) {
             // 143 is SIGTERM, which we expect to get when doing a Process.destroy(),
-            // unless we are on Windows, which will exit with a 1.
+            // unless we are on Windows, which will exit with a 1. However, sometimes
+            // there is a race and the main thread exits before SIGTERM can force
+            // an exit(143), so we need to allow exitValue 0 also.
             if (!Platform.isWindows()) {
-                return exitValue == 143;
+                return exitValue == 143 || exitValue == 0;
             } else {
-                return exitValue == 1;
+                return exitValue == 1 || exitValue == 0;
             }
         } else if (passName.equals("exit()")) {
             // This version of the test does an exit(1), so that's what we expect.
-            return exitValue == 1;
+            // But similar to the SIGTERM race issue, the exit(1) might not happen
+            // before the main thread exits, so we need to expect 0 also.
+            return exitValue == 1 || exitValue == 0;
         }
         return super.allowedExitValue(exitValue);
     }

--- a/test/jdk/com/sun/jdi/ConnectedVMs.java
+++ b/test/jdk/com/sun/jdi/ConnectedVMs.java
@@ -31,6 +31,9 @@
  * @library /test/lib
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g InstTarg.java
+ * @run driver ConnectedVMs Kill
+ * @run driver ConnectedVMs Resume-to-exit
+ * @run driver ConnectedVMs dispose()
  * @run driver ConnectedVMs exit()
  */
 import com.sun.jdi.*;


### PR DESCRIPTION
When using -Xcomp, the 5 second sleep in the debuggee main thread is not long enough to guarantee using SIGTERM on the debuggee will make it exit(143) before the main thread exits cleanly with exitValue 0. The easiest solution is to just allow exitValue 0. See the CR for more details on other solutions I rejected.