### PR TITLE
JDK-8307891: ProblemList gtest/NMTGtest.java subtests on aix

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -132,7 +132,8 @@ serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 #############################################################################
 
-gtest/NMTGtests.java 8306561 aix-ppc64
+gtest/NMTGtests.java#nmt-detail 8306561 aix-ppc64
+gtest/NMTGtests.java#nmt-summary 8306561 aix-ppc64
 
 #############################################################################
 


### PR DESCRIPTION
Just problem-listing gtest/NMTGtest.java on AIX is not sufficient because this does not problem-list the subtests (#subtestname) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307891](https://bugs.openjdk.org/browse/JDK-8307891): ProblemList gtest/NMTGtest.java subtests on aix


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13925/head:pull/13925` \
`$ git checkout pull/13925`

Update a local copy of the PR: \
`$ git checkout pull/13925` \
`$ git pull https://git.openjdk.org/jdk.git pull/13925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13925`

View PR using the GUI difftool: \
`$ git pr show -t 13925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13925.diff">https://git.openjdk.org/jdk/pull/13925.diff</a>

</details>
