### PR TITLE
8307911: javadoc for MemorySegment::reinterpret has duplicate restricted method paragraph

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -592,7 +592,7 @@ public sealed interface Linker permits AbstractLinker {
         }
 
         /**
-         * {@return A linker option used to save portions of the execution state immediately after
+         * {@return a linker option used to save portions of the execution state immediately after
          *          calling a foreign function associated with a downcall method handle,
          *          before it can be overwritten by the Java runtime, or read through conventional means}
          * <p>
@@ -640,7 +640,7 @@ public sealed interface Linker permits AbstractLinker {
         }
 
          /**
-         * {@return A struct layout that represents the layout of the capture state segment that is passed
+         * {@return a struct layout that represents the layout of the capture state segment that is passed
          *          to a downcall handle linked with {@link #captureCallState(String...)}}.
          * <p>
          * The capture state layout is <em>platform dependent</em> but is guaranteed to be
@@ -668,7 +668,7 @@ public sealed interface Linker permits AbstractLinker {
         }
 
         /**
-         * {@return A linker option used to mark a foreign function as <em>trivial</em>}
+         * {@return a linker option used to mark a foreign function as <em>trivial</em>}
          * <p>
          * A trivial function is a function that has an extremely short running time
          * in all cases (similar to calling an empty function), and does not call back into Java (e.g. using an upcall stub).

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -618,11 +618,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * if the provided scope is the scope of an {@linkplain Arena#ofAuto() automatic arena}, the cleanup action
      * must not prevent the scope from becoming <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
      * A failure to do so will permanently prevent the regions of memory allocated by the automatic arena from being deallocated.
-     * <p>
-     * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
-     * Restricted methods are unsafe, and, if used incorrectly, their use might crash
-     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param arena the arena to be associated with the returned segment.
      * @param cleanup the cleanup action that should be executed when the provided arena is closed (can be {@code null}).


### PR DESCRIPTION
As the title says, this patch fixes an issue with `MemorySegment::reinterpet`, which reports the customary "restricted method" section twice.

I also fixed some wrong capitalization in the text of the factories in `Linker.Option`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307911](https://bugs.openjdk.org/browse/JDK-8307911): javadoc for MemorySegment::reinterpret has duplicate restricted method paragraph


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13926/head:pull/13926` \
`$ git checkout pull/13926`

Update a local copy of the PR: \
`$ git checkout pull/13926` \
`$ git pull https://git.openjdk.org/jdk.git pull/13926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13926`

View PR using the GUI difftool: \
`$ git pr show -t 13926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13926.diff">https://git.openjdk.org/jdk/pull/13926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13926#issuecomment-1543712875)