### PR TITLE
8306806: JMX agent with JDP enabled won't start when PerfData is disabled

### DIFF
--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
+import java.nio.BufferUnderflowException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -502,8 +503,8 @@ public class Agent {
             Map<String,String> remoteProps = null;
             try {
                 remoteProps = ConnectorAddressLink.importRemoteFrom(0);
-            } catch (IOException ioe) {
-                warning(AGENT_EXCEPTION, "JDP not starting, PerfData not available: " + ioe.getMessage());
+            } catch (BufferUnderflowException bue) {
+                warning(AGENT_EXCEPTION, "JDP not starting, PerfData not available");
             }
             if (remoteProps != null) {
                 String jmxUrlStr = remoteProps.get("sun.management.JMXConnectorServer.0.remoteAddress");

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -499,12 +499,17 @@ public class Agent {
             }
 
             // Get service URL to broadcast it
-            Map<String,String> remoteProps = ConnectorAddressLink.importRemoteFrom(0);
-            String jmxUrlStr = remoteProps.get("sun.management.JMXConnectorServer.0.remoteAddress");
-
-            String instanceName = props.getProperty("com.sun.management.jdp.name");
-
-            JdpController.startDiscoveryService(address, port, instanceName, jmxUrlStr);
+            Map<String,String> remoteProps = null;
+            try {
+                remoteProps = ConnectorAddressLink.importRemoteFrom(0);
+            } catch (IOException ioe) {
+                warning(AGENT_EXCEPTION, "JDP not starting, PerfData not available: " + ioe.getMessage());
+            }
+            if (remoteProps != null) {
+                String jmxUrlStr = remoteProps.get("sun.management.JMXConnectorServer.0.remoteAddress");
+                String instanceName = props.getProperty("com.sun.management.jdp.name");
+                JdpController.startDiscoveryService(address, port, instanceName, jmxUrlStr);
+            }
         }
     }
 

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,6 +203,9 @@ public class ConnectorAddressLink {
             bb = perf.attach(vmid);
         } catch (IllegalArgumentException iae) {
             throw new IOException(iae.getMessage());
+        }
+        if (bb.capacity() == 0) {
+            throw new IOException("Empty PerfData buffer");
         }
         List<Counter> counters = new PerfInstrumentation(bb).getAllCounters();
         Map<String, String> properties = new HashMap<>();

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
@@ -204,9 +204,6 @@ public class ConnectorAddressLink {
         } catch (IllegalArgumentException iae) {
             throw new IOException(iae.getMessage());
         }
-        if (bb.capacity() == 0) {
-            throw new IOException("Empty PerfData buffer");
-        }
         List<Counter> counters = new PerfInstrumentation(bb).getAllCounters();
         Map<String, String> properties = new HashMap<>();
         for (Counter c : counters) {

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/ConnectorAddressLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Java Discovery Protocol (perhaps a hidden feature, but maybe should be more widely known!) and -XX:-UsePerfData together cause a failure to startup.

PerfData is the mechanism for communicating the URL and other properties for remote management, so disabling PerfData clearly breaks this.  But there should be a clearer message, and not a fatal error.

e.g.
$ java -XX:-UsePerfData  -Dcom.sun.management.jmxremote.autodiscovery=true -Dcom.sun.management.jmxremote.port=0 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false --version
Warning: Exception thrown by the agent : JDP not starting, PerfData not available: Empty PerfData buffer
java 21-internal 2023-09-19 LTS
...etc...

The use of PerfData is superior to the previous hard-coding of knowledge of the URL protocol and structure, and is required to communicate a dynamically assigned port (JDK-8167337).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306806](https://bugs.openjdk.org/browse/JDK-8306806): JMX agent with JDP enabled won't start when PerfData is disabled


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13928/head:pull/13928` \
`$ git checkout pull/13928`

Update a local copy of the PR: \
`$ git checkout pull/13928` \
`$ git pull https://git.openjdk.org/jdk.git pull/13928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13928`

View PR using the GUI difftool: \
`$ git pr show -t 13928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13928.diff">https://git.openjdk.org/jdk/pull/13928.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13928#issuecomment-1543883538)