### PR TITLE
8307945: Build of Client VM is broken after JDK-8307058

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -25,6 +25,7 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "code/codeBlob.hpp"
 #include "code/vmreg.inline.hpp"
+#include "compiler/compileTask.hpp"
 #include "gc/z/zAddress.hpp"
 #include "gc/z/zBarrier.inline.hpp"
 #include "gc/z/zBarrierSet.hpp"
@@ -320,12 +321,12 @@ static void emit_store_fast_path_check(MacroAssembler* masm, Address ref_addr, b
   __ jcc(Assembler::notEqual, medium_path);
 }
 
+#ifdef COMPILER2
 static int store_fast_path_check_size(MacroAssembler* masm, Address ref_addr, bool is_atomic, Label& medium_path) {
   if (!VM_Version::has_intel_jcc_erratum()) {
     return 0;
   }
   int size = 0;
-#ifdef COMPILER2
   bool in_scratch_emit_size = masm->code_section()->scratch_emit();
   if (!in_scratch_emit_size) {
     // Temporarily register as scratch buffer so that relocations don't register
@@ -347,9 +348,9 @@ static int store_fast_path_check_size(MacroAssembler* masm, Address ref_addr, bo
   }
   // Roll back code, now that we know the size
   masm->code_section()->set_end(insts_end);
-#endif
   return size;
 }
+#endif
 
 static void emit_store_fast_path_check_c2(MacroAssembler* masm, Address ref_addr, bool is_atomic, Label& medium_path) {
 #ifdef COMPILER2
@@ -1549,6 +1550,7 @@ void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, 
 }
 
 #undef __
+#endif // COMPILER2
 
 static int patch_barrier_relocation_offset(int format) {
   switch (format) {
@@ -1623,7 +1625,6 @@ void ZBarrierSetAssembler::patch_barriers() {
   }
 }
 
-#endif // COMPILER2
 
 #undef __
 #define __ masm->


### PR DESCRIPTION
Please review this small fix which fix the build failure of client VM.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307945](https://bugs.openjdk.org/browse/JDK-8307945): Build of Client VM is broken after JDK-8307058


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13934/head:pull/13934` \
`$ git checkout pull/13934`

Update a local copy of the PR: \
`$ git checkout pull/13934` \
`$ git pull https://git.openjdk.org/jdk.git pull/13934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13934`

View PR using the GUI difftool: \
`$ git pr show -t 13934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13934.diff">https://git.openjdk.org/jdk/pull/13934.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13934#issuecomment-1544189453)