### PR TITLE
JDK-8307954: Update string template regression tests to be robust on release updates

### DIFF
--- a/test/langtools/tools/javac/diags/examples/StringTemplate.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplate.java
@@ -23,7 +23,7 @@
 
  // key: compiler.misc.feature.string.templates
  // key: compiler.warn.preview.feature.use.plural
- // options: --enable-preview -source 21  -Xlint:preview
+ // options: --enable-preview -source ${jdk.version} -Xlint:preview
 
 class StringTemplate {
     String m() {

--- a/test/langtools/tools/javac/diags/examples/StringTemplateNoProcessor.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplateNoProcessor.java
@@ -24,7 +24,7 @@
  // key: compiler.err.processor.missing.from.string.template.expression
  // key: compiler.misc.feature.string.templates
  // key: compiler.warn.preview.feature.use.plural
- // options: --enable-preview -source 21  -Xlint:preview
+ // options: --enable-preview -source ${jdk.version} -Xlint:preview
 
 class StringTemplateNoProcessor {
     String m() {

--- a/test/langtools/tools/javac/diags/examples/StringTemplateNotProcessor.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplateNotProcessor.java
@@ -24,7 +24,7 @@
  // key: compiler.note.preview.filename
  // key: compiler.note.preview.recompile
  // key: compiler.err.not.a.processor.type
- // options: --enable-preview  -source 21
+ // options: --enable-preview  -source ${jdk.version}
 
 import java.lang.*;
 

--- a/test/langtools/tools/javac/diags/examples/StringTemplateRawProcessor.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplateRawProcessor.java
@@ -26,7 +26,7 @@
  // key: compiler.misc.unexpected.ret.val
  // key: compiler.err.prob.found.req
  // key: compiler.err.processor.type.cannot.be.a.raw.type
- // options: --enable-preview -source 21
+ // options: --enable-preview -source ${jdk.version}
 
 import java.lang.*;
 import java.lang.StringTemplate.Processor;

--- a/test/langtools/tools/javac/diags/examples/StringTemplateUnclosedString.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplateUnclosedString.java
@@ -25,7 +25,7 @@
  // key: compiler.note.preview.recompile
  // key: compiler.err.unclosed.str.lit
  // key: compiler.err.string.template.is.not.well.formed
- // options: --enable-preview -source 21
+ // options: --enable-preview -source ${jdk.version}
 
 import java.lang.*;
 

--- a/test/langtools/tools/javac/diags/examples/StringTemplateUnclosedTextBlock.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplateUnclosedTextBlock.java
@@ -26,7 +26,7 @@
  // key: compiler.err.unclosed.text.block
  // key: compiler.err.text.block.template.is.not.well.formed
  // key: compiler.err.premature.eof
- // options: --enable-preview -source 21
+ // options: --enable-preview -source ${jdk.version}
 
 import java.lang.*;
 


### PR DESCRIPTION
Change the string template diagnostic tests to use the preferred ${jdk.version} idiom rather than hard-coding a particular release value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307954](https://bugs.openjdk.org/browse/JDK-8307954): Update string template regression tests to be robust on release updates


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13936/head:pull/13936` \
`$ git checkout pull/13936`

Update a local copy of the PR: \
`$ git checkout pull/13936` \
`$ git pull https://git.openjdk.org/jdk.git pull/13936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13936`

View PR using the GUI difftool: \
`$ git pr show -t 13936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13936.diff">https://git.openjdk.org/jdk/pull/13936.diff</a>

</details>
