### PR TITLE
8307953: [AIX] C locale's font setting was changed by JEP 400

### DIFF
--- a/src/java.desktop/aix/data/fontconfig/fontconfig.properties
+++ b/src/java.desktop/aix/data/fontconfig/fontconfig.properties
@@ -307,6 +307,8 @@ monospaced.bolditalic.taiwanese-iso10646=-monotype-wt sans duo tw-medium-r-norma
 
 sequence.allfonts=latin-1
 sequence.allfonts.UTF-8=latin-1,japanese-iso10646
+# C and POSIX locale
+sequence.allfonts.UTF-8.en.=latin-1
 # Uk_UA
 sequence.allfonts.x-IBM1124=latin-1,ukranian-ibm1124
 # Japanese

--- a/src/java.desktop/aix/data/fontconfig/fontconfig.properties
+++ b/src/java.desktop/aix/data/fontconfig/fontconfig.properties
@@ -1,6 +1,6 @@
 #
 #
-# Copyright (c) 2013, 2019 SAP SE. All rights reserved.
+# Copyright (c) 2013, 2023 SAP SE. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -314,12 +314,12 @@ sequence.allfonts.x-IBM943C=latin-1,japanese-x0201,japanese-x0208,japanese-udc
 sequence.allfonts.x-IBM29626C=latin-1,japanese-x0201,japanese-x0208,japanese-udc
 sequence.allfonts.UTF-8.ja=japanese-iso10646,latin-1,iso10646-extB
 # Chinese
-sequence.allfonts.x-EUC_CN=latin-1,chinese
+sequence.allfonts.x-IBM1383=latin-1,chinese
 sequence.allfonts.GB18030=latin-1,chinese-iso10646,iso10646-extB
 sequence.allfonts.UTF-8.zh.CN=latin-1,chinese-iso10646,iso10646-extB
 # Taiwanese
 sequence.allfonts.x-IBM964=latin-1,taiwanese-iso10646
-sequence.allfonts.Big5=latin-1,taiwanese-iso10646
+sequence.allfonts.x-IBM950=latin-1,taiwanese-iso10646
 sequence.allfonts.UTF-8.zh.TW=latin-1,taiwanese-iso10646
 # Korean
 sequence.allfonts.x-IBM970=latin-1,korean

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -51,6 +51,8 @@ import sun.font.SunFontManager;
 import sun.font.FontUtilities;
 import sun.util.logging.PlatformLogger;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Provides the definitions of the five logical fonts: Serif, SansSerif,
  * Monospaced, Dialog, and DialogInput. The necessary information
@@ -136,7 +138,8 @@ public abstract class FontConfiguration {
     }
 
     private void setEncoding() {
-        encoding = Charset.defaultCharset().name();
+        encoding = Charset.forName(System.getProperty("native.encoding"),
+                                   UTF_8).name();
         startupLocale = SunToolkit.getStartupLocale();
     }
 

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -51,8 +51,6 @@ import sun.font.SunFontManager;
 import sun.font.FontUtilities;
 import sun.util.logging.PlatformLogger;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  * Provides the definitions of the five logical fonts: Serif, SansSerif,
  * Monospaced, Dialog, and DialogInput. The necessary information
@@ -138,8 +136,7 @@ public abstract class FontConfiguration {
     }
 
     private void setEncoding() {
-        encoding = Charset.forName(System.getProperty("native.encoding"),
-                                   UTF_8).name();
+        encoding = Charset.defaultCharset().name();
         startupLocale = SunToolkit.getStartupLocale();
     }
 


### PR DESCRIPTION
On AIX, lib/fontconfig.bfc file is used to find font setting.
I ran SwingSet2 List demo program with AIX C locale.
JDK21's line spacing is larger then JDK17.
Screen shots are in [JDK-8307953](https://bugs.openjdk.org/browse/JDK-8307953).
When I used `-Dfile.encoding=COMPAT` option on AIX C locale, SwingSet2 worked fine as expected.

This situation happens `Charset.defaultCharset()` always returns UTF-8 after JEP 400 by default.
According to following URL
https://docs.oracle.com/en/java/javase/20/intl/font-configuration-files.html

> Encoding - the canonical name of the default encoding, as provided by java.nio.charset.Charset.defaultCharset().name().

For C and POSIX locale, following entry is added into `src/java.desktop/aix/data/fontconfig/fontconfig.propertie`
```
sequence.allfonts.UTF-8.en.=latin-1
```

Additionally, following parts are changed:
`src/java.desktop/aix/data/fontconfig/fontconfig.propertie`s has invalid charset name.
For Java for AIX:
- Encoding name for AIX's Zh_TW locale is `big5`, charset name should be `x-IBM950` instead of `big5`.
- Encoding name for AIX's zh_CN locale is `IBM-eucCN`, charset name should be `x-IBM1383` instead of `x-EUCCN`.

In my understanding, this fix affects just for AIX platform.

Note:
macos-x64 tier1 test was failed, but I think it's not related this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8307953](https://bugs.openjdk.org/browse/JDK-8307953): [AIX] C locale's font setting was changed by JEP 400 (**Bug** - `"3"`)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13937/head:pull/13937` \
`$ git checkout pull/13937`

Update a local copy of the PR: \
`$ git checkout pull/13937` \
`$ git pull https://git.openjdk.org/jdk.git pull/13937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13937`

View PR using the GUI difftool: \
`$ git pr show -t 13937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13937.diff">https://git.openjdk.org/jdk/pull/13937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13937#issuecomment-1545046615)