### PR TITLE
6714245: [Col] Collator - Faster Comparison for identical strings.

### DIFF
--- a/src/java.base/share/classes/java/text/RuleBasedCollator.java
+++ b/src/java.base/share/classes/java/text/RuleBasedCollator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -356,6 +356,10 @@ public class RuleBasedCollator extends Collator{
     {
         if (source == null || target == null) {
             throw new NullPointerException();
+        }
+
+        if (source.equals(target)) {
+            return Collator.EQUAL;
         }
 
         // The basic algorithm here is that we use CollationElementIterators


### PR DESCRIPTION
Please review this PR which adds an initial equality check to `RuleBasedCollator.compare(String source, String target)`.

This speeds up the operation for equal input Strings, as it bypasses Collator rule comparisons of each element for both of the input Strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6714245](https://bugs.openjdk.org/browse/JDK-6714245): [Col] Collator - Faster Comparison for identical strings.


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13938/head:pull/13938` \
`$ git checkout pull/13938`

Update a local copy of the PR: \
`$ git checkout pull/13938` \
`$ git pull https://git.openjdk.org/jdk.git pull/13938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13938`

View PR using the GUI difftool: \
`$ git pr show -t 13938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13938.diff">https://git.openjdk.org/jdk/pull/13938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13938#issuecomment-1544495137)