### PR TITLE
8307955: Prefer to PTRACE_GETREGSET instead of PTRACE_GETREGS in method 'ps_proc.c::process_get_lwp_regs'

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -125,10 +125,6 @@ static bool process_write_data(struct ps_prochandle* ph,
 static bool process_get_lwp_regs(struct ps_prochandle* ph, pid_t pid, struct user_regs_struct *user) {
   // we have already attached to all thread 'pid's, just use ptrace call
   // to get regset now. Note that we don't cache regset upfront for processes.
-// Linux on x86 and sparc are different.  On x86 ptrace(PTRACE_GETREGS, ...)
-// uses pointer from 4th argument and ignores 3rd argument.  On sparc it uses
-// pointer from 3rd argument and ignores 4th argument
-#define ptrace_getregs(request, pid, addr, data) ptrace(request, pid, data, addr)
 
 #if defined(_LP64) && defined(PTRACE_GETREGS64)
 #define PTRACE_GETREGS_REQ PTRACE_GETREGS64
@@ -138,19 +134,19 @@ static bool process_get_lwp_regs(struct ps_prochandle* ph, pid_t pid, struct use
 #define PTRACE_GETREGS_REQ PT_GETREGS
 #endif
 
-#ifdef PTRACE_GETREGS_REQ
- if (ptrace_getregs(PTRACE_GETREGS_REQ, pid, user, NULL) < 0) {
+#if defined(PTRACE_GETREGSET)
+  struct iovec iov;
+  iov.iov_base = user;
+  iov.iov_len = sizeof(*user);
+  if (ptrace(PTRACE_GETREGSET, pid, NT_PRSTATUS, (void*) &iov) < 0) {
+    print_debug("ptrace(PTRACE_GETREGSET, ...) failed for lwp %d\n", pid);
+    return false;
+  }
+  return true;
+#elif defined(PTRACE_GETREGS_REQ)
+ if (ptrace(PTRACE_GETREGS_REQ, pid, NULL, user) < 0) {
    print_debug("ptrace(PTRACE_GETREGS, ...) failed for lwp(%d) errno(%d) \"%s\"\n", pid,
                errno, strerror(errno));
-   return false;
- }
- return true;
-#elif defined(PTRACE_GETREGSET)
- struct iovec iov;
- iov.iov_base = user;
- iov.iov_len = sizeof(*user);
- if (ptrace(PTRACE_GETREGSET, pid, NT_PRSTATUS, (void*) &iov) < 0) {
-   print_debug("ptrace(PTRACE_GETREGSET, ...) failed for lwp %d\n", pid);
    return false;
  }
  return true;


### PR DESCRIPTION
Hi all,

This patch revises the code of `ps_proc.c::process_get_lwp_regs`
to use `PTRACE_GETREGSET` first instead of `PTRACE_GETREGS`.
The `PTRACE_GETREGS` is not present on all architectures as the man page states [1].
And if we use `PTRACE_GETREGS` first, several tests will fail at the special envs,
such as my local riscv64-linux env. Please see [the issue](https://bugs.openjdk.org/browse/JDK-8307955) for more information.

And I remove the unnecessary comments and macro,
because the `sparc` arch related code had been removed.

Thanks for the review.

Best Regards,
-- Guoxiong

[1] https://man7.org/linux/man-pages/man2/ptrace.2.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8307955](https://bugs.openjdk.org/browse/JDK-8307955): Prefer to PTRACE_GETREGSET instead of PTRACE_GETREGS in method 'ps_proc.c::process_get_lwp_regs'


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13939/head:pull/13939` \
`$ git checkout pull/13939`

Update a local copy of the PR: \
`$ git checkout pull/13939` \
`$ git pull https://git.openjdk.org/jdk.git pull/13939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13939`

View PR using the GUI difftool: \
`$ git pr show -t 13939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13939.diff">https://git.openjdk.org/jdk/pull/13939.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13939#issuecomment-1544500826)