### PR TITLE
Optimize readFully method for improved performance

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
@@ -120,10 +120,14 @@ public final class RecordingInput implements DataInput, AutoCloseable {
 
     @Override
     public final void readFully(byte[] dest, int offset, int length) throws IOException {
-        // TODO: Optimize, use Arrays.copy if all bytes are in current block
-        // array
-        for (int i = 0; i < length; i++) {
-            dest[i + offset] = readByte();
+        // Optimize, use Arrays.copy if all bytes are in current block array
+        if (length <= currentBlockRemaining()) {
+            System.arraycopy(currentBlock, currentPosition, dest, offset, length);
+            currentPosition += length;
+        } else {
+            for (int i = 0; i < length; i++) {
+                dest[i + offset] = readByte();
+            }
         }
     }
 


### PR DESCRIPTION
The readFully method has been rewritten to more effectively handle fully connected block arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13942/head:pull/13942` \
`$ git checkout pull/13942`

Update a local copy of the PR: \
`$ git checkout pull/13942` \
`$ git pull https://git.openjdk.org/jdk.git pull/13942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13942`

View PR using the GUI difftool: \
`$ git pr show -t 13942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13942.diff">https://git.openjdk.org/jdk/pull/13942.diff</a>

</details>
