### PR TITLE
8307961: java/foreign/enablenativeaccess/TestEnableNativeAccess.java fails with ShouldNotReachHere

### DIFF
--- a/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
+++ b/test/jdk/java/foreign/enablenativeaccess/panama_module/org/openjdk/foreigntest/libLinkerInvokerModule.cpp
@@ -29,7 +29,7 @@ typedef struct {
    JavaVM* jvm;
    jobject linker;
    jobject desc;
-   jarray opts;
+   jobject opts;
 } Context;
 
 void call(void* arg) {
@@ -45,12 +45,15 @@ void call(void* arg) {
 
 extern "C" {
     JNIEXPORT void JNICALL
-    Java_org_openjdk_foreigntest_PanamaMainJNI_nativeLinker0(JNIEnv *env, jclass cls, jobject linker, jobject desc, jarray opts) {
+    Java_org_openjdk_foreigntest_PanamaMainJNI_nativeLinker0(JNIEnv *env, jclass cls, jobject linker, jobject desc, jobjectArray opts) {
         Context context;
         env->GetJavaVM(&context.jvm);
-        context.linker = linker;
-        context.desc = desc;
-        context.opts = opts;
+        context.linker = env->NewGlobalRef(linker);
+        context.desc = env->NewGlobalRef(desc);
+        context.opts = env->NewGlobalRef(opts);
         run_in_new_thread_and_join(call, &context);
+        env->DeleteGlobalRef(context.linker);
+        env->DeleteGlobalRef(context.desc);
+        env->DeleteGlobalRef(context.opts);
     }
 }


### PR DESCRIPTION
This patch fixes the JNI test for the enable native access flag, which was updated incorrectly as part of https://git.openjdk.org/jdk/pull/13863.

The problem is that the test doesn't make global references out of the local ones before sharing them with another thread.

I could reproduce the failure locally with `-Xcheck:jni`. With this patch, the test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307961](https://bugs.openjdk.org/browse/JDK-8307961): java/foreign/enablenativeaccess/TestEnableNativeAccess.java fails with ShouldNotReachHere


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13944/head:pull/13944` \
`$ git checkout pull/13944`

Update a local copy of the PR: \
`$ git checkout pull/13944` \
`$ git pull https://git.openjdk.org/jdk.git pull/13944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13944`

View PR using the GUI difftool: \
`$ git pr show -t 13944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13944.diff">https://git.openjdk.org/jdk/pull/13944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13944#issuecomment-1544733010)