### PR TITLE
8307962: Exclude gc/g1/TestSkipRebuildRemsetPhase.java fails with virtual test thread factory

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -136,6 +136,7 @@ vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemor
 ## So any test migth be added as incompatible, the bug is not required.
 
 gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
+gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all


### PR DESCRIPTION
The test set very specific memory settings. Using virtual threads might break its expectations. No plans to fix it. Just exclude as some other tests incompatible with virtual thread test factory mode

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307962](https://bugs.openjdk.org/browse/JDK-8307962): Exclude gc/g1/TestSkipRebuildRemsetPhase.java fails with virtual test thread factory


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13947/head:pull/13947` \
`$ git checkout pull/13947`

Update a local copy of the PR: \
`$ git checkout pull/13947` \
`$ git pull https://git.openjdk.org/jdk.git pull/13947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13947`

View PR using the GUI difftool: \
`$ git pr show -t 13947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13947.diff">https://git.openjdk.org/jdk/pull/13947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13947#issuecomment-1549030510)