### PR TITLE
8296920: Regression Test DialogOrient.java fails on MacOS

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogOrient.java
+++ b/test/jdk/java/awt/print/Dialog/DialogOrient.java
@@ -69,8 +69,8 @@ public class DialogOrient implements Printable {
       Sysout.printInstructions( instructions );
 
         PrinterJob job = PrinterJob.getPrinterJob();
-        job.setPrintable(new DialogOrient());
         PageFormat landscape = job.pageDialog(job.defaultPage());
+        job.setPrintable(new DialogOrient(), landscape);
 
         if (job.printDialog()) {
             job.print();


### PR DESCRIPTION
Test was failing with PrinterException: Wrong Orientation since printing was done with default orientation.
Fix is made to set the printable with correct PageFormat

It was not seen prior to [JDK-8262731](https://bugs.openjdk.org/browse/JDK-8262731) probably because the exception was being swallowed..