### PR TITLE
JDK-8306304: Fix xlc17 clang warnings in ppc and aix code

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -168,10 +168,14 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_clang_management.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_notificationThread.cpp := bitwise-instead-of-logical, \
     DISABLED_WARNINGS_clang_os_posix.cpp := mismatched-tags missing-field-initializers, \
+    DISABLED_WARNINGS_clang_aix_os_posix.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_postaloc.cpp := tautological-undefined-compare, \
     DISABLED_WARNINGS_clang_serviceThread.cpp := bitwise-instead-of-logical, \
     DISABLED_WARNINGS_clang_vm_version_x86.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_zTracer.cpp := undefined-var-template, \
+    DISABLED_WARNINGS_clang_aix_debug.cpp := format-nonliteral, \
+    DISABLED_WARNINGS_clang_aix_jvm.cpp := format-nonliteral, \
+    DISABLED_WARNINGS_clang_aix_osThread_aix.cpp := tautological-undefined-compare, \
     DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \
     DISABLED_WARNINGS_microsoft := $(DISABLED_WARNINGS_microsoft), \
     ASFLAGS := $(JVM_ASFLAGS), \

--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ int Assembler::patched_branch(int dest_pos, int inst, int inst_pos) {
   case bc_op: m = bd(-1); v = bd(disp(dest_pos, inst_pos)); break;
     default: ShouldNotReachHere();
   }
-  return inst & ~m | v;
+  return (inst & ~m) | v;
 }
 
 // Return the offset, relative to _code_begin, of the destination of

--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1013,15 +1013,15 @@ class Assembler : public AbstractAssembler {
   // Test if x is within signed immediate range for nbits.
   static bool is_simm(int x, unsigned int nbits) {
     assert(0 < nbits && nbits < 32, "out of bounds");
-    const int   min      = -(((int)1) << nbits-1);
-    const int   maxplus1 =  (((int)1) << nbits-1);
+    const int   min      = -(((int)1) << (nbits-1));
+    const int   maxplus1 =  (((int)1) << (nbits-1));
     return min <= x && x < maxplus1;
   }
 
   static bool is_simm(jlong x, unsigned int nbits) {
     assert(0 < nbits && nbits < 64, "out of bounds");
-    const jlong min      = -(((jlong)1) << nbits-1);
-    const jlong maxplus1 =  (((jlong)1) << nbits-1);
+    const jlong min      = -(((jlong)1) << (nbits-1));
+    const jlong maxplus1 =  (((jlong)1) << (nbits-1));
     return min <= x && x < maxplus1;
   }
 
@@ -1044,7 +1044,7 @@ class Assembler : public AbstractAssembler {
   // X is supposed to fit in a field "nbits" wide
   // and be sign-extended. Check the range.
   static void assert_signed_range(intptr_t x, int nbits) {
-    assert(nbits == 32 || (-(1 << nbits-1) <= x && x < (1 << nbits-1)),
+    assert(nbits == 32 || (-(1 << (nbits-1)) <= x && x < (1 << (nbits-1))),
            "value out of range");
   }
 
@@ -1086,7 +1086,7 @@ class Assembler : public AbstractAssembler {
   // Same as u_field for signed values
   static int s_field(int x, int hi_bit, int lo_bit) {
     int nbits = hi_bit - lo_bit + 1;
-    assert(nbits == 32 || (-(1 << nbits-1) <= x && x < (1 << nbits-1)),
+    assert(nbits == 32 || (-(1 << (nbits-1)) <= x && x < (1 << (nbits-1))),
       "value out of range");
     x &= fmask(hi_bit, lo_bit);
     int r = x << lo_bit;

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -423,7 +423,7 @@ void LIRGenerator::do_ArithmeticOp_Long(ArithmeticOp* x) {
   LIRItem right(x->y(), this);
   // Missing test if instr is commutative and if we should swap.
   if (right.value()->type()->as_LongConstant() &&
-      (x->op() == Bytecodes::_lsub && right.value()->type()->as_LongConstant()->value() == ((-1)<<15)) ) {
+      (x->op() == Bytecodes::_lsub && right.value()->type()->as_LongConstant()->value() == -32768 ) ) {
     // Sub is implemented by addi and can't support min_simm16 as constant..
     right.load_item();
   } else {
@@ -477,7 +477,7 @@ void LIRGenerator::do_ArithmeticOp_Int(ArithmeticOp* x) {
   LIRItem right(x->y(), this);
   // Missing test if instr is commutative and if we should swap.
   if (right.value()->type()->as_IntConstant() &&
-      (x->op() == Bytecodes::_isub && right.value()->type()->as_IntConstant()->value() == ((-1)<<15)) ) {
+      (x->op() == Bytecodes::_isub && right.value()->type()->as_IntConstant()->value() == -32768) ) {
     // Sub is implemented by addi and can't support min_simm16 as constant.
     right.load_item();
   } else {

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -3039,7 +3039,7 @@ void MacroAssembler::decode_klass_not_null(Register dst, Register src) {
   if (src == noreg) src = dst;
   Register shifted_src = src;
   if (CompressedKlassPointers::shift() != 0 ||
-      CompressedKlassPointers::base() == 0 && src != dst) {  // Move required.
+      (CompressedKlassPointers::base() == 0 && src != dst)) {  // Move required.
     shifted_src = dst;
     sldi(shifted_src, src, CompressedKlassPointers::shift());
   }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -11441,7 +11441,7 @@ instruct cmpL3_reg_reg(iRegIdst dst, iRegLsrc src1, iRegLsrc src2, flagsRegCR0 c
   match(Set dst (CmpL3 src1 src2));
   effect(KILL cr0);
   ins_cost(DEFAULT_COST * 5);
-  size(VM_Version::has_brw() ? 16 : 20);
+  size((VM_Version::has_brw() ? 16 : 20));
 
   format %{ "cmpL3_reg_reg $dst, $src1, $src2" %}
 
@@ -11776,7 +11776,7 @@ instruct cmpF3_reg_reg(iRegIdst dst, regF src1, regF src2, flagsRegCR0 cr0) %{
   match(Set dst (CmpF3 src1 src2));
   effect(KILL cr0);
   ins_cost(DEFAULT_COST * 6);
-  size(VM_Version::has_brw() ? 20 : 24);
+  size((VM_Version::has_brw() ? 20 : 24));
 
   format %{ "cmpF3_reg_reg $dst, $src1, $src2" %}
 
@@ -11860,7 +11860,7 @@ instruct cmpD3_reg_reg(iRegIdst dst, regD src1, regD src2, flagsRegCR0 cr0) %{
   match(Set dst (CmpD3 src1 src2));
   effect(KILL cr0);
   ins_cost(DEFAULT_COST * 6);
-  size(VM_Version::has_brw() ? 20 : 24);
+  size((VM_Version::has_brw() ? 20 : 24));
 
   format %{ "cmpD3_reg_reg $dst, $src1, $src2" %}
 
@@ -14403,7 +14403,7 @@ instruct CallStaticJavaDirect(method meth) %{
   ins_num_consts(3 /* up to 3 patchable constants: inline cache, 2 call targets. */);
 
   format %{ "CALL,static $meth \t// ==> " %}
-  size(Continuations::enabled() ? 8 : 4);
+  size((Continuations::enabled() ? 8 : 4));
   ins_encode( enc_java_static_call(meth) );
   ins_pipe(pipe_class_call);
 %}
@@ -14424,7 +14424,7 @@ instruct CallDynamicJavaDirectSched(method meth) %{
   ins_num_consts(1 /* 1 patchable constant: call destination */);
 
   format %{ "BL        \t// dynamic $meth ==> " %}
-  size(Continuations::enabled() ? 8 : 4);
+  size((Continuations::enabled() ? 8 : 4));
   ins_encode( enc_java_dynamic_call_sched(meth) );
   ins_pipe(pipe_class_call);
 %}
@@ -14502,7 +14502,7 @@ instruct CallLeafDirect(method meth) %{
   predicate(false);  // but never match.
 
   format %{ "BCTRL     \t// leaf call $meth ==> " %}
-  size(Continuations::enabled() ? 8 : 4);
+  size((Continuations::enabled() ? 8 : 4));
   ins_encode %{
     __ bctrl();
     __ post_call_nop();

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -286,7 +286,7 @@ static bool my_disclaim64(char* addr, size_t size) {
 
   char* p = addr;
 
-  for (int i = 0; i < numFullDisclaimsNeeded; i ++) {
+  for (unsigned int i = 0; i < numFullDisclaimsNeeded; i ++) {
     if (::disclaim(p, maxDisclaimSize, DISCLAIM_ZEROMEM) != 0) {
       trcVerbose("Cannot disclaim %p - %p (errno %d)\n", p, p + maxDisclaimSize, errno);
       return false;
@@ -371,7 +371,7 @@ static const char* describe_pagesize(size_t pagesize) {
 // Must be called before calling os::large_page_init().
 static void query_multipage_support() {
 
-  guarantee(g_multipage_support.pagesize == -1,
+  guarantee(g_multipage_support.pagesize == (size_t)-1,
             "do not call twice");
 
   g_multipage_support.pagesize = ::sysconf(_SC_PAGESIZE);
@@ -461,7 +461,7 @@ static void query_multipage_support() {
         IPC_CREAT | S_IRUSR | S_IWUSR);
       guarantee0(shmid != -1); // Should always work.
       // Try to set pagesize.
-      struct shmid_ds shm_buf = { 0 };
+      struct shmid_ds shm_buf = { {0,0,0,0,0,0,0,0},0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
       shm_buf.shm_pagesize = pagesize;
       if (::shmctl(shmid, SHM_PAGESIZE, &shm_buf) != 0) {
         const int en = errno;
@@ -672,6 +672,9 @@ bool os::Aix::get_meminfo(meminfo_t* pmi) {
 
 //////////////////////////////////////////////////////////////////////////////
 // create new thread
+#ifdef AIX_XLC_GE_17
+#include "alloca.h"
+#endif
 
 // Thread start routine for all newly created threads
 static void *thread_native_entry(Thread *thread) {
@@ -1578,7 +1581,7 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
   // Just for info: query the real page size. In case setting the page size did not
   // work (see above), the system may have given us something other then 4K (LDR_CNTRL).
   const size_t real_pagesize = os::Aix::query_pagesize(addr);
-  if (real_pagesize != shmbuf.shm_pagesize) {
+  if (real_pagesize != (size_t)shmbuf.shm_pagesize) {
     trcVerbose("pagesize is, surprisingly, " SIZE_FORMAT, real_pagesize);
   }
 

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,7 +233,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         goto run_stub;
       }
 
-      else if ((sig == USE_POLL_BIT_ONLY ? SIGTRAP : SIGSEGV) &&
+      else if ((sig == (USE_POLL_BIT_ONLY ? SIGTRAP : SIGSEGV)) &&
                ((NativeInstruction*)pc)->is_safepoint_poll() &&
                CodeCache::contains((void*) pc) &&
                ((cb = CodeCache::find_blob(pc)) != nullptr) &&
@@ -331,7 +331,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
         // End life with a fatal error, message and detail message and the context.
         // Note: no need to do any post-processing here (e.g. signal chaining)
-        va_list va_dummy;
+        va_list va_dummy = nullptr;
         VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg, va_dummy);
         va_end(va_dummy);
 

--- a/src/java.desktop/aix/native/libawt/porting_aix.c
+++ b/src/java.desktop/aix/native/libawt/porting_aix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ static int dladdr_dont_reload(void* addr, Dl_info* info) {
   memset((void *)info, 0, sizeof(Dl_info));
   for (;;) {
     if (addr >= p->ldinfo_textorg &&
-        addr < p->ldinfo_textorg + p->ldinfo_textsize) {
+        (char*)addr < (char*)(p->ldinfo_textorg) + p->ldinfo_textsize) {
       info->dli_fname = p->ldinfo_filename;
       info->dli_fbase = p->ldinfo_textorg;
       return 1; /* [sic] */


### PR DESCRIPTION
When using the new xlc17 compiler (based on a recent clang) to build OpenJDk on AIX , we run into various "warnings as errors".
Many of those are in the aix or ppc specific codebase and could be addressed by small adjustments.
A lot of those changes are in hotspot, some might be somewhere else in the OpenJDK C/C++ code.
With this PR we address only the platform dependent code changes.