### PR TITLE
8287834: Add SymbolLookup::or method

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -130,6 +130,30 @@ public interface SymbolLookup {
     Optional<MemorySegment> find(String name);
 
     /**
+     * {@return a composite symbol lookup which will retrieve symbols using both this and the provided symbol
+     * lookup} More specifically, if a symbol is not found using this lookup, the provided lookup will be
+     * used as fallback. In other words, the resulting symbol lookup will only return {@linkplain Optional#empty()}
+     * if both lookups fail to retrieve a given symbol.
+     *
+     * @apiNote This method could be used to chain multiple symbol lookups together, e.g. so that symbols could
+     * be retrieved, in order, from multiple libraries:
+     * {@snippet lang = java:
+     * var lookup = SymbolLookup.libraryLookup("foo", arena)
+     *         .or(SymbolLookup.libraryLookup("bar", arena))
+     *         .or(SymbolLookup.loaderLookup());
+     *}
+     * The above code creates a symbol lookup that first searches for symbols in the "foo" library. If no symbol is found
+     * in "foo" then "bar" is searched. Finally, if a symbol is not found in neither "foo" nor "bar", the {@linkplain
+     * SymbolLookup#loaderLookup() loader lookup} is used.
+     *
+     * @param other the symbol lookup that should be used to look for symbols not found in this lookup.
+     */
+    default SymbolLookup or(SymbolLookup other) {
+        Objects.requireNonNull(other);
+        return name -> find(name).or(() -> other.find(name));
+    }
+
+    /**
      * Returns a symbol lookup for symbols in the libraries associated with the caller's class loader.
      * <p>
      * A library is associated with a class loader {@code CL} when the library is loaded via an invocation of

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -130,7 +130,8 @@ public interface SymbolLookup {
     Optional<MemorySegment> find(String name);
 
     /**
-     * {@return a composed symbol lookup that returns result of finding the symbol with this lookup if found, otherwise returns the result of finding the symbol with the other lookup.}
+     * {@return a composed symbol lookup that returns result of finding the symbol with this lookup if found,
+     * otherwise returns the result of finding the symbol with the other lookup}
      *
      * @apiNote This method could be used to chain multiple symbol lookups together, e.g. so that symbols could
      * be retrieved, in order, from multiple libraries:

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -130,10 +130,7 @@ public interface SymbolLookup {
     Optional<MemorySegment> find(String name);
 
     /**
-     * {@return a composite symbol lookup which will retrieve symbols using both this and the provided symbol
-     * lookup} More specifically, if a symbol is not found using this lookup, the provided lookup will be
-     * used as fallback. In other words, the resulting symbol lookup will only return {@linkplain Optional#empty()}
-     * if both lookups fail to retrieve a given symbol.
+     * {@return a composed symbol lookup that returns result of finding the symbol with this lookup if found, otherwise returns the result of finding the symbol with the other lookup.}
      *
      * @apiNote This method could be used to chain multiple symbol lookups together, e.g. so that symbols could
      * be retrieved, in order, from multiple libraries:

--- a/test/jdk/java/foreign/CompositeLookupTest.java
+++ b/test/jdk/java/foreign/CompositeLookupTest.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+import org.testng.annotations.Test;
+
+import java.lang.foreign.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.testng.annotations.*;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @enablePreview
+ * @run testng CompositeLookupTest
+ */
+public class CompositeLookupTest {
+
+    @Test(dataProvider = "testCases")
+    public void testLookups(SymbolLookup lookup, List<Result> results) {
+        for (Result result : results) {
+            switch (result) {
+                case Success(String name, long expectedLookupId) -> {
+                    Optional<MemorySegment> symbol = lookup.find(name);
+                    assertTrue(symbol.isPresent());
+                    assertEquals(symbol.get().address(), expectedLookupId);
+                }
+                case Failure(String name) -> {
+                    Optional<MemorySegment> symbol = lookup.find(name);
+                    assertFalse(symbol.isPresent());
+                }
+            }
+        }
+    }
+
+    static class TestLookup implements SymbolLookup {
+
+        private Set<String> symbols;
+        private long id;
+
+        public TestLookup(long id, String... symbols) {
+            this.id = id;
+            this.symbols = Set.of(symbols);
+        }
+
+        @Override
+        public Optional<MemorySegment> find(String name) {
+            return symbols.contains(name) ?
+                    Optional.of(MemorySegment.ofAddress(id)) : Optional.empty();
+        }
+    }
+
+    sealed interface Result { }
+    record Success(String name, long expectedLookupId) implements Result { }
+    record Failure(String name) implements Result { }
+
+    @DataProvider(name = "testCases")
+    public Object[][] testCases() {
+        return new Object[][]{
+                {
+                    new TestLookup(1, "a", "b", "c")
+                            .or(new TestLookup(2,"d", "e", "f"))
+                            .or(new TestLookup(3,"g", "h", "i")),
+                    List.of(
+                            new Success("a", 1),
+                            new Success("b", 1),
+                            new Success("c", 1),
+                            new Success("d", 2),
+                            new Success("e", 2),
+                            new Success("f", 2),
+                            new Success("g", 3),
+                            new Success("h", 3),
+                            new Success("i", 3),
+                            new Failure("j")
+                    )
+                },
+                {
+                        new TestLookup(1, "a", "b", "c")
+                                .or(new TestLookup(2,"a", "b", "c"))
+                                .or(new TestLookup(3,"a", "b", "c")),
+                        List.of(
+                                new Success("a", 1),
+                                new Success("b", 1),
+                                new Success("c", 1),
+                                new Failure("d")
+                        )
+                },
+                {
+                        new TestLookup(1 )
+                                .or(new TestLookup(2))
+                                .or(new TestLookup(3,"a", "b", "c")),
+                        List.of(
+                                new Success("a", 3),
+                                new Success("b", 3),
+                                new Success("c", 3),
+                                new Failure("d")
+                        )
+                },
+                {
+                        new TestLookup(1, "a", "b", "c")
+                                .or(new TestLookup(2,"d")
+                                        .or(new TestLookup(3,"e"))
+                                        .or(new TestLookup(4,"f")))
+                                .or(new TestLookup(5,"g")
+                                        .or(new TestLookup(6,"h"))
+                                        .or(new TestLookup(7,"i"))),
+                        List.of(
+                                new Success("a", 1),
+                                new Success("b", 1),
+                                new Success("c", 1),
+                                new Success("d", 2),
+                                new Success("e", 3),
+                                new Success("f", 4),
+                                new Success("g", 5),
+                                new Success("h", 6),
+                                new Success("i", 7),
+                                new Failure("j")
+                        )
+                },
+        };
+    }
+}


### PR DESCRIPTION
This patch adds a simpler method for composing symbol lookups. It is common for clients to chain multiple symbol lookups together, e.g. to find a symbol in multiple libraries.

A new instance method, namely `SymbolLookup::or` is added, which first searches a symbol in the first lookup, and, if that fails, proceeds to search the symbol in the provided lookup.

We have considered alternatives to express this, such as a static factory `SymbolLookup::ofComposite` but settled on this because of the similarity with `Optional::or`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308002](https://bugs.openjdk.org/browse/JDK-8308002) to be approved

### Issues
 * [JDK-8287834](https://bugs.openjdk.org/browse/JDK-8287834): Add SymbolLookup::or method
 * [JDK-8308002](https://bugs.openjdk.org/browse/JDK-8308002): Add SymbolLookup::or method (**CSR**)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [27e82bb6](https://git.openjdk.org/jdk/pull/13954/files/27e82bb627594ac4b0400b9a74db3235379c1e0c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13954/head:pull/13954` \
`$ git checkout pull/13954`

Update a local copy of the PR: \
`$ git checkout pull/13954` \
`$ git pull https://git.openjdk.org/jdk.git pull/13954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13954`

View PR using the GUI difftool: \
`$ git pr show -t 13954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13954.diff">https://git.openjdk.org/jdk/pull/13954.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13954#issuecomment-1545655275)