### PR TITLE
8307403: java/util/zip/DeInflate.java timed out

### DIFF
--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -33,7 +33,6 @@ import java.nio.*;
 import java.util.*;
 import java.util.zip.*;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class DeInflate {
 
@@ -137,14 +136,14 @@ public class DeInflate {
     static void check(Deflater def, byte[] in, int len, boolean nowrap)
         throws Throwable
     {
-        byte[] tempBuffer = new byte[len];
+        byte[] tempBuffer = new byte[1024];
         byte[] out1, out2;
         int m = 0, n = 0;
         Inflater inf = new Inflater(nowrap);
         def.setInput(in, 0, len);
         def.finish();
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(len)) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             while (!def.finished()) {
                 int temp_counter = def.deflate(tempBuffer);
                 m += temp_counter;
@@ -314,6 +313,7 @@ public class DeInflate {
                     for (int i = 0; i < 5; i++) {
                         int len = (i == 0)? dataIn.length
                                           : new Random().nextInt(dataIn.length);
+                        System.out.println("iteration: " + (i + 1) + " input length: " + len);
                         // use a new deflater
                         Deflater def = newDeflater(level, strategy, dowrap, dataOut2);
                         check(def, dataIn, len, dowrap);


### PR DESCRIPTION
Can I please get a review of this test only change which addresses the issue noted in https://bugs.openjdk.org/browse/JDK-8307403?

When we recently did a change in https://bugs.openjdk.org/browse/JDK-8299748, there was a oversight that the `deflate.deflate(tempBuffer)` could potentially end up taking in a zero sized array. That would then mean the loop in which this `deflate` happens, would never exit leading to the test timing out.
I've added additional details as a comment to the JBS issue https://bugs.openjdk.org/browse/JDK-8307403?focusedCommentId=14581202&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14581202.

The commit in this PR uses a fixed size temporary buffer, unrelated to the input length, to get past this problem. The use of fixed size here will not re-introduce the original issue which https://bugs.openjdk.org/browse/JDK-8299748 fixed, because unlike previously, this is just a temporary size and we continue to deflate the content into a dynamically growing `ByteArrayOutputStream` till the deflater is "finished".

Additionally I've added a log message to help debug any future issues in this call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307403](https://bugs.openjdk.org/browse/JDK-8307403): java/util/zip/DeInflate.java timed out


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13955/head:pull/13955` \
`$ git checkout pull/13955`

Update a local copy of the PR: \
`$ git checkout pull/13955` \
`$ git pull https://git.openjdk.org/jdk.git pull/13955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13955`

View PR using the GUI difftool: \
`$ git pr show -t 13955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13955.diff">https://git.openjdk.org/jdk/pull/13955.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13955#issuecomment-1545702067)