### PR TITLE
8308010: X509Key and PKCS8Key allows garbage bytes at the end

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
@@ -95,8 +95,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
         try {
             decode(new DerValue(input));
         } catch (IOException e) {
-            throw new InvalidKeyException("IOException: " +
-                    e.getMessage());
+            throw new InvalidKeyException("Unable to decode key", e);
         }
     }
 
@@ -135,7 +134,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
             }
             throw new InvalidKeyException("Extra bytes");
         } catch (IOException e) {
-            throw new InvalidKeyException("IOException : " + e.getMessage());
+            throw new InvalidKeyException("Unable to decode key", e);
         } finally {
             if (val != null) {
                 val.clear();
@@ -246,8 +245,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
         try {
             decode(new DerValue(stream));
         } catch (InvalidKeyException e) {
-            throw new IOException("deserialized key is invalid: " +
-                                  e.getMessage());
+            throw new IOException("deserialized key is invalid", e);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
@@ -92,13 +92,16 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      * This method is also used by {@link #parseKey} to create a raw key.
      */
     protected PKCS8Key(byte[] input) throws InvalidKeyException {
-        decode(new ByteArrayInputStream(input));
+        try {
+            decode(new DerValue(input));
+        } catch (IOException e) {
+            throw new InvalidKeyException("IOException: " +
+                    e.getMessage());
+        }
     }
 
-    private void decode(InputStream is) throws InvalidKeyException {
-        DerValue val = null;
+    private void decode(DerValue val) throws InvalidKeyException {
         try {
-            val = new DerValue(is);
             if (val.tag != DerValue.tag_Sequence) {
                 throw new InvalidKeyException("invalid key format");
             }
@@ -241,7 +244,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
     @java.io.Serial
     private void readObject(ObjectInputStream stream) throws IOException {
         try {
-            decode(stream);
+            decode(new DerValue(stream));
         } catch (InvalidKeyException e) {
             throw new IOException("deserialized key is invalid: " +
                                   e.getMessage());

--- a/src/java.base/share/classes/sun/security/x509/X509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/X509Key.java
@@ -364,8 +364,7 @@ public class X509Key implements PublicKey, DerEncoder {
                 throw new InvalidKeyException ("excess key data");
 
         } catch (IOException e) {
-            throw new InvalidKeyException("IOException: " +
-                                          e.getMessage());
+            throw new InvalidKeyException("Unable to decode key", e);
         }
     }
 
@@ -373,8 +372,7 @@ public class X509Key implements PublicKey, DerEncoder {
         try {
             decode(new DerValue(encodedKey));
         } catch (IOException e) {
-            throw new InvalidKeyException("IOException: " +
-                    e.getMessage());
+            throw new InvalidKeyException("Unable to decode key", e);
         }
     }
 
@@ -396,9 +394,7 @@ public class X509Key implements PublicKey, DerEncoder {
         try {
             decode(new DerValue(stream));
         } catch (InvalidKeyException e) {
-            e.printStackTrace();
-            throw new IOException("deserialized key is invalid: " +
-                                  e.getMessage());
+            throw new IOException("deserialized key is invalid", e);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/x509/X509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/X509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,8 +334,7 @@ public class X509Key implements PublicKey, DerEncoder {
     }
 
     /**
-     * Initialize an X509Key object from an input stream.  The data on that
-     * input stream must be encoded using DER, obeying the X.509
+     * Initialize an X509Key object from a DerValue, obeying the X.509
      * <code>SubjectPublicKeyInfo</code> format.  That is, the data is a
      * sequence consisting of an algorithm ID and a bit string which holds
      * the key.  (That bit string is often used to encapsulate another DER
@@ -350,17 +349,11 @@ public class X509Key implements PublicKey, DerEncoder {
      * private keys may override this method, <code>encode</code>, and
      * of course <code>getFormat</code>.
      *
-     * @param in an input stream with a DER-encoded X.509
-     *          SubjectPublicKeyInfo value
+     * @param val a DER-encoded X.509 SubjectPublicKeyInfo value
      * @exception InvalidKeyException on parsing errors.
      */
-    public void decode(InputStream in)
-    throws InvalidKeyException
-    {
-        DerValue        val;
-
+    void decode(DerValue val) throws InvalidKeyException {
         try {
-            val = new DerValue(in);
             if (val.tag != DerValue.tag_Sequence)
                 throw new InvalidKeyException("invalid key format");
 
@@ -377,7 +370,12 @@ public class X509Key implements PublicKey, DerEncoder {
     }
 
     public void decode(byte[] encodedKey) throws InvalidKeyException {
-        decode(new ByteArrayInputStream(encodedKey));
+        try {
+            decode(new DerValue(encodedKey));
+        } catch (IOException e) {
+            throw new InvalidKeyException("IOException: " +
+                    e.getMessage());
+        }
     }
 
     /**
@@ -396,7 +394,7 @@ public class X509Key implements PublicKey, DerEncoder {
     @java.io.Serial
     private void readObject(ObjectInputStream stream) throws IOException {
         try {
-            decode(stream);
+            decode(new DerValue(stream));
         } catch (InvalidKeyException e) {
             e.printStackTrace();
             throw new IOException("deserialized key is invalid: " +

--- a/test/jdk/sun/security/pkcs/pkcs8/LongPKCS8orX509KeySpec.java
+++ b/test/jdk/sun/security/pkcs/pkcs8/LongPKCS8orX509KeySpec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308010
+ * @summary X509Key and PKCS8Key allows garbage bytes at the end
+ * @library /test/lib
+ */
+
+import jdk.test.lib.Utils;
+
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+
+public class LongPKCS8orX509KeySpec {
+
+    public static void main(String[] argv) throws Exception {
+        var g = KeyPairGenerator.getInstance("EC");
+        var f = KeyFactory.getInstance("EC");
+        Utils.runAndCheckException(() -> f.generatePublic(new X509EncodedKeySpec(
+                Arrays.copyOf(g.generateKeyPair().getPublic().getEncoded(), 1000))),
+                InvalidKeySpecException.class);
+        Utils.runAndCheckException(() -> f.generatePrivate(new PKCS8EncodedKeySpec(
+                Arrays.copyOf(g.generateKeyPair().getPrivate().getEncoded(), 1000))),
+                InvalidKeySpecException.class);
+    }
+}


### PR DESCRIPTION
When parsing a byte array to a private or public key, it's now converted to a `ByteArrayInputStream` and the parser does not report an error if there are extra bytes at the end.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308010](https://bugs.openjdk.org/browse/JDK-8308010): X509Key and PKCS8Key allows garbage bytes at the end


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13958/head:pull/13958` \
`$ git checkout pull/13958`

Update a local copy of the PR: \
`$ git checkout pull/13958` \
`$ git pull https://git.openjdk.org/jdk.git pull/13958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13958`

View PR using the GUI difftool: \
`$ git pr show -t 13958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13958.diff">https://git.openjdk.org/jdk/pull/13958.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13958#issuecomment-1546000531)