### PR TITLE
8307976: (fs) Files.createDirectories(dir) returns dir::toAbsolutePath instead of dir

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -758,7 +758,7 @@ public final class Files {
             // parent may not exist or other reason
         }
         SecurityException se = null;
-        Path absDir = null;
+        Path absDir = dir;
         try {
             absDir = dir.toAbsolutePath();
         } catch (SecurityException x) {

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -758,14 +758,15 @@ public final class Files {
             // parent may not exist or other reason
         }
         SecurityException se = null;
+        Path absDir = null;
         try {
-            dir = dir.toAbsolutePath();
+            absDir = dir.toAbsolutePath();
         } catch (SecurityException x) {
             // don't have permission to get absolute path
             se = x;
         }
         // find a descendant that exists
-        Path parent = dir.getParent();
+        Path parent = absDir.getParent();
         while (parent != null) {
             try {
                 provider(parent).checkAccess(parent);
@@ -778,7 +779,7 @@ public final class Files {
         if (parent == null) {
             // unable to find existing parent
             if (se == null) {
-                throw new FileSystemException(dir.toString(), null,
+                throw new FileSystemException(absDir.toString(), null,
                     "Unable to determine if root directory exists");
             } else {
                 throw se;
@@ -787,7 +788,7 @@ public final class Files {
 
         // create directories
         Path child = parent;
-        for (Path name: parent.relativize(dir)) {
+        for (Path name: parent.relativize(absDir)) {
             child = child.resolve(name);
             createAndCheckIsDirectory(child, attrs);
         }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -127,6 +127,6 @@ public class CreateDirectories {
         Files.deleteIfExists(temp.getParent());
         temp.toFile().deleteOnExit();
         Path a = Files.createDirectories(temp);
-        assertTrue(a == temp);
+        assertEquals(a, temp, a + " != " + temp);
     }
 }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @bug 8032220 8293792
+ * @bug 8032220 8293792 8307976
  * @summary Test java.nio.file.Files.createDirectories method
  * @library ..
  * @run testng CreateDirectories
@@ -120,5 +120,13 @@ public class CreateDirectories {
         Path root = Path.of("/");
         Files.createDirectories(root);
         Files.createDirectories(root.toAbsolutePath());
+
+        // the returned path should not be absolute
+        Path temp = Path.of(".temp/temp.abc/temp.def");
+        Files.deleteIfExists(temp);
+        Files.deleteIfExists(temp.getParent());
+        temp.toFile().deleteOnExit();
+        Path a = Files.createDirectories(temp);
+        assertFalse(a.isAbsolute(), a + " should not be absolute");
     }
 }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -127,6 +127,6 @@ public class CreateDirectories {
         Files.deleteIfExists(temp.getParent());
         temp.toFile().deleteOnExit();
         Path a = Files.createDirectories(temp);
-        assertTrue(a == temp, a + " should not be absolute");
+        assertTrue(a == temp);
     }
 }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -127,6 +127,6 @@ public class CreateDirectories {
         Files.deleteIfExists(temp.getParent());
         temp.toFile().deleteOnExit();
         Path a = Files.createDirectories(temp);
-        assertEquals(a, temp, a + " != " + temp);
+        assertTrue(a == temp, a + " != " + temp);
     }
 }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -91,7 +91,8 @@ public class CreateDirectories {
     public void testCreateDirectories() throws IOException {
         final Path tmpdir = TestUtil.createTemporaryDirectory();
         // a no-op
-        Files.createDirectories(tmpdir);
+        Path d = Files.createDirectories(tmpdir);
+        assertTrue(d == tmpdir, d + " != " + tmpdir);
 
         // create one directory
         Path subdir = tmpdir.resolve("a");
@@ -123,9 +124,6 @@ public class CreateDirectories {
 
         // the returned path should not be absolute
         Path temp = Path.of(".temp/temp.abc/temp.def");
-        Files.deleteIfExists(temp);
-        Files.deleteIfExists(temp.getParent());
-        temp.toFile().deleteOnExit();
         Path a = Files.createDirectories(temp);
         assertTrue(a == temp, a + " != " + temp);
     }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -127,6 +127,6 @@ public class CreateDirectories {
         Files.deleteIfExists(temp.getParent());
         temp.toFile().deleteOnExit();
         Path a = Files.createDirectories(temp);
-        assertFalse(a.isAbsolute(), a + " should not be absolute");
+        assertTrue(a == temp, a + " should not be absolute");
     }
 }


### PR DESCRIPTION
Return `dir`, not `dir::toAbsolutePath`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307976](https://bugs.openjdk.org/browse/JDK-8307976): (fs) Files.createDirectories(dir) returns dir::toAbsolutePath instead of dir


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13959/head:pull/13959` \
`$ git checkout pull/13959`

Update a local copy of the PR: \
`$ git checkout pull/13959` \
`$ git pull https://git.openjdk.org/jdk.git pull/13959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13959`

View PR using the GUI difftool: \
`$ git pr show -t 13959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13959.diff">https://git.openjdk.org/jdk/pull/13959.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13959#issuecomment-1546042023)