### PR TITLE
JDK-8308015: Syntax of "import static" is incorrect in com.sun.source.tree.ImportTree.java

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/ImportTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/ImportTree.java
@@ -32,7 +32,7 @@ package com.sun.source.tree;
  * <pre>
  *   import <em>qualifiedIdentifier</em> ;
  *
- *   static import <em>qualifiedIdentifier</em> ;
+ *   import static <em>qualifiedIdentifier</em> ;
  * </pre>
  *
  * @jls 7.5 Import Declarations


### PR DESCRIPTION
Please review a trivial change to fix a bug in a non-normative part of the spec for `ImportTree`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308015](https://bugs.openjdk.org/browse/JDK-8308015): Syntax of "import static" is incorrect in com.sun.source.tree.ImportTree.java


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13960/head:pull/13960` \
`$ git checkout pull/13960`

Update a local copy of the PR: \
`$ git checkout pull/13960` \
`$ git pull https://git.openjdk.org/jdk.git pull/13960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13960`

View PR using the GUI difftool: \
`$ git pr show -t 13960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13960.diff">https://git.openjdk.org/jdk/pull/13960.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13960#issuecomment-1546047185)