### PR TITLE
8308021: Update IANA Language Subtag Registry to Version 2023-05-11

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-04-13
+File-Date: 2023-05-11
 %%
 Type: language
 Subtag: aa
@@ -47610,6 +47610,23 @@ Subtag: bauddha
 Description: Buddhist Hybrid Sanskrit
 Added: 2010-07-28
 Prefix: sa
+%%
+Type: variant
+Subtag: bciav
+Description: BCI Blissymbolics AV
+Added: 2023-05-11
+Prefix: zbl
+Comments: Name given to a subset of the variety of Blissymbolics curated
+  by Blissymbolics Communication International, as represented by
+  entries in the BCI Authorized Vocabulary
+%%
+Type: variant
+Subtag: bcizbl
+Description: BCI Blissymbolics
+Added: 2023-05-11
+Prefix: zbl
+Comments: Name given to the variety of Blissymbolics curated by
+  Blissymbolics Communication International
 %%
 Type: variant
 Subtag: biscayan

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038 8287180 8302512 8304761 8306031
+ *      8258795 8267038 8287180 8302512 8304761 8306031 8308021
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-04-13) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-05-11) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
Please review this trivial fix which updates the IANA data to version 5/11/2023. As the update only includes variant sub-tags, there is no impact to JDK tests. The update can be found [here](https://mm.icann.org/pipermail/ietf-languages-announcements/2023-May/000087.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308021](https://bugs.openjdk.org/browse/JDK-8308021): Update IANA Language Subtag Registry to Version 2023-05-11


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13962/head:pull/13962` \
`$ git checkout pull/13962`

Update a local copy of the PR: \
`$ git checkout pull/13962` \
`$ git pull https://git.openjdk.org/jdk.git pull/13962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13962`

View PR using the GUI difftool: \
`$ git pr show -t 13962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13962.diff">https://git.openjdk.org/jdk/pull/13962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13962#issuecomment-1546099367)