### PR TITLE
8304685: Fix whitespace parsing in libjdwp

### DIFF
--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -85,13 +85,10 @@ dbgsysExec(char *cmdLine)
     }
 
     for (i = 0, p = args; i < argc; i++) {
+        p = skipWhitespace(p); // no-op on first iteration
         argv[i] = p;
         p = skipNonWhitespace(p);
         *p++ = '\0';
-        if ((i + 1) == argc) {
-            break; // finished: do not call skipWhitespace again
-        }
-        p = skipWhitespace(p);
     }
     argv[i] = NULL;  /* NULL terminate */
 

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -89,7 +89,7 @@ dbgsysExec(char *cmdLine)
         p = skipNonWhitespace(p);
         *p++ = '\0';
         if ((i + 1) == argc) {
-            break; // finished: do not call skipWhitespace once extra
+            break; // finished: do not call skipWhitespace again
         }
         p = skipWhitespace(p);
     }

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,9 @@ dbgsysExec(char *cmdLine)
         argv[i] = p;
         p = skipNonWhitespace(p);
         *p++ = '\0';
+        if ((i + 1) == argc) {
+            break; // finished: do not call skipWhitespace once extra
+        }
         p = skipWhitespace(p);
     }
     argv[i] = NULL;  /* NULL terminate */


### PR DESCRIPTION
Problem call to skipWhitespace in dbgsysExec src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c:91

We call skipWhitespace even when the loop will terminate, should guard against the last skipWhitespace call on the last iteration.

Could be done differently with the skipWhitespace call at the start of the loop, but skipped on the first iteration, but leaving the statements in the loop in the same order seems more readable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304685](https://bugs.openjdk.org/browse/JDK-8304685): Fix whitespace parsing in libjdwp


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13964/head:pull/13964` \
`$ git checkout pull/13964`

Update a local copy of the PR: \
`$ git checkout pull/13964` \
`$ git pull https://git.openjdk.org/jdk.git pull/13964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13964`

View PR using the GUI difftool: \
`$ git pr show -t 13964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13964.diff">https://git.openjdk.org/jdk/pull/13964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13964#issuecomment-1546147936)