### PR TITLE
JDK-8306607: Apply 80-column output to javac supported version output

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -87,13 +87,13 @@ javac.opt.profile=\
     This option is deprecated and may be removed in a future release.
 javac.opt.target=\
     Generate class files suitable for the specified Java SE release.\n\
-    Supported releases: {0}
+    Supported releases: \n    {0}
 javac.opt.release=\
     Compile for the specified Java SE release.\n\
-    Supported releases: {0}
+    Supported releases: \n    {0}
 javac.opt.source=\
     Provide source compatibility with the specified Java SE release.\n\
-    Supported releases: {0}
+    Supported releases: \n    {0}
 javac.opt.Werror=\
     Terminate compilation if warnings occur
 javac.opt.A=\


### PR DESCRIPTION
Please review a trivial `noreg-doc` output to fix a "long lines" issue.
The solution should be good enough for at least a few years, and by then, we may have pruned the list of supported releases :-)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306607](https://bugs.openjdk.org/browse/JDK-8306607): Apply 80-column output to javac supported version output


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13965/head:pull/13965` \
`$ git checkout pull/13965`

Update a local copy of the PR: \
`$ git checkout pull/13965` \
`$ git pull https://git.openjdk.org/jdk.git pull/13965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13965`

View PR using the GUI difftool: \
`$ git pr show -t 13965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13965.diff">https://git.openjdk.org/jdk/pull/13965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13965#issuecomment-1546247218)