### PR TITLE
8306593

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -141,8 +141,6 @@ gtest/NMTGtests.java#nmt-summary 8306561 aix-ppc64
 
 #############################################################################
 
-vmTestbase/nsk/jdi/ThreadReference/stop/stop001/TestDescription.java 7034630 generic-all
-
 vmTestbase/metaspace/gc/firstGC_10m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
@@ -269,6 +269,7 @@ public class stop001 {
                 line = pipe.readln();
                 log2("       returned string is: " + line);
                 if (vthreadMode) {
+                    // Because the stop() called failed, stop001a.tObj should be "null".
                     if (!line.equals("null")) {
                         log3("ERROR: 'stop001a.tObj' is not 'null'");
                         expresult = returnCode1;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,7 @@ public class stop001 {
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
+    static final boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
 
     //----------------------------------------------------- templete parameters
     static final String
@@ -180,7 +181,7 @@ public class stop001 {
                 log2("     : returned string is 'checkend'");
                 break ;
             } else if (!line.equals("checkready")) {
-                log3("ERROR: returned string is not 'checkready'");
+                log3("ERROR: returned string is not 'checkready': " + line);
                 testExitCode = FAILED;
                 break ;
             }
@@ -233,7 +234,7 @@ public class stop001 {
                 if (expresult != returnCode0)
                     break label1;
 
-
+                boolean caughtExpected = false;
                 try {
                     log2("      getting a mirror of the throwableObj");
                     throwableObj = (ObjectReference)
@@ -245,8 +246,19 @@ public class stop001 {
                 } catch ( InvalidTypeException e1 ) {
                     log3("ERROR: InvalidTypeException ???");
                     expresult = returnCode1;
-                } catch ( Exception e2 ) {
-                    log3("ERROR: unexpected exception: " + e2);
+                } catch ( IllegalThreadStateException e2 ) {
+                    if (vthreadMode) {
+                        caughtExpected = true;
+                    } else {
+                        log3("ERROR: unexpected exception: " + e2);
+                        expresult = returnCode1;
+                    }
+                } catch ( Exception e3 ) {
+                    log3("ERROR: unexpected exception: " + e3);
+                    expresult = returnCode1;
+                }
+                if (vthreadMode && !caughtExpected) {
+                    log3("ERROR: didn't catch expected IllegalThreadStateException");
                     expresult = returnCode1;
                 }
 
@@ -256,16 +268,23 @@ public class stop001 {
                 log2("......getting result from mainThread:");
                 line = pipe.readln();
                 log2("       returned string is: " + line);
-                if (line.equals("null")) {
-                    log3("ERROR: 'stop001a.tObj = e1;' was not assigned");
-                    expresult = returnCode1;
-                } else if (line.equals("equal")) {
-                } else if (line.equals("NOT_equal")) {
-                    log3("ERROR: in the debugee, e1 is not 'LineUnavailableException'");
-                    expresult = returnCode1;
+                if (vthreadMode) {
+                    if (!line.equals("null")) {
+                        log3("ERROR: 'stop001a.tObj' is not 'null'");
+                        expresult = returnCode1;
+                    }
                 } else {
-                    log3("ERROR: returned string is unexpected");
-                    expresult = returnCode4;
+                    if (line.equals("null")) {
+                        log3("ERROR: 'stop001a.tObj = e1;' was not assigned");
+                        expresult = returnCode1;
+                    } else if (line.equals("equal")) {
+                    } else if (line.equals("NOT_equal")) {
+                        log3("ERROR: in the debugee, e1 is not 'LineUnavailableException'");
+                        expresult = returnCode1;
+                    } else {
+                        log3("ERROR: returned string is unexpected");
+                        expresult = returnCode4;
+                    }
                 }
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,6 +189,8 @@ class Threadstop001a extends NamedTask {
 
     public static Object lockingObject2 = new Object();
 
+    static final boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+
     private int i1 = 0, i2 = 10;
 
     public void run() {
@@ -204,11 +206,19 @@ class Threadstop001a extends NamedTask {
                 synchronized (lockingObject) {
                     log("entered into block:  synchronized (lockingObject)");
                 }
-                logerr("ERROR:  normal exit from block:  synchronized (lockingObject)");
-                stop001a.exitCode = stop001a.FAILED;
+                if (!vthreadMode) {
+                    logerr("ERROR:  normal exit from block:  synchronized (lockingObject)");
+                    stop001a.exitCode = stop001a.FAILED;
+                }
             } catch ( Exception e1 ) {
-                log("Exception: " + e1.getMessage());
-                stop001a.tObj = e1;
+                if (vthreadMode) {
+                    logerr("ERROR:  Unexpected exception: " + e1);
+                    stop001a.exitCode = stop001a.FAILED;
+
+                } else {
+                    log("Exception: " + e1.getMessage());
+                    stop001a.tObj = e1;
+                }
             }
         }
 


### PR DESCRIPTION
nsk/jdi/stop/stop001 is problem listed due to [JDK-7034630](https://bugs.openjdk.org/browse/JDK-7034630), but that issue doesn't seem to reproduce anymore. It's suspected that it was only an issue on Solaris. For this reason stop001 should be removed from the problem list. However, it will fail due to lacking virtual thread support, so this issue also needs to be fixed at the same time. The issue is that for virtual threads, after work for [JDK-8306434](https://bugs.openjdk.org/browse/JDK-8306434) and [JDK-8306471](https://bugs.openjdk.org/browse/JDK-8306471) is complete, the test needs to expect IllegalThreadStateException rather than the stop() call succeeding.