### PR TITLE
8306467: Fix nsk/jdb/kill/kill001 to work with new JVMTI StopThread support for virtual threads.

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -79,7 +79,6 @@ vmTestbase/nsk/jdb/where/where005/where005.java 8278470 generic-all
 
 vmTestbase/nsk/jdb/list/list003/list003.java        8300707 generic-all
 vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java  8300707 generic-all
-vmTestbase/nsk/jdb/kill/kill001/kill001.java        8306467 generic-all
 
 ####
 ## NSK JDI tests failing with wrapper

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -88,17 +88,13 @@ public class kill001 extends JdbTest {
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
     static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
-    static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
+    static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".killed";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
 
     static int numThreads = nsk.jdb.kill.kill001.kill001a.numThreads;
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
@@ -147,11 +143,11 @@ public class kill001 extends JdbTest {
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
                                                    DEBUGGEE_RESULT + " =");
-        grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
-        if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+        Paragrep grep = new Paragrep(reply);
+        String killed = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        if (killed.length() > 0) {
+            if (killed.indexOf(DEBUGGEE_RESULT + " = " + numThreads) < 0) {
+                log.complain("Only " + killed + "out of " + numThreads + MYTHREAD + "s were killed.");
                 success = false;
             }
         } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -39,7 +39,7 @@
  * to the number of additional threads created. The value of
  * the "killed" variable is checked by "eval <expr>" command.
  * The test passes if the value is equal to the number of
- * additional thread created and fails otherwise.
+ * additional threads created and fails otherwise.
  * COMMENTS
  *  Modified due to fix of the test bug:
  *  4940902 TEST_BUG: race in nsk/jdb/kill/kill001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -38,7 +38,7 @@
  * the value of the special "killed" variable should to the set
  * to the number of additional threads created. The value of
  * the "killed" variable is checked by "eval <expr>" command.
- * The test passes if the value is equal to the nunber of
+ * The test passes if the value is equal to the number of
  * additional thread created and fails otherwise.
  * COMMENTS
  *  Modified due to fix of the test bug:

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -149,7 +149,7 @@ public class kill001 extends JdbTest {
         String killed = grep.findFirst(DEBUGGEE_RESULT + " =" );
         if (killed.length() > 0) {
             if (killed.indexOf(DEBUGGEE_RESULT + " = " + numThreads) < 0) {
-                log.complain("Only " + killed + "out of " + numThreads + MYTHREAD + "s were killed.");
+                log.complain("Only " + killed + " out of " + numThreads + " " + MYTHREAD + "s were killed.");
                 success = false;
             }
         } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -35,9 +35,11 @@
  * suspends debuggee at moment when additional threads try to obtain
  * lock on synchronized object (previously locked in main thread)
  * and then tries to kill them. If these threads are killed then
- * a value of the special "notKilled" variable should not be modified.
- * Value of "notKilled" variable is checked by "eval <expr>" command.
- * The test passes if the value is equal to 0 and fails otherwise..
+ * the value of the special "killed" variable should to the set
+ * to the number of additional threads created. The value of
+ * the "killed" variable is checked by "eval <expr>" command.
+ * The test passes if the value is equal to the nunber of
+ * additional thread created and fails otherwise.
  * COMMENTS
  *  Modified due to fix of the test bug:
  *  4940902 TEST_BUG: race in nsk/jdb/kill/kill001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -35,7 +35,7 @@
  * suspends debuggee at moment when additional threads try to obtain
  * lock on synchronized object (previously locked in main thread)
  * and then tries to kill them. If these threads are killed then
- * the value of the special "killed" variable should to the set
+ * the value of the special "killed" variable should be set
  * to the number of additional threads created. The value of
  * the "killed" variable is checked by "eval <expr>" command.
  * The test passes if the value is equal to the number of

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -144,7 +144,6 @@ class MyThread extends Thread {
     public void run() {
         // Concatenate strings in advance to avoid lambda calculations later
         String ThreadFinished = "Thread finished: " + this.name;
-        String ThreadInterrupted = "WARNING: Thread was interrupted while waiting for killing: " + this.name;
         String CaughtExpected = "Thread " + this.name + " caught expected async exception: " + expectedException;
         String CaughtUnexpected = "WARNING: Thread " + this.name + " caught unexpected exception:";
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -166,7 +166,6 @@ class MyThread extends Thread {
                 synchronized (kill001a.lock) {
                     kill001a.killed++;
                 }
-                kill001a.log.complain("No exception for " + this.name);
             } else {
                 kill001a.log.display(CaughtUnexpected);
                 kill001a.log.display(t);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -152,7 +152,7 @@ class MyThread extends Thread {
         synchronized (kill001a.waitnotify) {
             kill001a.waitnotify.notify();
         }
-            
+
         try {
             synchronized (kill001a.lock) { }
             // We need some code that does an invoke here to make sure the async exception


### PR DESCRIPTION
Currently kill001 assumes that JVMTI StopThread (via JDI ThreadReference.stop) is not supported for virtual threads. [JDK-8306034](https://bugs.openjdk.org/browse/JDK-8306034) is adding support for StopThread on a virtual thread as long as it is suspended and mounted. This means, for example, it will work for virtual threads in the following conditions:
 - Debuggee in a loop and suspended
 - Debuggee blocked on a java monitor and suspended (because it is mounted when blocked)
 - Debuggee at a breakpoint and suspended

But will continue to not work in the following situations:
- Debuggee in a loop but not suspended
- Debuggee blocked on a java monitor and not suspended
- Debuggee suspended but unmounted, such as during a call the Thread.sleep()

kill001 suspends all threads when a breakpoint is hit in the main thread, and then does a "jdb kill" on each thread, which translate to `ThreadReference.stop()`. Si this is expected to work now since the additional threads are all blocked on a java monitor, and therefore mounted (and the breakpoint also suspended them).

Most of the changes involve undoing the virtual thread specific code that was added to the test as part of [JDK-8282385](https://bugs.openjdk.org/browse/JDK-8282385). However, there is an additional issue that also needs fixing. The test relies on the fact that the async exception is normally not caught, and that jdb normally stops when an uncaught exception is thrown. With virtual threads there ends up being an exception handler in `java.lang.VirtualThread.run()`, resulting in jdb not stopping when the async exception is thrown. This is fixed by having the test issue a jdb "catch all <classname>" command for each async exception type that the test throws.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306467](https://bugs.openjdk.org/browse/JDK-8306467): Fix nsk/jdb/kill/kill001 to work with new JVMTI StopThread support for virtual threads.


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [c2e0f7b1](https://git.openjdk.org/jdk/pull/13967/files/c2e0f7b13fcb163e80980fcf63940d5c2a2e1bc7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13967/head:pull/13967` \
`$ git checkout pull/13967`

Update a local copy of the PR: \
`$ git checkout pull/13967` \
`$ git pull https://git.openjdk.org/jdk.git pull/13967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13967`

View PR using the GUI difftool: \
`$ git pr show -t 13967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13967.diff">https://git.openjdk.org/jdk/pull/13967.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13967#issuecomment-1546300382)