### PR TITLE
8307369: Add execution of all svc tests in CI

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -25,7 +25,13 @@
 # Bugs
 
 compiler/jvmci/compilerToVM/MaterializeVirtualObjectTest.java 8307125 generic-all
+serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-all
+serviceability/jvmti/GetThreadListStackTraces/OneGetThreadListStackTraces.java 8308027 generic-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
+serviceability/dcmd/thread/PrintConcurrentLocksTest.java 8308033 generic-all
+serviceability/dcmd/thread/PrintTest.java 8308033 generic-all
+serviceability/dcmd/thread/ThreadDumpToFileTest.java 8308033 generic-all
+serviceability/tmtools/jstack/DaemonThreadTest.java 8308033 generic-all
 
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -51,6 +51,8 @@ com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all
 
+sun/tools/jcmd/JcmdOutputEncodingTest.java 8308033 generic-all
+sun/tools/jstack/BasicJStackTest.java 8308033 generic-all
 
 ##########
 ## Tests incompatible with  with virtual test thread factory.
@@ -74,3 +76,4 @@ java/lang/SecurityManager/modules/CustomSecurityManagerTest.java 0000000 generic
 java/util/PluggableLocale/PermissionTest.java 0000000 generic-all
 java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
 java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java 0000000 generic-all

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -54,6 +54,8 @@ com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all
 sun/tools/jcmd/JcmdOutputEncodingTest.java 8308033 generic-all
 sun/tools/jstack/BasicJStackTest.java 8308033 generic-all
 
+javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
+
 ##########
 ## Tests incompatible with  with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -395,16 +395,15 @@ public final class ProcessTools {
       java <jvm-args> -Dmain.wrapper=<wrapper-name> jdk.test.lib.process.ProcessTools <wrapper-name> <test-class> <test-args>
      */
 
-        private static List<String> addMainWrapperArgs(String mainWrapper, List<String> command) {
+    private static List<String> addMainWrapperArgs(String mainWrapper, List<String> command) {
 
         final List<String> unsupportedArgs = List.of(
-             "-jar", "-cp", "-classpath", "--class-path", "--describe-module", "-d",
-             "--dry-run", "--list-modules","--validate-modules", "-m", "--module", "-version");
+                "-jar", "-cp", "-classpath", "--class-path", "--describe-module", "-d",
+                "--dry-run", "--list-modules","--validate-modules", "-m", "--module", "-version");
 
         final List<String> doubleWordArgs = List.of(
-             "-jar", "-cp", "-classpath", "--class-path", "--add-opens", "--upgrade-module-path",
-             "--describe-module", "--add-modules", "-d", "--add-exports", "--limit-modules",
-             "--add-reads", "--patch-module", "--module-path", "--module", "-m", "-p");
+                "--add-opens", "--upgrade-module-path", "--add-modules", "--add-exports",
+                "--limit-modules", "--add-reads", "--patch-module", "--module-path", "-p");
 
         ArrayList<String> args = new ArrayList<>();
 

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -399,7 +399,7 @@ public final class ProcessTools {
 
         final List<String> unsupportedArgs = List.of(
              "-jar", "-cp", "-classpath", "--class-path", "--describe-module", "-d",
-             "--dry-run", "--list-modules","--validate-modules", "-version");
+             "--dry-run", "--list-modules","--validate-modules", "-m", "--module", "-version");
 
         final List<String> doubleWordArgs = List.of(
              "-jar", "-cp", "-classpath", "--class-path", "--add-opens", "--upgrade-module-path",


### PR DESCRIPTION
The fix excludes svc tests which should be updated to work with the virtual threads factory.
Also, ProcessTools updated to skip '-m' '--module' execution, which could not be run with test thread factory

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307369](https://bugs.openjdk.org/browse/JDK-8307369): Add execution of all svc tests in CI


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13968/head:pull/13968` \
`$ git checkout pull/13968`

Update a local copy of the PR: \
`$ git checkout pull/13968` \
`$ git pull https://git.openjdk.org/jdk.git pull/13968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13968`

View PR using the GUI difftool: \
`$ git pr show -t 13968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13968.diff">https://git.openjdk.org/jdk/pull/13968.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13968#issuecomment-1546421997)