### PR TITLE
8307968: serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
@@ -202,10 +202,10 @@ public class StopThreadTest {
                 log("TestTask.run: caught expected AssertionError from method A()");
                 seenExceptionFromA = true;
             }
+            Thread.interrupted();
             if (!seenExceptionFromA) {
                 StopThreadTest.setFailed("TestTask.run: expected AssertionError from method A()");
             }
-            Thread.interrupted();
             sleep(1); // to cause yield
 
             boolean seenExceptionFromB = false;
@@ -215,10 +215,10 @@ public class StopThreadTest {
                 log("TestTask.run: caught expected AssertionError from method B()");
                 seenExceptionFromB = true;
             }
+            Thread.interrupted();
             if (!seenExceptionFromB) {
                 StopThreadTest.setFailed("TestTask.run: expected AssertionError from method B()");
             }
-            Thread.interrupted();
             sleep(1); // to cause yield
 
             boolean seenExceptionFromC = false;
@@ -228,6 +228,7 @@ public class StopThreadTest {
                 log("TestTask.run: caught expected AssertionError from method C()");
                 seenExceptionFromC = true;
             }
+            Thread.interrupted();
             if (!seenExceptionFromC) {
                 StopThreadTest.setFailed("TestTask.run: expected AssertionError from method C()");
             }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
@@ -104,7 +104,7 @@ public class StopThreadTest {
             } else {
                 testTaskThread = Thread.ofPlatform().name("TestTaskThread").start(testTask);
             }
-            testTask.ensureAtPointA();
+            TestTask.ensureAtPointA();
 
             if (is_virtual) { // this check is for virtual target thread only
                 log("\nMain #A.1: unsuspended");
@@ -153,7 +153,7 @@ public class StopThreadTest {
         {
             // StopThread is called from the test task (own thread) and expected to succeed.
             // No suspension of the test task thread is required or can be done in this case.
-            testTask.ensureFinished();
+            TestTask.ensureFinished();
         }
 
         try {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
@@ -104,7 +104,7 @@ public class StopThreadTest {
             } else {
                 testTaskThread = Thread.ofPlatform().name("TestTaskThread").start(testTask);
             }
-            testTask.ensureStarted();
+            testTask.ensureAtPointA();
 
             if (is_virtual) { // this check is for virtual target thread only
                 log("\nMain #A.1: unsuspended");
@@ -168,10 +168,10 @@ public class StopThreadTest {
         static Object lock = new Object();
         static void log(String str) { System.out.println(str); }
 
-        private volatile boolean started = false;
-        private volatile boolean finished = false;
+        static volatile boolean atPointA = false;
+        static volatile boolean finished = false;
 
-        static public void sleep(long millis) {
+        static void sleep(long millis) {
             try {
                 Thread.sleep(millis);
             } catch (InterruptedException e) {
@@ -179,15 +179,14 @@ public class StopThreadTest {
             }
         }
 
-        // Ensure thread is ready.
-        public void ensureStarted() {
-            while (!started) {
+        static void ensureAtPointA() {
+            while (!atPointA) {
                 sleep(1);
             }
         }
 
         // Ensure thread is finished.
-        public void ensureFinished() {
+        static void ensureFinished() {
             while (!finished) {
                 sleep(1);
             }
@@ -195,7 +194,6 @@ public class StopThreadTest {
 
         public void run() {
             log("TestTask.run: started");
-            started = true;
 
             boolean seenExceptionFromA = false;
             try {
@@ -203,14 +201,11 @@ public class StopThreadTest {
             } catch (AssertionError ex) {
                 log("TestTask.run: caught expected AssertionError from method A()");
                 seenExceptionFromA = true;
-                if (!Thread.currentThread().isVirtual()) { // platform thread
-                    // clear the interrupt status
-                    Thread.interrupted();
-                }
             }
             if (!seenExceptionFromA) {
                 StopThreadTest.setFailed("TestTask.run: expected AssertionError from method A()");
             }
+            Thread.interrupted();
             sleep(1); // to cause yield
 
             boolean seenExceptionFromB = false;
@@ -219,14 +214,11 @@ public class StopThreadTest {
             } catch (AssertionError ex) {
                 log("TestTask.run: caught expected AssertionError from method B()");
                 seenExceptionFromB = true;
-                if (!Thread.currentThread().isVirtual()) { // platform thread
-                    // clear the interrupt status
-                    Thread.interrupted();
-                }
             }
             if (!seenExceptionFromB) {
                 StopThreadTest.setFailed("TestTask.run: expected AssertionError from method B()");
             }
+            Thread.interrupted();
             sleep(1); // to cause yield
 
             boolean seenExceptionFromC = false;
@@ -248,6 +240,7 @@ public class StopThreadTest {
         //  - when suspended: JVMTI_ERROR_NONE is expected
         static void A() {
             log("TestTask.A: started");
+            atPointA = true;
             synchronized (lock) {
             }
             log("TestTask.A: finished");


### PR DESCRIPTION
This is newly integrated test times out because it has a race in in the Test #A.1 and #A.2.
The main root cause is a print statement which can case target virtual thread to unpark and unmount.
This causes that the `StopThreads` unexpectedly fails with the `JVMTI_ERROR_OPAQUE_FRAME` error code.
The target thread can be in some other unexpected states if JVMTI `StopThread`
is called before the target thread method `A()` reached the synchronized statement.

The fix is to replace the `ensureStarted()` with the `ensureAtPointA()`.
The fix also includes some simplifications related to clearing the target thread interrupt status.

Testing:
Hundreds of mach5 runs of `serviceability/jvmti/vthread` tests which include the fixed `StopThreadTest`.
TBD: To run mach5 tiers1-3.

The test does not fail with this fix anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307968](https://bugs.openjdk.org/browse/JDK-8307968): serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java timed out


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [58080db4](https://git.openjdk.org/jdk/pull/13969/files/58080db4706932c126f5bcd2075f0bd8e71c7e64)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [58080db4](https://git.openjdk.org/jdk/pull/13969/files/58080db4706932c126f5bcd2075f0bd8e71c7e64)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13969/head:pull/13969` \
`$ git checkout pull/13969`

Update a local copy of the PR: \
`$ git checkout pull/13969` \
`$ git pull https://git.openjdk.org/jdk.git pull/13969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13969`

View PR using the GUI difftool: \
`$ git pr show -t 13969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13969.diff">https://git.openjdk.org/jdk/pull/13969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13969#issuecomment-1546586671)