### PR TITLE
8308041: [JVMCI] WB_IsGCSupportedByJVMCICompiler must enter correct JVMCI env

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -368,7 +368,8 @@ WB_END
 WB_ENTRY(jboolean, WB_IsGCSupportedByJVMCICompiler(JNIEnv* env, jobject o, jint name))
 #if INCLUDE_JVMCI
   if (EnableJVMCI) {
-    JVMCIEnv jvmciEnv(thread, env, __FILE__, __LINE__);
+    // Enter the JVMCI env that will be used by the CompileBroker.
+    JVMCIEnv jvmciEnv(thread, __FILE__, __LINE__);
     return jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
   }
 #endif


### PR DESCRIPTION
The `WB_IsGCSupportedByJVMCICompiler` function in `whitebox.cpp` must use the same JVMCI environment (i.e. jarjvmci or libjvmci) that will be used by the `CompileBroker`. Otherwise, the question is being asked to the wrong JVMCI compiler implementation (which may not even exist in one of the 2 possible JVMCI environments).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308041](https://bugs.openjdk.org/browse/JDK-8308041): [JVMCI] WB_IsGCSupportedByJVMCICompiler must enter correct JVMCI env


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13971/head:pull/13971` \
`$ git checkout pull/13971`

Update a local copy of the PR: \
`$ git checkout pull/13971` \
`$ git pull https://git.openjdk.org/jdk.git pull/13971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13971`

View PR using the GUI difftool: \
`$ git pr show -t 13971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13971.diff">https://git.openjdk.org/jdk/pull/13971.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13971#issuecomment-1546733747)