### PR TITLE
8307795: AArch64: Optimize VectorMask.truecount() on Neon

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -5396,6 +5396,31 @@ instruct vmask_truecount_sve(iRegINoSp dst, pReg src) %{
   ins_pipe(pipe_slow);
 %}
 
+// Combined rule for VectorStoreMask + VectorMaskTrueCount when the vector element type is not T_BYTE.
+
+instruct vstoremask_truecount(iRegINoSp dst, vReg src, immI_gt_1 size, vReg vtmp) %{
+  predicate(UseSVE == 0);
+  match(Set dst (VectorMaskTrueCount (VectorStoreMask src size)));
+  effect(TEMP vtmp);
+  format %{ "vstoremask_truecount $dst, $src\t# KILL $vtmp" %}
+  ins_encode %{
+    // Input "src" is a vector mask represented as lanes with
+    // 0/-1 as element values.
+    uint esize = (uint)$size$$constant;
+    if (esize == 8) {
+      __ addpd($vtmp$$FloatRegister, $src$$FloatRegister);
+    } else {
+      uint length_in_bytes = Matcher::vector_length_in_bytes(this, $src);
+      Assembler::SIMD_Arrangement arrangement = Assembler::esize2arrangement(esize,
+                                                                             /* isQ */ length_in_bytes == 16);
+      __ addv($vtmp$$FloatRegister, arrangement, $src$$FloatRegister);
+    }
+    __ smov($dst$$Register, $vtmp$$FloatRegister, __ B, 0);
+    __ neg($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // first true
 
 instruct vmask_firsttrue_lt8e(iRegINoSp dst, vReg src, rFlagsReg cr) %{

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -3793,6 +3793,31 @@ instruct vmask_truecount_sve(iRegINoSp dst, pReg src) %{
   ins_pipe(pipe_slow);
 %}
 
+// Combined rule for VectorStoreMask + VectorMaskTrueCount when the vector element type is not T_BYTE.
+
+instruct vstoremask_truecount(iRegINoSp dst, vReg src, immI_gt_1 size, vReg vtmp) %{
+  predicate(UseSVE == 0);
+  match(Set dst (VectorMaskTrueCount (VectorStoreMask src size)));
+  effect(TEMP vtmp);
+  format %{ "vstoremask_truecount $dst, $src\t# KILL $vtmp" %}
+  ins_encode %{
+    // Input "src" is a vector mask represented as lanes with
+    // 0/-1 as element values.
+    uint esize = (uint)$size$$constant;
+    if (esize == 8) {
+      __ addpd($vtmp$$FloatRegister, $src$$FloatRegister);
+    } else {
+      uint length_in_bytes = Matcher::vector_length_in_bytes(this, $src);
+      Assembler::SIMD_Arrangement arrangement = Assembler::esize2arrangement(esize,
+                                                                             /* isQ */ length_in_bytes == 16);
+      __ addv($vtmp$$FloatRegister, arrangement, $src$$FloatRegister);
+    }
+    __ smov($dst$$Register, $vtmp$$FloatRegister, __ B, 0);
+    __ neg($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // first true
 
 instruct vmask_firsttrue_lt8e(iRegINoSp dst, vReg src, rFlagsReg cr) %{

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1368,6 +1368,11 @@ public class IRNode {
         machOnlyNameRegex(VNOT_L_MASKED, "vnotL_masked");
     }
 
+    public static final String VSTOREMASK_TRUECOUNT = PREFIX + "VSTOREMASK_TRUECOUNT" + POSTFIX;
+    static {
+        machOnlyNameRegex(VSTOREMASK_TRUECOUNT, "vstoremask_truecount");
+    }
+
     public static final String XOR = PREFIX + "XOR" + POSTFIX;
     static {
         beforeMatchingNameRegex(XOR, "Xor(I|L)");

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskTrueCount.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskTrueCount.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.incubator.vector.*;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8307795
+ * @key randomness
+ * @library /test/lib /
+ * @requires os.arch=="aarch64"
+ * @summary AArch64: Optimize VectorMask.truecount() on Neon
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.TestVectorMaskTrueCount
+ */
+
+public class TestVectorMaskTrueCount {
+    private static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_PREFERRED;
+    private static final int LENGTH = 1024;
+    private static final Random RD = new Random();
+    private static boolean[] ba;
+    private static boolean[] bb;
+
+    static {
+        ba = new boolean[LENGTH];
+        bb = new boolean[LENGTH];
+        for (int i = 0; i < LENGTH; i++) {
+            ba[i] = RD.nextBoolean();
+            bb[i] = RD.nextBoolean();
+        }
+    }
+
+    static int maskAndTrueCount(boolean[] a, boolean[] b, int idx) {
+        int trueCount = 0;
+        boolean[] c = new boolean[SPECIES.length()];
+
+        for (int i = idx; i < idx + SPECIES.length(); i++) {
+            c[i - idx] = a[i] & b[i];
+        }
+
+        for (int i = 0; i < c.length; i++) {
+            trueCount += c[i] ? 1 : 0;
+        }
+
+        return trueCount;
+    }
+
+    static void assertArrayEquals(int[] r, boolean[] a, boolean[] b) {
+        for (int i = 0; i < a.length; i += SPECIES.length()) {
+            Asserts.assertEquals(r[i], maskAndTrueCount(a, b, i));
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.VSTOREMASK_TRUECOUNT, ">= 1" })
+    public static void test() {
+        int[] r = new int[LENGTH];
+        for (int i = 0; i < LENGTH; i += SPECIES.length()) {
+            VectorMask<Double> ma = VectorMask.fromArray(SPECIES, ba, i);
+            VectorMask<Double> mb = VectorMask.fromArray(SPECIES, bb, i);
+            r[i] = ma.and(mb).trueCount();
+        }
+
+        assertArrayEquals(r, ba, bb);
+    }
+
+    public static void main(String[] args) {
+        TestFramework testFramework = new TestFramework();
+        testFramework.setDefaultWarmup(10000)
+                     .addFlags("--add-modules=jdk.incubator.vector")
+                     .addFlags("-XX:UseSVE=0")
+                     .start();
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2023, Arm Limited. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+//
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+public class StoreMaskTrueCount {
+    private static final VectorSpecies<Short> S_SPECIES = ShortVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_PREFERRED;
+    private static final int LENGTH = 1024;
+    private static final Random RD = new Random();
+    private static boolean[] ba;
+
+    static {
+        ba = new boolean[LENGTH];
+        for (int i = 0; i < LENGTH; i++) {
+            ba[i] = RD.nextBoolean();
+        }
+    }
+
+    @Benchmark
+    public static int testShort() {
+        VectorMask<Short> m = VectorMask.fromArray(S_SPECIES, ba, 0);
+        int res = 0;
+        for (int i = 0; i < LENGTH; i++) {
+            m = m.not();
+            res += m.trueCount();
+        }
+
+        return res;
+    }
+
+    @Benchmark
+    public static int testInt() {
+        VectorMask<Integer> m = VectorMask.fromArray(I_SPECIES, ba, 0);
+        int res = 0;
+        for (int i = 0; i < LENGTH; i++) {
+            m = m.not();
+            res += m.trueCount();
+        }
+
+        return res;
+    }
+
+    @Benchmark
+    public static int testLong() {
+        VectorMask<Long> m = VectorMask.fromArray(L_SPECIES, ba, 0);
+        int res = 0;
+        for (int i = 0; i < LENGTH; i++) {
+            m = m.not();
+            res += m.trueCount();
+        }
+
+        return res;
+    }
+}


### PR DESCRIPTION
In Vector API Java level, vector mask is represented as a boolean array
with 0x00/0x01 (8 bits of each element) as values, aka in-memory format.
When it is loaded into vector register, e.g. Neon, the in-memory format
will be converted to in-register format with 0/-1 value for each lane
(lane width aligned to its type) by VectorLoadMask [1] operation, and
convert back to in-memory format by VectorStoreMask[2]. In Neon, a
typical VectorStoreMask operation will first narrow given vector
registers by xtn insn [3] into byte element type, and then do a vector
negate to convert to 0x00/0x01 value for each element.

For most of the vector mask operations, the input mask is in-register
format. And a vector mask also works in-register format all through
the compilation. But for some operations like VectorMask.trueCount()[4]
which counts the elements of true value, the expected input mask is
in-memory format. So a VectorStoreMask is generated to convert the
mask from in-register format to in-memory format before those operations.

However, for trueCount() these xtn instructions in VectorStoreMask can
be saved, since the narrowing operations will not influence the number
of active lane (value of 0x01) of its input.

This patch adds an optimized rule
`VectorMaskTrueCount (VectorStoreMask mask)` to save the unnecessary
narrowing operations.

For example,

```
var m = VectorMask.fromArray(IntVector.SPECIES_PREFERRED, ba, 0);
m.not().trueCount();
```

will produce following assembly on a Neon machine before this patch:

```
...
mvn     v16.16b, v16.16b           // VectorMask.not()
xtn     v16.4h, v16.4s
xtn     v16.8b, v16.8h
neg     v16.8b, v16.8b             // VectorStoreMask
addv    b17, v16.8b
umov    w0, v17.b[0]               // VectorMask.trueCount()
...
```

After this patch:

```
...
mvn     v16.16b, v16.16b           // VectorMask.not()
addv    s17, v16.4s
smov    x0, v17.b[0]
neg     x0, x0                     // Optimized VectorMask.trueCount()
...
```

In this case, we can save two xtn insns.

Performance:

Benchmark     Before               After                          Unit
testInt           723.822 ± 1.029  1182.375 ± 12.363    ops/ms
testLong       632.154 ± 0.197  1382.74 ± 2.188        ops/ms
testShort      788.665 ± 1.852   1152.38 ± 3.77         ops/ms

[1]: https://github.com/openjdk/jdk/blob/e1e758a7b43c29840296d337bd2f0213ab0ca3c9/src/hotspot/cpu/aarch64/aarch64_vector.ad#L4740
[2]: https://github.com/openjdk/jdk/blob/f968da97a5a5c68c28ad29d13fdfbe3a4adf5ef7/src/hotspot/cpu/aarch64/aarch64_vector.ad#L4841
[3]: https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/XTN--XTN2--vector-
[4]: https://docs.oracle.com/en/java/javase/16/docs/api/jdk.incubator.vector/jdk/incubator/vector/VectorMask.html#trueCount()