### PR TITLE
8308072: [BACKOUT] update for deprecated sprintf for src/utils

### DIFF
--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -219,8 +219,6 @@ static void* decode(struct hsdis_app_data* app_data, const char* options) {
 const decode_func_vtype decode_func_virtual_address = &decode_instructions_virtual;
 const decode_func_stype decode_func_address = &decode_instructions;
 
-#define remaining_buflen(buf, bufsize, p) ((bufsize) - ((p) - (buf)))
-
 static const char* format_insn_close(const char* close,
                                      disassemble_info* dinfo,
                                      char* buf, size_t bufsize) {
@@ -246,9 +244,9 @@ static const char* format_insn_close(const char* close,
 
   strcpy(buf, close);
   char* p = buf;
-  if (type)    snprintf(p += strlen(p), remaining_buflen(buf, bufsize, p), " type='%s'", type);
-  if (dsize)   snprintf(p += strlen(p), remaining_buflen(buf, bufsize, p), " dsize='%d'", dsize);
-  if (delays)  snprintf(p += strlen(p), remaining_buflen(buf, bufsize, p), " delay='%d'", delays);
+  if (type)    sprintf(p += strlen(p), " type='%s'", type);
+  if (dsize)   sprintf(p += strlen(p), " dsize='%d'", dsize);
+  if (delays)  sprintf(p += strlen(p), " delay='%d'", delays);
   return buf;
 }
 


### PR DESCRIPTION
Clean backout of https://github.com/openjdk/jdk/pull/13915 / [JDK-8307855](https://bugs.openjdk.org/browse/JDK-8307855) because @kimbarrett noticed some issues after integration. Also the change is non-trivial and therefore missing a second review.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308072](https://bugs.openjdk.org/browse/JDK-8308072): [BACKOUT] update for deprecated sprintf for src/utils


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13975/head:pull/13975` \
`$ git checkout pull/13975`

Update a local copy of the PR: \
`$ git checkout pull/13975` \
`$ git pull https://git.openjdk.org/jdk.git pull/13975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13975`

View PR using the GUI difftool: \
`$ git pr show -t 13975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13975.diff">https://git.openjdk.org/jdk/pull/13975.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13975#issuecomment-1547208988)