### PR TITLE
8308076: X86_64: make rheapbase register allocatable in zero based compressedOops mode

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedOops_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/compressedOops_aarch64.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_AARCH64_COMPRESSEDOOPS_AARCH64_HPP
+#define CPU_AARCH64_COMPRESSEDOOPS_AARCH64_HPP
+
+#endif // CPU_AARCH64_COMPERSSEDOOPS_AARCH64_HPP

--- a/src/hotspot/cpu/arm/compressedOops_arm.hpp
+++ b/src/hotspot/cpu/arm/compressedOops_arm.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ARM_COMPRESSEDOOPS_ARM_HPP
+#define CPU_ARM_COMPRESSEDOOPS_ARM_HPP
+
+#endif // CPU_ARM_COMPERSSEDOOPS_ARM_HPP

--- a/src/hotspot/cpu/ppc/compressedOops_ppc.hpp
+++ b/src/hotspot/cpu/ppc/compressedOops_ppc.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ZERO_COMPRESSEDOOPS_ZERO_HPP
+#define CPU_ZERO_COMPRESSEDOOPS_ZERO_HPP
+
+#endif // CPU_ZERO_COMPERSSEDOOPS_ZERO_HPP

--- a/src/hotspot/cpu/riscv/compressedOops_riscv.hpp
+++ b/src/hotspot/cpu/riscv/compressedOops_riscv.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_COMPRESSEDOOPS_RISCV_HPP
+#define CPU_RISCV_COMPRESSEDOOPS_RISCV_HPP
+
+#endif // CPU_RISCV_COMPERSSEDOOPS_RISCV_HPP

--- a/src/hotspot/cpu/s390/compressedOops_s390.hpp
+++ b/src/hotspot/cpu/s390/compressedOops_s390.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_S390_COMPRESSEDOOPS_S390_HPP
+#define CPU_S390_COMPRESSEDOOPS_S390_HPP
+
+#endif // CPU_S390_COMPERSSEDOOPS_S390_HPP

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -610,6 +610,7 @@ void Assembler::emit_operand_helper(int reg_enc, int base_enc, int index_enc,
                                     RelocationHolder const& rspec,
                                     int post_addr_length) {
   bool no_relocation = (rspec.type() == relocInfo::none);
+  assert (post_addr_length != -1 || no_relocation, "sanity");
 
   if (is_valid_encoding(base_enc)) {
     if (is_valid_encoding(index_enc)) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -752,14 +752,12 @@ private:
                             Address::ScaleFactor scale, int index_enc, int base_enc,
                             int disp);
 
-public:
   void emit_operand_helper(int reg_enc,
                            int base_enc, int index_enc, Address::ScaleFactor scale,
                            int disp,
                            RelocationHolder const& rspec,
                            int post_addr_length);
 
-private:
   void emit_operand(Register reg,
                     Register base, Register index, Address::ScaleFactor scale,
                     int disp,
@@ -808,6 +806,16 @@ private:
   void emit_arith_operand(int op1, Register rm, Address adr, int32_t imm32);
   void emit_arith_operand_imm32(int op1, Register rm, Address adr, int32_t imm32);
 
+ public:
+  // a wrapper of emit_operand_helper ,only used in ad file
+  void emit_regmem(int reg_enc,
+                   int base_enc, int index_enc, Address::ScaleFactor scale,
+                   int disp,
+                   RelocationHolder const& rspec) {
+    assert(rspec.type() == relocInfo::none, "sanity");
+    emit_operand_helper(reg_enc, base_enc, index_enc, scale, disp, rspec,
+                        -1); // post_addr_length is unused if rspec is none
+  };
  protected:
 #ifdef ASSERT
   void check_relocation(RelocationHolder const& rspec, int format);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -752,12 +752,14 @@ private:
                             Address::ScaleFactor scale, int index_enc, int base_enc,
                             int disp);
 
+public:
   void emit_operand_helper(int reg_enc,
                            int base_enc, int index_enc, Address::ScaleFactor scale,
                            int disp,
                            RelocationHolder const& rspec,
                            int post_addr_length);
 
+private:
   void emit_operand(Register reg,
                     Register base, Register index, Address::ScaleFactor scale,
                     int disp,

--- a/src/hotspot/cpu/x86/compressedOops_x86.hpp
+++ b/src/hotspot/cpu/x86/compressedOops_x86.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_X86_COMPRESSEDOOPS_X86_HPP
+#define CPU_X86_COMPRESSEDOOPS_X86_HPP
+
+#if !defined(ZERO)
+#ifdef _LP64
+public:
+  static bool     need_heapbase_reg()        { return UseCompressedOops && (PreserveHeapbaseReg || _narrow_oop._base != nullptr); }
+#endif
+#endif // X86_64 only
+
+#endif // CPU_X86_COMPERSSEDOOPS_X86_HPP

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -214,7 +214,7 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
   product(bool, UseLibmIntrinsic, true, DIAGNOSTIC,                         \
           "Use Libm Intrinsics")                                            \
                                                                             \
-  product(bool, PreserveHeapbaseReg, true,                                  \
+  product(bool, PreserveHeapbaseReg, false,                                 \
           "preserve r12 as heapbase reg")                                   \
   /* Minimum array size in bytes to use AVX512 intrinsics */                \
   /* for copy, inflate and fill which don't bail out early based on any */  \

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -214,8 +214,8 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
   product(bool, UseLibmIntrinsic, true, DIAGNOSTIC,                         \
           "Use Libm Intrinsics")                                            \
                                                                             \
-  product(bool, PreserveHeapbaseReg, false,                                 \
-          "preserve r12 as heapbase reg")                                   \
+  LP64_ONLY(product(bool, PreserveHeapbaseReg, false,                       \
+          "preserve r12 as heapbase reg"))                                  \
   /* Minimum array size in bytes to use AVX512 intrinsics */                \
   /* for copy, inflate and fill which don't bail out early based on any */  \
   /* condition. When this value is set to zero compare operations like */   \

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -214,6 +214,8 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
   product(bool, UseLibmIntrinsic, true, DIAGNOSTIC,                         \
           "Use Libm Intrinsics")                                            \
                                                                             \
+  product(bool, PreserveHeapbaseReg, true,                                  \
+          "preserve r12 as heapbase reg")                                   \
   /* Minimum array size in bytes to use AVX512 intrinsics */                \
   /* for copy, inflate and fill which don't bail out early based on any */  \
   /* condition. When this value is set to zero compare operations like */   \

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5200,7 +5200,7 @@ void MacroAssembler::store_klass_gap(Register dst, Register src) {
 void MacroAssembler::verify_heapbase(const char* msg) {
   assert (UseCompressedOops, "should be compressed");
   assert (Universe::heap() != nullptr, "java heap should be initialized");
-  if (CheckCompressedOops) {
+  if (CheckCompressedOops && X86_ONLY(CompressedOops::need_heapbase_reg())) {
     Label ok;
     ExternalAddress src2(CompressedOops::ptrs_base_addr());
     const bool is_src2_reachable = reachable(src2);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5491,7 +5491,14 @@ void MacroAssembler::reinit_heapbase() {
   if (UseCompressedOops) {
     if (Universe::heap() != nullptr) {
       if (CompressedOops::base() == nullptr) {
-        MacroAssembler::xorptr(r12_heapbase, r12_heapbase);
+        if (CompressedOops::need_heapbase_reg()) {
+          MacroAssembler::xorptr(r12_heapbase, r12_heapbase);
+        }
+#ifndef PRODUCT
+        else {
+          mov64(r12_heapbase, (int64_t)0xAABBCCDDAABBCCDD);
+        }
+#endif
       } else {
         mov64(r12_heapbase, (int64_t)CompressedOops::ptrs_base());
       }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5328,7 +5328,7 @@ void  MacroAssembler::decode_heap_oop_not_null(Register dst, Register src) {
   // Also do not verify_oop as this is called by verify_oop.
   if (CompressedOops::shift() != 0) {
     assert(LogMinObjAlignmentInBytes == CompressedOops::shift(), "decode alg wrong");
-    if (LogMinObjAlignmentInBytes == Address::times_8) {
+    if (LogMinObjAlignmentInBytes == Address::times_8 && CompressedOops::base() != nullptr) {
       leaq(dst, Address(r12_heapbase, src, Address::times_8, 0));
     } else {
       if (dst != src) {

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -379,7 +379,8 @@ RegMask _STACK_OR_LONG_REG_mask;
 RegMask _STACK_OR_INT_REG_mask;
 
 static bool need_r12_heapbase() {
-  return UseCompressedOops;
+  // return UseCompressedOops && (PreserveHeapbaseReg || CompressedOops::ptrs_base() != nullptr);
+  return CompressedOops::need_heapbase_reg();
 }
 
 void reg_mask_init() {
@@ -635,68 +636,9 @@ void encode_RegMem(CodeBuffer &cbuf,
                    int base, int index, int scale, int disp, relocInfo::relocType disp_reloc)
 {
   assert(disp_reloc == relocInfo::none, "cannot have disp");
-  int regenc = reg & 7;
-  int baseenc = base & 7;
-  int indexenc = index & 7;
-
-  // There is no index & no scale, use form without SIB byte
-  if (index == 0x4 && scale == 0 && base != RSP_enc && base != R12_enc) {
-    // If no displacement, mode is 0x0; unless base is [RBP] or [R13]
-    if (disp == 0 && base != RBP_enc && base != R13_enc) {
-      emit_rm(cbuf, 0x0, regenc, baseenc); // *
-    } else if (-0x80 <= disp && disp < 0x80 && disp_reloc == relocInfo::none) {
-      // If 8-bit displacement, mode 0x1
-      emit_rm(cbuf, 0x1, regenc, baseenc); // *
-      emit_d8(cbuf, disp);
-    } else {
-      // If 32-bit displacement
-      if (base == -1) { // Special flag for absolute address
-        emit_rm(cbuf, 0x0, regenc, 0x5); // *
-        if (disp_reloc != relocInfo::none) {
-          emit_d32_reloc(cbuf, disp, relocInfo::oop_type, RELOC_DISP32);
-        } else {
-          emit_d32(cbuf, disp);
-        }
-      } else {
-        // Normal base + offset
-        emit_rm(cbuf, 0x2, regenc, baseenc); // *
-        if (disp_reloc != relocInfo::none) {
-          emit_d32_reloc(cbuf, disp, relocInfo::oop_type, RELOC_DISP32);
-        } else {
-          emit_d32(cbuf, disp);
-        }
-      }
-    }
-  } else {
-    // Else, encode with the SIB byte
-    // If no displacement, mode is 0x0; unless base is [RBP] or [R13]
-    if (disp == 0 && base != RBP_enc && base != R13_enc) {
-      // If no displacement
-      emit_rm(cbuf, 0x0, regenc, 0x4); // *
-      emit_rm(cbuf, scale, indexenc, baseenc);
-    } else {
-      if (-0x80 <= disp && disp < 0x80 && disp_reloc == relocInfo::none) {
-        // If 8-bit displacement, mode 0x1
-        emit_rm(cbuf, 0x1, regenc, 0x4); // *
-        emit_rm(cbuf, scale, indexenc, baseenc);
-        emit_d8(cbuf, disp);
-      } else {
-        // If 32-bit displacement
-        if (base == 0x04 ) {
-          emit_rm(cbuf, 0x2, regenc, 0x4);
-          emit_rm(cbuf, scale, indexenc, 0x04); // XXX is this valid???
-        } else {
-          emit_rm(cbuf, 0x2, regenc, 0x4);
-          emit_rm(cbuf, scale, indexenc, baseenc); // *
-        }
-        if (disp_reloc != relocInfo::none) {
-          emit_d32_reloc(cbuf, disp, relocInfo::oop_type, RELOC_DISP32);
-        } else {
-          emit_d32(cbuf, disp);
-        }
-      }
-    }
-  }
+  MacroAssembler masm(&cbuf);
+  masm.emit_operand_helper(reg, base, index, (Address::ScaleFactor)scale, disp, RelocationHolder::none,
+                           -1 /* post_addr_length is used only in reloc mode */);
 }
 
 // This could be in MacroAssembler but it's fairly C2 specific
@@ -3995,10 +3937,8 @@ operand indPosIndexScaleOffset(any_RegP reg, immL32 off, rRegI idx, immI2 scale)
 %}
 
 // Indirect Narrow Oop Plus Offset Operand
-// Note: x86 architecture doesn't support "scale * index + offset" without a base
-// we can't free r12 even with CompressedOops::base() == NULL.
 operand indCompressedOopOffset(rRegN reg, immL32 off) %{
-  predicate(UseCompressedOops && (CompressedOops::shift() == Address::times_8));
+  predicate(UseCompressedOops && (CompressedOops::shift() == Address::times_8) && CompressedOops::need_heapbase_reg());
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) off);
 
@@ -4006,6 +3946,22 @@ operand indCompressedOopOffset(rRegN reg, immL32 off) %{
   format %{"[R12 + $reg << 3 + $off] (compressed oop addressing)" %}
   interface(MEMORY_INTER) %{
     base(0xc); // R12
+    index($reg);
+    scale(0x3);
+    disp($off);
+  %}
+%}
+
+// Indirect Narrow Oop Plus Offset Operand Zero Base
+operand indCompressedOopOffsetZeroBase(rRegN reg, immL32 off) %{
+  predicate(UseCompressedOops && (CompressedOops::shift() == Address::times_8) && !CompressedOops::need_heapbase_reg());
+  constraint(ALLOC_IN_RC(ptr_reg));
+  match(AddP (DecodeN reg) off);
+
+  op_cost(10);
+  format %{"[,$reg << 3 + $off] (zero base compressed oop addressing)" %}
+  interface(MEMORY_INTER) %{
+    base(0xffffffff); // no base
     index($reg);
     scale(0x3);
     disp($off);
@@ -4340,7 +4296,7 @@ operand cmpOpUCF2() %{
 
 opclass memory(indirect, indOffset8, indOffset32, indIndexOffset, indIndex,
                indIndexScale, indPosIndexScale, indIndexScaleOffset, indPosIndexOffset, indPosIndexScaleOffset,
-               indCompressedOopOffset,
+               indCompressedOopOffset,indCompressedOopOffsetZeroBase,
                indirectNarrow, indOffset8Narrow, indOffset32Narrow,
                indIndexOffsetNarrow, indIndexNarrow, indIndexScaleNarrow,
                indIndexScaleOffsetNarrow, indPosIndexOffsetNarrow, indPosIndexScaleOffsetNarrow);
@@ -6093,7 +6049,7 @@ instruct storeP(memory mem, any_RegP src)
 
 instruct storeImmP0(memory mem, immP0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && n->as_Store()->barrier_data() == 0);
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && n->as_Store()->barrier_data() == 0 && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreP mem zero));
 
   ins_cost(125); // XXX
@@ -6145,7 +6101,7 @@ instruct storeNKlass(memory mem, rRegN src)
 
 instruct storeImmN0(memory mem, immN0 zero)
 %{
-  predicate(CompressedOops::base() == NULL);
+  predicate(CompressedOops::base() == NULL && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreN mem zero));
 
   ins_cost(125); // XXX
@@ -6188,7 +6144,7 @@ instruct storeImmNKlass(memory mem, immNKlass src)
 // Store Integer Immediate
 instruct storeImmI0(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreI mem zero));
 
   ins_cost(125); // XXX
@@ -6214,7 +6170,7 @@ instruct storeImmI(memory mem, immI src)
 // Store Long Immediate
 instruct storeImmL0(memory mem, immL0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreL mem zero));
 
   ins_cost(125); // XXX
@@ -6240,7 +6196,7 @@ instruct storeImmL(memory mem, immL32 src)
 // Store Short/Char Immediate
 instruct storeImmC0(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreC mem zero));
 
   ins_cost(125); // XXX
@@ -6267,7 +6223,7 @@ instruct storeImmI16(memory mem, immI16 src)
 // Store Byte Immediate
 instruct storeImmB0(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreB mem zero));
 
   ins_cost(125); // XXX
@@ -6293,7 +6249,7 @@ instruct storeImmB(memory mem, immI8 src)
 // Store CMS card-mark Immediate
 instruct storeImmCM0_reg(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreCM mem zero));
 
   ins_cost(125); // XXX
@@ -6332,7 +6288,7 @@ instruct storeF(memory mem, regF src)
 // Store immediate Float value (it is faster than store from XMM register)
 instruct storeF0(memory mem, immF0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreF mem zero));
 
   ins_cost(25); // XXX
@@ -6384,7 +6340,7 @@ instruct storeD0_imm(memory mem, immD0 src)
 
 instruct storeD0(memory mem, immD0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && CompressedOops::need_heapbase_reg());
   match(Set mem (StoreD mem zero));
 
   ins_cost(25); // XXX
@@ -12613,7 +12569,7 @@ instruct testP_mem(rFlagsReg cr, memory op, immP0 zero)
 instruct testP_mem_reg0(rFlagsReg cr, memory mem, immP0 zero)
 %{
   predicate(UseCompressedOops && (CompressedOops::base() == NULL) &&
-            n->in(1)->as_Load()->barrier_data() == 0);
+            n->in(1)->as_Load()->barrier_data() == 0 && CompressedOops::need_heapbase_reg());
   match(Set cr (CmpP (LoadP mem) zero));
 
   format %{ "cmpq    R12, $mem\t# ptr (R12_heapbase==0)" %}
@@ -12708,7 +12664,7 @@ instruct testN_mem(rFlagsReg cr, memory mem, immN0 zero)
 
 instruct testN_mem_reg0(rFlagsReg cr, memory mem, immN0 zero)
 %{
-  predicate(CompressedOops::base() == NULL);
+  predicate(CompressedOops::base() == NULL && CompressedOops::need_heapbase_reg());
   match(Set cr (CmpN (LoadN mem) zero));
 
   format %{ "cmpl    R12, $mem\t# compressed ptr (R12_heapbase==0)" %}

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -637,8 +637,7 @@ void encode_RegMem(CodeBuffer &cbuf,
 {
   assert(disp_reloc == relocInfo::none, "cannot have disp");
   MacroAssembler masm(&cbuf);
-  masm.emit_operand_helper(reg, base, index, (Address::ScaleFactor)scale, disp, RelocationHolder::none,
-                           -1 /* post_addr_length is used only in reloc mode */);
+  masm.emit_regmem(reg, base, index, (Address::ScaleFactor)scale, disp, RelocationHolder::none);
 }
 
 // This could be in MacroAssembler but it's fairly C2 specific

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -379,7 +379,6 @@ RegMask _STACK_OR_LONG_REG_mask;
 RegMask _STACK_OR_INT_REG_mask;
 
 static bool need_r12_heapbase() {
-  // return UseCompressedOops && (PreserveHeapbaseReg || CompressedOops::ptrs_base() != nullptr);
   return CompressedOops::need_heapbase_reg();
 }
 

--- a/src/hotspot/cpu/zero/compressedOops_zero.hpp
+++ b/src/hotspot/cpu/zero/compressedOops_zero.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ZERO_COMPRESSEDOOPS_ZERO_HPP
+#define CPU_ZERO_COMPRESSEDOOPS_ZERO_HPP
+
+#endif // CPU_ZERO_COMPERSSEDOOPS_ZERO_HPP

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -98,7 +98,7 @@ public:
   static address  ptrs_base_addr()           { return (address)&_narrow_oop._base; }
   static address  ptrs_base()                { return _narrow_oop._base; }
 
-#if defined(X86)
+#if defined(X86) && !defined(ZERO)
 #ifdef _LP64
   static bool     need_heapbase_reg()        { return UseCompressedOops && (PreserveHeapbaseReg || _narrow_oop._base != nullptr); }
 #endif

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -97,6 +97,10 @@ public:
   static address  ptrs_base_addr()           { return (address)&_narrow_oop._base; }
   static address  ptrs_base()                { return _narrow_oop._base; }
 
+#ifdef AMD64
+  static bool need_heapbase_reg()            { return UseCompressedOops && (PreserveHeapbaseReg || _narrow_oop._base != nullptr); }
+#endif
+
   static bool is_in(void* addr);
   static bool is_in(MemRegion mr);
 

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -29,6 +29,7 @@
 #include "memory/memRegion.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "runtime/globals.hpp"
 #include <type_traits>
 
 class outputStream;
@@ -97,9 +98,11 @@ public:
   static address  ptrs_base_addr()           { return (address)&_narrow_oop._base; }
   static address  ptrs_base()                { return _narrow_oop._base; }
 
-#ifdef AMD64
-  static bool need_heapbase_reg()            { return UseCompressedOops && (PreserveHeapbaseReg || _narrow_oop._base != nullptr); }
+#if defined(X86)
+#ifdef _LP64
+  static bool     need_heapbase_reg()        { return UseCompressedOops && (PreserveHeapbaseReg || _narrow_oop._base != nullptr); }
 #endif
+#endif // X86_64 only
 
   static bool is_in(void* addr);
   static bool is_in(MemRegion mr);

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -98,12 +98,6 @@ public:
   static address  ptrs_base_addr()           { return (address)&_narrow_oop._base; }
   static address  ptrs_base()                { return _narrow_oop._base; }
 
-#if defined(X86) && !defined(ZERO)
-#ifdef _LP64
-  static bool     need_heapbase_reg()        { return UseCompressedOops && (PreserveHeapbaseReg || _narrow_oop._base != nullptr); }
-#endif
-#endif // X86_64 only
-
   static bool is_in(void* addr);
   static bool is_in(MemRegion mr);
 
@@ -145,6 +139,8 @@ public:
 
   template<typename T>
   static inline narrowOop narrow_oop_cast(T i);
+
+#include CPU_HEADER(compressedOops)
 };
 
 // For UseCompressedClassPointers.

--- a/test/hotspot/gtest/x86/test_assembler_x86.cpp
+++ b/test/hotspot/gtest/x86/test_assembler_x86.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+
+#if defined(X86) && !defined(ZERO)
+#ifdef LP64
+
+#include "asm/macroAssembler.hpp"
+#include "compiler/disassembler.hpp"
+#include "memory/resourceArea.hpp"
+#include "unittest.hpp"
+
+#define __ _masm.
+
+static void asm_insn_check(const unsigned char *insns, const unsigned char *insns1, int len) {
+  bool ok = true;
+  if (memcmp(insns, insns1, len) != 0) {
+    ResourceMark rm;
+    stringStream ss;
+    ss.print_cr("Ours:");
+    Disassembler::decode((address)insns1, (address)(insns1+len), &ss);
+    ss.print_cr("Theirs:");
+    Disassembler::decode((address)insns, (address)(insns+len), &ss);
+
+    EXPECT_EQ(insns, insns1) << ss.as_string();
+  }
+}
+
+TEST_VM(AssemblerX86_64, validate) {
+  // Smoke test for assembler
+  BufferBlob* b = BufferBlob::create("x86_64Test", 500000);
+  CodeBuffer code(b);
+  MacroAssembler _masm(&code);
+  address entry = __ pc();
+
+  {
+    address PC = __ pc();
+    __ movq(rax, Address(noreg, r10, Address::times_8, 0x10));      // No base reg
+
+    static const unsigned char insns[] = {
+       0x4a, 0x8b, 0x04, 0xd5, 0x10, 0x00, 0x00, 0x00 // mov 0x10(,%r10,8),%rax
+    };
+    asm_insn_check(PC, insns, sizeof(insns) / sizeof(unsigned char));
+  }
+
+  BufferBlob::free(b);
+}
+
+#endif  // LP64
+#endif  // X86

--- a/test/hotspot/gtest/x86/test_assembler_x86.cpp
+++ b/test/hotspot/gtest/x86/test_assembler_x86.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
In x86 64 mode, decode heap oop could use SIB without base if heap base is zero. like
```asm
0d1     movl    R11, [,R9 << 3 + #72] (zero base compressed oop addressing) # compressed ptr ! Field: java/lang/ClassLoader.classAssertionStatus 
```
So rheapbase( r12 )  can be allocated as general register.

Tier 1/2 tests are passed without new failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8308076](https://bugs.openjdk.org/browse/JDK-8308076)

### Issue
 * [JDK-8308076](https://bugs.openjdk.org/browse/JDK-8308076): make rheapbase register allocatable in zero based compressedOops mode for x86_64 (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13976/head:pull/13976` \
`$ git checkout pull/13976`

Update a local copy of the PR: \
`$ git checkout pull/13976` \
`$ git pull https://git.openjdk.org/jdk.git pull/13976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13976`

View PR using the GUI difftool: \
`$ git pr show -t 13976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13976.diff">https://git.openjdk.org/jdk/pull/13976.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13976#issuecomment-1547275191)