### PR TITLE
8307997: gtest:ZIndexDistributorTest fails on PPC64

### DIFF
--- a/test/hotspot/gtest/gc/z/test_zIndexDistributor.cpp
+++ b/test/hotspot/gtest/gc/z/test_zIndexDistributor.cpp
@@ -38,10 +38,11 @@ protected:
 
   static void test_claim_tree_claim_level_end_index() {
     // First level is padded
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(0), 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(1), 16 + 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(2), 16 + 16 + 16 * 16);
-    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(3), 16 + 16 + 16 * 16 + 16 * 16 * 16);
+    const int first_level_end = int(ZCacheLineSize / sizeof(int));
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(0), first_level_end);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(1), first_level_end + 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(2), first_level_end + 16 + 16 * 16);
+    ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_end_index(3), first_level_end + 16 + 16 * 16 + 16 * 16 * 16);
   }
 
   static void test_claim_tree_claim_index() {
@@ -66,7 +67,7 @@ protected:
     // Second level should depend on first claimed index
 
     // Second-level start after first-level padding
-    const int second_level_start = 16;
+    const int second_level_start = int(ZCacheLineSize / sizeof(int));
 
     {
       int indices[4] = {0, 0, 0, 0};
@@ -150,6 +151,14 @@ protected:
     {
       int indices[4] = {1,2,1,0};
       ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 1 * 16 * 16 + 2 * 16 + 1);
+    }
+    {
+      int indices[4] = {1,2,3,0};
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 3), 1 * 16 * 16 + 2 * 16 + 3);
+    }
+    {
+      int indices[4] = {1,2,3,0};
+      ASSERT_EQ(ZIndexDistributorClaimTree::claim_level_index(indices, 2), 1 * 16 + 2);
     }
   }
 };


### PR DESCRIPTION
ZindexDistributorTest was written with the assumption that `ZCacheLineSize == 64`, which isn't the case on PPC. I've updated the test to handle this case.

Tested by temporarily changing ZCacheLineSize to 128. I also added two more cases just to disambiguate the counts in one of the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307997](https://bugs.openjdk.org/browse/JDK-8307997): gtest:ZIndexDistributorTest fails on PPC64


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13977/head:pull/13977` \
`$ git checkout pull/13977`

Update a local copy of the PR: \
`$ git checkout pull/13977` \
`$ git pull https://git.openjdk.org/jdk.git pull/13977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13977`

View PR using the GUI difftool: \
`$ git pr show -t 13977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13977.diff">https://git.openjdk.org/jdk/pull/13977.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13977#issuecomment-1547379494)