### PR TITLE
8308086: GHA: x86_32 host configuration failing with unmet dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
-      apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386'
+      apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386 libgcc-s1:i386 libstdc++6:i386'
       extra-conf-options: '--with-target-bits=32'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}


### PR DESCRIPTION
Currently failing at host configuration step with:

```
The following packages have unmet dependencies:
 libc6:i386 : Depends: libgcc-s1:i386 but it is not going to be installed
 libtiffxx5:i386 : Depends: libstdc++6:i386 (>= 5) but it is not going to be installed
``` 

The fix is to add the dependencies explicitly.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308086](https://bugs.openjdk.org/browse/JDK-8308086): GHA: x86_32 host configuration failing with unmet dependencies


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13981/head:pull/13981` \
`$ git checkout pull/13981`

Update a local copy of the PR: \
`$ git checkout pull/13981` \
`$ git pull https://git.openjdk.org/jdk.git pull/13981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13981`

View PR using the GUI difftool: \
`$ git pr show -t 13981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13981.diff">https://git.openjdk.org/jdk/pull/13981.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13981#issuecomment-1547569747)