### PR TITLE
8308091: Remove unused iRegIHeapbase() matching operand

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -5320,17 +5320,6 @@ operand iRegNNoSp()
   interface(REG_INTER);
 %}
 
-// heap base register -- used for encoding immN0
-
-operand iRegIHeapbase()
-%{
-  constraint(ALLOC_IN_RC(heapbase_reg));
-  match(RegI);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 // Float Register
 // Float register operands
 operand vRegF()

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3586,16 +3586,6 @@ operand iRegNNoSp()
   interface(REG_INTER);
 %}
 
-// heap base register -- used for encoding immN0
-operand iRegIHeapbase()
-%{
-  constraint(ALLOC_IN_RC(heapbase_reg));
-  match(RegI);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 // Long 64 bit Register R10 only
 operand iRegL_R10()
 %{


### PR DESCRIPTION
The `iRegIHeapbase()` matching operand has no usage on both AArch64 and RISC-V platforms after [JDK-8242449](https://bugs.openjdk.org/browse/JDK-8242449) and [JDK-8306667](https://bugs.openjdk.org/browse/JDK-8306667), respectively. As the following-up action discussed in the code review process of [JDK-8306667](https://bugs.openjdk.org/browse/JDK-8306667), this is a small cleanup for the `iRegIHeapbase()` matching operand.

Passed fastdebug/release build on both AArch64/RISC-V platforms.