### PR TITLE
8308024: HttpClient (HTTP/1.1) sends an extraneous empty chunk if the BodyPublisher supplies an empty buffer

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -350,11 +350,18 @@ class Http1Request {
                 http1Exchange.appendToOutgoing(t);
             } else {
                 int chunklen = item.remaining();
-                ArrayList<ByteBuffer> l = new ArrayList<>(3);
-                l.add(getHeader(chunklen));
-                l.add(item);
-                l.add(ByteBuffer.wrap(CRLF));
-                http1Exchange.appendToOutgoing(l);
+                if (chunklen > 0) {
+                    ArrayList<ByteBuffer> l = new ArrayList<>(3);
+                    l.add(getHeader(chunklen));
+                    l.add(item);
+                    l.add(ByteBuffer.wrap(CRLF));
+                    http1Exchange.appendToOutgoing(l);
+                } else {
+                    if (debug.on()) {
+                        debug.log("dropping empty buffer, request one more");
+                    }
+                    request(1);
+                }
             }
         }
 

--- a/test/jdk/java/net/httpclient/AbstractNoBody.java
+++ b/test/jdk/java/net/httpclient/AbstractNoBody.java
@@ -153,6 +153,7 @@ public abstract class AbstractNoBody implements HttpServerAdapters {
     @BeforeTest
     public void setup() throws Exception {
         printStamp(START, "setup");
+        HttpServerAdapters.enableServerLogging();
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
@@ -194,10 +195,14 @@ public abstract class AbstractNoBody implements HttpServerAdapters {
         http2TestServer.start();
         https2TestServer.start();
 
+        var shared = newHttpClient(true);
+
         out.println("HTTP/1.1 server       (http) listening at: " + httpTestServer.serverAuthority());
         out.println("HTTP/1.1 server       (TLS)  listening at: " + httpsTestServer.serverAuthority());
         out.println("HTTP/2   server       (h2c)  listening at: " + http2TestServer.serverAuthority());
         out.println("HTTP/2   server       (h2)   listening at: " + https2TestServer.serverAuthority());
+
+        out.println("Shared client is: " + shared);
 
         printStamp(END,"setup");
     }

--- a/test/jdk/java/net/httpclient/AbstractNoBody.java
+++ b/test/jdk/java/net/httpclient/AbstractNoBody.java
@@ -21,35 +21,43 @@
  * questions.
  */
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.concurrent.Executor;
+import java.net.URI;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.net.ssl.SSLContext;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
-import jdk.httpclient.test.lib.http2.Http2TestExchange;
-import jdk.httpclient.test.lib.http2.Http2Handler;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 
-public abstract class AbstractNoBody {
+import static java.lang.System.err;
+import static java.lang.System.out;
+import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
+import static org.testng.Assert.assertEquals;
+
+public abstract class AbstractNoBody implements HttpServerAdapters {
 
     SSLContext sslContext;
-    HttpServer httpTestServer;         // HTTP/1.1    [ 4 servers ]
-    HttpsServer httpsTestServer;       // HTTPS/1.1
-    Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
-    Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
+    HttpTestServer httpTestServer;         // HTTP/1.1    [ 4 servers ]
+    HttpTestServer httpsTestServer;       // HTTPS/1.1
+    HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
+    HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
     String httpURI_fixed;
     String httpURI_chunk;
     String httpsURI_fixed;
@@ -62,8 +70,17 @@ public abstract class AbstractNoBody {
     static final String SIMPLE_STRING = "Hello world. Goodbye world";
     static final int ITERATION_COUNT = 3;
     // a shared executor helps reduce the amount of threads created by the test
-    static final Executor executor = Executors.newFixedThreadPool(ITERATION_COUNT * 2);
+    static final ExecutorService executor = Executors.newFixedThreadPool(ITERATION_COUNT * 2);
     static final ExecutorService serverExecutor = Executors.newFixedThreadPool(ITERATION_COUNT * 4);
+    static final AtomicLong clientCount = new AtomicLong();
+    static final long start = System.nanoTime();
+    public static String now() {
+        long now = System.nanoTime() - start;
+        long secs = now / 1000_000_000;
+        long mill = (now % 1000_000_000) / 1000_000;
+        long nan = now % 1000_000;
+        return String.format("[%d s, %d ms, %d ns] ", secs, mill, nan);
+    }
 
     @DataProvider(name = "variants")
     public Object[][] variants() {
@@ -88,16 +105,49 @@ public abstract class AbstractNoBody {
         };
     }
 
-    HttpClient newHttpClient() {
+    private volatile HttpClient sharedClient;
+
+    static Version version(String uri) {
+        if (uri.contains("/http1/") || uri.contains("/https1/"))
+            return HTTP_1_1;
+        if (uri.contains("/http2/") || uri.contains("/https2/"))
+            return HTTP_2;
+        return null;
+    }
+
+    HttpRequest.Builder newRequestBuilder(String uri) {
+        var builder = HttpRequest.newBuilder(URI.create(uri));
+        return builder;
+    }
+
+    private HttpClient makeNewClient() {
+        clientCount.incrementAndGet();
         return HttpClient.newBuilder()
                 .executor(executor)
+                .proxy(NO_PROXY)
                 .sslContext(sslContext)
                 .build();
     }
 
-    static String serverAuthority(HttpServer server) {
-        return InetAddress.getLoopbackAddress().getHostName() + ":"
-                + server.getAddress().getPort();
+    HttpClient newHttpClient(boolean share) {
+        if (!share) return makeNewClient();
+        HttpClient shared = sharedClient;
+        if (shared != null) return shared;
+        synchronized (this) {
+            shared = sharedClient;
+            if (shared == null) {
+                shared = sharedClient = makeNewClient();
+            }
+            return shared;
+        }
+    }
+
+    record CloseableClient(HttpClient client, boolean shared)
+            implements Closeable {
+        public void close() {
+            if (shared) return;
+            client.close();
+        }
     }
 
     @BeforeTest
@@ -108,35 +158,32 @@ public abstract class AbstractNoBody {
             throw new AssertionError("Unexpected null sslContext");
 
         // HTTP/1.1
-        HttpHandler h1_fixedLengthNoBodyHandler = new HTTP1_FixedLengthNoBodyHandler();
-        HttpHandler h1_chunkNoBodyHandler = new HTTP1_ChunkedNoBodyHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpServer.create(sa, 0);
-        httpTestServer.setExecutor(serverExecutor);
-        httpTestServer.createContext("/http1/noBodyFixed", h1_fixedLengthNoBodyHandler);
-        httpTestServer.createContext("/http1/noBodyChunk", h1_chunkNoBodyHandler);
-        httpURI_fixed = "http://" + serverAuthority(httpTestServer) + "/http1/noBodyFixed";
-        httpURI_chunk = "http://" + serverAuthority(httpTestServer) + "/http1/noBodyChunk";
+        HttpTestHandler h1_fixedLengthNoBodyHandler = new FixedLengthNoBodyHandler();
+        HttpTestHandler h1_chunkNoBodyHandler = new ChunkedNoBodyHandler();
 
-        httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setExecutor(serverExecutor);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer.createContext("/https1/noBodyFixed", h1_fixedLengthNoBodyHandler);
-        httpsTestServer.createContext("/https1/noBodyChunk", h1_chunkNoBodyHandler);
-        httpsURI_fixed = "https://" + serverAuthority(httpsTestServer) + "/https1/noBodyFixed";
-        httpsURI_chunk = "https://" + serverAuthority(httpsTestServer) + "/https1/noBodyChunk";
+        httpTestServer = HttpTestServer.create(HTTP_1_1, null, serverExecutor);
+        httpTestServer.addHandler(h1_fixedLengthNoBodyHandler,"/http1/noBodyFixed");
+        httpTestServer.addHandler(h1_chunkNoBodyHandler, "/http1/noBodyChunk");
+        httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/noBodyFixed";
+        httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/noBodyChunk";
+
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext, serverExecutor);
+        httpsTestServer.addHandler(h1_fixedLengthNoBodyHandler,"/https1/noBodyFixed");
+        httpsTestServer.addHandler(h1_chunkNoBodyHandler, "/https1/noBodyChunk");
+        httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/noBodyFixed";
+        httpsURI_chunk = "https://" + httpsTestServer.serverAuthority() + "/https1/noBodyChunk";
 
         // HTTP/2
-        Http2Handler h2_fixedLengthNoBodyHandler = new HTTP2_FixedLengthNoBodyHandler();
-        Http2Handler h2_chunkedNoBodyHandler = new HTTP2_ChunkedNoBodyHandler();
+        HttpTestHandler h2_fixedLengthNoBodyHandler = new FixedLengthNoBodyHandler();
+        HttpTestHandler h2_chunkedNoBodyHandler = new ChunkedNoBodyHandler();
 
-        http2TestServer = new Http2TestServer("localhost", false, 0, serverExecutor, null);
+        http2TestServer = HttpTestServer.create(HTTP_2, null, serverExecutor);
         http2TestServer.addHandler(h2_fixedLengthNoBodyHandler, "/http2/noBodyFixed");
         http2TestServer.addHandler(h2_chunkedNoBodyHandler, "/http2/noBodyChunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/noBodyFixed";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/noBodyChunk";
 
-        https2TestServer = new Http2TestServer("localhost", true, 0, serverExecutor, sslContext);
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext, serverExecutor);
         https2TestServer.addHandler(h2_fixedLengthNoBodyHandler, "/https2/noBodyFixed");
         https2TestServer.addHandler(h2_chunkedNoBodyHandler, "/https2/noBodyChunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/noBodyFixed";
@@ -146,77 +193,98 @@ public abstract class AbstractNoBody {
         httpsTestServer.start();
         http2TestServer.start();
         https2TestServer.start();
+
+        out.println("HTTP/1.1 server       (http) listening at: " + httpTestServer.serverAuthority());
+        out.println("HTTP/1.1 server       (TLS)  listening at: " + httpsTestServer.serverAuthority());
+        out.println("HTTP/2   server       (h2c)  listening at: " + http2TestServer.serverAuthority());
+        out.println("HTTP/2   server       (h2)   listening at: " + https2TestServer.serverAuthority());
+
         printStamp(END,"setup");
     }
 
     @AfterTest
     public void teardown() throws Exception {
         printStamp(START, "teardown");
-        httpTestServer.stop(0);
-        httpsTestServer.stop(0);
+        sharedClient.close();
+        httpTestServer.stop();
+        httpsTestServer.stop();
         http2TestServer.stop();
         https2TestServer.stop();
+        executor.close();
+        serverExecutor.close();
         printStamp(END, "teardown");
     }
 
-    static final long start = System.nanoTime();
     static final String START = "start";
     static final String END   = "end  ";
-    static long elapsed() { return (System.nanoTime() - start)/1000_000;}
     void printStamp(String what, String fmt, Object... args) {
-        long elapsed = elapsed();
-        long sec = elapsed/1000;
-        long ms  = elapsed % 1000;
-        String time = sec > 0 ? sec + "sec " : "";
-        time = time + ms + "ms";
         System.out.printf("%s: %s \t [%s]\t %s%n",
-                getClass().getSimpleName(), what, time, String.format(fmt,args));
+                getClass().getSimpleName(), what, now(), String.format(fmt,args));
     }
 
 
-    static class HTTP1_FixedLengthNoBodyHandler implements HttpHandler {
+    static class FixedLengthNoBodyHandler implements HttpTestHandler {
         @Override
-        public void handle(HttpExchange t) throws IOException {
+        public void handle(HttpTestExchange t) throws IOException {
             //out.println("NoBodyHandler received request to " + t.getRequestURI());
+            boolean echo = "echo".equals(t.getRequestURI().getRawQuery());
+            byte[] reqbytes;
             try (InputStream is = t.getRequestBody()) {
-                is.readAllBytes();
+                reqbytes = is.readAllBytes();
             }
-            t.sendResponseHeaders(200, -1); // no body
+            if (echo) {
+                t.sendResponseHeaders(200, reqbytes.length);
+                if (reqbytes.length > 0) {
+                    try (var os = t.getResponseBody()) {
+                        os.write(reqbytes);
+                    }
+                }
+            } else {
+                t.sendResponseHeaders(200, 0); // no body
+            }
         }
     }
 
-    static class HTTP1_ChunkedNoBodyHandler implements HttpHandler {
+    static class ChunkedNoBodyHandler implements HttpTestHandler {
         @Override
-        public void handle(HttpExchange t) throws IOException {
+        public void handle(HttpTestExchange t) throws IOException {
             //out.println("NoBodyHandler received request to " + t.getRequestURI());
+            boolean echo = "echo".equals(t.getRequestURI().getRawQuery());
+            byte[] reqbytes;
             try (InputStream is = t.getRequestBody()) {
-                is.readAllBytes();
+                reqbytes = is.readAllBytes();
             }
-            t.sendResponseHeaders(200, 0); // chunked
-            t.getResponseBody().close();  // write nothing
+            if (echo) {
+                t.sendResponseHeaders(200, -1);
+                try (var os = t.getResponseBody()) {
+                    os.write(reqbytes);
+                }
+            } else {
+                t.sendResponseHeaders(200, -1); // chunked
+                t.getResponseBody().close();  // write nothing
+            }
         }
     }
 
-    static class HTTP2_FixedLengthNoBodyHandler implements Http2Handler {
-        @Override
-        public void handle(Http2TestExchange t) throws IOException {
-            //out.println("NoBodyHandler received request to " + t.getRequestURI());
-            try (InputStream is = t.getRequestBody()) {
-                is.readAllBytes();
-            }
-            t.sendResponseHeaders(200, 0);
-        }
+    /*
+     * Converts a ByteBuffer containing bytes encoded using
+     * the given charset into a string.
+     * This method does not throw but will replace
+     * unrecognized sequences with the replacement character.
+     */
+    public static String asString(ByteBuffer buffer, Charset charset) {
+        var decoded = charset.decode(buffer);
+        char[] chars = new char[decoded.length()];
+        decoded.get(chars);
+        return new String(chars);
     }
 
-    static class HTTP2_ChunkedNoBodyHandler implements Http2Handler {
-        @Override
-        public void handle(Http2TestExchange t) throws IOException {
-            //out.println("NoBodyHandler received request to " + t.getRequestURI());
-            try (InputStream is = t.getRequestBody()) {
-                is.readAllBytes();
-            }
-            t.sendResponseHeaders(200, -1);
-            t.getResponseBody().close();  // write nothing
-        }
+    /*
+     * Converts a ByteBuffer containing UTF-8 bytes into a
+     * string. This method does not throw but will replace
+     * unrecognized sequences with the replacement character.
+     */
+    public static String asString(ByteBuffer buffer) {
+        return asString(buffer, StandardCharsets.UTF_8);
     }
 }

--- a/test/jdk/java/net/httpclient/NoBodyPartOne.java
+++ b/test/jdk/java/net/httpclient/NoBodyPartOne.java
@@ -33,7 +33,6 @@
  *      NoBodyPartOne
  */
 
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -44,6 +43,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import org.testng.annotations.Test;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -55,20 +55,20 @@ public class NoBodyPartOne extends AbstractNoBody {
         printStamp(START, "testAsString(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
-
-            HttpRequest req = HttpRequest.newBuilder(URI.create(uri))
-                                         .PUT(BodyPublishers.ofString(SIMPLE_STRING))
-                                         .build();
-            BodyHandler<String> handler = i % 2 == 0 ? BodyHandlers.ofString()
-                                                     : BodyHandlers.ofString(UTF_8);
-            HttpResponse<String> response = client.send(req, handler);
-            String body = response.body();
-            assertEquals(body, "");
+            if (!sameClient || client == null) {
+                client = newHttpClient(sameClient);
+            }
+            try (var cl = new CloseableClient(client, sameClient)) {
+                HttpRequest req = newRequestBuilder(uri)
+                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                        .build();
+                BodyHandler<String> handler = i % 2 == 0 ? BodyHandlers.ofString()
+                        : BodyHandlers.ofString(UTF_8);
+                HttpResponse<String> response = client.send(req, handler);
+                String body = response.body();
+                assertEquals(body, "");
+            }
         }
-        // We have created many clients here. Try to speed up their release.
-        if (!sameClient) System.gc();
     }
 
     @Test(dataProvider = "variants")
@@ -76,20 +76,22 @@ public class NoBodyPartOne extends AbstractNoBody {
         printStamp(START, "testAsFile(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
+            if (!sameClient || client == null) {
+                client = newHttpClient(sameClient);
+            }
 
-            HttpRequest req = HttpRequest.newBuilder(URI.create(uri))
-                                         .PUT(BodyPublishers.ofString(SIMPLE_STRING))
-                                         .build();
-            Path p = Paths.get("NoBody_testAsFile.txt");
-            HttpResponse<Path> response = client.send(req, BodyHandlers.ofFile(p));
-            Path bodyPath = response.body();
-            assertTrue(Files.exists(bodyPath));
-            assertEquals(Files.size(bodyPath), 0);
+            try (var cl = new CloseableClient(client, sameClient)) {
+                HttpRequest req = newRequestBuilder(uri)
+                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                        .build();
+                Path p = Paths.get("NoBody_testAsFile.txt");
+                HttpResponse<Path> response = client.send(req, BodyHandlers.ofFile(p));
+                Path bodyPath = response.body();
+                assertEquals(response.statusCode(), 200);
+                assertTrue(Files.exists(bodyPath));
+                assertEquals(Files.size(bodyPath), 0, Files.readString(bodyPath));
+            }
         }
-        // We have created many clients here. Try to speed up their release.
-        if (!sameClient) System.gc();
     }
 
     @Test(dataProvider = "variants")
@@ -97,17 +99,18 @@ public class NoBodyPartOne extends AbstractNoBody {
         printStamp(START, "testAsByteArray(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
+            if (!sameClient || client == null) {
+                client = newHttpClient(sameClient);
+            }
 
-            HttpRequest req = HttpRequest.newBuilder(URI.create(uri))
-                                         .PUT(BodyPublishers.ofString(SIMPLE_STRING))
-                                         .build();
-            HttpResponse<byte[]> response = client.send(req, BodyHandlers.ofByteArray());
-            byte[] body = response.body();
-            assertEquals(body.length, 0);
+            try (var cl = new CloseableClient(client, sameClient)) {
+                HttpRequest req = newRequestBuilder(uri)
+                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                        .build();
+                HttpResponse<byte[]> response = client.send(req, BodyHandlers.ofByteArray());
+                byte[] body = response.body();
+                assertEquals(body.length, 0);
+            }
         }
-        // We have created many clients here. Try to speed up their release.
-        if (!sameClient) System.gc();
     }
 }

--- a/test/jdk/java/net/httpclient/NoBodyPartThree.java
+++ b/test/jdk/java/net/httpclient/NoBodyPartThree.java
@@ -28,7 +28,6 @@
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
  * @run testng/othervm
- *      -Djdk.internal.httpclient.debug=true
  *      -Djdk.httpclient.HttpClient.log=all
  *      NoBodyPartThree
  */

--- a/test/jdk/java/net/httpclient/NoBodyPartThree.java
+++ b/test/jdk/java/net/httpclient/NoBodyPartThree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +24,18 @@
 /*
  * @test
  * @bug 8161157
- * @summary Test response body handlers/subscribers when there is no body
+ * @summary Test request and response body handlers/subscribers when there is no body
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
  * @run testng/othervm
  *      -Djdk.internal.httpclient.debug=true
  *      -Djdk.httpclient.HttpClient.log=all
- *      NoBodyPartTwo
+ *      NoBodyPartThree
  */
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.net.http.HttpClient;
@@ -49,35 +50,44 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class NoBodyPartTwo extends AbstractNoBody {
+public class NoBodyPartThree extends AbstractNoBody {
 
     volatile boolean consumerHasBeenCalled;
     @Test(dataProvider = "variants")
-    public void testAsByteArrayConsumer(String uri, boolean sameClient) throws Exception {
-        printStamp(START, "testAsByteArrayConsumer(\"%s\", %s)", uri, sameClient);
+    public void testAsByteArrayPublisher(String uri, boolean sameClient) throws Exception {
+        printStamp(START, "testAsByteArrayPublisher(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
             if (!sameClient || client == null) {
                 client = newHttpClient(sameClient);
             }
             try (var cl = new CloseableClient(client, sameClient)) {
-                HttpRequest req = newRequestBuilder(uri)
-                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                HttpRequest req = newRequestBuilder(uri + "?echo")
+                        .PUT(BodyPublishers.ofByteArrays(List.of()))
                         .build();
                 Consumer<Optional<byte[]>> consumer = oba -> {
                     consumerHasBeenCalled = true;
-                    oba.ifPresent(ba -> fail("Unexpected non-empty optional: "
+                    oba.ifPresent(ba -> fail("Unexpected non-empty optional:"
                             + asString(ByteBuffer.wrap(ba))));
                 };
                 consumerHasBeenCalled = false;
-                client.send(req, BodyHandlers.ofByteArrayConsumer(consumer));
+                var response = client.send(req, BodyHandlers.ofByteArrayConsumer(consumer));
                 assertTrue(consumerHasBeenCalled);
+                assertEquals(response.statusCode(), 200);
+
+                req = newRequestBuilder(uri + "?echo")
+                        .PUT(BodyPublishers.ofByteArrays(List.of(new byte[0])))
+                        .build();
+                consumerHasBeenCalled = false;
+                response = client.send(req, BodyHandlers.ofByteArrayConsumer(consumer));
+                assertTrue(consumerHasBeenCalled);
+                assertEquals(response.statusCode(), 200);
             }
         }
     }
 
     @Test(dataProvider = "variants")
-    public void testAsInputStream(String uri, boolean sameClient) throws Exception {
+    public void testStringPublisher(String uri, boolean sameClient) throws Exception {
         printStamp(START, "testAsInputStream(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
@@ -85,10 +95,11 @@ public class NoBodyPartTwo extends AbstractNoBody {
                 client = newHttpClient(sameClient);
             }
             try (var cl = new CloseableClient(client, sameClient)) {
-                HttpRequest req = newRequestBuilder(uri)
-                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                HttpRequest req = newRequestBuilder(uri + "?echo")
+                        .PUT(BodyPublishers.ofString(""))
                         .build();
                 HttpResponse<InputStream> response = client.send(req, BodyHandlers.ofInputStream());
+                assertEquals(response.statusCode(), 200);
                 byte[] body = response.body().readAllBytes();
                 assertEquals(body.length, 0);
             }
@@ -96,7 +107,7 @@ public class NoBodyPartTwo extends AbstractNoBody {
     }
 
     @Test(dataProvider = "variants")
-    public void testBuffering(String uri, boolean sameClient) throws Exception {
+    public void testInputStreamPublisherBuffering(String uri, boolean sameClient) throws Exception {
         printStamp(START, "testBuffering(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
@@ -104,11 +115,12 @@ public class NoBodyPartTwo extends AbstractNoBody {
                 client = newHttpClient(sameClient);
             }
             try (var cl = new CloseableClient(client, sameClient)) {
-                HttpRequest req = newRequestBuilder(uri)
-                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                HttpRequest req = newRequestBuilder(uri + "?echo")
+                        .PUT(BodyPublishers.ofInputStream(InputStream::nullInputStream))
                         .build();
                 HttpResponse<byte[]> response = client.send(req,
                         BodyHandlers.buffering(BodyHandlers.ofByteArray(), 1024));
+                assertEquals(response.statusCode(), 200);
                 byte[] body = response.body();
                 assertEquals(body.length, 0);
             }
@@ -116,7 +128,7 @@ public class NoBodyPartTwo extends AbstractNoBody {
     }
 
     @Test(dataProvider = "variants")
-    public void testDiscard(String uri, boolean sameClient) throws Exception {
+    public void testEmptyArrayPublisher(String uri, boolean sameClient) throws Exception {
         printStamp(START, "testDiscard(\"%s\", %s)", uri, sameClient);
         HttpClient client = null;
         for (int i=0; i< ITERATION_COUNT; i++) {
@@ -124,12 +136,12 @@ public class NoBodyPartTwo extends AbstractNoBody {
                 client = newHttpClient(sameClient);
             }
             try (var cl = new CloseableClient(client, sameClient)) {
-                HttpRequest req = newRequestBuilder(uri)
-                        .PUT(BodyPublishers.ofString(SIMPLE_STRING))
+                HttpRequest req = newRequestBuilder(uri + "?echo")
+                        .PUT(BodyPublishers.ofByteArray(new byte[0]))
                         .build();
-                Object obj = new Object();
-                HttpResponse<Object> response = client.send(req, BodyHandlers.replacing(obj));
-                assertEquals(response.body(), obj);
+                var response = client.send(req, BodyHandlers.ofLines());
+                assertEquals(response.statusCode(), 200);
+                assertEquals(response.body().toList(), List.of());
             }
         }
     }

--- a/test/jdk/java/net/httpclient/NoBodyPartThree.java
+++ b/test/jdk/java/net/httpclient/NoBodyPartThree.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8161157
+ * @bug 8308024
  * @summary Test request and response body handlers/subscribers when there is no body
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer


### PR DESCRIPTION
When using HTTP/1.1, if a BodyPublisher reports an unknown length (-1), the HttpClient will send the request body in Chunked mode. If the publisher publishes an empty byte buffer, the client will generate an empty chunk, which the server will interpret as the end of the request body. Sending an empty chunk can never be valid, unless it's the last body chunk and marks the end of the body.

A new subclass of `AbstractNoBody.java` `NoBodyPartThree.java` is created to check this scenario. While at it, the tests `java/net/httpclient/NoBodyPartOne.java` and `java/net/httpclient/NoBodyPartTwo.java` which create a lot of clients are also updated to make use of `HttpClient::close`. 

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308024](https://bugs.openjdk.org/browse/JDK-8308024): HttpClient (HTTP/1.1) sends an extraneous empty chunk if the BodyPublisher supplies an empty buffer


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13988/head:pull/13988` \
`$ git checkout pull/13988`

Update a local copy of the PR: \
`$ git checkout pull/13988` \
`$ git pull https://git.openjdk.org/jdk.git pull/13988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13988`

View PR using the GUI difftool: \
`$ git pr show -t 13988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13988.diff">https://git.openjdk.org/jdk/pull/13988.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13988#issuecomment-1548169195)