### PR TITLE
8308043: Deadlock in TestCSLocker.java due to blocking GC while allocating

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -40,6 +40,4 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8307462 generic-all
 
-gc/cslocker/TestCSLocker.java 8293289 generic-x64
-
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64

--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -51,7 +51,6 @@ public class TestCSLocker extends Thread
 
         // check timeout to success deadlocking
         while(System.currentTimeMillis() < startTime + timeout) {
-            System.out.println("sleeping...");
             sleep(1000);
         }
 

--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -48,10 +48,10 @@ public class TestCSLocker extends Thread
         // start CS locker thread
         CSLocker csLocker = new CSLocker();
         csLocker.start();
-	// After the CSLocker thread has started, any operation such as an allocation,
-	// which could rely on the GC to make progress, will cause a deadlock that will
-	// make the test time out. That includes printing. Please don't use any such
-	// code until unlock() is called below.
+        // After the CSLocker thread has started, any operation such as an allocation,
+        // which could rely on the GC to make progress, will cause a deadlock that will
+        // make the test time out. That includes printing. Please don't use any such
+        // code until unlock() is called below.
 
         // check timeout to success deadlocking
         while (System.currentTimeMillis() < startTime + timeout) {

--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -48,9 +48,13 @@ public class TestCSLocker extends Thread
         // start CS locker thread
         CSLocker csLocker = new CSLocker();
         csLocker.start();
+	// After the CSLocker thread has started, any operation such as an allocation,
+	// which could rely on the GC to make progress, will cause a deadlock that will
+	// make the test time out. That includes printing. Please don't use any such
+	// code until unlock() is called below.
 
         // check timeout to success deadlocking
-        while(System.currentTimeMillis() < startTime + timeout) {
+        while (System.currentTimeMillis() < startTime + timeout) {
             sleep(1000);
         }
 


### PR DESCRIPTION
The TestCSLocker.java test spawns a thread that grabs the GC locker, and then wait for the first thread to run some java code and then get signal back to release the GC locker. All of this while another thread is allocating garbage and triggering GCs. Naturally, if the thread that is to signal the release of the GC locker requires GC in order to make progress, we will end up with a deadlock that leads to a timeout. As it turns out, that does indeed happen. A println statement is performed, which in its internal implementation performs an allocation, which requires GC. I think any GC can spuriously fail here, but it seems more likely with generational ZGC for whatever reason. While it seems really shady to wait with the GC locker held while a Java thread executing Java code is supposed to make progress, in general, I think the test can be fixed by removing the println statement causing the allocation. I have run the test 200 times, and it's no longer failing with generational ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308043](https://bugs.openjdk.org/browse/JDK-8308043): Deadlock in TestCSLocker.java due to blocking GC while allocating


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [c4124a0f](https://git.openjdk.org/jdk/pull/13989/files/c4124a0fc9e9010fc8f23e284f76014f29ed0a38)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [c4124a0f](https://git.openjdk.org/jdk/pull/13989/files/c4124a0fc9e9010fc8f23e284f76014f29ed0a38)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13989/head:pull/13989` \
`$ git checkout pull/13989`

Update a local copy of the PR: \
`$ git checkout pull/13989` \
`$ git pull https://git.openjdk.org/jdk.git pull/13989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13989`

View PR using the GUI difftool: \
`$ git pr show -t 13989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13989.diff">https://git.openjdk.org/jdk/pull/13989.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13989#issuecomment-1547990365)