### PR TITLE
8307315: Missing ResourceMark in CDS and JVMTI code

### DIFF
--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -492,6 +492,7 @@ public:
   static void record_non_existent_class_path_entry(const char* path);
 
 #if INCLUDE_JVMTI
+  // Caller needs a ResourceMark because parts of the returned cfs are resource-allocated.
   static ClassFileStream* open_stream_for_jvmti(InstanceKlass* ik, Handle class_loader, TRAPS);
 #endif
 

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -54,7 +54,7 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
   assert(ik != nullptr, "sanity");
   assert(ik->is_shared(), "expecting a shared class");
   if (JvmtiExport::should_post_class_file_load_hook()) {
-
+    ResourceMark rm(THREAD);
     // Post the CFLH
     JvmtiCachedClassFileData* cached_class_file = nullptr;
     if (cfs == nullptr) {

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -54,7 +54,6 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
   assert(ik != nullptr, "sanity");
   assert(ik->is_shared(), "expecting a shared class");
   if (JvmtiExport::should_post_class_file_load_hook()) {
-    // Caller needs a ResourceMark because parts of the returned cfs are resource-allocated.
     ResourceMark rm(THREAD);
     // Post the CFLH
     JvmtiCachedClassFileData* cached_class_file = nullptr;

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -54,6 +54,7 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
   assert(ik != nullptr, "sanity");
   assert(ik->is_shared(), "expecting a shared class");
   if (JvmtiExport::should_post_class_file_load_hook()) {
+    // Caller needs a ResourceMark because parts of the returned cfs are resource-allocated.
     ResourceMark rm(THREAD);
     // Post the CFLH
     JvmtiCachedClassFileData* cached_class_file = nullptr;

--- a/src/hotspot/share/classfile/klassFactory.hpp
+++ b/src/hotspot/share/classfile/klassFactory.hpp
@@ -65,7 +65,6 @@ class KlassFactory : AllStatic {
                                            ClassLoaderData* loader_data,
                                            const ClassLoadInfo& cl_info,
                                            TRAPS);
-  // Caller needs a ResourceMark because parts of the returned cfs are resource-allocated.
   static InstanceKlass* check_shared_class_file_load_hook(
                                           InstanceKlass* ik,
                                           Symbol* class_name,

--- a/src/hotspot/share/classfile/klassFactory.hpp
+++ b/src/hotspot/share/classfile/klassFactory.hpp
@@ -65,6 +65,7 @@ class KlassFactory : AllStatic {
                                            ClassLoaderData* loader_data,
                                            const ClassLoadInfo& cl_info,
                                            TRAPS);
+  // Caller needs a ResourceMark because parts of the returned cfs are resource-allocated.
   static InstanceKlass* check_shared_class_file_load_hook(
                                           InstanceKlass* ik,
                                           Symbol* class_name,


### PR DESCRIPTION
Please review this simple fix for adding a missing `ResourceMark` in `KlassFactory::check_shared_class_file_load_hook` which is a common caller of `FileMapInfo::open_stream_for_jvmti` and `JvmtiClassFileLoadHookPoster::post_to_env `(indirectly via `JvmtiExport::post_class_file_load_hook`).

Passed tiers 1 - 3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307315](https://bugs.openjdk.org/browse/JDK-8307315): Missing ResourceMark in CDS and JVMTI code


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [930633d6](https://git.openjdk.org/jdk/pull/13992/files/930633d6fb85fb58d90042d049309336ac170d2d)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [dd01033f](https://git.openjdk.org/jdk/pull/13992/files/dd01033fcbd72a644e0001cd07c110311e1f2d78)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13992/head:pull/13992` \
`$ git checkout pull/13992`

Update a local copy of the PR: \
`$ git checkout pull/13992` \
`$ git pull https://git.openjdk.org/jdk.git pull/13992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13992`

View PR using the GUI difftool: \
`$ git pr show -t 13992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13992.diff">https://git.openjdk.org/jdk/pull/13992.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13992#issuecomment-1548134930)