### PR TITLE
8306428: RunThese30M.java crashed with assert(early->flag() == current->flag() || early->flag() == mtNone)

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -842,10 +842,20 @@ void MemDetailDiffReporter::old_virtual_memory_site(const VirtualMemoryAllocatio
 
 void MemDetailDiffReporter::diff_virtual_memory_site(const VirtualMemoryAllocationSite* early,
   const VirtualMemoryAllocationSite* current) const {
-  assert(early->flag() == current->flag() || early->flag() == mtNone,
-    "Expect the same flag, but %s != %s", NMTUtil::flag_to_name(early->flag()),NMTUtil::flag_to_name(current->flag()));
+  if ((early->flag() != current->flag()) || (current->flag() == mtNone) || (early->flag() == mtNone)) {
+    tty->print("Detected an anomaly in MemDetailDiffReporter::diff_virtual_memory_site:");
+    early->call_stack()->print_on(tty);
+    current->call_stack()->print_on(tty);
+  }
+  assert(current->flag() != mtNone && early->flag() != mtNone,
+         "Expect the flag not to be mtNone, but %s or %s is.",
+         NMTUtil::flag_to_name(early->flag()), NMTUtil::flag_to_name(current->flag()));
+  assert(early->flag() == current->flag(),
+         "Expect the same flag, but %s != %s",
+         NMTUtil::flag_to_name(early->flag()), NMTUtil::flag_to_name(current->flag()));
+
   diff_virtual_memory_site(current->call_stack(), current->reserved(), current->committed(),
-    early->reserved(), early->committed(), current->flag());
+                           early->reserved(), early->committed(), current->flag());
 }
 
 void MemDetailDiffReporter::diff_virtual_memory_site(const NativeCallStack* stack, size_t current_reserved,


### PR DESCRIPTION
We print the stack of the allocation site to help us figure out which flag is wrong, and help us debug that part of the code.

This fix is in the same spirit as https://github.com/openjdk/jdk/pull/8906 where we are going to add more debug info, in hopes that it will help analyze it successfully.

Tested locally with jcmd PID VM.native_memory baseline/detail.diff to make sure we are not messing anything up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306428](https://bugs.openjdk.org/browse/JDK-8306428): RunThese30M.java crashed with assert(early-&gt;flag() == current-&gt;flag() || early-&gt;flag() == mtNone)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13993/head:pull/13993` \
`$ git checkout pull/13993`

Update a local copy of the PR: \
`$ git checkout pull/13993` \
`$ git pull https://git.openjdk.org/jdk.git pull/13993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13993`

View PR using the GUI difftool: \
`$ git pr show -t 13993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13993.diff">https://git.openjdk.org/jdk/pull/13993.diff</a>

</details>
