### PR TITLE
JDK-8308110: Resolve multiple definition of 'JNI_OnLoad_jsound' linking error

### DIFF
--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.c
@@ -44,11 +44,6 @@ static int alsa_inited = 0;
 static int alsa_enumerate_pcm_subdevices = FALSE; // default: no
 static int alsa_enumerate_midi_subdevices = FALSE; // default: no
 
-/*
- * Declare library specific JNI_Onload entry if static build
- */
-DEF_STATIC_JNI_OnLoad
-
 void initAlsaSupport() {
     char* enumerate;
     if (!alsa_inited) {


### PR DESCRIPTION
Remove DEF_STATIC_JNI_OnLoad from src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_CommonUtils.c. src/java.desktop/share/native/libjsound/Platform.c defines DEF_STATIC_JNI_OnLoad for libjsound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308110](https://bugs.openjdk.org/browse/JDK-8308110): Resolve multiple definition of 'JNI_OnLoad_jsound' linking error


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chuck Rasbold](https://openjdk.org/census#rasbold) (@rasbold - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13994/head:pull/13994` \
`$ git checkout pull/13994`

Update a local copy of the PR: \
`$ git checkout pull/13994` \
`$ git pull https://git.openjdk.org/jdk.git pull/13994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13994`

View PR using the GUI difftool: \
`$ git pr show -t 13994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13994.diff">https://git.openjdk.org/jdk/pull/13994.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13994#issuecomment-1548285848)