### PR TITLE
8308071: [REDO] update for deprecated sprintf for src/utils

### DIFF
--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -242,19 +242,18 @@ static const char* format_insn_close(const char* close,
   case dis_noninsn:     type = "noninsn";    break;
   }
 
-  strcpy(buf, close);
-  size_t used_size = strlen(close);
+  /* the buf capacity has been checked previously */
+  size_t used_size = snprintf(buf, bufsize, "%s", close);
   char* p = buf + used_size;
   bufsize -= used_size;
+
   if (type) {
-    /* the buf capacity has been checked previously */
     used_size = snprintf(p, bufsize, " type='%s'", type);
     p += used_size;
     bufsize -= used_size;
   }
 
   if (dsize) {
-    /* the buf capacity has been checked previously */
     used_size = snprintf(p, bufsize, " dsize='%d'", dsize);
     p += used_size;
     bufsize -= used_size;

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -242,7 +242,7 @@ static const char* format_insn_close(const char* close,
   case dis_noninsn:     type = "noninsn";    break;
   }
 
-  size_t used_size = snprintf(buf, bufsize, "%s", close);
+  int used_size = snprintf(buf, bufsize, "%s", close);
   if ((used_size < 0) || (used_size >= bufsize)) {
     return close;
   }

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -243,10 +243,27 @@ static const char* format_insn_close(const char* close,
   }
 
   strcpy(buf, close);
-  char* p = buf;
-  if (type)    sprintf(p += strlen(p), " type='%s'", type);
-  if (dsize)   sprintf(p += strlen(p), " dsize='%d'", dsize);
-  if (delays)  sprintf(p += strlen(p), " delay='%d'", delays);
+  size_t used_size = strlen(close);
+  char* p = buf + used_size;
+  bufsize -= used_size;
+  if (type) {
+    /* the buf capacity has been checked previously */
+    used_size = snprintf(p, bufsize, " type='%s'", type);
+    p += used_size;
+    bufsize -= used_size;
+  }
+
+  if (dsize) {
+    /* the buf capacity has been checked previously */
+    used_size = snprintf(p, bufsize, " dsize='%d'", dsize);
+    p += used_size;
+    bufsize -= used_size;
+  }
+
+  if (delays) {
+    snprintf(p, bufsize, " delay='%d'", delays);
+  }
+
   return buf;
 }
 

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -242,25 +242,36 @@ static const char* format_insn_close(const char* close,
   case dis_noninsn:     type = "noninsn";    break;
   }
 
-  /* the buf capacity has been checked previously */
   size_t used_size = snprintf(buf, bufsize, "%s", close);
+  if ((used_size < 0) || (used_size >= bufsize)) {
+    return close;
+  }
   char* p = buf + used_size;
   bufsize -= used_size;
 
   if (type) {
     used_size = snprintf(p, bufsize, " type='%s'", type);
+    if ((used_size < 0) || (used_size >= bufsize)) {
+      return close;
+    }
     p += used_size;
     bufsize -= used_size;
   }
 
   if (dsize) {
     used_size = snprintf(p, bufsize, " dsize='%d'", dsize);
+    if ((used_size < 0) || (used_size >= bufsize)) {
+      return close;
+    }
     p += used_size;
     bufsize -= used_size;
   }
 
   if (delays) {
-    snprintf(p, bufsize, " delay='%d'", delays);
+    used_size = snprintf(p, bufsize, " delay='%d'", delays);
+    if ((used_size < 0) || (used_size >= bufsize)) {
+      return close;
+    }
   }
 
   return buf;

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -243,7 +243,7 @@ static const char* format_insn_close(const char* close,
   }
 
   int used_size = snprintf(buf, bufsize, "%s", close);
-  if ((used_size < 0) || (used_size >= bufsize)) {
+  if ((used_size < 0) || ((size_t)used_size >= bufsize)) {
     return close;
   }
   char* p = buf + used_size;
@@ -251,7 +251,7 @@ static const char* format_insn_close(const char* close,
 
   if (type) {
     used_size = snprintf(p, bufsize, " type='%s'", type);
-    if ((used_size < 0) || (used_size >= bufsize)) {
+    if ((used_size < 0) || ((size_t)used_size >= bufsize)) {
       return close;
     }
     p += used_size;
@@ -260,7 +260,7 @@ static const char* format_insn_close(const char* close,
 
   if (dsize) {
     used_size = snprintf(p, bufsize, " dsize='%d'", dsize);
-    if ((used_size < 0) || (used_size >= bufsize)) {
+    if ((used_size < 0) || ((size_t)used_size >= bufsize)) {
       return close;
     }
     p += used_size;
@@ -269,7 +269,7 @@ static const char* format_insn_close(const char* close,
 
   if (delays) {
     used_size = snprintf(p, bufsize, " delay='%d'", delays);
-    if ((used_size < 0) || (used_size >= bufsize)) {
+    if ((used_size < 0) || ((size_t)used_size >= bufsize)) {
       return close;
     }
   }


### PR DESCRIPTION
Hi,

This is a redo of JDK-8307855, where issues were found after integration.

The sprintf is deprecated in Xcode 14, and Microsoft Virtual Studio, because of security concerns. The issue was addressed in [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) for building failure, and [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378)/[JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635)/[JDK-8301132](https://bugs.openjdk.org/browse/JDK-8301132) for testing issues . This is a break-down update for sprintf uses in the src/utils directory.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8308071](https://bugs.openjdk.org/browse/JDK-8308071): [REDO] update for deprecated sprintf for src/utils (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13995/head:pull/13995` \
`$ git checkout pull/13995`

Update a local copy of the PR: \
`$ git checkout pull/13995` \
`$ git pull https://git.openjdk.org/jdk.git pull/13995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13995`

View PR using the GUI difftool: \
`$ git pr show -t 13995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13995.diff">https://git.openjdk.org/jdk/pull/13995.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13995#issuecomment-1548509336)