### PR TITLE
8308118: Avoid multiarray allocations in AESCrypt.makeSessionKey

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
@@ -1330,12 +1330,13 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
                     k.length + " bytes");
         }
 
-        int ROUNDS          = getRounds(k.length);
-        int ROUND_KEY_COUNT = (ROUNDS + 1) * 4;
-
         final int BC = 4;
-        int[] Ke = new int[(ROUNDS + 1)*BC]; // encryption round keys
-        int[] Kd = new int[(ROUNDS + 1)*BC]; // decryption round keys
+
+        int ROUNDS          = getRounds(k.length);
+        int ROUND_KEY_COUNT = (ROUNDS + 1) * BC;
+
+        int[] Ke = new int[ROUND_KEY_COUNT]; // encryption round keys
+        int[] Kd = new int[ROUND_KEY_COUNT]; // decryption round keys
 
         int KC = k.length/4; // keylen in 32-bit elements
 
@@ -1395,10 +1396,16 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
         }
 
         // For decryption round keys, need to rotate right by 4 ints.
-        int[] KdTail = Arrays.copyOfRange(Kd, Kd.length - 4, Kd.length);
-        System.arraycopy(Kd, 0, Kd, BC, Kd.length - BC);
-        System.arraycopy(KdTail, 0, Kd, 0, BC);
-        Arrays.fill(KdTail, 0);
+        // Do that without allocating and zeroing the small buffer.
+        int KdTail_0 = Kd[Kd.length - 4];
+        int KdTail_1 = Kd[Kd.length - 3];
+        int KdTail_2 = Kd[Kd.length - 2];
+        int KdTail_3 = Kd[Kd.length - 1];
+        System.arraycopy(Kd, 0, Kd, 4, Kd.length - 4);
+        Kd[0] = KdTail_0;
+        Kd[1] = KdTail_1;
+        Kd[2] = KdTail_2;
+        Kd[3] = KdTail_3;
 
         Arrays.fill(tk, 0);
         ROUNDS_12 = (ROUNDS>=12);

--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
@@ -1365,8 +1365,15 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
         int ROUND_KEY_COUNT = (ROUNDS + 1) * 4;
 
         int BC = 4;
-        int[][] Ke = new int[ROUNDS + 1][4]; // encryption round keys
-        int[][] Kd = new int[ROUNDS + 1][4]; // decryption round keys
+        int[][] Ke = new int[ROUNDS + 1][]; // encryption round keys
+        int[][] Kd = new int[ROUNDS + 1][]; // decryption round keys
+
+        // Due to JDK-8308105, it is significantly faster to avoid multiarray
+        // allocation in this code.
+        for (int c = 0; c < ROUNDS + 1; c++) {
+            Ke[c] = new int[BC];
+            Kd[c] = new int[BC];
+        }
 
         int KC = k.length/4; // keylen in 32-bit elements
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
@@ -1365,14 +1365,11 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
         int ROUND_KEY_COUNT = (ROUNDS + 1) * 4;
 
         int BC = 4;
-        int[][] Ke = new int[ROUNDS + 1][]; // encryption round keys
+        int[] Ke = new int[(ROUNDS + 1)*BC]; // encryption round keys
         int[][] Kd = new int[ROUNDS + 1][]; // decryption round keys
 
-        // It is significantly faster to allocate individual arrays,
-        // instead of doing the multi-array allocation. See JDK-8308105.
         for (int c = 0; c < ROUNDS + 1; c++) {
-            Ke[c] = new int[4];
-            Kd[c] = new int[4];
+            Kd[c] = new int[BC];
         }
 
         int KC = k.length/4; // keylen in 32-bit elements
@@ -1391,7 +1388,7 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
         // copy values into round key arrays
         int t = 0;
         for (j = 0; (j < KC) && (t < ROUND_KEY_COUNT); j++, t++) {
-            Ke[t / 4][t % 4] = tk[j];
+            Ke[t] = tk[j];
             Kd[ROUNDS - (t / 4)][t % 4] = tk[j];
         }
         int tt, rconpointer = 0;
@@ -1416,7 +1413,7 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
             }
             // copy values into round key arrays
             for (j = 0; (j < KC) && (t < ROUND_KEY_COUNT); j++, t++) {
-                Ke[t / 4][t % 4] = tk[j];
+                Ke[t] = tk[j];
                 Kd[ROUNDS - (t / 4)][t % 4] = tk[j];
             }
         }
@@ -1433,12 +1430,8 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
 
         // assemble the encryption (Ke) and decryption (Kd) round keys
         // and expand them into arrays of ints.
-        int[] expandedKe = expandToSubKey(Ke, false); // decrypting==false
         int[] expandedKd = expandToSubKey(Kd, true);  // decrypting==true
         Arrays.fill(tk, 0);
-        for (int[] ia: Ke) {
-            Arrays.fill(ia, 0);
-        }
         for (int[] ia: Kd) {
             Arrays.fill(ia, 0);
         }
@@ -1454,7 +1447,7 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
         } else {
             sessionK = new int[2][];
         }
-        sessionK[0] = expandedKe;
+        sessionK[0] = Ke;
         sessionK[1] = expandedKd;
     }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCrypt.java
@@ -1368,11 +1368,11 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
         int[][] Ke = new int[ROUNDS + 1][]; // encryption round keys
         int[][] Kd = new int[ROUNDS + 1][]; // decryption round keys
 
-        // Due to JDK-8308105, it is significantly faster to avoid multiarray
-        // allocation in this code.
+        // It is significantly faster to allocate individual arrays,
+        // instead of doing the multi-array allocation. See JDK-8308105.
         for (int c = 0; c < ROUNDS + 1; c++) {
-            Ke[c] = new int[BC];
-            Kd[c] = new int[BC];
+            Ke[c] = new int[4];
+            Kd[c] = new int[4];
         }
 
         int KC = k.length/4; // keylen in 32-bit elements
@@ -1451,8 +1451,11 @@ final class AESCrypt extends SymmetricCipher implements AESConstants {
             // erase the previous values in sessionK
             Arrays.fill(sessionK[0], 0);
             Arrays.fill(sessionK[1], 0);
+        } else {
+            sessionK = new int[2][];
         }
-        sessionK = new int[][] { expandedKe, expandedKd };
+        sessionK[0] = expandedKe;
+        sessionK[1] = expandedKd;
     }
 
     /**

--- a/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.crypto;
+
+import org.openjdk.jmh.annotations.*;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class AESReinit {
+
+    private Cipher cipher;
+    private Random random;
+
+    byte[] key = new byte[16];
+    byte[] iv  = new byte[16];
+
+    @Setup
+    public void prepare() throws Exception {
+        random = new Random();
+        cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        key = new byte[16];
+        iv = new byte[16];
+    }
+
+    @Benchmark
+    public void test() throws Exception {
+        random.nextBytes(key);
+        random.nextBytes(iv);
+        SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
+        GCMParameterSpec param = new GCMParameterSpec(128, iv);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, param);
+    }
+
+}


### PR DESCRIPTION
One of our services has a hot path with AES/GCM cipher reuse. The JDK code reinitializes the session key on that path, and [JDK-8308105](https://bugs.openjdk.org/browse/JDK-8308105) shows up prominently there.

Fixing [JDK-8308105](https://bugs.openjdk.org/browse/JDK-8308105) would take a while, as would likely require multiple patches in VM internals. Meanwhile, we can avoid the multiarray allocations in AESCrypt.makeSessionKey completely, reaping performance benefits. We can go even deeper: replace the multi-array with the flat array and drop `expandToSubKey` completely.

Example original profile is in the bug.

There are other things we can polish in that code, but experiments show those polishings have rather diminshed returns.

On new benchmark:

```
Benchmark       Mode  Cnt    Score   Error  Units

## Mac M1

# Before
AESReinit.test  avgt   15   873,842 ± 6,911  ns/op

# After
AESReinit.test  avgt   15   347,632 ± 8,764  ns/op  ; <--- 2.5x faster

## Xeon, c6.8xlarge

# Before
AESReinit.test  avgt   15  1524.307 ± 24.231 ns/op

# After
AESReinit.test  avgt   15   554.727 ± 12.876 ns/op  ; <--- 2.75x faster

## Graviton, m6g.4xlarge

# Before
AESReinit.test  avgt   15  1913.492 ± 23.489 ns/op

# After
AESReinit.test  avgt   15   639.701 ± 5.033  ns/op  ; <--- 2.99x faster
```

Additional testing:
 - [x] Benchmarks
 - [x] macos-aarch64-server-release, `jdk_security`
 - [x] linux-x86_64-server-fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308118](https://bugs.openjdk.org/browse/JDK-8308118): Avoid multiarray allocations in AESCrypt.makeSessionKey


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * @schlosna (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13996/head:pull/13996` \
`$ git checkout pull/13996`

Update a local copy of the PR: \
`$ git checkout pull/13996` \
`$ git pull https://git.openjdk.org/jdk.git pull/13996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13996`

View PR using the GUI difftool: \
`$ git pr show -t 13996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13996.diff">https://git.openjdk.org/jdk/pull/13996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/13996#issuecomment-1548530219)