### PR TITLE
8308149: C2 VerifyIterativeGVN: verify CFG consistency (MultiBranchNode::required_outcnt() == outcnt())

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -615,8 +615,9 @@
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
           "Verify Iterative Global Value Numbering"                         \
-          "=XY, with Y: verify Def-Use modifications during IGVN"           \
-          "          X: verify that type(n) == n->Value() after IGVN"       \
+          "=XYZ, with Y: verify Def-Use modifications during IGVN"          \
+          "           X: verify that type(n) == n->Value() after IGVN"      \
+          "           Z: verify CFG consistency"                            \
           "X and Y in 0=off; 1=on")                                         \
           constraint(VerifyIterativeGVNConstraintFunc, AtParse)             \
                                                                             \

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2728,6 +2728,16 @@ int PCTableNode::required_outcnt() const {
               arg0->as_Type()->type()->higher_equal(TypePtr::NULL_PTR)) {
             return _size - 1;
           }
+        } else if (call->is_AllocateArray()) {
+          // Check for illegal array length. In such case, the optimizer has
+          // detected that the allocation attempt will always result in an
+          // exception. There is no fall-through projection of this CatchNode.
+          if (call->in(AllocateNode::KlassNode)->is_top() ||
+              call->in(AllocateNode::ALength)->is_top() ||
+              call->in(AllocateNode::ValidLengthTest)->is_top() ||
+              call->in(AllocateNode::ValidLengthTest)->find_int_con(1) == 0) {
+            return _size - 1;
+          }
         } else if (call->entry_point() == OptoRuntime::new_array_Java() ||
                    call->entry_point() == OptoRuntime::new_array_nozero_Java()) {
           // Check for illegal array length. In such case, the optimizer has

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2708,6 +2708,45 @@ Node *PCTableNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   return remove_dead_region(phase, can_reshape) ? this : nullptr;
 }
 
+int PCTableNode::required_outcnt() const {
+  if (outcnt() != _size) {
+    // Check for a few special cases.  Rethrow Nodes never take the
+    // 'fall-thru' path, so expected kids is 1 less.
+    if (in(0) != nullptr && in(0)->in(0) != nullptr) {
+      if (in(0)->in(0)->is_Call()) {
+        CallNode* call = in(0)->in(0)->as_Call();
+        if (call->entry_point() == OptoRuntime::rethrow_stub()) {
+          return _size - 1; // Rethrow always has 1 less kid
+        } else if (call->req() > TypeFunc::Parms &&
+                   call->is_CallDynamicJava()) {
+          // Check for null receiver. In such case, the optimizer has
+          // detected that the virtual call will always result in a null
+          // pointer exception. The fall-through projection of this CatchNode
+          // will not be populated.
+          Node* arg0 = call->in(TypeFunc::Parms);
+          if (arg0->is_Type() &&
+              arg0->as_Type()->type()->higher_equal(TypePtr::NULL_PTR)) {
+            return _size - 1;
+          }
+        } else if (call->entry_point() == OptoRuntime::new_array_Java() ||
+                   call->entry_point() == OptoRuntime::new_array_nozero_Java()) {
+          // Check for illegal array length. In such case, the optimizer has
+          // detected that the allocation attempt will always result in an
+          // exception. There is no fall-through projection of this CatchNode.
+          assert(call->is_CallStaticJava(), "static call expected");
+          assert(call->req() == call->jvms()->endoff() + 1, "missing extra input");
+          uint valid_length_test_input = call->req() - 1;
+          Node* valid_length_test = call->in(valid_length_test_input);
+          if (valid_length_test->find_int_con(1) == 0) {
+            return _size - 1;
+          }
+        }
+      }
+    }
+  }
+  return _size;
+}
+
 //=============================================================================
 uint JumpProjNode::hash() const {
   return Node::hash() + _dest_bci;

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -504,7 +504,7 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type *bottom_type() const;
   virtual bool pinned() const { return true; }
-  virtual int required_outcnt() const { return _size; }
+  virtual int required_outcnt() const;
 };
 
 //------------------------------JumpNode---------------------------------------

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -584,6 +584,10 @@ public:
     // '-XX:VerifyIterativeGVN=10'
     return ((VerifyIterativeGVN % 100) / 10) == 1;
   }
+  static bool is_verify_CFG() {
+    // '-XX:VerifyIterativeGVN=100'
+    return ((VerifyIterativeGVN % 1000) / 100) == 1;
+  }
 protected:
   // Sub-quadratic implementation of '-XX:VerifyIterativeGVN=1' (Use-Def verification).
   julong _verify_counter;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -313,7 +313,7 @@ JVMFlag::Error TypeProfileLevelConstraintFunc(uint value, bool verbose) {
 
 JVMFlag::Error VerifyIterativeGVNConstraintFunc(uint value, bool verbose) {
   uint original_value = value;
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 3; i++) {
     if (value % 10 > 1) {
       JVMFlag::printError(verbose,
                           "Invalid value (" UINT32_FORMAT ") "


### PR DESCRIPTION
This is a subtask IGVN verification [JDK-8298951](https://bugs.openjdk.org/browse/JDK-8298951).

Recently, we have had a series of `malformed control flow` bugs.
They only get triggered in Compile::final_graph_reshaping.
I want to find more of them, and find them already after IGVN.

I added it as `-XX:VerifyIterativeGVN=100`.

Had to refactor `PCTableNode::required_outcnt`: it used to give the wrong count, and then correct the count on its use in `Compile::final_graph_reshaping`. I pushed the correction code into `PCTableNode::required_outcnt`, so that it always gives the correct count. Now I can use `required_outcnt` for verification during IGVN.

I expect this to mostly reproduce "bad if" cases, where one branch has died due to dead data, but the if itself has not folded.

TODO: testing...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308149](https://bugs.openjdk.org/browse/JDK-8308149): C2 VerifyIterativeGVN: verify CFG consistency (MultiBranchNode::required_outcnt() == outcnt()) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/13999/head:pull/13999` \
`$ git checkout pull/13999`

Update a local copy of the PR: \
`$ git checkout pull/13999` \
`$ git pull https://git.openjdk.org/jdk.git pull/13999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13999`

View PR using the GUI difftool: \
`$ git pr show -t 13999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/13999.diff">https://git.openjdk.org/jdk/pull/13999.diff</a>

</details>
