### PR TITLE
8308000: add PopFrame support for virtual threads

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -2958,6 +2958,10 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
           <jthread impl="noconvert"/>
             <description>
               The thread whose current frame is to be popped.
+              The <functionlink id="PopFrame"></functionlink> function may be used to
+              pop the current frame of a virtual thread when it is suspended at an event.
+              An implementation may support popping the current frame of a suspended
+              virtual thread in other cases.
             </description>
         </param>
       </parameters>
@@ -2967,8 +2971,8 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
           The implementation is unable to pop this frame.
         </error>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
-          The thread is a virtual thread and the implementation is unable
-          to pop this frame.
+          The thread is a suspended virtual thread and the implementation
+          was unable to pop the current frame.
         </error>
         <error id="JVMTI_ERROR_THREAD_NOT_SUSPENDED">
           Thread was not suspended and was not the current thread.

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1883,9 +1883,20 @@ JvmtiEnv::PopFrame(jthread thread) {
   oop thread_obj = nullptr;
   jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
 
-  if (thread_obj != nullptr && thread_obj->is_a(vmClasses::BaseVirtualThread_klass())) {
-    // No support for virtual threads (yet).
-    return JVMTI_ERROR_OPAQUE_FRAME;
+  bool is_virtual = thread_obj != nullptr && thread_obj->is_a(vmClasses::BaseVirtualThread_klass());
+
+  if (is_virtual && !is_JavaThread_current(java_thread, thread_obj)) {
+    if (!is_vthread_suspended(thread_obj, java_thread)) {
+      return JVMTI_ERROR_THREAD_NOT_SUSPENDED;
+    }
+    if (java_thread == nullptr) { // unmounted virtual thread
+      return JVMTI_ERROR_OPAQUE_FRAME;
+    }
+  } else {
+    if (java_thread != current_thread && !java_thread->is_suspended() &&
+        !java_thread->is_carrier_thread_suspended()) {
+      return JVMTI_ERROR_THREAD_NOT_SUSPENDED;
+    }
   }
   if (err != JVMTI_ERROR_NONE) {
     return err;

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2211,13 +2211,8 @@ UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
   }
   assert(java_thread == _state->get_thread(), "Must be");
 
-  if (!self && !java_thread->is_suspended() && !java_thread->is_carrier_thread_suspended()) {
-    _result = JVMTI_ERROR_THREAD_NOT_SUSPENDED;
-    return;
-  }
-
   // Check to see if a PopFrame was already in progress
-  if (java_thread->popframe_condition() != JavaThread::popframe_inactive) {
+  if (!self && java_thread->popframe_condition() != JavaThread::popframe_inactive) {
     // Probably possible for JVMTI clients to trigger this, but the
     // JPDA backend shouldn't allow this to happen
     _result = JVMTI_ERROR_INTERNAL;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/PopFrameTest/PopFrameTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/PopFrameTest/PopFrameTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=default
+ * @summary Verifies JVMTI PopFrame support for virtual threads.
+ * @requires vm.continuations
+ * @run main/othervm/native -agentlib:PopFrameTest PopFrameTest
+ */
+
+/*
+ * @test id=no-vmcontinuations
+ * @summary Verifies JVMTI PopFrame support for bound virtual threads.
+ * @run main/othervm/native -agentlib:PopFrameTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations PopFrameTest
+ */
+
+/*
+ * @test id=platform
+ * @summary Verifies JVMTI PopFrame support for platform threads.
+ * @run main/othervm/native -agentlib:PopFrameTest PopFrameTest platform
+ */
+
+import java.lang.AssertionError;
+
+/*
+ *     The test exercises the JVMTI function PopFrame.
+ *     The test creates a new virtual or platform thread.
+ *     Its method run() invokes the following methods:
+ *      - method A() that is blocked on a monitor
+ *      - method B() that is stopped at a breakpoint
+ *      - method C() that forces agent to call PopFrame on its own thread
+ *     JVMTI PopFrame is called in all cases.
+ */
+public class PopFrameTest {
+    private static final String agentLib = "PopFrameTest";
+    static final int JVMTI_ERROR_NONE = 0;
+    static final int THREAD_NOT_SUSPENDED = 13;
+    static final int OPAQUE_FRAME = 32;
+    static final int PASSED = 0;
+    static final int FAILED = 2;
+
+    static void log(String str) { System.out.println(str); }
+
+    static native void prepareAgent(Class taskClass);
+    static native void suspendThread(Thread thread);
+    static native void resumeThread(Thread thread);
+    static native void ensureAtBreakpoint();
+    static native void notifyAtBreakpoint();
+    static native int  popFrame(Thread thread);
+
+    static int status = PASSED;
+    static boolean is_virtual = true;
+
+    static void setFailed(String msg) {
+        log("\nFAILED: " + msg);
+        status = FAILED;
+    }
+
+    static void throwFailed(String msg) {
+        log("\nFAILED: " + msg);
+        throw new RuntimeException("PopFrameTest failed!");
+    }
+
+    public static void main(String args[]) {
+        is_virtual = !(args.length > 0 && args[0].equals("platform"));
+        run();
+        if (status == FAILED) {
+            throwFailed("PopFrameTest!");
+        }
+        log("\nPopFrameTest passed");
+    }
+
+    public static void run() {
+        TestTask testTask = new TestTask();
+        Thread testTaskThread = null;
+        int errCode;
+
+        prepareAgent(TestTask.class);
+
+        log("\nMain #A: method A() must be blocked on entering a synchronized statement");
+        if (is_virtual) {
+            testTaskThread = Thread.ofVirtual().name("TestTaskThread").start(testTask);
+        } else {
+            testTaskThread = Thread.ofPlatform().name("TestTaskThread").start(testTask);
+        }
+        testTask.ensureStarted();
+
+        log("\nMain #A.1: unsuspended");
+        {
+            errCode = popFrame(testTaskThread);
+            if (errCode != THREAD_NOT_SUSPENDED) {
+                throwFailed("Main #A.1: expected THREAD_NOT_SUSPENDED instead of: " + errCode);
+            } else {
+                log("Main #A.1: got expected THREAD_NOT_SUSPENDED");
+            }
+
+            log("\nMain #A.2: suspended");
+            suspendThread(testTaskThread);
+            errCode = popFrame(testTaskThread);
+            if (errCode != JVMTI_ERROR_NONE) {
+                throwFailed("Main #A.2: expected JVMTI_ERROR_NONE instead of: " + errCode);
+            } else {
+                log("Main #A.2: got expected JVMTI_ERROR_NONE");
+            }
+            resumeThread(testTaskThread);
+            testTask.clearDoLoop();
+            testTask.sleep(5);
+        }
+
+        log("\nMain #B: method B() must be blocked in a breakpoint event handler");
+        {
+            ensureAtBreakpoint();
+
+            log("\nMain #B.1: unsuspended");
+            errCode = popFrame(testTaskThread);
+            if (errCode != THREAD_NOT_SUSPENDED) {
+                throwFailed("Main #B.1: expected THREAD_NOT_SUSPENDED instead of: " + errCode);
+            }
+            log("Main #B.1: got expected THREAD_NOT_SUSPENDED");
+
+            log("\nMain #B.2: suspended");
+            suspendThread(testTaskThread);
+            errCode = popFrame(testTaskThread);
+            if (errCode != JVMTI_ERROR_NONE) {
+                throwFailed("Main #B.2: expected JVMTI_ERROR_NONE");
+            }
+            log("Main #B.2: got expected JVMTI_ERROR_NONE");
+            resumeThread(testTaskThread);
+            notifyAtBreakpoint();
+
+            log("\nMain #B.3: unsuspended, call PopFrame on own thread");
+            ensureAtBreakpoint();
+            notifyAtBreakpoint();
+            testTask.sleep(5);
+        }
+
+        log("\nMain #C: method C() calls PopFrame on its own thread");
+        {
+            // PopFrame is called from the test task (own thread) and expected to succeed.
+            // No suspension of the test task thread is required or can be done in this case.
+            testTask.ensureFinished();
+        }
+
+        try {
+            testTaskThread.join();
+        } catch (InterruptedException ex) {
+            throwFailed("Unexpected " + ex);
+        }
+    }
+
+
+    static class TestTask implements Runnable {
+        static private volatile boolean doLoop = true;
+        static void log(String str) { System.out.println(str); }
+
+        private volatile boolean started = false;
+        private volatile boolean finished = false;
+
+        static public void sleep(long millis) {
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interruption in TestTask.sleep: \n\t" + e);
+            }
+        }
+
+        // Ensure thread is ready.
+        public void ensureStarted() {
+            while (!started) {
+                sleep(1);
+            }
+        }
+
+        // Ensure thread is finished.
+        public void ensureFinished() {
+            while (!finished) {
+                sleep(1);
+            }
+        }
+
+        static public void clearDoLoop() {
+            doLoop = false;
+        }
+
+        public void run() {
+            log("TestTask.run: started");
+            started = true;
+
+            A();
+            sleep(1); // to cause yield
+
+            B();
+            sleep(1); // to cause yield
+
+            B();
+            sleep(1); // to cause yield
+
+            C();
+            finished = true;
+        }
+
+        // Method is blocked on entering a synchronized statement.
+        // PopFrame is used two times:
+        //  - when not suspended: THREAD_NOT_SUSPENDED is expected
+        //  - when suspended: JVMTI_ERROR_NONE is expected
+        static void A() {
+            log("TestTask.A: started");
+            while (doLoop) {
+            }
+            log("TestTask.A: finished");
+        }
+
+        // A breakpoint is set at start of this method.
+        // PopFrame is used two times:
+        //  - when not suspended: THREAD_NOT_SUSPENDED is expected
+        //  - when suspended: expected to succeed
+        static void B() {
+            log("TestTask.B: started");
+        }
+
+        // This method uses PoopFrame on its own thread. It is expected to succeed.
+        static void C() {
+            log("TestTask.C: started");
+            int errCode = PopFrameTest.popFrame(Thread.currentThread());
+            if (errCode == OPAQUE_FRAME) {
+                log("TestTask.C: got expected OPAQUE_FRAME");
+            } else {
+                setFailed("TestTask.C: expected OPAQUE_FRAME from PopFrame instead of: " + errCode);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/PopFrameTest/libPopFrameTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/PopFrameTest/libPopFrameTest.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "jvmti.h"
+#include "jvmti_common.h"
+
+extern "C" {
+
+static jvmtiEnv *jvmti = NULL;
+static jmethodID mid_B = NULL;
+static jrawMonitorID monitor = NULL;
+static volatile bool bp_sync_reached = false;
+
+static void JNICALL
+Breakpoint(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
+           jmethodID method, jlocation location) {
+  jvmtiError err;
+
+  if (method != mid_B) {
+    fatal(jni, "Breakpoint: Failed with wrong location: expected in method TestTask.B()");
+  }
+  err = jvmti->ClearBreakpoint(mid_B, 0);
+  check_jvmti_status(jni, err, "Breakpoint: Failed in JVMTI ClearBreakpoint");
+
+  LOG("Breakpoint: In method TestTask.B(): before sync section enter\n");
+
+  err = jvmti->RawMonitorEnter(monitor);
+  check_jvmti_status(jni, err, "Breakpoint: Failed in RawMonitorEnter");
+
+  bp_sync_reached = true;
+
+  // wait for notify from notifyAtBreakpoint
+  err = jvmti->RawMonitorWait(monitor, 0);
+  check_jvmti_status(jni, err, "Breakpoint: Failed in RawMonitorWait");
+
+  err = jvmti->RawMonitorExit(monitor);
+  check_jvmti_status(jni, err, "Breakpoint: Failed in RawMonitorExit");
+
+  err = jvmti->PopFrame(thread);
+  LOG("Main: popFrame: PopFrame returned code: %s (%d)\n", TranslateError(err), err);
+  check_jvmti_status(jni, err, "Breakpoint: Failed in PopFrame");
+
+  LOG("Breakpoint: In method TestTask.B(): after sync section exit\n");
+}
+
+jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  static jvmtiCapabilities caps;
+  static jvmtiEventCallbacks callbacks;
+  jvmtiError err;
+  jint res;
+
+  LOG("Agent init\n");
+  res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
+  if (res != JNI_OK || jvmti == NULL) {
+    LOG("Agent init: Failed in GetEnv!\n");
+    return JNI_ERR;
+  }
+  err = jvmti->GetPotentialCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("Agent init: Failed in GetPotentialCapabilities: %s (%d)\n", TranslateError(err), err);
+    return JNI_ERR;
+  }
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("Agent init: Failed in AddCapabilities: %s (%d)\n", TranslateError(err), err);
+    return JNI_ERR;
+  }
+  err = jvmti->GetCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("Agent init: Failed in GetCapabilities: %s (%d)\n", TranslateError(err), err);
+    return JNI_ERR;
+  }
+  if (!caps.can_generate_breakpoint_events) {
+    LOG("Agent init: Failed: Breakpoint event is not implemented\n");
+    return JNI_ERR;
+  }
+  callbacks.Breakpoint = &Breakpoint;
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("Agent init: Failed in SetEventCallbacks: %s (%d)\n", TranslateError(err), err);
+    return JNI_ERR;
+  }
+
+  monitor = create_raw_monitor(jvmti, "Raw monitor to test");
+  return JNI_OK;
+}
+
+extern JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT void JNICALL
+Java_PopFrameTest_prepareAgent(JNIEnv *jni, jclass cls, jclass task_clazz) {
+  jvmtiError err;
+
+  LOG("Main: prepareAgent started\n");
+
+  if (jvmti == NULL) {
+    fatal(jni, "prepareAgent: Failed as JVMTI client was not properly loaded!\n");
+  }
+  mid_B = jni->GetStaticMethodID(task_clazz, "B", "()V");
+  if (mid_B == NULL) {
+    fatal(jni, "prepareAgent: Failed to find Method ID for method: TestTask.B()\n");
+  }
+  err = jvmti->SetBreakpoint(mid_B, 0);
+  check_jvmti_status(jni, err, "prepareAgent: Failed in JVMTI SetBreakpoint");
+
+  set_event_notification_mode(jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL);
+
+  LOG("Main: prepareAgent finished\n");
+}
+
+JNIEXPORT void JNICALL
+Java_PopFrameTest_suspendThread(JNIEnv *jni, jclass cls, jthread thread) {
+  LOG("Main: suspendThread\n");
+  suspend_thread(jvmti, jni, thread);
+}
+
+JNIEXPORT void JNICALL
+Java_PopFrameTest_resumeThread(JNIEnv *jni, jclass cls, jthread thread) {
+  LOG("Main: resumeThread\n");
+  resume_thread(jvmti, jni, thread);
+}
+
+JNIEXPORT jint JNICALL
+Java_PopFrameTest_popFrame(JNIEnv *jni, jclass cls, jthread thread) {
+  jvmtiError err = jvmti->PopFrame(thread);
+  LOG("Main: popFrame: PopFrame returned code: %s (%d)\n", TranslateError(err), err);
+  return (jint)err;
+}
+
+JNIEXPORT void JNICALL
+Java_PopFrameTest_ensureAtBreakpoint(JNIEnv *jni, jclass cls) {
+  jvmtiError err;
+  bool need_stop = false;
+
+  LOG("Main: ensureAtBreakpoint\n");
+
+  while (!need_stop) {
+    err = jvmti->RawMonitorEnter(monitor);
+    check_jvmti_status(jni, err, "ensureAtBreakpoint: Failed in RawMonitorEnter");
+
+    need_stop = bp_sync_reached;
+
+    err = jvmti->RawMonitorExit(monitor);
+    check_jvmti_status(jni, err, "ensureAtBreakpoint: Failed in RawMonitorExit");
+
+    sleep_ms(1); // 1 millisecond
+  }
+}
+
+JNIEXPORT void JNICALL
+Java_PopFrameTest_notifyAtBreakpoint(JNIEnv *jni, jclass cls) {
+  jvmtiError err;
+
+  LOG("Main: notifyAtBreakpoint\n");
+
+  err = jvmti->RawMonitorEnter(monitor);
+  check_jvmti_status(jni, err, "notifyAtBreakpoint: Fatal Error in RawMonitorEnter");
+
+  err = jvmti->RawMonitorNotify(monitor);
+  check_jvmti_status(jni, err, "notifyAtBreakpoint: Fatal Error in RawMonitorNotify");
+
+  err = jvmti->RawMonitorExit(monitor);
+  check_jvmti_status(jni, err, "notifyAtBreakpoint: Fatal Error in RawMonitorExit");
+}
+
+} // extern "C"


### PR DESCRIPTION
This enhancement adds `PopFrame` support for virtual threads. The spec defines minimal support that the JVMTI `PopFrame` can be used for a virtual thread suspended an an event. 
Actually, the `PopFrame` can supports suspended and mounted virtual threads. 

CSR (approved): https://bugs.openjdk.org/browse/JDK-8308001: add PopFrame support for virtual threads

Testing:
New test was developed: `serviceability/vthread/PopFrameTest`.
Submitted mach5 tiers 1-6 are good.
TBD: rerun mach5 tiers 1-6 at the end of review again if necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308001](https://bugs.openjdk.org/browse/JDK-8308001) to be approved

### Issues
 * [JDK-8308000](https://bugs.openjdk.org/browse/JDK-8308000): add PopFrame support for virtual threads
 * [JDK-8308001](https://bugs.openjdk.org/browse/JDK-8308001): add PopFrame support for virtual threads (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14002/head:pull/14002` \
`$ git checkout pull/14002`

Update a local copy of the PR: \
`$ git checkout pull/14002` \
`$ git pull https://git.openjdk.org/jdk.git pull/14002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14002`

View PR using the GUI difftool: \
`$ git pr show -t 14002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14002.diff">https://git.openjdk.org/jdk/pull/14002.diff</a>

</details>
