### PR TITLE
JDK-8308156: VerifyCACerts.java misses blank in error output

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -293,8 +293,8 @@ public class VerifyCACerts {
         String checksum = HEX.formatHex(md.digest(data));
         if (!checksum.equals(CHECKSUM)) {
             atLeastOneFailed = true;
-            System.err.println("ERROR: wrong checksum" + checksum);
-            System.err.println("Expected checksum" + CHECKSUM);
+            System.err.println("ERROR: wrong checksum " + checksum);
+            System.err.println("Expected checksum " + CHECKSUM);
         }
 
         KeyStore ks = KeyStore.getInstance("JKS");


### PR DESCRIPTION
In the checksum-related check, we miss blanks in the error output of the calculated and expected checksum.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308156](https://bugs.openjdk.org/browse/JDK-8308156): VerifyCACerts.java misses blank in error output


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14003/head:pull/14003` \
`$ git checkout pull/14003`

Update a local copy of the PR: \
`$ git checkout pull/14003` \
`$ git pull https://git.openjdk.org/jdk.git pull/14003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14003`

View PR using the GUI difftool: \
`$ git pr show -t 14003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14003.diff">https://git.openjdk.org/jdk/pull/14003.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14003#issuecomment-1549265866)