### PR TITLE
8306119: Many components respond to a mouse event by requesting focus without supplying the MOUSE_EVENT cause

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
@@ -26,6 +26,7 @@
 package com.apple.laf;
 
 import java.awt.*;
+import java.awt.event.FocusEvent;
 import java.awt.event.MouseEvent;
 
 import javax.swing.*;
@@ -356,7 +357,7 @@ public class AquaSliderUI extends BasicSliderUI implements Sizeable {
             currentMouseY = e.getY();
 
             if (slider.isRequestFocusEnabled()) {
-                slider.requestFocus();
+                slider.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
 
             boolean isMouseEventInThumb = thumbRect.contains(currentMouseX, currentMouseY);

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSpinnerUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSpinnerUI.java
@@ -603,7 +603,7 @@ public class AquaSpinnerUI extends SpinnerUI {
             final Component child = ftp.getComponentAfter(root, spinner);
 
             if (child != null && SwingUtilities.isDescendingFrom(child, spinner)) {
-                child.requestFocus();
+                child.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
         }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldSearch.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldSearch.java
@@ -178,7 +178,7 @@ public class AquaTextFieldSearch {
         });
         b.addMouseListener(new MouseAdapter() {
             public void mousePressed(final MouseEvent e) {
-                c.requestFocusInWindow();
+                c.requestFocusInWindow(FocusEvent.Cause.MOUSE_EVENT);
             }
         });
 
@@ -198,7 +198,7 @@ public class AquaTextFieldSearch {
             b.addMouseListener(new MouseAdapter() {
                 public void mousePressed(final MouseEvent e) {
                     ((JPopupMenu)findPopup).show(b, 8, b.getHeight() - 2);
-                    c.requestFocusInWindow();
+                    c.requestFocusInWindow(FocusEvent.Cause.MOUSE_EVENT);
                     c.repaint();
                 }
             });

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKColorChooserPanel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKColorChooserPanel.java
@@ -703,7 +703,7 @@ class GTKColorChooserPanel extends AbstractColorChooserPanel implements
                 int y = ((MouseEvent)e).getY() - size;
 
                 if (!hasFocus()) {
-                    requestFocus();
+                    requestFocus(FocusEvent.Cause.MOUSE_EVENT);
                 }
                 if (!isSet(FLAGS_DRAGGING_TRIANGLE) &&
                       adjustHue(x, y, e.getID() == MouseEvent.MOUSE_PRESSED)) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonListener.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonListener.java
@@ -261,7 +261,7 @@ public class BasicButtonListener implements MouseListener, MouseMotionListener,
              }
              model.setPressed(true);
              if(!b.hasFocus() && b.isRequestFocusEnabled()) {
-                b.requestFocus();
+                b.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
              }
           }
        }
@@ -322,7 +322,7 @@ public class BasicButtonListener implements MouseListener, MouseMotionListener,
                 model.setArmed(true);
                 model.setPressed(true);
                 if(!b.hasFocus()) {
-                    b.requestFocus();
+                    b.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
                 }
             }
             else if (key == RELEASE) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonListener.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonListener.java
@@ -322,7 +322,7 @@ public class BasicButtonListener implements MouseListener, MouseMotionListener,
                 model.setArmed(true);
                 model.setPressed(true);
                 if(!b.hasFocus()) {
-                    b.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
+                    b.requestFocus();
                 }
             }
             else if (key == RELEASE) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
@@ -927,11 +927,11 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
             if ( comboBox.isEditable() ) {
                 Component comp = comboBox.getEditor().getEditorComponent();
                 if ((!(comp instanceof JComponent)) || ((JComponent)comp).isRequestFocusEnabled()) {
-                    comp.requestFocus();
+                    comp.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
                 }
             }
             else if (comboBox.isRequestFocusEnabled()) {
-                comboBox.requestFocus();
+                comboBox.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
             togglePopup();
         }
@@ -1237,11 +1237,19 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
         if ( comboBox.isEditable() ) {
             Component comp = comboBox.getEditor().getEditorComponent();
             if ((!(comp instanceof JComponent)) || ((JComponent)comp).isRequestFocusEnabled()) {
-                comp.requestFocus();
+                if (e != null) {
+                    comp.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
+                } else {
+                    comp.requestFocus();
+                }
             }
         }
         else if (comboBox.isRequestFocusEnabled()) {
-            comboBox.requestFocus();
+            if (e != null) {
+                comboBox.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
+            } else {
+                comboBox.requestFocus();
+            }
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1281,7 +1281,7 @@ public class BasicScrollBarUI
                 return;
 
             if (!scrollbar.hasFocus() && scrollbar.isRequestFocusEnabled()) {
-                scrollbar.requestFocus();
+                scrollbar.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
 
             useCachedValue = true;
@@ -1558,7 +1558,7 @@ public class BasicScrollBarUI
 
             handledEvent = true;
             if (!scrollbar.hasFocus() && scrollbar.isRequestFocusEnabled()) {
-                scrollbar.requestFocus();
+                scrollbar.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
         }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -1981,7 +1981,7 @@ public class BasicSliderUI extends SliderUI{
             currentMouseY = e.getY();
 
             if (slider.isRequestFocusEnabled()) {
-                slider.requestFocus();
+                slider.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
 
             // Clicked in the Thumb area?

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSpinnerUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSpinnerUI.java
@@ -866,7 +866,7 @@ public class BasicSpinnerUI extends SpinnerUI
 
                     if (child != null && SwingUtilities.isDescendingFrom(
                                                         child, spinner)) {
-                        child.requestFocus();
+                        child.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
                     }
                 }
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -4142,7 +4142,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
                 else if (tabPane.isRequestFocusEnabled()) {
                     // Clicking on selected tab, try and give the tabbedpane
                     // focus.  Repaint will occur in focusGained.
-                    tabPane.requestFocus();
+                    tabPane.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
                 }
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -582,10 +582,10 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
         if ((component != null) && component.isEnabled() &&
                                    component.isRequestFocusEnabled()) {
             if (inWindow) {
-                component.requestFocusInWindow();
+                component.requestFocusInWindow(FocusEvent.Cause.MOUSE_EVENT);
             }
             else {
-                component.requestFocus();
+                component.requestFocus(FocusEvent.Cause.MOUSE_EVENT);
             }
         }
     }

--- a/test/jdk/javax/swing/event/FocusEventCauseTest.java
+++ b/test/jdk/javax/swing/event/FocusEventCauseTest.java
@@ -25,7 +25,7 @@
  * @test
  * @key headful
  * @bug 8306119
- * @summary Verifies FocusEvent cause when components requests focus 
+ * @summary Verifies FocusEvent cause when components requests focus
  *          via mouse events
  * @run main FocusEventCauseTest
  */
@@ -47,10 +47,10 @@ public class FocusEventCauseTest {
     static JButton button2;
     static volatile Point pt;
     static volatile Dimension dim;
-    static volatile boolean expected;    
+    static volatile boolean expected;
 
     public static void main(String[] args) throws Exception {
-        try {	    
+        try {
             Robot robot = new Robot();
             robot.setAutoDelay(100);
             SwingUtilities.invokeAndWait(() -> {
@@ -64,7 +64,7 @@ public class FocusEventCauseTest {
                         System.out.println("FocusEvent getCause " + e.getCause());
                         if (e.getCause() == FocusEvent.Cause.MOUSE_EVENT) {
                             expected = true;
-                        }			    
+                        }
                     }
                 });
                 panel.add(button1);
@@ -83,21 +83,20 @@ public class FocusEventCauseTest {
             robot.mouseMove(pt.x + dim.width/2, pt.y + dim.height/2);
             robot.waitForIdle();
             robot.delay(500);
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);	
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.waitForIdle();	
+            robot.waitForIdle();
             robot.delay(500);
             if (!expected) {
                 throw new RuntimeException("Focus requested without " +
                                            "supplying expected cause");
-            }		
+            }
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();
                 }
             });
-        }	    
+        }
     }
-}    
-            		
+}

--- a/test/jdk/javax/swing/event/FocusEventCauseTest.java
+++ b/test/jdk/javax/swing/event/FocusEventCauseTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 8306119
+ * @summary Verifies FocusEvent cause when components requests focus 
+ *          via mouse events
+ * @run main FocusEventCauseTest
+ */
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+public class FocusEventCauseTest {
+    static JFrame frame;
+    static JButton button1;
+    static JButton button2;
+    static volatile Point pt;
+    static volatile Dimension dim;
+    static volatile boolean expected;    
+
+    public static void main(String[] args) throws Exception {
+        try {	    
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("FocusEventCauseTest");
+                JPanel panel = new JPanel();
+                button1 = new JButton("Button1");
+                button2 = new JButton("Button2");
+                button2.addFocusListener(new FocusAdapter() {
+                    @Override
+                    public void focusGained(FocusEvent e) {
+                        System.out.println("FocusEvent getCause " + e.getCause());
+                        if (e.getCause() == FocusEvent.Cause.MOUSE_EVENT) {
+                            expected = true;
+                        }			    
+                    }
+                });
+                panel.add(button1);
+                panel.add(button2);
+                frame.add(panel);
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pt = button2.getLocationOnScreen();
+                dim = button2.getSize();
+            });
+            robot.mouseMove(pt.x + dim.width/2, pt.y + dim.height/2);
+            robot.waitForIdle();
+            robot.delay(500);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);	
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();	
+            robot.delay(500);
+            if (!expected) {
+                throw new RuntimeException("Focus requested without " +
+                                           "supplying expected cause");
+            }		
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }	    
+    }
+}    
+            		


### PR DESCRIPTION
Many Swing components request a focus transfer in response to a mouse event, but fail to supply a Cause when requesting focus. A focus event listener will find the cause to be UNKNOWN, but MOUSE_EVENT would be more appropriate. 
Fixed by adding MOUSE_EVENT cause to requestFocus() when it is called for mouse events...

All jtreg/jck tests are ok..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306119](https://bugs.openjdk.org/browse/JDK-8306119): Many components respond to a mouse event by requesting focus without supplying the MOUSE_EVENT cause


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14004/head:pull/14004` \
`$ git checkout pull/14004`

Update a local copy of the PR: \
`$ git checkout pull/14004` \
`$ git pull https://git.openjdk.org/jdk.git pull/14004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14004`

View PR using the GUI difftool: \
`$ git pr show -t 14004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14004.diff">https://git.openjdk.org/jdk/pull/14004.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14004#issuecomment-1549277662)