### PR TITLE
8299075: TestStringDeduplicationInterned.java fails because extra deduplication

### DIFF
--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -406,7 +406,7 @@ class TestStringDeduplicationTools {
         }
 
         private static void checkNotDeduplicated(Object value1, Object value2) {
-            // Note that the following check is invalid since a concurrent GC
+            // Note that the following check is invalid since a GC
             // can run and actually deduplicate the strings.
             //
             // if (value1 == value2) {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -348,9 +348,8 @@ class TestStringDeduplicationTools {
             // Create duplicate of baseString
             StringBuilder sb1 = new StringBuilder(baseString);
             String dupString1 = sb1.toString();
-            if (getValue(dupString1) == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+
+            checkNotDeduplicated(getValue(dupString1), getValue(baseString));
 
             // Force baseString to be inspected for deduplication
             // and be inserted into the deduplication hashtable.
@@ -363,9 +362,8 @@ class TestStringDeduplicationTools {
             // Create a new duplicate of baseString
             StringBuilder sb2 = new StringBuilder(baseString);
             String dupString2 = sb2.toString();
-            if (getValue(dupString2) == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+
+            checkNotDeduplicated(getValue(dupString2), getValue(baseString));
 
             // Intern the new duplicate
             Object beforeInternedValue = getValue(dupString2);
@@ -384,16 +382,13 @@ class TestStringDeduplicationTools {
             // Check original value of interned string, to make sure
             // deduplication happened on the interned string and not
             // on the base string
-            if (beforeInternedValue == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+            checkNotDeduplicated(beforeInternedValue, getValue(baseString));
 
             // Create duplicate of baseString
             StringBuilder sb3 = new StringBuilder(baseString);
             String dupString3 = sb3.toString();
-            if (getValue(dupString3) == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+
+            checkNotDeduplicated(dupString3, getValue(baseString));
 
             forceDeduplication(ageThreshold, FullGC);
 
@@ -408,6 +403,15 @@ class TestStringDeduplicationTools {
             }
 
             System.out.println("End: InternedTest");
+        }
+
+        private static void checkNotDeduplicated(Object value1, Object value2) {
+            // Note that the following check is invalid since a concurrent GC
+            // can run and actually deduplicate the strings.
+            //
+            // if (value1 == value2) {
+            //     throw new RuntimeException("Values should not match");
+            // }
         }
 
         public static OutputAnalyzer run() throws Exception {


### PR DESCRIPTION
The tests assumes that some strings have not been deduplicated and checks for that. Unfortunately, we can have concurrently triggered GCs that invalidate those checks. I kept the call sites to show the intention of the test, but then I added a comment explaining why those checks are invalid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299075](https://bugs.openjdk.org/browse/JDK-8299075): TestStringDeduplicationInterned.java fails because extra deduplication


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [ea47391b](https://git.openjdk.org/jdk/pull/14005/files/ea47391b650d91642121847c26006e116ce8873d)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14005/head:pull/14005` \
`$ git checkout pull/14005`

Update a local copy of the PR: \
`$ git checkout pull/14005` \
`$ git pull https://git.openjdk.org/jdk.git pull/14005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14005`

View PR using the GUI difftool: \
`$ git pr show -t 14005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14005.diff">https://git.openjdk.org/jdk/pull/14005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14005#issuecomment-1549342650)