### PR TITLE
8300086: Replace NULL with nullptr in share/c1/

### DIFF
--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ void CFGPrinter::print_intervals(IntervalList* intervals, const char* name) {
 
 
 CFGPrinterOutput::CFGPrinterOutput(Compilation* compilation)
- : _output(NULL),
+ : _output(nullptr),
    _compilation(compilation),
    _do_print_HIR(false),
    _do_print_LIR(false)
@@ -209,7 +209,7 @@ void CFGPrinterOutput::print_HIR(BlockBegin* block) {
   print_begin("HIR");
 
   Value cur = block->next();
-  while (cur != NULL) {
+  while (cur != nullptr) {
     print_HIR(cur);
     cur = cur->next();
   }
@@ -233,7 +233,7 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
   print_begin("block");
   print("name \"B%d\"", block->block_id());
   print("from_bci %d", block->bci());
-  print("to_bci %d", (block->end() == NULL ? -1 : block->end()->printable_bci()));
+  print("to_bci %d", (block->end() == nullptr ? -1 : block->end()->printable_bci()));
 
   output()->indent();
   output()->print("predecessors ");
@@ -245,7 +245,7 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
 
   output()->indent();
   output()->print("successors ");
-  if (block->end() != NULL) {
+  if (block->end() != nullptr) {
     for (i = 0; i < block->number_of_sux(); i++) {
       output()->print("\"B%d\" ", block->sux_at(i)->block_id());
     }
@@ -272,7 +272,7 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
   if (block->is_set(BlockBegin::linear_scan_loop_end_flag))     output()->print("\"lle\" ");
   output()->cr();
 
-  if (block->dominator() != NULL) {
+  if (block->dominator() != nullptr) {
     print("dominator \"B%d\"", block->dominator()->block_id());
   }
   if (block->loop_index() != -1) {
@@ -324,7 +324,7 @@ void CFGPrinterOutput::print_intervals(IntervalList* intervals, const char* name
   print("name \"%s\"", name);
 
   for (int i = 0; i < intervals->length(); i++) {
-    if (intervals->at(i) != NULL) {
+    if (intervals->at(i) != nullptr) {
       intervals->at(i)->print_on(output(), true);
     }
   }

--- a/src/hotspot/share/c1/c1_CFGPrinter.hpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,10 +55,10 @@ class CFGPrinterOutput : public CHeapObj<mtCompiler> {
   bool _do_print_LIR;
 
   class PrintBlockClosure: public BlockClosure {
-    void block_do(BlockBegin* block) { if (block != NULL) Compilation::current()->cfg_printer_output()->print_block(block); }
+    void block_do(BlockBegin* block) { if (block != nullptr) Compilation::current()->cfg_printer_output()->print_block(block); }
   };
 
-  outputStream* output() { assert(_output != NULL, ""); return _output; }
+  outputStream* output() { assert(_output != nullptr, ""); return _output; }
 
   void inc_indent();
   void dec_indent();

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ class PrintValueVisitor: public ValueVisitor {
 };
 
 void Canonicalizer::set_canonical(Value x) {
-  assert(x != NULL, "value must exist");
+  assert(x != nullptr, "value must exist");
   // Note: we can not currently substitute root nodes which show up in
   // the instruction stream (because the instruction list is embedded
   // in the instructions).
@@ -200,11 +200,11 @@ void Canonicalizer::do_LoadField      (LoadField*       x) {}
 // GraphBuilder. This is the only block that has not BlockEnd yet.
 static bool in_current_block(Value v) {
   int max_distance = 4;
-  while (max_distance > 0 && v != NULL && v->as_BlockEnd() == NULL) {
+  while (max_distance > 0 && v != nullptr && v->as_BlockEnd() == nullptr) {
     v = v->next();
     max_distance--;
   }
-  return v == NULL;
+  return v == nullptr;
 }
 
 void Canonicalizer::do_StoreField     (StoreField*      x) {
@@ -213,7 +213,7 @@ void Canonicalizer::do_StoreField     (StoreField*      x) {
   // are packed to their natural size.
   Convert* conv = x->value()->as_Convert();
   if (conv) {
-    Value value = NULL;
+    Value value = nullptr;
     BasicType type = x->field()->type()->basic_type();
     switch (conv->op()) {
     case Bytecodes::_i2b: if (type == T_BYTE)  value = conv->value(); break;
@@ -222,7 +222,7 @@ void Canonicalizer::do_StoreField     (StoreField*      x) {
     default             : break;
     }
     // limit this optimization to current block
-    if (value != NULL && in_current_block(conv)) {
+    if (value != nullptr && in_current_block(conv)) {
       set_canonical(new StoreField(x->obj(), x->offset(), x->field(), value, x->is_static(),
                                    x->state_before(), x->needs_patching()));
       return;
@@ -236,31 +236,31 @@ void Canonicalizer::do_ArrayLength    (ArrayLength*     x) {
   Constant*  ct;
   LoadField* lf;
 
-  if ((na = x->array()->as_NewArray()) != NULL) {
+  if ((na = x->array()->as_NewArray()) != nullptr) {
     // New arrays might have the known length.
     // Do not use the Constant itself, but create a new Constant
     // with same value Otherwise a Constant is live over multiple
     // blocks without being registered in a state array.
     Constant* length;
     NewMultiArray* nma;
-    if (na->length() != NULL &&
-        (length = na->length()->as_Constant()) != NULL) {
-      assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
+    if (na->length() != nullptr &&
+        (length = na->length()->as_Constant()) != nullptr) {
+      assert(length->type()->as_IntConstant() != nullptr, "array length must be integer");
       set_constant(length->type()->as_IntConstant()->value());
-    } else if ((nma = x->array()->as_NewMultiArray()) != NULL &&
-               (length = nma->dims()->at(0)->as_Constant()) != NULL) {
-      assert(length->type()->as_IntConstant() != NULL, "array length must be integer");
+    } else if ((nma = x->array()->as_NewMultiArray()) != nullptr &&
+               (length = nma->dims()->at(0)->as_Constant()) != nullptr) {
+      assert(length->type()->as_IntConstant() != nullptr, "array length must be integer");
       set_constant(length->type()->as_IntConstant()->value());
     }
 
-  } else if ((ct = x->array()->as_Constant()) != NULL) {
+  } else if ((ct = x->array()->as_Constant()) != nullptr) {
     // Constant arrays have constant lengths.
     ArrayConstant* cnst = ct->type()->as_ArrayConstant();
-    if (cnst != NULL) {
+    if (cnst != nullptr) {
       set_constant(cnst->value()->length());
     }
 
-  } else if ((lf = x->array()->as_LoadField()) != NULL) {
+  } else if ((lf = x->array()->as_LoadField()) != nullptr) {
     ciField* field = lf->field();
     if (field->is_static_constant()) {
       // Constant field loads are usually folded during parsing.
@@ -278,10 +278,10 @@ void Canonicalizer::do_LoadIndexed    (LoadIndexed*     x) {
   StableArrayConstant* array = x->array()->type()->as_StableArrayConstant();
   IntConstant* index = x->index()->type()->as_IntConstant();
 
-  assert(array == NULL || FoldStableValues, "not enabled");
+  assert(array == nullptr || FoldStableValues, "not enabled");
 
   // Constant fold loads from stable arrays.
-  if (!x->mismatched() && array != NULL && index != NULL) {
+  if (!x->mismatched() && array != nullptr && index != nullptr) {
     jint idx = index->value();
     if (idx < 0 || idx >= array->value()->length()) {
       // Leave the load as is. The range check will handle it.
@@ -292,7 +292,7 @@ void Canonicalizer::do_LoadIndexed    (LoadIndexed*     x) {
     if (!field_val.is_null_or_zero()) {
       jint dimension = array->dimension();
       assert(dimension <= array->value()->array_type()->dimension(), "inconsistent info");
-      ValueType* value = NULL;
+      ValueType* value = nullptr;
       if (dimension > 1) {
         // Preserve information about the dimension for the element.
         assert(field_val.as_object()->is_array(), "not an array");
@@ -312,7 +312,7 @@ void Canonicalizer::do_StoreIndexed   (StoreIndexed*    x) {
   // are packed to their natural size.
   Convert* conv = x->value()->as_Convert();
   if (conv) {
-    Value value = NULL;
+    Value value = nullptr;
     BasicType type = x->elt_type();
     switch (conv->op()) {
     case Bytecodes::_i2b: if (type == T_BYTE)  value = conv->value(); break;
@@ -321,7 +321,7 @@ void Canonicalizer::do_StoreIndexed   (StoreIndexed*    x) {
     default             : break;
     }
     // limit this optimization to current block
-    if (value != NULL && in_current_block(conv)) {
+    if (value != nullptr && in_current_block(conv)) {
       set_canonical(new StoreIndexed(x->array(), x->index(), x->length(),
                                      x->elt_type(), value, x->state_before(),
                                      x->check_boolean()));
@@ -479,7 +479,7 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
   switch (x->id()) {
   case vmIntrinsics::_floatToRawIntBits   : {
     FloatConstant* c = x->argument_at(0)->type()->as_FloatConstant();
-    if (c != NULL) {
+    if (c != nullptr) {
       JavaValue v;
       v.set_jfloat(c->value());
       set_constant(v.get_jint());
@@ -488,7 +488,7 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
   }
   case vmIntrinsics::_intBitsToFloat      : {
     IntConstant* c = x->argument_at(0)->type()->as_IntConstant();
-    if (c != NULL) {
+    if (c != nullptr) {
       JavaValue v;
       v.set_jint(c->value());
       set_constant(v.get_jfloat());
@@ -497,7 +497,7 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
   }
   case vmIntrinsics::_doubleToRawLongBits : {
     DoubleConstant* c = x->argument_at(0)->type()->as_DoubleConstant();
-    if (c != NULL) {
+    if (c != nullptr) {
       JavaValue v;
       v.set_jdouble(c->value());
       set_constant(v.get_jlong());
@@ -506,7 +506,7 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
   }
   case vmIntrinsics::_longBitsToDouble    : {
     LongConstant* c = x->argument_at(0)->type()->as_LongConstant();
-    if (c != NULL) {
+    if (c != nullptr) {
       JavaValue v;
       v.set_jlong(c->value());
       set_constant(v.get_jdouble());
@@ -517,8 +517,8 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
     assert(x->number_of_arguments() == 2, "wrong type");
 
     InstanceConstant* c = x->argument_at(0)->type()->as_InstanceConstant();
-    if (c != NULL && !c->value()->is_null_object()) {
-      // ciInstance::java_mirror_type() returns non-NULL only for Java mirrors
+    if (c != nullptr && !c->value()->is_null_object()) {
+      // ciInstance::java_mirror_type() returns non-null only for Java mirrors
       ciType* t = c->value()->java_mirror_type();
       if (t->is_klass()) {
         // substitute cls.isInstance(obj) of a constant Class into
@@ -540,7 +540,7 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
 
     // Class.isPrimitive is known on constant classes:
     InstanceConstant* c = x->argument_at(0)->type()->as_InstanceConstant();
-    if (c != NULL && !c->value()->is_null_object()) {
+    if (c != nullptr && !c->value()->is_null_object()) {
       ciType* t = c->value()->java_mirror_type();
       set_constant(t->is_primitive_type());
     }
@@ -551,7 +551,7 @@ void Canonicalizer::do_Intrinsic      (Intrinsic*       x) {
 
     // Optimize for Foo.class.getModifier()
     InstanceConstant* c = x->argument_at(0)->type()->as_InstanceConstant();
-    if (c != NULL && !c->value()->is_null_object()) {
+    if (c != nullptr && !c->value()->is_null_object()) {
       ciType* t = c->value()->java_mirror_type();
       if (t->is_klass()) {
         set_constant(t->as_klass()->modifier_flags());
@@ -640,7 +640,7 @@ void Canonicalizer::do_Convert        (Convert*         x) {
 }
 
 void Canonicalizer::do_NullCheck      (NullCheck*       x) {
-  if (x->obj()->as_NewArray() != NULL || x->obj()->as_NewInstance() != NULL) {
+  if (x->obj()->as_NewArray() != nullptr || x->obj()->as_NewInstance() != nullptr) {
     set_canonical(x->obj());
   } else {
     Constant* con = x->obj()->as_Constant();
@@ -666,10 +666,10 @@ void Canonicalizer::do_CheckCast      (CheckCast*       x) {
   if (x->klass()->is_loaded()) {
     Value obj = x->obj();
     ciType* klass = obj->exact_type();
-    if (klass == NULL) {
+    if (klass == nullptr) {
       klass = obj->declared_type();
     }
-    if (klass != NULL && klass->is_loaded()) {
+    if (klass != nullptr && klass->is_loaded()) {
       bool is_interface = klass->is_instance_klass() &&
                           klass->as_instance_klass()->is_interface();
       // Interface casts can't be statically optimized away since verifier doesn't
@@ -689,7 +689,7 @@ void Canonicalizer::do_InstanceOf     (InstanceOf*      x) {
   if (x->klass()->is_loaded()) {
     Value obj = x->obj();
     ciType* exact = obj->exact_type();
-    if (exact != NULL && exact->is_loaded() && (obj->as_NewInstance() || obj->as_NewArray())) {
+    if (exact != nullptr && exact->is_loaded() && (obj->as_NewInstance() || obj->as_NewArray())) {
       set_constant(exact->is_subtype_of(x->klass()) ? 1 : 0);
       return;
     }
@@ -737,7 +737,7 @@ void Canonicalizer::do_If(If* x) {
 
   if (l == r && !lt->is_float_kind()) {
     // pattern: If (a cond a) => simplify to Goto
-    BlockBegin* sux = NULL;
+    BlockBegin* sux = nullptr;
     switch (x->cond()) {
     case If::eql: sux = x->sux_for(true);  break;
     case If::neq: sux = x->sux_for(false); break;
@@ -753,20 +753,20 @@ void Canonicalizer::do_If(If* x) {
   }
 
   if (lt->is_constant() && rt->is_constant()) {
-    if (x->x()->as_Constant() != NULL) {
+    if (x->x()->as_Constant() != nullptr) {
       // pattern: If (lc cond rc) => simplify to: Goto
       BlockBegin* sux = x->x()->as_Constant()->compare(x->cond(), x->y(),
                                                        x->sux_for(true),
                                                        x->sux_for(false));
-      if (sux != NULL) {
+      if (sux != nullptr) {
         // If is a safepoint then the debug information should come from the state_before of the If.
         set_canonical(new Goto(sux, x->state_before(), is_safepoint(x, sux)));
       }
     }
-  } else if (rt->as_IntConstant() != NULL) {
+  } else if (rt->as_IntConstant() != nullptr) {
     // pattern: If (l cond rc) => investigate further
     const jint rc = rt->as_IntConstant()->value();
-    if (l->as_CompareOp() != NULL) {
+    if (l->as_CompareOp() != nullptr) {
       // pattern: If ((a cmp b) cond rc) => simplify to: If (x cond y) or: Goto
       CompareOp* cmp = l->as_CompareOp();
       bool unordered_is_less = cmp->op() == Bytecodes::_fcmpl || cmp->op() == Bytecodes::_dcmpl;
@@ -784,8 +784,8 @@ void Canonicalizer::do_If(If* x) {
         // two successors differ and two successors are the same => simplify to: If (x cmp y)
         // determine new condition & successors
         If::Condition cond = If::eql;
-        BlockBegin* tsux = NULL;
-        BlockBegin* fsux = NULL;
+        BlockBegin* tsux = nullptr;
+        BlockBegin* fsux = nullptr;
              if (lss_sux == eql_sux) { cond = If::leq; tsux = lss_sux; fsux = gtr_sux; }
         else if (lss_sux == gtr_sux) { cond = If::neq; tsux = lss_sux; fsux = eql_sux; }
         else if (eql_sux == gtr_sux) { cond = If::geq; tsux = eql_sux; fsux = lss_sux; }

--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -54,7 +54,7 @@ class CodeStub: public CompilationResourceObj {
   // code generation
   void assert_no_unbound_labels()                { assert(!_entry.is_unbound() && !_continuation.is_unbound(), "unbound label"); }
   virtual void emit_code(LIR_Assembler* e) = 0;
-  virtual CodeEmitInfo* info() const             { return NULL; }
+  virtual CodeEmitInfo* info() const             { return nullptr; }
   virtual bool is_exception_throw_stub() const   { return false; }
   virtual bool is_simple_exception_stub() const  { return false; }
   virtual int nr_immediate_oops_patched() const  { return 0; }
@@ -170,7 +170,7 @@ class RangeCheckStub: public CodeStub {
   // For ArrayIndexOutOfBoundsException.
   RangeCheckStub(CodeEmitInfo* info, LIR_Opr index, LIR_Opr array)
     : _index(index), _array(array), _throw_index_out_of_bounds_exception(false) {
-    assert(info != NULL, "must have info");
+    assert(info != nullptr, "must have info");
     _info = new CodeEmitInfo(info);
     FrameMap* f = Compilation::current()->frame_map();
     f->update_reserved_argument_area_size(2 * BytesPerWord);
@@ -178,7 +178,7 @@ class RangeCheckStub: public CodeStub {
   // For IndexOutOfBoundsException.
   RangeCheckStub(CodeEmitInfo* info, LIR_Opr index)
     : _index(index), _array(), _throw_index_out_of_bounds_exception(true) {
-    assert(info != NULL, "must have info");
+    assert(info != nullptr, "must have info");
     _info = new CodeEmitInfo(info);
     FrameMap* f = Compilation::current()->frame_map();
     f->update_reserved_argument_area_size(2 * BytesPerWord);
@@ -423,7 +423,7 @@ class PatchingStub: public CodeStub {
 
   PatchingStub(MacroAssembler* masm, PatchID id, int index = -1):
       _id(id)
-    , _info(NULL)
+    , _info(nullptr)
     , _index(index) {
     // force alignment of patch sites so we
     // can guarantee atomic writes to the patch site.

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -83,13 +83,13 @@ class PhaseTraceTime: public TraceTime {
  public:
   PhaseTraceTime(TimerName timer)
   : TraceTime("", &timers[timer], CITime || CITimeEach, Verbose),
-    _log(NULL), _timer(timer)
+    _log(nullptr), _timer(timer)
   {
-    if (Compilation::current() != NULL) {
+    if (Compilation::current() != nullptr) {
       _log = Compilation::current()->log();
     }
 
-    if (_log != NULL) {
+    if (_log != nullptr) {
       _log->begin_head("phase name='%s'", timer_name[_timer]);
       _log->stamp();
       _log->end_head();
@@ -97,7 +97,7 @@ class PhaseTraceTime: public TraceTime {
   }
 
   ~PhaseTraceTime() {
-    if (_log != NULL)
+    if (_log != nullptr)
       _log->done("phase name='%s'", timer_name[_timer]);
   }
 };
@@ -108,7 +108,7 @@ class PhaseTraceTime: public TraceTime {
 #ifndef PRODUCT
 
 void Compilation::maybe_print_current_instruction() {
-  if (_current_instruction != NULL && _last_instruction_printed != _current_instruction) {
+  if (_current_instruction != nullptr && _last_instruction_printed != _current_instruction) {
     _last_instruction_printed = _current_instruction;
     _current_instruction->print_line();
   }
@@ -142,7 +142,7 @@ void Compilation::build_hir() {
 
   // setup ir
   CompileLog* log = this->log();
-  if (log != NULL) {
+  if (log != nullptr) {
     log->begin_head("parse method='%d' ",
                     log->identify(_method));
     log->stamp();
@@ -212,7 +212,7 @@ void Compilation::build_hir() {
 #endif
 
   if (RangeCheckElimination) {
-    if (_hir->osr_entry() == NULL) {
+    if (_hir->osr_entry() == nullptr) {
       PhaseTraceTime timeit(_t_rangeCheckElimination);
       RangeCheckElimination::eliminate(_hir);
     }
@@ -482,7 +482,7 @@ void Compilation::compile_method() {
     install_code(frame_size);
   }
 
-  if (log() != NULL) // Print code cache state into compiler log
+  if (log() != nullptr) // Print code cache state into compiler log
     log()->code_cache_state();
 
   totalInstructionNodes += Instruction::number_of_instructions();
@@ -561,10 +561,10 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 , _log(env->log())
 , _method(method)
 , _osr_bci(osr_bci)
-, _hir(NULL)
+, _hir(nullptr)
 , _max_spills(-1)
-, _frame_map(NULL)
-, _masm(NULL)
+, _frame_map(nullptr)
+, _masm(nullptr)
 , _has_exception_handlers(false)
 , _has_fpu_code(true)   // pessimistic assumption
 , _has_unsafe_access(false)
@@ -574,17 +574,17 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 , _has_reserved_stack_access(method->has_reserved_stack_access())
 , _has_monitors(false)
 , _install_code(install_code)
-, _bailout_msg(NULL)
-, _exception_info_list(NULL)
-, _allocator(NULL)
+, _bailout_msg(nullptr)
+, _exception_info_list(nullptr)
+, _allocator(nullptr)
 , _code(buffer_blob)
 , _has_access_indexed(false)
 , _interpreter_frame_size(0)
 , _immediate_oops_patched(0)
-, _current_instruction(NULL)
+, _current_instruction(nullptr)
 #ifndef PRODUCT
-, _last_instruction_printed(NULL)
-, _cfg_printer_output(NULL)
+, _last_instruction_printed(nullptr)
+, _cfg_printer_output(nullptr)
 #endif // PRODUCT
 {
   PhaseTraceTime timeit(_t_compile);
@@ -607,7 +607,7 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
     }
   } else if (is_profiling()) {
     ciMethodData *md = method->method_data_or_null();
-    if (md != NULL) {
+    if (md != nullptr) {
       md->set_would_profile(_would_profile);
     }
   }
@@ -617,7 +617,7 @@ Compilation::~Compilation() {
   // simulate crash during compilation
   assert(CICrashAt < 0 || (uintx)_env->compile_id() != (uintx)CICrashAt, "just as planned");
 
-  _env->set_compiler_data(NULL);
+  _env->set_compiler_data(nullptr);
 }
 
 void Compilation::add_exception_handlers_for_pco(int pco, XHandlers* exception_handlers) {
@@ -637,7 +637,7 @@ void Compilation::notice_inlined_method(ciMethod* method) {
 
 
 void Compilation::bailout(const char* msg) {
-  assert(msg != NULL, "bailout message must exist");
+  assert(msg != nullptr, "bailout message must exist");
   if (!bailed_out()) {
     // keep first bailout message
     if (PrintCompilation || PrintBailouts) tty->print_cr("compilation bailout: %s", msg);
@@ -646,15 +646,15 @@ void Compilation::bailout(const char* msg) {
 }
 
 ciKlass* Compilation::cha_exact_type(ciType* type) {
-  if (type != NULL && type->is_loaded() && type->is_instance_klass()) {
+  if (type != nullptr && type->is_loaded() && type->is_instance_klass()) {
     ciInstanceKlass* ik = type->as_instance_klass();
-    assert(ik->exact_klass() == NULL, "no cha for final klass");
+    assert(ik->exact_klass() == nullptr, "no cha for final klass");
     if (DeoptC1 && UseCHA && !(ik->has_subklass() || ik->is_interface())) {
       dependency_recorder()->assert_leaf_type(ik);
       return ik;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 void Compilation::print_timers() {

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,14 +198,14 @@ class Compilation: public StackObj {
 #ifndef PRODUCT
   void maybe_print_current_instruction();
   CFGPrinterOutput* cfg_printer_output() {
-    guarantee(_cfg_printer_output != NULL, "CFG printer output not initialized");
+    guarantee(_cfg_printer_output != nullptr, "CFG printer output not initialized");
     return _cfg_printer_output;
   }
 #endif // PRODUCT
 
   // error handling
   void bailout(const char* msg);
-  bool bailed_out() const                        { return _bailout_msg != NULL; }
+  bool bailed_out() const                        { return _bailout_msg != nullptr; }
   const char* bailout_msg() const                { return _bailout_msg; }
 
   static int desired_max_code_buffer_size() {

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -65,7 +65,7 @@ void Compiler::initialize() {
   BufferBlob* buffer_blob = init_buffer_blob();
 
   if (should_perform_init()) {
-    if (buffer_blob == NULL) {
+    if (buffer_blob == nullptr) {
       // When we come here we are in state 'initializing'; entire C1 compilation
       // can be shut down.
       set_state(failed);
@@ -83,12 +83,12 @@ int Compiler::code_buffer_size() {
 BufferBlob* Compiler::init_buffer_blob() {
   // Allocate buffer blob once at startup since allocation for each
   // compilation seems to be too expensive (at least on Intel win32).
-  assert (CompilerThread::current()->get_buffer_blob() == NULL, "Should initialize only once");
+  assert (CompilerThread::current()->get_buffer_blob() == nullptr, "Should initialize only once");
 
   // setup CodeBuffer.  Preallocate a BufferBlob of size
   // NMethodSizeLimit plus some extra space for constants.
   BufferBlob* buffer_blob = BufferBlob::create("C1 temporary CodeBuffer", code_buffer_size());
-  if (buffer_blob != NULL) {
+  if (buffer_blob != nullptr) {
     CompilerThread::current()->set_buffer_blob(buffer_blob);
   }
 
@@ -244,7 +244,7 @@ bool Compiler::is_intrinsic_supported(const methodHandle& method) {
 
 void Compiler::compile_method(ciEnv* env, ciMethod* method, int entry_bci, bool install_code, DirectiveSet* directive) {
   BufferBlob* buffer_blob = CompilerThread::current()->get_buffer_blob();
-  assert(buffer_blob != NULL, "Must exist");
+  assert(buffer_blob != nullptr, "Must exist");
   // invoke compilation
   {
     // We are nested here because we need for the destructor

--- a/src/hotspot/share/c1/c1_FrameMap.cpp
+++ b/src/hotspot/share/c1/c1_FrameMap.cpp
@@ -118,7 +118,7 @@ CallingConvention* FrameMap::c_calling_convention(const BasicTypeArray* signatur
     }
   }
 
-  intptr_t out_preserve = SharedRuntime::c_calling_convention(sig_bt, regs, NULL, sizeargs);
+  intptr_t out_preserve = SharedRuntime::c_calling_convention(sig_bt, regs, nullptr, sizeargs);
   LIR_OprList* args = new LIR_OprList(signature->length());
   for (i = 0; i < sizeargs;) {
     BasicType t = sig_bt[i];
@@ -238,7 +238,7 @@ bool FrameMap::locations_for_slot  (int index, Location::Type loc_type,
   if (!location_for_sp_offset(offset_from_sp, loc_type, loc)) {
     return false;
   }
-  if (second != NULL) {
+  if (second != nullptr) {
     // two word item
     offset_from_sp = offset_from_sp + in_ByteSize(4);
     return location_for_sp_offset(offset_from_sp, loc_type, second);

--- a/src/hotspot/share/c1/c1_FrameMap.hpp
+++ b/src/hotspot/share/c1/c1_FrameMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,7 +226,7 @@ class FrameMap : public CompilationResourceObj {
     return location_for_sp_offset(sp_offset_for_monitor_object(monitor_index), Location::oop, loc);
   }
   bool locations_for_slot  (int index, Location::Type loc_type,
-                            Location* loc, Location* second = NULL) const;
+                            Location* loc, Location* second = nullptr) const;
 
   VMReg slot_regname(int index) const {
     return sp_offset2vmreg(sp_offset_for_slot(index));

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3418,7 +3418,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
   CHECK_BAILOUT();
 
 # ifdef ASSERT
-  //All blocks reachable from start_block have _end != null
+  //All blocks reachable from start_block have _end isn't null
   {
     BlockList processed;
     BlockList to_go;
@@ -3426,7 +3426,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
     while(to_go.length() > 0) {
       BlockBegin* current = to_go.pop();
       assert(current != nullptr, "Should not happen.");
-      assert(current->end() != nullptr, "All blocks reachable from start_block should have end() != null.");
+      assert(current->end() != nullptr, "All blocks reachable from start_block should have end() != nullptr.");
       processed.append(current);
       for(int i = 0; i < current->number_of_sux(); i++) {
         BlockBegin* s = current->sux_at(i);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2951,7 +2951,7 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
       case Bytecodes::_freturn        : method_return(fpop(), ignore_return); break;
       case Bytecodes::_dreturn        : method_return(dpop(), ignore_return); break;
       case Bytecodes::_areturn        : method_return(apop(), ignore_return); break;
-      case Bytecodes::_return         : method_return(nullptr  , ignore_return); break;
+      case Bytecodes::_return         : method_return(nullptr, ignore_return); break;
       case Bytecodes::_getstatic      : // fall through
       case Bytecodes::_putstatic      : // fall through
       case Bytecodes::_getfield       : // fall through
@@ -3418,7 +3418,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
   CHECK_BAILOUT();
 
 # ifdef ASSERT
-  //All blocks reachable from start_block have _end isn't null
+  // For all blocks reachable from start_block: _end must be non-null
   {
     BlockList processed;
     BlockList to_go;

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -117,7 +117,7 @@ BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int
  : _compilation(compilation)
  , _scope(scope)
  , _blocks(16)
- , _bci2block(new BlockList(scope->method()->code_size(), NULL))
+ , _bci2block(new BlockList(scope->method()->code_size(), nullptr))
  , _bci2block_successors(scope->method()->code_size())
  , _active()         // size not known yet
  , _visited()        // size not known yet
@@ -148,12 +148,12 @@ BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int
 
 void BlockListBuilder::set_entries(int osr_bci) {
   // generate start blocks
-  BlockBegin* std_entry = make_block_at(0, NULL);
-  if (scope()->caller() == NULL) {
+  BlockBegin* std_entry = make_block_at(0, nullptr);
+  if (scope()->caller() == nullptr) {
     std_entry->set(BlockBegin::std_entry_flag);
   }
   if (osr_bci != -1) {
-    BlockBegin* osr_entry = make_block_at(osr_bci, NULL);
+    BlockBegin* osr_entry = make_block_at(osr_bci, nullptr);
     osr_entry->set(BlockBegin::osr_entry_flag);
   }
 
@@ -162,7 +162,7 @@ void BlockListBuilder::set_entries(int osr_bci) {
   const int n = list->length();
   for (int i = 0; i < n; i++) {
     XHandler* h = list->handler_at(i);
-    BlockBegin* entry = make_block_at(h->handler_bci(), NULL);
+    BlockBegin* entry = make_block_at(h->handler_bci(), nullptr);
     entry->set(BlockBegin::exception_entry_flag);
     h->set_entry_block(entry);
   }
@@ -173,17 +173,17 @@ BlockBegin* BlockListBuilder::make_block_at(int cur_bci, BlockBegin* predecessor
   assert(method()->bci_block_start().at(cur_bci), "wrong block starts of MethodLivenessAnalyzer");
 
   BlockBegin* block = _bci2block->at(cur_bci);
-  if (block == NULL) {
+  if (block == nullptr) {
     block = new BlockBegin(cur_bci);
     block->init_stores_to_locals(method()->max_locals());
     _bci2block->at_put(cur_bci, block);
     _bci2block_successors.at_put_grow(cur_bci, BlockList());
     _blocks.append(block);
 
-    assert(predecessor == NULL || predecessor->bci() < cur_bci, "targets for backward branches must already exist");
+    assert(predecessor == nullptr || predecessor->bci() < cur_bci, "targets for backward branches must already exist");
   }
 
-  if (predecessor != NULL) {
+  if (predecessor != nullptr) {
     if (block->is_set(BlockBegin::exception_entry_flag)) {
       BAILOUT_("Exception handler can be reached by both normal and exceptional control flow", block);
     }
@@ -215,7 +215,7 @@ void BlockListBuilder::handle_exceptions(BlockBegin* current, int cur_bci) {
 
     if (h->covers(cur_bci)) {
       BlockBegin* entry = h->entry_block();
-      assert(entry != NULL && entry == _bci2block->at(h->handler_bci()), "entry must be set");
+      assert(entry != nullptr && entry == _bci2block->at(h->handler_bci()), "entry must be set");
       assert(entry->is_set(BlockBegin::exception_entry_flag), "flag must be set");
 
       // add each exception handler only once
@@ -246,7 +246,7 @@ void BlockListBuilder::handle_jsr(BlockBegin* current, int sr_bci, int next_bci)
 
 void BlockListBuilder::set_leaders() {
   bool has_xhandlers = xhandlers()->has_handlers();
-  BlockBegin* current = NULL;
+  BlockBegin* current = nullptr;
 
   // The information which bci starts a new block simplifies the analysis
   // Without it, backward branches could jump to a bci where no block was created
@@ -263,7 +263,7 @@ void BlockListBuilder::set_leaders() {
     if (bci_block_start.at(cur_bci)) {
       current = make_block_at(cur_bci, current);
     }
-    assert(current != NULL, "must have current block");
+    assert(current != nullptr, "must have current block");
 
     if (has_xhandlers && GraphBuilder::can_trap(method(), s.cur_bc())) {
       handle_exceptions(current, cur_bci);
@@ -307,7 +307,7 @@ void BlockListBuilder::set_leaders() {
       case Bytecodes::_dreturn: // fall through
       case Bytecodes::_areturn: // fall through
       case Bytecodes::_return:
-        current = NULL;
+        current = nullptr;
         break;
 
       case Bytecodes::_ifeq:      // fall through
@@ -330,27 +330,27 @@ void BlockListBuilder::set_leaders() {
           make_block_at(s.next_bci(), current);
         }
         make_block_at(s.get_dest(), current);
-        current = NULL;
+        current = nullptr;
         break;
 
       case Bytecodes::_goto:
         make_block_at(s.get_dest(), current);
-        current = NULL;
+        current = nullptr;
         break;
 
       case Bytecodes::_goto_w:
         make_block_at(s.get_far_dest(), current);
-        current = NULL;
+        current = nullptr;
         break;
 
       case Bytecodes::_jsr:
         handle_jsr(current, s.get_dest(), s.next_bci());
-        current = NULL;
+        current = nullptr;
         break;
 
       case Bytecodes::_jsr_w:
         handle_jsr(current, s.get_far_dest(), s.next_bci());
-        current = NULL;
+        current = nullptr;
         break;
 
       case Bytecodes::_tableswitch: {
@@ -361,7 +361,7 @@ void BlockListBuilder::set_leaders() {
           make_block_at(cur_bci + sw.dest_offset_at(i), current);
         }
         make_block_at(cur_bci + sw.default_offset(), current);
-        current = NULL;
+        current = nullptr;
         break;
       }
 
@@ -373,7 +373,7 @@ void BlockListBuilder::set_leaders() {
           make_block_at(cur_bci + sw.pair_at(i).offset(), current);
         }
         make_block_at(cur_bci + sw.default_offset(), current);
-        current = NULL;
+        current = nullptr;
         break;
       }
 
@@ -576,14 +576,14 @@ class FieldBuffer: public CompilationResourceObj {
     if (offset < _values.length()) {
       return _values.at(offset);
     } else {
-      return NULL;
+      return nullptr;
     }
   }
 
   void at_put(ciField* field, Value value) {
     assert(field->holder()->is_loaded(), "must be a loaded field");
     int offset = field->offset_in_bytes();
-    _values.at_put_grow(offset, value, NULL);
+    _values.at_put_grow(offset, value, nullptr);
   }
 
 };
@@ -628,19 +628,19 @@ class MemoryBuffer: public CompilationResourceObj {
       if (index != -1) {
         // newly allocated object with no other stores performed on this field
         FieldBuffer* buf = _fields.at(index);
-        if (buf->at(field) == NULL && is_default_value(value)) {
+        if (buf->at(field) == nullptr && is_default_value(value)) {
 #ifndef PRODUCT
           if (PrintIRDuringConstruction && Verbose) {
             tty->print_cr("Eliminated store for object %d:", index);
             st->print_line();
           }
 #endif
-          return NULL;
+          return nullptr;
         } else {
           buf->at_put(field, value);
         }
       } else {
-        _objects.at_put_grow(offset, object, NULL);
+        _objects.at_put_grow(offset, object, nullptr);
         _values.at_put(field, value);
       }
 
@@ -692,14 +692,14 @@ class MemoryBuffer: public CompilationResourceObj {
     Value object   = load->obj();
     if (field->holder()->is_loaded() && !field->is_volatile()) {
       int offset = field->offset_in_bytes();
-      Value result = NULL;
+      Value result = nullptr;
       int index = _newobjects.find(object);
       if (index != -1) {
         result = _fields.at(index)->at(field);
-      } else if (_objects.at_grow(offset, NULL) == object) {
+      } else if (_objects.at_grow(offset, nullptr) == object) {
         result = _values.at(field);
       }
-      if (result != NULL) {
+      if (result != nullptr) {
 #ifndef PRODUCT
         if (PrintIRDuringConstruction && Verbose) {
           tty->print_cr("Eliminated load: ");
@@ -717,7 +717,7 @@ class MemoryBuffer: public CompilationResourceObj {
   void new_instance(NewInstance* object) {
     int index = _newobjects.length();
     _newobjects.append(object);
-    if (_fields.at_grow(index, NULL) == NULL) {
+    if (_fields.at_grow(index, nullptr) == nullptr) {
       _fields.at_put(index, new FieldBuffer());
     } else {
       _fields.at(index)->kill();
@@ -751,22 +751,22 @@ class MemoryBuffer: public CompilationResourceObj {
 
 GraphBuilder::ScopeData::ScopeData(ScopeData* parent)
   : _parent(parent)
-  , _bci2block(NULL)
-  , _scope(NULL)
+  , _bci2block(nullptr)
+  , _scope(nullptr)
   , _has_handler(false)
-  , _stream(NULL)
-  , _work_list(NULL)
+  , _stream(nullptr)
+  , _work_list(nullptr)
   , _caller_stack_size(-1)
-  , _continuation(NULL)
+  , _continuation(nullptr)
   , _parsing_jsr(false)
-  , _jsr_xhandlers(NULL)
+  , _jsr_xhandlers(nullptr)
   , _num_returns(0)
-  , _cleanup_block(NULL)
-  , _cleanup_return_prev(NULL)
-  , _cleanup_state(NULL)
+  , _cleanup_block(nullptr)
+  , _cleanup_return_prev(nullptr)
+  , _cleanup_state(nullptr)
   , _ignore_return(false)
 {
-  if (parent != NULL) {
+  if (parent != nullptr) {
     _max_inline_size = (intx) ((float) NestedInliningSizeRatio * (float) parent->max_inline_size() / 100.0f);
   } else {
     _max_inline_size = C1MaxInlineSize;
@@ -792,7 +792,7 @@ BlockBegin* GraphBuilder::ScopeData::block_at(int bci) {
     // of the method containing the jsr (because those exception
     // handlers may contain ret instructions in some cases).
     BlockBegin* block = bci2block()->at(bci);
-    if (block != NULL && block == parent()->bci2block()->at(bci)) {
+    if (block != nullptr && block == parent()->bci2block()->at(bci)) {
       BlockBegin* new_block = new BlockBegin(block->bci());
       if (PrintInitialBlockList) {
         tty->print_cr("CFG: cloned block %d (bci %d) as block %d for jsr",
@@ -823,7 +823,7 @@ BlockBegin* GraphBuilder::ScopeData::block_at(int bci) {
 
 
 XHandlers* GraphBuilder::ScopeData::xhandlers() const {
-  if (_jsr_xhandlers == NULL) {
+  if (_jsr_xhandlers == nullptr) {
     assert(!parsing_jsr(), "");
     return scope()->xhandlers();
   }
@@ -835,7 +835,7 @@ XHandlers* GraphBuilder::ScopeData::xhandlers() const {
 void GraphBuilder::ScopeData::set_scope(IRScope* scope) {
   _scope = scope;
   bool parent_has_handler = false;
-  if (parent() != NULL) {
+  if (parent() != nullptr) {
     parent_has_handler = parent()->has_handler();
   }
   _has_handler = parent_has_handler || scope->xhandlers()->has_handlers();
@@ -852,7 +852,7 @@ void GraphBuilder::ScopeData::set_inline_cleanup_info(BlockBegin* block,
 
 
 void GraphBuilder::ScopeData::add_to_work_list(BlockBegin* block) {
-  if (_work_list == NULL) {
+  if (_work_list == nullptr) {
     _work_list = new BlockList();
   }
 
@@ -897,14 +897,14 @@ void GraphBuilder::sort_top_into_worklist(BlockList* worklist, BlockBegin* top) 
 
 BlockBegin* GraphBuilder::ScopeData::remove_from_work_list() {
   if (is_work_list_empty()) {
-    return NULL;
+    return nullptr;
   }
   return _work_list->pop();
 }
 
 
 bool GraphBuilder::ScopeData::is_work_list_empty() const {
-  return (_work_list == NULL || _work_list->length() == 0);
+  return (_work_list == nullptr || _work_list->length() == 0);
 }
 
 
@@ -953,7 +953,7 @@ void GraphBuilder::load_constant() {
   ciConstant con = stream()->get_constant();
   if (con.is_valid()) {
     ValueType* t = illegalType;
-    ValueStack* patch_state = NULL;
+    ValueStack* patch_state = nullptr;
     switch (con.basic_type()) {
       case T_BOOLEAN: t = new IntConstant   (con.as_boolean()); break;
       case T_BYTE   : t = new IntConstant   (con.as_byte   ()); break;
@@ -986,7 +986,7 @@ void GraphBuilder::load_constant() {
       default: ShouldNotReachHere();
     }
     Value x;
-    if (patch_state != NULL) {
+    if (patch_state != nullptr) {
       // Arbitrary memory effects from running BSM or class loading (using custom loader) during linkage.
       bool kills_memory = stream()->is_dynamic_constant() ||
                           (!stream()->is_string_constant() && !method()->holder()->has_trusted_loader());
@@ -997,7 +997,7 @@ void GraphBuilder::load_constant() {
 
     // Unbox the value at runtime, if needed.
     // ConstantDynamic entry can be of a primitive type, but it is cached in boxed form.
-    if (patch_state != NULL) {
+    if (patch_state != nullptr) {
       int index = stream()->get_constant_pool_index();
       BasicType type = stream()->get_basic_type_for_constant_at(index);
       if (is_java_primitive(type)) {
@@ -1021,7 +1021,7 @@ void GraphBuilder::load_constant() {
 
 void GraphBuilder::load_local(ValueType* type, int index) {
   Value x = state()->local_at(index);
-  assert(x != NULL && !x->type()->is_illegal(), "access of illegal local variable");
+  assert(x != nullptr && !x->type()->is_illegal(), "access of illegal local variable");
   push(type, x);
 }
 
@@ -1045,7 +1045,7 @@ void GraphBuilder::store_local(ValueStack* state, Value x, int index) {
       // they are using this local. We don't handle skipping over a
       // ret.
       for (ScopeData* cur_scope_data = scope_data()->parent();
-           cur_scope_data != NULL && cur_scope_data->parsing_jsr() && cur_scope_data->scope() == scope();
+           cur_scope_data != nullptr && cur_scope_data->parsing_jsr() && cur_scope_data->scope() == scope();
            cur_scope_data = cur_scope_data->parent()) {
         if (cur_scope_data->jsr_return_address_local() == index) {
           BAILOUT("subroutine overwrites return address from previous subroutine");
@@ -1066,9 +1066,9 @@ void GraphBuilder::load_indexed(BasicType type) {
   compilation()->set_has_access_indexed(true);
   Value index = ipop();
   Value array = apop();
-  Value length = NULL;
+  Value length = nullptr;
   if (CSEArrayLength ||
-      (array->as_Constant() != NULL) ||
+      (array->as_Constant() != nullptr) ||
       (array->as_AccessField() && array->as_AccessField()->field()->is_constant()) ||
       (array->as_NewArray() && array->as_NewArray()->length() && array->as_NewArray()->length()->type()->is_constant()) ||
       (array->as_NewMultiArray() && array->as_NewMultiArray()->dims()->at(0)->type()->is_constant())) {
@@ -1085,9 +1085,9 @@ void GraphBuilder::store_indexed(BasicType type) {
   Value value = pop(as_ValueType(type));
   Value index = ipop();
   Value array = apop();
-  Value length = NULL;
+  Value length = nullptr;
   if (CSEArrayLength ||
-      (array->as_Constant() != NULL) ||
+      (array->as_Constant() != nullptr) ||
       (array->as_AccessField() && array->as_AccessField()->field()->is_constant()) ||
       (array->as_NewArray() && array->as_NewArray()->length() && array->as_NewArray()->length()->type()->is_constant()) ||
       (array->as_NewMultiArray() && array->as_NewMultiArray()->dims()->at(0)->type()->is_constant())) {
@@ -1095,7 +1095,7 @@ void GraphBuilder::store_indexed(BasicType type) {
   }
   ciType* array_type = array->declared_type();
   bool check_boolean = false;
-  if (array_type != NULL) {
+  if (array_type != nullptr) {
     if (array_type->is_loaded() &&
       array_type->as_array_klass()->element_type()->basic_type() == T_BOOLEAN) {
       assert(type == T_BYTE, "boolean store uses bastore");
@@ -1229,13 +1229,13 @@ void GraphBuilder::shift_op(ValueType* type, Bytecodes::Code code) {
   if (CanonicalizeNodes && code == Bytecodes::_iushr) {
     // pattern: x >>> s
     IntConstant* s1 = s->type()->as_IntConstant();
-    if (s1 != NULL) {
+    if (s1 != nullptr) {
       // pattern: x >>> s1, with s1 constant
       ShiftOp* l = x->as_ShiftOp();
-      if (l != NULL && l->op() == Bytecodes::_ishl) {
+      if (l != nullptr && l->op() == Bytecodes::_ishl) {
         // pattern: (a << b) >>> s1
         IntConstant* s0 = l->y()->type()->as_IntConstant();
-        if (s0 != NULL) {
+        if (s0 != nullptr) {
           // pattern: (a << s0) >>> s1
           const int s0c = s0->value() & 0x1F; // only the low 5 bits are significant for shifts
           const int s1c = s1->value() & 0x1F; // only the low 5 bits are significant for shifts
@@ -1311,16 +1311,16 @@ void GraphBuilder::if_node(Value x, If::Condition cond, Value y, ValueStack* sta
   bool is_bb = tsux->bci() < stream()->cur_bci() || fsux->bci() < stream()->cur_bci();
   // In case of loop invariant code motion or predicate insertion
   // before the body of a loop the state is needed
-  Instruction *i = append(new If(x, cond, false, y, tsux, fsux, (is_bb || compilation()->is_optimistic()) ? state_before : NULL, is_bb));
+  Instruction *i = append(new If(x, cond, false, y, tsux, fsux, (is_bb || compilation()->is_optimistic()) ? state_before : nullptr, is_bb));
 
-  assert(i->as_Goto() == NULL ||
+  assert(i->as_Goto() == nullptr ||
          (i->as_Goto()->sux_at(0) == tsux  && i->as_Goto()->is_safepoint() == tsux->bci() < stream()->cur_bci()) ||
          (i->as_Goto()->sux_at(0) == fsux  && i->as_Goto()->is_safepoint() == fsux->bci() < stream()->cur_bci()),
          "safepoint state of Goto returned by canonicalizer incorrect");
 
   if (is_profiling()) {
     If* if_node = i->as_If();
-    if (if_node != NULL) {
+    if (if_node != nullptr) {
       // Note that we'd collect profile data in this method if we wanted it.
       compilation()->set_would_profile(true);
       // At level 2 we need the proper bci to count backedges
@@ -1338,7 +1338,7 @@ void GraphBuilder::if_node(Value x, If::Condition cond, Value y, ValueStack* sta
 
     // Check if this If was reduced to Goto.
     Goto *goto_node = i->as_Goto();
-    if (goto_node != NULL) {
+    if (goto_node != nullptr) {
       compilation()->set_would_profile(true);
       goto_node->set_profiled_bci(bci());
       if (profile_branches()) {
@@ -1389,7 +1389,7 @@ void GraphBuilder::jsr(int dest) {
   // might end up trying to re-parse a block containing a jsr which
   // has already been activated. Watch for this case and bail out.
   for (ScopeData* cur_scope_data = scope_data();
-       cur_scope_data != NULL && cur_scope_data->parsing_jsr() && cur_scope_data->scope() == scope();
+       cur_scope_data != nullptr && cur_scope_data->parsing_jsr() && cur_scope_data->scope() == scope();
        cur_scope_data = cur_scope_data->parent()) {
     if (cur_scope_data->jsr_entry_bci() == dest) {
       BAILOUT("too-complicated jsr/ret structure");
@@ -1432,7 +1432,7 @@ void GraphBuilder::table_switch() {
     append(new If(ipop(), If::eql, true, key, tsux, fsux, state_before, is_bb));
   } else {
     // collect successors
-    BlockList* sux = new BlockList(l + 1, NULL);
+    BlockList* sux = new BlockList(l + 1, nullptr);
     int i;
     bool has_bb = false;
     for (i = 0; i < l; i++) {
@@ -1478,7 +1478,7 @@ void GraphBuilder::lookup_switch() {
     append(new If(ipop(), If::eql, true, key, tsux, fsux, state_before, is_bb));
   } else {
     // collect successors & keys
-    BlockList* sux = new BlockList(l + 1, NULL);
+    BlockList* sux = new BlockList(l + 1, nullptr);
     intArray* keys = new intArray(l, l, 0);
     int i;
     bool has_bb = false;
@@ -1513,10 +1513,10 @@ void GraphBuilder::call_register_finalizer() {
 
   // Gather some type information about the receiver
   Value receiver = state()->local_at(0);
-  assert(receiver != NULL, "must have a receiver");
+  assert(receiver != nullptr, "must have a receiver");
   ciType* declared_type = receiver->declared_type();
   ciType* exact_type = receiver->exact_type();
-  if (exact_type == NULL &&
+  if (exact_type == nullptr &&
       receiver->as_Local() &&
       receiver->as_Local()->java_index() == 0) {
     ciInstanceKlass* ik = compilation()->method()->holder();
@@ -1533,9 +1533,9 @@ void GraphBuilder::call_register_finalizer() {
 
   // see if we know statically that registration isn't required
   bool needs_check = true;
-  if (exact_type != NULL) {
+  if (exact_type != nullptr) {
     needs_check = exact_type->as_instance_klass()->has_finalizer();
-  } else if (declared_type != NULL) {
+  } else if (declared_type != nullptr) {
     ciInstanceKlass* ik = declared_type->as_instance_klass();
     if (!Dependencies::has_finalizable_subclass(ik)) {
       compilation()->dependency_recorder()->assert_has_no_finalizable_subclasses(ik);
@@ -1603,16 +1603,16 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
 
   // Check to see whether we are inlining. If so, Return
   // instructions become Gotos to the continuation point.
-  if (continuation() != NULL) {
+  if (continuation() != nullptr) {
 
     int invoke_bci = state()->caller_state()->bci();
 
-    if (x != NULL  && !ignore_return) {
+    if (x != nullptr  && !ignore_return) {
       ciMethod* caller = state()->scope()->caller()->method();
       Bytecodes::Code invoke_raw_bc = caller->raw_code_at_bci(invoke_bci);
       if (invoke_raw_bc == Bytecodes::_invokehandle || invoke_raw_bc == Bytecodes::_invokedynamic) {
         ciType* declared_ret_type = caller->get_declared_signature_at_bci(invoke_bci)->return_type();
-        if (declared_ret_type->is_klass() && x->exact_type() == NULL &&
+        if (declared_ret_type->is_klass() && x->exact_type() == nullptr &&
             x->declared_type() != declared_ret_type && declared_ret_type != compilation()->env()->Object_klass()) {
           x = append(new TypeCast(declared_ret_type->as_klass(), x, copy_state_before()));
         }
@@ -1643,7 +1643,7 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
     // without the method parameters on stack, including the
     // return value, if any, of the inlined method on operand stack.
     set_state(state()->caller_state()->copy_for_parsing());
-    if (x != NULL) {
+    if (x != nullptr) {
       if (!ignore_return) {
         state()->push(x->type(), x);
       }
@@ -1688,7 +1688,7 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
 }
 
 Value GraphBuilder::make_constant(ciConstant field_value, ciField* field) {
-  if (!field_value.is_valid())  return NULL;
+  if (!field_value.is_valid())  return nullptr;
 
   BasicType field_type = field_value.basic_type();
   ValueType* value = as_ValueType(field_value);
@@ -1707,7 +1707,7 @@ Value GraphBuilder::make_constant(ciConstant field_value, ciField* field) {
       if (field_value.as_object()->should_be_constant()) {
         return new Constant(value);
       }
-      return NULL; // Not a constant.
+      return nullptr; // Not a constant.
     default:
       return new Constant(value);
   }
@@ -1724,16 +1724,16 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                               !field->will_link(method(), code) ||
                               PatchALot;
 
-  ValueStack* state_before = NULL;
+  ValueStack* state_before = nullptr;
   if (!holder->is_initialized() || needs_patching) {
     // save state before instruction for debug info when
     // deoptimization happens during patching
     state_before = copy_state_before();
   }
 
-  Value obj = NULL;
+  Value obj = nullptr;
   if (code == Bytecodes::_getstatic || code == Bytecodes::_putstatic) {
-    if (state_before != NULL) {
+    if (state_before != nullptr) {
       // build a patching constant
       obj = new Constant(new InstanceConstant(holder->java_mirror()), state_before);
     } else {
@@ -1756,17 +1756,17 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
   switch (code) {
     case Bytecodes::_getstatic: {
       // check for compile-time constants, i.e., initialized static final fields
-      Value constant = NULL;
+      Value constant = nullptr;
       if (field->is_static_constant() && !PatchALot) {
         ciConstant field_value = field->constant_value();
         assert(!field->is_stable() || !field_value.is_null_or_zero(),
                "stable static w/ default value shouldn't be a constant");
         constant = make_constant(field_value, field);
       }
-      if (constant != NULL) {
+      if (constant != nullptr) {
         push(type, append(constant));
       } else {
-        if (state_before == NULL) {
+        if (state_before == nullptr) {
           state_before = copy_state_for_exception();
         }
         push(type, append(new LoadField(append(obj), offset, field, true,
@@ -1776,7 +1776,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     }
     case Bytecodes::_putstatic: {
       Value val = pop(type);
-      if (state_before == NULL) {
+      if (state_before == nullptr) {
         state_before = copy_state_for_exception();
       }
       if (field->type()->basic_type() == T_BOOLEAN) {
@@ -1788,7 +1788,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     }
     case Bytecodes::_getfield: {
       // Check for compile-time constants, i.e., trusted final non-static fields.
-      Value constant = NULL;
+      Value constant = nullptr;
       obj = apop();
       ObjectType* obj_type = obj->type()->as_ObjectType();
       if (field->is_constant() && obj_type->is_constant() && !PatchALot) {
@@ -1808,10 +1808,10 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
           }
         }
       }
-      if (constant != NULL) {
+      if (constant != nullptr) {
         push(type, append(constant));
       } else {
-        if (state_before == NULL) {
+        if (state_before == nullptr) {
           state_before = copy_state_for_exception();
         }
         LoadField* load = new LoadField(obj, offset, field, false, state_before, needs_patching);
@@ -1845,7 +1845,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     case Bytecodes::_putfield: {
       Value val = pop(type);
       obj = apop();
-      if (state_before == NULL) {
+      if (state_before == nullptr) {
         state_before = copy_state_for_exception();
       }
       if (field->type()->basic_type() == T_BOOLEAN) {
@@ -1854,7 +1854,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       }
       StoreField* store = new StoreField(obj, offset, field, val, false, state_before, needs_patching);
       if (!needs_patching) store = _memory->store(store);
-      if (store != NULL) {
+      if (store != nullptr) {
         append(store);
       }
       break;
@@ -1878,13 +1878,13 @@ Values* GraphBuilder::args_list_for_profiling(ciMethod* target, int& start, bool
   start = has_receiver ? 1 : 0;
   if (profile_arguments()) {
     ciProfileData* data = method()->method_data()->bci_to_data(bci());
-    if (data != NULL && (data->is_CallTypeData() || data->is_VirtualCallTypeData())) {
+    if (data != nullptr && (data->is_CallTypeData() || data->is_VirtualCallTypeData())) {
       n = data->is_CallTypeData() ? data->as_CallTypeData()->number_of_arguments() : data->as_VirtualCallTypeData()->number_of_arguments();
     }
   }
   // If we are inlining then we need to collect arguments to profile parameters for the target
-  if (profile_parameters() && target != NULL) {
-    if (target->method_data() != NULL && target->method_data()->parameters_type_data() != NULL) {
+  if (profile_parameters() && target != nullptr) {
+    if (target->method_data() != nullptr && target->method_data()->parameters_type_data() != nullptr) {
       // The receiver is profiled on method entry so it's included in
       // the number of parameters but here we're only interested in
       // actual arguments.
@@ -1894,13 +1894,13 @@ Values* GraphBuilder::args_list_for_profiling(ciMethod* target, int& start, bool
   if (n > 0) {
     return new Values(n);
   }
-  return NULL;
+  return nullptr;
 }
 
 void GraphBuilder::check_args_for_profiling(Values* obj_args, int expected) {
 #ifdef ASSERT
   bool ignored_will_link;
-  ciSignature* declared_signature = NULL;
+  ciSignature* declared_signature = nullptr;
   ciMethod* real_target = method()->get_method_at_bci(bci(), ignored_will_link, &declared_signature);
   assert(expected == obj_args->capacity() || real_target->is_method_handle_intrinsic(), "missed on arg?");
 #endif
@@ -1910,8 +1910,8 @@ void GraphBuilder::check_args_for_profiling(Values* obj_args, int expected) {
 Values* GraphBuilder::collect_args_for_profiling(Values* args, ciMethod* target, bool may_have_receiver) {
   int start = 0;
   Values* obj_args = args_list_for_profiling(target, start, may_have_receiver);
-  if (obj_args == NULL) {
-    return NULL;
+  if (obj_args == nullptr) {
+    return nullptr;
   }
   int s = obj_args->capacity();
   // if called through method handle invoke, some arguments may have been popped
@@ -1927,11 +1927,11 @@ Values* GraphBuilder::collect_args_for_profiling(Values* args, ciMethod* target,
 
 void GraphBuilder::invoke(Bytecodes::Code code) {
   bool will_link;
-  ciSignature* declared_signature = NULL;
+  ciSignature* declared_signature = nullptr;
   ciMethod*             target = stream()->get_method(will_link, &declared_signature);
   ciKlass*              holder = stream()->get_declared_method_holder();
   const Bytecodes::Code bc_raw = stream()->cur_bc_raw();
-  assert(declared_signature != NULL, "cannot be null");
+  assert(declared_signature != nullptr, "cannot be null");
   assert(will_link == target->is_loaded(), "");
   JFR_ONLY(Jfr::on_resolution(this, holder, target); CHECK_BAILOUT();)
 
@@ -1944,7 +1944,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
   ciInstanceKlass* actual_recv = callee_holder;
 
   CompileLog* log = compilation()->log();
-  if (log != NULL)
+  if (log != nullptr)
       log->elem("call method='%d' instr='%s'",
                 log->identify(target),
                 Bytecodes::name(code));
@@ -2010,30 +2010,30 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
     apush(arg);
   }
 
-  ciMethod* cha_monomorphic_target = NULL;
-  ciMethod* exact_target = NULL;
-  Value better_receiver = NULL;
+  ciMethod* cha_monomorphic_target = nullptr;
+  ciMethod* exact_target = nullptr;
+  Value better_receiver = nullptr;
   if (UseCHA && DeoptC1 && target->is_loaded() &&
       !(// %%% FIXME: Are both of these relevant?
         target->is_method_handle_intrinsic() ||
         target->is_compiled_lambda_form()) &&
       !patch_for_appendix) {
-    Value receiver = NULL;
-    ciInstanceKlass* receiver_klass = NULL;
+    Value receiver = nullptr;
+    ciInstanceKlass* receiver_klass = nullptr;
     bool type_is_exact = false;
     // try to find a precise receiver type
     if (will_link && !target->is_static()) {
       int index = state()->stack_size() - (target->arg_size_no_receiver() + 1);
       receiver = state()->stack_at(index);
       ciType* type = receiver->exact_type();
-      if (type != NULL && type->is_loaded() &&
+      if (type != nullptr && type->is_loaded() &&
           type->is_instance_klass() && !type->as_instance_klass()->is_interface()) {
         receiver_klass = (ciInstanceKlass*) type;
         type_is_exact = true;
       }
-      if (type == NULL) {
+      if (type == nullptr) {
         type = receiver->declared_type();
-        if (type != NULL && type->is_loaded() &&
+        if (type != nullptr && type->is_loaded() &&
             type->is_instance_klass() && !type->as_instance_klass()->is_interface()) {
           receiver_klass = (ciInstanceKlass*) type;
           if (receiver_klass->is_leaf_type() && !receiver_klass->is_final()) {
@@ -2045,17 +2045,17 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
         }
       }
     }
-    if (receiver_klass != NULL && type_is_exact &&
+    if (receiver_klass != nullptr && type_is_exact &&
         receiver_klass->is_loaded() && code != Bytecodes::_invokespecial) {
       // If we have the exact receiver type we can bind directly to
       // the method to call.
       exact_target = target->resolve_invoke(calling_klass, receiver_klass);
-      if (exact_target != NULL) {
+      if (exact_target != nullptr) {
         target = exact_target;
         code = Bytecodes::_invokespecial;
       }
     }
-    if (receiver_klass != NULL &&
+    if (receiver_klass != nullptr &&
         receiver_klass->is_subtype_of(actual_recv) &&
         actual_recv->is_initialized()) {
       actual_recv = receiver_klass;
@@ -2065,7 +2065,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
         (code == Bytecodes::_invokeinterface && callee_holder->is_initialized() && !actual_recv->is_interface())) {
       // Use CHA on the receiver to select a more precise method.
       cha_monomorphic_target = target->find_monomorphic_target(calling_klass, callee_holder, actual_recv);
-    } else if (code == Bytecodes::_invokeinterface && callee_holder->is_loaded() && receiver != NULL) {
+    } else if (code == Bytecodes::_invokeinterface && callee_holder->is_loaded() && receiver != nullptr) {
       assert(callee_holder->is_interface(), "invokeinterface to non interface?");
       // If there is only one implementor of this interface then we
       // may be able bind this invoke directly to the implementing
@@ -2083,10 +2083,10 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       // no point in inlining.
       ciInstanceKlass* declared_interface = callee_holder;
       ciInstanceKlass* singleton = declared_interface->unique_implementor();
-      if (singleton != NULL) {
+      if (singleton != nullptr) {
         assert(singleton != declared_interface, "not a unique implementor");
         cha_monomorphic_target = target->find_monomorphic_target(calling_klass, declared_interface, singleton);
-        if (cha_monomorphic_target != NULL) {
+        if (cha_monomorphic_target != nullptr) {
           if (cha_monomorphic_target->holder() != compilation()->env()->Object_klass()) {
             ciInstanceKlass* holder = cha_monomorphic_target->holder();
             ciInstanceKlass* constraint = (holder->is_subtype_of(singleton) ? holder : singleton); // avoid upcasts
@@ -2102,14 +2102,14 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
 
             dependency_recorder()->assert_unique_implementor(declared_interface, singleton);
           } else {
-            cha_monomorphic_target = NULL; // subtype check against Object is useless
+            cha_monomorphic_target = nullptr; // subtype check against Object is useless
           }
         }
       }
     }
   }
 
-  if (cha_monomorphic_target != NULL) {
+  if (cha_monomorphic_target != nullptr) {
     assert(!target->can_be_statically_bound() || target == cha_monomorphic_target, "");
     assert(!cha_monomorphic_target->is_abstract(), "");
     if (!cha_monomorphic_target->can_be_statically_bound(actual_recv)) {
@@ -2133,8 +2133,8 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
         (code == Bytecodes::_invokevirtual && target->is_final_method()) ||
         code == Bytecodes::_invokedynamic) {
       // static binding => check if callee is ok
-      ciMethod* inline_target = (cha_monomorphic_target != NULL) ? cha_monomorphic_target : target;
-      bool holder_known = (cha_monomorphic_target != NULL) || (exact_target != NULL);
+      ciMethod* inline_target = (cha_monomorphic_target != nullptr) ? cha_monomorphic_target : target;
+      bool holder_known = (cha_monomorphic_target != nullptr) || (exact_target != nullptr);
       bool success = try_inline(inline_target, holder_known, false /* ignore_return */, code, better_receiver);
 
       CHECK_BAILOUT();
@@ -2177,7 +2177,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
     code == Bytecodes::_invokevirtual   ||
     code == Bytecodes::_invokeinterface;
   Values* args = state()->pop_arguments(target->arg_size_no_receiver() + patching_appendix_arg);
-  Value recv = has_receiver ? apop() : NULL;
+  Value recv = has_receiver ? apop() : nullptr;
 
   // A null check is required here (when there is a receiver) for any of the following cases
   // - invokespecial, always need a null check.
@@ -2196,7 +2196,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       (target->is_loaded() && (target->is_final_method() || (is_profiling() && profile_calls())));
 
   if (need_null_check) {
-    if (recv != NULL) {
+    if (recv != nullptr) {
       null_check(recv);
     }
 
@@ -2205,14 +2205,14 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       compilation()->set_would_profile(true);
 
       if (profile_calls()) {
-        assert(cha_monomorphic_target == NULL || exact_target == NULL, "both can not be set");
-        ciKlass* target_klass = NULL;
-        if (cha_monomorphic_target != NULL) {
+        assert(cha_monomorphic_target == nullptr || exact_target == nullptr, "both can not be set");
+        ciKlass* target_klass = nullptr;
+        if (cha_monomorphic_target != nullptr) {
           target_klass = cha_monomorphic_target->holder();
-        } else if (exact_target != NULL) {
+        } else if (exact_target != nullptr) {
           target_klass = exact_target->holder();
         }
-        profile_call(target, recv, target_klass, collect_args_for_profiling(args, NULL, false), false);
+        profile_call(target, recv, target_klass, collect_args_for_profiling(args, nullptr, false), false);
       }
     }
   }
@@ -2330,7 +2330,7 @@ void GraphBuilder::new_multi_array(int dimensions) {
   ciKlass* klass = stream()->get_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_exhandling();
 
-  Values* dims = new Values(dimensions, dimensions, NULL);
+  Values* dims = new Values(dimensions, dimensions, nullptr);
   // fill in all dimensions
   int i = dimensions;
   while (i-- > 0) dims->at_put(i, ipop());
@@ -2360,9 +2360,9 @@ Value GraphBuilder::round_fp(Value fp_value) {
       // are results of expressions (i.e., not loads from memory or
       // constants)
       if (fp_value->type()->tag() == doubleTag &&
-          fp_value->as_Constant() == NULL &&
-          fp_value->as_Local() == NULL &&       // method parameters need no rounding
-          fp_value->as_RoundFP() == NULL) {
+          fp_value->as_Constant() == nullptr &&
+          fp_value->as_Local() == nullptr &&       // method parameters need no rounding
+          fp_value->as_RoundFP() == nullptr) {
         return append(new RoundFP(fp_value));
       }
     }
@@ -2397,7 +2397,7 @@ Instruction* GraphBuilder::append_with_bci(Instruction* instr, int bci) {
   }
 
   // i1 was not eliminated => append it
-  assert(i1->next() == NULL, "shouldn't already be linked");
+  assert(i1->next() == nullptr, "shouldn't already be linked");
   _last = _last->set_next(i1, canon.bci());
 
   if (++_instruction_count >= InstructionCountCutoff && !bailed_out()) {
@@ -2419,10 +2419,10 @@ Instruction* GraphBuilder::append_with_bci(Instruction* instr, int bci) {
 
   // save state after modification of operand stack for StateSplit instructions
   StateSplit* s = i1->as_StateSplit();
-  if (s != NULL) {
+  if (s != nullptr) {
     if (EliminateFieldAccess) {
       Intrinsic* intrinsic = s->as_Intrinsic();
-      if (s->as_Invoke() != NULL || (intrinsic && !intrinsic->preserves_state())) {
+      if (s->as_Invoke() != nullptr || (intrinsic && !intrinsic->preserves_state())) {
         _memory->kill();
       }
     }
@@ -2432,14 +2432,14 @@ Instruction* GraphBuilder::append_with_bci(Instruction* instr, int bci) {
   // set up exception handlers for this instruction if necessary
   if (i1->can_trap()) {
     i1->set_exception_handlers(handle_exception(i1));
-    assert(i1->exception_state() != NULL || !i1->needs_exception_state() || bailed_out(), "handle_exception must set exception state");
+    assert(i1->exception_state() != nullptr || !i1->needs_exception_state() || bailed_out(), "handle_exception must set exception state");
   }
   return i1;
 }
 
 
 Instruction* GraphBuilder::append(Instruction* instr) {
-  assert(instr->as_StateSplit() == NULL || instr->as_BlockEnd() != NULL, "wrong append used");
+  assert(instr->as_StateSplit() == nullptr || instr->as_BlockEnd() != nullptr, "wrong append used");
   return append_with_bci(instr, bci());
 }
 
@@ -2450,7 +2450,7 @@ Instruction* GraphBuilder::append_split(StateSplit* instr) {
 
 
 void GraphBuilder::null_check(Value value) {
-  if (value->as_NewArray() != NULL || value->as_NewInstance() != NULL) {
+  if (value->as_NewArray() != nullptr || value->as_NewInstance() != nullptr) {
     return;
   } else {
     Constant* con = value->as_Constant();
@@ -2470,8 +2470,8 @@ void GraphBuilder::null_check(Value value) {
 
 
 XHandlers* GraphBuilder::handle_exception(Instruction* instruction) {
-  if (!has_handler() && (!instruction->needs_exception_state() || instruction->exception_state() != NULL)) {
-    assert(instruction->exception_state() == NULL
+  if (!has_handler() && (!instruction->needs_exception_state() || instruction->exception_state() != nullptr)) {
+    assert(instruction->exception_state() == nullptr
            || instruction->exception_state()->kind() == ValueStack::EmptyExceptionState
            || (instruction->exception_state()->kind() == ValueStack::ExceptionState && _compilation->env()->should_retain_local_variables()),
            "exception_state should be of exception kind");
@@ -2481,10 +2481,10 @@ XHandlers* GraphBuilder::handle_exception(Instruction* instruction) {
   XHandlers*  exception_handlers = new XHandlers();
   ScopeData*  cur_scope_data = scope_data();
   ValueStack* cur_state = instruction->state_before();
-  ValueStack* prev_state = NULL;
+  ValueStack* prev_state = nullptr;
   int scope_count = 0;
 
-  assert(cur_state != NULL, "state_before must be set");
+  assert(cur_state != nullptr, "state_before must be set");
   do {
     int cur_bci = cur_state->bci();
     assert(cur_scope_data->scope() == cur_state->scope(), "scopes do not match");
@@ -2511,13 +2511,13 @@ XHandlers* GraphBuilder::handle_exception(Instruction* instruction) {
 
         // previously this was a BAILOUT, but this is not necessary
         // now because asynchronous exceptions are not handled this way.
-        assert(entry->state() == NULL || cur_state->total_locks_size() == entry->state()->total_locks_size(), "locks do not match");
+        assert(entry->state() == nullptr || cur_state->total_locks_size() == entry->state()->total_locks_size(), "locks do not match");
 
         // xhandler start with an empty expression stack
         if (cur_state->stack_size() != 0) {
           cur_state = cur_state->copy(ValueStack::ExceptionState, cur_state->bci());
         }
-        if (instruction->exception_state() == NULL) {
+        if (instruction->exception_state() == nullptr) {
           instruction->set_exception_state(cur_state);
         }
 
@@ -2569,10 +2569,10 @@ XHandlers* GraphBuilder::handle_exception(Instruction* instruction) {
       } else {
         cur_state = cur_state->copy(ValueStack::EmptyExceptionState, cur_state->bci());
       }
-      if (prev_state != NULL) {
+      if (prev_state != nullptr) {
         prev_state->set_caller_state(cur_state);
       }
-      if (instruction->exception_state() == NULL) {
+      if (instruction->exception_state() == nullptr) {
         instruction->set_exception_state(cur_state);
       }
     }
@@ -2593,7 +2593,7 @@ XHandlers* GraphBuilder::handle_exception(Instruction* instruction) {
     cur_state = cur_state->caller_state();
     cur_scope_data = cur_scope_data->parent();
     scope_count++;
-  } while (cur_scope_data != NULL);
+  } while (cur_scope_data != nullptr);
 
   return exception_handlers;
 }
@@ -2620,7 +2620,7 @@ class PhiSimplifier : public BlockClosure {
 Value PhiSimplifier::simplify(Value v) {
   Phi* phi = v->as_Phi();
 
-  if (phi == NULL) {
+  if (phi == nullptr) {
     // no phi function
     return v;
   } else if (v->has_subst()) {
@@ -2641,11 +2641,11 @@ Value PhiSimplifier::simplify(Value v) {
     phi->set(Phi::visited);
 
     // simplify x = [y, x] and x = [y, y] to y
-    Value subst = NULL;
+    Value subst = nullptr;
     int opd_count = phi->operand_count();
     for (int i = 0; i < opd_count; i++) {
       Value opd = phi->operand_at(i);
-      assert(opd != NULL, "Operand must exist!");
+      assert(opd != nullptr, "Operand must exist!");
 
       if (opd->type()->is_illegal()) {
         // if one operand is illegal, the entire phi function is illegal
@@ -2655,10 +2655,10 @@ Value PhiSimplifier::simplify(Value v) {
       }
 
       Value new_opd = simplify(opd);
-      assert(new_opd != NULL, "Simplified operand must exist!");
+      assert(new_opd != nullptr, "Simplified operand must exist!");
 
       if (new_opd != phi && new_opd != subst) {
-        if (subst == NULL) {
+        if (subst == nullptr) {
           subst = new_opd;
         } else {
           // no simplification possible
@@ -2670,7 +2670,7 @@ Value PhiSimplifier::simplify(Value v) {
     }
 
     // successfully simplified phi function
-    assert(subst != NULL, "illegal phi function");
+    assert(subst != nullptr, "illegal phi function");
     _has_substitutions = true;
     phi->clear(Phi::visited);
     phi->set_subst(subst);
@@ -2699,7 +2699,7 @@ void PhiSimplifier::block_do(BlockBegin* b) {
   ValueStack* state = b->state()->caller_state();
   for_each_state_value(state, value,
     Phi* phi = value->as_Phi();
-    assert(phi == NULL || phi->block() != b, "must not have phi function to simplify in caller state");
+    assert(phi == nullptr || phi->block() != b, "must not have phi function to simplify in caller state");
   );
 #endif
 }
@@ -2734,7 +2734,7 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
   }
 #endif
   _skip_block = false;
-  assert(state() != NULL, "ValueStack missing!");
+  assert(state() != nullptr, "ValueStack missing!");
   CompileLog* log = compilation()->log();
   ciBytecodeStream s(method());
   s.reset_to_bci(bci);
@@ -2744,19 +2744,19 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
   Bytecodes::Code code = Bytecodes::_illegal;
   bool push_exception = false;
 
-  if (block()->is_set(BlockBegin::exception_entry_flag) && block()->next() == NULL) {
+  if (block()->is_set(BlockBegin::exception_entry_flag) && block()->next() == nullptr) {
     // first thing in the exception entry block should be the exception object.
     push_exception = true;
   }
 
   bool ignore_return = scope_data()->ignore_return();
 
-  while (!bailed_out() && last()->as_BlockEnd() == NULL &&
+  while (!bailed_out() && last()->as_BlockEnd() == nullptr &&
          (code = stream()->next()) != ciBytecodeStream::EOBC() &&
-         (block_at(s.cur_bci()) == NULL || block_at(s.cur_bci()) == block())) {
+         (block_at(s.cur_bci()) == nullptr || block_at(s.cur_bci()) == block())) {
     assert(state()->kind() == ValueStack::Parsing, "invalid state kind");
 
-    if (log != NULL)
+    if (log != nullptr)
       log->set_context("bc code='%d' bci='%d'", (int)code, s.cur_bci());
 
     // Check for active jsr during OSR compilation
@@ -2951,7 +2951,7 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
       case Bytecodes::_freturn        : method_return(fpop(), ignore_return); break;
       case Bytecodes::_dreturn        : method_return(dpop(), ignore_return); break;
       case Bytecodes::_areturn        : method_return(apop(), ignore_return); break;
-      case Bytecodes::_return         : method_return(NULL  , ignore_return); break;
+      case Bytecodes::_return         : method_return(nullptr  , ignore_return); break;
       case Bytecodes::_getstatic      : // fall through
       case Bytecodes::_putstatic      : // fall through
       case Bytecodes::_getfield       : // fall through
@@ -2976,18 +2976,18 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
       case Bytecodes::_ifnonnull      : if_null(objectType, If::neq); break;
       case Bytecodes::_goto_w         : _goto(s.cur_bci(), s.get_far_dest()); break;
       case Bytecodes::_jsr_w          : jsr(s.get_far_dest()); break;
-      case Bytecodes::_breakpoint     : BAILOUT_("concurrent setting of breakpoint", NULL);
+      case Bytecodes::_breakpoint     : BAILOUT_("concurrent setting of breakpoint", nullptr);
       default                         : ShouldNotReachHere(); break;
     }
 
-    if (log != NULL)
+    if (log != nullptr)
       log->clear_context(); // skip marker if nothing was printed
 
     // save current bci to setup Goto at the end
     prev_bci = s.cur_bci();
 
   }
-  CHECK_BAILOUT_(NULL);
+  CHECK_BAILOUT_(nullptr);
   // stop processing of this block (see try_inline_full)
   if (_skip_block) {
     _skip_block = false;
@@ -2996,15 +2996,15 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
   }
   // if there are any, check if last instruction is a BlockEnd instruction
   BlockEnd* end = last()->as_BlockEnd();
-  if (end == NULL) {
+  if (end == nullptr) {
     // all blocks must end with a BlockEnd instruction => add a Goto
     end = new Goto(block_at(s.cur_bci()), false);
     append(end);
   }
   assert(end == last()->as_BlockEnd(), "inconsistency");
 
-  assert(end->state() != NULL, "state must already be present");
-  assert(end->as_Return() == NULL || end->as_Throw() == NULL || end->state()->stack_size() == 0, "stack not needed for return and throw");
+  assert(end->state() != nullptr, "state must already be present");
+  assert(end->as_Return() == nullptr || end->as_Throw() == nullptr || end->state()->stack_size() == 0, "stack not needed for return and throw");
 
   // connect to begin & set state
   // NOTE that inlining may have changed the block we are parsing
@@ -3014,11 +3014,11 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
     BlockBegin* sux = end->sux_at(i);
     assert(sux->is_predecessor(block()), "predecessor missing");
     // be careful, bailout if bytecodes are strange
-    if (!sux->try_merge(end->state(), compilation()->has_irreducible_loops())) BAILOUT_("block join failed", NULL);
+    if (!sux->try_merge(end->state(), compilation()->has_irreducible_loops())) BAILOUT_("block join failed", nullptr);
     scope_data()->add_to_work_list(end->sux_at(i));
   }
 
-  scope_data()->set_stream(NULL);
+  scope_data()->set_stream(nullptr);
 
   // done
   return end;
@@ -3032,7 +3032,7 @@ void GraphBuilder::iterate_all_blocks(bool start_in_current_block_for_inlining) 
       start_in_current_block_for_inlining = false;
     } else {
       BlockBegin* b;
-      while ((b = scope_data()->remove_from_work_list()) != NULL) {
+      while ((b = scope_data()->remove_from_work_list()) != nullptr) {
         if (!b->is_set(BlockBegin::was_visited_flag)) {
           if (b->is_set(BlockBegin::osr_entry_flag)) {
             // we're about to parse the osr entry block, so make sure
@@ -3166,12 +3166,12 @@ BlockBegin* GraphBuilder::setup_start_block(int osr_bci, BlockBegin* std_entry, 
   start->set_state(state->copy(ValueStack::StateAfter, std_entry->bci()));
   base->set_state(state->copy(ValueStack::StateAfter, std_entry->bci()));
 
-  if (base->std_entry()->state() == NULL) {
+  if (base->std_entry()->state() == nullptr) {
     // setup states for header blocks
     base->std_entry()->merge(state, compilation()->has_irreducible_loops());
   }
 
-  assert(base->std_entry()->state() != NULL, "");
+  assert(base->std_entry()->state() != nullptr, "");
   return start;
 }
 
@@ -3190,7 +3190,7 @@ void GraphBuilder::setup_osr_entry_block() {
   _osr_entry->set(BlockBegin::osr_entry_flag);
   _osr_entry->set_depth_first_number(0);
   BlockBegin* target = bci2block()->at(osr_bci);
-  assert(target != NULL && target->is_set(BlockBegin::osr_entry_flag), "must be there");
+  assert(target != nullptr && target->is_set(BlockBegin::osr_entry_flag), "must be there");
   // the osr entry has no values for locals
   ValueStack* state = target->state()->copy();
   _osr_entry->set_state(state);
@@ -3246,19 +3246,19 @@ void GraphBuilder::setup_osr_entry_block() {
 
   // the storage for the OSR buffer is freed manually in the LIRGenerator.
 
-  assert(state->caller_state() == NULL, "should be top scope");
+  assert(state->caller_state() == nullptr, "should be top scope");
   state->clear_locals();
   Goto* g = new Goto(target, false);
   append(g);
   _osr_entry->set_end(g);
   target->merge(_osr_entry->end()->state(), compilation()->has_irreducible_loops());
 
-  scope_data()->set_stream(NULL);
+  scope_data()->set_stream(nullptr);
 }
 
 
 ValueStack* GraphBuilder::state_at_entry() {
-  ValueStack* state = new ValueStack(scope(), NULL);
+  ValueStack* state = new ValueStack(scope(), nullptr);
 
   // Set up locals for receiver
   int idx = 0;
@@ -3282,7 +3282,7 @@ ValueStack* GraphBuilder::state_at_entry() {
 
   // lock synchronized method
   if (method()->is_synchronized()) {
-    state->lock(NULL);
+    state->lock(nullptr);
   }
 
   return state;
@@ -3290,12 +3290,12 @@ ValueStack* GraphBuilder::state_at_entry() {
 
 
 GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
-  : _scope_data(NULL)
+  : _scope_data(nullptr)
   , _compilation(compilation)
   , _memory(new MemoryBuffer())
-  , _inline_bailout_msg(NULL)
+  , _inline_bailout_msg(nullptr)
   , _instruction_count(0)
-  , _osr_entry(NULL)
+  , _osr_entry(nullptr)
 {
   int osr_bci = compilation->osr_bci();
 
@@ -3418,15 +3418,15 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
   CHECK_BAILOUT();
 
 # ifdef ASSERT
-  //All blocks reachable from start_block have _end != NULL
+  //All blocks reachable from start_block have _end != null
   {
     BlockList processed;
     BlockList to_go;
     to_go.append(start_block);
     while(to_go.length() > 0) {
       BlockBegin* current = to_go.pop();
-      assert(current != NULL, "Should not happen.");
-      assert(current->end() != NULL, "All blocks reachable from start_block should have end() != NULL.");
+      assert(current != nullptr, "Should not happen.");
+      assert(current->end() != nullptr, "All blocks reachable from start_block should have end() != null.");
       processed.append(current);
       for(int i = 0; i < current->number_of_sux(); i++) {
         BlockBegin* s = current->sux_at(i);
@@ -3478,13 +3478,13 @@ ValueStack* GraphBuilder::copy_state_before_with_bci(int bci) {
 }
 
 ValueStack* GraphBuilder::copy_state_exhandling_with_bci(int bci) {
-  if (!has_handler()) return NULL;
+  if (!has_handler()) return nullptr;
   return state()->copy(ValueStack::StateBefore, bci);
 }
 
 ValueStack* GraphBuilder::copy_state_for_exception_with_bci(int bci) {
   ValueStack* s = copy_state_exhandling_with_bci(bci);
-  if (s == NULL) {
+  if (s == nullptr) {
     if (_compilation->env()->should_retain_local_variables()) {
       s = state()->copy(ValueStack::ExceptionState, bci);
     } else {
@@ -3496,7 +3496,7 @@ ValueStack* GraphBuilder::copy_state_for_exception_with_bci(int bci) {
 
 int GraphBuilder::recursive_inline_level(ciMethod* cur_callee) const {
   int recur_level = 0;
-  for (IRScope* s = scope(); s != NULL; s = s->caller()) {
+  for (IRScope* s = scope(); s != nullptr; s = s->caller()) {
     if (s->method() == cur_callee) {
       ++recur_level;
     }
@@ -3506,14 +3506,14 @@ int GraphBuilder::recursive_inline_level(ciMethod* cur_callee) const {
 
 
 bool GraphBuilder::try_inline(ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc, Value receiver) {
-  const char* msg = NULL;
+  const char* msg = nullptr;
 
   // clear out any existing inline bailout condition
   clear_inline_bailout();
 
   // exclude methods we don't want to inline
   msg = should_not_inline(callee);
-  if (msg != NULL) {
+  if (msg != nullptr) {
     print_inlining(callee, msg, /*success*/ false);
     return false;
   }
@@ -3544,7 +3544,7 @@ bool GraphBuilder::try_inline(ciMethod* callee, bool holder_known, bool ignore_r
 
   // certain methods cannot be parsed at all
   msg = check_can_parse(callee);
-  if (msg != NULL) {
+  if (msg != nullptr) {
     print_inlining(callee, msg, /*success*/ false);
     return false;
   }
@@ -3574,14 +3574,14 @@ const char* GraphBuilder::check_can_parse(ciMethod* callee) const {
   if ( callee->is_native())            return "native method";
   if ( callee->is_abstract())          return "abstract method";
   if (!callee->can_be_parsed())        return "cannot be parsed";
-  return NULL;
+  return nullptr;
 }
 
-// negative filter: should callee NOT be inlined?  returns NULL, ok to inline, or rejection msg
+// negative filter: should callee NOT be inlined?  returns null, ok to inline, or rejection msg
 const char* GraphBuilder::should_not_inline(ciMethod* callee) const {
   if ( compilation()->directive()->should_not_inline(callee)) return "disallowed by CompileCommand";
   if ( callee->dont_inline())          return "don't inline by annotation";
-  return NULL;
+  return nullptr;
 }
 
 void GraphBuilder::build_graph_for_intrinsic(ciMethod* callee, bool ignore_return) {
@@ -3662,12 +3662,12 @@ void GraphBuilder::build_graph_for_intrinsic(ciMethod* callee, bool ignore_retur
       // Note that we'd collect profile data in this method if we wanted it.
       compilation()->set_would_profile(true);
       if (profile_calls()) {
-        Value recv = NULL;
+        Value recv = nullptr;
         if (has_receiver) {
           recv = args->at(0);
           null_check(recv);
         }
-        profile_call(callee, recv, NULL, collect_args_for_profiling(args, callee, true), true);
+        profile_call(callee, recv, nullptr, collect_args_for_profiling(args, callee, true), true);
       }
     }
   }
@@ -3716,7 +3716,7 @@ bool GraphBuilder::try_inline_jsr(int jsr_dest_bci) {
   // Introduce a new callee continuation point - all Ret instructions
   // will be replaced with Gotos to this point.
   BlockBegin* cont = block_at(next_bci());
-  assert(cont != NULL, "continuation must exist (BlockListBuilder starts a new block after a jsr");
+  assert(cont != nullptr, "continuation must exist (BlockListBuilder starts a new block after a jsr");
 
   // Note: can not assign state to continuation yet, as we have to
   // pick up the state from the Ret instructions.
@@ -3729,18 +3729,18 @@ bool GraphBuilder::try_inline_jsr(int jsr_dest_bci) {
   scope_data()->set_stream(scope_data()->parent()->stream());
 
   BlockBegin* jsr_start_block = block_at(jsr_dest_bci);
-  assert(jsr_start_block != NULL, "jsr start block must exist");
+  assert(jsr_start_block != nullptr, "jsr start block must exist");
   assert(!jsr_start_block->is_set(BlockBegin::was_visited_flag), "should not have visited jsr yet");
   Goto* goto_sub = new Goto(jsr_start_block, false);
   // Must copy state to avoid wrong sharing when parsing bytecodes
-  assert(jsr_start_block->state() == NULL, "should have fresh jsr starting block");
+  assert(jsr_start_block->state() == nullptr, "should have fresh jsr starting block");
   jsr_start_block->set_state(copy_state_before_with_bci(jsr_dest_bci));
   append(goto_sub);
   _block->set_end(goto_sub);
   _last = _block = jsr_start_block;
 
   // Clear out bytecode stream
-  scope_data()->set_stream(NULL);
+  scope_data()->set_stream(nullptr);
 
   scope_data()->add_to_work_list(jsr_start_block);
 
@@ -3755,7 +3755,7 @@ bool GraphBuilder::try_inline_jsr(int jsr_dest_bci) {
   // iterate_bytecodes_for_block()/ret() and we should not touch the
   // iteration state. The calling activation of
   // iterate_bytecodes_for_block will then complete normally.
-  if (cont->state() != NULL) {
+  if (cont->state() != nullptr) {
     if (!cont->is_set(BlockBegin::was_visited_flag)) {
       // add continuation to work list instead of parsing it immediately
       scope_data()->parent()->add_to_work_list(cont);
@@ -3783,10 +3783,10 @@ bool GraphBuilder::try_inline_jsr(int jsr_dest_bci) {
 // guaranteed to be non-null by the explicit null check at the
 // beginning of inlining.
 void GraphBuilder::inline_sync_entry(Value lock, BlockBegin* sync_handler) {
-  assert(lock != NULL && sync_handler != NULL, "lock or handler missing");
+  assert(lock != nullptr && sync_handler != nullptr, "lock or handler missing");
 
   monitorenter(lock, SynchronizationEntryBCI);
-  assert(_last->as_MonitorEnter() != NULL, "monitor enter expected");
+  assert(_last->as_MonitorEnter() != nullptr, "monitor enter expected");
   _last->set_needs_null_check(false);
 
   sync_handler->set(BlockBegin::exception_entry_flag);
@@ -3811,10 +3811,10 @@ void GraphBuilder::fill_sync_handler(Value lock, BlockBegin* sync_handler, bool 
   _last = _block = sync_handler;
   _state = sync_handler->state()->copy();
 
-  assert(sync_handler != NULL, "handler missing");
+  assert(sync_handler != nullptr, "handler missing");
   assert(!sync_handler->is_set(BlockBegin::was_visited_flag), "is visited here");
 
-  assert(lock != NULL || default_handler, "lock or handler missing");
+  assert(lock != nullptr || default_handler, "lock or handler missing");
 
   XHandler* h = scope_data()->xhandlers()->remove_last();
   assert(h->entry_block() == sync_handler, "corrupt list of handlers");
@@ -3890,7 +3890,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   const int args_base = state()->stack_size() - callee->arg_size();
   assert(args_base >= 0, "stack underflow during inlining");
 
-  Value recv = NULL;
+  Value recv = nullptr;
   if (has_receiver) {
     assert(!callee->is_static(), "callee must not be static");
     assert(callee->arg_size() > 0, "must have at least a receiver");
@@ -3928,7 +3928,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
         callee->holder()->is_subclass_of(ciEnv::current()->Throwable_klass())) {
       // Throwable constructor call
       IRScope* top = scope();
-      while (top->caller() != NULL) {
+      while (top->caller() != nullptr) {
         top = top->caller();
       }
       if (!top->method()->holder()->is_subclass_of(ciEnv::current()->Throwable_klass())) {
@@ -3967,7 +3967,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
     if (profile_calls()) {
       int start = 0;
       Values* obj_args = args_list_for_profiling(callee, start, has_receiver);
-      if (obj_args != NULL) {
+      if (obj_args != nullptr) {
         int s = obj_args->capacity();
         // if called through method handle invoke, some arguments may have been popped
         for (int i = args_base+start, j = 0; j < obj_args->capacity() && i < state()->stack_size(); ) {
@@ -3979,7 +3979,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
         }
         check_args_for_profiling(obj_args, s);
       }
-      profile_call(callee, recv, holder_known ? callee->holder() : NULL, obj_args, true);
+      profile_call(callee, recv, holder_known ? callee->holder() : nullptr, obj_args, true);
     }
   }
 
@@ -3990,7 +3990,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   // continuation point.
   BlockBegin* cont = block_at(next_bci());
   bool continuation_existed = true;
-  if (cont == NULL) {
+  if (cont == nullptr) {
     cont = new BlockBegin(next_bci());
     // low number so that continuation gets parsed as early as possible
     cont->set_depth_first_number(0);
@@ -4032,8 +4032,8 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   caller_state->truncate_stack(args_base);
   assert(callee_state->stack_size() == 0, "callee stack must be empty");
 
-  Value lock = NULL;
-  BlockBegin* sync_handler = NULL;
+  Value lock = nullptr;
+  BlockBegin* sync_handler = nullptr;
 
   // Inline the locking of the receiver if the callee is synchronized
   if (callee->is_synchronized()) {
@@ -4054,7 +4054,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   }
 
   BlockBegin* callee_start_block = block_at(0);
-  if (callee_start_block != NULL) {
+  if (callee_start_block != nullptr) {
     assert(callee_start_block->is_set(BlockBegin::parser_loop_header_flag), "must be loop header");
     Goto* goto_callee = new Goto(callee_start_block, false);
     // The state for this goto is in the scope of the callee, so use
@@ -4069,17 +4069,17 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   }
 
   // Clear out bytecode stream
-  scope_data()->set_stream(NULL);
+  scope_data()->set_stream(nullptr);
   scope_data()->set_ignore_return(ignore_return);
 
   CompileLog* log = compilation()->log();
-  if (log != NULL) log->head("parse method='%d'", log->identify(callee));
+  if (log != nullptr) log->head("parse method='%d'", log->identify(callee));
 
   // Ready to resume parsing in callee (either in the same block we
   // were in before or in the callee's start block)
-  iterate_all_blocks(callee_start_block == NULL);
+  iterate_all_blocks(callee_start_block == nullptr);
 
-  if (log != NULL) log->done("parse");
+  if (log != nullptr) log->done("parse");
 
   // If we bailed out during parsing, return immediately (this is bad news)
   if (bailed_out())
@@ -4128,7 +4128,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   }
 
   // Fill the exception handler for synchronized methods with instructions
-  if (callee->is_synchronized() && sync_handler->state() != NULL) {
+  if (callee->is_synchronized() && sync_handler->state() != nullptr) {
     fill_sync_handler(lock, sync_handler);
   } else {
     pop_scope();
@@ -4205,7 +4205,7 @@ bool GraphBuilder::try_method_handle_inline(ciMethod* callee, bool ignore_return
           if (!target->is_static()) {
             ciKlass* tk = signature->accessing_klass();
             Value obj = state()->stack_at(args_base);
-            if (obj->exact_type() == NULL &&
+            if (obj->exact_type() == nullptr &&
                 obj->declared_type() != tk && tk != compilation()->env()->Object_klass()) {
               TypeCast* c = new TypeCast(tk, obj, state_before);
               append(c);
@@ -4218,7 +4218,7 @@ bool GraphBuilder::try_method_handle_inline(ciMethod* callee, bool ignore_return
             if (t->is_klass()) {
               ciKlass* tk = t->as_klass();
               Value obj = state()->stack_at(args_base + receiver_skip + j);
-              if (obj->exact_type() == NULL &&
+              if (obj->exact_type() == nullptr &&
                   obj->declared_type() != tk && tk != compilation()->env()->Object_klass()) {
                 TypeCast* c = new TypeCast(t, obj, state_before);
                 append(c);
@@ -4257,18 +4257,18 @@ bool GraphBuilder::try_method_handle_inline(ciMethod* callee, bool ignore_return
 
 
 void GraphBuilder::inline_bailout(const char* msg) {
-  assert(msg != NULL, "inline bailout msg must exist");
+  assert(msg != nullptr, "inline bailout msg must exist");
   _inline_bailout_msg = msg;
 }
 
 
 void GraphBuilder::clear_inline_bailout() {
-  _inline_bailout_msg = NULL;
+  _inline_bailout_msg = nullptr;
 }
 
 
 void GraphBuilder::push_root_scope(IRScope* scope, BlockList* bci2block, BlockBegin* start) {
-  ScopeData* data = new ScopeData(NULL);
+  ScopeData* data = new ScopeData(nullptr);
   data->set_scope(scope);
   data->set_bci2block(bci2block);
   _scope_data = data;
@@ -4286,7 +4286,7 @@ void GraphBuilder::push_scope(ciMethod* callee, BlockBegin* continuation) {
   if (!blb.bci2block()->at(0)->is_set(BlockBegin::parser_loop_header_flag)) {
     // this scope can be inlined directly into the caller so remove
     // the block at bci 0.
-    blb.bci2block()->at_put(0, NULL);
+    blb.bci2block()->at_put(0, nullptr);
   }
 
   set_state(new ValueStack(callee_scope, state()->copy(ValueStack::CallerState, bci())));
@@ -4411,11 +4411,11 @@ void GraphBuilder::append_char_access(ciMethod* callee, bool is_store) {
   Value index = args->at(1);
   if (is_store) {
     Value value = args->at(2);
-    Instruction* store = append(new StoreIndexed(array, index, NULL, T_CHAR, value, state_before, false, true));
+    Instruction* store = append(new StoreIndexed(array, index, nullptr, T_CHAR, value, state_before, false, true));
     store->set_flag(Instruction::NeedsRangeCheckFlag, false);
     _memory->store_value(value);
   } else {
-    Instruction* load = append(new LoadIndexed(array, index, NULL, T_CHAR, state_before, true));
+    Instruction* load = append(new LoadIndexed(array, index, nullptr, T_CHAR, state_before, true));
     load->set_flag(Instruction::NeedsRangeCheckFlag, false);
     push(load->type(), load);
   }
@@ -4423,8 +4423,8 @@ void GraphBuilder::append_char_access(ciMethod* callee, bool is_store) {
 
 void GraphBuilder::print_inlining(ciMethod* callee, const char* msg, bool success) {
   CompileLog* log = compilation()->log();
-  if (log != NULL) {
-    assert(msg != NULL, "inlining msg should not be null!");
+  if (log != nullptr) {
+    assert(msg != nullptr, "inlining msg should not be null!");
     if (success) {
       log->inline_success(msg);
     } else {
@@ -4468,11 +4468,11 @@ void GraphBuilder::print_stats() {
 #endif // PRODUCT
 
 void GraphBuilder::profile_call(ciMethod* callee, Value recv, ciKlass* known_holder, Values* obj_args, bool inlined) {
-  assert(known_holder == NULL || (known_holder->is_instance_klass() &&
+  assert(known_holder == nullptr || (known_holder->is_instance_klass() &&
                                   (!known_holder->is_interface() ||
                                    ((ciInstanceKlass*)known_holder)->has_nonstatic_concrete_methods())), "should be non-static concrete method");
-  if (known_holder != NULL) {
-    if (known_holder->exact_klass() == NULL) {
+  if (known_holder != nullptr) {
+    if (known_holder->exact_klass() == nullptr) {
       known_holder = compilation()->cha_exact_type(known_holder);
     }
   }
@@ -4481,8 +4481,8 @@ void GraphBuilder::profile_call(ciMethod* callee, Value recv, ciKlass* known_hol
 }
 
 void GraphBuilder::profile_return_type(Value ret, ciMethod* callee, ciMethod* m, int invoke_bci) {
-  assert((m == NULL) == (invoke_bci < 0), "invalid method and invalid bci together");
-  if (m == NULL) {
+  assert((m == nullptr) == (invoke_bci < 0), "invalid method and invalid bci together");
+  if (m == nullptr) {
     m = method();
   }
   if (invoke_bci < 0) {
@@ -4490,7 +4490,7 @@ void GraphBuilder::profile_return_type(Value ret, ciMethod* callee, ciMethod* m,
   }
   ciMethodData* md = m->method_data_or_null();
   ciProfileData* data = md->bci_to_data(invoke_bci);
-  if (data != NULL && (data->is_CallTypeData() || data->is_VirtualCallTypeData())) {
+  if (data != nullptr && (data->is_CallTypeData() || data->is_VirtualCallTypeData())) {
     bool has_return = data->is_CallTypeData() ? ((ciCallTypeData*)data)->has_return() : ((ciVirtualCallTypeData*)data)->has_return();
     if (has_return) {
       append(new ProfileReturnType(m , invoke_bci, callee, ret));

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ class GraphBuilder {
 
     // How to get a block to be parsed
     void add_to_work_list(BlockBegin* block);
-    // How to remove the next block to be parsed; returns NULL if none left
+    // How to remove the next block to be parsed; returns null if none left
     BlockBegin* remove_from_work_list();
     // Indicates parse is over
     bool is_work_list_empty() const;
@@ -237,7 +237,7 @@ class GraphBuilder {
   void load_indexed (BasicType type);
   void store_indexed(BasicType type);
   void stack_op(Bytecodes::Code code);
-  void arithmetic_op(ValueType* type, Bytecodes::Code code, ValueStack* state_before = NULL);
+  void arithmetic_op(ValueType* type, Bytecodes::Code code, ValueStack* state_before = nullptr);
   void negate_op(ValueType* type);
   void shift_op(ValueType* type, Bytecodes::Code code);
   void logic_op(ValueType* type, Bytecodes::Code code);
@@ -309,7 +309,7 @@ class GraphBuilder {
   ValueStack* copy_state_exhandling();
   ValueStack* copy_state_for_exception_with_bci(int bci);
   ValueStack* copy_state_for_exception();
-  ValueStack* copy_state_if_bb(bool is_bb) { return (is_bb || compilation()->is_optimistic()) ? copy_state_before() : NULL; }
+  ValueStack* copy_state_if_bb(bool is_bb) { return (is_bb || compilation()->is_optimistic()) ? copy_state_before() : nullptr; }
   ValueStack* copy_state_indexed_access() { return compilation()->is_optimistic() ? copy_state_before() : copy_state_for_exception(); }
 
   //
@@ -350,9 +350,9 @@ class GraphBuilder {
   void build_graph_for_intrinsic(ciMethod* callee, bool ignore_return);
 
   // inliners
-  bool try_inline(           ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc = Bytecodes::_illegal, Value receiver = NULL);
+  bool try_inline(           ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc = Bytecodes::_illegal, Value receiver = nullptr);
   bool try_inline_intrinsics(ciMethod* callee, bool ignore_return = false);
-  bool try_inline_full(      ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc = Bytecodes::_illegal, Value receiver = NULL);
+  bool try_inline_full(      ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc = Bytecodes::_illegal, Value receiver = nullptr);
   bool try_inline_jsr(int jsr_dest_bci);
 
   const char* check_can_parse(ciMethod* callee) const;
@@ -383,7 +383,7 @@ class GraphBuilder {
   void print_inlining(ciMethod* callee, const char* msg, bool success = true);
 
   void profile_call(ciMethod* callee, Value recv, ciKlass* predicted_holder, Values* obj_args, bool inlined);
-  void profile_return_type(Value ret, ciMethod* callee, ciMethod* m = NULL, int bci = -1);
+  void profile_return_type(Value ret, ciMethod* callee, ciMethod* m = nullptr, int bci = -1);
   void profile_invocation(ciMethod* inlinee, ValueStack* state);
 
   // Shortcuts to profiling control.

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ bool XHandlers::could_catch(ciInstanceKlass* klass, bool type_is_exact) const {
 
 
 bool XHandlers::equals(XHandlers* others) const {
-  if (others == NULL) return false;
+  if (others == nullptr) return false;
   if (length() != others->length()) return false;
 
   for (int i = 0; i < length(); i++) {
@@ -127,7 +127,7 @@ bool XHandler::equals(XHandler* other) const {
 BlockBegin* IRScope::build_graph(Compilation* compilation, int osr_bci) {
   GraphBuilder gm(compilation, this);
   NOT_PRODUCT(if (PrintValueNumbering && Verbose) gm.print_stats());
-  if (compilation->bailed_out()) return NULL;
+  if (compilation->bailed_out()) return nullptr;
   return gm.start();
 }
 
@@ -138,7 +138,7 @@ IRScope::IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMe
 , _requires_phi_function(method->max_locals())
 {
   _caller             = caller;
-  _level              = caller == NULL ?  0 : caller->level() + 1;
+  _level              = caller == nullptr ?  0 : caller->level() + 1;
   _method             = method;
   _xhandlers          = new XHandlers(method);
   _number_of_locks    = 0;
@@ -146,7 +146,7 @@ IRScope::IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMe
   _wrote_final        = false;
   _wrote_fields       = false;
   _wrote_volatile     = false;
-  _start              = NULL;
+  _start              = nullptr;
 
   if (osr_bci != -1) {
     // selective creation of phi functions is not possibel in osr-methods
@@ -173,7 +173,7 @@ int IRScope::max_stack() const {
 bool IRScopeDebugInfo::should_reexecute() {
   ciMethod* cur_method = scope()->method();
   int       cur_bci    = bci();
-  if (cur_method != NULL && cur_bci != SynchronizationEntryBCI) {
+  if (cur_method != nullptr && cur_bci != SynchronizationEntryBCI) {
     Bytecodes::Code code = cur_method->java_code_at_bci(cur_bci);
     return Interpreter::bytecode_should_reexecute(code);
   } else
@@ -185,30 +185,30 @@ bool IRScopeDebugInfo::should_reexecute() {
 
 // Stack must be NON-null
 CodeEmitInfo::CodeEmitInfo(ValueStack* stack, XHandlers* exception_handlers, bool deoptimize_on_exception)
-  : _scope_debug_info(NULL)
+  : _scope_debug_info(nullptr)
   , _scope(stack->scope())
   , _exception_handlers(exception_handlers)
-  , _oop_map(NULL)
+  , _oop_map(nullptr)
   , _stack(stack)
   , _is_method_handle_invoke(false)
   , _deoptimize_on_exception(deoptimize_on_exception)
   , _force_reexecute(false) {
-  assert(_stack != NULL, "must be non null");
+  assert(_stack != nullptr, "must be non null");
 }
 
 
 CodeEmitInfo::CodeEmitInfo(CodeEmitInfo* info, ValueStack* stack)
-  : _scope_debug_info(NULL)
+  : _scope_debug_info(nullptr)
   , _scope(info->_scope)
-  , _exception_handlers(NULL)
-  , _oop_map(NULL)
-  , _stack(stack == NULL ? info->_stack : stack)
+  , _exception_handlers(nullptr)
+  , _oop_map(nullptr)
+  , _stack(stack == nullptr ? info->_stack : stack)
   , _is_method_handle_invoke(info->_is_method_handle_invoke)
   , _deoptimize_on_exception(info->_deoptimize_on_exception)
   , _force_reexecute(info->_force_reexecute) {
 
   // deep copy of exception handlers
-  if (info->_exception_handlers != NULL) {
+  if (info->_exception_handlers != nullptr) {
     _exception_handlers = new XHandlers(info->_exception_handlers);
   }
 }
@@ -224,7 +224,7 @@ void CodeEmitInfo::record_debug_info(DebugInformationRecorder* recorder, int pc_
 
 
 void CodeEmitInfo::add_register_oop(LIR_Opr opr) {
-  assert(_oop_map != NULL, "oop map must already exist");
+  assert(_oop_map != nullptr, "oop map must already exist");
   assert(opr->is_single_cpu(), "should not call otherwise");
 
   VMReg name = frame_map()->regname(opr);
@@ -241,7 +241,7 @@ int CodeEmitInfo::interpreter_frame_size() const {
   int callee_locals = 0;
   int extra_args = state->scope()->method()->max_stack() - state->stack_size();
 
-  while (state != NULL) {
+  while (state != nullptr) {
     int locks = state->locks_size();
     int temps = state->stack_size();
     bool is_top_frame = (state == _stack);
@@ -270,8 +270,8 @@ IR::IR(Compilation* compilation, ciMethod* method, int osr_bci) :
   _num_loops(0) {
   // setup IR fields
   _compilation = compilation;
-  _top_scope   = new IRScope(compilation, NULL, -1, method, osr_bci, true);
-  _code        = NULL;
+  _top_scope   = new IRScope(compilation, nullptr, -1, method, osr_bci, true);
+  _code        = nullptr;
 }
 
 
@@ -336,11 +336,11 @@ class CriticalEdgeFinder: public BlockClosure {
   }
 
   void split_edges() {
-    BlockPair* last_pair = NULL;
+    BlockPair* last_pair = nullptr;
     blocks.sort(sort_pairs);
     for (int i = 0; i < blocks.length(); i++) {
       BlockPair* pair = blocks.at(i);
-      if (last_pair != NULL && pair->is_same(last_pair)) continue;
+      if (last_pair != nullptr && pair->is_same(last_pair)) continue;
       BlockBegin* from = pair->from();
       BlockBegin* to = pair->to();
       BlockBegin* split = from->insert_block_between(to);
@@ -397,7 +397,7 @@ class UseCountComputer: public ValueVisitor, BlockClosure {
     } else {
       (*n)->input_values_do(this);
       // special handling for some instructions
-      if ((*n)->as_BlockEnd() != NULL) {
+      if ((*n)->as_BlockEnd() != nullptr) {
         // note on BlockEnd:
         //   must 'use' the stack only if the method doesn't
         //   terminate, however, in those cases stack is empty
@@ -410,7 +410,7 @@ class UseCountComputer: public ValueVisitor, BlockClosure {
   void block_do(BlockBegin* b) {
     depth = 0;
     // process all pinned nodes as the roots of expression trees
-    for (Instruction* n = b; n != NULL; n = n->next()) {
+    for (Instruction* n = b; n != nullptr; n = n->next()) {
       if (n->is_pinned()) uses_do(&n);
     }
     assert(depth == 0, "should have counted back down");
@@ -531,7 +531,7 @@ ComputeLinearScanOrder::ComputeLinearScanOrder(Compilation* c, BlockBegin* start
   _num_blocks(0),
   _num_loops(0),
   _iterative_dominators(false),
-  _linear_scan_order(NULL), // initialized later with correct size
+  _linear_scan_order(nullptr), // initialized later with correct size
   _visited_blocks(_max_block_id),
   _active_blocks(_max_block_id),
   _dominator_blocks(_max_block_id),
@@ -543,13 +543,13 @@ ComputeLinearScanOrder::ComputeLinearScanOrder(Compilation* c, BlockBegin* start
 {
   TRACE_LINEAR_SCAN(2, tty->print_cr("***** computing linear-scan block order"));
 
-  count_edges(start_block, NULL);
+  count_edges(start_block, nullptr);
 
   if (compilation()->is_profiling()) {
     ciMethod *method = compilation()->method();
     if (!method->is_accessor()) {
       ciMethodData* md = method->method_data_or_null();
-      assert(md != NULL, "Sanity");
+      assert(md != nullptr, "Sanity");
       md->set_compilation_stats(_num_loops, _num_blocks);
     }
   }
@@ -574,13 +574,13 @@ ComputeLinearScanOrder::ComputeLinearScanOrder(Compilation* c, BlockBegin* start
 // * number loop header blocks
 // * create a list with all loop end blocks
 void ComputeLinearScanOrder::count_edges(BlockBegin* cur, BlockBegin* parent) {
-  TRACE_LINEAR_SCAN(3, tty->print_cr("Enter count_edges for block B%d coming from B%d", cur->block_id(), parent != NULL ? parent->block_id() : -1));
-  assert(cur->dominator() == NULL, "dominator already initialized");
+  TRACE_LINEAR_SCAN(3, tty->print_cr("Enter count_edges for block B%d coming from B%d", cur->block_id(), parent != nullptr ? parent->block_id() : -1));
+  assert(cur->dominator() == nullptr, "dominator already initialized");
 
   if (is_active(cur)) {
     TRACE_LINEAR_SCAN(3, tty->print_cr("backward branch"));
     assert(is_visited(cur), "block must be visisted when block is active");
-    assert(parent != NULL, "must have parent");
+    assert(parent != nullptr, "must have parent");
 
     cur->set(BlockBegin::backward_branch_target_flag);
 
@@ -757,20 +757,20 @@ void ComputeLinearScanOrder::assign_loop_depth(BlockBegin* start_block) {
 
 
 BlockBegin* ComputeLinearScanOrder::common_dominator(BlockBegin* a, BlockBegin* b) {
-  assert(a != NULL && b != NULL, "must have input blocks");
+  assert(a != nullptr && b != nullptr, "must have input blocks");
 
   _dominator_blocks.clear();
-  while (a != NULL) {
+  while (a != nullptr) {
     _dominator_blocks.set_bit(a->block_id());
-    assert(a->dominator() != NULL || a == _linear_scan_order->at(0), "dominator must be initialized");
+    assert(a->dominator() != nullptr || a == _linear_scan_order->at(0), "dominator must be initialized");
     a = a->dominator();
   }
-  while (b != NULL && !_dominator_blocks.at(b->block_id())) {
-    assert(b->dominator() != NULL || b == _linear_scan_order->at(0), "dominator must be initialized");
+  while (b != nullptr && !_dominator_blocks.at(b->block_id())) {
+    assert(b->dominator() != nullptr || b == _linear_scan_order->at(0), "dominator must be initialized");
     b = b->dominator();
   }
 
-  assert(b != NULL, "could not find dominator");
+  assert(b != nullptr, "could not find dominator");
   return b;
 }
 
@@ -783,7 +783,7 @@ void ComputeLinearScanOrder::compute_dominator_impl(BlockBegin* cur, BlockBegin*
   // Mark as visited to avoid recursive calls with same parent
   set_visited(cur);
 
-  if (cur->dominator() == NULL) {
+  if (cur->dominator() == nullptr) {
     TRACE_LINEAR_SCAN(4, tty->print_cr("DOM: initializing dominator of B%d to B%d", cur->block_id(), parent->block_id()));
     cur->set_dominator(parent);
 
@@ -809,7 +809,7 @@ void ComputeLinearScanOrder::compute_dominator_impl(BlockBegin* cur, BlockBegin*
 
 
 int ComputeLinearScanOrder::compute_weight(BlockBegin* cur) {
-  BlockBegin* single_sux = NULL;
+  BlockBegin* single_sux = nullptr;
   if (cur->number_of_sux() == 1) {
     single_sux = cur->sux_at(0);
   }
@@ -837,8 +837,8 @@ int ComputeLinearScanOrder::compute_weight(BlockBegin* cur) {
 
   // exceptions should not be thrown in normal control flow, so these blocks
   // are added as late as possible
-  INC_WEIGHT_IF(cur->end()->as_Throw() == NULL  && (single_sux == NULL || single_sux->end()->as_Throw()  == NULL));
-  INC_WEIGHT_IF(cur->end()->as_Return() == NULL && (single_sux == NULL || single_sux->end()->as_Return() == NULL));
+  INC_WEIGHT_IF(cur->end()->as_Throw() == nullptr  && (single_sux == nullptr || single_sux->end()->as_Throw()  == nullptr));
+  INC_WEIGHT_IF(cur->end()->as_Return() == nullptr && (single_sux == nullptr || single_sux->end()->as_Return() == nullptr));
 
   // exceptions handlers are added as late as possible
   INC_WEIGHT_IF(!cur->is_set(BlockBegin::exception_entry_flag));
@@ -880,7 +880,7 @@ void ComputeLinearScanOrder::sort_into_work_list(BlockBegin* cur) {
   }
 #endif
 
-  _work_list.append(NULL); // provide space for new element
+  _work_list.append(nullptr); // provide space for new element
 
   int insert_idx = _work_list.length() - 1;
   while (insert_idx > 0 && _work_list.at(insert_idx - 1)->linear_scan_number() > cur_weight) {
@@ -918,12 +918,12 @@ void ComputeLinearScanOrder::compute_order(BlockBegin* start_block) {
   _linear_scan_order = new BlockList(_num_blocks);
   append_block(start_block);
 
-  assert(start_block->end()->as_Base() != NULL, "start block must end with Base-instruction");
+  assert(start_block->end()->as_Base() != nullptr, "start block must end with Base-instruction");
   BlockBegin* std_entry = ((Base*)start_block->end())->std_entry();
   BlockBegin* osr_entry = ((Base*)start_block->end())->osr_entry();
 
-  BlockBegin* sux_of_osr_entry = NULL;
-  if (osr_entry != NULL) {
+  BlockBegin* sux_of_osr_entry = nullptr;
+  if (osr_entry != nullptr) {
     // special handling for osr entry:
     // ignore the edge between the osr entry and its successor for processing
     // the osr entry block is added manually below
@@ -983,7 +983,7 @@ bool ComputeLinearScanOrder::compute_dominators_iter() {
   bool changed = false;
   int num_blocks = _linear_scan_order->length();
 
-  assert(_linear_scan_order->at(0)->dominator() == NULL, "must not have dominator");
+  assert(_linear_scan_order->at(0)->dominator() == nullptr, "must not have dominator");
   assert(_linear_scan_order->at(0)->number_of_preds() == 0, "must not have predecessors");
   for (int i = 1; i < num_blocks; i++) {
     BlockBegin* block = _linear_scan_order->at(i);
@@ -1077,10 +1077,10 @@ void ComputeLinearScanOrder::print_blocks() {
       tty->print(cur->is_set(BlockBegin::linear_scan_loop_header_flag) ? " lh" : "   ");
       tty->print(cur->is_set(BlockBegin::linear_scan_loop_end_flag)    ? " le" : "   ");
 
-      if (cur->dominator() != NULL) {
+      if (cur->dominator() != nullptr) {
         tty->print("    dom: B%d ", cur->dominator()->block_id());
       } else {
-        tty->print("    dom: NULL ");
+        tty->print("    dom: null ");
       }
 
       if (cur->number_of_preds() > 0) {
@@ -1156,9 +1156,9 @@ void ComputeLinearScanOrder::verify() {
 
     // check dominator
     if (i == 0) {
-      assert(cur->dominator() == NULL, "first block has no dominator");
+      assert(cur->dominator() == nullptr, "first block has no dominator");
     } else {
-      assert(cur->dominator() != NULL, "all but first block must have dominator");
+      assert(cur->dominator() != nullptr, "all but first block must have dominator");
     }
     // Assertion does not hold for exception handlers
     assert(cur->number_of_preds() != 1 || cur->dominator() == cur->pred_at(0) || cur->is_set(BlockBegin::exception_entry_flag), "Single predecessor must also be dominator");
@@ -1269,7 +1269,7 @@ void IR::print(bool cfg_only, bool live_only) {
 class EndNotNullValidator : public BlockClosure {
  public:
   virtual void block_do(BlockBegin* block) {
-    assert(block->end() != NULL, "Expect block end to exist.");
+    assert(block->end() != nullptr, "Expect block end to exist.");
   }
 };
 
@@ -1304,11 +1304,11 @@ class PredecessorAndCodeValidator : public BlockClosure {
  public:
   PredecessorAndCodeValidator(IR* hir) {
     ResourceMark rm;
-    _predecessors = new BlockListList(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), NULL);
+    _predecessors = new BlockListList(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), nullptr);
     _blocks = new BlockList(BlockBegin::number_of_blocks());
 
     hir->start()->iterate_preorder(this);
-    if (hir->code() != NULL) {
+    if (hir->code() != nullptr) {
       assert(hir->code()->length() == _blocks->length(), "must match");
       for (int i = 0; i < _blocks->length(); i++) {
         assert(hir->code()->contains(_blocks->at(i)), "should be in both lists");
@@ -1337,8 +1337,8 @@ class PredecessorAndCodeValidator : public BlockClosure {
   }
 
   void collect_predecessor(BlockBegin* const pred, const BlockBegin* sux) {
-    BlockList* preds = _predecessors->at_grow(sux->block_id(), NULL);
-    if (preds == NULL) {
+    BlockList* preds = _predecessors->at_grow(sux->block_id(), nullptr);
+    if (preds == nullptr) {
       preds = new BlockList();
       _predecessors->at_put(sux->block_id(), preds);
     }
@@ -1347,7 +1347,7 @@ class PredecessorAndCodeValidator : public BlockClosure {
 
   void verify_block_preds_against_collected_preds(const BlockBegin* block) const {
     BlockList* preds = _predecessors->at(block->block_id());
-    if (preds == NULL) {
+    if (preds == nullptr) {
       assert(block->number_of_preds() == 0, "should be the same");
       return;
     }
@@ -1370,7 +1370,7 @@ class PredecessorAndCodeValidator : public BlockClosure {
 class VerifyBlockBeginField : public BlockClosure {
 public:
   virtual void block_do(BlockBegin* block) {
-    for (Instruction* cur = block; cur != NULL; cur = cur->next()) {
+    for (Instruction* cur = block; cur != nullptr; cur = cur->next()) {
       assert(cur->block() == block, "Block begin is not correct");
     }
   }
@@ -1388,8 +1388,8 @@ class ValidateEdgeMutuality : public BlockClosure {
     }
 
     for (int i = 0; i < block->number_of_preds(); i++) {
-      assert(block->pred_at(i) != NULL, "Predecessor must exist");
-      assert(block->pred_at(i)->end() != NULL, "Predecessor end must exist");
+      assert(block->pred_at(i) != nullptr, "Predecessor must exist");
+      assert(block->pred_at(i)->end() != nullptr, "Predecessor end must exist");
       bool is_sux      = block->pred_at(i)->end()->is_sux(block);
       bool is_xhandler = block->pred_at(i)->is_exception_handler(block);
       assert(is_sux || is_xhandler, "Block's predecessor should have it as successor or xhandler");
@@ -1474,12 +1474,12 @@ class SubstitutionChecker: public ValueVisitor {
 
 
 void SubstitutionResolver::block_do(BlockBegin* block) {
-  Instruction* last = NULL;
-  for (Instruction* n = block; n != NULL;) {
+  Instruction* last = nullptr;
+  for (Instruction* n = block; n != nullptr;) {
     n->values_do(this);
     // need to remove this instruction from the instruction stream
     if (n->subst() != n) {
-      guarantee(last != NULL, "must have last");
+      guarantee(last != nullptr, "must have last");
       last->set_next(n->next());
     } else {
       last = n;

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,8 +51,8 @@ class XHandler: public CompilationResourceObj {
   // creation
   XHandler(ciExceptionHandler* desc)
     : _desc(desc)
-    , _entry_block(NULL)
-    , _entry_code(NULL)
+    , _entry_block(nullptr)
+    , _entry_code(nullptr)
     , _entry_pco(-1)
     , _phi_operand(-1)
     , _scope_count(-1)
@@ -137,7 +137,7 @@ class IRScope: public CompilationResourceObj {
  private:
   // hierarchy
   Compilation*  _compilation;                    // the current compilation
-  IRScope*      _caller;                         // the caller scope, or NULL
+  IRScope*      _caller;                         // the caller scope, or null
   int           _level;                          // the inlining level
   ciMethod*     _method;                         // the corresponding method
   IRScopeList   _callees;                        // the inlined method scopes
@@ -169,13 +169,13 @@ class IRScope: public CompilationResourceObj {
   BitMap&       requires_phi_function()          { return _requires_phi_function; }
 
   // hierarchy
-  bool          is_top_scope() const             { return _caller == NULL; }
+  bool          is_top_scope() const             { return _caller == nullptr; }
   void          add_callee(IRScope* callee)      { _callees.append(callee); }
   int           number_of_callees() const        { return _callees.length(); }
   IRScope*      callee_no(int i) const           { return _callees.at(i); }
 
   // accessors, graph
-  bool          is_valid() const                 { return start() != NULL; }
+  bool          is_valid() const                 { return start() != nullptr; }
   XHandlers*    xhandlers() const                { return _xhandlers; }
   int           number_of_locks() const          { return _number_of_locks; }
   void          set_min_number_of_locks(int n)   { if (n > _number_of_locks) _number_of_locks = n; }
@@ -233,7 +233,7 @@ class IRScopeDebugInfo: public CompilationResourceObj {
   bool should_reexecute();
 
   void record_debug_info(DebugInformationRecorder* recorder, int pc_offset, bool reexecute, bool is_method_handle_invoke = false) {
-    if (caller() != NULL) {
+    if (caller() != nullptr) {
       // Order is significant:  Must record caller first.
       caller()->record_debug_info(recorder, pc_offset, false/*reexecute*/);
     }
@@ -273,7 +273,7 @@ class CodeEmitInfo: public CompilationResourceObj {
   CodeEmitInfo(ValueStack* stack, XHandlers* exception_handlers, bool deoptimize_on_exception = false);
 
   // make a copy
-  CodeEmitInfo(CodeEmitInfo* info, ValueStack* stack = NULL);
+  CodeEmitInfo(CodeEmitInfo* info, ValueStack* stack = nullptr);
 
   // accessors
   OopMap* oop_map()                              { return _oop_map; }
@@ -331,7 +331,7 @@ class IR: public CompilationResourceObj {
 
   // The linear-scan order and the code emission order are equal, but
   // this may change in future
-  BlockList* linear_scan_order() {  assert(_code != NULL, "not computed"); return _code; }
+  BlockList* linear_scan_order() {  assert(_code != nullptr, "not computed"); return _code; }
 
   // iteration
   void iterate_preorder   (BlockClosure* closure);

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -100,7 +100,7 @@ void Instruction::state_values_do(ValueVisitor* f) {
   if (state_before() != nullptr) {
     state_before()->values_do(f);
   }
-  if (exception_state() != nullptr){
+  if (exception_state() != nullptr) {
     exception_state()->values_do(f);
   }
 }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,20 +76,20 @@ Instruction::Condition Instruction::negate(Condition cond) {
 }
 
 void Instruction::update_exception_state(ValueStack* state) {
-  if (state != NULL && (state->kind() == ValueStack::EmptyExceptionState || state->kind() == ValueStack::ExceptionState)) {
+  if (state != nullptr && (state->kind() == ValueStack::EmptyExceptionState || state->kind() == ValueStack::ExceptionState)) {
     assert(state->kind() == ValueStack::EmptyExceptionState || Compilation::current()->env()->should_retain_local_variables(), "unexpected state kind");
     _exception_state = state;
   } else {
-    _exception_state = NULL;
+    _exception_state = nullptr;
   }
 }
 
 // Prev without need to have BlockBegin
 Instruction* Instruction::prev() {
-  Instruction* p = NULL;
+  Instruction* p = nullptr;
   Instruction* q = block();
   while (q != this) {
-    assert(q != NULL, "this is not in the block's instruction list");
+    assert(q != nullptr, "this is not in the block's instruction list");
     p = q; q = q->next();
   }
   return p;
@@ -97,26 +97,26 @@ Instruction* Instruction::prev() {
 
 
 void Instruction::state_values_do(ValueVisitor* f) {
-  if (state_before() != NULL) {
+  if (state_before() != nullptr) {
     state_before()->values_do(f);
   }
-  if (exception_state() != NULL){
+  if (exception_state() != nullptr){
     exception_state()->values_do(f);
   }
 }
 
 ciType* Instruction::exact_type() const {
   ciType* t =  declared_type();
-  if (t != NULL && t->is_klass()) {
+  if (t != nullptr && t->is_klass()) {
     return t->as_klass()->exact_klass();
   }
-  return NULL;
+  return nullptr;
 }
 
 
 #ifndef PRODUCT
 void Instruction::check_state(ValueStack* state) {
-  if (state != NULL) {
+  if (state != nullptr) {
     state->verify();
   }
 }
@@ -168,12 +168,12 @@ ciType* Constant::exact_type() const {
   if (type()->is_object() && type()->as_ObjectType()->is_loaded()) {
     return type()->as_ObjectType()->exact_type();
   }
-  return NULL;
+  return nullptr;
 }
 
 ciType* LoadIndexed::exact_type() const {
   ciType* array_type = array()->exact_type();
-  if (array_type != NULL) {
+  if (array_type != nullptr) {
     assert(array_type->is_array_klass(), "what else?");
     ciArrayKlass* ak = (ciArrayKlass*)array_type;
 
@@ -190,8 +190,8 @@ ciType* LoadIndexed::exact_type() const {
 
 ciType* LoadIndexed::declared_type() const {
   ciType* array_type = array()->declared_type();
-  if (array_type == NULL || !array_type->is_loaded()) {
-    return NULL;
+  if (array_type == nullptr || !array_type->is_loaded()) {
+    return nullptr;
   }
   assert(array_type->is_array_klass(), "what else?");
   ciArrayKlass* ak = (ciArrayKlass*)array_type;
@@ -304,7 +304,7 @@ IRScope* StateSplit::scope() const {
 
 void StateSplit::state_values_do(ValueVisitor* f) {
   Instruction::state_values_do(f);
-  if (state() != NULL) state()->values_do(f);
+  if (state() != nullptr) state()->values_do(f);
 }
 
 
@@ -333,7 +333,7 @@ Invoke::Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values*
   set_flag(TargetIsLoadedFlag,   target->is_loaded());
   set_flag(TargetIsFinalFlag,    target_is_loaded() && target->is_final_method());
 
-  assert(args != NULL, "args must exist");
+  assert(args != nullptr, "args must exist");
 #ifdef ASSERT
   AssertValues assert_value;
   values_do(&assert_value);
@@ -354,8 +354,8 @@ Invoke::Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values*
 
 void Invoke::state_values_do(ValueVisitor* f) {
   StateSplit::state_values_do(f);
-  if (state_before() != NULL) state_before()->values_do(f);
-  if (state()        != NULL) state()->values_do(f);
+  if (state_before() != nullptr) state_before()->values_do(f);
+  if (state()        != nullptr) state()->values_do(f);
 }
 
 ciType* Invoke::declared_type() const {
@@ -367,7 +367,7 @@ ciType* Invoke::declared_type() const {
 
 // Implementation of Constant
 intx Constant::hash() const {
-  if (state_before() == NULL) {
+  if (state_before() == nullptr) {
     switch (type()->tag()) {
     case intTag:
       return HASH2(name(), type()->as_IntConstant()->value());
@@ -399,42 +399,42 @@ intx Constant::hash() const {
 }
 
 bool Constant::is_equal(Value v) const {
-  if (v->as_Constant() == NULL) return false;
+  if (v->as_Constant() == nullptr) return false;
 
   switch (type()->tag()) {
     case intTag:
       {
         IntConstant* t1 =    type()->as_IntConstant();
         IntConstant* t2 = v->type()->as_IntConstant();
-        return (t1 != NULL && t2 != NULL &&
+        return (t1 != nullptr && t2 != nullptr &&
                 t1->value() == t2->value());
       }
     case longTag:
       {
         LongConstant* t1 =    type()->as_LongConstant();
         LongConstant* t2 = v->type()->as_LongConstant();
-        return (t1 != NULL && t2 != NULL &&
+        return (t1 != nullptr && t2 != nullptr &&
                 t1->value() == t2->value());
       }
     case floatTag:
       {
         FloatConstant* t1 =    type()->as_FloatConstant();
         FloatConstant* t2 = v->type()->as_FloatConstant();
-        return (t1 != NULL && t2 != NULL &&
+        return (t1 != nullptr && t2 != nullptr &&
                 jint_cast(t1->value()) == jint_cast(t2->value()));
       }
     case doubleTag:
       {
         DoubleConstant* t1 =    type()->as_DoubleConstant();
         DoubleConstant* t2 = v->type()->as_DoubleConstant();
-        return (t1 != NULL && t2 != NULL &&
+        return (t1 != nullptr && t2 != nullptr &&
                 jlong_cast(t1->value()) == jlong_cast(t2->value()));
       }
     case objectTag:
       {
         ObjectType* t1 =    type()->as_ObjectType();
         ObjectType* t2 = v->type()->as_ObjectType();
-        return (t1 != NULL && t2 != NULL &&
+        return (t1 != nullptr && t2 != nullptr &&
                 t1->is_loaded() && t2->is_loaded() &&
                 t1->constant_value() == t2->constant_value());
       }
@@ -442,7 +442,7 @@ bool Constant::is_equal(Value v) const {
       {
         MetadataType* t1 =    type()->as_MetadataType();
         MetadataType* t2 = v->type()->as_MetadataType();
-        return (t1 != NULL && t2 != NULL &&
+        return (t1 != nullptr && t2 != nullptr &&
                 t1->is_loaded() && t2->is_loaded() &&
                 t1->constant_value() == t2->constant_value());
       }
@@ -454,7 +454,7 @@ bool Constant::is_equal(Value v) const {
 Constant::CompareResult Constant::compare(Instruction::Condition cond, Value right) const {
   Constant* rc = right->as_Constant();
   // other is not a constant
-  if (rc == NULL) return not_comparable;
+  if (rc == nullptr) return not_comparable;
 
   ValueType* lt = type();
   ValueType* rt = rc->type();
@@ -492,7 +492,7 @@ Constant::CompareResult Constant::compare(Instruction::Condition cond, Value rig
   case objectTag: {
     ciObject* xvalue = lt->as_ObjectType()->constant_value();
     ciObject* yvalue = rt->as_ObjectType()->constant_value();
-    assert(xvalue != NULL && yvalue != NULL, "not constants");
+    assert(xvalue != nullptr && yvalue != nullptr, "not constants");
     if (xvalue->is_loaded() && yvalue->is_loaded()) {
       switch (cond) {
       case If::eql: return xvalue == yvalue ? cond_true : cond_false;
@@ -505,7 +505,7 @@ Constant::CompareResult Constant::compare(Instruction::Condition cond, Value rig
   case metaDataTag: {
     ciMetadata* xvalue = lt->as_MetadataType()->constant_value();
     ciMetadata* yvalue = rt->as_MetadataType()->constant_value();
-    assert(xvalue != NULL && yvalue != NULL, "not constants");
+    assert(xvalue != nullptr && yvalue != nullptr, "not constants");
     if (xvalue->is_loaded() && yvalue->is_loaded()) {
       switch (cond) {
       case If::eql: return xvalue == yvalue ? cond_true : cond_false;
@@ -525,11 +525,11 @@ Constant::CompareResult Constant::compare(Instruction::Condition cond, Value rig
 // Implementation of BlockBegin
 
 void BlockBegin::set_end(BlockEnd* new_end) { // Assumes that no predecessor of new_end still has it as its successor
-  assert(new_end != NULL, "Should not reset block new_end to NULL");
+  assert(new_end != nullptr, "Should not reset block new_end to null");
   if (new_end == _end) return;
 
   // Remove this block as predecessor of its current successors
-  if (_end != NULL) {
+  if (_end != nullptr) {
     for (int i = 0; i < number_of_sux(); i++) {
       sux_at(i)->remove_predecessor(this);
     }
@@ -656,14 +656,14 @@ void BlockBegin::remove_predecessor(BlockBegin* pred) {
 
 
 void BlockBegin::add_exception_handler(BlockBegin* b) {
-  assert(b != NULL && (b->is_set(exception_entry_flag)), "exception handler must exist");
+  assert(b != nullptr && (b->is_set(exception_entry_flag)), "exception handler must exist");
   // add only if not in the list already
   if (!_exception_handlers.contains(b)) _exception_handlers.append(b);
 }
 
 int BlockBegin::add_exception_state(ValueStack* state) {
   assert(is_set(exception_entry_flag), "only for xhandlers");
-  if (_exception_states == NULL) {
+  if (_exception_states == nullptr) {
     _exception_states = new ValueStackStack(4);
   }
   _exception_states->append(state);
@@ -708,7 +708,7 @@ void BlockBegin::iterate_postorder(BlockClosure* closure) {
 
 
 void BlockBegin::block_values_do(ValueVisitor* f) {
-  for (Instruction* n = this; n != NULL; n = n->next()) n->values_do(f);
+  for (Instruction* n = this; n != nullptr; n = n->next()) n->values_do(f);
 }
 
 
@@ -727,7 +727,7 @@ bool BlockBegin::try_merge(ValueStack* new_state, bool has_irreducible_loops) {
   Value new_value, existing_value;
 
   ValueStack* existing_state = state();
-  if (existing_state == NULL) {
+  if (existing_state == nullptr) {
     TRACE_PHI(tty->print_cr("first call of try_merge for this block"));
 
     if (is_set(BlockBegin::was_visited_flag)) {
@@ -789,9 +789,9 @@ bool BlockBegin::try_merge(ValueStack* new_state, bool has_irreducible_loops) {
 
       for_each_local_value(existing_state, index, existing_value) {
         Value new_value = new_state->local_at(index);
-        if (new_value == NULL || new_value->type()->tag() != existing_value->type()->tag()) {
+        if (new_value == nullptr || new_value->type()->tag() != existing_value->type()->tag()) {
           Phi* existing_phi = existing_value->as_Phi();
-          if (existing_phi == NULL) {
+          if (existing_phi == nullptr) {
             return false; // BAILOUT in caller
           }
           // Invalidate the phi function here. This case is very rare except for
@@ -802,7 +802,7 @@ bool BlockBegin::try_merge(ValueStack* new_state, bool has_irreducible_loops) {
           TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
         }
 
-        if (existing_value != new_state->local_at(index) && existing_value->as_Phi() == NULL) {
+        if (existing_value != new_state->local_at(index) && existing_value->as_Phi() == nullptr) {
           TRACE_PHI(tty->print_cr("required phi for local %d is missing, irreducible loop?", index));
           return false; // BAILOUT in caller
         }
@@ -811,10 +811,10 @@ bool BlockBegin::try_merge(ValueStack* new_state, bool has_irreducible_loops) {
 #ifdef ASSERT
       // check that all necessary phi functions are present
       for_each_stack_value(existing_state, index, existing_value) {
-        assert(existing_value->as_Phi() != NULL && existing_value->as_Phi()->block() == this, "phi function required");
+        assert(existing_value->as_Phi() != nullptr && existing_value->as_Phi()->block() == this, "phi function required");
       }
       for_each_local_value(existing_state, index, existing_value) {
-        assert(existing_value == new_state->local_at(index) || (existing_value->as_Phi() != NULL && existing_value->as_Phi()->as_Phi()->block() == this), "phi function required");
+        assert(existing_value == new_state->local_at(index) || (existing_value->as_Phi() != nullptr && existing_value->as_Phi()->as_Phi()->block() == this), "phi function required");
       }
 #endif
 
@@ -826,7 +826,7 @@ bool BlockBegin::try_merge(ValueStack* new_state, bool has_irreducible_loops) {
         Value new_value = new_state->stack_at(index);
         Phi* existing_phi = existing_value->as_Phi();
 
-        if (new_value != existing_value && (existing_phi == NULL || existing_phi->block() != this)) {
+        if (new_value != existing_value && (existing_phi == nullptr || existing_phi->block() != this)) {
           existing_state->setup_phi_for_stack(this, index);
           TRACE_PHI(tty->print_cr("creating phi-function %c%d for stack %d", existing_state->stack_at(index)->type()->tchar(), existing_state->stack_at(index)->id(), index));
         }
@@ -837,10 +837,10 @@ bool BlockBegin::try_merge(ValueStack* new_state, bool has_irreducible_loops) {
         Value new_value = new_state->local_at(index);
         Phi* existing_phi = existing_value->as_Phi();
 
-        if (new_value == NULL || new_value->type()->tag() != existing_value->type()->tag()) {
+        if (new_value == nullptr || new_value->type()->tag() != existing_value->type()->tag()) {
           existing_state->invalidate_local(index);
           TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
-        } else if (new_value != existing_value && (existing_phi == NULL || existing_phi->block() != this)) {
+        } else if (new_value != existing_value && (existing_phi == nullptr || existing_phi->block() != this)) {
           existing_state->setup_phi_for_local(this, index);
           TRACE_PHI(tty->print_cr("creating phi-function %c%d for local %d", existing_state->local_at(index)->type()->tchar(), existing_state->local_at(index)->id(), index));
         }
@@ -872,7 +872,7 @@ void BlockBegin::print_block(InstructionPrinter& ip, bool live_only) {
   ip.print_stack(this->state()); tty->cr();
   ip.print_inline_level(this);
   ip.print_head();
-  for (Instruction* n = next(); n != NULL; n = n->next()) {
+  for (Instruction* n = next(); n != nullptr; n = n->next()) {
     if (!live_only || n->is_pinned() || n->use_count() > 0) {
       ip.print_line(n);
     }
@@ -934,7 +934,7 @@ Value Phi::operand_at(int i) const {
   } else {
     state = _block->pred_at(i)->end()->state();
   }
-  assert(state != NULL, "");
+  assert(state != nullptr, "");
 
   if (is_local()) {
     return state->local_at(local_index());
@@ -986,5 +986,5 @@ void RangeCheckPredicate::check_state() {
 }
 
 void ProfileInvoke::state_values_do(ValueVisitor* f) {
-  if (state() != NULL) state()->values_do(f);
+  if (state() != nullptr) state()->values_do(f);
 }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -236,7 +236,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                \
+    if (_v == nullptr) return false;                  \
     if (f1 != _v->f1) return false;                   \
     return true;                                      \
   }                                                   \
@@ -249,7 +249,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                \
+    if (_v == nullptr) return false;                  \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     return true;                                      \
@@ -263,7 +263,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                \
+    if (_v == nullptr) return false;                  \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     if (f3 != _v->f3) return false;                   \

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -236,7 +236,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                   \
+    if (_v == nullptr  ) return false;                \
     if (f1 != _v->f1) return false;                   \
     return true;                                      \
   }                                                   \
@@ -249,7 +249,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                   \
+    if (_v == nullptr  ) return false;                \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     return true;                                      \
@@ -263,7 +263,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == nullptr  ) return false;                   \
+    if (_v == nullptr  ) return false;                \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     if (f3 != _v->f3) return false;                   \

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,7 +236,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == NULL  ) return false;                   \
+    if (_v == nullptr  ) return false;                   \
     if (f1 != _v->f1) return false;                   \
     return true;                                      \
   }                                                   \
@@ -249,7 +249,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == NULL  ) return false;                   \
+    if (_v == nullptr  ) return false;                   \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     return true;                                      \
@@ -263,7 +263,7 @@ class InstructionVisitor: public StackObj {
   virtual bool is_equal(Value v) const {              \
     if (!(enabled)  ) return false;                   \
     class_name* _v = v->as_##class_name();            \
-    if (_v == NULL  ) return false;                   \
+    if (_v == nullptr  ) return false;                   \
     if (f1 != _v->f1) return false;                   \
     if (f2 != _v->f2) return false;                   \
     if (f3 != _v->f3) return false;                   \
@@ -282,12 +282,12 @@ class Instruction: public CompilationResourceObj {
   int          _use_count;                       // the number of instructions referring to this value (w/o prev/next); only roots can have use count = 0 or > 1
   int          _pin_state;                       // set of PinReason describing the reason for pinning
   ValueType*   _type;                            // the instruction value type
-  Instruction* _next;                            // the next instruction if any (NULL for BlockEnd instructions)
+  Instruction* _next;                            // the next instruction if any (null for BlockEnd instructions)
   Instruction* _subst;                           // the substitution instruction if any
   LIR_Opr      _operand;                         // LIR specific information
   unsigned int _flags;                           // Flag bits
 
-  ValueStack*  _state_before;                    // Copy of state with input operands still on stack (or NULL)
+  ValueStack*  _state_before;                    // Copy of state with input operands still on stack (or null)
   ValueStack*  _exception_state;                 // Copy of state for exception handling
   XHandlers*   _exception_handlers;              // Flat list of exception handlers covering this instruction
 
@@ -299,7 +299,7 @@ class Instruction: public CompilationResourceObj {
   BlockBegin*  _block;                           // Block that contains this instruction
 
   void set_type(ValueType* type) {
-    assert(type != NULL, "type must exist");
+    assert(type != nullptr, "type must exist");
     _type = type;
   }
 
@@ -395,7 +395,7 @@ class Instruction: public CompilationResourceObj {
   }
 
   // creation
-  Instruction(ValueType* type, ValueStack* state_before = NULL, bool type_is_constant = false)
+  Instruction(ValueType* type, ValueStack* state_before = nullptr, bool type_is_constant = false)
   : _id(Compilation::current()->get_next_id()),
 #ifndef PRODUCT
   _printable_bci(-99),
@@ -403,16 +403,16 @@ class Instruction: public CompilationResourceObj {
     _use_count(0)
   , _pin_state(0)
   , _type(type)
-  , _next(NULL)
-  , _subst(NULL)
+  , _next(nullptr)
+  , _subst(nullptr)
   , _operand(LIR_OprFact::illegalOpr)
   , _flags(0)
   , _state_before(state_before)
-  , _exception_handlers(NULL)
-  , _block(NULL)
+  , _exception_handlers(nullptr)
+  , _block(nullptr)
   {
     check_state(state_before);
-    assert(type != NULL && (!type->is_constant() || type_is_constant), "type must exist");
+    assert(type != nullptr && (!type->is_constant() || type_is_constant), "type must exist");
     update_exception_state(_state_before);
   }
 
@@ -431,16 +431,16 @@ class Instruction: public CompilationResourceObj {
   BlockBegin *block() const                      { return _block; }
   Instruction* prev();                           // use carefully, expensive operation
   Instruction* next() const                      { return _next; }
-  bool has_subst() const                         { return _subst != NULL; }
-  Instruction* subst()                           { return _subst == NULL ? this : _subst->subst(); }
+  bool has_subst() const                         { return _subst != nullptr; }
+  Instruction* subst()                           { return _subst == nullptr ? this : _subst->subst(); }
   LIR_Opr operand() const                        { return _operand; }
 
   void set_needs_null_check(bool f)              { set_flag(NeedsNullCheckFlag, f); }
   bool needs_null_check() const                  { return check_flag(NeedsNullCheckFlag); }
   bool is_linked() const                         { return check_flag(IsLinkedInBlockFlag); }
-  bool can_be_linked()                           { return as_Local() == NULL && as_Phi() == NULL; }
+  bool can_be_linked()                           { return as_Local() == nullptr && as_Phi() == nullptr; }
 
-  bool is_null_obj()                             { return as_Constant() != NULL && type()->as_ObjectType()->constant_value()->is_null_object(); }
+  bool is_null_obj()                             { return as_Constant() != nullptr && type()->as_ObjectType()->constant_value()->is_null_object(); }
 
   bool has_uses() const                          { return use_count() > 0; }
   ValueStack* state_before() const               { return _state_before; }
@@ -456,8 +456,8 @@ class Instruction: public CompilationResourceObj {
 
   Instruction* set_next(Instruction* next) {
     assert(next->has_printable_bci(), "_printable_bci should have been set");
-    assert(next != NULL, "must not be NULL");
-    assert(as_BlockEnd() == NULL, "BlockEnd instructions must have no next");
+    assert(next != nullptr, "must not be null");
+    assert(as_BlockEnd() == nullptr, "BlockEnd instructions must have no next");
     assert(next->can_be_linked(), "shouldn't link these instructions into list");
 
     BlockBegin *block = this->block();
@@ -499,7 +499,7 @@ class Instruction: public CompilationResourceObj {
   }
 
   void set_subst(Instruction* subst)             {
-    assert(subst == NULL ||
+    assert(subst == nullptr ||
            type()->base() == subst->type()->base() ||
            subst->type()->base() == illegalType, "type can't change");
     _subst = subst;
@@ -514,59 +514,59 @@ class Instruction: public CompilationResourceObj {
 
   // generic
   virtual Instruction*      as_Instruction()     { return this; } // to satisfy HASHING1 macro
-  virtual Phi*              as_Phi()             { return NULL; }
-  virtual Local*            as_Local()           { return NULL; }
-  virtual Constant*         as_Constant()        { return NULL; }
-  virtual AccessField*      as_AccessField()     { return NULL; }
-  virtual LoadField*        as_LoadField()       { return NULL; }
-  virtual StoreField*       as_StoreField()      { return NULL; }
-  virtual AccessArray*      as_AccessArray()     { return NULL; }
-  virtual ArrayLength*      as_ArrayLength()     { return NULL; }
-  virtual AccessIndexed*    as_AccessIndexed()   { return NULL; }
-  virtual LoadIndexed*      as_LoadIndexed()     { return NULL; }
-  virtual StoreIndexed*     as_StoreIndexed()    { return NULL; }
-  virtual NegateOp*         as_NegateOp()        { return NULL; }
-  virtual Op2*              as_Op2()             { return NULL; }
-  virtual ArithmeticOp*     as_ArithmeticOp()    { return NULL; }
-  virtual ShiftOp*          as_ShiftOp()         { return NULL; }
-  virtual LogicOp*          as_LogicOp()         { return NULL; }
-  virtual CompareOp*        as_CompareOp()       { return NULL; }
-  virtual IfOp*             as_IfOp()            { return NULL; }
-  virtual Convert*          as_Convert()         { return NULL; }
-  virtual NullCheck*        as_NullCheck()       { return NULL; }
-  virtual OsrEntry*         as_OsrEntry()        { return NULL; }
-  virtual StateSplit*       as_StateSplit()      { return NULL; }
-  virtual Invoke*           as_Invoke()          { return NULL; }
-  virtual NewInstance*      as_NewInstance()     { return NULL; }
-  virtual NewArray*         as_NewArray()        { return NULL; }
-  virtual NewTypeArray*     as_NewTypeArray()    { return NULL; }
-  virtual NewObjectArray*   as_NewObjectArray()  { return NULL; }
-  virtual NewMultiArray*    as_NewMultiArray()   { return NULL; }
-  virtual TypeCheck*        as_TypeCheck()       { return NULL; }
-  virtual CheckCast*        as_CheckCast()       { return NULL; }
-  virtual InstanceOf*       as_InstanceOf()      { return NULL; }
-  virtual TypeCast*         as_TypeCast()        { return NULL; }
-  virtual AccessMonitor*    as_AccessMonitor()   { return NULL; }
-  virtual MonitorEnter*     as_MonitorEnter()    { return NULL; }
-  virtual MonitorExit*      as_MonitorExit()     { return NULL; }
-  virtual Intrinsic*        as_Intrinsic()       { return NULL; }
-  virtual BlockBegin*       as_BlockBegin()      { return NULL; }
-  virtual BlockEnd*         as_BlockEnd()        { return NULL; }
-  virtual Goto*             as_Goto()            { return NULL; }
-  virtual If*               as_If()              { return NULL; }
-  virtual TableSwitch*      as_TableSwitch()     { return NULL; }
-  virtual LookupSwitch*     as_LookupSwitch()    { return NULL; }
-  virtual Return*           as_Return()          { return NULL; }
-  virtual Throw*            as_Throw()           { return NULL; }
-  virtual Base*             as_Base()            { return NULL; }
-  virtual RoundFP*          as_RoundFP()         { return NULL; }
-  virtual ExceptionObject*  as_ExceptionObject() { return NULL; }
-  virtual UnsafeOp*         as_UnsafeOp()        { return NULL; }
-  virtual ProfileInvoke*    as_ProfileInvoke()   { return NULL; }
-  virtual RangeCheckPredicate* as_RangeCheckPredicate() { return NULL; }
+  virtual Phi*              as_Phi()             { return nullptr; }
+  virtual Local*            as_Local()           { return nullptr; }
+  virtual Constant*         as_Constant()        { return nullptr; }
+  virtual AccessField*      as_AccessField()     { return nullptr; }
+  virtual LoadField*        as_LoadField()       { return nullptr; }
+  virtual StoreField*       as_StoreField()      { return nullptr; }
+  virtual AccessArray*      as_AccessArray()     { return nullptr; }
+  virtual ArrayLength*      as_ArrayLength()     { return nullptr; }
+  virtual AccessIndexed*    as_AccessIndexed()   { return nullptr; }
+  virtual LoadIndexed*      as_LoadIndexed()     { return nullptr; }
+  virtual StoreIndexed*     as_StoreIndexed()    { return nullptr; }
+  virtual NegateOp*         as_NegateOp()        { return nullptr; }
+  virtual Op2*              as_Op2()             { return nullptr; }
+  virtual ArithmeticOp*     as_ArithmeticOp()    { return nullptr; }
+  virtual ShiftOp*          as_ShiftOp()         { return nullptr; }
+  virtual LogicOp*          as_LogicOp()         { return nullptr; }
+  virtual CompareOp*        as_CompareOp()       { return nullptr; }
+  virtual IfOp*             as_IfOp()            { return nullptr; }
+  virtual Convert*          as_Convert()         { return nullptr; }
+  virtual NullCheck*        as_NullCheck()       { return nullptr; }
+  virtual OsrEntry*         as_OsrEntry()        { return nullptr; }
+  virtual StateSplit*       as_StateSplit()      { return nullptr; }
+  virtual Invoke*           as_Invoke()          { return nullptr; }
+  virtual NewInstance*      as_NewInstance()     { return nullptr; }
+  virtual NewArray*         as_NewArray()        { return nullptr; }
+  virtual NewTypeArray*     as_NewTypeArray()    { return nullptr; }
+  virtual NewObjectArray*   as_NewObjectArray()  { return nullptr; }
+  virtual NewMultiArray*    as_NewMultiArray()   { return nullptr; }
+  virtual TypeCheck*        as_TypeCheck()       { return nullptr; }
+  virtual CheckCast*        as_CheckCast()       { return nullptr; }
+  virtual InstanceOf*       as_InstanceOf()      { return nullptr; }
+  virtual TypeCast*         as_TypeCast()        { return nullptr; }
+  virtual AccessMonitor*    as_AccessMonitor()   { return nullptr; }
+  virtual MonitorEnter*     as_MonitorEnter()    { return nullptr; }
+  virtual MonitorExit*      as_MonitorExit()     { return nullptr; }
+  virtual Intrinsic*        as_Intrinsic()       { return nullptr; }
+  virtual BlockBegin*       as_BlockBegin()      { return nullptr; }
+  virtual BlockEnd*         as_BlockEnd()        { return nullptr; }
+  virtual Goto*             as_Goto()            { return nullptr; }
+  virtual If*               as_If()              { return nullptr; }
+  virtual TableSwitch*      as_TableSwitch()     { return nullptr; }
+  virtual LookupSwitch*     as_LookupSwitch()    { return nullptr; }
+  virtual Return*           as_Return()          { return nullptr; }
+  virtual Throw*            as_Throw()           { return nullptr; }
+  virtual Base*             as_Base()            { return nullptr; }
+  virtual RoundFP*          as_RoundFP()         { return nullptr; }
+  virtual ExceptionObject*  as_ExceptionObject() { return nullptr; }
+  virtual UnsafeOp*         as_UnsafeOp()        { return nullptr; }
+  virtual ProfileInvoke*    as_ProfileInvoke()   { return nullptr; }
+  virtual RangeCheckPredicate* as_RangeCheckPredicate() { return nullptr; }
 
 #ifdef ASSERT
-  virtual Assert*           as_Assert()          { return NULL; }
+  virtual Assert*           as_Assert()          { return nullptr; }
 #endif
 
   virtual void visit(InstructionVisitor* v)      = 0;
@@ -579,7 +579,7 @@ class Instruction: public CompilationResourceObj {
           void       values_do(ValueVisitor* f)   { input_values_do(f); state_values_do(f); other_values_do(f); }
 
   virtual ciType* exact_type() const;
-  virtual ciType* declared_type() const          { return NULL; }
+  virtual ciType* declared_type() const          { return nullptr; }
 
   // hashing
   virtual const char* name() const               = 0;
@@ -615,7 +615,7 @@ class Instruction: public CompilationResourceObj {
 
 #ifdef ASSERT
 class AssertValues: public ValueVisitor {
-  void visit(Value* x)             { assert((*x) != NULL, "value must exist"); }
+  void visit(Value* x)             { assert((*x) != nullptr, "value must exist"); }
 };
   #define ASSERT_VALUES                          { AssertValues assert_value; values_do(&assert_value); }
 #else
@@ -714,7 +714,7 @@ LEAF(Constant, Instruction)
  public:
   // creation
   Constant(ValueType* type):
-      Instruction(type, NULL, /*type_is_constant*/ true)
+      Instruction(type, nullptr, /*type_is_constant*/ true)
   {
     assert(type->is_constant(), "must be a constant");
   }
@@ -722,14 +722,14 @@ LEAF(Constant, Instruction)
   Constant(ValueType* type, ValueStack* state_before, bool kills_memory = false):
     Instruction(type, state_before, /*type_is_constant*/ true)
   {
-    assert(state_before != NULL, "only used for constants which need patching");
+    assert(state_before != nullptr, "only used for constants which need patching");
     assert(type->is_constant(), "must be a constant");
     set_flag(KillsMemoryFlag, kills_memory);
     pin(); // since it's patching it needs to be pinned
   }
 
   // generic
-  virtual bool can_trap() const                  { return state_before() != NULL; }
+  virtual bool can_trap() const                  { return state_before() != nullptr; }
   virtual void input_values_do(ValueVisitor* f)   { /* no values */ }
 
   virtual intx hash() const;
@@ -746,14 +746,14 @@ LEAF(Constant, Instruction)
                       BlockBegin* true_sux, BlockBegin* false_sux) const {
     switch (compare(cond, right)) {
     case not_comparable:
-      return NULL;
+      return nullptr;
     case cond_false:
       return false_sux;
     case cond_true:
       return true_sux;
     default:
       ShouldNotReachHere();
-      return NULL;
+      return nullptr;
     }
   }
 };
@@ -774,7 +774,7 @@ BASE(AccessField, Instruction)
   , _obj(obj)
   , _offset(offset)
   , _field(field)
-  , _explicit_null_check(NULL)
+  , _explicit_null_check(nullptr)
   {
     set_needs_null_check(!is_static);
     set_flag(IsStaticFlag, is_static);
@@ -884,7 +884,7 @@ LEAF(ArrayLength, AccessArray)
   // creation
   ArrayLength(Value array, ValueStack* state_before)
   : AccessArray(intType, array, state_before)
-  , _explicit_null_check(NULL) {}
+  , _explicit_null_check(nullptr) {}
 
   // accessors
   NullCheck* explicit_null_check() const         { return _explicit_null_check; }
@@ -924,12 +924,12 @@ BASE(AccessIndexed, AccessArray)
   BasicType elt_type() const                     { return _elt_type; }
   bool mismatched() const                        { return _mismatched; }
 
-  void clear_length()                            { _length = NULL; }
+  void clear_length()                            { _length = nullptr; }
   // perform elimination of range checks involving constants
   bool compute_needs_range_check();
 
   // generic
-  virtual void input_values_do(ValueVisitor* f)   { AccessArray::input_values_do(f); f->visit(&_index); if (_length != NULL) f->visit(&_length); }
+  virtual void input_values_do(ValueVisitor* f)   { AccessArray::input_values_do(f); f->visit(&_index); if (_length != nullptr) f->visit(&_length); }
 };
 
 
@@ -941,7 +941,7 @@ LEAF(LoadIndexed, AccessIndexed)
   // creation
   LoadIndexed(Value array, Value index, Value length, BasicType elt_type, ValueStack* state_before, bool mismatched = false)
   : AccessIndexed(array, index, length, elt_type, state_before, mismatched)
-  , _explicit_null_check(NULL) {}
+  , _explicit_null_check(nullptr) {}
 
   // accessors
   NullCheck* explicit_null_check() const         { return _explicit_null_check; }
@@ -971,7 +971,7 @@ LEAF(StoreIndexed, AccessIndexed)
   StoreIndexed(Value array, Value index, Value length, BasicType elt_type, Value value, ValueStack* state_before,
                bool check_boolean, bool mismatched = false)
   : AccessIndexed(array, index, length, elt_type, state_before, mismatched)
-  , _value(value), _profiled_method(NULL), _profiled_bci(0), _check_boolean(check_boolean)
+  , _value(value), _profiled_method(nullptr), _profiled_bci(0), _check_boolean(check_boolean)
   {
     set_flag(NeedsWriteBarrierFlag, (as_ValueType(elt_type)->is_object()));
     set_flag(NeedsStoreCheckFlag, (as_ValueType(elt_type)->is_object()));
@@ -1022,7 +1022,7 @@ BASE(Op2, Instruction)
 
  public:
   // creation
-  Op2(ValueType* type, Bytecodes::Code op, Value x, Value y, ValueStack* state_before = NULL)
+  Op2(ValueType* type, Bytecodes::Code op, Value x, Value y, ValueStack* state_before = nullptr)
   : Instruction(type, state_before)
   , _op(op)
   , _x(x)
@@ -1207,9 +1207,9 @@ BASE(StateSplit, Instruction)
 
  public:
   // creation
-  StateSplit(ValueType* type, ValueStack* state_before = NULL)
+  StateSplit(ValueType* type, ValueStack* state_before = nullptr)
   : Instruction(type, state_before)
-  , _state(NULL)
+  , _state(nullptr)
   {
     pin(PinStateSplitConstructor);
   }
@@ -1219,7 +1219,7 @@ BASE(StateSplit, Instruction)
   IRScope* scope() const;                        // the state's scope
 
   // manipulation
-  void set_state(ValueStack* state)              { assert(_state == NULL, "overwriting existing state"); check_state(state); _state = state; }
+  void set_state(ValueStack* state)              { assert(_state == nullptr, "overwriting existing state"); check_state(state); _state = state; }
 
   // generic
   virtual void input_values_do(ValueVisitor* f)   { /* no values */ }
@@ -1243,7 +1243,7 @@ LEAF(Invoke, StateSplit)
   // accessors
   Bytecodes::Code code() const                   { return _code; }
   Value receiver() const                         { return _recv; }
-  bool has_receiver() const                      { return receiver() != NULL; }
+  bool has_receiver() const                      { return receiver() != nullptr; }
   int number_of_arguments() const                { return _args->length(); }
   Value argument_at(int i) const                 { return _args->at(i); }
   BasicTypeList* signature() const               { return _signature; }
@@ -1307,7 +1307,7 @@ BASE(NewArray, StateSplit)
   : StateSplit(objectType, state_before)
   , _length(length)
   {
-    // Do not ASSERT_VALUES since length is NULL for NewMultiArray
+    // Do not ASSERT_VALUES since length is null for NewMultiArray
   }
 
   // accessors
@@ -1315,7 +1315,7 @@ BASE(NewArray, StateSplit)
 
   virtual bool needs_exception_state() const     { return false; }
 
-  ciType* exact_type() const                     { return NULL; }
+  ciType* exact_type() const                     { return nullptr; }
   ciType* declared_type() const;
 
   // generic
@@ -1362,7 +1362,7 @@ LEAF(NewMultiArray, NewArray)
 
  public:
   // creation
-  NewMultiArray(ciKlass* klass, Values* dims, ValueStack* state_before) : NewArray(NULL, state_before), _klass(klass), _dims(dims) {
+  NewMultiArray(ciKlass* klass, Values* dims, ValueStack* state_before) : NewArray(nullptr, state_before), _klass(klass), _dims(dims) {
     ASSERT_VALUES
   }
 
@@ -1397,7 +1397,7 @@ BASE(TypeCheck, StateSplit)
   // creation
   TypeCheck(ciKlass* klass, Value obj, ValueType* type, ValueStack* state_before)
   : StateSplit(type, state_before), _klass(klass), _obj(obj),
-    _profiled_method(NULL), _profiled_bci(0) {
+    _profiled_method(nullptr), _profiled_bci(0) {
     ASSERT_VALUES
     set_direct_compare(false);
   }
@@ -1405,7 +1405,7 @@ BASE(TypeCheck, StateSplit)
   // accessors
   ciKlass* klass() const                         { return _klass; }
   Value obj() const                              { return _obj; }
-  bool is_loaded() const                         { return klass() != NULL; }
+  bool is_loaded() const                         { return klass() != nullptr; }
   bool direct_compare() const                    { return check_flag(DirectCompareFlag); }
 
   // manipulation
@@ -1468,7 +1468,7 @@ BASE(AccessMonitor, StateSplit)
 
  public:
   // creation
-  AccessMonitor(Value obj, int monitor_no, ValueStack* state_before = NULL)
+  AccessMonitor(Value obj, int monitor_no, ValueStack* state_before = nullptr)
   : StateSplit(illegalType, state_before)
   , _obj(obj)
   , _monitor_no(monitor_no)
@@ -1504,7 +1504,7 @@ LEAF(MonitorExit, AccessMonitor)
  public:
   // creation
   MonitorExit(Value obj, int monitor_no)
-  : AccessMonitor(obj, monitor_no, NULL)
+  : AccessMonitor(obj, monitor_no, nullptr)
   {
     ASSERT_VALUES
   }
@@ -1536,9 +1536,9 @@ LEAF(Intrinsic, StateSplit)
   : StateSplit(type, state_before)
   , _id(id)
   , _args(args)
-  , _recv(NULL)
+  , _recv(nullptr)
   {
-    assert(args != NULL, "args must exist");
+    assert(args != nullptr, "args must exist");
     ASSERT_VALUES
     set_flag(PreservesStateFlag, preserves_state);
     set_flag(CanTrapFlag,        cantrap);
@@ -1558,7 +1558,7 @@ LEAF(Intrinsic, StateSplit)
   int number_of_arguments() const                { return _args->length(); }
   Value argument_at(int i) const                 { return _args->at(i); }
 
-  bool has_receiver() const                      { return (_recv != NULL); }
+  bool has_receiver() const                      { return (_recv != nullptr); }
   Value receiver() const                         { assert(has_receiver(), "must have receiver"); return _recv; }
   bool preserves_state() const                   { return check_flag(PreservesStateFlag); }
 
@@ -1652,18 +1652,18 @@ LEAF(BlockBegin, StateSplit)
   , _stores_to_locals()
   , _predecessors(2)
   , _dominates(2)
-  , _dominator(NULL)
-  , _end(NULL)
+  , _dominator(nullptr)
+  , _end(nullptr)
   , _exception_handlers(1)
-  , _exception_states(NULL)
+  , _exception_states(nullptr)
   , _exception_handler_pco(-1)
-  , _lir(NULL)
+  , _lir(nullptr)
   , _live_in()
   , _live_out()
   , _live_gen()
   , _live_kill()
   , _fpu_register_usage()
-  , _fpu_stack_state(NULL)
+  , _fpu_stack_state(nullptr)
   , _first_lir_instruction_id(-1)
   , _last_lir_instruction_id(-1)
   {
@@ -1739,7 +1739,7 @@ LEAF(BlockBegin, StateSplit)
   BlockBegin* exception_handler_at(int i) const  { return _exception_handlers.at(i); }
 
   // states of the instructions that have an edge to this exception handler
-  int number_of_exception_states()               { assert(is_set(exception_entry_flag), "only for xhandlers"); return _exception_states == NULL ? 0 : _exception_states->length(); }
+  int number_of_exception_states()               { assert(is_set(exception_entry_flag), "only for xhandlers"); return _exception_states == nullptr ? 0 : _exception_states->length(); }
   ValueStack* exception_state_at(int idx) const  { assert(is_set(exception_entry_flag), "only for xhandlers"); return _exception_states->at(idx); }
   int add_exception_state(ValueStack* state);
 
@@ -1801,8 +1801,8 @@ BASE(BlockEnd, StateSplit)
 
   void set_sux(BlockList* sux) {
 #ifdef ASSERT
-    assert(sux != NULL, "sux must exist");
-    for (int i = sux->length() - 1; i >= 0; i--) assert(sux->at(i) != NULL, "sux must exist");
+    assert(sux != nullptr, "sux must exist");
+    for (int i = sux->length() - 1; i >= 0; i--) assert(sux->at(i) != nullptr, "sux must exist");
 #endif
     _sux = sux;
   }
@@ -1811,7 +1811,7 @@ BASE(BlockEnd, StateSplit)
   // creation
   BlockEnd(ValueType* type, ValueStack* state_before, bool is_safepoint)
   : StateSplit(type, state_before)
-  , _sux(NULL)
+  , _sux(nullptr)
   {
     set_flag(IsSafepointFlag, is_safepoint);
   }
@@ -1826,9 +1826,9 @@ BASE(BlockEnd, StateSplit)
   inline int find_sux(BlockBegin* sux) {return _sux->find(sux);}
 
   // successors
-  int number_of_sux() const                      { return _sux != NULL ? _sux->length() : 0; }
+  int number_of_sux() const                      { return _sux != nullptr ? _sux->length() : 0; }
   BlockBegin* sux_at(int i) const                { return _sux->at(i); }
-  bool is_sux(BlockBegin* sux) const             { return _sux == NULL ? false : _sux->contains(sux); }
+  bool is_sux(BlockBegin* sux) const             { return _sux == nullptr ? false : _sux->contains(sux); }
   BlockBegin* default_sux() const                { return sux_at(number_of_sux() - 1); }
   void substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux);
 };
@@ -1848,7 +1848,7 @@ LEAF(Goto, BlockEnd)
   // creation
   Goto(BlockBegin* sux, ValueStack* state_before, bool is_safepoint = false)
     : BlockEnd(illegalType, state_before, is_safepoint)
-    , _profiled_method(NULL)
+    , _profiled_method(nullptr)
     , _profiled_bci(0)
     , _direction(none) {
     BlockList* s = new BlockList(1);
@@ -1856,8 +1856,8 @@ LEAF(Goto, BlockEnd)
     set_sux(s);
   }
 
-  Goto(BlockBegin* sux, bool is_safepoint) : BlockEnd(illegalType, NULL, is_safepoint)
-                                           , _profiled_method(NULL)
+  Goto(BlockBegin* sux, bool is_safepoint) : BlockEnd(illegalType, nullptr, is_safepoint)
+                                           , _profiled_method(nullptr)
                                            , _profiled_bci(0)
                                            , _direction(none) {
     BlockList* s = new BlockList(1);
@@ -1928,7 +1928,7 @@ LEAF(RangeCheckPredicate, StateSplit)
   RangeCheckPredicate(ValueStack* state) : StateSplit(illegalType)
   {
     this->set_state(state);
-    _x = _y = NULL;
+    _x = _y = nullptr;
     check_state();
   }
 
@@ -1938,7 +1938,7 @@ LEAF(RangeCheckPredicate, StateSplit)
   bool unordered_is_true() const                 { return check_flag(UnorderedIsTrueFlag); }
   Value y() const                                { return _y; }
 
-  void always_fail()                             { _x = _y = NULL; }
+  void always_fail()                             { _x = _y = nullptr; }
 
   // generic
   virtual void input_values_do(ValueVisitor* f)  { StateSplit::input_values_do(f); f->visit(&_x); f->visit(&_y); }
@@ -1962,7 +1962,7 @@ LEAF(If, BlockEnd)
   , _x(x)
   , _cond(cond)
   , _y(y)
-  , _profiled_method(NULL)
+  , _profiled_method(nullptr)
   , _profiled_bci(0)
   , _swapped(false)
   {
@@ -2053,7 +2053,7 @@ LEAF(LookupSwitch, Switch)
   LookupSwitch(Value tag, BlockList* sux, intArray* keys, ValueStack* state_before, bool is_safepoint)
   : Switch(tag, sux, state_before, is_safepoint)
   , _keys(keys) {
-    assert(keys != NULL, "keys must exist");
+    assert(keys != nullptr, "keys must exist");
     assert(keys->length() == length(), "sux & keys have incompatible lengths");
   }
 
@@ -2069,12 +2069,12 @@ LEAF(Return, BlockEnd)
  public:
   // creation
   Return(Value result) :
-    BlockEnd(result == NULL ? voidType : result->type()->base(), NULL, true),
+    BlockEnd(result == nullptr ? voidType : result->type()->base(), nullptr, true),
     _result(result) {}
 
   // accessors
   Value result() const                           { return _result; }
-  bool has_result() const                        { return result() != NULL; }
+  bool has_result() const                        { return result() != nullptr; }
 
   // generic
   virtual void input_values_do(ValueVisitor* f) {
@@ -2106,18 +2106,18 @@ LEAF(Throw, BlockEnd)
 LEAF(Base, BlockEnd)
  public:
   // creation
-  Base(BlockBegin* std_entry, BlockBegin* osr_entry) : BlockEnd(illegalType, NULL, false) {
+  Base(BlockBegin* std_entry, BlockBegin* osr_entry) : BlockEnd(illegalType, nullptr, false) {
     assert(std_entry->is_set(BlockBegin::std_entry_flag), "std entry must be flagged");
-    assert(osr_entry == NULL || osr_entry->is_set(BlockBegin::osr_entry_flag), "osr entry must be flagged");
+    assert(osr_entry == nullptr || osr_entry->is_set(BlockBegin::osr_entry_flag), "osr entry must be flagged");
     BlockList* s = new BlockList(2);
-    if (osr_entry != NULL) s->append(osr_entry);
+    if (osr_entry != nullptr) s->append(osr_entry);
     s->append(std_entry); // must be default sux!
     set_sux(s);
   }
 
   // accessors
   BlockBegin* std_entry() const                  { return default_sux(); }
-  BlockBegin* osr_entry() const                  { return number_of_sux() < 2 ? NULL : sux_at(0); }
+  BlockBegin* osr_entry() const                  { return number_of_sux() < 2 ? nullptr : sux_at(0); }
 };
 
 
@@ -2296,7 +2296,7 @@ LEAF(ProfileCall, Instruction)
   ciMethod* callee()             const { return _callee; }
   Value recv()                   const { return _recv; }
   ciKlass* known_holder()        const { return _known_holder; }
-  int nb_profiled_args()         const { return _obj_args == NULL ? 0 : _obj_args->length(); }
+  int nb_profiled_args()         const { return _obj_args == nullptr ? 0 : _obj_args->length(); }
   Value profiled_arg_at(int i)   const { return _obj_args->at(i); }
   bool arg_needs_null_check(int i) const {
     return _nonnull_state.arg_needs_null_check(i);
@@ -2308,7 +2308,7 @@ LEAF(ProfileCall, Instruction)
   }
 
   virtual void input_values_do(ValueVisitor* f)   {
-    if (_recv != NULL) {
+    if (_recv != nullptr) {
       f->visit(&_recv);
     }
     for (int i = 0; i < nb_profiled_args(); i++) {
@@ -2343,7 +2343,7 @@ LEAF(ProfileReturnType, Instruction)
   Value ret()                    const { return _ret; }
 
   virtual void input_values_do(ValueVisitor* f)   {
-    if (_ret != NULL) {
+    if (_ret != nullptr) {
       f->visit(&_ret);
     }
   }
@@ -2436,8 +2436,8 @@ class BlockPair: public CompilationResourceObj {
 
 typedef GrowableArray<BlockPair*> BlockPairList;
 
-inline int         BlockBegin::number_of_sux() const            { assert(_end != NULL, "need end"); return _end->number_of_sux(); }
-inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end != NULL , "need end"); return _end->sux_at(i); }
+inline int         BlockBegin::number_of_sux() const            { assert(_end != nullptr, "need end"); return _end->number_of_sux(); }
+inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end != nullptr , "need end"); return _end->sux_at(i); }
 
 #undef ASSERT_VALUES
 

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 
 const char* InstructionPrinter::basic_type_name(BasicType type) {
   const char* n = type2name(type);
-  if (n == NULL || type > T_VOID) {
+  if (n == nullptr || type > T_VOID) {
     return "???";
   }
   return n;
@@ -54,7 +54,7 @@ const char* InstructionPrinter::cond_name(If::Condition cond) {
     case If::beq: return "|<=|";
     default:
       ShouldNotReachHere();
-      return NULL;
+      return nullptr;
   }
 }
 
@@ -102,7 +102,7 @@ const char* InstructionPrinter::op_name(Bytecodes::Code op) {
 
 
 bool InstructionPrinter::is_illegal_phi(Value v) {
-  Phi* phi = v ? v->as_Phi() : NULL;
+  Phi* phi = v ? v->as_Phi() : nullptr;
   if (phi && phi->is_illegal()) {
     return true;
   }
@@ -111,7 +111,7 @@ bool InstructionPrinter::is_illegal_phi(Value v) {
 
 
 bool InstructionPrinter::is_phi_of_block(Value v, BlockBegin* b) {
-  Phi* phi = v ? v->as_Phi() : NULL;
+  Phi* phi = v ? v->as_Phi() : nullptr;
   return phi && phi->block() == b;
 }
 
@@ -123,7 +123,7 @@ void InstructionPrinter::print_klass(ciKlass* klass) {
 
 void InstructionPrinter::print_object(Value obj) {
   ValueType* type = obj->type();
-  if (type->as_ObjectConstant() != NULL) {
+  if (type->as_ObjectConstant() != nullptr) {
     ciObject* value = type->as_ObjectConstant()->value();
     if (value->is_null_object()) {
       output()->print("null");
@@ -134,7 +134,7 @@ void InstructionPrinter::print_object(Value obj) {
       print_klass(value->klass());
       output()->print(">");
     }
-  } else if (type->as_InstanceConstant() != NULL) {
+  } else if (type->as_InstanceConstant() != nullptr) {
     ciInstance* value = type->as_InstanceConstant()->value();
     if (value->is_loaded()) {
       output()->print("<instance " INTPTR_FORMAT " klass=", p2i(value->constant_encoding()));
@@ -143,16 +143,16 @@ void InstructionPrinter::print_object(Value obj) {
     } else {
       output()->print("<unloaded instance " INTPTR_FORMAT ">", p2i(value));
     }
-  } else if (type->as_ArrayConstant() != NULL) {
+  } else if (type->as_ArrayConstant() != nullptr) {
     output()->print("<array " INTPTR_FORMAT ">", p2i(type->as_ArrayConstant()->value()->constant_encoding()));
-  } else if (type->as_ClassConstant() != NULL) {
+  } else if (type->as_ClassConstant() != nullptr) {
     ciInstanceKlass* klass = type->as_ClassConstant()->value();
     if (!klass->is_loaded()) {
       output()->print("<unloaded> ");
     }
     output()->print("class ");
     print_klass(klass);
-  } else if (type->as_MethodConstant() != NULL) {
+  } else if (type->as_MethodConstant() != nullptr) {
     ciMethod* m = type->as_MethodConstant()->value();
     output()->print("<method %s.%s>", m->holder()->name()->as_utf8(), m->name()->as_utf8());
   } else {
@@ -177,7 +177,7 @@ void InstructionPrinter::print_indexed(AccessIndexed* indexed) {
   output()->put('[');
   print_value(indexed->index());
   output()->put(']');
-  if (indexed->length() != NULL) {
+  if (indexed->length() != nullptr) {
     output()->put('(');
     print_value(indexed->length());
     output()->put(')');
@@ -200,8 +200,8 @@ void InstructionPrinter::print_op2(Op2* instr) {
 
 
 void InstructionPrinter::print_value(Value value) {
-  if (value == NULL) {
-    output()->print("NULL");
+  if (value == nullptr) {
+    output()->print("null");
   } else {
     print_temp(value);
   }
@@ -225,7 +225,7 @@ void InstructionPrinter::print_stack(ValueStack* stack) {
       Value value = stack->stack_at_inc(i);
       print_value(value);
       Phi* phi = value->as_Phi();
-      if (phi != NULL) {
+      if (phi != nullptr) {
         if (phi->operand()->is_valid()) {
           output()->print(" ");
           phi->operand()->print(output());
@@ -244,7 +244,7 @@ void InstructionPrinter::print_stack(ValueStack* stack) {
       Value t = stack->lock_at(i);
       if (i > 0) output()->print(", ");
       output()->print("%d:", i);
-      if (t == NULL) {
+      if (t == nullptr) {
         // synchronized methods push null on the lock stack
         output()->print("this");
       } else {
@@ -280,7 +280,7 @@ void InstructionPrinter::print_phi(int i, Value v, BlockBegin* b) {
       output()->print(" ");
       Value opd = phi->operand_at(j);
       if (opd) print_value(opd);
-      else output()->print("NULL");
+      else output()->print("null");
     }
     output()->print("] ");
   }
@@ -324,7 +324,7 @@ void InstructionPrinter::print_line(Instruction* instr) {
   // add a line for StateSplit instructions w/ non-empty stacks
   // (make it robust so we can print incomplete instructions)
   StateSplit* split = instr->as_StateSplit();
-  if (split != NULL && split->state() != NULL && !split->state()->stack_is_empty()) {
+  if (split != nullptr && split->state() != nullptr && !split->state()->stack_is_empty()) {
     fill_to(instr_pos); print_stack(split->state());
     output()->cr();
   }
@@ -464,7 +464,7 @@ void InstructionPrinter::do_TypeCast(TypeCast* x) {
 
 
 void InstructionPrinter::do_Invoke(Invoke* x) {
-  if (x->receiver() != NULL) {
+  if (x->receiver() != nullptr) {
     print_value(x->receiver());
     output()->print(".");
   }
@@ -532,13 +532,13 @@ void InstructionPrinter::do_Intrinsic(Intrinsic* x) {
   const char* name = vmIntrinsics::name_at(x->id());
   if (name[0] == '_')  name++;  // strip leading bug from _hashCode, etc.
   const char* kname = vmSymbols::name_for(vmIntrinsics::class_for(x->id()));
-  if (strchr(name, '_') == NULL) {
-    kname = NULL;
+  if (strchr(name, '_') == nullptr) {
+    kname = nullptr;
   } else {
     const char* kptr = strrchr(kname, '/');
-    if (kptr != NULL)  kname = kptr + 1;
+    if (kptr != nullptr)  kname = kptr + 1;
   }
-  if (kname == NULL)
+  if (kname == nullptr)
     output()->print("%s(", name);
   else
     output()->print("%s.%s(", kname, name);
@@ -588,10 +588,10 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
   if (printed_flag) output()->print(") ");
 
   // print block bci range
-  output()->print("[%d, %d]", x->bci(), (end == NULL ? -1 : end->printable_bci()));
+  output()->print("[%d, %d]", x->bci(), (end == nullptr ? -1 : end->printable_bci()));
 
   // print block successors
-  if (end != NULL && end->number_of_sux() > 0) {
+  if (end != nullptr && end->number_of_sux() > 0) {
     output()->print(" ->");
     for (int i = 0; i < end->number_of_sux(); i++) {
       output()->print(" B%d", end->sux_at(i)->block_id());
@@ -608,7 +608,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
   }
 
   // print dominator block
-  if (x->dominator() != NULL) {
+  if (x->dominator() != nullptr) {
     output()->print(" dom B%d", x->dominator()->block_id());
   }
 
@@ -645,7 +645,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
         if (v && !v->type()->is_illegal()) i += v->type()->size(); else i ++;
       }
       state = state->caller_state();
-    } while (state != NULL);
+    } while (state != nullptr);
 
   }
 
@@ -667,7 +667,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
       }
       output()->cr();
       state = state->caller_state();
-    } while (state != NULL);
+    } while (state != nullptr);
   }
 
   // print values on stack
@@ -748,7 +748,7 @@ void InstructionPrinter::do_LookupSwitch(LookupSwitch* x) {
 
 
 void InstructionPrinter::do_Return(Return* x) {
-  if (x->result() == NULL) {
+  if (x->result() == nullptr) {
     output()->print("return");
   } else {
     output()->print("%creturn ", x->type()->tchar());
@@ -807,7 +807,7 @@ void InstructionPrinter::do_UnsafeGetAndSet(UnsafeGetAndSet* x) {
 
 void InstructionPrinter::do_RangeCheckPredicate(RangeCheckPredicate* x) {
 
-  if (x->x() != NULL && x->y() != NULL) {
+  if (x->x() != nullptr && x->y() != nullptr) {
     output()->print("if ");
     print_value(x->x());
     output()->print(" %s ", cond_name(x->cond()));
@@ -831,7 +831,7 @@ void InstructionPrinter::do_ProfileCall(ProfileCall* x) {
   output()->print("profile ");
   print_value(x->recv());
   output()->print(" %s.%s", x->method()->holder()->name()->as_utf8(), x->method()->name()->as_utf8());
-  if (x->known_holder() != NULL) {
+  if (x->known_holder() != nullptr) {
     output()->print(", ");
     print_klass(x->known_holder());
     output()->print(" ");

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -510,9 +510,9 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
       if (opBranch->_opr1->is_valid()) do_input(opBranch->_opr1);
       if (opBranch->_opr2->is_valid()) do_input(opBranch->_opr2);
 
-      if (opBranch->_info != nullptr)     do_info(opBranch->_info);
+      if (opBranch->_info != nullptr)  do_info(opBranch->_info);
       assert(opBranch->_result->is_illegal(), "not used");
-      if (opBranch->_stub != nullptr)     opBranch->stub()->visit(this);
+      if (opBranch->_stub != nullptr)  opBranch->stub()->visit(this);
 
       break;
     }
@@ -2071,7 +2071,7 @@ void LIR_OpProfileCall::print_instr(outputStream* out) const {
 // LIR_OpProfileType
 void LIR_OpProfileType::print_instr(outputStream* out) const {
   out->print("exact = ");
-  if  (exact_klass() == nullptr) {
+  if (exact_klass() == nullptr) {
     out->print("unknown");
   } else {
     exact_klass()->print_name_on(out);

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -53,13 +53,13 @@ LIR_Opr LIR_OprFact::value_type(ValueType* type) {
   switch (tag) {
   case metaDataTag : {
     ClassConstant* c = type->as_ClassConstant();
-    if (c != NULL && !c->value()->is_loaded()) {
-      return LIR_OprFact::metadataConst(NULL);
-    } else if (c != NULL) {
+    if (c != nullptr && !c->value()->is_loaded()) {
+      return LIR_OprFact::metadataConst(nullptr);
+    } else if (c != nullptr) {
       return LIR_OprFact::metadataConst(c->value()->constant_encoding());
     } else {
       MethodConstant* m = type->as_MethodConstant();
-      assert (m != NULL, "not a class or a method?");
+      assert (m != nullptr, "not a class or a method?");
       return LIR_OprFact::metadataConst(m->value()->constant_encoding());
     }
   }
@@ -236,32 +236,32 @@ void LIR_Op2::verify() const {
 
 
 LIR_OpBranch::LIR_OpBranch(LIR_Condition cond, BlockBegin* block)
-  : LIR_Op2(lir_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*)NULL)
+  : LIR_Op2(lir_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*)nullptr)
   , _label(block->label())
   , _block(block)
-  , _ublock(NULL)
-  , _stub(NULL) {
+  , _ublock(nullptr)
+  , _stub(nullptr) {
 }
 
 LIR_OpBranch::LIR_OpBranch(LIR_Condition cond, CodeStub* stub) :
-  LIR_Op2(lir_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*)NULL)
+  LIR_Op2(lir_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*)nullptr)
   , _label(stub->entry())
-  , _block(NULL)
-  , _ublock(NULL)
+  , _block(nullptr)
+  , _ublock(nullptr)
   , _stub(stub) {
 }
 
 LIR_OpBranch::LIR_OpBranch(LIR_Condition cond, BlockBegin* block, BlockBegin* ublock)
-  : LIR_Op2(lir_cond_float_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*)NULL)
+  : LIR_Op2(lir_cond_float_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*)nullptr)
   , _label(block->label())
   , _block(block)
   , _ublock(ublock)
-  , _stub(NULL)
+  , _stub(nullptr)
 {
 }
 
 void LIR_OpBranch::change_block(BlockBegin* b) {
-  assert(_block != NULL, "must have old block");
+  assert(_block != nullptr, "must have old block");
   assert(_block->label() == label(), "must be equal");
 
   _block = b;
@@ -269,7 +269,7 @@ void LIR_OpBranch::change_block(BlockBegin* b) {
 }
 
 void LIR_OpBranch::change_ublock(BlockBegin* b) {
-  assert(_ublock != NULL, "must have old block");
+  assert(_ublock != nullptr, "must have old block");
   _ublock = b;
 }
 
@@ -291,7 +291,7 @@ LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr result, LIR_Opr object, 
                                  bool fast_check, CodeEmitInfo* info_for_exception, CodeEmitInfo* info_for_patch,
                                  CodeStub* stub)
 
-  : LIR_Op(code, result, NULL)
+  : LIR_Op(code, result, nullptr)
   , _object(object)
   , _array(LIR_OprFact::illegalOpr)
   , _klass(klass)
@@ -302,14 +302,14 @@ LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr result, LIR_Opr object, 
   , _info_for_patch(info_for_patch)
   , _info_for_exception(info_for_exception)
   , _stub(stub)
-  , _profiled_method(NULL)
+  , _profiled_method(nullptr)
   , _profiled_bci(-1)
   , _should_profile(false)
 {
   if (code == lir_checkcast) {
-    assert(info_for_exception != NULL, "checkcast throws exceptions");
+    assert(info_for_exception != nullptr, "checkcast throws exceptions");
   } else if (code == lir_instanceof) {
-    assert(info_for_exception == NULL, "instanceof throws no exceptions");
+    assert(info_for_exception == nullptr, "instanceof throws no exceptions");
   } else {
     ShouldNotReachHere();
   }
@@ -318,24 +318,24 @@ LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr result, LIR_Opr object, 
 
 
 LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, CodeEmitInfo* info_for_exception)
-  : LIR_Op(code, LIR_OprFact::illegalOpr, NULL)
+  : LIR_Op(code, LIR_OprFact::illegalOpr, nullptr)
   , _object(object)
   , _array(array)
-  , _klass(NULL)
+  , _klass(nullptr)
   , _tmp1(tmp1)
   , _tmp2(tmp2)
   , _tmp3(tmp3)
   , _fast_check(false)
-  , _info_for_patch(NULL)
+  , _info_for_patch(nullptr)
   , _info_for_exception(info_for_exception)
-  , _stub(NULL)
-  , _profiled_method(NULL)
+  , _stub(nullptr)
+  , _profiled_method(nullptr)
   , _profiled_bci(-1)
   , _should_profile(false)
 {
   if (code == lir_store_check) {
     _stub = new ArrayStoreExceptionStub(object, info_for_exception);
-    assert(info_for_exception != NULL, "store_check throws exceptions");
+    assert(info_for_exception != nullptr, "store_check throws exceptions");
   } else {
     ShouldNotReachHere();
   }
@@ -357,7 +357,7 @@ LIR_OpArrayCopy::LIR_OpArrayCopy(LIR_Opr src, LIR_Opr src_pos, LIR_Opr dst, LIR_
 }
 
 LIR_OpUpdateCRC32::LIR_OpUpdateCRC32(LIR_Opr crc, LIR_Opr val, LIR_Opr res)
-  : LIR_Op(lir_updatecrc32, res, NULL)
+  : LIR_Op(lir_updatecrc32, res, nullptr)
   , _crc(crc)
   , _val(val) {
 }
@@ -409,8 +409,8 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_membar_storeload:         // result and info always invalid
     case lir_on_spin_wait:
     {
-      assert(op->as_Op0() != NULL, "must be");
-      assert(op->_info == NULL, "info not used by this instruction");
+      assert(op->as_Op0() != nullptr, "must be");
+      assert(op->_info == nullptr, "info not used by this instruction");
       assert(op->_result->is_illegal(), "not used");
       break;
     }
@@ -420,8 +420,8 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_osr_entry:                // may have result, info always invalid
     case lir_get_thread:               // may have result, info always invalid
     {
-      assert(op->as_Op0() != NULL, "must be");
-      if (op->_info != NULL)           do_info(op->_info);
+      assert(op->as_Op0() != nullptr, "must be");
+      if (op->_info != nullptr)           do_info(op->_info);
       if (op->_result->is_valid())     do_output(op->_result);
       break;
     }
@@ -430,8 +430,8 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 // LIR_OpLabel
     case lir_label:                    // result and info always invalid
     {
-      assert(op->as_OpLabel() != NULL, "must be");
-      assert(op->_info == NULL, "info not used by this instruction");
+      assert(op->as_OpLabel() != nullptr, "must be");
+      assert(op->_info == nullptr, "info not used by this instruction");
       assert(op->_result->is_illegal(), "not used");
       break;
     }
@@ -447,7 +447,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_null_check:     // input and info always valid, result always invalid
     case lir_move:           // input and result always valid, may have info
     {
-      assert(op->as_Op1() != NULL, "must be");
+      assert(op->as_Op1() != nullptr, "must be");
       LIR_Op1* op1 = (LIR_Op1*)op;
 
       if (op1->_info)                  do_info(op1->_info);
@@ -459,23 +459,23 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
     case lir_return:
     {
-      assert(op->as_OpReturn() != NULL, "must be");
+      assert(op->as_OpReturn() != nullptr, "must be");
       LIR_OpReturn* op_ret = (LIR_OpReturn*)op;
 
       if (op_ret->_info)               do_info(op_ret->_info);
       if (op_ret->_opr->is_valid())    do_input(op_ret->_opr);
       if (op_ret->_result->is_valid()) do_output(op_ret->_result);
-      if (op_ret->stub() != NULL)      do_stub(op_ret->stub());
+      if (op_ret->stub() != nullptr)      do_stub(op_ret->stub());
 
       break;
     }
 
     case lir_safepoint:
     {
-      assert(op->as_Op1() != NULL, "must be");
+      assert(op->as_Op1() != nullptr, "must be");
       LIR_Op1* op1 = (LIR_Op1*)op;
 
-      assert(op1->_info != NULL, "");  do_info(op1->_info);
+      assert(op1->_info != nullptr, "");  do_info(op1->_info);
       if (op1->_opr->is_valid())       do_temp(op1->_opr); // safepoints on SPARC need temporary register
       assert(op1->_result->is_illegal(), "safepoint does not produce value");
 
@@ -485,10 +485,10 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 // LIR_OpConvert;
     case lir_convert:        // input and result always valid, info always invalid
     {
-      assert(op->as_OpConvert() != NULL, "must be");
+      assert(op->as_OpConvert() != nullptr, "must be");
       LIR_OpConvert* opConvert = (LIR_OpConvert*)op;
 
-      assert(opConvert->_info == NULL, "must be");
+      assert(opConvert->_info == nullptr, "must be");
       if (opConvert->_opr->is_valid())       do_input(opConvert->_opr);
       if (opConvert->_result->is_valid())    do_output(opConvert->_result);
       do_stub(opConvert->_stub);
@@ -500,7 +500,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_branch:                   // may have info, input and result register always invalid
     case lir_cond_float_branch:        // may have info, input and result register always invalid
     {
-      assert(op->as_OpBranch() != NULL, "must be");
+      assert(op->as_OpBranch() != nullptr, "must be");
       LIR_OpBranch* opBranch = (LIR_OpBranch*)op;
 
       assert(opBranch->_tmp1->is_illegal() && opBranch->_tmp2->is_illegal() &&
@@ -510,9 +510,9 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
       if (opBranch->_opr1->is_valid()) do_input(opBranch->_opr1);
       if (opBranch->_opr2->is_valid()) do_input(opBranch->_opr2);
 
-      if (opBranch->_info != NULL)     do_info(opBranch->_info);
+      if (opBranch->_info != nullptr)     do_info(opBranch->_info);
       assert(opBranch->_result->is_illegal(), "not used");
-      if (opBranch->_stub != NULL)     opBranch->stub()->visit(this);
+      if (opBranch->_stub != nullptr)     opBranch->stub()->visit(this);
 
       break;
     }
@@ -521,7 +521,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 // LIR_OpAllocObj
     case lir_alloc_object:
     {
-      assert(op->as_OpAllocObj() != NULL, "must be");
+      assert(op->as_OpAllocObj() != nullptr, "must be");
       LIR_OpAllocObj* opAllocObj = (LIR_OpAllocObj*)op;
 
       if (opAllocObj->_info)                     do_info(opAllocObj->_info);
@@ -540,10 +540,10 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpRoundFP;
     case lir_roundfp: {
-      assert(op->as_OpRoundFP() != NULL, "must be");
+      assert(op->as_OpRoundFP() != nullptr, "must be");
       LIR_OpRoundFP* opRoundFP = (LIR_OpRoundFP*)op;
 
-      assert(op->_info == NULL, "info not used by this instruction");
+      assert(op->_info == nullptr, "info not used by this instruction");
       assert(opRoundFP->_tmp->is_illegal(), "not used");
       do_input(opRoundFP->_opr);
       do_output(opRoundFP->_result);
@@ -575,7 +575,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_xchg:
     case lir_assert:
     {
-      assert(op->as_Op2() != NULL, "must be");
+      assert(op->as_Op2() != nullptr, "must be");
       LIR_Op2* op2 = (LIR_Op2*)op;
       assert(op2->_tmp2->is_illegal() && op2->_tmp3->is_illegal() &&
              op2->_tmp4->is_illegal() && op2->_tmp5->is_illegal(), "not used");
@@ -600,10 +600,10 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     // to the result operand, otherwise the backend fails
     case lir_cmove:
     {
-      assert(op->as_Op4() != NULL, "must be");
+      assert(op->as_Op4() != nullptr, "must be");
       LIR_Op4* op4 = (LIR_Op4*)op;
 
-      assert(op4->_info == NULL && op4->_tmp1->is_illegal() && op4->_tmp2->is_illegal() &&
+      assert(op4->_info == nullptr && op4->_tmp1->is_illegal() && op4->_tmp2->is_illegal() &&
              op4->_tmp3->is_illegal() && op4->_tmp4->is_illegal() && op4->_tmp5->is_illegal(), "not used");
       assert(op4->_opr1->is_valid() && op4->_opr2->is_valid() && op4->_result->is_valid(), "used");
 
@@ -623,10 +623,10 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_mul:
     case lir_div:
     {
-      assert(op->as_Op2() != NULL, "must be");
+      assert(op->as_Op2() != nullptr, "must be");
       LIR_Op2* op2 = (LIR_Op2*)op;
 
-      assert(op2->_info == NULL, "not used");
+      assert(op2->_info == nullptr, "not used");
       assert(op2->_opr1->is_valid(), "used");
       assert(op2->_opr2->is_valid(), "used");
       assert(op2->_result->is_valid(), "used");
@@ -642,7 +642,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     }
 
     case lir_throw: {
-      assert(op->as_Op2() != NULL, "must be");
+      assert(op->as_Op2() != nullptr, "must be");
       LIR_Op2* op2 = (LIR_Op2*)op;
 
       if (op2->_info)                     do_info(op2->_info);
@@ -656,10 +656,10 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     }
 
     case lir_unwind: {
-      assert(op->as_Op1() != NULL, "must be");
+      assert(op->as_Op1() != nullptr, "must be");
       LIR_Op1* op1 = (LIR_Op1*)op;
 
-      assert(op1->_info == NULL, "no info");
+      assert(op1->_info == nullptr, "no info");
       assert(op1->_opr->is_valid(), "exception oop");         do_input(op1->_opr);
       assert(op1->_result->is_illegal(), "no result");
 
@@ -669,7 +669,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 // LIR_Op3
     case lir_idiv:
     case lir_irem: {
-      assert(op->as_Op3() != NULL, "must be");
+      assert(op->as_Op3() != nullptr, "must be");
       LIR_Op3* op3= (LIR_Op3*)op;
 
       if (op3->_info)                     do_info(op3->_info);
@@ -688,9 +688,9 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
     case lir_fmad:
     case lir_fmaf: {
-      assert(op->as_Op3() != NULL, "must be");
+      assert(op->as_Op3() != nullptr, "must be");
       LIR_Op3* op3= (LIR_Op3*)op;
-      assert(op3->_info == NULL, "no info");
+      assert(op3->_info == nullptr, "no info");
       do_input(op3->_opr1);
       do_input(op3->_opr2);
       do_input(op3->_opr3);
@@ -704,7 +704,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_icvirtual_call:
     case lir_dynamic_call: {
       LIR_OpJavaCall* opJavaCall = op->as_OpJavaCall();
-      assert(opJavaCall != NULL, "must be");
+      assert(opJavaCall != nullptr, "must be");
 
       if (opJavaCall->_receiver->is_valid())     do_input(opJavaCall->_receiver);
 
@@ -731,7 +731,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpRTCall
     case lir_rtcall: {
-      assert(op->as_OpRTCall() != NULL, "must be");
+      assert(op->as_OpRTCall() != nullptr, "must be");
       LIR_OpRTCall* opRTCall = (LIR_OpRTCall*)op;
 
       // only visit register parameters
@@ -752,7 +752,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpArrayCopy
     case lir_arraycopy: {
-      assert(op->as_OpArrayCopy() != NULL, "must be");
+      assert(op->as_OpArrayCopy() != nullptr, "must be");
       LIR_OpArrayCopy* opArrayCopy = (LIR_OpArrayCopy*)op;
 
       assert(opArrayCopy->_result->is_illegal(), "unused");
@@ -773,13 +773,13 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpUpdateCRC32
     case lir_updatecrc32: {
-      assert(op->as_OpUpdateCRC32() != NULL, "must be");
+      assert(op->as_OpUpdateCRC32() != nullptr, "must be");
       LIR_OpUpdateCRC32* opUp = (LIR_OpUpdateCRC32*)op;
 
       assert(opUp->_crc->is_valid(), "used");          do_input(opUp->_crc);     do_temp(opUp->_crc);
       assert(opUp->_val->is_valid(), "used");          do_input(opUp->_val);     do_temp(opUp->_val);
       assert(opUp->_result->is_valid(), "used");       do_output(opUp->_result);
-      assert(opUp->_info == NULL, "no info for LIR_OpUpdateCRC32");
+      assert(opUp->_info == nullptr, "no info for LIR_OpUpdateCRC32");
 
       break;
     }
@@ -788,7 +788,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 // LIR_OpLock
     case lir_lock:
     case lir_unlock: {
-      assert(op->as_OpLock() != NULL, "must be");
+      assert(op->as_OpLock() != nullptr, "must be");
       LIR_OpLock* opLock = (LIR_OpLock*)op;
 
       if (opLock->_info)                          do_info(opLock->_info);
@@ -810,7 +810,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpDelay
     case lir_delay_slot: {
-      assert(op->as_OpDelay() != NULL, "must be");
+      assert(op->as_OpDelay() != nullptr, "must be");
       LIR_OpDelay* opDelay = (LIR_OpDelay*)op;
 
       visit(opDelay->delay_op());
@@ -821,7 +821,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_instanceof:
     case lir_checkcast:
     case lir_store_check: {
-      assert(op->as_OpTypeCheck() != NULL, "must be");
+      assert(op->as_OpTypeCheck() != nullptr, "must be");
       LIR_OpTypeCheck* opTypeCheck = (LIR_OpTypeCheck*)op;
 
       if (opTypeCheck->_info_for_exception)       do_info(opTypeCheck->_info_for_exception);
@@ -843,7 +843,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_cas_long:
     case lir_cas_obj:
     case lir_cas_int: {
-      assert(op->as_OpCompareAndSwap() != NULL, "must be");
+      assert(op->as_OpCompareAndSwap() != nullptr, "must be");
       LIR_OpCompareAndSwap* opCmpAndSwap = (LIR_OpCompareAndSwap*)op;
 
       if (opCmpAndSwap->_info)                              do_info(opCmpAndSwap->_info);
@@ -863,7 +863,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpAllocArray;
     case lir_alloc_array: {
-      assert(op->as_OpAllocArray() != NULL, "must be");
+      assert(op->as_OpAllocArray() != nullptr, "must be");
       LIR_OpAllocArray* opAllocArray = (LIR_OpAllocArray*)op;
 
       if (opAllocArray->_info)                        do_info(opAllocArray->_info);
@@ -886,7 +886,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_load_klass:
     {
       LIR_OpLoadKlass* opLoadKlass = op->as_OpLoadKlass();
-      assert(opLoadKlass != NULL, "must be");
+      assert(opLoadKlass != nullptr, "must be");
 
       do_input(opLoadKlass->_obj);
       do_output(opLoadKlass->_result);
@@ -897,7 +897,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpProfileCall:
     case lir_profile_call: {
-      assert(op->as_OpProfileCall() != NULL, "must be");
+      assert(op->as_OpProfileCall() != nullptr, "must be");
       LIR_OpProfileCall* opProfileCall = (LIR_OpProfileCall*)op;
 
       if (opProfileCall->_recv->is_valid())              do_temp(opProfileCall->_recv);
@@ -908,7 +908,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
 // LIR_OpProfileType:
     case lir_profile_type: {
-      assert(op->as_OpProfileType() != NULL, "must be");
+      assert(op->as_OpProfileType() != nullptr, "must be");
       LIR_OpProfileType* opProfileType = (LIR_OpProfileType*)op;
 
       do_input(opProfileType->_mdp); do_temp(opProfileType->_mdp);
@@ -926,17 +926,17 @@ void LIR_Op::visit(LIR_OpVisitState* state) {
 }
 
 void LIR_OpVisitState::do_stub(CodeStub* stub) {
-  if (stub != NULL) {
+  if (stub != nullptr) {
     stub->visit(this);
   }
 }
 
 XHandlers* LIR_OpVisitState::all_xhandler() {
-  XHandlers* result = NULL;
+  XHandlers* result = nullptr;
 
   int i;
   for (i = 0; i < info_count(); i++) {
-    if (info_at(i)->exception_handlers() != NULL) {
+    if (info_at(i)->exception_handlers() != nullptr) {
       result = info_at(i)->exception_handlers();
       break;
     }
@@ -944,13 +944,13 @@ XHandlers* LIR_OpVisitState::all_xhandler() {
 
 #ifdef ASSERT
   for (i = 0; i < info_count(); i++) {
-    assert(info_at(i)->exception_handlers() == NULL ||
+    assert(info_at(i)->exception_handlers() == nullptr ||
            info_at(i)->exception_handlers() == result,
            "only one xhandler list allowed per LIR-operation");
   }
 #endif
 
-  if (result != NULL) {
+  if (result != nullptr) {
     return result;
   } else {
     return new XHandlers();
@@ -975,8 +975,8 @@ bool LIR_OpVisitState::no_operands(LIR_Op* op) {
 
 // LIR_OpReturn
 LIR_OpReturn::LIR_OpReturn(LIR_Opr opr) :
-    LIR_Op1(lir_return, opr, (CodeEmitInfo*)NULL /* info */),
-    _stub(NULL) {
+    LIR_Op1(lir_return, opr, (CodeEmitInfo*)nullptr /* info */),
+    _stub(nullptr) {
   if (VM_Version::supports_stack_watermark_barrier()) {
     _stub = new C1SafepointPollStub();
   }
@@ -1028,7 +1028,7 @@ void LIR_OpBranch::emit_code(LIR_Assembler* masm) {
 
 void LIR_OpConvert::emit_code(LIR_Assembler* masm) {
   masm->emit_opConvert(this);
-  if (stub() != NULL) {
+  if (stub() != nullptr) {
     masm->append_code_stub(stub());
   }
 }
@@ -1098,7 +1098,7 @@ LIR_List::LIR_List(Compilation* compilation, BlockBegin* block)
   , _block(block)
 #endif
 #ifdef ASSERT
-  , _file(NULL)
+  , _file(nullptr)
   , _line(0)
 #endif
 #ifdef RISCV
@@ -1111,8 +1111,8 @@ LIR_List::LIR_List(Compilation* compilation, BlockBegin* block)
 #ifdef ASSERT
 void LIR_List::set_file_and_line(const char * file, int line) {
   const char * f = strrchr(file, '/');
-  if (f == NULL) f = strrchr(file, '\\');
-  if (f == NULL) {
+  if (f == nullptr) f = strrchr(file, '\\');
+  if (f == nullptr) {
     f = file;
   } else {
     f++;
@@ -1161,7 +1161,7 @@ void LIR_List::append(LIR_InsertionBuffer* buffer) {
 
   if (buffer->number_of_ops() > 0) {
     // increase size of instructions list
-    _operations.at_grow(n + buffer->number_of_ops() - 1, NULL);
+    _operations.at_grow(n + buffer->number_of_ops() - 1, nullptr);
     // insert ops from buffer into instructions list
     int op_index = buffer->number_of_ops() - 1;
     int ip_index = buffer->number_of_insertion_points() - 1;
@@ -1426,7 +1426,7 @@ void LIR_List::unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scr
                     lock,
                     scratch,
                     stub,
-                    NULL));
+                    nullptr));
 }
 
 
@@ -1443,7 +1443,7 @@ void LIR_List::checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
                           ciMethod* profiled_method, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_checkcast, result, object, klass,
                                            tmp1, tmp2, tmp3, fast_check, info_for_exception, info_for_patch, stub);
-  if (profiled_method != NULL) {
+  if (profiled_method != nullptr) {
     c->set_profiled_method(profiled_method);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
@@ -1452,8 +1452,8 @@ void LIR_List::checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
 }
 
 void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, int profiled_bci) {
-  LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_instanceof, result, object, klass, tmp1, tmp2, tmp3, fast_check, NULL, info_for_patch, NULL);
-  if (profiled_method != NULL) {
+  LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_instanceof, result, object, klass, tmp1, tmp2, tmp3, fast_check, nullptr, info_for_patch, nullptr);
+  if (profiled_method != nullptr) {
     c->set_profiled_method(profiled_method);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
@@ -1465,7 +1465,7 @@ void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Op
 void LIR_List::store_check(LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3,
                            CodeEmitInfo* info_for_exception, ciMethod* profiled_method, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_store_check, object, array, tmp1, tmp2, tmp3, info_for_exception);
-  if (profiled_method != NULL) {
+  if (profiled_method != nullptr) {
     c->set_profiled_method(profiled_method);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
@@ -1477,7 +1477,7 @@ void LIR_List::null_check(LIR_Opr opr, CodeEmitInfo* info, bool deoptimize_on_nu
   if (deoptimize_on_null) {
     // Emit an explicit null check and deoptimize if opr is null
     CodeStub* deopt = new DeoptimizeStub(info, Deoptimization::Reason_null_check, Deoptimization::Action_none);
-    cmp(lir_cond_equal, opr, LIR_OprFact::oopConst(NULL));
+    cmp(lir_cond_equal, opr, LIR_OprFact::oopConst(nullptr));
     branch(lir_cond_equal, deopt);
   } else {
     // Emit an implicit null check
@@ -1618,7 +1618,7 @@ static void print_block(BlockBegin* x) {
   if (x->is_set(BlockBegin::linear_scan_loop_end_flag))    tty->print("le ");
 
   // print block bci range
-  tty->print("[%d, %d] ", x->bci(), (end == NULL ? -1 : end->printable_bci()));
+  tty->print("[%d, %d] ", x->bci(), (end == nullptr ? -1 : end->printable_bci()));
 
   // print predecessors and successors
   if (x->number_of_preds() > 0) {
@@ -1628,7 +1628,7 @@ static void print_block(BlockBegin* x) {
     }
   }
 
-  if (end != NULL && x->number_of_sux() > 0) {
+  if (end != nullptr && x->number_of_sux() > 0) {
     tty->print("sux: ");
     for (int i = 0; i < x->number_of_sux(); i ++) {
       tty->print("B%d ", x->sux_at(i)->block_id());
@@ -1674,16 +1674,16 @@ void LIR_Op::print_on(outputStream* out) const {
   }
   out->print("%s ", name());
   print_instr(out);
-  if (info() != NULL) out->print(" [bci:%d]", info()->stack()->bci());
+  if (info() != nullptr) out->print(" [bci:%d]", info()->stack()->bci());
 #ifdef ASSERT
-  if (Verbose && _file != NULL) {
+  if (Verbose && _file != nullptr) {
     out->print(" (%s:%d)", _file, _line);
   }
 #endif
 }
 
 const char * LIR_Op::name() const {
-  const char* s = NULL;
+  const char* s = nullptr;
   switch(code()) {
      // LIR_Op0
      case lir_membar:                s = "membar";        break;
@@ -1886,17 +1886,17 @@ void LIR_OpBranch::print_instr(outputStream* out) const {
   print_condition(out, cond());             out->print(" ");
   in_opr1()->print(out); out->print(" ");
   in_opr2()->print(out); out->print(" ");
-  if (block() != NULL) {
+  if (block() != nullptr) {
     out->print("[B%d] ", block()->block_id());
-  } else if (stub() != NULL) {
+  } else if (stub() != nullptr) {
     out->print("[");
     stub()->print_name(out);
     out->print(": " INTPTR_FORMAT "]", p2i(stub()));
-    if (stub()->info() != NULL) out->print(" [bci:%d]", stub()->info()->stack()->bci());
+    if (stub()->info() != nullptr) out->print(" [bci:%d]", stub()->info()->stack()->bci());
   } else {
     out->print("[label:" INTPTR_FORMAT "] ", p2i(label()));
   }
-  if (ublock() != NULL) {
+  if (ublock() != nullptr) {
     out->print("unordered: [B%d] ", ublock()->block_id());
   }
 }
@@ -2005,7 +2005,7 @@ void LIR_OpTypeCheck::print_instr(outputStream* out) const {
   tmp2()->print(out);                    out->print(" ");
   tmp3()->print(out);                    out->print(" ");
   result_opr()->print(out);              out->print(" ");
-  if (info_for_exception() != NULL) out->print(" [bci:%d]", info_for_exception()->stack()->bci());
+  if (info_for_exception() != nullptr) out->print(" [bci:%d]", info_for_exception()->stack()->bci());
 }
 
 
@@ -2071,7 +2071,7 @@ void LIR_OpProfileCall::print_instr(outputStream* out) const {
 // LIR_OpProfileType
 void LIR_OpProfileType::print_instr(outputStream* out) const {
   out->print("exact = ");
-  if  (exact_klass() == NULL) {
+  if  (exact_klass() == nullptr) {
     out->print("unknown");
   } else {
     exact_klass()->print_name_on(out);

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -68,8 +68,8 @@ class LIR_OprPtr: public CompilationResourceObj {
   bool is_oop_pointer() const                    { return (type() == T_OBJECT); }
   bool is_float_kind() const                     { BasicType t = type(); return (t == T_FLOAT) || (t == T_DOUBLE); }
 
-  virtual LIR_Const*  as_constant()              { return NULL; }
-  virtual LIR_Address* as_address()              { return NULL; }
+  virtual LIR_Const*  as_constant()              { return nullptr; }
+  virtual LIR_Address* as_address()              { return nullptr; }
   virtual BasicType type() const                 = 0;
   virtual void print_value_on(outputStream* out) const = 0;
 };
@@ -384,8 +384,8 @@ class LIR_Opr {
   bool is_register() const     { return is_cpu_register() || is_fpu_register(); }
   bool is_virtual() const      { return is_virtual_cpu()  || is_virtual_fpu();  }
 
-  bool is_constant() const     { return is_pointer() && pointer()->as_constant() != NULL; }
-  bool is_address() const      { return is_pointer() && pointer()->as_address() != NULL; }
+  bool is_constant() const     { return is_pointer() && pointer()->as_constant() != nullptr; }
+  bool is_address() const      { return is_pointer() && pointer()->as_address() != nullptr; }
 
   bool is_float_kind() const   { return is_pointer() ? pointer()->is_float_kind() : (kind_field() == fpu_register); }
   bool is_oop() const;
@@ -1085,21 +1085,21 @@ class LIR_Op: public CompilationResourceObj {
   LIR_Op()
     :
 #ifdef ASSERT
-      _file(NULL)
+      _file(nullptr)
     , _line(0),
 #endif
       _result(LIR_OprFact::illegalOpr)
     , _code(lir_none)
     , _flags(0)
-    , _info(NULL)
+    , _info(nullptr)
     , _id(-1)
     , _fpu_pop_count(0)
-    , _source(NULL) {}
+    , _source(nullptr) {}
 
   LIR_Op(LIR_Code code, LIR_Opr result, CodeEmitInfo* info)
     :
 #ifdef ASSERT
-      _file(NULL)
+      _file(nullptr)
     , _line(0),
 #endif
       _result(result)
@@ -1108,7 +1108,7 @@ class LIR_Op: public CompilationResourceObj {
     , _info(info)
     , _id(-1)
     , _fpu_pop_count(0)
-    , _source(NULL) {}
+    , _source(nullptr) {}
 
   CodeEmitInfo* info() const                  { return _info;   }
   LIR_Code code()      const                  { return (LIR_Code)_code;   }
@@ -1141,32 +1141,32 @@ class LIR_Op: public CompilationResourceObj {
   virtual void print_on(outputStream* st) const PRODUCT_RETURN;
 
   virtual bool is_patching() { return false; }
-  virtual LIR_OpCall* as_OpCall() { return NULL; }
-  virtual LIR_OpJavaCall* as_OpJavaCall() { return NULL; }
-  virtual LIR_OpLabel* as_OpLabel() { return NULL; }
-  virtual LIR_OpDelay* as_OpDelay() { return NULL; }
-  virtual LIR_OpLock* as_OpLock() { return NULL; }
-  virtual LIR_OpAllocArray* as_OpAllocArray() { return NULL; }
-  virtual LIR_OpAllocObj* as_OpAllocObj() { return NULL; }
-  virtual LIR_OpRoundFP* as_OpRoundFP() { return NULL; }
-  virtual LIR_OpBranch* as_OpBranch() { return NULL; }
-  virtual LIR_OpReturn* as_OpReturn() { return NULL; }
-  virtual LIR_OpRTCall* as_OpRTCall() { return NULL; }
-  virtual LIR_OpConvert* as_OpConvert() { return NULL; }
-  virtual LIR_Op0* as_Op0() { return NULL; }
-  virtual LIR_Op1* as_Op1() { return NULL; }
-  virtual LIR_Op2* as_Op2() { return NULL; }
-  virtual LIR_Op3* as_Op3() { return NULL; }
-  virtual LIR_Op4* as_Op4() { return NULL; }
-  virtual LIR_OpArrayCopy* as_OpArrayCopy() { return NULL; }
-  virtual LIR_OpUpdateCRC32* as_OpUpdateCRC32() { return NULL; }
-  virtual LIR_OpTypeCheck* as_OpTypeCheck() { return NULL; }
-  virtual LIR_OpCompareAndSwap* as_OpCompareAndSwap() { return NULL; }
-  virtual LIR_OpLoadKlass* as_OpLoadKlass() { return NULL; }
-  virtual LIR_OpProfileCall* as_OpProfileCall() { return NULL; }
-  virtual LIR_OpProfileType* as_OpProfileType() { return NULL; }
+  virtual LIR_OpCall* as_OpCall() { return nullptr; }
+  virtual LIR_OpJavaCall* as_OpJavaCall() { return nullptr; }
+  virtual LIR_OpLabel* as_OpLabel() { return nullptr; }
+  virtual LIR_OpDelay* as_OpDelay() { return nullptr; }
+  virtual LIR_OpLock* as_OpLock() { return nullptr; }
+  virtual LIR_OpAllocArray* as_OpAllocArray() { return nullptr; }
+  virtual LIR_OpAllocObj* as_OpAllocObj() { return nullptr; }
+  virtual LIR_OpRoundFP* as_OpRoundFP() { return nullptr; }
+  virtual LIR_OpBranch* as_OpBranch() { return nullptr; }
+  virtual LIR_OpReturn* as_OpReturn() { return nullptr; }
+  virtual LIR_OpRTCall* as_OpRTCall() { return nullptr; }
+  virtual LIR_OpConvert* as_OpConvert() { return nullptr; }
+  virtual LIR_Op0* as_Op0() { return nullptr; }
+  virtual LIR_Op1* as_Op1() { return nullptr; }
+  virtual LIR_Op2* as_Op2() { return nullptr; }
+  virtual LIR_Op3* as_Op3() { return nullptr; }
+  virtual LIR_Op4* as_Op4() { return nullptr; }
+  virtual LIR_OpArrayCopy* as_OpArrayCopy() { return nullptr; }
+  virtual LIR_OpUpdateCRC32* as_OpUpdateCRC32() { return nullptr; }
+  virtual LIR_OpTypeCheck* as_OpTypeCheck() { return nullptr; }
+  virtual LIR_OpCompareAndSwap* as_OpCompareAndSwap() { return nullptr; }
+  virtual LIR_OpLoadKlass* as_OpLoadKlass() { return nullptr; }
+  virtual LIR_OpProfileCall* as_OpProfileCall() { return nullptr; }
+  virtual LIR_OpProfileType* as_OpProfileType() { return nullptr; }
 #ifdef ASSERT
-  virtual LIR_OpAssert* as_OpAssert() { return NULL; }
+  virtual LIR_OpAssert* as_OpAssert() { return nullptr; }
 #endif
 
   virtual void verify() const {}
@@ -1181,7 +1181,7 @@ class LIR_OpCall: public LIR_Op {
   LIR_OprList* _arguments;
  protected:
   LIR_OpCall(LIR_Code code, address addr, LIR_Opr result,
-             LIR_OprList* arguments, CodeEmitInfo* info = NULL)
+             LIR_OprList* arguments, CodeEmitInfo* info = nullptr)
     : LIR_Op(code, result, info)
     , _addr(addr)
     , _arguments(arguments) {}
@@ -1250,7 +1250,7 @@ class LIR_OpLabel: public LIR_Op {
   Label* _label;
  public:
   LIR_OpLabel(Label* lbl)
-   : LIR_Op(lir_label, LIR_OprFact::illegalOpr, NULL)
+   : LIR_Op(lir_label, LIR_OprFact::illegalOpr, nullptr)
    , _label(lbl)                                 {}
   Label* label() const                           { return _label; }
 
@@ -1337,8 +1337,8 @@ class LIR_Op0: public LIR_Op {
 
  public:
   LIR_Op0(LIR_Code code)
-   : LIR_Op(code, LIR_OprFact::illegalOpr, NULL)  { assert(is_in_range(code, begin_op0, end_op0), "code check"); }
-  LIR_Op0(LIR_Code code, LIR_Opr result, CodeEmitInfo* info = NULL)
+   : LIR_Op(code, LIR_OprFact::illegalOpr, nullptr)  { assert(is_in_range(code, begin_op0, end_op0), "code check"); }
+  LIR_Op0(LIR_Code code, LIR_Opr result, CodeEmitInfo* info = nullptr)
    : LIR_Op(code, result, info)  { assert(is_in_range(code, begin_op0, end_op0), "code check"); }
 
   virtual void emit_code(LIR_Assembler* masm);
@@ -1367,7 +1367,7 @@ class LIR_Op1: public LIR_Op {
   }
 
  public:
-  LIR_Op1(LIR_Code code, LIR_Opr opr, LIR_Opr result = LIR_OprFact::illegalOpr, BasicType type = T_ILLEGAL, LIR_PatchCode patch = lir_patch_none, CodeEmitInfo* info = NULL)
+  LIR_Op1(LIR_Code code, LIR_Opr opr, LIR_Opr result = LIR_OprFact::illegalOpr, BasicType type = T_ILLEGAL, LIR_PatchCode patch = lir_patch_none, CodeEmitInfo* info = nullptr)
     : LIR_Op(code, result, info)
     , _opr(opr)
     , _type(type)
@@ -1417,7 +1417,7 @@ class LIR_OpRTCall: public LIR_OpCall {
   LIR_Opr _tmp;
  public:
   LIR_OpRTCall(address addr, LIR_Opr tmp,
-               LIR_Opr result, LIR_OprList* arguments, CodeEmitInfo* info = NULL)
+               LIR_Opr result, LIR_OprList* arguments, CodeEmitInfo* info = nullptr)
     : LIR_OpCall(lir_rtcall, addr, result, arguments, info)
     , _tmp(tmp) {}
 
@@ -1578,7 +1578,7 @@ public:
   int       profiled_bci() const                 { return _profiled_bci;      }
   bool      should_profile() const               { return _should_profile;    }
 
-  virtual bool is_patching() { return _info_for_patch != NULL; }
+  virtual bool is_patching() { return _info_for_patch != nullptr; }
   virtual void emit_code(LIR_Assembler* masm);
   virtual LIR_OpTypeCheck* as_OpTypeCheck() { return this; }
   void print_instr(outputStream* out) const PRODUCT_RETURN;
@@ -1604,7 +1604,7 @@ class LIR_Op2: public LIR_Op {
   void verify() const;
 
  public:
-  LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, CodeEmitInfo* info = NULL, BasicType type = T_ILLEGAL)
+  LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, CodeEmitInfo* info = nullptr, BasicType type = T_ILLEGAL)
     : LIR_Op(code, LIR_OprFact::illegalOpr, info)
     , _fpu_stack_size(0)
     , _opr1(opr1)
@@ -1620,7 +1620,7 @@ class LIR_Op2: public LIR_Op {
   }
 
   LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result, BasicType type)
-    : LIR_Op(code, result, NULL)
+    : LIR_Op(code, result, nullptr)
     , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
@@ -1636,7 +1636,7 @@ class LIR_Op2: public LIR_Op {
   }
 
   LIR_Op2(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result = LIR_OprFact::illegalOpr,
-          CodeEmitInfo* info = NULL, BasicType type = T_ILLEGAL)
+          CodeEmitInfo* info = nullptr, BasicType type = T_ILLEGAL)
     : LIR_Op(code, result, info)
     , _fpu_stack_size(0)
     , _opr1(opr1)
@@ -1653,7 +1653,7 @@ class LIR_Op2: public LIR_Op {
 
   LIR_Op2(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result, LIR_Opr tmp1, LIR_Opr tmp2 = LIR_OprFact::illegalOpr,
           LIR_Opr tmp3 = LIR_OprFact::illegalOpr, LIR_Opr tmp4 = LIR_OprFact::illegalOpr, LIR_Opr tmp5 = LIR_OprFact::illegalOpr)
-    : LIR_Op(code, result, NULL)
+    : LIR_Op(code, result, nullptr)
     , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
@@ -1704,11 +1704,11 @@ class LIR_OpBranch: public LIR_Op2 {
 
  public:
   LIR_OpBranch(LIR_Condition cond, Label* lbl)
-    : LIR_Op2(lir_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*) NULL)
+    : LIR_Op2(lir_branch, cond, LIR_OprFact::illegalOpr, LIR_OprFact::illegalOpr, (CodeEmitInfo*) nullptr)
     , _label(lbl)
-    , _block(NULL)
-    , _ublock(NULL)
-    , _stub(NULL) { }
+    , _block(nullptr)
+    , _ublock(nullptr)
+    , _stub(nullptr) { }
 
   LIR_OpBranch(LIR_Condition cond, BlockBegin* block);
   LIR_OpBranch(LIR_Condition cond, CodeStub* stub);
@@ -1753,7 +1753,7 @@ class LIR_OpAllocArray : public LIR_Op {
 
  public:
   LIR_OpAllocArray(LIR_Opr klass, LIR_Opr len, LIR_Opr result, LIR_Opr t1, LIR_Opr t2, LIR_Opr t3, LIR_Opr t4, BasicType type, CodeStub* stub)
-    : LIR_Op(lir_alloc_array, result, NULL)
+    : LIR_Op(lir_alloc_array, result, nullptr)
     , _klass(klass)
     , _len(len)
     , _tmp1(t1)
@@ -1787,7 +1787,7 @@ class LIR_Op3: public LIR_Op {
   LIR_Opr _opr2;
   LIR_Opr _opr3;
  public:
-  LIR_Op3(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr opr3, LIR_Opr result, CodeEmitInfo* info = NULL)
+  LIR_Op3(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr opr3, LIR_Opr result, CodeEmitInfo* info = nullptr)
     : LIR_Op(code, result, info)
     , _opr1(opr1)
     , _opr2(opr2)
@@ -1819,7 +1819,7 @@ class LIR_Op4: public LIR_Op {
  public:
   LIR_Op4(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr opr3, LIR_Opr opr4,
           LIR_Opr result, BasicType type)
-    : LIR_Op(code, result, NULL)
+    : LIR_Op(code, result, nullptr)
     , _opr1(opr1)
     , _opr2(opr2)
     , _opr3(opr3)
@@ -1974,7 +1974,7 @@ class LIR_OpCompareAndSwap : public LIR_Op {
  public:
   LIR_OpCompareAndSwap(LIR_Code code, LIR_Opr addr, LIR_Opr cmp_value, LIR_Opr new_value,
                        LIR_Opr t1, LIR_Opr t2, LIR_Opr result)
-    : LIR_Op(code, result, NULL)  // no result, no info
+    : LIR_Op(code, result, nullptr)  // no result, no info
     , _addr(addr)
     , _cmp_value(cmp_value)
     , _new_value(new_value)
@@ -2008,7 +2008,7 @@ class LIR_OpProfileCall : public LIR_Op {
  public:
   // Destroys recv
   LIR_OpProfileCall(ciMethod* profiled_method, int profiled_bci, ciMethod* profiled_callee, LIR_Opr mdo, LIR_Opr recv, LIR_Opr t1, ciKlass* known_holder)
-    : LIR_Op(lir_profile_call, LIR_OprFact::illegalOpr, NULL)  // no result, no info
+    : LIR_Op(lir_profile_call, LIR_OprFact::illegalOpr, nullptr)  // no result, no info
     , _profiled_method(profiled_method)
     , _profiled_bci(profiled_bci)
     , _profiled_callee(profiled_callee)
@@ -2044,16 +2044,16 @@ class LIR_OpProfileType : public LIR_Op {
   LIR_Opr      _mdp;
   LIR_Opr      _obj;
   LIR_Opr      _tmp;
-  ciKlass*     _exact_klass;   // non NULL if we know the klass statically (no need to load it from _obj)
+  ciKlass*     _exact_klass;   // non null if we know the klass statically (no need to load it from _obj)
   intptr_t     _current_klass; // what the profiling currently reports
   bool         _not_null;      // true if we know statically that _obj cannot be null
-  bool         _no_conflict;   // true if we're profling parameters, _exact_klass is not NULL and we know
+  bool         _no_conflict;   // true if we're profling parameters, _exact_klass is not null and we know
                                // _exact_klass it the only possible type for this parameter in any context.
 
  public:
   // Destroys recv
   LIR_OpProfileType(LIR_Opr mdp, LIR_Opr obj, ciKlass* exact_klass, intptr_t current_klass, LIR_Opr tmp, bool not_null, bool no_conflict)
-    : LIR_Op(lir_profile_type, LIR_OprFact::illegalOpr, NULL)  // no result, no info
+    : LIR_Op(lir_profile_type, LIR_OprFact::illegalOpr, nullptr)  // no result, no info
     , _mdp(mdp)
     , _obj(obj)
     , _tmp(tmp)
@@ -2104,7 +2104,7 @@ class LIR_List: public CompilationResourceObj {
 
  public:
   void append(LIR_Op* op) {
-    if (op->source() == NULL)
+    if (op->source() == nullptr)
       op->set_source(_compilation->current_instruction());
 #ifndef PRODUCT
     if (PrintIRWithLIR) {
@@ -2124,12 +2124,12 @@ class LIR_List: public CompilationResourceObj {
 #ifdef ASSERT
     op->verify();
     op->set_file_and_line(_file, _line);
-    _file = NULL;
+    _file = nullptr;
     _line = 0;
 #endif
   }
 
-  LIR_List(Compilation* compilation, BlockBegin* block = NULL);
+  LIR_List(Compilation* compilation, BlockBegin* block = nullptr);
 
 #ifdef ASSERT
   void set_file_and_line(const char * file, int line);
@@ -2195,29 +2195,29 @@ class LIR_List: public CompilationResourceObj {
 
   void branch_destination(Label* lbl)            { append(new LIR_OpLabel(lbl)); }
 
-  void leal(LIR_Opr from, LIR_Opr result_reg, LIR_PatchCode patch_code = lir_patch_none, CodeEmitInfo* info = NULL) { append(new LIR_Op1(lir_leal, from, result_reg, T_ILLEGAL, patch_code, info)); }
+  void leal(LIR_Opr from, LIR_Opr result_reg, LIR_PatchCode patch_code = lir_patch_none, CodeEmitInfo* info = nullptr) { append(new LIR_Op1(lir_leal, from, result_reg, T_ILLEGAL, patch_code, info)); }
 
   // result is a stack location for old backend and vreg for UseLinearScan
   // stack_loc_temp is an illegal register for old backend
   void roundfp(LIR_Opr reg, LIR_Opr stack_loc_temp, LIR_Opr result) { append(new LIR_OpRoundFP(reg, stack_loc_temp, result)); }
-  void move(LIR_Opr src, LIR_Opr dst, CodeEmitInfo* info = NULL) { append(new LIR_Op1(lir_move, src, dst, dst->type(), lir_patch_none, info)); }
-  void move(LIR_Address* src, LIR_Opr dst, CodeEmitInfo* info = NULL) { append(new LIR_Op1(lir_move, LIR_OprFact::address(src), dst, src->type(), lir_patch_none, info)); }
-  void move(LIR_Opr src, LIR_Address* dst, CodeEmitInfo* info = NULL) { append(new LIR_Op1(lir_move, src, LIR_OprFact::address(dst), dst->type(), lir_patch_none, info)); }
-  void move_wide(LIR_Address* src, LIR_Opr dst, CodeEmitInfo* info = NULL) {
+  void move(LIR_Opr src, LIR_Opr dst, CodeEmitInfo* info = nullptr) { append(new LIR_Op1(lir_move, src, dst, dst->type(), lir_patch_none, info)); }
+  void move(LIR_Address* src, LIR_Opr dst, CodeEmitInfo* info = nullptr) { append(new LIR_Op1(lir_move, LIR_OprFact::address(src), dst, src->type(), lir_patch_none, info)); }
+  void move(LIR_Opr src, LIR_Address* dst, CodeEmitInfo* info = nullptr) { append(new LIR_Op1(lir_move, src, LIR_OprFact::address(dst), dst->type(), lir_patch_none, info)); }
+  void move_wide(LIR_Address* src, LIR_Opr dst, CodeEmitInfo* info = nullptr) {
     if (UseCompressedOops) {
       append(new LIR_Op1(lir_move, LIR_OprFact::address(src), dst, src->type(), lir_patch_none, info, lir_move_wide));
     } else {
       move(src, dst, info);
     }
   }
-  void move_wide(LIR_Opr src, LIR_Address* dst, CodeEmitInfo* info = NULL) {
+  void move_wide(LIR_Opr src, LIR_Address* dst, CodeEmitInfo* info = nullptr) {
     if (UseCompressedOops) {
       append(new LIR_Op1(lir_move, src, LIR_OprFact::address(dst), dst->type(), lir_patch_none, info, lir_move_wide));
     } else {
       move(src, dst, info);
     }
   }
-  void volatile_move(LIR_Opr src, LIR_Opr dst, BasicType type, CodeEmitInfo* info = NULL, LIR_PatchCode patch_code = lir_patch_none) { append(new LIR_Op1(lir_move, src, dst, type, patch_code, info, lir_move_volatile)); }
+  void volatile_move(LIR_Opr src, LIR_Opr dst, BasicType type, CodeEmitInfo* info = nullptr, LIR_PatchCode patch_code = lir_patch_none) { append(new LIR_Op1(lir_move, src, dst, type, patch_code, info, lir_move_volatile)); }
 
   void oop2reg  (jobject o, LIR_Opr reg)         { assert(reg->type() == T_OBJECT, "bad reg"); append(new LIR_Op1(lir_move, LIR_OprFact::oopConst(o),    reg));   }
   void oop2reg_patch(jobject o, LIR_Opr reg, CodeEmitInfo* info);
@@ -2228,7 +2228,7 @@ class LIR_List: public CompilationResourceObj {
   void safepoint(LIR_Opr tmp, CodeEmitInfo* info)  { append(new LIR_Op1(lir_safepoint, tmp, info)); }
   void return_op(LIR_Opr result)                   { append(new LIR_OpReturn(result)); }
 
-  void convert(Bytecodes::Code code, LIR_Opr left, LIR_Opr dst, ConversionStub* stub = NULL/*, bool is_32bit = false*/) { append(new LIR_OpConvert(code, left, dst, stub)); }
+  void convert(Bytecodes::Code code, LIR_Opr left, LIR_Opr dst, ConversionStub* stub = nullptr/*, bool is_32bit = false*/) { append(new LIR_OpConvert(code, left, dst, stub)); }
 
   void logical_and (LIR_Opr left, LIR_Opr right, LIR_Opr dst) { append(new LIR_Op2(lir_logic_and,  left, right, dst)); }
   void logical_or  (LIR_Opr left, LIR_Opr right, LIR_Opr dst) { append(new LIR_Op2(lir_logic_or,   left, right, dst)); }
@@ -2245,10 +2245,10 @@ class LIR_List: public CompilationResourceObj {
   void push(LIR_Opr opr)                                   { append(new LIR_Op1(lir_push, opr)); }
   void pop(LIR_Opr reg)                                    { append(new LIR_Op1(lir_pop,  reg)); }
 
-  void cmp(LIR_Condition condition, LIR_Opr left, LIR_Opr right, CodeEmitInfo* info = NULL) {
+  void cmp(LIR_Condition condition, LIR_Opr left, LIR_Opr right, CodeEmitInfo* info = nullptr) {
     append(new LIR_Op2(lir_cmp, condition, left, right, info));
   }
-  void cmp(LIR_Condition condition, LIR_Opr left, int right, CodeEmitInfo* info = NULL) {
+  void cmp(LIR_Condition condition, LIR_Opr left, int right, CodeEmitInfo* info = nullptr) {
     cmp(condition, left, LIR_OprFact::intConst(right), info);
   }
 
@@ -2278,21 +2278,21 @@ class LIR_List: public CompilationResourceObj {
   void hf2f(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op2(lir_hf2f, from, tmp, to)); }
 
   void add (LIR_Opr left, LIR_Opr right, LIR_Opr res)      { append(new LIR_Op2(lir_add, left, right, res)); }
-  void sub (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = NULL) { append(new LIR_Op2(lir_sub, left, right, res, info)); }
+  void sub (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = nullptr) { append(new LIR_Op2(lir_sub, left, right, res, info)); }
   void mul (LIR_Opr left, LIR_Opr right, LIR_Opr res) { append(new LIR_Op2(lir_mul, left, right, res)); }
   void mul (LIR_Opr left, LIR_Opr right, LIR_Opr res, LIR_Opr tmp) { append(new LIR_Op2(lir_mul, left, right, res, tmp)); }
-  void div (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = NULL)      { append(new LIR_Op2(lir_div, left, right, res, info)); }
+  void div (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = nullptr)      { append(new LIR_Op2(lir_div, left, right, res, info)); }
   void div (LIR_Opr left, LIR_Opr right, LIR_Opr res, LIR_Opr tmp) { append(new LIR_Op2(lir_div, left, right, res, tmp)); }
-  void rem (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = NULL)      { append(new LIR_Op2(lir_rem, left, right, res, info)); }
+  void rem (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = nullptr)      { append(new LIR_Op2(lir_rem, left, right, res, info)); }
 
   void volatile_load_mem_reg(LIR_Address* address, LIR_Opr dst, CodeEmitInfo* info, LIR_PatchCode patch_code = lir_patch_none);
   void volatile_load_unsafe_reg(LIR_Opr base, LIR_Opr offset, LIR_Opr dst, BasicType type, CodeEmitInfo* info, LIR_PatchCode patch_code);
 
-  void load(LIR_Address* addr, LIR_Opr src, CodeEmitInfo* info = NULL, LIR_PatchCode patch_code = lir_patch_none);
+  void load(LIR_Address* addr, LIR_Opr src, CodeEmitInfo* info = nullptr, LIR_PatchCode patch_code = lir_patch_none);
 
   void store_mem_int(jint v,    LIR_Opr base, int offset_in_bytes, BasicType type, CodeEmitInfo* info, LIR_PatchCode patch_code = lir_patch_none);
   void store_mem_oop(jobject o, LIR_Opr base, int offset_in_bytes, BasicType type, CodeEmitInfo* info, LIR_PatchCode patch_code = lir_patch_none);
-  void store(LIR_Opr src, LIR_Address* addr, CodeEmitInfo* info = NULL, LIR_PatchCode patch_code = lir_patch_none);
+  void store(LIR_Opr src, LIR_Address* addr, CodeEmitInfo* info = nullptr, LIR_PatchCode patch_code = lir_patch_none);
   void volatile_store_mem_reg(LIR_Opr src, LIR_Address* address, CodeEmitInfo* info, LIR_PatchCode patch_code = lir_patch_none);
   void volatile_store_unsafe_reg(LIR_Opr src, LIR_Opr base, LIR_Opr offset, BasicType type, CodeEmitInfo* info, LIR_PatchCode patch_code);
 
@@ -2386,7 +2386,7 @@ void print_LIR(BlockList* blocks);
 
 class LIR_InsertionBuffer : public CompilationResourceObj {
  private:
-  LIR_List*   _lir;   // the lir list where ops of this buffer should be inserted later (NULL when uninitialized)
+  LIR_List*   _lir;   // the lir list where ops of this buffer should be inserted later (null when uninitialized)
 
   // list of insertion points. index and count are stored alternately:
   // _index_and_count[i * 2]:     the index into lir list where "count" ops should be inserted
@@ -2404,13 +2404,13 @@ class LIR_InsertionBuffer : public CompilationResourceObj {
   void verify();
 #endif
  public:
-  LIR_InsertionBuffer() : _lir(NULL), _index_and_count(8), _ops(8) { }
+  LIR_InsertionBuffer() : _lir(nullptr), _index_and_count(8), _ops(8) { }
 
   // must be called before using the insertion buffer
   void init(LIR_List* lir)  { assert(!initialized(), "already initialized"); _lir = lir; _index_and_count.clear(); _ops.clear(); }
-  bool initialized() const  { return _lir != NULL; }
+  bool initialized() const  { return _lir != nullptr; }
   // called automatically when the buffer is appended to the LIR_List
-  void finish()             { _lir = NULL; }
+  void finish()             { _lir = nullptr; }
 
   // accessors
   LIR_List*  lir_list() const             { return _lir; }
@@ -2425,7 +2425,7 @@ class LIR_InsertionBuffer : public CompilationResourceObj {
   void append(int index, LIR_Op* op);
 
   // instruction
-  void move(int index, LIR_Opr src, LIR_Opr dst, CodeEmitInfo* info = NULL) { append(index, new LIR_Op1(lir_move, src, dst, dst->type(), lir_patch_none, info)); }
+  void move(int index, LIR_Opr src, LIR_Opr dst, CodeEmitInfo* info = nullptr) { append(index, new LIR_Op1(lir_move, src, dst, dst->type(), lir_patch_none, info)); }
 };
 
 
@@ -2474,7 +2474,7 @@ class LIR_OpVisitState: public StackObj {
 
     } else if (opr->is_pointer()) {
       LIR_Address* address = opr->as_address_ptr();
-      if (address != NULL) {
+      if (address != nullptr) {
         // special handling for addresses: add base and index register of the address
         // both are always input operands or temp if we want to extend
         // their liveness!
@@ -2502,7 +2502,7 @@ class LIR_OpVisitState: public StackObj {
   }
 
   void append(CodeEmitInfo* info) {
-    assert(info != NULL, "should not call this otherwise");
+    assert(info != nullptr, "should not call this otherwise");
     assert(_info_len < maxNumberOfInfos, "array overflow");
     _info_new[_info_len++] = info;
   }
@@ -2517,7 +2517,7 @@ class LIR_OpVisitState: public StackObj {
   bool has_slow_case() const { return _has_slow_case; }
 
   void reset() {
-    _op = NULL;
+    _op = nullptr;
     _has_call = false;
     _has_slow_case = false;
 

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -106,8 +106,8 @@ LIR_Assembler::LIR_Assembler(Compilation* c):
    _masm(c->masm())
  , _compilation(c)
  , _frame_map(c->frame_map())
- , _current_block(NULL)
- , _pending_non_safepoint(NULL)
+ , _current_block(nullptr)
+ , _pending_non_safepoint(nullptr)
  , _pending_non_safepoint_offset(0)
  , _immediate_oops_patched(0)
 {
@@ -195,13 +195,13 @@ void LIR_Assembler::emit_exception_entries(ExceptionInfoList* info_list) {
     for (int j = 0; j < handlers->length(); j++) {
       XHandler* handler = handlers->handler_at(j);
       assert(handler->lir_op_id() != -1, "handler not processed by LinearScan");
-      assert(handler->entry_code() == NULL ||
+      assert(handler->entry_code() == nullptr ||
              handler->entry_code()->instructions_list()->last()->code() == lir_branch ||
              handler->entry_code()->instructions_list()->last()->code() == lir_delay_slot, "last operation must be branch");
 
       if (handler->entry_pco() == -1) {
         // entry code not emitted yet
-        if (handler->entry_code() != NULL && handler->entry_code()->instructions_list()->length() > 1) {
+        if (handler->entry_code() != nullptr && handler->entry_code()->instructions_list()->length() > 1) {
           handler->set_entry_pco(code_offset());
           if (CommentedAssembly) {
             _masm->block_comment("Exception adapter block");
@@ -255,7 +255,7 @@ void LIR_Assembler::emit_block(BlockBegin* block) {
   }
 #endif /* PRODUCT */
 
-  assert(block->lir() != NULL, "must have LIR");
+  assert(block->lir() != nullptr, "must have LIR");
   X86_ONLY(assert(_masm->rsp_offset() == 0, "frame size should be fixed"));
 
 #ifndef PRODUCT
@@ -335,7 +335,7 @@ void LIR_Assembler::add_debug_info_for_branch(CodeEmitInfo* info) {
   int pc_offset = code_offset();
   flush_debug_info(pc_offset);
   info->record_debug_info(compilation()->debug_info_recorder(), pc_offset);
-  if (info->exception_handlers() != NULL) {
+  if (info->exception_handlers() != nullptr) {
     compilation()->add_exception_handlers_for_pco(pc_offset, info->exception_handlers());
   }
 }
@@ -344,28 +344,28 @@ void LIR_Assembler::add_debug_info_for_branch(CodeEmitInfo* info) {
 void LIR_Assembler::add_call_info(int pc_offset, CodeEmitInfo* cinfo) {
   flush_debug_info(pc_offset);
   cinfo->record_debug_info(compilation()->debug_info_recorder(), pc_offset);
-  if (cinfo->exception_handlers() != NULL) {
+  if (cinfo->exception_handlers() != nullptr) {
     compilation()->add_exception_handlers_for_pco(pc_offset, cinfo->exception_handlers());
   }
 }
 
 static ValueStack* debug_info(Instruction* ins) {
   StateSplit* ss = ins->as_StateSplit();
-  if (ss != NULL) return ss->state();
+  if (ss != nullptr) return ss->state();
   return ins->state_before();
 }
 
 void LIR_Assembler::process_debug_info(LIR_Op* op) {
   Instruction* src = op->source();
-  if (src == NULL)  return;
+  if (src == nullptr)  return;
   int pc_offset = code_offset();
   if (_pending_non_safepoint == src) {
     _pending_non_safepoint_offset = pc_offset;
     return;
   }
   ValueStack* vstack = debug_info(src);
-  if (vstack == NULL)  return;
-  if (_pending_non_safepoint != NULL) {
+  if (vstack == nullptr)  return;
+  if (_pending_non_safepoint != nullptr) {
     // Got some old debug info.  Get rid of it.
     if (debug_info(_pending_non_safepoint) == vstack) {
       _pending_non_safepoint_offset = pc_offset;
@@ -374,7 +374,7 @@ void LIR_Assembler::process_debug_info(LIR_Op* op) {
     if (_pending_non_safepoint_offset < pc_offset) {
       record_non_safepoint_debug_info();
     }
-    _pending_non_safepoint = NULL;
+    _pending_non_safepoint = nullptr;
   }
   // Remember the debug info.
   if (pc_offset > compilation()->debug_info_recorder()->last_pc_offset()) {
@@ -384,18 +384,18 @@ void LIR_Assembler::process_debug_info(LIR_Op* op) {
 }
 
 // Index caller states in s, where 0 is the oldest, 1 its callee, etc.
-// Return NULL if n is too large.
+// Return null if n is too large.
 // Returns the caller_bci for the next-younger state, also.
 static ValueStack* nth_oldest(ValueStack* s, int n, int& bci_result) {
   ValueStack* t = s;
   for (int i = 0; i < n; i++) {
-    if (t == NULL)  break;
+    if (t == nullptr)  break;
     t = t->caller_state();
   }
-  if (t == NULL)  return NULL;
+  if (t == nullptr)  return nullptr;
   for (;;) {
     ValueStack* tc = t->caller_state();
-    if (tc == NULL)  return s;
+    if (tc == nullptr)  return s;
     t = tc;
     bci_result = tc->bci();
     s = s->caller_state();
@@ -416,7 +416,7 @@ void LIR_Assembler::record_non_safepoint_debug_info() {
   for (int n = 0; ; n++) {
     int s_bci = bci;
     ValueStack* s = nth_oldest(vstack, n, s_bci);
-    if (s == NULL)  break;
+    if (s == nullptr)  break;
     IRScope* scope = s->scope();
     //Always pass false for reexecute since these ScopeDescs are never used for deopt
     methodHandle null_mh;
@@ -528,10 +528,10 @@ void LIR_Assembler::emit_op1(LIR_Op1* op) {
     }
 
     case lir_return: {
-      assert(op->as_OpReturn() != NULL, "sanity");
+      assert(op->as_OpReturn() != nullptr, "sanity");
       LIR_OpReturn *ret_op = (LIR_OpReturn*)op;
       return_op(ret_op->in_opr(), ret_op->stub());
-      if (ret_op->stub() != NULL) {
+      if (ret_op->stub() != nullptr) {
         append_code_stub(ret_op->stub());
       }
       break;
@@ -598,7 +598,7 @@ void LIR_Assembler::emit_op1(LIR_Op1* op) {
 void LIR_Assembler::emit_op0(LIR_Op0* op) {
   switch (op->code()) {
     case lir_nop:
-      assert(op->info() == NULL, "not supported");
+      assert(op->info() == nullptr, "not supported");
       _masm->nop();
       break;
 
@@ -683,7 +683,7 @@ void LIR_Assembler::emit_op0(LIR_Op0* op) {
 void LIR_Assembler::emit_op2(LIR_Op2* op) {
   switch (op->code()) {
     case lir_cmp:
-      if (op->info() != NULL) {
+      if (op->info() != nullptr) {
         assert(op->in_opr1()->is_address() || op->in_opr2()->is_address(),
                "shouldn't be codeemitinfo for non-address operands");
         add_debug_info_for_null_check_here(op->info()); // exception possible
@@ -790,10 +790,10 @@ void LIR_Assembler::roundfp_op(LIR_Opr src, LIR_Opr tmp, LIR_Opr dest, bool pop_
 void LIR_Assembler::move_op(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_PatchCode patch_code, CodeEmitInfo* info, bool pop_fpu_stack, bool wide) {
   if (src->is_register()) {
     if (dest->is_register()) {
-      assert(patch_code == lir_patch_none && info == NULL, "no patching and info allowed here");
+      assert(patch_code == lir_patch_none && info == nullptr, "no patching and info allowed here");
       reg2reg(src,  dest);
     } else if (dest->is_stack()) {
-      assert(patch_code == lir_patch_none && info == NULL, "no patching and info allowed here");
+      assert(patch_code == lir_patch_none && info == nullptr, "no patching and info allowed here");
       reg2stack(src, dest, type, pop_fpu_stack);
     } else if (dest->is_address()) {
       reg2mem(src, dest, type, patch_code, info, pop_fpu_stack, wide);
@@ -802,7 +802,7 @@ void LIR_Assembler::move_op(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
     }
 
   } else if (src->is_stack()) {
-    assert(patch_code == lir_patch_none && info == NULL, "no patching and info allowed here");
+    assert(patch_code == lir_patch_none && info == nullptr, "no patching and info allowed here");
     if (dest->is_register()) {
       stack2reg(src, dest, type);
     } else if (dest->is_stack()) {
@@ -815,7 +815,7 @@ void LIR_Assembler::move_op(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
     if (dest->is_register()) {
       const2reg(src, dest, patch_code, info); // patching is possible
     } else if (dest->is_stack()) {
-      assert(patch_code == lir_patch_none && info == NULL, "no patching and info allowed here");
+      assert(patch_code == lir_patch_none && info == nullptr, "no patching and info allowed here");
       const2stack(src, dest);
     } else if (dest->is_address()) {
       assert(patch_code == lir_patch_none, "no patching allowed here");

--- a/src/hotspot/share/c1/c1_LIRAssembler.hpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,10 @@ class LIR_Assembler: public CompilationResourceObj {
 
   // non-safepoint debug info management
   void flush_debug_info(int before_pc_offset) {
-    if (_pending_non_safepoint != NULL) {
+    if (_pending_non_safepoint != nullptr) {
       if (_pending_non_safepoint_offset < before_pc_offset)
         record_non_safepoint_debug_info();
-      _pending_non_safepoint = NULL;
+      _pending_non_safepoint = nullptr;
     }
   }
   void process_debug_info(LIR_Op* op);
@@ -237,7 +237,7 @@ class LIR_Assembler: public CompilationResourceObj {
   void align_call(LIR_Code code);
 
   void negate(LIR_Opr left, LIR_Opr dest, LIR_Opr tmp = LIR_OprFact::illegalOpr);
-  void leal(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_code = lir_patch_none, CodeEmitInfo* info = NULL);
+  void leal(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_code = lir_patch_none, CodeEmitInfo* info = nullptr);
 
   void rt_call(LIR_Opr result, address dest, const LIR_OprList* args, LIR_Opr tmp, CodeEmitInfo* info);
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -108,10 +108,10 @@ void PhiResolver::move_to_temp(LIR_Opr src) {
 
 // Traverse assignment graph in depth first order and generate moves in post order
 // ie. two assignments: b := c, a := b start with node c:
-// Call graph: move(NULL, c) -> move(c, b) -> move(b, a)
+// Call graph: move(null, c) -> move(c, b) -> move(b, a)
 // Generates moves in this order: move b to a and move c to b
 // ie. cycle a := b, b := a start with node a
-// Call graph: move(NULL, a) -> move(a, b) -> move(b, a)
+// Call graph: move(null, a) -> move(a, b) -> move(b, a)
 // Generates moves in this order: move b to temp, move a to b, move temp to a
 void PhiResolver::move(ResolveNode* src, ResolveNode* dest) {
   if (!dest->visited()) {
@@ -121,7 +121,7 @@ void PhiResolver::move(ResolveNode* src, ResolveNode* dest) {
     }
   } else if (!dest->start_node()) {
     // cylce in graph detected
-    assert(_loop == NULL, "only one loop valid!");
+    assert(_loop == nullptr, "only one loop valid!");
     _loop = dest;
     move_to_temp(src->operand());
     return;
@@ -131,7 +131,7 @@ void PhiResolver::move(ResolveNode* src, ResolveNode* dest) {
     if (_loop == dest) {
       move_temp_to(dest->operand());
       dest->set_assigned();
-    } else if (src != NULL) {
+    } else if (src != nullptr) {
       emit_move(src->operand(), dest->operand());
       dest->set_assigned();
     }
@@ -145,8 +145,8 @@ PhiResolver::~PhiResolver() {
   for (i = virtual_operands().length() - 1; i >= 0; i --) {
     ResolveNode* node = virtual_operands().at(i);
     if (!node->visited()) {
-      _loop = NULL;
-      move(NULL, node);
+      _loop = nullptr;
+      move(nullptr, node);
       node->set_start_node();
       assert(_temp->is_illegal(), "move_temp_to() call missing");
     }
@@ -166,9 +166,9 @@ ResolveNode* PhiResolver::create_node(LIR_Opr opr, bool source) {
   ResolveNode* node;
   if (opr->is_virtual()) {
     int vreg_num = opr->vreg_number();
-    node = vreg_table().at_grow(vreg_num, NULL);
-    assert(node == NULL || node->operand() == opr, "");
-    if (node == NULL) {
+    node = vreg_table().at_grow(vreg_num, nullptr);
+    assert(node == nullptr || node->operand() == opr, "");
+    if (node == nullptr) {
       node = new ResolveNode(opr);
       vreg_table().at_put(vreg_num, node);
     }
@@ -204,7 +204,7 @@ void LIRItem::set_result(LIR_Opr opr) {
   value()->set_operand(opr);
 
   if (opr->is_virtual()) {
-    _gen->_instruction_for_operand.at_put_grow(opr->vreg_number(), value(), NULL);
+    _gen->_instruction_for_operand.at_put_grow(opr->vreg_number(), value(), nullptr);
   }
 
   _result = opr;
@@ -259,41 +259,41 @@ ciObject* LIRItem::get_jobject_constant() const {
   if (oc) {
     return oc->constant_value();
   }
-  return NULL;
+  return nullptr;
 }
 
 
 jint LIRItem::get_jint_constant() const {
-  assert(is_constant() && value() != NULL, "");
-  assert(type()->as_IntConstant() != NULL, "type check");
+  assert(is_constant() && value() != nullptr, "");
+  assert(type()->as_IntConstant() != nullptr, "type check");
   return type()->as_IntConstant()->value();
 }
 
 
 jint LIRItem::get_address_constant() const {
-  assert(is_constant() && value() != NULL, "");
-  assert(type()->as_AddressConstant() != NULL, "type check");
+  assert(is_constant() && value() != nullptr, "");
+  assert(type()->as_AddressConstant() != nullptr, "type check");
   return type()->as_AddressConstant()->value();
 }
 
 
 jfloat LIRItem::get_jfloat_constant() const {
-  assert(is_constant() && value() != NULL, "");
-  assert(type()->as_FloatConstant() != NULL, "type check");
+  assert(is_constant() && value() != nullptr, "");
+  assert(type()->as_FloatConstant() != nullptr, "type check");
   return type()->as_FloatConstant()->value();
 }
 
 
 jdouble LIRItem::get_jdouble_constant() const {
-  assert(is_constant() && value() != NULL, "");
-  assert(type()->as_DoubleConstant() != NULL, "type check");
+  assert(is_constant() && value() != nullptr, "");
+  assert(type()->as_DoubleConstant() != nullptr, "type check");
   return type()->as_DoubleConstant()->value();
 }
 
 
 jlong LIRItem::get_jlong_constant() const {
-  assert(is_constant() && value() != NULL, "");
-  assert(type()->as_LongConstant() != NULL, "type check");
+  assert(is_constant() && value() != nullptr, "");
+  assert(type()->as_LongConstant() != nullptr, "type check");
   return type()->as_LongConstant()->value();
 }
 
@@ -310,7 +310,7 @@ void LIRGenerator::block_do_prolog(BlockBegin* block) {
 #endif
 
   // set up the list of LIR instructions
-  assert(block->lir() == NULL, "LIR list already computed for this block");
+  assert(block->lir() == nullptr, "LIR list already computed for this block");
   _lir = new LIR_List(compilation(), block);
   block->set_lir(_lir);
 
@@ -351,11 +351,11 @@ void LIRGenerator::block_do(BlockBegin* block) {
   block_do_prolog(block);
   set_block(block);
 
-  for (Instruction* instr = block; instr != NULL; instr = instr->next()) {
+  for (Instruction* instr = block; instr != nullptr; instr = instr->next()) {
     if (instr->is_pinned()) do_root(instr);
   }
 
-  set_block(NULL);
+  set_block(nullptr);
   block_do_epilog(block);
 }
 
@@ -374,7 +374,7 @@ void LIRGenerator::do_root(Value instr) {
   instr->visit(this);
 
   assert(!instr->has_uses() || instr->operand()->is_valid() ||
-         instr->as_Constant() != NULL || bailed_out(), "invalid item set");
+         instr->as_Constant() != nullptr || bailed_out(), "invalid item set");
 }
 
 
@@ -382,18 +382,18 @@ void LIRGenerator::do_root(Value instr) {
 void LIRGenerator::walk(Value instr) {
   InstructionMark im(compilation(), instr);
   //stop walk when encounter a root
-  if ((instr->is_pinned() && instr->as_Phi() == NULL) || instr->operand()->is_valid()) {
-    assert(instr->operand() != LIR_OprFact::illegalOpr || instr->as_Constant() != NULL, "this root has not yet been visited");
+  if ((instr->is_pinned() && instr->as_Phi() == nullptr) || instr->operand()->is_valid()) {
+    assert(instr->operand() != LIR_OprFact::illegalOpr || instr->as_Constant() != nullptr, "this root has not yet been visited");
   } else {
     assert(instr->subst() == instr, "shouldn't have missed substitution");
     instr->visit(this);
-    // assert(instr->use_count() > 0 || instr->as_Phi() != NULL, "leaf instruction must have a use");
+    // assert(instr->use_count() > 0 || instr->as_Phi() != null, "leaf instruction must have a use");
   }
 }
 
 
 CodeEmitInfo* LIRGenerator::state_for(Instruction* x, ValueStack* state, bool ignore_xhandler) {
-  assert(state != NULL, "state must be defined");
+  assert(state != nullptr, "state must be defined");
 
 #ifndef PRODUCT
   state->verify();
@@ -410,7 +410,7 @@ CodeEmitInfo* LIRGenerator::state_for(Instruction* x, ValueStack* state, bool ig
     Value value;
     for_each_stack_value(s, index, value) {
       assert(value->subst() == value, "missed substitution");
-      if (!value->is_pinned() && value->as_Constant() == NULL && value->as_Local() == NULL) {
+      if (!value->is_pinned() && value->as_Constant() == nullptr && value->as_Local() == nullptr) {
         walk(value);
         assert(value->operand()->is_valid(), "must be evaluated now");
       }
@@ -437,19 +437,19 @@ CodeEmitInfo* LIRGenerator::state_for(Instruction* x, ValueStack* state, bool ig
       for_each_local_value(s, index, value) {
         assert(value->subst() == value, "missed substitution");
         if (liveness.at(index) && !value->type()->is_illegal()) {
-          if (!value->is_pinned() && value->as_Constant() == NULL && value->as_Local() == NULL) {
+          if (!value->is_pinned() && value->as_Constant() == nullptr && value->as_Local() == nullptr) {
             walk(value);
             assert(value->operand()->is_valid(), "must be evaluated now");
           }
         } else {
-          // NULL out this local so that linear scan can assume that all non-NULL values are live.
+          // null out this local so that linear scan can assume that all non-null values are live.
           s->invalidate_local(index);
         }
       }
     }
   }
 
-  return new CodeEmitInfo(state, ignore_xhandler ? NULL : x->exception_handlers(), x->check_flag(Instruction::DeoptimizeOnException));
+  return new CodeEmitInfo(state, ignore_xhandler ? nullptr : x->exception_handlers(), x->check_flag(Instruction::DeoptimizeOnException));
 }
 
 
@@ -463,8 +463,8 @@ void LIRGenerator::klass2reg_with_patching(LIR_Opr r, ciMetadata* obj, CodeEmitI
    * is active and the class hasn't yet been resolved we need to emit a patch that resolves
    * the class. */
   if ((!CompilerConfig::is_c1_only_no_jvmci() && need_resolve) || !obj->is_loaded() || PatchALot) {
-    assert(info != NULL, "info must be set if class is not loaded");
-    __ klass2reg_patch(NULL, r, info);
+    assert(info != nullptr, "info must be set if class is not loaded");
+    __ klass2reg_patch(nullptr, r, info);
   } else {
     // no patching needed
     __ metadata2reg(obj->constant_encoding(), r);
@@ -679,21 +679,21 @@ static bool positive_constant(Instruction* inst) {
 
 
 static ciArrayKlass* as_array_klass(ciType* type) {
-  if (type != NULL && type->is_array_klass() && type->is_loaded()) {
+  if (type != nullptr && type->is_array_klass() && type->is_loaded()) {
     return (ciArrayKlass*)type;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
 static ciType* phi_declared_type(Phi* phi) {
   ciType* t = phi->operand_at(0)->declared_type();
-  if (t == NULL) {
-    return NULL;
+  if (t == nullptr) {
+    return nullptr;
   }
   for(int i = 1; i < phi->operand_count(); i++) {
     if (t != phi->operand_at(i)->declared_type()) {
-      return NULL;
+      return nullptr;
     }
   }
   return t;
@@ -707,34 +707,34 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
   Instruction* length  = x->argument_at(4);
 
   // first try to identify the likely type of the arrays involved
-  ciArrayKlass* expected_type = NULL;
+  ciArrayKlass* expected_type = nullptr;
   bool is_exact = false, src_objarray = false, dst_objarray = false;
   {
     ciArrayKlass* src_exact_type    = as_array_klass(src->exact_type());
     ciArrayKlass* src_declared_type = as_array_klass(src->declared_type());
     Phi* phi;
-    if (src_declared_type == NULL && (phi = src->as_Phi()) != NULL) {
+    if (src_declared_type == nullptr && (phi = src->as_Phi()) != nullptr) {
       src_declared_type = as_array_klass(phi_declared_type(phi));
     }
     ciArrayKlass* dst_exact_type    = as_array_klass(dst->exact_type());
     ciArrayKlass* dst_declared_type = as_array_klass(dst->declared_type());
-    if (dst_declared_type == NULL && (phi = dst->as_Phi()) != NULL) {
+    if (dst_declared_type == nullptr && (phi = dst->as_Phi()) != nullptr) {
       dst_declared_type = as_array_klass(phi_declared_type(phi));
     }
 
-    if (src_exact_type != NULL && src_exact_type == dst_exact_type) {
+    if (src_exact_type != nullptr && src_exact_type == dst_exact_type) {
       // the types exactly match so the type is fully known
       is_exact = true;
       expected_type = src_exact_type;
-    } else if (dst_exact_type != NULL && dst_exact_type->is_obj_array_klass()) {
+    } else if (dst_exact_type != nullptr && dst_exact_type->is_obj_array_klass()) {
       ciArrayKlass* dst_type = (ciArrayKlass*) dst_exact_type;
-      ciArrayKlass* src_type = NULL;
-      if (src_exact_type != NULL && src_exact_type->is_obj_array_klass()) {
+      ciArrayKlass* src_type = nullptr;
+      if (src_exact_type != nullptr && src_exact_type->is_obj_array_klass()) {
         src_type = (ciArrayKlass*) src_exact_type;
-      } else if (src_declared_type != NULL && src_declared_type->is_obj_array_klass()) {
+      } else if (src_declared_type != nullptr && src_declared_type->is_obj_array_klass()) {
         src_type = (ciArrayKlass*) src_declared_type;
       }
-      if (src_type != NULL) {
+      if (src_type != nullptr) {
         if (src_type->element_type()->is_subtype_of(dst_type->element_type())) {
           is_exact = true;
           expected_type = dst_type;
@@ -742,9 +742,9 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
       }
     }
     // at least pass along a good guess
-    if (expected_type == NULL) expected_type = dst_exact_type;
-    if (expected_type == NULL) expected_type = src_declared_type;
-    if (expected_type == NULL) expected_type = dst_declared_type;
+    if (expected_type == nullptr) expected_type = dst_exact_type;
+    if (expected_type == nullptr) expected_type = src_declared_type;
+    if (expected_type == nullptr) expected_type = dst_declared_type;
 
     src_objarray = (src_exact_type && src_exact_type->is_obj_array_klass()) || (src_declared_type && src_declared_type->is_obj_array_klass());
     dst_objarray = (dst_exact_type && dst_exact_type->is_obj_array_klass()) || (dst_declared_type && dst_declared_type->is_obj_array_klass());
@@ -765,11 +765,11 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
     flags &= ~LIR_OpArrayCopy::dst_null_check;
 
 
-  if (expected_type != NULL) {
-    Value length_limit = NULL;
+  if (expected_type != nullptr) {
+    Value length_limit = nullptr;
 
     IfOp* ifop = length->as_IfOp();
-    if (ifop != NULL) {
+    if (ifop != nullptr) {
       // look for expressions like min(v, a.length) which ends up as
       //   x > y ? y : x  or  x >= y ? y : x
       if ((ifop->cond() == If::gtr || ifop->cond() == If::geq) &&
@@ -781,9 +781,9 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
 
     // try to skip null checks and range checks
     NewArray* src_array = src->as_NewArray();
-    if (src_array != NULL) {
+    if (src_array != nullptr) {
       flags &= ~LIR_OpArrayCopy::src_null_check;
-      if (length_limit != NULL &&
+      if (length_limit != nullptr &&
           src_array->length() == length_limit &&
           is_constant_zero(src_pos)) {
         flags &= ~LIR_OpArrayCopy::src_range_check;
@@ -791,9 +791,9 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
     }
 
     NewArray* dst_array = dst->as_NewArray();
-    if (dst_array != NULL) {
+    if (dst_array != nullptr) {
       flags &= ~LIR_OpArrayCopy::dst_null_check;
-      if (length_limit != NULL &&
+      if (length_limit != nullptr &&
           dst_array->length() == length_limit &&
           is_constant_zero(dst_pos)) {
         flags &= ~LIR_OpArrayCopy::dst_range_check;
@@ -811,7 +811,7 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
     // see if the range check can be elided, which might also imply
     // that src or dst is non-null.
     ArrayLength* al = length->as_ArrayLength();
-    if (al != NULL) {
+    if (al != nullptr) {
       if (al->array() == src) {
         // it's the length of the source array
         flags &= ~LIR_OpArrayCopy::length_positive_check;
@@ -840,7 +840,7 @@ void LIRGenerator::arraycopy_helper(Intrinsic* x, int* flagsp, ciArrayKlass** ex
     if (src_int->value() >= dst_int->value()) {
       flags &= ~LIR_OpArrayCopy::overlapping;
     }
-    if (expected_type != NULL) {
+    if (expected_type != nullptr) {
       BasicType t = expected_type->element_type()->basic_type();
       int element_size = type2aelembytes(t);
       if (((arrayOopDesc::base_offset_in_bytes(t) + s_offs * element_size) % HeapWordSize == 0) &&
@@ -908,11 +908,11 @@ LIR_Opr LIRGenerator::force_to_spill(LIR_Opr value, BasicType t) {
 void LIRGenerator::profile_branch(If* if_instr, If::Condition cond) {
   if (if_instr->should_profile()) {
     ciMethod* method = if_instr->profiled_method();
-    assert(method != NULL, "method should be set if branch is profiled");
+    assert(method != nullptr, "method should be set if branch is profiled");
     ciMethodData* md = method->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(if_instr->profiled_bci());
-    assert(data != NULL, "must have profiling data");
+    assert(data != nullptr, "must have profiling data");
     assert(data->is_BranchData(), "need BranchData for two-way branches");
     int taken_count_offset     = md->byte_offset_of_slot(data, BranchData::taken_offset());
     int not_taken_count_offset = md->byte_offset_of_slot(data, BranchData::not_taken_offset());
@@ -963,17 +963,17 @@ void LIRGenerator::profile_branch(If* if_instr, If::Condition cond) {
 void LIRGenerator::move_to_phi(PhiResolver* resolver, Value cur_val, Value sux_val) {
   Phi* phi = sux_val->as_Phi();
   // cur_val can be null without phi being null in conjunction with inlining
-  if (phi != NULL && cur_val != NULL && cur_val != phi && !phi->is_illegal()) {
+  if (phi != nullptr && cur_val != nullptr && cur_val != phi && !phi->is_illegal()) {
     if (phi->is_local()) {
       for (int i = 0; i < phi->operand_count(); i++) {
         Value op = phi->operand_at(i);
-        if (op != NULL && op->type()->is_illegal()) {
+        if (op != nullptr && op->type()->is_illegal()) {
           bailout("illegal phi operand");
         }
       }
     }
     Phi* cur_phi = cur_val->as_Phi();
-    if (cur_phi != NULL && cur_phi->is_illegal()) {
+    if (cur_phi != nullptr && cur_phi->is_illegal()) {
       // Phi and local would need to get invalidated
       // (which is unexpected for Linear Scan).
       // But this case is very rare so we simply bail out.
@@ -982,7 +982,7 @@ void LIRGenerator::move_to_phi(PhiResolver* resolver, Value cur_val, Value sux_v
     }
     LIR_Opr operand = cur_val->operand();
     if (operand->is_illegal()) {
-      assert(cur_val->as_Constant() != NULL || cur_val->as_Local() != NULL,
+      assert(cur_val->as_Constant() != nullptr || cur_val->as_Local() != nullptr,
              "these can be produced lazily");
       operand = operand_for_instruction(cur_val);
     }
@@ -1081,7 +1081,7 @@ ciObject* LIRGenerator::get_jobject_constant(Value value) {
   if (oc) {
     return oc->constant_value();
   }
-  return NULL;
+  return nullptr;
 }
 
 
@@ -1097,9 +1097,9 @@ void LIRGenerator::do_ExceptionObject(ExceptionObject* x) {
   LIR_Opr thread_reg = getThreadPointer();
   __ move_wide(new LIR_Address(thread_reg, in_bytes(JavaThread::exception_oop_offset()), T_OBJECT),
                exceptionOopOpr());
-  __ move_wide(LIR_OprFact::oopConst(NULL),
+  __ move_wide(LIR_OprFact::oopConst(nullptr),
                new LIR_Address(thread_reg, in_bytes(JavaThread::exception_oop_offset()), T_OBJECT));
-  __ move_wide(LIR_OprFact::oopConst(NULL),
+  __ move_wide(LIR_OprFact::oopConst(nullptr),
                new LIR_Address(thread_reg, in_bytes(JavaThread::exception_pc_offset()), T_OBJECT));
 
   LIR_Opr result = new_register(T_OBJECT);
@@ -1126,11 +1126,11 @@ void LIRGenerator::do_Phi(Phi* x) {
 
 // Code for a constant is generated lazily unless the constant is frequently used and can't be inlined.
 void LIRGenerator::do_Constant(Constant* x) {
-  if (x->state_before() != NULL) {
+  if (x->state_before() != nullptr) {
     // Any constant with a ValueStack requires patching so emit the patch here
     LIR_Opr reg = rlock_result(x);
     CodeEmitInfo* info = state_for(x, x->state_before());
-    __ oop2reg_patch(NULL, reg, info);
+    __ oop2reg_patch(nullptr, reg, info);
   } else if (x->use_count() > 1 && !can_inline_as_constant(x)) {
     if (!x->is_pinned()) {
       // unpinned constants are handled specially so that they can be
@@ -1173,7 +1173,7 @@ void LIRGenerator::do_Return(Return* x) {
     LIR_Opr meth = new_register(T_METADATA);
     __ metadata2reg(method()->constant_encoding(), meth);
     args->append(meth);
-    call_runtime(&signature, args, CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit), voidType, NULL);
+    call_runtime(&signature, args, CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit), voidType, nullptr);
   }
 
   if (x->type()->is_void()) {
@@ -1200,7 +1200,7 @@ void LIRGenerator::do_Reference_get(Intrinsic* x) {
   reference.load_item();
 
   // need to perform the null check on the reference object
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (x->needs_null_check()) {
     info = state_for(x);
   }
@@ -1236,7 +1236,7 @@ void LIRGenerator::do_isInstance(Intrinsic* x) {
   LIR_Opr call_result = call_runtime(clazz.value(), object.value(),
                                      CAST_FROM_FN_PTR(address, Runtime1::is_instance_of),
                                      x->type(),
-                                     NULL); // NULL CodeEmitInfo results in a leaf call
+                                     nullptr); // null CodeEmitInfo results in a leaf call
   __ move(call_result, result);
 }
 
@@ -1254,7 +1254,7 @@ void LIRGenerator::do_getClass(Intrinsic* x) {
   LIR_Opr result = rlock_result(x);
 
   // need to perform the null check on the rcvr
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (x->needs_null_check()) {
     info = state_for(x);
   }
@@ -1276,7 +1276,7 @@ void LIRGenerator::do_isPrimitive(Intrinsic* x) {
   LIR_Opr temp = new_register(T_METADATA);
   LIR_Opr result = rlock_result(x);
 
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (x->needs_null_check()) {
     info = state_for(x);
   }
@@ -1294,7 +1294,7 @@ void LIRGenerator::do_getModifiers(Intrinsic* x) {
   receiver.load_item();
   LIR_Opr result = rlock_result(x);
 
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (x->needs_null_check()) {
     info = state_for(x);
   }
@@ -1330,7 +1330,7 @@ void LIRGenerator::do_getObjectSize(Intrinsic* x) {
   value.load_item();
 
   LIR_Opr klass = new_register(T_METADATA);
-  load_klass(value.result(), klass, NULL);
+  load_klass(value.result(), klass, nullptr);
   LIR_Opr layout = new_register(T_INT);
   __ move(new LIR_Address(klass, in_bytes(Klass::layout_helper_offset()), T_INT), layout);
 
@@ -1473,13 +1473,13 @@ void LIRGenerator::do_RegisterFinalizer(Intrinsic* x) {
 LIR_Opr LIRGenerator::operand_for_instruction(Instruction* x) {
   if (x->operand()->is_illegal()) {
     Constant* c = x->as_Constant();
-    if (c != NULL) {
+    if (c != nullptr) {
       x->set_operand(LIR_OprFact::value_type(c->type()));
     } else {
-      assert(x->as_Phi() || x->as_Local() != NULL, "only for Phi and Local");
+      assert(x->as_Phi() || x->as_Local() != nullptr, "only for Phi and Local");
       // allocate a virtual register for this local or phi
       x->set_operand(rlock(x));
-      _instruction_for_operand.at_put_grow(x->operand()->vreg_number(), x, NULL);
+      _instruction_for_operand.at_put_grow(x->operand()->vreg_number(), x, nullptr);
     }
   }
   return x->operand();
@@ -1490,7 +1490,7 @@ Instruction* LIRGenerator::instruction_for_opr(LIR_Opr opr) {
   if (opr->is_virtual()) {
     return instruction_for_vreg(opr->vreg_number());
   }
-  return NULL;
+  return nullptr;
 }
 
 
@@ -1498,7 +1498,7 @@ Instruction* LIRGenerator::instruction_for_vreg(int reg_num) {
   if (reg_num < _instruction_for_operand.length()) {
     return _instruction_for_operand.at(reg_num);
   }
-  return NULL;
+  return nullptr;
 }
 
 
@@ -1613,13 +1613,13 @@ void LIRGenerator::do_StoreField(StoreField* x) {
   bool is_volatile = x->field()->is_volatile();
   BasicType field_type = x->field_type();
 
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (needs_patching) {
-    assert(x->explicit_null_check() == NULL, "can't fold null check into patching field access");
+    assert(x->explicit_null_check() == nullptr, "can't fold null check into patching field access");
     info = state_for(x, x->state_before());
   } else if (x->needs_null_check()) {
     NullCheck* nc = x->explicit_null_check();
-    if (nc == NULL) {
+    if (nc == nullptr) {
       info = state_for(x);
     } else {
       info = state_for(nc);
@@ -1658,7 +1658,7 @@ void LIRGenerator::do_StoreField(StoreField* x) {
       (needs_patching ||
        MacroAssembler::needs_explicit_null_check(x->offset()))) {
     // Emit an explicit null check because the offset is too large.
-    // If the class is not loaded and the object is NULL, we need to deoptimize to throw a
+    // If the class is not loaded and the object is null, we need to deoptimize to throw a
     // NoClassDefFoundError in the interpreter instead of an implicit NPE from compiled code.
     __ null_check(object.result(), new CodeEmitInfo(info), /* deoptimize */ needs_patching);
   }
@@ -1672,15 +1672,15 @@ void LIRGenerator::do_StoreField(StoreField* x) {
   }
 
   access_store_at(decorators, field_type, object, LIR_OprFact::intConst(x->offset()),
-                  value.result(), info != NULL ? new CodeEmitInfo(info) : NULL, info);
+                  value.result(), info != nullptr ? new CodeEmitInfo(info) : nullptr, info);
 }
 
 void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
   assert(x->is_pinned(),"");
   bool needs_range_check = x->compute_needs_range_check();
-  bool use_length = x->length() != NULL;
+  bool use_length = x->length() != nullptr;
   bool obj_store = is_reference_type(x->elt_type());
-  bool needs_store_check = obj_store && (x->value()->as_Constant() == NULL ||
+  bool needs_store_check = obj_store && (x->value()->as_Constant() == nullptr ||
                                          !get_jobject_constant(x->value())->is_null_object() ||
                                          x->should_profile());
 
@@ -1709,7 +1709,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
   // LIR-instruction because spilling can occur anywhere between two
   // instructions and so the debug information must be different
   CodeEmitInfo* range_check_info = state_for(x);
-  CodeEmitInfo* null_check_info = NULL;
+  CodeEmitInfo* null_check_info = nullptr;
   if (x->needs_null_check()) {
     null_check_info = new CodeEmitInfo(range_check_info);
   }
@@ -1721,7 +1721,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
     } else {
       array_range_check(array.result(), index.result(), null_check_info, range_check_info);
       // range_check also does the null check
-      null_check_info = NULL;
+      null_check_info = nullptr;
     }
   }
 
@@ -1736,7 +1736,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
   }
 
   access_store_at(decorators, x->elt_type(), array, index.result(), value.result(),
-                  NULL, null_check_info);
+                  nullptr, null_check_info);
 }
 
 void LIRGenerator::access_load_at(DecoratorSet decorators, BasicType type,
@@ -1822,13 +1822,13 @@ void LIRGenerator::do_LoadField(LoadField* x) {
   bool is_volatile = x->field()->is_volatile();
   BasicType field_type = x->field_type();
 
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (needs_patching) {
-    assert(x->explicit_null_check() == NULL, "can't fold null check into patching field access");
+    assert(x->explicit_null_check() == nullptr, "can't fold null check into patching field access");
     info = state_for(x, x->state_before());
   } else if (x->needs_null_check()) {
     NullCheck* nc = x->explicit_null_check();
-    if (nc == NULL) {
+    if (nc == nullptr) {
       info = state_for(x);
     } else {
       info = state_for(nc);
@@ -1854,10 +1854,10 @@ void LIRGenerator::do_LoadField(LoadField* x) {
     LIR_Opr obj = object.result();
     if (stress_deopt) {
       obj = new_register(T_OBJECT);
-      __ move(LIR_OprFact::oopConst(NULL), obj);
+      __ move(LIR_OprFact::oopConst(nullptr), obj);
     }
     // Emit an explicit null check because the offset is too large.
-    // If the class is not loaded and the object is NULL, we need to deoptimize to throw a
+    // If the class is not loaded and the object is null, we need to deoptimize to throw a
     // NoClassDefFoundError in the interpreter instead of an implicit NPE from compiled code.
     __ null_check(obj, new CodeEmitInfo(info), /* deoptimize */ needs_patching);
   }
@@ -1873,7 +1873,7 @@ void LIRGenerator::do_LoadField(LoadField* x) {
   LIR_Opr result = rlock_result(x, field_type);
   access_load_at(decorators, field_type,
                  object, LIR_OprFact::intConst(x->offset()), result,
-                 info ? new CodeEmitInfo(info) : NULL, info);
+                 info ? new CodeEmitInfo(info) : nullptr, info);
 }
 
 // int/long jdk.internal.util.Preconditions.checkIndex
@@ -1949,17 +1949,17 @@ void LIRGenerator::do_ArrayLength(ArrayLength* x) {
   array.load_item();
   LIR_Opr reg = rlock_result(x);
 
-  CodeEmitInfo* info = NULL;
+  CodeEmitInfo* info = nullptr;
   if (x->needs_null_check()) {
     NullCheck* nc = x->explicit_null_check();
-    if (nc == NULL) {
+    if (nc == nullptr) {
       info = state_for(x);
     } else {
       info = state_for(nc);
     }
     if (StressLoopInvariantCodeMotion && info->deoptimize_on_exception()) {
       LIR_Opr obj = new_register(T_OBJECT);
-      __ move(LIR_OprFact::oopConst(NULL), obj);
+      __ move(LIR_OprFact::oopConst(nullptr), obj);
       __ null_check(obj, new CodeEmitInfo(info));
     }
   }
@@ -1968,7 +1968,7 @@ void LIRGenerator::do_ArrayLength(ArrayLength* x) {
 
 
 void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
-  bool use_length = x->length() != NULL;
+  bool use_length = x->length() != nullptr;
   LIRItem array(x->array(), this);
   LIRItem index(x->index(), this);
   LIRItem length(this);
@@ -1988,17 +1988,17 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   }
 
   CodeEmitInfo* range_check_info = state_for(x);
-  CodeEmitInfo* null_check_info = NULL;
+  CodeEmitInfo* null_check_info = nullptr;
   if (x->needs_null_check()) {
     NullCheck* nc = x->explicit_null_check();
-    if (nc != NULL) {
+    if (nc != nullptr) {
       null_check_info = state_for(nc);
     } else {
       null_check_info = range_check_info;
     }
     if (StressLoopInvariantCodeMotion && null_check_info->deoptimize_on_exception()) {
       LIR_Opr obj = new_register(T_OBJECT);
-      __ move(LIR_OprFact::oopConst(NULL), obj);
+      __ move(LIR_OprFact::oopConst(nullptr), obj);
       __ null_check(obj, new CodeEmitInfo(null_check_info));
     }
   }
@@ -2014,7 +2014,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
     } else {
       array_range_check(array.result(), index.result(), null_check_info, range_check_info);
       // The range check performs the null check, so clear it out for the load
-      null_check_info = NULL;
+      null_check_info = nullptr;
     }
   }
 
@@ -2023,7 +2023,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   LIR_Opr result = rlock_result(x, x->elt_type());
   access_load_at(decorators, x->elt_type(),
                  array, index.result(), result,
-                 NULL, null_check_info);
+                 nullptr, null_check_info);
 }
 
 
@@ -2067,11 +2067,11 @@ void LIRGenerator::do_Throw(Throw* x) {
     // get some idea of the throw type
     bool type_is_exact = true;
     ciType* throw_type = x->exception()->exact_type();
-    if (throw_type == NULL) {
+    if (throw_type == nullptr) {
       type_is_exact = false;
       throw_type = x->exception()->declared_type();
     }
-    if (throw_type != NULL && throw_type->is_instance_klass()) {
+    if (throw_type != nullptr && throw_type->is_instance_klass()) {
       ciInstanceKlass* throw_klass = (ciInstanceKlass*)throw_type;
       unwind = !x->exception_handlers()->could_catch(throw_klass, type_is_exact);
     }
@@ -2081,7 +2081,7 @@ void LIRGenerator::do_Throw(Throw* x) {
   // to avoid a fixed interval with an oop during the null check.
   // Use a copy of the CodeEmitInfo because debug information is
   // different for null_check and throw.
-  if (x->exception()->as_NewInstance() == NULL && x->exception()->as_ExceptionObject() == NULL) {
+  if (x->exception()->as_NewInstance() == nullptr && x->exception()->as_ExceptionObject() == nullptr) {
     // if the exception object wasn't created using new then it might be null.
     __ null_check(exception_opr, new CodeEmitInfo(info, x->state()->copy(ValueStack::ExceptionState, x->state()->bci())));
   }
@@ -2319,9 +2319,9 @@ void LIRGenerator::do_TableSwitch(TableSwitch* x) {
   if (compilation()->env()->comp_level() == CompLevel_full_profile && UseSwitchProfiling) {
     ciMethod* method = x->state()->scope()->method();
     ciMethodData* md = method->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(x->state()->bci());
-    assert(data != NULL, "must have profiling data");
+    assert(data != nullptr, "must have profiling data");
     assert(data->is_MultiBranchData(), "bad profile data?");
     int default_count_offset = md->byte_offset_of_slot(data, MultiBranchData::default_count_offset());
     LIR_Opr md_reg = new_register(T_METADATA);
@@ -2377,9 +2377,9 @@ void LIRGenerator::do_LookupSwitch(LookupSwitch* x) {
   if (compilation()->env()->comp_level() == CompLevel_full_profile && UseSwitchProfiling) {
     ciMethod* method = x->state()->scope()->method();
     ciMethodData* md = method->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(x->state()->bci());
-    assert(data != NULL, "must have profiling data");
+    assert(data != nullptr, "must have profiling data");
     assert(data->is_MultiBranchData(), "bad profile data?");
     int default_count_offset = md->byte_offset_of_slot(data, MultiBranchData::default_count_offset());
     LIR_Opr md_reg = new_register(T_METADATA);
@@ -2445,11 +2445,11 @@ void LIRGenerator::do_Goto(Goto* x) {
   // Gotos can be folded Ifs, handle this case.
   if (x->should_profile()) {
     ciMethod* method = x->profiled_method();
-    assert(method != NULL, "method should be set if branch is profiled");
+    assert(method != nullptr, "method should be set if branch is profiled");
     ciMethodData* md = method->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(x->profiled_bci());
-    assert(data != NULL, "must have profiling data");
+    assert(data != nullptr, "must have profiling data");
     int offset;
     if (x->direction() == Goto::taken) {
       assert(data->is_BranchData(), "need BranchData for two-way branches");
@@ -2494,7 +2494,7 @@ void LIRGenerator::do_Goto(Goto* x) {
 ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md_offset, intptr_t profiled_k,
                                     Value obj, LIR_Opr& mdp, bool not_null, ciKlass* signature_at_call_k,
                                     ciKlass* callee_signature_k) {
-  ciKlass* result = NULL;
+  ciKlass* result = nullptr;
   bool do_null = !not_null && !TypeEntries::was_null_seen(profiled_k);
   bool do_update = !TypeEntries::is_type_unknown(profiled_k);
   // known not to be null or null bit already set and already set to
@@ -2503,31 +2503,31 @@ ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md
     return result;
   }
 
-  ciKlass* exact_klass = NULL;
+  ciKlass* exact_klass = nullptr;
   Compilation* comp = Compilation::current();
   if (do_update) {
     // try to find exact type, using CHA if possible, so that loading
     // the klass from the object can be avoided
     ciType* type = obj->exact_type();
-    if (type == NULL) {
+    if (type == nullptr) {
       type = obj->declared_type();
       type = comp->cha_exact_type(type);
     }
-    assert(type == NULL || type->is_klass(), "type should be class");
-    exact_klass = (type != NULL && type->is_loaded()) ? (ciKlass*)type : NULL;
+    assert(type == nullptr || type->is_klass(), "type should be class");
+    exact_klass = (type != nullptr && type->is_loaded()) ? (ciKlass*)type : nullptr;
 
-    do_update = exact_klass == NULL || ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
+    do_update = exact_klass == nullptr || ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
   }
 
   if (!do_null && !do_update) {
     return result;
   }
 
-  ciKlass* exact_signature_k = NULL;
+  ciKlass* exact_signature_k = nullptr;
   if (do_update) {
     // Is the type from the signature exact (the only one possible)?
     exact_signature_k = signature_at_call_k->exact_klass();
-    if (exact_signature_k == NULL) {
+    if (exact_signature_k == nullptr) {
       exact_signature_k = comp->cha_exact_type(signature_at_call_k);
     } else {
       result = exact_signature_k;
@@ -2535,25 +2535,25 @@ ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md
       // LIR_Assembler::emit_profile_type() from emitting useless code
       profiled_k = ciTypeEntries::with_status(result, profiled_k);
     }
-    // exact_klass and exact_signature_k can be both non NULL but
+    // exact_klass and exact_signature_k can be both non null but
     // different if exact_klass is loaded after the ciObject for
     // exact_signature_k is created.
-    if (exact_klass == NULL && exact_signature_k != NULL && exact_klass != exact_signature_k) {
+    if (exact_klass == nullptr && exact_signature_k != nullptr && exact_klass != exact_signature_k) {
       // sometimes the type of the signature is better than the best type
       // the compiler has
       exact_klass = exact_signature_k;
     }
-    if (callee_signature_k != NULL &&
+    if (callee_signature_k != nullptr &&
         callee_signature_k != signature_at_call_k) {
       ciKlass* improved_klass = callee_signature_k->exact_klass();
-      if (improved_klass == NULL) {
+      if (improved_klass == nullptr) {
         improved_klass = comp->cha_exact_type(callee_signature_k);
       }
-      if (exact_klass == NULL && improved_klass != NULL && exact_klass != improved_klass) {
+      if (exact_klass == nullptr && improved_klass != nullptr && exact_klass != improved_klass) {
         exact_klass = exact_signature_k;
       }
     }
-    do_update = exact_klass == NULL || ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
+    do_update = exact_klass == nullptr || ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
   }
 
   if (!do_null && !do_update) {
@@ -2572,7 +2572,7 @@ ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md
   LIRItem value(obj, this);
   value.load_item();
   __ profile_type(new LIR_Address(mdp, md_offset, T_METADATA),
-                  value.result(), exact_klass, profiled_k, new_pointer_register(), not_null, exact_signature_k != NULL);
+                  value.result(), exact_klass, profiled_k, new_pointer_register(), not_null, exact_signature_k != nullptr);
   return result;
 }
 
@@ -2581,9 +2581,9 @@ void LIRGenerator::profile_parameters(Base* x) {
   if (compilation()->profile_parameters()) {
     CallingConvention* args = compilation()->frame_map()->incoming_arguments();
     ciMethodData* md = scope()->method()->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
 
-    if (md->parameters_type_data() != NULL) {
+    if (md->parameters_type_data() != nullptr) {
       ciParametersTypeData* parameters_type_data = md->parameters_type_data();
       ciTypeStackSlotEntries* parameters =  parameters_type_data->parameters();
       LIR_Opr mdp = LIR_OprFact::illegalOpr;
@@ -2596,9 +2596,9 @@ void LIRGenerator::profile_parameters(Base* x) {
           Local* local = x->state()->local_at(java_index)->as_Local();
           ciKlass* exact = profile_type(md, md->byte_offset_of_slot(parameters_type_data, ParametersTypeData::type_offset(0)),
                                         in_bytes(ParametersTypeData::type_offset(j)) - in_bytes(ParametersTypeData::type_offset(0)),
-                                        profiled_k, local, mdp, false, local->declared_type()->as_klass(), NULL);
+                                        profiled_k, local, mdp, false, local->declared_type()->as_klass(), nullptr);
           // If the profile is known statically set it once for all and do not emit any code
-          if (exact != NULL) {
+          if (exact != nullptr) {
             md->set_parameter_type(j, exact);
           }
           j++;
@@ -2638,13 +2638,13 @@ void LIRGenerator::do_Base(Base* x) {
 
     // Assign new location to Local instruction for this local
     Local* local = x->state()->local_at(java_index)->as_Local();
-    assert(local != NULL, "Locals for incoming arguments must have been created");
+    assert(local != nullptr, "Locals for incoming arguments must have been created");
 #ifndef __SOFTFP__
     // The java calling convention passes double as long and float as int.
     assert(as_ValueType(t)->tag() == local->type()->tag(), "check");
 #endif // __SOFTFP__
     local->set_operand(dest);
-    _instruction_for_operand.at_put_grow(dest->vreg_number(), local, NULL);
+    _instruction_for_operand.at_put_grow(dest->vreg_number(), local, nullptr);
     java_index += type2size[t];
   }
 
@@ -2657,7 +2657,7 @@ void LIRGenerator::do_Base(Base* x) {
     LIR_Opr meth = new_register(T_METADATA);
     __ metadata2reg(method()->constant_encoding(), meth);
     args->append(meth);
-    call_runtime(&signature, args, CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry), voidType, NULL);
+    call_runtime(&signature, args, CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry), voidType, nullptr);
   }
 
   if (method()->is_synchronized()) {
@@ -2667,7 +2667,7 @@ void LIRGenerator::do_Base(Base* x) {
       __ oop2reg(method()->holder()->java_mirror()->constant_encoding(), obj);
     } else {
       Local* receiver = x->state()->local_at(0)->as_Local();
-      assert(receiver != NULL, "must already exist");
+      assert(receiver != nullptr, "must already exist");
       obj = receiver->operand();
     }
     assert(obj->is_valid(), "must be valid");
@@ -2676,17 +2676,17 @@ void LIRGenerator::do_Base(Base* x) {
       LIR_Opr lock = syncLockOpr();
       __ load_stack_address_monitor(0, lock);
 
-      CodeEmitInfo* info = new CodeEmitInfo(scope()->start()->state()->copy(ValueStack::StateBefore, SynchronizationEntryBCI), NULL, x->check_flag(Instruction::DeoptimizeOnException));
+      CodeEmitInfo* info = new CodeEmitInfo(scope()->start()->state()->copy(ValueStack::StateBefore, SynchronizationEntryBCI), nullptr, x->check_flag(Instruction::DeoptimizeOnException));
       CodeStub* slow_path = new MonitorEnterStub(obj, lock, info);
 
-      // receiver is guaranteed non-NULL so don't need CodeEmitInfo
-      __ lock_object(syncTempOpr(), obj, lock, new_register(T_OBJECT), slow_path, NULL);
+      // receiver is guaranteed non-null so don't need CodeEmitInfo
+      __ lock_object(syncTempOpr(), obj, lock, new_register(T_OBJECT), slow_path, nullptr);
     }
   }
   // increment invocation counters if needed
   if (!method()->is_accessor()) { // Accessors do not have MDOs, so no counting.
     profile_parameters(x);
-    CodeEmitInfo* info = new CodeEmitInfo(scope()->start()->state()->copy(ValueStack::StateBefore, SynchronizationEntryBCI), NULL, false);
+    CodeEmitInfo* info = new CodeEmitInfo(scope()->start()->state()->copy(ValueStack::StateBefore, SynchronizationEntryBCI), nullptr, false);
     increment_invocation_counter(info);
   }
 
@@ -3032,9 +3032,9 @@ void LIRGenerator::profile_arguments(ProfileCall* x) {
   if (compilation()->profile_arguments()) {
     int bci = x->bci_of_invoke();
     ciMethodData* md = x->method()->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(bci);
-    if (data != NULL) {
+    if (data != nullptr) {
       if ((data->is_CallTypeData() && data->as_CallTypeData()->has_arguments()) ||
           (data->is_VirtualCallTypeData() && data->as_VirtualCallTypeData()->has_arguments())) {
         ByteSize extra = data->is_CallTypeData() ? CallTypeData::args_data_offset() : VirtualCallTypeData::args_data_offset();
@@ -3053,10 +3053,10 @@ void LIRGenerator::profile_arguments(ProfileCall* x) {
         ciSignature* callee_signature = x->callee()->signature();
         // method handle call to virtual method
         bool has_receiver = x->callee()->is_loaded() && !x->callee()->is_static() && !Bytecodes::has_receiver(bc);
-        ciSignatureStream callee_signature_stream(callee_signature, has_receiver ? x->callee()->holder() : NULL);
+        ciSignatureStream callee_signature_stream(callee_signature, has_receiver ? x->callee()->holder() : nullptr);
 
         bool ignored_will_link;
-        ciSignature* signature_at_call = NULL;
+        ciSignature* signature_at_call = nullptr;
         x->method()->get_method_at_bci(bci, ignored_will_link, &signature_at_call);
         ciSignatureStream signature_at_call_stream(signature_at_call);
 
@@ -3067,7 +3067,7 @@ void LIRGenerator::profile_arguments(ProfileCall* x) {
               args->type(i), x->profiled_arg_at(i+start), mdp,
               !x->arg_needs_null_check(i+start),
               signature_at_call_stream.next_klass(), callee_signature_stream.next_klass());
-          if (exact != NULL) {
+          if (exact != nullptr) {
             md->set_argument_type(bci, i, exact);
           }
         }
@@ -3088,14 +3088,14 @@ void LIRGenerator::profile_arguments(ProfileCall* x) {
 void LIRGenerator::profile_parameters_at_call(ProfileCall* x) {
   if (compilation()->profile_parameters() && x->inlined()) {
     ciMethodData* md = x->callee()->method_data_or_null();
-    if (md != NULL) {
+    if (md != nullptr) {
       ciParametersTypeData* parameters_type_data = md->parameters_type_data();
-      if (parameters_type_data != NULL) {
+      if (parameters_type_data != nullptr) {
         ciTypeStackSlotEntries* parameters =  parameters_type_data->parameters();
         LIR_Opr mdp = LIR_OprFact::illegalOpr;
         bool has_receiver = !x->callee()->is_static();
         ciSignature* sig = x->callee()->signature();
-        ciSignatureStream sig_stream(sig, has_receiver ? x->callee()->holder() : NULL);
+        ciSignatureStream sig_stream(sig, has_receiver ? x->callee()->holder() : nullptr);
         int i = 0; // to iterate on the Instructions
         Value arg = x->recv();
         bool not_null = false;
@@ -3104,7 +3104,7 @@ void LIRGenerator::profile_parameters_at_call(ProfileCall* x) {
         // The first parameter is the receiver so that's what we start
         // with if it exists. One exception is method handle call to
         // virtual method: the receiver is in the args list
-        if (arg == NULL || !Bytecodes::has_receiver(bc)) {
+        if (arg == nullptr || !Bytecodes::has_receiver(bc)) {
           i = 1;
           arg = x->profiled_arg_at(0);
           not_null = !x->arg_needs_null_check(0);
@@ -3114,9 +3114,9 @@ void LIRGenerator::profile_parameters_at_call(ProfileCall* x) {
           intptr_t profiled_k = parameters->type(k);
           ciKlass* exact = profile_type(md, md->byte_offset_of_slot(parameters_type_data, ParametersTypeData::type_offset(0)),
                                         in_bytes(ParametersTypeData::type_offset(k)) - in_bytes(ParametersTypeData::type_offset(0)),
-                                        profiled_k, arg, mdp, not_null, sig_stream.next_klass(), NULL);
+                                        profiled_k, arg, mdp, not_null, sig_stream.next_klass(), nullptr);
           // If the profile is known statically set it once for all and do not emit any code
-          if (exact != NULL) {
+          if (exact != nullptr) {
             md->set_parameter_type(k, exact);
           }
           k++;
@@ -3125,7 +3125,7 @@ void LIRGenerator::profile_parameters_at_call(ProfileCall* x) {
             int extra = 0;
             if (MethodData::profile_arguments() && TypeProfileParmsLimit != -1 &&
                 x->nb_profiled_args() >= TypeProfileParmsLimit &&
-                x->recv() != NULL && Bytecodes::has_receiver(bc)) {
+                x->recv() != nullptr && Bytecodes::has_receiver(bc)) {
               extra += 1;
             }
             assert(i == x->nb_profiled_args() - extra || (TypeProfileParmsLimit != -1 && TypeProfileArgsLimit > TypeProfileParmsLimit), "unused parameters?");
@@ -3153,11 +3153,11 @@ void LIRGenerator::do_ProfileCall(ProfileCall* x) {
   }
 
   // profile parameters on inlined method entry including receiver
-  if (x->recv() != NULL || x->nb_profiled_args() > 0) {
+  if (x->recv() != nullptr || x->nb_profiled_args() > 0) {
     profile_parameters_at_call(x);
   }
 
-  if (x->recv() != NULL) {
+  if (x->recv() != nullptr) {
     LIRItem value(x->recv(), this);
     value.load_item();
     recv = new_register(T_OBJECT);
@@ -3169,15 +3169,15 @@ void LIRGenerator::do_ProfileCall(ProfileCall* x) {
 void LIRGenerator::do_ProfileReturnType(ProfileReturnType* x) {
   int bci = x->bci_of_invoke();
   ciMethodData* md = x->method()->method_data_or_null();
-  assert(md != NULL, "Sanity");
+  assert(md != nullptr, "Sanity");
   ciProfileData* data = md->bci_to_data(bci);
-  if (data != NULL) {
+  if (data != nullptr) {
     assert(data->is_CallTypeData() || data->is_VirtualCallTypeData(), "wrong profile data type");
     ciReturnTypeEntry* ret = data->is_CallTypeData() ? ((ciCallTypeData*)data)->ret() : ((ciVirtualCallTypeData*)data)->ret();
     LIR_Opr mdp = LIR_OprFact::illegalOpr;
 
     bool ignored_will_link;
-    ciSignature* signature_at_call = NULL;
+    ciSignature* signature_at_call = nullptr;
     x->method()->get_method_at_bci(bci, ignored_will_link, &signature_at_call);
 
     // The offset within the MDO of the entry to update may be too large
@@ -3188,7 +3188,7 @@ void LIRGenerator::do_ProfileReturnType(ProfileReturnType* x) {
         !x->needs_null_check(),
         signature_at_call->return_type()->as_klass(),
         x->callee()->signature()->return_type()->as_klass());
-    if (exact != NULL) {
+    if (exact != nullptr) {
       md->set_return_type(bci, exact);
     }
   }
@@ -3260,7 +3260,7 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
   LIR_Opr counter_holder;
   if (level == CompLevel_limited_profile) {
     MethodCounters* counters_adr = method->ensure_method_counters();
-    if (counters_adr == NULL) {
+    if (counters_adr == nullptr) {
       bailout("method counters allocation failed");
       return;
     }
@@ -3273,7 +3273,7 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
     offset = in_bytes(backedge ? MethodData::backedge_counter_offset() :
                                  MethodData::invocation_counter_offset());
     ciMethodData* md = method->method_data_or_null();
-    assert(md != NULL, "Sanity");
+    assert(md != nullptr, "Sanity");
     __ metadata2reg(md->constant_encoding(), counter_holder);
   } else {
     ShouldNotReachHere();
@@ -3327,7 +3327,7 @@ void LIRGenerator::do_RuntimeCall(RuntimeCall* x) {
     signature->append(as_BasicType(a->type()));
   }
 
-  LIR_Opr result = call_runtime(signature, args, x->entry(), x->type(), NULL);
+  LIR_Opr result = call_runtime(signature, args, x->entry(), x->type(), nullptr);
   if (x->type() == voidType) {
     set_no_result(x);
   } else {
@@ -3559,7 +3559,7 @@ LIR_Opr LIRGenerator::mask_boolean(LIR_Opr array, LIR_Opr value, CodeEmitInfo*& 
   }
   LIR_Opr klass = new_register(T_METADATA);
   load_klass(array, klass, null_check_info);
-  null_check_info = NULL;
+  null_check_info = nullptr;
   LIR_Opr layout = new_register(T_INT);
   __ move(new LIR_Address(klass, in_bytes(Klass::layout_helper_offset()), T_INT), layout);
   int diffbit = Klass::layout_helper_boolean_diffbit();

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -387,7 +387,7 @@ void LIRGenerator::walk(Value instr) {
   } else {
     assert(instr->subst() == instr, "shouldn't have missed substitution");
     instr->visit(this);
-    // assert(instr->use_count() > 0 || instr->as_Phi() != null, "leaf instruction must have a use");
+    // assert(instr->use_count() > 0 || instr->as_Phi() != nullptr, "leaf instruction must have a use");
   }
 }
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +224,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
     x->set_operand(opr);
     assert(opr == x->operand(), "must be");
     if (opr->is_virtual()) {
-      _instruction_for_operand.at_put_grow(opr->vreg_number(), x, NULL);
+      _instruction_for_operand.at_put_grow(opr->vreg_number(), x, nullptr);
     }
   }
   void  set_no_result(Value x)                     { assert(!x->has_uses(), "can't have use"); x->clear_operand(); }
@@ -289,11 +289,11 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
  public:
   void access_store_at(DecoratorSet decorators, BasicType type,
                        LIRItem& base, LIR_Opr offset, LIR_Opr value,
-                       CodeEmitInfo* patch_info = NULL, CodeEmitInfo* store_emit_info = NULL);
+                       CodeEmitInfo* patch_info = nullptr, CodeEmitInfo* store_emit_info = nullptr);
 
   void access_load_at(DecoratorSet decorators, BasicType type,
                       LIRItem& base, LIR_Opr offset, LIR_Opr result,
-                      CodeEmitInfo* patch_info = NULL, CodeEmitInfo* load_emit_info = NULL);
+                      CodeEmitInfo* patch_info = nullptr, CodeEmitInfo* load_emit_info = nullptr);
 
   void access_load(DecoratorSet decorators, BasicType type,
                    LIR_Opr addr, LIR_Opr result);
@@ -343,7 +343,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void increment_counter(address counter, BasicType type, int step = 1);
   void increment_counter(LIR_Address* addr, int step = 1);
 
-  void arithmetic_op(Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr tmp, CodeEmitInfo* info = NULL);
+  void arithmetic_op(Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr tmp, CodeEmitInfo* info = nullptr);
   // machine dependent.  returns true if it emitted code for the multiply
   bool strength_reduce_multiply(LIR_Opr left, jint constant, LIR_Opr result, LIR_Opr tmp);
 
@@ -355,7 +355,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void array_range_check          (LIR_Opr array, LIR_Opr index, CodeEmitInfo* null_check_info, CodeEmitInfo* range_check_info);
 
   void arithmetic_op_int  (Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr tmp);
-  void arithmetic_op_long (Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, CodeEmitInfo* info = NULL);
+  void arithmetic_op_long (Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, CodeEmitInfo* info = nullptr);
   void arithmetic_op_fpu  (Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr tmp = LIR_OprFact::illegalOpr);
 
   void shift_op   (Bytecodes::Code code, LIR_Opr dst_reg, LIR_Opr value, LIR_Opr count, LIR_Opr tmp);
@@ -620,13 +620,13 @@ class LIRItem: public CompilationResourceObj {
     _destroys_register = false;
     _gen = gen;
     _result = LIR_OprFact::illegalOpr;
-    set_instruction(NULL);
+    set_instruction(nullptr);
   }
 
   void set_instruction(Value value) {
     _value = value;
     _result = LIR_OprFact::illegalOpr;
-    if (_value != NULL) {
+    if (_value != nullptr) {
       _gen->walk(_value);
       _result = _value->operand();
     }
@@ -666,7 +666,7 @@ class LIRItem: public CompilationResourceObj {
     _destroys_register = true;
   }
 
-  bool is_constant() const { return value()->as_Constant() != NULL; }
+  bool is_constant() const { return value()->as_Constant() != nullptr; }
   bool is_stack()          { return result()->is_stack(); }
   bool is_register()       { return result()->is_register(); }
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -83,8 +83,8 @@ LinearScan::LinearScan(IR* ir, LIRGenerator* gen, FrameMap* frame_map)
  , _max_spills(0)
  , _unused_spill_slot(-1)
  , _intervals(0)   // initialized later with correct length
- , _new_intervals_from_allocation(NULL)
- , _sorted_intervals(NULL)
+ , _new_intervals_from_allocation(nullptr)
+ , _sorted_intervals(nullptr)
  , _needs_full_resort(false)
  , _lir_ops(0)     // initialized later with correct length
  , _block_of_op(0) // initialized later with correct length
@@ -93,13 +93,13 @@ LinearScan::LinearScan(IR* ir, LIRGenerator* gen, FrameMap* frame_map)
  , _interval_in_loop(0)  // initialized later with correct length
  , _scope_value_cache(0) // initialized later with correct length
 #ifdef IA32
- , _fpu_stack_allocator(NULL)
+ , _fpu_stack_allocator(nullptr)
 #endif
 {
-  assert(this->ir() != NULL,          "check if valid");
-  assert(this->compilation() != NULL, "check if valid");
-  assert(this->gen() != NULL,         "check if valid");
-  assert(this->frame_map() != NULL,   "check if valid");
+  assert(this->ir() != nullptr,          "check if valid");
+  assert(this->compilation() != nullptr, "check if valid");
+  assert(this->gen() != nullptr,         "check if valid");
+  assert(this->frame_map() != nullptr,   "check if valid");
 }
 
 
@@ -268,7 +268,7 @@ void LinearScan::propagate_spill_slots() {
 // create a new interval with a predefined reg_num
 // (only used for parent intervals that are created during the building phase)
 Interval* LinearScan::create_interval(int reg_num) {
-  assert(_intervals.at(reg_num) == NULL, "overwriting existing interval");
+  assert(_intervals.at(reg_num) == nullptr, "overwriting existing interval");
 
   Interval* interval = new Interval(reg_num);
   _intervals.at_put(reg_num, interval);
@@ -286,7 +286,7 @@ void LinearScan::append_interval(Interval* it) {
   it->set_reg_num(_intervals.length());
   _intervals.append(it);
   IntervalList* new_intervals = _new_intervals_from_allocation;
-  if (new_intervals == NULL) {
+  if (new_intervals == nullptr) {
     new_intervals = _new_intervals_from_allocation = new IntervalList();
   }
   new_intervals->append(it);
@@ -393,14 +393,14 @@ void LinearScan::eliminate_spill_moves() {
   // the list is sorted by Interval::spill_definition_pos
   Interval* interval;
   Interval* temp_list;
-  create_unhandled_lists(&interval, &temp_list, must_store_at_definition, NULL);
+  create_unhandled_lists(&interval, &temp_list, must_store_at_definition, nullptr);
 
 #ifdef ASSERT
-  Interval* prev = NULL;
+  Interval* prev = nullptr;
   Interval* temp = interval;
   while (temp != Interval::end()) {
     assert(temp->spill_definition_pos() > 0, "invalid spill definition pos");
-    if (prev != NULL) {
+    if (prev != nullptr) {
       assert(temp->from() >= prev->from(), "intervals not sorted");
       assert(temp->spill_definition_pos() >= prev->spill_definition_pos(), "when intervals are sorted by from, then they must also be sorted by spill_definition_pos");
     }
@@ -432,7 +432,7 @@ void LinearScan::eliminate_spill_moves() {
         // remove move from register to stack if the stack slot is guaranteed to be correct.
         // only moves that have been inserted by LinearScan can be removed.
         assert(op->code() == lir_move, "only moves can have a op_id of -1");
-        assert(op->as_Op1() != NULL, "move must be LIR_Op1");
+        assert(op->as_Op1() != nullptr, "move must be LIR_Op1");
         assert(op->as_Op1()->result_opr()->is_virtual(), "LinearScan inserts only moves to virtual registers");
 
         LIR_Op1* op1 = (LIR_Op1*)op;
@@ -441,7 +441,7 @@ void LinearScan::eliminate_spill_moves() {
         if (interval->assigned_reg() >= LinearScan::nof_regs && interval->always_in_memory()) {
           // move target is a stack slot that is always correct, so eliminate instruction
           TRACE_LINEAR_SCAN(4, tty->print_cr("eliminating move from interval %d to %d", op1->in_opr()->vreg_number(), op1->result_opr()->vreg_number()));
-          instructions->at_put(j, NULL); // NULL-instructions are deleted by assign_reg_num
+          instructions->at_put(j, nullptr); // null-instructions are deleted by assign_reg_num
         }
 
       } else {
@@ -498,8 +498,8 @@ void LinearScan::number_instructions() {
   }
 
   // initialize with correct length
-  _lir_ops = LIR_OpArray(num_instructions, num_instructions, NULL);
-  _block_of_op = BlockBeginArray(num_instructions, num_instructions, NULL);
+  _lir_ops = LIR_OpArray(num_instructions, num_instructions, nullptr);
+  _block_of_op = BlockBeginArray(num_instructions, num_instructions, nullptr);
 
   int op_id = 0;
   int idx = 0;
@@ -540,10 +540,10 @@ void LinearScan::set_live_gen_kill(Value value, LIR_Op* op, BitMap& live_gen, Bi
 
   // check some asumptions about debug information
   assert(!value->type()->is_illegal(), "if this local is used by the interpreter it shouldn't be of indeterminate type");
-  assert(con == NULL || opr->is_virtual() || opr->is_constant() || opr->is_illegal(), "assumption: Constant instructions have only constant operands");
-  assert(con != NULL || opr->is_virtual(), "assumption: non-Constant instructions have only virtual operands");
+  assert(con == nullptr || opr->is_virtual() || opr->is_constant() || opr->is_illegal(), "assumption: Constant instructions have only constant operands");
+  assert(con != nullptr || opr->is_virtual(), "assumption: non-Constant instructions have only virtual operands");
 
-  if ((con == NULL || con->is_pinned()) && opr->is_register()) {
+  if ((con == nullptr || con->is_pinned()) && opr->is_register()) {
     assert(reg_num(opr) == opr->vreg_number() && !is_valid_reg_num(reg_numHi(opr)), "invalid optimization below");
     int reg = opr->vreg_number();
     if (!live_kill.at(reg)) {
@@ -839,7 +839,7 @@ void LinearScan::compute_global_live_sets() {
     for (unsigned int i = 0; i < ir()->start()->live_in().size(); i++) {
       if (ir()->start()->live_in().at(i)) {
         Instruction* instr = gen()->instruction_for_vreg(i);
-        tty->print_cr("* vreg %d (HIR instruction %c%d)", i, instr == NULL ? ' ' : instr->type()->tchar(), instr == NULL ? 0 : instr->id());
+        tty->print_cr("* vreg %d (HIR instruction %c%d)", i, instr == nullptr ? ' ' : instr->type()->tchar(), instr == nullptr ? 0 : instr->id());
 
         for (int j = 0; j < num_blocks; j++) {
           BlockBegin* block = block_at(j);
@@ -870,7 +870,7 @@ void LinearScan::add_use(Value value, int from, int to, IntervalUseKind use_kind
   LIR_Opr opr = value->operand();
   Constant* con = value->as_Constant();
 
-  if ((con == NULL || con->is_pinned()) && opr->is_register()) {
+  if ((con == nullptr || con->is_pinned()) && opr->is_register()) {
     assert(reg_num(opr) == opr->vreg_number() && !is_valid_reg_num(reg_numHi(opr)), "invalid optimization below");
     add_use(opr, from, to, use_kind);
   }
@@ -940,7 +940,7 @@ void LinearScan::add_temp(LIR_Opr opr, int temp_pos, IntervalUseKind use_kind) {
 
 void LinearScan::add_def(int reg_num, int def_pos, IntervalUseKind use_kind, BasicType type) {
   Interval* interval = interval_at(reg_num);
-  if (interval != NULL) {
+  if (interval != nullptr) {
     assert(interval->reg_num() == reg_num, "wrong interval");
 
     if (type != T_ILLEGAL) {
@@ -985,7 +985,7 @@ void LinearScan::add_def(int reg_num, int def_pos, IntervalUseKind use_kind, Bas
 
 void LinearScan::add_use(int reg_num, int from, int to, IntervalUseKind use_kind, BasicType type) {
   Interval* interval = interval_at(reg_num);
-  if (interval == NULL) {
+  if (interval == nullptr) {
     interval = create_interval(reg_num);
   }
   assert(interval->reg_num() == reg_num, "wrong interval");
@@ -1000,7 +1000,7 @@ void LinearScan::add_use(int reg_num, int from, int to, IntervalUseKind use_kind
 
 void LinearScan::add_temp(int reg_num, int temp_pos, IntervalUseKind use_kind, BasicType type) {
   Interval* interval = interval_at(reg_num);
-  if (interval == NULL) {
+  if (interval == nullptr) {
     interval = create_interval(reg_num);
   }
   assert(interval->reg_num() == reg_num, "wrong interval");
@@ -1019,7 +1019,7 @@ void LinearScan::add_temp(int reg_num, int temp_pos, IntervalUseKind use_kind, B
 // it is not reloaded to a register.
 IntervalUseKind LinearScan::use_kind_of_output_operand(LIR_Op* op, LIR_Opr opr) {
   if (op->code() == lir_move) {
-    assert(op->as_Op1() != NULL, "lir_move must be LIR_Op1");
+    assert(op->as_Op1() != nullptr, "lir_move must be LIR_Op1");
     LIR_Op1* move = (LIR_Op1*)op;
     LIR_Opr res = move->result_opr();
     bool result_in_memory = res->is_virtual() && gen()->is_vreg_flag_set(res->vreg_number(), LIRGenerator::must_start_in_memory);
@@ -1055,7 +1055,7 @@ IntervalUseKind LinearScan::use_kind_of_output_operand(LIR_Op* op, LIR_Opr opr) 
 
 IntervalUseKind LinearScan::use_kind_of_input_operand(LIR_Op* op, LIR_Opr opr) {
   if (op->code() == lir_move) {
-    assert(op->as_Op1() != NULL, "lir_move must be LIR_Op1");
+    assert(op->as_Op1() != nullptr, "lir_move must be LIR_Op1");
     LIR_Op1* move = (LIR_Op1*)op;
     LIR_Opr res = move->result_opr();
     bool result_in_memory = res->is_virtual() && gen()->is_vreg_flag_set(res->vreg_number(), LIRGenerator::must_start_in_memory);
@@ -1100,7 +1100,7 @@ IntervalUseKind LinearScan::use_kind_of_input_operand(LIR_Op* op, LIR_Opr opr) {
         case lir_mul:
         case lir_div:
         {
-          assert(op->as_Op2() != NULL, "must be LIR_Op2");
+          assert(op->as_Op2() != nullptr, "must be LIR_Op2");
           LIR_Op2* op2 = (LIR_Op2*)op;
           if (op2->in_opr1() != op2->in_opr2() && op2->in_opr2() == opr) {
             assert((op2->result_opr()->is_register() || op->code() == lir_cmp) && op2->in_opr1()->is_register(), "cannot mark second operand as stack if others are not in register");
@@ -1118,7 +1118,7 @@ IntervalUseKind LinearScan::use_kind_of_input_operand(LIR_Op* op, LIR_Opr opr) {
         case lir_mul:
         case lir_div:
         {
-          assert(op->as_Op2() != NULL, "must be LIR_Op2");
+          assert(op->as_Op2() != nullptr, "must be LIR_Op2");
           LIR_Op2* op2 = (LIR_Op2*)op;
           if (op2->in_opr1() != op2->in_opr2() && op2->in_opr2() == opr) {
             assert((op2->result_opr()->is_register() || op->code() == lir_cmp) && op2->in_opr1()->is_register(), "cannot mark second operand as stack if others are not in register");
@@ -1142,7 +1142,7 @@ IntervalUseKind LinearScan::use_kind_of_input_operand(LIR_Op* op, LIR_Opr opr) {
       case lir_logic_or:
       case lir_logic_xor:
       {
-        assert(op->as_Op2() != NULL, "must be LIR_Op2");
+        assert(op->as_Op2() != nullptr, "must be LIR_Op2");
         LIR_Op2* op2 = (LIR_Op2*)op;
         if (op2->in_opr1() != op2->in_opr2() && op2->in_opr2() == opr) {
           assert((op2->result_opr()->is_register() || op->code() == lir_cmp) && op2->in_opr1()->is_register(), "cannot mark second operand as stack if others are not in register");
@@ -1166,7 +1166,7 @@ void LinearScan::handle_method_arguments(LIR_Op* op) {
   // it is split before the first use by the register allocator.
 
   if (op->code() == lir_move) {
-    assert(op->as_Op1() != NULL, "must be LIR_Op1");
+    assert(op->as_Op1() != nullptr, "must be LIR_Op1");
     LIR_Op1* move = (LIR_Op1*)op;
 
     if (move->in_opr()->is_stack()) {
@@ -1202,12 +1202,12 @@ void LinearScan::handle_doubleword_moves(LIR_Op* op) {
   // in this case the registers of the input address and the result
   // registers must not overlap -> add a temp range for the input registers
   if (op->code() == lir_move) {
-    assert(op->as_Op1() != NULL, "must be LIR_Op1");
+    assert(op->as_Op1() != nullptr, "must be LIR_Op1");
     LIR_Op1* move = (LIR_Op1*)op;
 
     if (move->result_opr()->is_double_cpu() && move->in_opr()->is_pointer()) {
       LIR_Address* address = move->in_opr()->as_address_ptr();
-      if (address != NULL) {
+      if (address != nullptr) {
         if (address->base()->is_valid()) {
           add_temp(address->base(), op->id(), noUse);
         }
@@ -1223,7 +1223,7 @@ void LinearScan::add_register_hints(LIR_Op* op) {
   switch (op->code()) {
     case lir_move:      // fall through
     case lir_convert: {
-      assert(op->as_Op1() != NULL, "lir_move, lir_convert must be LIR_Op1");
+      assert(op->as_Op1() != nullptr, "lir_move, lir_convert must be LIR_Op1");
       LIR_Op1* move = (LIR_Op1*)op;
 
       LIR_Opr move_from = move->in_opr();
@@ -1232,7 +1232,7 @@ void LinearScan::add_register_hints(LIR_Op* op) {
       if (move_to->is_register() && move_from->is_register()) {
         Interval* from = interval_at(reg_num(move_from));
         Interval* to = interval_at(reg_num(move_to));
-        if (from != NULL && to != NULL) {
+        if (from != nullptr && to != nullptr) {
           to->set_register_hint(from);
           TRACE_LINEAR_SCAN(4, tty->print_cr("operation at op_id %d: added hint from interval %d to %d", move->id(), from->reg_num(), to->reg_num()));
         }
@@ -1240,7 +1240,7 @@ void LinearScan::add_register_hints(LIR_Op* op) {
       break;
     }
     case lir_cmove: {
-      assert(op->as_Op4() != NULL, "lir_cmove must be LIR_Op4");
+      assert(op->as_Op4() != nullptr, "lir_cmove must be LIR_Op4");
       LIR_Op4* cmove = (LIR_Op4*)op;
 
       LIR_Opr move_from = cmove->in_opr1();
@@ -1249,7 +1249,7 @@ void LinearScan::add_register_hints(LIR_Op* op) {
       if (move_to->is_register() && move_from->is_register()) {
         Interval* from = interval_at(reg_num(move_from));
         Interval* to = interval_at(reg_num(move_to));
-        if (from != NULL && to != NULL) {
+        if (from != nullptr && to != nullptr) {
           to->set_register_hint(from);
           TRACE_LINEAR_SCAN(4, tty->print_cr("operation at op_id %d: added hint from interval %d to %d", cmove->id(), from->reg_num(), to->reg_num()));
         }
@@ -1269,7 +1269,7 @@ void LinearScan::build_intervals() {
   // (32 is added to have some space for split children without having to resize the list)
   _intervals = IntervalList(num_virtual_regs() + 32);
   // initialize all slots that are used by build_intervals
-  _intervals.at_put_grow(num_virtual_regs() - 1, NULL, NULL);
+  _intervals.at_put_grow(num_virtual_regs() - 1, nullptr, nullptr);
 
   // create a list with all caller-save registers (cpu, fpu, xmm)
   // when an instruction is a call, a temp range is created for all these registers
@@ -1421,7 +1421,7 @@ void LinearScan::build_intervals() {
   // -> the register allocator need not handle unhandled fixed intervals
   for (int n = 0; n < LinearScan::nof_regs; n++) {
     Interval* interval = interval_at(n);
-    if (interval != NULL) {
+    if (interval != nullptr) {
       interval->add_range(0, 1);
     }
   }
@@ -1431,14 +1431,14 @@ void LinearScan::build_intervals() {
 // ********** Phase 5: actual register allocation
 
 int LinearScan::interval_cmp(Interval** a, Interval** b) {
-  if (*a != NULL) {
-    if (*b != NULL) {
+  if (*a != nullptr) {
+    if (*b != nullptr) {
       return (*a)->from() - (*b)->from();
     } else {
       return -1;
     }
   } else {
-    if (*b != NULL) {
+    if (*b != nullptr) {
       return 1;
     } else {
       return 0;
@@ -1491,7 +1491,7 @@ bool LinearScan::is_sorted(IntervalArray* intervals) {
 
   for (int i = 0; i < intervals->length(); i++) {
     Interval* it = intervals->at(i);
-    if (it != NULL) {
+    if (it != nullptr) {
       assert(from <= it->from(), "Intervals are unordered");
       from = it->from();
     } else {
@@ -1505,7 +1505,7 @@ bool LinearScan::is_sorted(IntervalArray* intervals) {
 
   for (int i = 0; i < interval_count(); i++) {
     Interval* interval = interval_at(i);
-    if (interval != NULL) {
+    if (interval != nullptr) {
       assert(find_interval(interval, intervals), "Lists do not contain same intervals");
     } else {
       null_count++;
@@ -1513,14 +1513,14 @@ bool LinearScan::is_sorted(IntervalArray* intervals) {
   }
 
   assert(interval_count() - null_count == intervals->length(),
-      "Sorted list should contain the same amount of non-NULL intervals as unsorted list");
+      "Sorted list should contain the same amount of non-null intervals as unsorted list");
 
   return true;
 }
 #endif
 
 void LinearScan::add_to_list(Interval** first, Interval** prev, Interval* interval) {
-  if (*prev != NULL) {
+  if (*prev != nullptr) {
     (*prev)->set_next(interval);
   } else {
     *first = interval;
@@ -1533,27 +1533,27 @@ void LinearScan::create_unhandled_lists(Interval** list1, Interval** list2, bool
 
   *list1 = *list2 = Interval::end();
 
-  Interval* list1_prev = NULL;
-  Interval* list2_prev = NULL;
+  Interval* list1_prev = nullptr;
+  Interval* list2_prev = nullptr;
   Interval* v;
 
   const int n = _sorted_intervals->length();
   for (int i = 0; i < n; i++) {
     v = _sorted_intervals->at(i);
-    if (v == NULL) continue;
+    if (v == nullptr) continue;
 
     if (is_list1(v)) {
       add_to_list(list1, &list1_prev, v);
-    } else if (is_list2 == NULL || is_list2(v)) {
+    } else if (is_list2 == nullptr || is_list2(v)) {
       add_to_list(list2, &list2_prev, v);
     }
   }
 
-  if (list1_prev != NULL) list1_prev->set_next(Interval::end());
-  if (list2_prev != NULL) list2_prev->set_next(Interval::end());
+  if (list1_prev != nullptr) list1_prev->set_next(Interval::end());
+  if (list2_prev != nullptr) list2_prev->set_next(Interval::end());
 
-  assert(list1_prev == NULL || list1_prev->next() == Interval::end(), "linear list ends not with sentinel");
-  assert(list2_prev == NULL || list2_prev->next() == Interval::end(), "linear list ends not with sentinel");
+  assert(list1_prev == nullptr || list1_prev->next() == Interval::end(), "linear list ends not with sentinel");
+  assert(list2_prev == nullptr || list2_prev->next() == Interval::end(), "linear list ends not with sentinel");
 }
 
 
@@ -1575,20 +1575,20 @@ void LinearScan::sort_intervals_before_allocation() {
   int sorted_idx = 0;
   int sorted_from_max = -1;
 
-  // calc number of items for sorted list (sorted list must not contain NULL values)
+  // calc number of items for sorted list (sorted list must not contain null values)
   for (unsorted_idx = 0; unsorted_idx < unsorted_len; unsorted_idx++) {
-    if (unsorted_list->at(unsorted_idx) != NULL) {
+    if (unsorted_list->at(unsorted_idx) != nullptr) {
       sorted_len++;
     }
   }
-  IntervalArray* sorted_list = new IntervalArray(sorted_len, sorted_len, NULL);
+  IntervalArray* sorted_list = new IntervalArray(sorted_len, sorted_len, nullptr);
 
   // special sorting algorithm: the original interval-list is almost sorted,
   // only some intervals are swapped. So this is much faster than a complete QuickSort
   for (unsorted_idx = 0; unsorted_idx < unsorted_len; unsorted_idx++) {
     Interval* cur_interval = unsorted_list->at(unsorted_idx);
 
-    if (cur_interval != NULL) {
+    if (cur_interval != nullptr) {
       int cur_from = cur_interval->from();
 
       if (sorted_from_max <= cur_from) {
@@ -1622,7 +1622,7 @@ void LinearScan::sort_intervals_after_allocation() {
   IntervalArray* old_list = _sorted_intervals;
   IntervalList* new_list = _new_intervals_from_allocation;
   int old_len = old_list->length();
-  int new_len = new_list == NULL ? 0 : new_list->length();
+  int new_len = new_list == nullptr ? 0 : new_list->length();
 
   if (new_len == 0) {
     // no intervals have been added during allocation, so sorted list is already up to date
@@ -1635,7 +1635,7 @@ void LinearScan::sort_intervals_after_allocation() {
 
   // merge old and new list (both already sorted) into one combined list
   int combined_list_len = old_len + new_len;
-  IntervalArray* combined_list = new IntervalArray(combined_list_len, combined_list_len, NULL);
+  IntervalArray* combined_list = new IntervalArray(combined_list_len, combined_list_len, nullptr);
   int old_idx = 0;
   int new_idx = 0;
 
@@ -1698,10 +1698,10 @@ void LinearScan::allocate_registers() {
 // (insert moves at edges between blocks if intervals have been split)
 
 // wrapper for Interval::split_child_at_op_id that performs a bailout in product mode
-// instead of returning NULL
+// instead of returning null
 Interval* LinearScan::split_child_at_op_id(Interval* interval, int op_id, LIR_OpVisitState::OprMode mode) {
   Interval* result = interval->split_child_at_op_id(op_id, mode);
-  if (result != NULL) {
+  if (result != nullptr) {
     return result;
   }
 
@@ -1709,27 +1709,27 @@ Interval* LinearScan::split_child_at_op_id(Interval* interval, int op_id, LIR_Op
   result = new Interval(LIR_Opr::vreg_base);
   result->assign_reg(0);
   result->set_type(T_INT);
-  BAILOUT_("LinearScan: interval is NULL", result);
+  BAILOUT_("LinearScan: interval is null", result);
 }
 
 
 Interval* LinearScan::interval_at_block_begin(BlockBegin* block, int reg_num) {
   assert(LinearScan::nof_regs <= reg_num && reg_num < num_virtual_regs(), "register number out of bounds");
-  assert(interval_at(reg_num) != NULL, "no interval found");
+  assert(interval_at(reg_num) != nullptr, "no interval found");
 
   return split_child_at_op_id(interval_at(reg_num), block->first_lir_instruction_id(), LIR_OpVisitState::outputMode);
 }
 
 Interval* LinearScan::interval_at_block_end(BlockBegin* block, int reg_num) {
   assert(LinearScan::nof_regs <= reg_num && reg_num < num_virtual_regs(), "register number out of bounds");
-  assert(interval_at(reg_num) != NULL, "no interval found");
+  assert(interval_at(reg_num) != nullptr, "no interval found");
 
   return split_child_at_op_id(interval_at(reg_num), block->last_lir_instruction_id() + 1, LIR_OpVisitState::outputMode);
 }
 
 Interval* LinearScan::interval_at_op_id(int reg_num, int op_id) {
   assert(LinearScan::nof_regs <= reg_num && reg_num < num_virtual_regs(), "register number out of bounds");
-  assert(interval_at(reg_num) != NULL, "no interval found");
+  assert(interval_at(reg_num) != nullptr, "no interval found");
 
   return split_child_at_op_id(interval_at(reg_num), op_id, LIR_OpVisitState::inputMode);
 }
@@ -1763,7 +1763,7 @@ void LinearScan::resolve_find_insert_pos(BlockBegin* from_block, BlockBegin* to_
 
     LIR_OpList* instructions = from_block->lir()->instructions_list();
     LIR_OpBranch* branch = instructions->last()->as_OpBranch();
-    if (branch != NULL) {
+    if (branch != nullptr) {
       // insert moves before branch
       assert(branch->cond() == lir_cond_always, "block does not end with an unconditional jump");
       move_resolver.set_insert_position(from_block->lir(), instructions->length() - 2);
@@ -1774,7 +1774,7 @@ void LinearScan::resolve_find_insert_pos(BlockBegin* from_block, BlockBegin* to_
   } else {
     TRACE_LINEAR_SCAN(4, tty->print_cr("inserting moves at beginning of to_block B%d", to_block->block_id()));
 #ifdef ASSERT
-    assert(from_block->lir()->instructions_list()->at(0)->as_OpLabel() != NULL, "block does not start with a label");
+    assert(from_block->lir()->instructions_list()->at(0)->as_OpLabel() != nullptr, "block does not start with a label");
 
     // because the number of predecessor edges matches the number of
     // successor edges, blocks which are reached by switch statements
@@ -1860,7 +1860,7 @@ void LinearScan::resolve_data_flow() {
 
 
 void LinearScan::resolve_exception_entry(BlockBegin* block, int reg_num, MoveResolver &move_resolver) {
-  if (interval_at(reg_num) == NULL) {
+  if (interval_at(reg_num) == nullptr) {
     // if a phi function is never used, no interval is created -> ignore this
     return;
   }
@@ -1933,7 +1933,7 @@ void LinearScan::resolve_exception_entry(BlockBegin* block, MoveResolver &move_r
 
 
 void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, int reg_num, Phi* phi, MoveResolver &move_resolver) {
-  if (interval_at(reg_num) == NULL) {
+  if (interval_at(reg_num) == nullptr) {
     // if a phi function is never used, no interval is created -> ignore this
     return;
   }
@@ -1943,7 +1943,7 @@ void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, i
   BlockBegin* to_block = handler->entry_block();
   Interval* to_interval = interval_at_block_begin(to_block, reg_num);
 
-  if (phi != NULL) {
+  if (phi != nullptr) {
     // phi function of the exception entry block
     // no moves are created for this phi function in the LIR_Generator, so the
     // interval at the throwing instruction must be searched using the operands
@@ -1955,7 +1955,7 @@ void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, i
     move_resolver.set_multiple_reads_allowed();
 
     Constant* con = from_value->as_Constant();
-    if (con != NULL && (!con->is_pinned() || con->operand()->is_constant())) {
+    if (con != nullptr && (!con->is_pinned() || con->operand()->is_constant())) {
       // Need a mapping from constant to interval if unpinned (may have no register) or if the operand is a constant (no register).
       move_resolver.add_mapping(LIR_OprFact::value_type(con->type()), to_interval);
     } else {
@@ -1983,13 +1983,13 @@ void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, M
   DEBUG_ONLY(move_resolver.check_empty());
   assert(handler->lir_op_id() == -1, "already processed this xhandler");
   DEBUG_ONLY(handler->set_lir_op_id(throwing_op_id));
-  assert(handler->entry_code() == NULL, "code already present");
+  assert(handler->entry_code() == nullptr, "code already present");
 
   // visit all registers where the live_in bit is set
   BlockBegin* block = handler->entry_block();
   auto resolver = [&](BitMap::idx_t index) {
     int r = static_cast<int>(index);
-    resolve_exception_edge(handler, throwing_op_id, r, NULL, move_resolver);
+    resolve_exception_edge(handler, throwing_op_id, r, nullptr, move_resolver);
   };
   block->live_in().iterate(resolver, 0, live_set_size());
 
@@ -2215,7 +2215,7 @@ LIR_Opr LinearScan::color_lir_opr(LIR_Opr opr, int op_id, LIR_OpVisitState::OprM
   assert(opr->is_virtual(), "should not call this otherwise");
 
   Interval* interval = interval_at(opr->vreg_number());
-  assert(interval != NULL, "interval must exist");
+  assert(interval != nullptr, "interval must exist");
 
   if (op_id != -1) {
 #ifdef ASSERT
@@ -2225,7 +2225,7 @@ LIR_Opr LinearScan::color_lir_opr(LIR_Opr opr, int op_id, LIR_OpVisitState::OprM
       // before the branch instruction. So the split child information for this branch would
       // be incorrect.
       LIR_OpBranch* branch = block->lir()->instructions_list()->last()->as_OpBranch();
-      if (branch != NULL) {
+      if (branch != nullptr) {
         if (block->live_out().at(opr->vreg_number())) {
           assert(branch->cond() == lir_cond_always, "block does not end with an unconditional jump");
           assert(false, "can't get split child for the last branch of a block because the information would be incorrect (moves are inserted before the branch in resolve_data_flow)");
@@ -2265,7 +2265,7 @@ LIR_Opr LinearScan::color_lir_opr(LIR_Opr opr, int op_id, LIR_OpVisitState::OprM
 // some methods used to check correctness of debug information
 
 void assert_no_register_values(GrowableArray<ScopeValue*>* values) {
-  if (values == NULL) {
+  if (values == nullptr) {
     return;
   }
 
@@ -2280,7 +2280,7 @@ void assert_no_register_values(GrowableArray<ScopeValue*>* values) {
 }
 
 void assert_no_register_values(GrowableArray<MonitorValue*>* values) {
-  if (values == NULL) {
+  if (values == nullptr) {
     return;
   }
 
@@ -2329,41 +2329,41 @@ void assert_equal(IRScopeDebugInfo* d1, IRScopeDebugInfo* d2) {
   assert(d1->scope() == d2->scope(), "not equal");
   assert(d1->bci() == d2->bci(), "not equal");
 
-  if (d1->locals() != NULL) {
-    assert(d1->locals() != NULL && d2->locals() != NULL, "not equal");
+  if (d1->locals() != nullptr) {
+    assert(d1->locals() != nullptr && d2->locals() != nullptr, "not equal");
     assert(d1->locals()->length() == d2->locals()->length(), "not equal");
     for (int i = 0; i < d1->locals()->length(); i++) {
       assert_equal(d1->locals()->at(i), d2->locals()->at(i));
     }
   } else {
-    assert(d1->locals() == NULL && d2->locals() == NULL, "not equal");
+    assert(d1->locals() == nullptr && d2->locals() == nullptr, "not equal");
   }
 
-  if (d1->expressions() != NULL) {
-    assert(d1->expressions() != NULL && d2->expressions() != NULL, "not equal");
+  if (d1->expressions() != nullptr) {
+    assert(d1->expressions() != nullptr && d2->expressions() != nullptr, "not equal");
     assert(d1->expressions()->length() == d2->expressions()->length(), "not equal");
     for (int i = 0; i < d1->expressions()->length(); i++) {
       assert_equal(d1->expressions()->at(i), d2->expressions()->at(i));
     }
   } else {
-    assert(d1->expressions() == NULL && d2->expressions() == NULL, "not equal");
+    assert(d1->expressions() == nullptr && d2->expressions() == nullptr, "not equal");
   }
 
-  if (d1->monitors() != NULL) {
-    assert(d1->monitors() != NULL && d2->monitors() != NULL, "not equal");
+  if (d1->monitors() != nullptr) {
+    assert(d1->monitors() != nullptr && d2->monitors() != nullptr, "not equal");
     assert(d1->monitors()->length() == d2->monitors()->length(), "not equal");
     for (int i = 0; i < d1->monitors()->length(); i++) {
       assert_equal(d1->monitors()->at(i), d2->monitors()->at(i));
     }
   } else {
-    assert(d1->monitors() == NULL && d2->monitors() == NULL, "not equal");
+    assert(d1->monitors() == nullptr && d2->monitors() == nullptr, "not equal");
   }
 
-  if (d1->caller() != NULL) {
-    assert(d1->caller() != NULL && d2->caller() != NULL, "not equal");
+  if (d1->caller() != nullptr) {
+    assert(d1->caller() != nullptr && d2->caller() != nullptr, "not equal");
     assert_equal(d1->caller(), d2->caller());
   } else {
-    assert(d1->caller() == NULL && d2->caller() == NULL, "not equal");
+    assert(d1->caller() == nullptr && d2->caller() == nullptr, "not equal");
   }
 }
 
@@ -2403,7 +2403,7 @@ IntervalWalker* LinearScan::init_compute_oop_maps() {
   Interval* oop_intervals;
   Interval* non_oop_intervals;
 
-  create_unhandled_lists(&oop_intervals, &non_oop_intervals, is_oop_interval, NULL);
+  create_unhandled_lists(&oop_intervals, &non_oop_intervals, is_oop_interval, nullptr);
 
   // intervals that have no oops inside need not to be processed
   // to ensure a walking until the last instruction id, add a dummy interval
@@ -2464,7 +2464,7 @@ OopMap* LinearScan::compute_oop_map(IntervalWalker* iw, LIR_Op* op, CodeEmitInfo
   }
 
   // add oops from lock stack
-  assert(info->stack() != NULL, "CodeEmitInfo must always have a stack");
+  assert(info->stack() != nullptr, "CodeEmitInfo must always have a stack");
   int locks_count = info->stack()->total_locks_size();
   for (int i = 0; i < locks_count; i++) {
     set_oop(map, frame_map()->monitor_object_regname(i));
@@ -2496,7 +2496,7 @@ void LinearScan::compute_oop_map(IntervalWalker* iw, const LIR_OpVisitState &vis
       oop_map = compute_oop_map(iw, op, info, visitor.has_call());
     }
 
-    if (info->_oop_map == NULL) {
+    if (info->_oop_map == nullptr) {
       info->_oop_map = oop_map;
     } else {
       // a CodeEmitInfo can not be shared between different LIR-instructions
@@ -2513,7 +2513,7 @@ void LinearScan::compute_oop_map(IntervalWalker* iw, const LIR_OpVisitState &vis
 // Allocate them with new so they are never destroyed (otherwise, a
 // forced exit could destroy these objects while they are still in
 // use).
-ConstantOopWriteValue* LinearScan::_oop_null_scope_value = new (mtCompiler) ConstantOopWriteValue(NULL);
+ConstantOopWriteValue* LinearScan::_oop_null_scope_value = new (mtCompiler) ConstantOopWriteValue(nullptr);
 ConstantIntValue*      LinearScan::_int_m1_scope_value = new (mtCompiler) ConstantIntValue(-1);
 ConstantIntValue*      LinearScan::_int_0_scope_value =  new (mtCompiler) ConstantIntValue((jint)0);
 ConstantIntValue*      LinearScan::_int_1_scope_value =  new (mtCompiler) ConstantIntValue(1);
@@ -2524,7 +2524,7 @@ void LinearScan::init_compute_debug_info() {
   // cache for frequently used scope values
   // (cpu registers and stack slots)
   int cache_size = (LinearScan::nof_cpu_regs + frame_map()->argcount() + max_spills()) * 2;
-  _scope_value_cache = ScopeValueArray(cache_size, cache_size, NULL);
+  _scope_value_cache = ScopeValueArray(cache_size, cache_size, nullptr);
 }
 
 MonitorValue* LinearScan::location_for_monitor_index(int monitor_index) {
@@ -2557,7 +2557,7 @@ int LinearScan::append_scope_value_for_constant(LIR_Opr opr, GrowableArray<Scope
   switch (t) {
     case T_OBJECT: {
       jobject value = c->as_jobject();
-      if (value == NULL) {
+      if (value == nullptr) {
         scope_values->append(_oop_null_scope_value);
       } else {
         scope_values->append(new ConstantOopWriteValue(c->as_jobject()));
@@ -2617,7 +2617,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
     int cache_idx = (stack_idx + LinearScan::nof_cpu_regs) * 2 + (is_oop ? 1 : 0);
 
     ScopeValue* sv = _scope_value_cache.at(cache_idx);
-    if (sv == NULL) {
+    if (sv == nullptr) {
       Location::Type loc_type = is_oop ? Location::oop : Location::normal;
       sv = location_for_name(stack_idx, loc_type);
       _scope_value_cache.at_put(cache_idx, sv);
@@ -2635,7 +2635,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
     Location::Type int_loc_type = NOT_LP64(Location::normal) LP64_ONLY(Location::int_in_long);
 
     ScopeValue* sv = _scope_value_cache.at(cache_idx);
-    if (sv == NULL) {
+    if (sv == nullptr) {
       Location::Type loc_type = is_oop ? Location::oop : int_loc_type;
       VMReg rname = frame_map()->regname(opr);
       sv = new LocationValue(Location::new_reg_loc(loc_type, rname));
@@ -2663,7 +2663,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
     // during fpu stack allocation, so the stack allocator object
     // must be present
     assert(use_fpu_stack_allocation(), "should not have float stack values without fpu stack allocation (all floats must be SSE2)");
-    assert(_fpu_stack_allocator != NULL, "must be present");
+    assert(_fpu_stack_allocator != nullptr, "must be present");
     opr = _fpu_stack_allocator->to_fpu_stack(opr);
 #elif defined(AMD64)
     assert(false, "FPU not used on x86-64");
@@ -2710,7 +2710,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
 #ifdef _LP64
       Location loc1;
       Location::Type loc_type = opr->type() == T_LONG ? Location::lng : Location::dbl;
-      if (!frame_map()->locations_for_slot(opr->double_stack_ix(), loc_type, &loc1, NULL)) {
+      if (!frame_map()->locations_for_slot(opr->double_stack_ix(), loc_type, &loc1, nullptr)) {
         bailout("too large frame");
       }
 
@@ -2776,7 +2776,7 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
       // during fpu stack allocation, so the stack allocator object
       // must be present
       assert(use_fpu_stack_allocation(), "should not have float stack values without fpu stack allocation (all floats must be SSE2)");
-      assert(_fpu_stack_allocator != NULL, "must be present");
+      assert(_fpu_stack_allocator != nullptr, "must be present");
       opr = _fpu_stack_allocator->to_fpu_stack(opr);
 
       assert(opr->fpu_regnrLo() == opr->fpu_regnrHi(), "assumed in calculation (only fpu_regnrLo is used)");
@@ -2808,11 +2808,11 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
 
     } else {
       ShouldNotReachHere();
-      first = NULL;
-      second = NULL;
+      first = nullptr;
+      second = nullptr;
     }
 
-    assert(first != NULL && second != NULL, "must be set");
+    assert(first != nullptr && second != nullptr, "must be set");
     // The convention the interpreter uses is that the second local
     // holds the first raw word of the native double representation.
     // This is actually reasonable, since locals and stack arrays
@@ -2827,14 +2827,14 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
 
 
 int LinearScan::append_scope_value(int op_id, Value value, GrowableArray<ScopeValue*>* scope_values) {
-  if (value != NULL) {
+  if (value != nullptr) {
     LIR_Opr opr = value->operand();
     Constant* con = value->as_Constant();
 
-    assert(con == NULL || opr->is_virtual() || opr->is_constant() || opr->is_illegal(), "assumption: Constant instructions have only constant operands (or illegal if constant is optimized away)");
-    assert(con != NULL || opr->is_virtual(), "assumption: non-Constant instructions have only virtual operands");
+    assert(con == nullptr || opr->is_virtual() || opr->is_constant() || opr->is_illegal(), "assumption: Constant instructions have only constant operands (or illegal if constant is optimized away)");
+    assert(con != nullptr || opr->is_virtual(), "assumption: non-Constant instructions have only virtual operands");
 
-    if (con != NULL && !con->is_pinned() && !opr->is_constant()) {
+    if (con != nullptr && !con->is_pinned() && !opr->is_constant()) {
       // Unpinned constants may have a virtual operand for a part of the lifetime
       // or may be illegal when it was optimized away,
       // so always use a constant operand
@@ -2852,7 +2852,7 @@ int LinearScan::append_scope_value(int op_id, Value value, GrowableArray<ScopeVa
         // and so the wrong operand would be returned (spill moves at block boundaries are not
         // considered in the live ranges of intervals)
         // Solution: use the first op_id of the branch target block instead.
-        if (block->lir()->instructions_list()->last()->as_OpBranch() != NULL) {
+        if (block->lir()->instructions_list()->last()->as_OpBranch() != nullptr) {
           if (block->live_out().at(opr->vreg_number())) {
             op_id = block->sux_at(0)->first_lir_instruction_id();
             mode = LIR_OpVisitState::outputMode;
@@ -2870,7 +2870,7 @@ int LinearScan::append_scope_value(int op_id, Value value, GrowableArray<ScopeVa
       return append_scope_value_for_operand(opr, scope_values);
 
     } else {
-      assert(value->as_Constant() != NULL, "all other instructions have only virtual operands");
+      assert(value->as_Constant() != nullptr, "all other instructions have only virtual operands");
       assert(opr->is_constant(), "operand must be constant");
 
       return append_scope_value_for_constant(opr, scope_values);
@@ -2884,10 +2884,10 @@ int LinearScan::append_scope_value(int op_id, Value value, GrowableArray<ScopeVa
 
 
 IRScopeDebugInfo* LinearScan::compute_debug_info_for_scope(int op_id, IRScope* cur_scope, ValueStack* cur_state, ValueStack* innermost_state) {
-  IRScopeDebugInfo* caller_debug_info = NULL;
+  IRScopeDebugInfo* caller_debug_info = nullptr;
 
   ValueStack* caller_state = cur_state->caller_state();
-  if (caller_state != NULL) {
+  if (caller_state != nullptr) {
     // process recursively to compute outermost scope first
     caller_debug_info = compute_debug_info_for_scope(op_id, cur_scope->caller(), caller_state, innermost_state);
   }
@@ -2895,9 +2895,9 @@ IRScopeDebugInfo* LinearScan::compute_debug_info_for_scope(int op_id, IRScope* c
   // initialize these to null.
   // If we don't need deopt info or there are no locals, expressions or monitors,
   // then these get recorded as no information and avoids the allocation of 0 length arrays.
-  GrowableArray<ScopeValue*>*   locals      = NULL;
-  GrowableArray<ScopeValue*>*   expressions = NULL;
-  GrowableArray<MonitorValue*>* monitors    = NULL;
+  GrowableArray<ScopeValue*>*   locals      = nullptr;
+  GrowableArray<ScopeValue*>*   expressions = nullptr;
+  GrowableArray<MonitorValue*>* monitors    = nullptr;
 
   // describe local variable values
   int nof_locals = cur_state->locals_size();
@@ -2942,7 +2942,7 @@ IRScopeDebugInfo* LinearScan::compute_debug_info_for_scope(int op_id, IRScope* c
   // describe monitors
   int nof_locks = cur_state->locks_size();
   if (nof_locks > 0) {
-    int lock_offset = cur_state->caller_state() != NULL ? cur_state->caller_state()->total_locks_size() : 0;
+    int lock_offset = cur_state->caller_state() != nullptr ? cur_state->caller_state()->total_locks_size() : 0;
     monitors = new GrowableArray<MonitorValue*>(nof_locks);
     for (int i = 0; i < nof_locks; i++) {
       monitors->append(location_for_monitor_index(lock_offset + i));
@@ -2959,11 +2959,11 @@ void LinearScan::compute_debug_info(CodeEmitInfo* info, int op_id) {
   IRScope* innermost_scope = info->scope();
   ValueStack* innermost_state = info->stack();
 
-  assert(innermost_scope != NULL && innermost_state != NULL, "why is it missing?");
+  assert(innermost_scope != nullptr && innermost_state != nullptr, "why is it missing?");
 
   DEBUG_ONLY(check_stack_depth(info, innermost_state->stack_size()));
 
-  if (info->_scope_debug_info == NULL) {
+  if (info->_scope_debug_info == nullptr) {
     // compute debug information
     info->_scope_debug_info = compute_debug_info_for_scope(op_id, innermost_scope, innermost_state, innermost_state);
   } else {
@@ -2980,7 +2980,7 @@ void LinearScan::assign_reg_num(LIR_OpList* instructions, IntervalWalker* iw) {
 
   for (int j = 0; j < num_inst; j++) {
     LIR_Op* op = instructions->at(j);
-    if (op == NULL) {  // this can happen when spill-moves are removed in eliminate_spill_moves
+    if (op == nullptr) {  // this can happen when spill-moves are removed in eliminate_spill_moves
       has_dead = true;
       continue;
     }
@@ -3007,8 +3007,8 @@ void LinearScan::assign_reg_num(LIR_OpList* instructions, IntervalWalker* iw) {
         int n = xhandlers->length();
         for (int k = 0; k < n; k++) {
           XHandler* handler = xhandlers->handler_at(k);
-          if (handler->entry_code() != NULL) {
-            assign_reg_num(handler->entry_code()->instructions_list(), NULL);
+          if (handler->entry_code() != nullptr) {
+            assign_reg_num(handler->entry_code()->instructions_list(), nullptr);
           }
         }
       } else {
@@ -3016,7 +3016,7 @@ void LinearScan::assign_reg_num(LIR_OpList* instructions, IntervalWalker* iw) {
       }
 
       // compute oop map
-      assert(iw != NULL, "needed for compute_oop_map");
+      assert(iw != nullptr, "needed for compute_oop_map");
       compute_oop_map(iw, visitor, op);
 
       // compute debug information
@@ -3039,14 +3039,14 @@ void LinearScan::assign_reg_num(LIR_OpList* instructions, IntervalWalker* iw) {
 
     // remove useless moves
     if (op->code() == lir_move) {
-      assert(op->as_Op1() != NULL, "move must be LIR_Op1");
+      assert(op->as_Op1() != nullptr, "move must be LIR_Op1");
       LIR_Op1* move = (LIR_Op1*)op;
       LIR_Opr src = move->in_opr();
       LIR_Opr dst = move->result_opr();
       if (dst == src ||
           (!dst->is_pointer() && !src->is_pointer() &&
            src->is_same_register(dst))) {
-        instructions->at_put(j, NULL);
+        instructions->at_put(j, nullptr);
         has_dead = true;
       }
     }
@@ -3057,7 +3057,7 @@ void LinearScan::assign_reg_num(LIR_OpList* instructions, IntervalWalker* iw) {
     int insert_point = 0;
     for (int j = 0; j < num_inst; j++) {
       LIR_Op* op = instructions->at(j);
-      if (op != NULL) {
+      if (op != nullptr) {
         if (insert_point != j) {
           instructions->at_put(insert_point, op);
         }
@@ -3180,7 +3180,7 @@ void LinearScan::print_intervals(const char* label) {
 
     for (i = 0; i < interval_count(); i++) {
       Interval* interval = interval_at(i);
-      if (interval != NULL) {
+      if (interval != nullptr) {
         interval->print();
       }
     }
@@ -3254,7 +3254,7 @@ LIR_Opr LinearScan::get_operand(int reg_num) {
 
 Interval* LinearScan::find_interval_at(int reg_num) const {
   if (reg_num < 0 || reg_num >= _intervals.length()) {
-    return NULL;
+    return nullptr;
   }
   return interval_at(reg_num);
 }
@@ -3288,7 +3288,7 @@ void LinearScan::verify_intervals() {
 
   for (int i = 0; i < len; i++) {
     Interval* i1 = interval_at(i);
-    if (i1 == NULL) continue;
+    if (i1 == nullptr) continue;
 
     i1->check_split_children();
 
@@ -3335,7 +3335,7 @@ void LinearScan::verify_intervals() {
 
     for (int j = i + 1; j < len; j++) {
       Interval* i2 = interval_at(j);
-      if (i2 == NULL || (i2->from() == 1 && i2->to() == 2)) continue;
+      if (i2 == nullptr || (i2->from() == 1 && i2->to() == 2)) continue;
 
       int r1 = i1->assigned_reg();
       int r1Hi = i1->assigned_regHi();
@@ -3357,7 +3357,7 @@ void LinearScan::verify_intervals() {
 void LinearScan::verify_no_oops_in_fixed_intervals() {
   Interval* fixed_intervals;
   Interval* other_intervals;
-  create_unhandled_lists(&fixed_intervals, &other_intervals, is_precolored_cpu_interval, NULL);
+  create_unhandled_lists(&fixed_intervals, &other_intervals, is_precolored_cpu_interval, nullptr);
 
   // to ensure a walking until the last instruction id, add a dummy interval
   // with a high operation id
@@ -3385,7 +3385,7 @@ void LinearScan::verify_no_oops_in_fixed_intervals() {
           check_live = (move->patch_code() == lir_patch_none);
         }
         LIR_OpBranch* branch = op->as_OpBranch();
-        if (branch != NULL && branch->stub() != NULL && branch->stub()->is_exception_throw_stub()) {
+        if (branch != nullptr && branch->stub() != nullptr && branch->stub()->is_exception_throw_stub()) {
           // Don't bother checking the stub in this case since the
           // exception stub will never return to normal control flow.
           check_live = false;
@@ -3438,7 +3438,7 @@ void LinearScan::verify_no_oops_in_fixed_intervals() {
               TRACE_LINEAR_SCAN(4, op->print_on(tty); tty->print("checking operand "); opr->print(); tty->cr());
 
               Interval* interval = interval_at(reg_num(opr));
-              assert(interval != NULL, "no interval");
+              assert(interval != nullptr, "no interval");
 
               if (mode == LIR_OpVisitState::inputMode) {
                 if (interval->to() >= op_id + 1) {
@@ -3477,10 +3477,10 @@ void LinearScan::verify_constants() {
 
       Value value = gen()->instruction_for_vreg(r);
 
-      assert(value != NULL, "all intervals live across block boundaries must have Value");
+      assert(value != nullptr, "all intervals live across block boundaries must have Value");
       assert(value->operand()->is_register() && value->operand()->is_virtual(), "value must have virtual operand");
       assert(value->operand()->vreg_number() == r, "register number must match");
-      // TKR assert(value->as_Constant() == NULL || value->is_pinned(), "only pinned constants can be alive across block boundaries");
+      // TKR assert(value->as_Constant() == null || value->is_pinned(), "only pinned constants can be alive across block boundaries");
     };
     live_at_edge.iterate(visitor, 0, size);
   }
@@ -3520,7 +3520,7 @@ class RegisterVerifier: public StackObj {
   RegisterVerifier(LinearScan* allocator)
     : _allocator(allocator)
     , _work_list(16)
-    , _saved_states(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), NULL)
+    , _saved_states(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), nullptr)
   { }
 
   void verify(BlockBegin* start);
@@ -3537,7 +3537,7 @@ void LinearScan::verify_registers() {
 void RegisterVerifier::verify(BlockBegin* start) {
   // setup input registers (method arguments) for first block
   int input_state_len = state_size();
-  IntervalList* input_state = new IntervalList(input_state_len, input_state_len, NULL);
+  IntervalList* input_state = new IntervalList(input_state_len, input_state_len, nullptr);
   CallingConvention* args = compilation()->frame_map()->incoming_arguments();
   for (int n = 0; n < args->length(); n++) {
     LIR_Opr opr = args->at(n);
@@ -3575,7 +3575,7 @@ void RegisterVerifier::process_block(BlockBegin* block) {
     tty->print_cr("Input-State of intervals:");
     tty->print("    ");
     for (int i = 0; i < state_size(); i++) {
-      if (input_state->at(i) != NULL) {
+      if (input_state->at(i) != nullptr) {
         tty->print(" %4d", input_state->at(i)->reg_num());
       } else {
         tty->print("   __");
@@ -3600,7 +3600,7 @@ void RegisterVerifier::process_xhandler(XHandler* xhandler, IntervalList* input_
   // must copy state because it is modified
   input_state = copy(input_state);
 
-  if (xhandler->entry_code() != NULL) {
+  if (xhandler->entry_code() != nullptr) {
     process_operations(xhandler->entry_code(), input_state);
   }
   process_successor(xhandler->entry_block(), input_state);
@@ -3609,7 +3609,7 @@ void RegisterVerifier::process_xhandler(XHandler* xhandler, IntervalList* input_
 void RegisterVerifier::process_successor(BlockBegin* block, IntervalList* input_state) {
   IntervalList* saved_state = state_for_block(block);
 
-  if (saved_state != NULL) {
+  if (saved_state != nullptr) {
     // this block was already processed before.
     // check if new input_state is consistent with saved_state
 
@@ -3618,12 +3618,12 @@ void RegisterVerifier::process_successor(BlockBegin* block, IntervalList* input_
       if (input_state->at(i) != saved_state->at(i)) {
         // current input_state and previous saved_state assume a different
         // interval in this register -> assume that this register is invalid
-        if (saved_state->at(i) != NULL) {
+        if (saved_state->at(i) != nullptr) {
           // invalidate old calculation only if it assumed that
           // register was valid. when the register was already invalid,
           // then the old calculation was correct.
           saved_state_correct = false;
-          saved_state->at_put(i, NULL);
+          saved_state->at_put(i, nullptr);
 
           TRACE_LINEAR_SCAN(4, tty->print_cr("process_successor B%d: invalidating slot %d", block->block_id(), i));
         }
@@ -3657,10 +3657,10 @@ IntervalList* RegisterVerifier::copy(IntervalList* input_state) {
 
 void RegisterVerifier::state_put(IntervalList* input_state, int reg, Interval* interval) {
   if (reg != LinearScan::any_reg && reg < state_size()) {
-    if (interval != NULL) {
+    if (interval != nullptr) {
       TRACE_LINEAR_SCAN(4, tty->print_cr("        reg[%d] = %d", reg, interval->reg_num()));
-    } else if (input_state->at(reg) != NULL) {
-      TRACE_LINEAR_SCAN(4, tty->print_cr("        reg[%d] = NULL", reg));
+    } else if (input_state->at(reg) != nullptr) {
+      TRACE_LINEAR_SCAN(4, tty->print_cr("        reg[%d] = null", reg));
     }
 
     input_state->at_put(reg, interval);
@@ -3705,8 +3705,8 @@ void RegisterVerifier::process_operations(LIR_List* ops, IntervalList* input_sta
         // When an operand is marked with is_last_use, then the fpu stack allocator
         // removes the register from the fpu stack -> the register contains no value
         if (opr->is_last_use()) {
-          state_put(input_state, interval->assigned_reg(),   NULL);
-          state_put(input_state, interval->assigned_regHi(), NULL);
+          state_put(input_state, interval->assigned_reg(),   nullptr);
+          state_put(input_state, interval->assigned_regHi(), nullptr);
         }
       }
     }
@@ -3714,16 +3714,16 @@ void RegisterVerifier::process_operations(LIR_List* ops, IntervalList* input_sta
     // invalidate all caller save registers at calls
     if (visitor.has_call()) {
       for (j = 0; j < FrameMap::nof_caller_save_cpu_regs(); j++) {
-        state_put(input_state, reg_num(FrameMap::caller_save_cpu_reg_at(j)), NULL);
+        state_put(input_state, reg_num(FrameMap::caller_save_cpu_reg_at(j)), nullptr);
       }
       for (j = 0; j < FrameMap::nof_caller_save_fpu_regs; j++) {
-        state_put(input_state, reg_num(FrameMap::caller_save_fpu_reg_at(j)), NULL);
+        state_put(input_state, reg_num(FrameMap::caller_save_fpu_reg_at(j)), nullptr);
       }
 
 #ifdef X86
       int num_caller_save_xmm_regs = FrameMap::get_num_caller_save_xmms();
       for (j = 0; j < num_caller_save_xmm_regs; j++) {
-        state_put(input_state, reg_num(FrameMap::caller_save_xmm_reg_at(j)), NULL);
+        state_put(input_state, reg_num(FrameMap::caller_save_xmm_reg_at(j)), nullptr);
       }
 #endif
     }
@@ -3735,7 +3735,7 @@ void RegisterVerifier::process_operations(LIR_List* ops, IntervalList* input_sta
       process_xhandler(xhandlers->handler_at(k), input_state);
     }
 
-    // set temp operands (some operations use temp operands also as output operands, so can't set them NULL)
+    // set temp operands (some operations use temp operands also as output operands, so can't set them null)
     n = visitor.opr_count(LIR_OpVisitState::tempMode);
     for (j = 0; j < n; j++) {
       LIR_Opr opr = visitor.opr_at(LIR_OpVisitState::tempMode, j);
@@ -3776,7 +3776,7 @@ void RegisterVerifier::process_operations(LIR_List* ops, IntervalList* input_sta
 
 MoveResolver::MoveResolver(LinearScan* allocator) :
   _allocator(allocator),
-  _insert_list(NULL),
+  _insert_list(nullptr),
   _insert_idx(-1),
   _insertion_buffer(),
   _mapping_from(8),
@@ -3804,13 +3804,13 @@ void MoveResolver::check_empty() {
 void MoveResolver::verify_before_resolve() {
   assert(_mapping_from.length() == _mapping_from_opr.length(), "length must be equal");
   assert(_mapping_from.length() == _mapping_to.length(), "length must be equal");
-  assert(_insert_list != NULL && _insert_idx != -1, "insert position not set");
+  assert(_insert_list != nullptr && _insert_idx != -1, "insert position not set");
 
   int i, j;
   if (!_multiple_reads_allowed) {
     for (i = 0; i < _mapping_from.length(); i++) {
       for (j = i + 1; j < _mapping_from.length(); j++) {
-        assert(_mapping_from.at(i) == NULL || _mapping_from.at(i) != _mapping_from.at(j), "cannot read from same interval twice");
+        assert(_mapping_from.at(i) == nullptr || _mapping_from.at(i) != _mapping_from.at(j), "cannot read from same interval twice");
       }
     }
   }
@@ -3826,7 +3826,7 @@ void MoveResolver::verify_before_resolve() {
   if (!_multiple_reads_allowed) {
     for (i = 0; i < _mapping_from.length(); i++) {
       Interval* it = _mapping_from.at(i);
-      if (it != NULL) {
+      if (it != nullptr) {
         assert(!used_regs.at(it->assigned_reg()), "cannot read from same register twice");
         used_regs.set_bit(it->assigned_reg());
 
@@ -3853,7 +3853,7 @@ void MoveResolver::verify_before_resolve() {
   used_regs.clear();
   for (i = 0; i < _mapping_from.length(); i++) {
     Interval* it = _mapping_from.at(i);
-    if (it != NULL && it->assigned_reg() >= LinearScan::nof_regs) {
+    if (it != nullptr && it->assigned_reg() >= LinearScan::nof_regs) {
       used_regs.set_bit(it->assigned_reg());
     }
   }
@@ -3898,7 +3898,7 @@ void MoveResolver::unblock_registers(Interval* it) {
 bool MoveResolver::save_to_process_move(Interval* from, Interval* to) {
   int from_reg = -1;
   int from_regHi = -1;
-  if (from != NULL) {
+  if (from != nullptr) {
     from_reg = from->assigned_reg();
     from_regHi = from->assigned_regHi();
   }
@@ -3931,14 +3931,14 @@ void MoveResolver::append_insertion_buffer() {
   }
   assert(!_insertion_buffer.initialized(), "must be uninitialized now");
 
-  _insert_list = NULL;
+  _insert_list = nullptr;
   _insert_idx = -1;
 }
 
 void MoveResolver::insert_move(Interval* from_interval, Interval* to_interval) {
   assert(from_interval->reg_num() != to_interval->reg_num(), "from and to interval equal");
   assert(from_interval->type() == to_interval->type(), "move between different types");
-  assert(_insert_list != NULL && _insert_idx != -1, "must setup insert position first");
+  assert(_insert_list != nullptr && _insert_idx != -1, "must setup insert position first");
   assert(_insertion_buffer.lir_list() == _insert_list, "wrong insertion buffer");
 
   LIR_Opr from_opr = get_virtual_register(from_interval);
@@ -3957,7 +3957,7 @@ void MoveResolver::insert_move(Interval* from_interval, Interval* to_interval) {
 
 void MoveResolver::insert_move(LIR_Opr from_opr, Interval* to_interval) {
   assert(from_opr->type() == to_interval->type(), "move between different types");
-  assert(_insert_list != NULL && _insert_idx != -1, "must setup insert position first");
+  assert(_insert_list != nullptr && _insert_idx != -1, "must setup insert position first");
   assert(_insertion_buffer.lir_list() == _insert_list, "wrong insertion buffer");
 
   LIR_Opr to_opr = get_virtual_register(to_interval);
@@ -3983,7 +3983,7 @@ LIR_Opr MoveResolver::get_virtual_register(Interval* interval) {
 }
 
 void MoveResolver::resolve_mappings() {
-  TRACE_LINEAR_SCAN(4, tty->print_cr("MoveResolver: resolving mappings for Block B%d, index %d", _insert_list->block() != NULL ? _insert_list->block()->block_id() : -1, _insert_idx));
+  TRACE_LINEAR_SCAN(4, tty->print_cr("MoveResolver: resolving mappings for Block B%d, index %d", _insert_list->block() != nullptr ? _insert_list->block()->block_id() : -1, _insert_idx));
   DEBUG_ONLY(verify_before_resolve());
 
   // Block all registers that are used as input operands of a move.
@@ -3992,7 +3992,7 @@ void MoveResolver::resolve_mappings() {
   int i;
   for (i = _mapping_from.length() - 1; i >= 0; i--) {
     Interval* from_interval = _mapping_from.at(i);
-    if (from_interval != NULL) {
+    if (from_interval != nullptr) {
       block_registers(from_interval);
     }
   }
@@ -4007,7 +4007,7 @@ void MoveResolver::resolve_mappings() {
 
       if (save_to_process_move(from_interval, to_interval)) {
         // this interval can be processed because target is free
-        if (from_interval != NULL) {
+        if (from_interval != nullptr) {
           insert_move(from_interval, to_interval);
           unblock_registers(from_interval);
         } else {
@@ -4018,7 +4018,7 @@ void MoveResolver::resolve_mappings() {
         _mapping_to.remove_at(i);
 
         processed_interval = true;
-      } else if (from_interval != NULL && from_interval->assigned_reg() < LinearScan::nof_regs) {
+      } else if (from_interval != nullptr && from_interval->assigned_reg() < LinearScan::nof_regs) {
         // this interval cannot be processed now because target is not free
         // it starts in a register, so it is a possible candidate for spilling
         spill_candidate = i;
@@ -4068,8 +4068,8 @@ void MoveResolver::resolve_mappings() {
 
 
 void MoveResolver::set_insert_position(LIR_List* insert_list, int insert_idx) {
-  TRACE_LINEAR_SCAN(4, tty->print_cr("MoveResolver: setting insert position to Block B%d, index %d", insert_list->block() != NULL ? insert_list->block()->block_id() : -1, insert_idx));
-  assert(_insert_list == NULL && _insert_idx == -1, "use move_insert_position instead of set_insert_position when data already set");
+  TRACE_LINEAR_SCAN(4, tty->print_cr("MoveResolver: setting insert position to Block B%d, index %d", insert_list->block() != nullptr ? insert_list->block()->block_id() : -1, insert_idx));
+  assert(_insert_list == nullptr && _insert_idx == -1, "use move_insert_position instead of set_insert_position when data already set");
 
   create_insertion_buffer(insert_list);
   _insert_list = insert_list;
@@ -4077,9 +4077,9 @@ void MoveResolver::set_insert_position(LIR_List* insert_list, int insert_idx) {
 }
 
 void MoveResolver::move_insert_position(LIR_List* insert_list, int insert_idx) {
-  TRACE_LINEAR_SCAN(4, tty->print_cr("MoveResolver: moving insert position to Block B%d, index %d", insert_list->block() != NULL ? insert_list->block()->block_id() : -1, insert_idx));
+  TRACE_LINEAR_SCAN(4, tty->print_cr("MoveResolver: moving insert position to Block B%d, index %d", insert_list->block() != nullptr ? insert_list->block()->block_id() : -1, insert_idx));
 
-  if (_insert_list != NULL && (insert_list != _insert_list || insert_idx != _insert_idx)) {
+  if (_insert_list != nullptr && (insert_list != _insert_list || insert_idx != _insert_idx)) {
     // insert position changed -> resolve current mappings
     resolve_mappings();
   }
@@ -4108,7 +4108,7 @@ void MoveResolver::add_mapping(LIR_Opr from_opr, Interval* to_interval) {
   TRACE_LINEAR_SCAN(4, tty->print("MoveResolver: adding mapping from "); from_opr->print(); tty->print_cr(" to %d (%d, %d)", to_interval->reg_num(), to_interval->assigned_reg(), to_interval->assigned_regHi()));
   assert(from_opr->is_constant(), "only for constants");
 
-  _mapping_from.append(NULL);
+  _mapping_from.append(nullptr);
   _mapping_from_opr.append(from_opr);
   _mapping_to.append(to_interval);
 }
@@ -4132,17 +4132,17 @@ Range::Range(int from, int to, Range* next) :
 }
 
 // initialize sentinel
-Range* Range::_end = NULL;
+Range* Range::_end = nullptr;
 void Range::initialize() {
   assert(_end == nullptr, "Range initialized more than once");
   alignas(Range) static uint8_t end_storage[sizeof(Range)];
-  _end = ::new(static_cast<void*>(end_storage)) Range(max_jint, max_jint, NULL);
+  _end = ::new(static_cast<void*>(end_storage)) Range(max_jint, max_jint, nullptr);
 }
 
 int Range::intersects_at(Range* r2) const {
   const Range* r1 = this;
 
-  assert(r1 != NULL && r2 != NULL, "null ranges not allowed");
+  assert(r1 != nullptr && r2 != nullptr, "null ranges not allowed");
   assert(r1 != _end && r2 != _end, "empty ranges not allowed");
 
   do {
@@ -4181,7 +4181,7 @@ void Range::print(outputStream* out) const {
 // **** Implementation of Interval **********************************
 
 // initialize sentinel
-Interval* Interval::_end = NULL;
+Interval* Interval::_end = nullptr;
 void Interval::initialize() {
   Range::initialize();
   assert(_end == nullptr, "Interval initialized more than once");
@@ -4202,12 +4202,12 @@ Interval::Interval(int reg_num) :
   _cached_to(-1),
   _cached_opr(LIR_OprFact::illegalOpr),
   _cached_vm_reg(VMRegImpl::Bad()),
-  _split_children(NULL),
+  _split_children(nullptr),
   _canonical_spill_slot(-1),
   _insert_move_when_activated(false),
   _spill_state(noDefinitionFound),
   _spill_definition_pos(-1),
-  _register_hint(NULL)
+  _register_hint(nullptr)
 {
   _split_parent = this;
   _current_split_child = this;
@@ -4227,7 +4227,7 @@ int Interval::calc_to() {
 #ifdef ASSERT
 // consistency check of split-children
 void Interval::check_split_children() {
-  if (_split_children != NULL && _split_children->length() > 0) {
+  if (_split_children != nullptr && _split_children->length() > 0) {
     assert(is_split_parent(), "only split parents can have children");
 
     for (int i = 0; i < _split_children->length(); i++) {
@@ -4259,13 +4259,13 @@ Interval* Interval::register_hint(bool search_split_child) const {
     return _register_hint;
   }
 
-  if (_register_hint != NULL) {
+  if (_register_hint != nullptr) {
     assert(_register_hint->is_split_parent(), "only split parents are valid hint registers");
 
     if (_register_hint->assigned_reg() >= 0 && _register_hint->assigned_reg() < LinearScan::nof_regs) {
       return _register_hint;
 
-    } else if (_register_hint->_split_children != NULL && _register_hint->_split_children->length() > 0) {
+    } else if (_register_hint->_split_children != nullptr && _register_hint->_split_children->length() > 0) {
       // search the first split child that has a register assigned
       int len = _register_hint->_split_children->length();
       for (int i = 0; i < len; i++) {
@@ -4279,7 +4279,7 @@ Interval* Interval::register_hint(bool search_split_child) const {
   }
 
   // no hint interval found that has a register assigned
-  return NULL;
+  return nullptr;
 }
 
 
@@ -4288,10 +4288,10 @@ Interval* Interval::split_child_at_op_id(int op_id, LIR_OpVisitState::OprMode mo
   assert(op_id >= 0, "invalid op_id (method can not be called for spill moves)");
 
   Interval* result;
-  if (_split_children == NULL || _split_children->length() == 0) {
+  if (_split_children == nullptr || _split_children->length() == 0) {
     result = this;
   } else {
-    result = NULL;
+    result = nullptr;
     int len = _split_children->length();
 
     // in outputMode, the end of the interval (op_id == cur->to()) is not valid
@@ -4326,7 +4326,7 @@ Interval* Interval::split_child_at_op_id(int op_id, LIR_OpVisitState::OprMode mo
 #endif
   }
 
-  assert(result != NULL, "no matching interval found");
+  assert(result != nullptr, "no matching interval found");
   assert(result->covers(op_id, mode), "op_id not covered by interval");
 
   return result;
@@ -4338,20 +4338,20 @@ Interval* Interval::split_child_before_op_id(int op_id) {
   assert(op_id >= 0, "invalid op_id");
 
   Interval* parent = split_parent();
-  Interval* result = NULL;
+  Interval* result = nullptr;
 
-  assert(parent->_split_children != NULL, "no split children available");
+  assert(parent->_split_children != nullptr, "no split children available");
   int len = parent->_split_children->length();
   assert(len > 0, "no split children available");
 
   for (int i = len - 1; i >= 0; i--) {
     Interval* cur = parent->_split_children->at(i);
-    if (cur->to() <= op_id && (result == NULL || result->to() < cur->to())) {
+    if (cur->to() <= op_id && (result == nullptr || result->to() < cur->to())) {
       result = cur;
     }
   }
 
-  assert(result != NULL, "no split child found");
+  assert(result != nullptr, "no split child found");
   return result;
 }
 
@@ -4460,7 +4460,7 @@ Interval* Interval::new_split_child() {
   result->set_register_hint(parent);
 
   // insert new interval in children-list of parent
-  if (parent->_split_children == NULL) {
+  if (parent->_split_children == nullptr) {
     assert(is_split_parent(), "list must be initialized at first split");
 
     parent->_split_children = new IntervalList(4);
@@ -4488,7 +4488,7 @@ Interval* Interval::split(int split_pos) {
   Interval* result = new_split_child();
 
   // split the ranges
-  Range* prev = NULL;
+  Range* prev = nullptr;
   Range* cur = _first;
   while (cur != Range::end() && cur->to() <= split_pos) {
     prev = cur;
@@ -4502,7 +4502,7 @@ Interval* Interval::split(int split_pos) {
     cur->set_next(Range::end());
 
   } else {
-    assert(prev != NULL, "split before start of first range");
+    assert(prev != nullptr, "split before start of first range");
     result->_first = cur;
     prev->set_next(Range::end());
   }
@@ -4623,7 +4623,7 @@ bool Interval::has_hole_between(int hole_from, int hole_to) {
 
 // Check if there is an intersection with any of the split children of 'interval'
 bool Interval::intersects_any_children_of(Interval* interval) const {
-  if (interval->_split_children != NULL) {
+  if (interval->_split_children != nullptr) {
     for (int i = 0; i < interval->_split_children->length(); i++) {
       if (intersects(interval->_split_children->at(i))) {
         return true;
@@ -4667,14 +4667,14 @@ void Interval::print_on(outputStream* out, bool is_cfg_printer) const {
     }
     out->print(" ");
   }
-  out->print("%d %d ", split_parent()->reg_num(), (register_hint(false) != NULL ? register_hint(false)->reg_num() : -1));
+  out->print("%d %d ", split_parent()->reg_num(), (register_hint(false) != nullptr ? register_hint(false)->reg_num() : -1));
 
   // print ranges
   Range* cur = _first;
   while (cur != Range::end()) {
     cur->print(out);
     cur = cur->next();
-    assert(cur != NULL, "range list not closed with range sentinel");
+    assert(cur != nullptr, "range list not closed with range sentinel");
   }
 
   // print use positions
@@ -4701,7 +4701,7 @@ void Interval::print_parent() const {
 }
 
 void Interval::print_children() const {
-  if (_split_children == NULL) {
+  if (_split_children == nullptr) {
     tty->print_cr("Children: []");
   } else {
     tty->print_cr("Children:");
@@ -4729,19 +4729,19 @@ IntervalWalker::IntervalWalker(LinearScan* allocator, Interval* unhandled_fixed_
   _active_first[anyKind]      = Interval::end();
   _inactive_first[anyKind]    = Interval::end();
   _current_position = -1;
-  _current = NULL;
+  _current = nullptr;
   next_interval();
 }
 
 
 // append interval in order of current range from()
 void IntervalWalker::append_sorted(Interval** list, Interval* interval) {
-  Interval* prev = NULL;
+  Interval* prev = nullptr;
   Interval* cur  = *list;
   while (cur->current_from() < interval->current_from()) {
     prev = cur; cur = cur->next();
   }
-  if (prev == NULL) {
+  if (prev == nullptr) {
     *list = interval;
   } else {
     prev->set_next(interval);
@@ -4752,12 +4752,12 @@ void IntervalWalker::append_sorted(Interval** list, Interval* interval) {
 void IntervalWalker::append_to_unhandled(Interval** list, Interval* interval) {
   assert(interval->from() >= current()->current_from(), "cannot append new interval before current walk position");
 
-  Interval* prev = NULL;
+  Interval* prev = nullptr;
   Interval* cur  = *list;
   while (cur->from() < interval->from() || (cur->from() == interval->from() && cur->first_usage(noUse) < interval->first_usage(noUse))) {
     prev = cur; cur = cur->next();
   }
-  if (prev == NULL) {
+  if (prev == nullptr) {
     *list = interval;
   } else {
     prev->set_next(interval);
@@ -4862,7 +4862,7 @@ void IntervalWalker::next_interval() {
   } else if (fixed != Interval::end()) {
     kind = fixedKind;
   } else {
-    _current = NULL; return;
+    _current = nullptr; return;
   }
   _current_kind = kind;
   _current = _unhandled_first[kind];
@@ -4874,7 +4874,7 @@ void IntervalWalker::next_interval() {
 
 void IntervalWalker::walk_to(int lir_op_id) {
   assert(_current_position <= lir_op_id, "can not walk backwards");
-  while (current() != NULL) {
+  while (current() != nullptr) {
     bool is_active = current()->from() <= lir_op_id;
     int id = is_active ? current()->from() : lir_op_id;
 
@@ -5300,7 +5300,7 @@ void LinearScanWalker::split_for_spilling(Interval* it) {
     // position. This avoids short interval in register surrounded by intervals in
     // memory -> avoid useless moves from memory to register and back
     Interval* parent = it;
-    while (parent != NULL && parent->is_split_child()) {
+    while (parent != nullptr && parent->is_split_child()) {
       parent = parent->split_child_before_op_id(parent->from());
 
       if (parent->assigned_reg() < LinearScan::nof_regs) {
@@ -5310,7 +5310,7 @@ void LinearScanWalker::split_for_spilling(Interval* it) {
           allocator()->assign_spill_slot(parent);
         } else {
           // do not go further back because the register is actually used by the interval
-          parent = NULL;
+          parent = nullptr;
         }
       }
     }
@@ -5480,7 +5480,7 @@ bool LinearScanWalker::alloc_free_reg(Interval* cur) {
 
   int hint_reg, hint_regHi;
   Interval* register_hint = cur->register_hint();
-  if (register_hint != NULL) {
+  if (register_hint != nullptr) {
     hint_reg = register_hint->assigned_reg();
     hint_regHi = register_hint->assigned_regHi();
 
@@ -5796,7 +5796,7 @@ bool LinearScanWalker::is_move(LIR_Op* op, Interval* from, Interval* to) {
   if (op->code() != lir_move) {
     return false;
   }
-  assert(op->as_Op1() != NULL, "move must be LIR_Op1");
+  assert(op->as_Op1() != nullptr, "move must be LIR_Op1");
 
   LIR_Opr in = ((LIR_Op1*)op)->in_opr();
   LIR_Opr res = ((LIR_Op1*)op)->result_opr();
@@ -5812,7 +5812,7 @@ void LinearScanWalker::combine_spilled_intervals(Interval* cur) {
   }
 
   Interval* register_hint = cur->register_hint(false);
-  if (register_hint == NULL) {
+  if (register_hint == nullptr) {
     // cur is not the target of a move, otherwise register_hint would be set
     return;
   }
@@ -5919,7 +5919,7 @@ bool LinearScanWalker::activate_current() {
   // load spilled values that become active from stack slot to register
   if (cur->insert_move_when_activated()) {
     assert(cur->is_split_child(), "must be");
-    assert(cur->current_split_child() != NULL, "must be");
+    assert(cur->current_split_child() != nullptr, "must be");
     assert(cur->current_split_child()->reg_num() != cur->reg_num(), "cannot insert move between same interval");
     TRACE_LINEAR_SCAN(4, tty->print_cr("Inserting move from interval %d to %d because insert_move_when_activated is set", cur->current_split_child()->reg_num(), cur->reg_num()));
 
@@ -5976,7 +5976,7 @@ LIR_Op* EdgeMoveOptimizer::instruction_at(int edge) {
   if (idx < instructions->length()) {
     return instructions->at(idx);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -5993,14 +5993,14 @@ void EdgeMoveOptimizer::remove_cur_instruction(int edge, bool decrement_index) {
 
 
 bool EdgeMoveOptimizer::operations_different(LIR_Op* op1, LIR_Op* op2) {
-  if (op1 == NULL || op2 == NULL) {
+  if (op1 == nullptr || op2 == nullptr) {
     // at least one block is already empty -> no optimization possible
     return true;
   }
 
   if (op1->code() == lir_move && op2->code() == lir_move) {
-    assert(op1->as_Op1() != NULL, "move must be LIR_Op1");
-    assert(op2->as_Op1() != NULL, "move must be LIR_Op1");
+    assert(op1->as_Op1() != nullptr, "move must be LIR_Op1");
+    assert(op2->as_Op1() != nullptr, "move must be LIR_Op1");
     LIR_Op1* move1 = (LIR_Op1*)op1;
     LIR_Op1* move2 = (LIR_Op1*)op2;
     if (move1->info() == move2->info() && move1->in_opr() == move2->in_opr() && move1->result_opr() == move2->result_opr()) {
@@ -6009,8 +6009,8 @@ bool EdgeMoveOptimizer::operations_different(LIR_Op* op1, LIR_Op* op2) {
     }
 
   } else if (op1->code() == lir_fxch && op2->code() == lir_fxch) {
-    assert(op1->as_Op1() != NULL, "fxch must be LIR_Op1");
-    assert(op2->as_Op1() != NULL, "fxch must be LIR_Op1");
+    assert(op1->as_Op1() != nullptr, "fxch must be LIR_Op1");
+    assert(op2->as_Op1() != nullptr, "fxch must be LIR_Op1");
     LIR_Op1* fxch1 = (LIR_Op1*)op1;
     LIR_Op1* fxch2 = (LIR_Op1*)op2;
     if (fxch1->in_opr()->as_jint() == fxch2->in_opr()->as_jint()) {
@@ -6055,10 +6055,10 @@ void EdgeMoveOptimizer::optimize_moves_at_block_end(BlockBegin* block) {
     assert(pred->number_of_sux() == 1, "can handle only one successor");
     assert(pred->sux_at(0) == block, "invalid control flow");
     assert(pred_instructions->last()->code() == lir_branch, "block with successor must end with branch");
-    assert(pred_instructions->last()->as_OpBranch() != NULL, "branch must be LIR_OpBranch");
+    assert(pred_instructions->last()->as_OpBranch() != nullptr, "branch must be LIR_OpBranch");
     assert(pred_instructions->last()->as_OpBranch()->cond() == lir_cond_always, "block must end with unconditional branch");
 
-    if (pred_instructions->last()->info() != NULL) {
+    if (pred_instructions->last()->info() != nullptr) {
       // can not optimize instructions when debug info is needed
       return;
     }
@@ -6102,16 +6102,16 @@ void EdgeMoveOptimizer::optimize_moves_at_block_begin(BlockBegin* block) {
 
   assert(num_sux == 2, "method should not be called otherwise");
   assert(cur_instructions->last()->code() == lir_branch, "block with successor must end with branch");
-  assert(cur_instructions->last()->as_OpBranch() != NULL, "branch must be LIR_OpBranch");
+  assert(cur_instructions->last()->as_OpBranch() != nullptr, "branch must be LIR_OpBranch");
   assert(cur_instructions->last()->as_OpBranch()->cond() == lir_cond_always, "block must end with unconditional branch");
 
-  if (cur_instructions->last()->info() != NULL) {
+  if (cur_instructions->last()->info() != nullptr) {
     // can no optimize instructions when debug info is needed
     return;
   }
 
   LIR_Op* branch = cur_instructions->at(cur_instructions->length() - 2);
-  if (branch->info() != NULL || (branch->code() != lir_branch && branch->code() != lir_cond_float_branch)) {
+  if (branch->info() != nullptr || (branch->code() != lir_branch && branch->code() != lir_cond_float_branch)) {
     // not a valid case for optimization
     // currently, only blocks that end with two branches (conditional branch followed
     // by unconditional branch) are optimized
@@ -6126,7 +6126,7 @@ void EdgeMoveOptimizer::optimize_moves_at_block_begin(BlockBegin* block) {
 #ifdef ASSERT
   for (i = insert_idx - 1; i >= 0; i--) {
     LIR_Op* op = cur_instructions->at(i);
-    if ((op->code() == lir_branch || op->code() == lir_cond_float_branch) && ((LIR_OpBranch*)op)->block() != NULL) {
+    if ((op->code() == lir_branch || op->code() == lir_cond_float_branch) && ((LIR_OpBranch*)op)->block() != nullptr) {
       assert(false, "block with two successors can have only two branch instructions");
     }
   }
@@ -6255,13 +6255,13 @@ bool ControlFlowOptimizer::can_delete_block(BlockBegin* block) {
 
   assert(instructions->length() >= 2, "block must have label and branch");
   assert(instructions->at(0)->code() == lir_label, "first instruction must always be a label");
-  assert(instructions->last()->as_OpBranch() != NULL, "last instruction must always be a branch");
+  assert(instructions->last()->as_OpBranch() != nullptr, "last instruction must always be a branch");
   assert(instructions->last()->as_OpBranch()->cond() == lir_cond_always, "branch must be unconditional");
   assert(instructions->last()->as_OpBranch()->block() == block->sux_at(0), "branch target must be the successor");
 
   // block must have exactly one successor
 
-  if (instructions->length() == 2 && instructions->last()->info() == NULL) {
+  if (instructions->length() == 2 && instructions->last()->info() == nullptr) {
     return true;
   }
   return false;
@@ -6278,7 +6278,7 @@ void ControlFlowOptimizer::substitute_branch_target(BlockBegin* block, BlockBegi
     LIR_Op* op = instructions->at(i);
 
     if (op->code() == lir_branch || op->code() == lir_cond_float_branch) {
-      assert(op->as_OpBranch() != NULL, "branch must be of type LIR_OpBranch");
+      assert(op->as_OpBranch() != nullptr, "branch must be of type LIR_OpBranch");
       LIR_OpBranch* branch = (LIR_OpBranch*)op;
 
       if (branch->block() == target_from) {
@@ -6347,13 +6347,13 @@ void ControlFlowOptimizer::delete_unnecessary_jumps(BlockList* code) {
 
     LIR_Op* last_op = instructions->last();
     if (last_op->code() == lir_branch) {
-      assert(last_op->as_OpBranch() != NULL, "branch must be of type LIR_OpBranch");
+      assert(last_op->as_OpBranch() != nullptr, "branch must be of type LIR_OpBranch");
       LIR_OpBranch* last_branch = (LIR_OpBranch*)last_op;
 
-      assert(last_branch->block() != NULL, "last branch must always have a block as target");
+      assert(last_branch->block() != nullptr, "last branch must always have a block as target");
       assert(last_branch->label() == last_branch->block()->label(), "must be equal");
 
-      if (last_branch->info() == NULL) {
+      if (last_branch->info() == nullptr) {
         if (last_branch->block() == code->at(i + 1)) {
 
           TRACE_LINEAR_SCAN(3, tty->print_cr("Deleting unconditional branch at end of block B%d", block->block_id()));
@@ -6364,34 +6364,34 @@ void ControlFlowOptimizer::delete_unnecessary_jumps(BlockList* code) {
         } else {
           LIR_Op* prev_op = instructions->at(instructions->length() - 2);
           if (prev_op->code() == lir_branch || prev_op->code() == lir_cond_float_branch) {
-            assert(prev_op->as_OpBranch() != NULL, "branch must be of type LIR_OpBranch");
+            assert(prev_op->as_OpBranch() != nullptr, "branch must be of type LIR_OpBranch");
             LIR_OpBranch* prev_branch = (LIR_OpBranch*)prev_op;
 
-            if (prev_branch->stub() == NULL) {
+            if (prev_branch->stub() == nullptr) {
 
-              LIR_Op2* prev_cmp = NULL;
+              LIR_Op2* prev_cmp = nullptr;
               // There might be a cmove inserted for profiling which depends on the same
               // compare. If we change the condition of the respective compare, we have
               // to take care of this cmove as well.
-              LIR_Op4* prev_cmove = NULL;
+              LIR_Op4* prev_cmove = nullptr;
 
-              for(int j = instructions->length() - 3; j >= 0 && prev_cmp == NULL; j--) {
+              for(int j = instructions->length() - 3; j >= 0 && prev_cmp == nullptr; j--) {
                 prev_op = instructions->at(j);
                 // check for the cmove
                 if (prev_op->code() == lir_cmove) {
-                  assert(prev_op->as_Op4() != NULL, "cmove must be of type LIR_Op4");
+                  assert(prev_op->as_Op4() != nullptr, "cmove must be of type LIR_Op4");
                   prev_cmove = (LIR_Op4*)prev_op;
                   assert(prev_branch->cond() == prev_cmove->condition(), "should be the same");
                 }
                 if (prev_op->code() == lir_cmp) {
-                  assert(prev_op->as_Op2() != NULL, "branch must be of type LIR_Op2");
+                  assert(prev_op->as_Op2() != nullptr, "branch must be of type LIR_Op2");
                   prev_cmp = (LIR_Op2*)prev_op;
                   assert(prev_branch->cond() == prev_cmp->condition(), "should be the same");
                 }
               }
               // Guarantee because it is dereferenced below.
-              guarantee(prev_cmp != NULL, "should have found comp instruction for branch");
-              if (prev_branch->block() == code->at(i + 1) && prev_branch->info() == NULL) {
+              guarantee(prev_cmp != nullptr, "should have found comp instruction for branch");
+              if (prev_branch->block() == code->at(i + 1) && prev_branch->info() == nullptr) {
 
                 TRACE_LINEAR_SCAN(3, tty->print_cr("Negating conditional branch and deleting unconditional branch at end of block B%d", block->block_id()));
 
@@ -6401,7 +6401,7 @@ void ControlFlowOptimizer::delete_unnecessary_jumps(BlockList* code) {
                 prev_cmp->set_condition(prev_branch->cond());
                 instructions->trunc_to(instructions->length() - 1);
                 // if we do change the condition, we have to change the cmove as well
-                if (prev_cmove != NULL) {
+                if (prev_cmove != nullptr) {
                   prev_cmove->set_condition(prev_branch->cond());
                   LIR_Opr t = prev_cmove->in_opr1();
                   prev_cmove->set_in_opr1(prev_cmove->in_opr2());
@@ -6438,12 +6438,12 @@ void ControlFlowOptimizer::delete_jumps_to_return(BlockList* code) {
       //       because the predecessors might have other (conditional) jumps to this block
       //       -> this may lead to unnecessary return instructions in the final code
 
-      assert(cur_last_op->info() == NULL, "return instructions do not have debug information");
+      assert(cur_last_op->info() == nullptr, "return instructions do not have debug information");
       assert(block->number_of_sux() == 0 ||
              (return_converted.at(block->block_id()) && block->number_of_sux() == 1),
              "blocks that end with return must not have successors");
 
-      assert(cur_last_op->as_Op1() != NULL, "return must be LIR_Op1");
+      assert(cur_last_op->as_Op1() != nullptr, "return must be LIR_Op1");
       LIR_Opr return_opr = ((LIR_Op1*)cur_last_op)->in_opr();
 
       for (int j = block->number_of_preds() - 1; j >= 0; j--) {
@@ -6452,10 +6452,10 @@ void ControlFlowOptimizer::delete_jumps_to_return(BlockList* code) {
         LIR_Op*     pred_last_op = pred_instructions->last();
 
         if (pred_last_op->code() == lir_branch) {
-          assert(pred_last_op->as_OpBranch() != NULL, "branch must be LIR_OpBranch");
+          assert(pred_last_op->as_OpBranch() != nullptr, "branch must be LIR_OpBranch");
           LIR_OpBranch* pred_last_branch = (LIR_OpBranch*)pred_last_op;
 
-          if (pred_last_branch->block() == block && pred_last_branch->cond() == lir_cond_always && pred_last_branch->info() == NULL) {
+          if (pred_last_branch->block() == block && pred_last_branch->cond() == lir_cond_always && pred_last_branch->info() == nullptr) {
             // replace the jump to a return with a direct return
             // Note: currently the edge between the blocks is not deleted
             pred_instructions->at_put(pred_instructions->length() - 1, new LIR_OpReturn(return_opr));
@@ -6480,9 +6480,9 @@ void ControlFlowOptimizer::verify(BlockList* code) {
     for (j = 0; j < instructions->length(); j++) {
       LIR_OpBranch* op_branch = instructions->at(j)->as_OpBranch();
 
-      if (op_branch != NULL) {
-        assert(op_branch->block() == NULL || code->find(op_branch->block()) != -1, "branch target not valid");
-        assert(op_branch->ublock() == NULL || code->find(op_branch->ublock()) != -1, "branch target not valid");
+      if (op_branch != nullptr) {
+        assert(op_branch->block() == nullptr || code->find(op_branch->block()) != -1, "branch target not valid");
+        assert(op_branch->ublock() == nullptr || code->find(op_branch->ublock()) != -1, "branch target not valid");
       }
     }
 
@@ -6630,7 +6630,7 @@ void LinearScanStatistic::collect(LinearScan* allocator) {
   for (i = 0; i < allocator->interval_count(); i++) {
     Interval* cur = allocator->interval_at(i);
 
-    if (cur != NULL) {
+    if (cur != nullptr) {
       inc_counter(counter_interval);
       inc_counter(counter_use_pos, cur->num_use_positions());
       if (LinearScan::is_precolored_interval(cur)) {
@@ -6717,7 +6717,7 @@ void LinearScanStatistic::collect(LinearScan* allocator) {
         case lir_branch:
         case lir_cond_float_branch: {
           LIR_OpBranch* branch = op->as_OpBranch();
-          if (branch->block() == NULL) {
+          if (branch->block() == nullptr) {
             inc_counter(counter_stub_branch);
           } else if (branch->cond() == lir_cond_always) {
             inc_counter(counter_uncond_branch);

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -2980,7 +2980,7 @@ void LinearScan::assign_reg_num(LIR_OpList* instructions, IntervalWalker* iw) {
 
   for (int j = 0; j < num_inst; j++) {
     LIR_Op* op = instructions->at(j);
-    if (op == nullptr) {  // this can happen when spill-moves are removed in eliminate_spill_moves
+    if (op == nullptr) { // this can happen when spill-moves are removed in eliminate_spill_moves
       has_dead = true;
       continue;
     }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -3480,7 +3480,7 @@ void LinearScan::verify_constants() {
       assert(value != nullptr, "all intervals live across block boundaries must have Value");
       assert(value->operand()->is_register() && value->operand()->is_virtual(), "value must have virtual operand");
       assert(value->operand()->vreg_number() == r, "register number must match");
-      // TKR assert(value->as_Constant() == null || value->is_pinned(), "only pinned constants can be alive across block boundaries");
+      // TKR assert(value->as_Constant() == nullptr || value->is_pinned(), "only pinned constants can be alive across block boundaries");
     };
     live_at_edge.iterate(visitor, 0, size);
   }

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,13 +56,13 @@ class CE_Eliminator: public BlockClosure {
     }
 
     CompileLog* log = _hir->compilation()->log();
-    if (log != NULL)
+    if (log != nullptr)
       log->set_context("optimize name='cee'");
   }
 
   ~CE_Eliminator() {
     CompileLog* log = _hir->compilation()->log();
-    if (log != NULL)
+    if (log != nullptr)
       log->clear_context(); // skip marker if nothing was printed
   }
 
@@ -96,7 +96,7 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   // 1) find conditional expression
   // check if block ends with an If
   If* if_ = block->end()->as_If();
-  if (if_ == NULL) return;
+  if (if_ == nullptr) return;
 
   // check if If works on int or object types
   // (we cannot handle If's working on long, float or doubles yet,
@@ -111,22 +111,22 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   Instruction* f_cur = f_block->next();
 
   // one Constant may be present between BlockBegin and BlockEnd
-  Value t_const = NULL;
-  Value f_const = NULL;
-  if (t_cur->as_Constant() != NULL && !t_cur->can_trap()) {
+  Value t_const = nullptr;
+  Value f_const = nullptr;
+  if (t_cur->as_Constant() != nullptr && !t_cur->can_trap()) {
     t_const = t_cur;
     t_cur = t_cur->next();
   }
-  if (f_cur->as_Constant() != NULL && !f_cur->can_trap()) {
+  if (f_cur->as_Constant() != nullptr && !f_cur->can_trap()) {
     f_const = f_cur;
     f_cur = f_cur->next();
   }
 
   // check if both branches end with a goto
   Goto* t_goto = t_cur->as_Goto();
-  if (t_goto == NULL) return;
+  if (t_goto == nullptr) return;
   Goto* f_goto = f_cur->as_Goto();
-  if (f_goto == NULL) return;
+  if (f_goto == nullptr) return;
 
   // check if both gotos merge into the same block
   BlockBegin* sux = t_goto->default_sux();
@@ -139,12 +139,12 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   if (if_state->scope()->level() > sux_state->scope()->level()) {
     while (sux_state->scope() != if_state->scope()) {
       if_state = if_state->caller_state();
-      assert(if_state != NULL, "states do not match up");
+      assert(if_state != nullptr, "states do not match up");
     }
   } else if (if_state->scope()->level() < sux_state->scope()->level()) {
     while (sux_state->scope() != if_state->scope()) {
       sux_state = sux_state->caller_state();
-      assert(sux_state != NULL, "states do not match up");
+      assert(sux_state != nullptr, "states do not match up");
     }
   }
 
@@ -153,7 +153,7 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   // check if phi function is present at end of successor stack and that
   // only this phi was pushed on the stack
   Value sux_phi = sux_state->stack_at(if_state->stack_size());
-  if (sux_phi == NULL || sux_phi->as_Phi() == NULL || sux_phi->as_Phi()->block() != sux) return;
+  if (sux_phi == nullptr || sux_phi->as_Phi() == nullptr || sux_phi->as_Phi()->block() != sux) return;
   if (sux_phi->type()->size() != sux_state->stack_size() - if_state->stack_size()) return;
 
   // get the values that were pushed in the true- and false-branch
@@ -219,7 +219,7 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   }
 
   Value result = make_ifop(if_->x(), if_->cond(), if_->y(), t_value, f_value);
-  assert(result != NULL, "make_ifop must return a non-null instruction");
+  assert(result != nullptr, "make_ifop must return a non-null instruction");
   if (!result->is_linked() && result->can_be_linked()) {
     NOT_PRODUCT(result->set_printable_bci(if_->printable_bci()));
     cur_end = cur_end->set_next(result);
@@ -289,13 +289,13 @@ Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Va
   y = y->subst();
 
   Constant* y_const = y->as_Constant();
-  if (y_const != NULL) {
+  if (y_const != nullptr) {
     IfOp* x_ifop = x->as_IfOp();
-    if (x_ifop != NULL) {                 // x is an ifop, y is a constant
+    if (x_ifop != nullptr) {                 // x is an ifop, y is a constant
       Constant* x_tval_const = x_ifop->tval()->subst()->as_Constant();
       Constant* x_fval_const = x_ifop->fval()->subst()->as_Constant();
 
-      if (x_tval_const != NULL && x_fval_const != NULL) {
+      if (x_tval_const != nullptr && x_fval_const != nullptr) {
         Instruction::Condition x_ifop_cond = x_ifop->cond();
 
         Constant::CompareResult t_compare_res = x_tval_const->compare(cond, y_const);
@@ -316,7 +316,7 @@ Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Va
       }
     } else {
       Constant* x_const = x->as_Constant();
-      if (x_const != NULL) {         // x and y are constants
+      if (x_const != nullptr) {         // x and y are constants
         Constant::CompareResult x_compare_res = x_const->compare(cond, y_const);
         // not_comparable here is a valid return in case we're comparing unloaded oop constants
         if (x_compare_res != Constant::not_comparable) {
@@ -360,19 +360,19 @@ class BlockMerger: public BlockClosure {
   {
     _hir->iterate_preorder(this);
     CompileLog* log = _hir->compilation()->log();
-    if (log != NULL)
+    if (log != nullptr)
       log->set_context("optimize name='eliminate_blocks'");
   }
 
   ~BlockMerger() {
     CompileLog* log = _hir->compilation()->log();
-    if (log != NULL)
+    if (log != nullptr)
       log->clear_context(); // skip marker if nothing was printed
   }
 
   bool try_merge(BlockBegin* block) {
     BlockEnd* end = block->end();
-    if (end->as_Goto() == NULL) return false;
+    if (end->as_Goto() == nullptr) return false;
 
     assert(end->number_of_sux() == 1, "end must have exactly one successor");
     // Note: It would be sufficient to check for the number of successors (= 1)
@@ -404,7 +404,7 @@ class BlockMerger: public BlockClosure {
     }
     for_each_local_value(sux_state, index, sux_value) {
       Phi* sux_phi = sux_value->as_Phi();
-      if (sux_phi != NULL && sux_phi->is_illegal()) continue;
+      if (sux_phi != nullptr && sux_phi->is_illegal()) continue;
         assert(sux_value == end_state->local_at(index), "locals not equal");
       }
     assert(sux_state->caller_state() == end_state->caller_state(), "caller not equal");
@@ -419,7 +419,7 @@ class BlockMerger: public BlockClosure {
     // find instruction before end & append first instruction of sux block
     Instruction* prev = end->prev();
     Instruction* next = sux->next();
-    assert(prev->as_BlockEnd() == NULL, "must not be a BlockEnd");
+    assert(prev->as_BlockEnd() == nullptr, "must not be a BlockEnd");
     prev->set_next(next);
     prev->fixup_block_pointers();
 
@@ -472,14 +472,14 @@ class BlockMerger: public BlockClosure {
         if (tval && fval) {
           // Find the instruction before if_, starting with ifop.
           // When if_ and ifop are not in the same block, prev
-          // becomes NULL In such (rare) cases it is not
+          // becomes null In such (rare) cases it is not
           // profitable to perform the optimization.
           Value prev = ifop;
-          while (prev != NULL && prev->next() != if_) {
+          while (prev != nullptr && prev->next() != if_) {
             prev = prev->next();
           }
 
-          if (prev != NULL) {
+          if (prev != nullptr) {
             Instruction::Condition cond = if_->cond();
             BlockBegin* tsux = if_->tsux();
             BlockBegin* fsux = if_->fsux();
@@ -607,19 +607,19 @@ class NullCheckEliminator: public ValueVisitor {
   BlockList*        _work_list;                   // Basic blocks to visit
 
   bool visitable(Value x) {
-    assert(_visitable_instructions != NULL, "check");
+    assert(_visitable_instructions != nullptr, "check");
     return _visitable_instructions->contains(x);
   }
   void mark_visited(Value x) {
-    assert(_visitable_instructions != NULL, "check");
+    assert(_visitable_instructions != nullptr, "check");
     _visitable_instructions->remove(x);
   }
   void mark_visitable(Value x) {
-    assert(_visitable_instructions != NULL, "check");
+    assert(_visitable_instructions != nullptr, "check");
     _visitable_instructions->put(x);
   }
   void clear_visitable_state() {
-    assert(_visitable_instructions != NULL, "check");
+    assert(_visitable_instructions != nullptr, "check");
     _visitable_instructions->clear();
   }
 
@@ -628,9 +628,9 @@ class NullCheckEliminator: public ValueVisitor {
   NullCheckVisitor  _visitor;
   NullCheck*        _last_explicit_null_check;
 
-  bool set_contains(Value x)                      { assert(_set != NULL, "check"); return _set->contains(x); }
-  void set_put     (Value x)                      { assert(_set != NULL, "check"); _set->put(x); }
-  void set_remove  (Value x)                      { assert(_set != NULL, "check"); _set->remove(x); }
+  bool set_contains(Value x)                      { assert(_set != nullptr, "check"); return _set->contains(x); }
+  void set_put     (Value x)                      { assert(_set != nullptr, "check"); _set->put(x); }
+  void set_remove  (Value x)                      { assert(_set != nullptr, "check"); _set->remove(x); }
 
   BlockList* work_list()                          { return _work_list; }
 
@@ -651,18 +651,18 @@ class NullCheckEliminator: public ValueVisitor {
     : _opt(opt)
     , _work_list(new BlockList())
     , _set(new ValueSet())
-    , _block_states(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), NULL)
-    , _last_explicit_null_check(NULL) {
+    , _block_states(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), nullptr)
+    , _last_explicit_null_check(nullptr) {
     _visitable_instructions = new ValueSet();
     _visitor.set_eliminator(this);
     CompileLog* log = _opt->ir()->compilation()->log();
-    if (log != NULL)
+    if (log != nullptr)
       log->set_context("optimize name='null_check_elimination'");
   }
 
   ~NullCheckEliminator() {
     CompileLog* log = _opt->ir()->compilation()->log();
-    if (log != NULL)
+    if (log != nullptr)
       log->clear_context(); // skip marker if nothing was printed
   }
 
@@ -685,13 +685,13 @@ class NullCheckEliminator: public ValueVisitor {
   NullCheck*  last_explicit_null_check()                     { return _last_explicit_null_check; }
   Value       last_explicit_null_check_obj()                 { return (_last_explicit_null_check
                                                                          ? _last_explicit_null_check->obj()
-                                                                         : NULL); }
+                                                                         : nullptr); }
   NullCheck*  consume_last_explicit_null_check() {
     _last_explicit_null_check->unpin(Instruction::PinExplicitNullCheck);
     _last_explicit_null_check->set_can_trap(false);
     return _last_explicit_null_check;
   }
-  void        clear_last_explicit_null_check()               { _last_explicit_null_check = NULL; }
+  void        clear_last_explicit_null_check()               { _last_explicit_null_check = nullptr; }
 
   // Handlers for relevant instructions
   // (separated out from NullCheckVisitor for clarity)
@@ -779,7 +779,7 @@ void NullCheckVisitor::do_Assert         (Assert*          x) {}
 #endif
 
 void NullCheckEliminator::visit(Value* p) {
-  assert(*p != NULL, "should not find NULL instructions");
+  assert(*p != nullptr, "should not find null instructions");
   if (visitable(*p)) {
     mark_visited(*p);
     (*p)->visit(&_visitor);
@@ -788,7 +788,7 @@ void NullCheckEliminator::visit(Value* p) {
 
 bool NullCheckEliminator::merge_state_for(BlockBegin* block, ValueSet* incoming_state) {
   ValueSet* state = state_for(block);
-  if (state == NULL) {
+  if (state == nullptr) {
     state = incoming_state->copy();
     set_state_for(block, state);
     return true;
@@ -812,7 +812,7 @@ void NullCheckEliminator::iterate_all() {
 void NullCheckEliminator::iterate_one(BlockBegin* block) {
   clear_visitable_state();
   // clear out an old explicit null checks
-  set_last_explicit_null_check(NULL);
+  set_last_explicit_null_check(nullptr);
 
   if (PrintNullCheckElimination) {
     tty->print_cr(" ...iterating block %d in null check elimination for %s::%s%s",
@@ -823,7 +823,7 @@ void NullCheckEliminator::iterate_one(BlockBegin* block) {
   }
 
   // Create new state if none present (only happens at root)
-  if (state_for(block) == NULL) {
+  if (state_for(block) == nullptr) {
     ValueSet* tmp_state = new ValueSet();
     set_state_for(block, tmp_state);
     // Initial state is that local 0 (receiver) is non-null for
@@ -833,10 +833,10 @@ void NullCheckEliminator::iterate_one(BlockBegin* block) {
     ciMethod*   method = scope->method();
     if (!method->is_static()) {
       Local* local0 = stack->local_at(0)->as_Local();
-      assert(local0 != NULL, "must be");
+      assert(local0 != nullptr, "must be");
       assert(local0->type() == objectType, "invalid type of receiver");
 
-      if (local0 != NULL) {
+      if (local0 != nullptr) {
         // Local 0 is used in this scope
         tmp_state->put(local0);
         if (PrintNullCheckElimination) {
@@ -858,7 +858,7 @@ void NullCheckEliminator::iterate_one(BlockBegin* block) {
                    );
 
   BlockEnd* e = block->end();
-  assert(e != NULL, "incomplete graph");
+  assert(e != nullptr, "incomplete graph");
   int i;
 
   // Propagate the state before this block into the exception
@@ -876,13 +876,13 @@ void NullCheckEliminator::iterate_one(BlockBegin* block) {
   }
 
   // Iterate through block, updating state.
-  for (Instruction* instr = block; instr != NULL; instr = instr->next()) {
+  for (Instruction* instr = block; instr != nullptr; instr = instr->next()) {
     // Mark instructions in this block as visitable as they are seen
     // in the instruction list.  This keeps the iteration from
     // visiting instructions which are references in other blocks or
     // visiting instructions more than once.
     mark_visitable(instr);
-    if (instr->is_pinned() || instr->can_trap() || (instr->as_NullCheck() != NULL)) {
+    if (instr->is_pinned() || instr->can_trap() || (instr->as_NullCheck() != nullptr)) {
       mark_visited(instr);
       instr->input_values_do(this);
       instr->visit(&_visitor);
@@ -908,7 +908,7 @@ void NullCheckEliminator::iterate(BlockBegin* block) {
 
 void NullCheckEliminator::handle_AccessField(AccessField* x) {
   if (x->is_static()) {
-    if (x->as_LoadField() != NULL) {
+    if (x->as_LoadField() != nullptr) {
       // If the field is a non-null static final object field (as is
       // often the case for sun.misc.Unsafe), put this LoadField into
       // the non-null map
@@ -944,7 +944,7 @@ void NullCheckEliminator::handle_AccessField(AccessField* x) {
                       x->explicit_null_check()->id(), x->id(), obj->id());
       }
     } else {
-      x->set_explicit_null_check(NULL);
+      x->set_explicit_null_check(nullptr);
       x->set_needs_null_check(false);
       if (PrintNullCheckElimination) {
         tty->print_cr("Eliminated AccessField %d's null check for value %d", x->id(), obj->id());
@@ -957,7 +957,7 @@ void NullCheckEliminator::handle_AccessField(AccessField* x) {
     }
     // Ensure previous passes do not cause wrong state
     x->set_needs_null_check(true);
-    x->set_explicit_null_check(NULL);
+    x->set_explicit_null_check(nullptr);
   }
   clear_last_explicit_null_check();
 }
@@ -975,7 +975,7 @@ void NullCheckEliminator::handle_ArrayLength(ArrayLength* x) {
                       x->explicit_null_check()->id(), x->id(), array->id());
       }
     } else {
-      x->set_explicit_null_check(NULL);
+      x->set_explicit_null_check(nullptr);
       x->set_needs_null_check(false);
       if (PrintNullCheckElimination) {
         tty->print_cr("Eliminated ArrayLength %d's null check for value %d", x->id(), array->id());
@@ -988,7 +988,7 @@ void NullCheckEliminator::handle_ArrayLength(ArrayLength* x) {
     }
     // Ensure previous passes do not cause wrong state
     x->set_needs_null_check(true);
-    x->set_explicit_null_check(NULL);
+    x->set_explicit_null_check(nullptr);
   }
   clear_last_explicit_null_check();
 }
@@ -1006,7 +1006,7 @@ void NullCheckEliminator::handle_LoadIndexed(LoadIndexed* x) {
                       x->explicit_null_check()->id(), x->id(), array->id());
       }
     } else {
-      x->set_explicit_null_check(NULL);
+      x->set_explicit_null_check(nullptr);
       x->set_needs_null_check(false);
       if (PrintNullCheckElimination) {
         tty->print_cr("Eliminated LoadIndexed %d's null check for value %d", x->id(), array->id());
@@ -1019,7 +1019,7 @@ void NullCheckEliminator::handle_LoadIndexed(LoadIndexed* x) {
     }
     // Ensure previous passes do not cause wrong state
     x->set_needs_null_check(true);
-    x->set_explicit_null_check(NULL);
+    x->set_explicit_null_check(nullptr);
   }
   clear_last_explicit_null_check();
 }

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -316,7 +316,7 @@ Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Va
       }
     } else {
       Constant* x_const = x->as_Constant();
-      if (x_const != nullptr) {         // x and y are constants
+      if (x_const != nullptr) { // x and y are constants
         Constant::CompareResult x_compare_res = x_const->compare(cond, y_const);
         // not_comparable here is a valid return in case we're comparing unloaded oop constants
         if (x_compare_res != Constant::not_comparable) {

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,8 @@ void RangeCheckElimination::eliminate(IR *ir) {
 
 // Constructor
 RangeCheckEliminator::RangeCheckEliminator(IR *ir) :
-  _bounds(Instruction::number_of_instructions(), Instruction::number_of_instructions(), NULL),
-  _access_indexed_info(Instruction::number_of_instructions(), Instruction::number_of_instructions(), NULL)
+  _bounds(Instruction::number_of_instructions(), Instruction::number_of_instructions(), nullptr),
+  _access_indexed_info(Instruction::number_of_instructions(), Instruction::number_of_instructions(), nullptr)
 {
   _visitor.set_range_check_eliminator(this);
   _ir = ir;
@@ -92,7 +92,7 @@ RangeCheckEliminator::RangeCheckEliminator(IR *ir) :
   TRACE_RANGE_CHECK_ELIMINATION(
     tty->print_cr("Starting pass over dominator tree . . .")
   );
-  calc_bounds(ir->start(), NULL);
+  calc_bounds(ir->start(), nullptr);
 
   TRACE_RANGE_CHECK_ELIMINATION(
     tty->print_cr("Finished!")
@@ -103,9 +103,9 @@ RangeCheckEliminator::RangeCheckEliminator(IR *ir) :
 // Constant
 void RangeCheckEliminator::Visitor::do_Constant(Constant *c) {
   IntConstant *ic = c->type()->as_IntConstant();
-  if (ic != NULL) {
+  if (ic != nullptr) {
     int value = ic->value();
-    _bound = new Bound(value, NULL, value, NULL);
+    _bound = new Bound(value, nullptr, value, nullptr);
   }
 }
 
@@ -114,13 +114,13 @@ void RangeCheckEliminator::Visitor::do_LogicOp(LogicOp *lo) {
   if (lo->type()->as_IntType() && lo->op() == Bytecodes::_iand && (lo->x()->as_Constant() || lo->y()->as_Constant())) {
     int constant = 0;
     Constant *c = lo->x()->as_Constant();
-    if (c != NULL) {
+    if (c != nullptr) {
       constant = c->type()->as_IntConstant()->value();
     } else {
       constant = lo->y()->as_Constant()->type()->as_IntConstant()->value();
     }
     if (constant >= 0) {
-      _bound = new Bound(0, NULL, constant, NULL);
+      _bound = new Bound(0, nullptr, constant, nullptr);
     }
   }
 }
@@ -134,7 +134,7 @@ void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
   bool has_upper = true;
   bool has_lower = true;
   assert(phi, "Phi must not be null");
-  Bound *bound = NULL;
+  Bound *bound = nullptr;
 
   // TODO: support more difficult phis
   for (int i=0; i<op_count; i++) {
@@ -144,7 +144,7 @@ void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
 
     // Check if instruction is connected with phi itself
     Op2 *op2 = v->as_Op2();
-    if (op2 != NULL) {
+    if (op2 != nullptr) {
       Value x = op2->x();
       Value y = op2->y();
       if ((x == phi || y == phi)) {
@@ -153,11 +153,11 @@ void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
           other = y;
         }
         ArithmeticOp *ao = v->as_ArithmeticOp();
-        if (ao != NULL && ao->op() == Bytecodes::_iadd) {
+        if (ao != nullptr && ao->op() == Bytecodes::_iadd) {
           assert(ao->op() == Bytecodes::_iadd, "Has to be add!");
           if (ao->type()->as_IntType()) {
             Constant *c = other->as_Constant();
-            if (c != NULL) {
+            if (c != nullptr) {
               assert(c->type()->as_IntConstant(), "Constant has to be of type integer");
               int value = c->type()->as_IntConstant()->value();
               if (value == 1) {
@@ -184,7 +184,7 @@ void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
 
     if (v->type()->as_IntConstant()) {
       cur_constant = v->type()->as_IntConstant()->value();
-      cur_value = NULL;
+      cur_value = nullptr;
     }
     if (!v_bound->has_upper() || !v_bound->has_lower()) {
       cur_bound = new Bound(cur_constant, cur_value, cur_constant, cur_value);
@@ -199,7 +199,7 @@ void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
       }
     } else {
       // No bound!
-      bound = NULL;
+      bound = nullptr;
       break;
     }
   }
@@ -226,8 +226,8 @@ void RangeCheckEliminator::Visitor::do_ArithmeticOp(ArithmeticOp *ao) {
   if (ao->op() == Bytecodes::_irem) {
     Bound* x_bound = _rce->get_bound(x);
     Bound* y_bound = _rce->get_bound(y);
-    if (x_bound->lower() >= 0 && x_bound->lower_instr() == NULL && y->as_ArrayLength() != NULL) {
-      _bound = new Bound(0, NULL, -1, y);
+    if (x_bound->lower() >= 0 && x_bound->lower_instr() == nullptr && y->as_ArrayLength() != nullptr) {
+      _bound = new Bound(0, nullptr, -1, y);
     } else if (y->type()->as_IntConstant() && y->type()->as_IntConstant()->value() != 0) {
       // The binary % operator is said to yield the remainder of its operands from an implied division; the
       // left-hand operand is the dividend and the right-hand operand is the divisor.
@@ -242,7 +242,7 @@ void RangeCheckEliminator::Visitor::do_ArithmeticOp(ArithmeticOp *ao) {
       // -x % y  ==> [-y + 1, 0]
       // -x % -y ==> [-y + 1, 0]
       if (x_bound->has_lower() && x_bound->lower() >= 0) {
-        _bound = new Bound(0, NULL, y->type()->as_IntConstant()->value() - 1, NULL);
+        _bound = new Bound(0, nullptr, y->type()->as_IntConstant()->value() - 1, nullptr);
       } else {
         _bound = new Bound();
       }
@@ -292,7 +292,7 @@ void RangeCheckEliminator::Visitor::do_ArithmeticOp(ArithmeticOp *ao) {
       Bound *bound = _rce->get_bound(x);
       if (ao->op() == Bytecodes::_isub) {
         if (bound->lower_instr() == y) {
-          _bound = new Bound(Instruction::geq, NULL, bound->lower());
+          _bound = new Bound(Instruction::geq, nullptr, bound->lower());
         } else {
           _bound = new Bound();
         }
@@ -315,14 +315,14 @@ void RangeCheckEliminator::Visitor::do_IfOp(IfOp *ifOp)
       min = max;
       max = tmp;
     }
-    _bound = new Bound(min, NULL, max, NULL);
+    _bound = new Bound(min, nullptr, max, nullptr);
   }
 }
 
 // Get bound. Returns the current bound on Value v. Normally this is the topmost element on the bound stack.
 RangeCheckEliminator::Bound *RangeCheckEliminator::get_bound(Value v) {
-  // Wrong type or NULL -> No bound
-  if (!v || (!v->type()->as_IntType() && !v->type()->as_ObjectType())) return NULL;
+  // Wrong type or null -> No bound
+  if (!v || (!v->type()->as_IntType() && !v->type()->as_ObjectType())) return nullptr;
 
   if (!_bounds.at(v->id())) {
     // First (default) bound is calculated
@@ -365,7 +365,7 @@ void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Instructi
 bool RangeCheckEliminator::loop_invariant(BlockBegin *loop_header, Instruction *instruction) {
   assert(loop_header, "Loop header must not be null!");
   if (!instruction) return true;
-  for (BlockBegin *d = loop_header->dominator(); d != NULL; d = d->dominator()) {
+  for (BlockBegin *d = loop_header->dominator(); d != nullptr; d = d->dominator()) {
     if (d == instruction->block()) {
       return true;
     }
@@ -383,7 +383,7 @@ void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Bound *bo
     get_bound(v);
     assert(_bounds.at(v->id()), "Now Stack must exist");
   }
-  Bound *top = NULL;
+  Bound *top = nullptr;
   if (_bounds.at(v->id())->length() > 0) {
     top = _bounds.at(v->id())->top();
   }
@@ -398,7 +398,7 @@ void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Bound *bo
 void RangeCheckEliminator::add_access_indexed_info(InstructionList &indices, int idx, Value instruction, AccessIndexed *ai) {
   int id = instruction->id();
   AccessIndexedInfo *aii = _access_indexed_info.at(id);
-  if (aii == NULL) {
+  if (aii == nullptr) {
     aii = new AccessIndexedInfo();
     _access_indexed_info.at_put(id, aii);
     indices.append(instruction);
@@ -438,7 +438,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
 
       Value index = ai->index();
       Constant *c = index->as_Constant();
-      if (c != NULL) {
+      if (c != nullptr) {
         int constant_value = c->type()->as_IntConstant()->value();
         if (constant_value >= 0) {
           if (constant_value <= max_constant) {
@@ -455,7 +455,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
         int base = 0;
         ArithmeticOp *ao = index->as_ArithmeticOp();
 
-        while (ao != NULL && (ao->x()->as_Constant() || ao->y()->as_Constant()) && (ao->op() == Bytecodes::_iadd || ao->op() == Bytecodes::_isub)) {
+        while (ao != nullptr && (ao->x()->as_Constant() || ao->y()->as_Constant()) && (ao->op() == Bytecodes::_iadd || ao->op() == Bytecodes::_isub)) {
           c = ao->y()->as_Constant();
           Instruction *other = ao->x();
           if (!c && ao->op() == Bytecodes::_iadd) {
@@ -488,7 +488,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
       for (int i = 0; i < indices.length(); i++) {
         Instruction *index_instruction = indices.at(i);
         AccessIndexedInfo *info = _access_indexed_info.at(index_instruction->id());
-        assert(info != NULL, "Info must not be null");
+        assert(info != nullptr, "Info must not be null");
 
         // if idx < 0, max > 0, max + idx may fall between 0 and
         // length-1 and if min < 0, min + idx may overflow and be >=
@@ -507,7 +507,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
           ValueStack *state = first->state_before();
 
           // Load min Constant
-          Constant *min_constant = NULL;
+          Constant *min_constant = nullptr;
           if (info->_min != 0) {
             min_constant = new Constant(new IntConstant(info->_min));
             NOT_PRODUCT(min_constant->set_printable_bci(first->printable_bci()));
@@ -515,7 +515,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
           }
 
           // Load max Constant
-          Constant *max_constant = NULL;
+          Constant *max_constant = nullptr;
           if (info->_max != 0) {
             max_constant = new Constant(new IntConstant(info->_max));
             NOT_PRODUCT(max_constant->set_printable_bci(first->printable_bci()));
@@ -535,7 +535,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
           // Calculate lower bound
           Instruction *lower_compare = index_instruction;
           if (min_constant) {
-            ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, min_constant, lower_compare, NULL);
+            ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, min_constant, lower_compare, nullptr);
             insert_position = insert_position->insert_after_same_bci(ao);
             lower_compare = ao;
           }
@@ -543,7 +543,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
           // Calculate upper bound
           Instruction *upper_compare = index_instruction;
           if (max_constant) {
-            ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, max_constant, upper_compare, NULL);
+            ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, max_constant, upper_compare, nullptr);
             insert_position = insert_position->insert_after_same_bci(ao);
             upper_compare = ao;
           }
@@ -588,7 +588,7 @@ void RangeCheckEliminator::in_block_motion(BlockBegin *block, AccessIndexedList 
     // Clear data structures for next array
     for (int i = 0; i < indices.length(); i++) {
       Instruction *index_instruction = indices.at(i);
-      _access_indexed_info.at_put(index_instruction->id(), NULL);
+      _access_indexed_info.at_put(index_instruction->id(), nullptr);
     }
     indices.clear();
   }
@@ -599,7 +599,7 @@ bool RangeCheckEliminator::set_process_block_flags(BlockBegin *block) {
   bool process = false;
 
   while (cur) {
-    process |= (cur->as_AccessIndexed() != NULL);
+    process |= (cur->as_AccessIndexed() != nullptr);
     cur = cur->next();
   }
 
@@ -665,7 +665,7 @@ Instruction* RangeCheckEliminator::predicate_cmp_with_const(Instruction* instr, 
 Instruction* RangeCheckEliminator::predicate_add(Instruction* left, int left_const, Instruction::Condition cond, Instruction* right, ValueStack* state, Instruction *insert_position, int bci) {
   Constant *constant = new Constant(new IntConstant(left_const));
   insert_position = insert_after(insert_position, constant, bci);
-  ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, constant, left, NULL);
+  ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, constant, left, nullptr);
   insert_position = insert_position->insert_after_same_bci(ao);
   return predicate(ao, cond, right, state, insert_position);
 }
@@ -754,19 +754,19 @@ void RangeCheckEliminator::add_if_condition(IntegerStack &pushed, Value x, Value
   Constant *c = x->as_Constant();
   ArithmeticOp *ao = x->as_ArithmeticOp();
 
-  if (c != NULL) {
+  if (c != nullptr) {
     const_value = c->type()->as_IntConstant()->value();
-    instr_value = NULL;
-  } else if (ao != NULL &&  (!ao->x()->as_Constant() || !ao->y()->as_Constant()) && ((ao->op() == Bytecodes::_isub && ao->y()->as_Constant()) || ao->op() == Bytecodes::_iadd)) {
+    instr_value = nullptr;
+  } else if (ao != nullptr &&  (!ao->x()->as_Constant() || !ao->y()->as_Constant()) && ((ao->op() == Bytecodes::_isub && ao->y()->as_Constant()) || ao->op() == Bytecodes::_iadd)) {
     assert(!ao->x()->as_Constant() || !ao->y()->as_Constant(), "At least one operator must be non-constant!");
     assert(ao->op() == Bytecodes::_isub || ao->op() == Bytecodes::_iadd, "Operation has to be add or sub!");
     c = ao->x()->as_Constant();
-    if (c != NULL) {
+    if (c != nullptr) {
       const_value = c->type()->as_IntConstant()->value();
       instr_value = ao->y();
     } else {
       c = ao->y()->as_Constant();
-      if (c != NULL) {
+      if (c != nullptr) {
         const_value = c->type()->as_IntConstant()->value();
         instr_value = ao->x();
       }
@@ -808,7 +808,7 @@ void RangeCheckEliminator::process_access_indexed(BlockBegin *loop_header, Block
     tty->fill_to(block->dominator_depth()*2)
   );
   TRACE_RANGE_CHECK_ELIMINATION(
-    tty->print_cr("Access indexed: index=%d length=%d", ai->index()->id(), (ai->length() != NULL ? ai->length()->id() :-1 ))
+    tty->print_cr("Access indexed: index=%d length=%d", ai->index()->id(), (ai->length() != nullptr ? ai->length()->id() :-1 ))
   );
 
   if (ai->check_flag(Instruction::NeedsRangeCheckFlag)) {
@@ -891,7 +891,7 @@ void RangeCheckEliminator::process_access_indexed(BlockBegin *loop_header, Block
       Value length_instr = ai->length();
       if (!loop_invariant(loop_header, length_instr)) {
         // Generate length instruction yourself!
-        length_instr = NULL;
+        length_instr = nullptr;
       }
 
       TRACE_RANGE_CHECK_ELIMINATION(
@@ -900,11 +900,11 @@ void RangeCheckEliminator::process_access_indexed(BlockBegin *loop_header, Block
       );
 
       BlockBegin *pred_block = loop_header->dominator();
-      assert(pred_block != NULL, "Every loop header has a dominator!");
+      assert(pred_block != nullptr, "Every loop header has a dominator!");
       BlockEnd *pred_block_end = pred_block->end();
       Instruction *insert_position = pred_block_end->prev();
       ValueStack *state = pred_block_end->state_before();
-      if (pred_block_end->as_Goto() && state == NULL) state = pred_block_end->state();
+      if (pred_block_end->as_Goto() && state == nullptr) state = pred_block_end->state();
       assert(state, "State must not be null");
 
       // Add deoptimization to dominator of loop header
@@ -949,9 +949,9 @@ void RangeCheckEliminator::remove_range_check(AccessIndexed *ai) {
     Value cur_value = array_length;
     if (cur_value->type()->as_IntConstant()) {
       cur_constant += cur_value->type()->as_IntConstant()->value();
-      cur_value = NULL;
+      cur_value = nullptr;
     }
-    Bound *new_index_bound = new Bound(0, NULL, cur_constant, cur_value);
+    Bound *new_index_bound = new Bound(0, nullptr, cur_constant, cur_value);
     add_assertions(new_index_bound, ai->index(), ai);
   );
 }
@@ -971,9 +971,9 @@ void RangeCheckEliminator::calc_bounds(BlockBegin *block, BlockBegin *loop_heade
   IntegerStack pushed;
   // Process If
   BlockBegin *parent = block->dominator();
-  if (parent != NULL) {
+  if (parent != nullptr) {
     If *cond = parent->end()->as_If();
-    if (cond != NULL) {
+    if (cond != nullptr) {
       process_if(pushed, block, cond);
     }
   }
@@ -988,7 +988,7 @@ void RangeCheckEliminator::calc_bounds(BlockBegin *block, BlockBegin *loop_heade
     if (cur->id() < this->_bounds.length()) {
       // Process only if it is an access indexed instruction
       AccessIndexed *ai = cur->as_AccessIndexed();
-      if (ai != NULL) {
+      if (ai != nullptr) {
         process_access_indexed(loop_header, block, ai);
         accessIndexed.append(ai);
         if (!arrays.contains(ai->array())) {
@@ -997,16 +997,16 @@ void RangeCheckEliminator::calc_bounds(BlockBegin *block, BlockBegin *loop_heade
         Bound *b = get_bound(ai->index());
         if (!b->lower_instr()) {
           // Lower bound is constant
-          update_bound(pushed, ai->index(), Instruction::geq, NULL, 0);
+          update_bound(pushed, ai->index(), Instruction::geq, nullptr, 0);
         }
         if (!b->has_upper()) {
           if (ai->length() && ai->length()->type()->as_IntConstant()) {
             int value = ai->length()->type()->as_IntConstant()->value();
-            update_bound(pushed, ai->index(), Instruction::lss, NULL, value);
+            update_bound(pushed, ai->index(), Instruction::lss, nullptr, value);
           } else {
             // Has no upper bound
             Instruction *instr = ai->length();
-            if (instr == NULL) instr = ai->array();
+            if (instr == nullptr) instr = ai->array();
             update_bound(pushed, ai->index(), Instruction::lss, instr, 0);
           }
         }
@@ -1099,10 +1099,10 @@ void RangeCheckEliminator::Verification::block_do(BlockBegin *block) {
   if (block->number_of_sux() > 1) {
     for (int i=0; i<block->number_of_sux(); i++) {
       BlockBegin *sux = block->sux_at(i);
-      BlockBegin *pred = NULL;
+      BlockBegin *pred = nullptr;
       for (int j=0; j<sux->number_of_preds(); j++) {
         BlockBegin *cur = sux->pred_at(j);
-        assert(cur != NULL, "Predecessor must not be null");
+        assert(cur != nullptr, "Predecessor must not be null");
         if (!pred) {
           pred = cur;
         }
@@ -1221,7 +1221,7 @@ bool RangeCheckEliminator::Verification::dominates(BlockBegin *dominator, BlockB
 }
 
 // Try to reach Block end beginning in Block start and not using Block dont_use
-bool RangeCheckEliminator::Verification::can_reach(BlockBegin *start, BlockBegin *end, BlockBegin *dont_use /* = NULL */) {
+bool RangeCheckEliminator::Verification::can_reach(BlockBegin *start, BlockBegin *end, BlockBegin *dont_use /* = nullptr */) {
   if (start == end) return start != dont_use;
   // Simple BSF from start to end
   //  BlockBeginList _current;
@@ -1260,7 +1260,7 @@ bool RangeCheckEliminator::Verification::can_reach(BlockBegin *start, BlockBegin
     }
     for (int i=0; i<_successors.length(); i++) {
       BlockBegin *sux = _successors.at(i);
-      assert(sux != NULL, "Successor must not be NULL!");
+      assert(sux != nullptr, "Successor must not be null!");
       if (sux == end) {
         return true;
       }
@@ -1284,8 +1284,8 @@ RangeCheckEliminator::Bound::~Bound() {
 RangeCheckEliminator::Bound::Bound() {
   this->_lower = min_jint;
   this->_upper = max_jint;
-  this->_lower_instr = NULL;
-  this->_upper_instr = NULL;
+  this->_lower_instr = nullptr;
+  this->_upper_instr = nullptr;
 }
 
 // Bound constructor
@@ -1311,9 +1311,9 @@ RangeCheckEliminator::Bound::Bound(Instruction::Condition cond, Value v, int con
   } else if (cond == Instruction::neq) {
     _lower = min_jint;
     _upper = max_jint;
-    _lower_instr = NULL;
-    _upper_instr = NULL;
-    if (v == NULL) {
+    _lower_instr = nullptr;
+    _upper_instr = nullptr;
+    if (v == nullptr) {
       if (constant == min_jint) {
         _lower++;
       }
@@ -1325,10 +1325,10 @@ RangeCheckEliminator::Bound::Bound(Instruction::Condition cond, Value v, int con
     _lower = constant;
     _lower_instr = v;
     _upper = max_jint;
-    _upper_instr = NULL;
+    _upper_instr = nullptr;
   } else if (cond == Instruction::leq) {
     _lower = min_jint;
-    _lower_instr = NULL;
+    _lower_instr = nullptr;
     _upper = constant;
     _upper_instr = v;
   } else {
@@ -1361,14 +1361,14 @@ void RangeCheckEliminator::Bound::or_op(Bound *b) {
   // Watch out, bound is not guaranteed not to overflow!
   // Update lower bound
   if (_lower_instr != b->_lower_instr || (_lower_instr && _lower != b->_lower)) {
-    _lower_instr = NULL;
+    _lower_instr = nullptr;
     _lower = min_jint;
   } else {
     _lower = MIN2(_lower, b->_lower);
   }
   // Update upper bound
   if (_upper_instr != b->_upper_instr || (_upper_instr && _upper != b->_upper)) {
-    _upper_instr = NULL;
+    _upper_instr = nullptr;
     _upper = max_jint;
   } else {
     _upper = MAX2(_upper, b->_upper);
@@ -1383,7 +1383,7 @@ void RangeCheckEliminator::Bound::and_op(Bound *b) {
   }
   if (b->has_lower()) {
     bool set = true;
-    if (_lower_instr != NULL && b->_lower_instr != NULL) {
+    if (_lower_instr != nullptr && b->_lower_instr != nullptr) {
       set = (_lower_instr->dominator_depth() > b->_lower_instr->dominator_depth());
     }
     if (set) {
@@ -1397,7 +1397,7 @@ void RangeCheckEliminator::Bound::and_op(Bound *b) {
   }
   if (b->has_upper()) {
     bool set = true;
-    if (_upper_instr != NULL && b->_upper_instr != NULL) {
+    if (_upper_instr != nullptr && b->_upper_instr != nullptr) {
       set = (_upper_instr->dominator_depth() > b->_upper_instr->dominator_depth());
     }
     if (set) {
@@ -1409,7 +1409,7 @@ void RangeCheckEliminator::Bound::and_op(Bound *b) {
 
 // has_upper
 bool RangeCheckEliminator::Bound::has_upper() {
-  return _upper_instr != NULL || _upper < max_jint;
+  return _upper_instr != nullptr || _upper < max_jint;
 }
 
 // is_smaller
@@ -1422,17 +1422,17 @@ bool RangeCheckEliminator::Bound::is_smaller(Bound *b) {
 
 // has_lower
 bool RangeCheckEliminator::Bound::has_lower() {
-  return _lower_instr != NULL || _lower > min_jint;
+  return _lower_instr != nullptr || _lower > min_jint;
 }
 
 // in_array_bound
 bool RangeCheckEliminator::in_array_bound(Bound *bound, Value array){
   if (!bound) return false;
-  assert(array != NULL, "Must not be null!");
-  assert(bound != NULL, "Must not be null!");
-  if (bound->lower() >=0 && bound->lower_instr() == NULL && bound->upper() < 0 && bound->upper_instr() != NULL) {
+  assert(array != nullptr, "Must not be null!");
+  assert(bound != nullptr, "Must not be null!");
+  if (bound->lower() >=0 && bound->lower_instr() == nullptr && bound->upper() < 0 && bound->upper_instr() != nullptr) {
     ArrayLength *len = bound->upper_instr()->as_ArrayLength();
-    if (bound->upper_instr() == array || (len != NULL && len->array() == array)) {
+    if (bound->upper_instr() == array || (len != nullptr && len->array() == array)) {
       return true;
     }
   }
@@ -1442,13 +1442,13 @@ bool RangeCheckEliminator::in_array_bound(Bound *bound, Value array){
 // remove_lower
 void RangeCheckEliminator::Bound::remove_lower() {
   _lower = min_jint;
-  _lower_instr = NULL;
+  _lower_instr = nullptr;
 }
 
 // remove_upper
 void RangeCheckEliminator::Bound::remove_upper() {
   _upper = max_jint;
-  _upper_instr = NULL;
+  _upper_instr = nullptr;
 }
 
 // upper
@@ -1519,7 +1519,7 @@ RangeCheckEliminator::Bound *RangeCheckEliminator::Bound::copy() {
 // Add assertion
 void RangeCheckEliminator::Bound::add_assertion(Instruction *instruction, Instruction *position, int i, Value instr, Instruction::Condition cond) {
   Instruction *result = position;
-  Instruction *compare_with = NULL;
+  Instruction *compare_with = nullptr;
   ValueStack *state = position->state_before();
   if (position->as_BlockEnd() && !position->as_Goto()) {
     state = position->as_BlockEnd()->state_before();
@@ -1530,7 +1530,7 @@ void RangeCheckEliminator::Bound::add_assertion(Instruction *instruction, Instru
   }
   result = instruction_before;
   // Load constant only if needed
-  Constant *constant = NULL;
+  Constant *constant = nullptr;
   if (i != 0 || !instr) {
     constant = new Constant(new IntConstant(i));
     NOT_PRODUCT(constant->set_printable_bci(position->printable_bci()));
@@ -1554,15 +1554,15 @@ void RangeCheckEliminator::Bound::add_assertion(Instruction *instruction, Instru
     }
     // Add operation only if necessary
     if (constant) {
-      ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, constant, op, NULL);
+      ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, constant, op, nullptr);
       NOT_PRODUCT(ao->set_printable_bci(position->printable_bci()));
       result = result->insert_after(ao);
       compare_with = ao;
       // TODO: Check that add operation does not overflow!
     }
   }
-  assert(compare_with != NULL, "You have to compare with something!");
-  assert(instruction != NULL, "Instruction must not be null!");
+  assert(compare_with != nullptr, "You have to compare with something!");
+  assert(instruction != nullptr, "Instruction must not be null!");
 
   if (instruction->type()->as_ObjectType()) {
     // Load array length if necessary

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
@@ -134,7 +134,7 @@ void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
   bool has_upper = true;
   bool has_lower = true;
   assert(phi, "Phi must not be null");
-  Bound *bound = nullptr;
+  Bound* bound = nullptr;
 
   // TODO: support more difficult phis
   for (int i=0; i<op_count; i++) {
@@ -365,7 +365,7 @@ void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Instructi
 bool RangeCheckEliminator::loop_invariant(BlockBegin *loop_header, Instruction *instruction) {
   assert(loop_header, "Loop header must not be null!");
   if (!instruction) return true;
-  for (BlockBegin *d = loop_header->dominator(); d != nullptr; d = d->dominator()) {
+  for (BlockBegin* d = loop_header->dominator(); d != nullptr; d = d->dominator()) {
     if (d == instruction->block()) {
       return true;
     }
@@ -383,7 +383,7 @@ void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Bound *bo
     get_bound(v);
     assert(_bounds.at(v->id()), "Now Stack must exist");
   }
-  Bound *top = nullptr;
+  Bound* top = nullptr;
   if (_bounds.at(v->id())->length() > 0) {
     top = _bounds.at(v->id())->top();
   }
@@ -951,7 +951,7 @@ void RangeCheckEliminator::remove_range_check(AccessIndexed *ai) {
       cur_constant += cur_value->type()->as_IntConstant()->value();
       cur_value = nullptr;
     }
-    Bound *new_index_bound = new Bound(0, nullptr, cur_constant, cur_value);
+    Bound* new_index_bound = new Bound(0, nullptr, cur_constant, cur_value);
     add_assertions(new_index_bound, ai->index(), ai);
   );
 }
@@ -1098,8 +1098,8 @@ void RangeCheckEliminator::Verification::block_do(BlockBegin *block) {
   // Watch out: tsux and fsux can be the same!
   if (block->number_of_sux() > 1) {
     for (int i=0; i<block->number_of_sux(); i++) {
-      BlockBegin *sux = block->sux_at(i);
-      BlockBegin *pred = nullptr;
+      BlockBegin* sux = block->sux_at(i);
+      BlockBegin* pred = nullptr;
       for (int j=0; j<sux->number_of_preds(); j++) {
         BlockBegin *cur = sux->pred_at(j);
         assert(cur != nullptr, "Predecessor must not be null");
@@ -1221,7 +1221,7 @@ bool RangeCheckEliminator::Verification::dominates(BlockBegin *dominator, BlockB
 }
 
 // Try to reach Block end beginning in Block start and not using Block dont_use
-bool RangeCheckEliminator::Verification::can_reach(BlockBegin *start, BlockBegin *end, BlockBegin *dont_use /* = nullptr */) {
+bool RangeCheckEliminator::Verification::can_reach(BlockBegin* start, BlockBegin* end, BlockBegin* dont_use /* = nullptr */) {
   if (start == end) return start != dont_use;
   // Simple BSF from start to end
   //  BlockBeginList _current;
@@ -1518,19 +1518,19 @@ RangeCheckEliminator::Bound *RangeCheckEliminator::Bound::copy() {
 #ifdef ASSERT
 // Add assertion
 void RangeCheckEliminator::Bound::add_assertion(Instruction *instruction, Instruction *position, int i, Value instr, Instruction::Condition cond) {
-  Instruction *result = position;
-  Instruction *compare_with = nullptr;
-  ValueStack *state = position->state_before();
+  Instruction* result = position;
+  Instruction* compare_with = nullptr;
+  ValueStack* state = position->state_before();
   if (position->as_BlockEnd() && !position->as_Goto()) {
     state = position->as_BlockEnd()->state_before();
   }
-  Instruction *instruction_before = position->prev();
+  Instruction* instruction_before = position->prev();
   if (position->as_Return() && Compilation::current()->method()->is_synchronized() && instruction_before->as_MonitorExit()) {
     instruction_before = instruction_before->prev();
   }
   result = instruction_before;
   // Load constant only if needed
-  Constant *constant = nullptr;
+  Constant* constant = nullptr;
   if (i != 0 || !instr) {
     constant = new Constant(new IntConstant(i));
     NOT_PRODUCT(constant->set_printable_bci(position->printable_bci()));
@@ -1554,7 +1554,7 @@ void RangeCheckEliminator::Bound::add_assertion(Instruction *instruction, Instru
     }
     // Add operation only if necessary
     if (constant) {
-      ArithmeticOp *ao = new ArithmeticOp(Bytecodes::_iadd, constant, op, nullptr);
+      ArithmeticOp* ao = new ArithmeticOp(Bytecodes::_iadd, constant, op, nullptr);
       NOT_PRODUCT(ao->set_printable_bci(position->printable_bci()));
       result = result->insert_after(ao);
       compare_with = ao;

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ private:
     void operator delete(void* p) { ShouldNotReachHere(); }
     void operator delete[](void* p) { ShouldNotReachHere(); }
 
-    bool can_reach(BlockBegin *start, BlockBegin *end, BlockBegin *dont_use = NULL);
+    bool can_reach(BlockBegin *start, BlockBegin *end, BlockBegin *dont_use = nullptr);
     bool dominates(BlockBegin *dominator, BlockBegin *block);
     bool is_backbranch_from_xhandler(BlockBegin* block);
 
@@ -115,7 +115,7 @@ public:
   public:
     void set_range_check_eliminator(RangeCheckEliminator *rce) { _rce = rce; }
     Bound *bound() const { return _bound; }
-    void clear_bound() { _bound = NULL; }
+    void clear_bound() { _bound = nullptr; }
 
   protected:
     // visitor functions

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -606,7 +606,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
 
   // If the stack guard pages are enabled, check whether there is a handler in
   // the current method.  Otherwise (guard pages disabled), force an unwind and
-  // skip the exception cache update (i.e., just leave continuation==null).
+  // skip the exception cache update (i.e., just leave continuation as null).
   address continuation = nullptr;
   if (guard_pages_enabled) {
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -956,8 +956,8 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
   int patch_field_offset = -1;
   Klass* init_klass = nullptr; // klass needed by load_klass_patching code
   Klass* load_klass = nullptr; // klass needed by load_klass_patching code
-  Handle mirror(current, nullptr);                    // oop needed by load_mirror_patching code
-  Handle appendix(current, nullptr);                  // oop needed by appendix_patching code
+  Handle mirror(current, nullptr); // oop needed by load_mirror_patching code
+  Handle appendix(current, nullptr); // oop needed by appendix_patching code
   bool load_klass_or_mirror_patch_id =
     (stub_id == Runtime1::load_klass_patching_id || stub_id == Runtime1::load_mirror_patching_id);
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -155,7 +155,7 @@ address Runtime1::arraycopy_count_address(BasicType type) {
   case T_OBJECT: return (address)&_oop_arraycopy_stub_cnt;
   default:
     ShouldNotReachHere();
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -215,9 +215,9 @@ CodeBlob* Runtime1::generate_blob(BufferBlob* buffer_blob, int stub_id, const ch
   StubAssembler* sasm = new StubAssembler(&code, name, stub_id);
   // generate code for runtime stub
   oop_maps = cl->generate_code(sasm);
-  assert(oop_maps == NULL || sasm->frame_size() != no_frame_size,
+  assert(oop_maps == nullptr || sasm->frame_size() != no_frame_size,
          "if stub has an oop map it must have a valid frame size");
-  assert(!expect_oop_map || oop_maps != NULL, "must have an oopmap");
+  assert(!expect_oop_map || oop_maps != nullptr, "must have an oopmap");
 
   // align so printing shows nop's instead of random code at the end (SimpleStubs are aligned)
   sasm->align(BytesPerWord);
@@ -233,7 +233,7 @@ CodeBlob* Runtime1::generate_blob(BufferBlob* buffer_blob, int stub_id, const ch
                                                  frame_size,
                                                  oop_maps,
                                                  must_gc_arguments);
-  assert(blob != NULL, "blob must exist");
+  assert(blob != nullptr, "blob must exist");
   return blob;
 }
 
@@ -272,7 +272,7 @@ void Runtime1::initialize(BufferBlob* blob) {
     ResourceMark rm;
     for (int id = 0; id < number_of_ids; id++) {
       _blobs[id]->print();
-      if (_blobs[id]->oop_maps() != NULL) {
+      if (_blobs[id]->oop_maps() != nullptr) {
         _blobs[id]->oop_maps()->print();
       }
     }
@@ -442,7 +442,7 @@ JRT_END
 // method) method is passed as an argument. In order to do that it is embedded in the code as
 // a constant.
 static nmethod* counter_overflow_helper(JavaThread* current, int branch_bci, Method* m) {
-  nmethod* osr_nm = NULL;
+  nmethod* osr_nm = nullptr;
   methodHandle method(current, m);
 
   RegisterMap map(current,
@@ -451,7 +451,7 @@ static nmethod* counter_overflow_helper(JavaThread* current, int branch_bci, Met
                   RegisterMap::WalkContinuation::skip);
   frame fr =  current->last_frame().sender(&map);
   nmethod* nm = (nmethod*) fr.cb();
-  assert(nm!= NULL && nm->is_nmethod(), "Sanity check");
+  assert(nm!= nullptr && nm->is_nmethod(), "Sanity check");
   methodHandle enclosing_method(current, nm->method());
 
   CompLevel level = (CompLevel)nm->comp_level();
@@ -486,7 +486,7 @@ JRT_BLOCK_ENTRY(address, Runtime1::counter_overflow(JavaThread* current, int bci
   nmethod* osr_nm;
   JRT_BLOCK
     osr_nm = counter_overflow_helper(current, bci, method);
-    if (osr_nm != NULL) {
+    if (osr_nm != nullptr) {
       RegisterMap map(current,
                       RegisterMap::UpdateMap::skip,
                       RegisterMap::ProcessFrames::include,
@@ -495,7 +495,7 @@ JRT_BLOCK_ENTRY(address, Runtime1::counter_overflow(JavaThread* current, int bci
       Deoptimization::deoptimize_frame(current, fr.id());
     }
   JRT_BLOCK_END
-  return NULL;
+  return nullptr;
 JRT_END
 
 extern void vm_exit(int code);
@@ -533,7 +533,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   }
 
   nm = CodeCache::find_nmethod(pc);
-  assert(nm != NULL, "this is not an nmethod");
+  assert(nm != nullptr, "this is not an nmethod");
   // Adjust the pc as needed/
   if (nm->is_deopt_pc(pc)) {
     RegisterMap map(current,
@@ -545,7 +545,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     assert(exception_frame.is_deoptimized_frame(), "must be deopted");
     pc = exception_frame.pc();
   }
-  assert(exception.not_null(), "NULL exceptions should be handled by throw_exception");
+  assert(exception.not_null(), "null exceptions should be handled by throw_exception");
   // Check that exception is a subclass of Throwable
   assert(exception->is_a(vmClasses::Throwable_klass()),
          "Exception not subclass of Throwable");
@@ -555,7 +555,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   if (log_is_enabled(Info, exceptions)) {
     ResourceMark rm; // print_value_string
     stringStream tempst;
-    assert(nm->method() != NULL, "Unexpected NULL method()");
+    assert(nm->method() != nullptr, "Unexpected null method()");
     tempst.print("C1 compiled method <%s>\n"
                  " at PC" INTPTR_FORMAT " for thread " INTPTR_FORMAT,
                  nm->method()->print_value_string(), p2i(pc), p2i(current));
@@ -597,7 +597,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
   // ExceptionCache is used only for exceptions at call sites and not for implicit exceptions
   if (guard_pages_enabled) {
     address fast_continuation = nm->handler_for_exception_and_pc(exception, pc);
-    if (fast_continuation != NULL) {
+    if (fast_continuation != nullptr) {
       // Set flag if return address is a method handle call site.
       current->set_is_method_handle_return(nm->is_method_handle_return(pc));
       return fast_continuation;
@@ -606,8 +606,8 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
 
   // If the stack guard pages are enabled, check whether there is a handler in
   // the current method.  Otherwise (guard pages disabled), force an unwind and
-  // skip the exception cache update (i.e., just leave continuation==NULL).
-  address continuation = NULL;
+  // skip the exception cache update (i.e., just leave continuation==null).
+  address continuation = nullptr;
   if (guard_pages_enabled) {
 
     // New exception handling mechanism can support inlined methods
@@ -630,7 +630,7 @@ JRT_ENTRY_NO_ASYNC(static address, exception_handler_for_pc_helper(JavaThread* c
     // another exception during the computation of the compiled
     // exception handler. Checking for exception oop equality is not
     // sufficient because some exceptions are pre-allocated and reused.
-    if (continuation != NULL && !recursive_exception) {
+    if (continuation != nullptr && !recursive_exception) {
       nm->add_handler_for_exception_and_pc(exception, pc, continuation);
     }
   }
@@ -659,8 +659,8 @@ address Runtime1::exception_handler_for_pc(JavaThread* current) {
   address pc = current->exception_pc();
   // Still in Java mode
   DEBUG_ONLY(NoHandleMark nhm);
-  nmethod* nm = NULL;
-  address continuation = NULL;
+  nmethod* nm = nullptr;
+  address continuation = nullptr;
   {
     // Enter VM mode by calling the helper
     ResetNoHandleMark rnhm;
@@ -670,11 +670,11 @@ address Runtime1::exception_handler_for_pc(JavaThread* current) {
 
   // Now check to see if the nmethod we were called from is now deoptimized.
   // If so we must return to the deopt blob and deoptimize the nmethod
-  if (nm != NULL && caller_is_deopted(current)) {
+  if (nm != nullptr && caller_is_deopted(current)) {
     continuation = SharedRuntime::deopt_blob()->unpack_with_exception_in_tls();
   }
 
-  assert(continuation != NULL, "no handler found");
+  assert(continuation != nullptr, "no handler found");
   return continuation;
 }
 
@@ -771,7 +771,7 @@ JRT_LEAF(void, Runtime1::monitorexit(JavaThread* current, BasicObjectLock* lock)
 #endif
   assert(current->last_Java_sp(), "last_Java_sp must be set");
   oop obj = lock->obj();
-  assert(oopDesc::is_oop(obj), "must be NULL or an object");
+  assert(oopDesc::is_oop(obj), "must be null or an object");
   SharedRuntime::monitor_exit_helper(obj, lock->lock(), current);
 JRT_END
 
@@ -786,7 +786,7 @@ JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
   assert(stub_frame.is_runtime_frame(), "Sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
   nmethod* nm = caller_frame.cb()->as_nmethod_or_null();
-  assert(nm != NULL, "Sanity check");
+  assert(nm != nullptr, "Sanity check");
   methodHandle method(current, nm->method());
   assert(nm == CodeCache::find_nmethod(caller_frame.pc()), "Should be the same");
   Deoptimization::DeoptAction action = Deoptimization::trap_request_action(trap_request);
@@ -796,7 +796,7 @@ JRT_ENTRY(void, Runtime1::deoptimize(JavaThread* current, jint trap_request))
     if (nm->make_not_entrant()) {
       if (reason == Deoptimization::Reason_tenured) {
         MethodData* trap_mdo = Deoptimization::get_method_data(current, method, true /*create_if_missing*/);
-        if (trap_mdo != NULL) {
+        if (trap_mdo != nullptr) {
           trap_mdo->inc_tenure_traps();
         }
       }
@@ -891,7 +891,7 @@ static Klass* resolve_field_return_klass(const methodHandle& caller, int bci, TR
 // initializing inside the calls to resolve_field below.  The
 // initializing class will continue on it's way.  Once the class is
 // fully_initialized, the intializing_thread of the class becomes
-// NULL, so the next thread to execute this code will fail the test,
+// null, so the next thread to execute this code will fail the test,
 // call into patch_code and complete the patching process by copying
 // the patch body back into the main part of the nmethod and resume
 // executing.
@@ -954,10 +954,10 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
   bool deoptimize_for_volatile = false;
   bool deoptimize_for_atomic = false;
   int patch_field_offset = -1;
-  Klass* init_klass = NULL; // klass needed by load_klass_patching code
-  Klass* load_klass = NULL; // klass needed by load_klass_patching code
-  Handle mirror(current, NULL);                    // oop needed by load_mirror_patching code
-  Handle appendix(current, NULL);                  // oop needed by appendix_patching code
+  Klass* init_klass = nullptr; // klass needed by load_klass_patching code
+  Klass* load_klass = nullptr; // klass needed by load_klass_patching code
+  Handle mirror(current, nullptr);                    // oop needed by load_mirror_patching code
+  Handle appendix(current, nullptr);                  // oop needed by appendix_patching code
   bool load_klass_or_mirror_patch_id =
     (stub_id == Runtime1::load_klass_patching_id || stub_id == Runtime1::load_mirror_patching_id);
 
@@ -997,7 +997,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
     deoptimize_for_atomic = (AlwaysAtomicAccesses && (patch_field_type == T_DOUBLE || patch_field_type == T_LONG));
 
   } else if (load_klass_or_mirror_patch_id) {
-    Klass* k = NULL;
+    Klass* k = nullptr;
     switch (code) {
       case Bytecodes::_putstatic:
       case Bytecodes::_getstatic:
@@ -1088,7 +1088,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
     // It's possible the nmethod was invalidated in the last
     // safepoint, but if it's still alive then make it not_entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
-    if (nm != NULL) {
+    if (nm != nullptr) {
       nm->make_not_entrant();
     }
 
@@ -1134,13 +1134,13 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
           tty->print_cr(" Patching %s at bci %d at address " INTPTR_FORMAT "  (%s)", Bytecodes::name(code), bci,
                         p2i(instr_pc), (stub_id == Runtime1::access_field_patching_id) ? "field" : "klass");
           nmethod* caller_code = CodeCache::find_nmethod(caller_frame.pc());
-          assert(caller_code != NULL, "nmethod not found");
+          assert(caller_code != nullptr, "nmethod not found");
 
           // NOTE we use pc() not original_pc() because we already know they are
           // identical otherwise we'd have never entered this block of code
 
           const ImmutableOopMap* map = caller_code->oop_map_for_return_address(caller_frame.pc());
-          assert(map != NULL, "null check");
+          assert(map != nullptr, "null check");
           map->print();
           tty->cr();
 
@@ -1175,7 +1175,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
                    n_copy->data() == (intptr_t)Universe::non_oop_word(),
                    "illegal init value");
             if (stub_id == Runtime1::load_klass_patching_id) {
-              assert(load_klass != NULL, "klass not set");
+              assert(load_klass != nullptr, "klass not set");
               n_copy->set_data((intx) (load_klass));
             } else {
               // Don't need a G1 pre-barrier here since we assert above that data isn't an oop.
@@ -1208,8 +1208,8 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
               stub_id == Runtime1::load_appendix_patching_id) &&
               nativeMovConstReg_at(copy_buff)->is_pc_relative()) {
             nmethod* nm = CodeCache::find_nmethod(instr_pc);
-            address addr = NULL;
-            assert(nm != NULL, "invalid nmethod_pc");
+            address addr = nullptr;
+            assert(nm != nullptr, "invalid nmethod_pc");
             RelocIterator mds(nm, copy_buff, copy_buff + 1);
             while (mds.next()) {
               if (mds.type() == relocInfo::oop_type) {
@@ -1225,7 +1225,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
                 break;
               }
             }
-            assert(addr != NULL, "metadata relocation must exist");
+            assert(addr != nullptr, "metadata relocation must exist");
             copy_buff -= *byte_count;
             NativeMovConstReg* n_copy2 = nativeMovConstReg_at(copy_buff);
             n_copy2->set_pc_relative_offset(addr, instr_pc);
@@ -1249,7 +1249,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
                                    relocInfo::oop_type;
             // update relocInfo to metadata
             nmethod* nm = CodeCache::find_nmethod(instr_pc);
-            assert(nm != NULL, "invalid nmethod_pc");
+            assert(nm != nullptr, "invalid nmethod_pc");
 
             // The old patch site is now a move instruction so update
             // the reloc info so that it will get updated during
@@ -1272,7 +1272,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
   {
     MutexLocker ml_code (current, CodeCache_lock, Mutex::_no_safepoint_check_flag);
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
-    guarantee(nm != NULL, "only nmethods can contain non-perm oops");
+    guarantee(nm != nullptr, "only nmethods can contain non-perm oops");
 
     // Since we've patched some oops in the nmethod,
     // (re)register it with the heap.
@@ -1340,7 +1340,7 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
   if (is_patching_needed(current, stub_id)) {
     // Make sure the nmethod is invalidated, i.e. made not entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
-    if (nm != NULL) {
+    if (nm != nullptr) {
       nm->make_not_entrant();
     }
   }
@@ -1452,9 +1452,9 @@ JRT_LEAF(int, Runtime1::is_instance_of(oopDesc* mirror, oopDesc* obj))
   // JVM takes the whole %eax as the return value, which may misinterpret
   // the return value as a boolean true.
 
-  assert(mirror != NULL, "should null-check on mirror before calling");
+  assert(mirror != nullptr, "should null-check on mirror before calling");
   Klass* k = java_lang_Class::as_Klass(mirror);
-  return (k != NULL && obj != NULL && obj->is_a(k)) ? 1 : 0;
+  return (k != nullptr && obj != nullptr && obj->is_a(k)) ? 1 : 0;
 JRT_END
 
 JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
@@ -1468,13 +1468,13 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
   frame caller_frame = runtime_frame.sender(&reg_map);
 
   nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
-  assert (nm != NULL, "no more nmethod?");
+  assert (nm != nullptr, "no more nmethod?");
   nm->make_not_entrant();
 
   methodHandle m(current, nm->method());
   MethodData* mdo = m->method_data();
 
-  if (mdo == NULL && !HAS_PENDING_EXCEPTION) {
+  if (mdo == nullptr && !HAS_PENDING_EXCEPTION) {
     // Build an MDO.  Ignore errors like OutOfMemory;
     // that simply means we won't have an MDO to update.
     Method::build_profiling_method_data(m, THREAD);
@@ -1486,7 +1486,7 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
     mdo = m->method_data();
   }
 
-  if (mdo != NULL) {
+  if (mdo != nullptr) {
     mdo->inc_trap_count(Deoptimization::Reason_none);
   }
 

--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -152,8 +152,8 @@ Value ValueMap::find_insert(Value x) {
   NOT_PRODUCT(_number_of_kills++);                                                       \
                                                                                          \
   for (int i = size() - 1; i >= 0; i--) {                                                \
-    ValueMapEntry* prev_entry = nullptr;                                                    \
-    for (ValueMapEntry* entry = entry_at(i); entry != nullptr; entry = entry->next()) {     \
+    ValueMapEntry* prev_entry = nullptr;                                                 \
+    for (ValueMapEntry* entry = entry_at(i); entry != nullptr; entry = entry->next()) {  \
       Value value = entry->value();                                                      \
                                                                                          \
       must_kill_implementation(must_kill, entry, value)                                  \
@@ -161,7 +161,7 @@ Value ValueMap::find_insert(Value x) {
       if (must_kill) {                                                                   \
         kill_value(value);                                                               \
                                                                                          \
-        if (prev_entry == nullptr) {                                                        \
+        if (prev_entry == nullptr) {                                                     \
           _entries.at_put(i, entry->next());                                             \
           _entry_count--;                                                                \
         } else if (prev_entry->nesting() == nesting()) {                                 \
@@ -182,13 +182,13 @@ Value ValueMap::find_insert(Value x) {
   bool must_kill = value->as_LoadField() != nullptr || value->as_LoadIndexed() != nullptr;
 
 #define MUST_KILL_ARRAY(must_kill, entry, value)                                         \
-  bool must_kill = value->as_LoadIndexed() != nullptr                                       \
+  bool must_kill = value->as_LoadIndexed() != nullptr                                    \
                    && value->type()->tag() == type->tag();
 
 #define MUST_KILL_FIELD(must_kill, entry, value)                                         \
   /* ciField's are not unique; must compare their contents */                            \
   LoadField* lf = value->as_LoadField();                                                 \
-  bool must_kill = lf != nullptr                                                            \
+  bool must_kill = lf != nullptr                                                         \
                    && lf->field()->holder() == field->holder()                           \
                    && (all_offsets || lf->field()->offset_in_bytes() == field->offset_in_bytes());
 

--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -46,7 +46,7 @@
 
 ValueMap::ValueMap()
   : _nesting(0)
-  , _entries(ValueMapInitialSize, ValueMapInitialSize, NULL)
+  , _entries(ValueMapInitialSize, ValueMapInitialSize, nullptr)
   , _killed_values()
   , _entry_count(0)
 {
@@ -56,7 +56,7 @@ ValueMap::ValueMap()
 
 ValueMap::ValueMap(ValueMap* old)
   : _nesting(old->_nesting + 1)
-  , _entries(old->_entries.length(), old->_entries.length(), NULL)
+  , _entries(old->_entries.length(), old->_entries.length(), nullptr)
   , _killed_values()
   , _entry_count(old->_entry_count)
 {
@@ -72,14 +72,14 @@ void ValueMap::increase_table_size() {
   int new_size = old_size * 2 + 1;
 
   ValueMapEntryList worklist(8);
-  ValueMapEntryArray new_entries(new_size, new_size, NULL);
+  ValueMapEntryArray new_entries(new_size, new_size, nullptr);
   int new_entry_count = 0;
 
   TRACE_VALUE_NUMBERING(tty->print_cr("increasing table size from %d to %d", old_size, new_size));
 
   for (int i = old_size - 1; i >= 0; i--) {
     ValueMapEntry* entry;
-    for (entry = entry_at(i); entry != NULL; entry = entry->next()) {
+    for (entry = entry_at(i); entry != nullptr; entry = entry->next()) {
       if (!is_killed(entry->value())) {
         worklist.push(entry);
       }
@@ -93,7 +93,7 @@ void ValueMap::increase_table_size() {
         // changing entries with a lower nesting than the current nesting of the table
         // is not allowed because then the same entry is contained in multiple value maps.
         // clone entry when next-pointer must be changed
-        entry = new ValueMapEntry(entry->hash(), entry->value(), entry->nesting(), NULL);
+        entry = new ValueMapEntry(entry->hash(), entry->value(), entry->nesting(), nullptr);
       }
       entry->set_next(new_entries.at(new_index));
       new_entries.at_put(new_index, entry);
@@ -112,7 +112,7 @@ Value ValueMap::find_insert(Value x) {
     // 0 hash means: exclude from value numbering
     NOT_PRODUCT(_number_of_finds++);
 
-    for (ValueMapEntry* entry = entry_at(entry_index(hash, size())); entry != NULL; entry = entry->next()) {
+    for (ValueMapEntry* entry = entry_at(entry_index(hash, size())); entry != nullptr; entry = entry->next()) {
       if (entry->hash() == hash) {
         Value f = entry->value();
 
@@ -120,7 +120,7 @@ Value ValueMap::find_insert(Value x) {
           NOT_PRODUCT(_number_of_hits++);
           TRACE_VALUE_NUMBERING(tty->print_cr("Value Numbering: %s %c%d equal to %c%d  (size %d, entries %d, nesting-diff %d)", x->name(), x->type()->tchar(), x->id(), f->type()->tchar(), f->id(), size(), entry_count(), nesting() - entry->nesting()));
 
-          if (entry->nesting() != nesting() && f->as_Constant() == NULL) {
+          if (entry->nesting() != nesting() && f->as_Constant() == nullptr) {
             // non-constant values of of another block must be pinned,
             // otherwise it is possible that they are not evaluated
             f->pin(Instruction::PinGlobalValueNumbering);
@@ -152,8 +152,8 @@ Value ValueMap::find_insert(Value x) {
   NOT_PRODUCT(_number_of_kills++);                                                       \
                                                                                          \
   for (int i = size() - 1; i >= 0; i--) {                                                \
-    ValueMapEntry* prev_entry = NULL;                                                    \
-    for (ValueMapEntry* entry = entry_at(i); entry != NULL; entry = entry->next()) {     \
+    ValueMapEntry* prev_entry = nullptr;                                                    \
+    for (ValueMapEntry* entry = entry_at(i); entry != nullptr; entry = entry->next()) {     \
       Value value = entry->value();                                                      \
                                                                                          \
       must_kill_implementation(must_kill, entry, value)                                  \
@@ -161,7 +161,7 @@ Value ValueMap::find_insert(Value x) {
       if (must_kill) {                                                                   \
         kill_value(value);                                                               \
                                                                                          \
-        if (prev_entry == NULL) {                                                        \
+        if (prev_entry == nullptr) {                                                        \
           _entries.at_put(i, entry->next());                                             \
           _entry_count--;                                                                \
         } else if (prev_entry->nesting() == nesting()) {                                 \
@@ -179,16 +179,16 @@ Value ValueMap::find_insert(Value x) {
   }                                                                                      \
 
 #define MUST_KILL_MEMORY(must_kill, entry, value)                                        \
-  bool must_kill = value->as_LoadField() != NULL || value->as_LoadIndexed() != NULL;
+  bool must_kill = value->as_LoadField() != nullptr || value->as_LoadIndexed() != nullptr;
 
 #define MUST_KILL_ARRAY(must_kill, entry, value)                                         \
-  bool must_kill = value->as_LoadIndexed() != NULL                                       \
+  bool must_kill = value->as_LoadIndexed() != nullptr                                       \
                    && value->type()->tag() == type->tag();
 
 #define MUST_KILL_FIELD(must_kill, entry, value)                                         \
   /* ciField's are not unique; must compare their contents */                            \
   LoadField* lf = value->as_LoadField();                                                 \
-  bool must_kill = lf != NULL                                                            \
+  bool must_kill = lf != nullptr                                                            \
                    && lf->field()->holder() == field->holder()                           \
                    && (all_offsets || lf->field()->offset_in_bytes() == field->offset_in_bytes());
 
@@ -213,7 +213,7 @@ void ValueMap::kill_map(ValueMap* map) {
 void ValueMap::kill_all() {
   assert(is_local_value_numbering(), "only for local value numbering");
   for (int i = size() - 1; i >= 0; i--) {
-    _entries.at_put(i, NULL);
+    _entries.at_put(i, nullptr);
   }
   _entry_count = 0;
 }
@@ -226,14 +226,14 @@ void ValueMap::print() {
 
   int entries = 0;
   for (int i = 0; i < size(); i++) {
-    if (entry_at(i) != NULL) {
+    if (entry_at(i) != nullptr) {
       tty->print("  %2d: ", i);
-      for (ValueMapEntry* entry = entry_at(i); entry != NULL; entry = entry->next()) {
+      for (ValueMapEntry* entry = entry_at(i); entry != nullptr; entry = entry->next()) {
         Value value = entry->value();
         tty->print("%s %c%d (%s%d) -> ", value->name(), value->type()->tchar(), value->id(), is_killed(value) ? "x" : "", entry->nesting());
         entries++;
       }
-      tty->print_cr("NULL");
+      tty->print_cr("null");
     }
   }
 
@@ -327,7 +327,7 @@ class LoopInvariantCodeMotion : public StackObj  {
 };
 
 LoopInvariantCodeMotion::LoopInvariantCodeMotion(ShortLoopOptimizer *slo, GlobalValueNumbering* gvn, BlockBegin* loop_header, BlockList* loop_blocks)
-  : _gvn(gvn), _short_loop_optimizer(slo), _insertion_point(NULL), _state(NULL), _insert_is_pred(false) {
+  : _gvn(gvn), _short_loop_optimizer(slo), _insertion_point(nullptr), _state(nullptr), _insert_is_pred(false) {
 
   TRACE_VALUE_NUMBERING(tty->print_cr("using loop invariant code motion loop_header = %d", loop_header->block_id()));
   TRACE_VALUE_NUMBERING(tty->print_cr("** loop invariant code motion for short loop B%d", loop_header->block_id()));
@@ -337,7 +337,7 @@ LoopInvariantCodeMotion::LoopInvariantCodeMotion(ShortLoopOptimizer *slo, Global
     return;  // only the entry block does not have a predecessor
   }
 
-  assert(insertion_block->end()->as_Base() == NULL, "cannot insert into entry block");
+  assert(insertion_block->end()->as_Base() == nullptr, "cannot insert into entry block");
   _insertion_point = insertion_block->end()->prev();
   _insert_is_pred = loop_header->is_predecessor(insertion_block);
 
@@ -365,31 +365,31 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
   Instruction* prev = block;
   Instruction* cur = block->next();
 
-  while (cur != NULL) {
+  while (cur != nullptr) {
     // determine if cur instruction is loop invariant
     // only selected instruction types are processed here
     bool cur_invariant = false;
 
-    if (cur->as_Constant() != NULL) {
+    if (cur->as_Constant() != nullptr) {
       cur_invariant = !cur->can_trap();
-    } else if (cur->as_ArithmeticOp() != NULL || cur->as_LogicOp() != NULL || cur->as_ShiftOp() != NULL) {
-      assert(cur->as_Op2() != NULL, "must be Op2");
+    } else if (cur->as_ArithmeticOp() != nullptr || cur->as_LogicOp() != nullptr || cur->as_ShiftOp() != nullptr) {
+      assert(cur->as_Op2() != nullptr, "must be Op2");
       Op2* op2 = (Op2*)cur;
       cur_invariant = !op2->can_trap() && is_invariant(op2->x()) && is_invariant(op2->y());
-    } else if (cur->as_LoadField() != NULL) {
+    } else if (cur->as_LoadField() != nullptr) {
       LoadField* lf = (LoadField*)cur;
       // deoptimizes on NullPointerException
       cur_invariant = !lf->needs_patching() && !lf->field()->is_volatile() && !_short_loop_optimizer->has_field_store(lf->field()->type()->basic_type()) && is_invariant(lf->obj()) && _insert_is_pred;
-    } else if (cur->as_ArrayLength() != NULL) {
+    } else if (cur->as_ArrayLength() != nullptr) {
       ArrayLength *length = cur->as_ArrayLength();
       cur_invariant = is_invariant(length->array());
-    } else if (cur->as_LoadIndexed() != NULL) {
+    } else if (cur->as_LoadIndexed() != nullptr) {
       LoadIndexed *li = (LoadIndexed *)cur->as_LoadIndexed();
       cur_invariant = !_short_loop_optimizer->has_indexed_store(as_BasicType(cur->type())) && is_invariant(li->array()) && is_invariant(li->index()) && _insert_is_pred;
-    } else if (cur->as_NegateOp() != NULL) {
+    } else if (cur->as_NegateOp() != nullptr) {
       NegateOp* neg = (NegateOp*)cur->as_NegateOp();
       cur_invariant = is_invariant(neg->x());
-    } else if (cur->as_Convert() != NULL) {
+    } else if (cur->as_Convert() != nullptr) {
       Convert* cvt = (Convert*)cur->as_Convert();
       cur_invariant = is_invariant(cvt->value());
     }
@@ -398,7 +398,7 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
       // perform value numbering and mark instruction as loop-invariant
       _gvn->substitute(cur);
 
-      if (cur->as_Constant() == NULL) {
+      if (cur->as_Constant() == nullptr) {
         // ensure that code for non-constant instructions is always generated
         cur->pin();
       }
@@ -413,15 +413,15 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
       cur->set_flag(Instruction::DeoptimizeOnException, true);
 
       //  Clear exception handlers
-      cur->set_exception_handlers(NULL);
+      cur->set_exception_handlers(nullptr);
 
       TRACE_VALUE_NUMBERING(tty->print_cr("Instruction %c%d is loop invariant", cur->type()->tchar(), cur->id()));
       TRACE_VALUE_NUMBERING(cur->print_line());
 
-      if (cur->state_before() != NULL) {
+      if (cur->state_before() != nullptr) {
         cur->set_state_before(_state->copy());
       }
-      if (cur->exception_state() != NULL) {
+      if (cur->exception_state() != nullptr) {
         cur->set_exception_state(_state->copy());
       }
 
@@ -458,7 +458,7 @@ bool ShortLoopOptimizer::process(BlockBegin* loop_header) {
       }
 
       ValueMap* pred_map = value_map_of(pred);
-      if (pred_map != NULL) {
+      if (pred_map != nullptr) {
         current_map()->kill_map(pred_map);
       } else if (!_loop_blocks.contains(pred)) {
         if (_loop_blocks.length() >= ValueMapMaxLoopSize) {
@@ -469,7 +469,7 @@ bool ShortLoopOptimizer::process(BlockBegin* loop_header) {
     }
 
     // use the instruction visitor for killing values
-    for (Value instr = block->next(); instr != NULL; instr = instr->next()) {
+    for (Value instr = block->next(); instr != nullptr; instr = instr->next()) {
       instr->visit(this);
       if (_too_complicated_loop) {
         return false;
@@ -490,8 +490,8 @@ bool ShortLoopOptimizer::process(BlockBegin* loop_header) {
 
 GlobalValueNumbering::GlobalValueNumbering(IR* ir)
   : _compilation(ir->compilation())
-  , _current_map(NULL)
-  , _value_maps(ir->linear_scan_order()->length(), ir->linear_scan_order()->length(), NULL)
+  , _current_map(nullptr)
+  , _value_maps(ir->linear_scan_order()->length(), ir->linear_scan_order()->length(), nullptr)
   , _has_substitutions(false)
 {
   TRACE_VALUE_NUMBERING(tty->print_cr("****** start of global value numbering"));
@@ -502,12 +502,12 @@ GlobalValueNumbering::GlobalValueNumbering(IR* ir)
   int num_blocks = blocks->length();
 
   BlockBegin* start_block = blocks->at(0);
-  assert(start_block == ir->start() && start_block->number_of_preds() == 0 && start_block->dominator() == NULL, "must be start block");
-  assert(start_block->next()->as_Base() != NULL && start_block->next()->next() == NULL, "start block must not have instructions");
+  assert(start_block == ir->start() && start_block->number_of_preds() == 0 && start_block->dominator() == nullptr, "must be start block");
+  assert(start_block->next()->as_Base() != nullptr && start_block->next()->next() == nullptr, "start block must not have instructions");
 
   // method parameters are not linked in instructions list, so process them separately
   for_each_state_value(start_block->state(), value,
-     assert(value->as_Local() != NULL, "only method parameters allowed");
+     assert(value->as_Local() != nullptr, "only method parameters allowed");
      set_processed(value);
   );
 
@@ -522,8 +522,8 @@ GlobalValueNumbering::GlobalValueNumbering(IR* ir)
     assert(num_preds > 0, "block must have predecessors");
 
     BlockBegin* dominator = block->dominator();
-    assert(dominator != NULL, "dominator must exist");
-    assert(value_map_of(dominator) != NULL, "value map of dominator must exist");
+    assert(dominator != nullptr, "dominator must exist");
+    assert(value_map_of(dominator) != nullptr, "value map of dominator must exist");
 
     // create new value map with increased nesting
     _current_map = new ValueMap(value_map_of(dominator));
@@ -546,7 +546,7 @@ GlobalValueNumbering::GlobalValueNumbering(IR* ir)
         BlockBegin* pred = block->pred_at(j);
         ValueMap* pred_map = value_map_of(pred);
 
-        if (pred_map != NULL) {
+        if (pred_map != nullptr) {
           // propagate killed values of the predecessor to this block
           current_map()->kill_map(value_map_of(pred));
         } else {
@@ -565,7 +565,7 @@ GlobalValueNumbering::GlobalValueNumbering(IR* ir)
     TRACE_VALUE_NUMBERING(tty->print("value map before processing block: "); current_map()->print());
 
     // visit all instructions of this block
-    for (Value instr = block->next(); instr != NULL; instr = instr->next()) {
+    for (Value instr = block->next(); instr != nullptr; instr = instr->next()) {
       // check if instruction kills any values
       instr->visit(this);
       // perform actual value numbering

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ class GlobalValueNumbering: public ValueNumberingVisitor {
   Compilation*  compilation() const              { return _compilation; }
   ValueMap*     current_map()                    { return _current_map; }
   ValueMap*     value_map_of(BlockBegin* block)  { return _value_maps.at(block->linear_scan_number()); }
-  void          set_value_map_of(BlockBegin* block, ValueMap* map)   { assert(value_map_of(block) == NULL, ""); _value_maps.at_put(block->linear_scan_number(), map); }
+  void          set_value_map_of(BlockBegin* block, ValueMap* map)   { assert(value_map_of(block) == nullptr, ""); _value_maps.at_put(block->linear_scan_number(), map); }
 
   bool          is_processed(Value v)            { return _processed_values.contains(v); }
   void          set_processed(Value v)           { _processed_values.put(v); }

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -243,7 +243,7 @@ class GlobalValueNumbering: public ValueNumberingVisitor {
   Compilation*  compilation() const              { return _compilation; }
   ValueMap*     current_map()                    { return _current_map; }
   ValueMap*     value_map_of(BlockBegin* block)  { return _value_maps.at(block->linear_scan_number()); }
-  void          set_value_map_of(BlockBegin* block, ValueMap* map)   { assert(value_map_of(block) == nullptr, ""); _value_maps.at_put(block->linear_scan_number(), map); }
+  void          set_value_map_of(BlockBegin* block, ValueMap* map) { assert(value_map_of(block) == nullptr, ""); _value_maps.at_put(block->linear_scan_number(), map); }
 
   bool          is_processed(Value v)            { return _processed_values.contains(v); }
   void          set_processed(Value v)           { _processed_values.put(v); }

--- a/src/hotspot/share/c1/c1_ValueStack.cpp
+++ b/src/hotspot/share/c1/c1_ValueStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,9 @@ ValueStack::ValueStack(IRScope* scope, ValueStack* caller_state)
 , _caller_state(caller_state)
 , _bci(-99)
 , _kind(Parsing)
-, _locals(scope->method()->max_locals(), scope->method()->max_locals(), NULL)
+, _locals(scope->method()->max_locals(), scope->method()->max_locals(), nullptr)
 , _stack(scope->method()->max_stack())
-, _locks(NULL)
+, _locks(nullptr)
 {
   verify();
 }
@@ -49,7 +49,7 @@ ValueStack::ValueStack(ValueStack* copy_from, Kind kind, int bci)
   , _kind(kind)
   , _locals(copy_from->locals_size_for_copy(kind))
   , _stack(copy_from->stack_size_for_copy(kind))
-  , _locks(copy_from->locks_size() == 0 ? NULL : new Values(copy_from->locks_size()))
+  , _locks(copy_from->locks_size() == 0 ? nullptr : new Values(copy_from->locks_size()))
 {
   assert(kind != EmptyExceptionState || !Compilation::current()->env()->should_retain_local_variables(), "need locals");
   if (kind != EmptyExceptionState) {
@@ -103,7 +103,7 @@ bool ValueStack::is_same(ValueStack* s) {
   }
   for (int i = 0; i < locks_size(); i++) {
     value = lock_at(i);
-    if (value != NULL && value != s->lock_at(i)) {
+    if (value != nullptr && value != s->lock_at(i)) {
       return false;
     }
   }
@@ -112,14 +112,14 @@ bool ValueStack::is_same(ValueStack* s) {
 
 void ValueStack::clear_locals() {
   for (int i = _locals.length() - 1; i >= 0; i--) {
-    _locals.at_put(i, NULL);
+    _locals.at_put(i, nullptr);
   }
 }
 
 
 void ValueStack::pin_stack_for_linear_scan() {
   for_each_state_value(this, v,
-    if (v->as_Constant() == NULL && v->as_Local() == NULL) {
+    if (v->as_Constant() == nullptr && v->as_Local() == nullptr) {
       v->pin(Instruction::PinStackForStateSplit);
     }
   );
@@ -131,12 +131,12 @@ void ValueStack::apply(const Values& list, ValueVisitor* f) {
   for (int i = 0; i < list.length(); i++) {
     Value* va = list.adr_at(i);
     Value v0 = *va;
-    if (v0 != NULL && !v0->type()->is_illegal()) {
+    if (v0 != nullptr && !v0->type()->is_illegal()) {
       f->visit(va);
 #ifdef ASSERT
       Value v1 = *va;
       assert(v1->type()->is_illegal() || v0->type()->tag() == v1->type()->tag(), "types must match");
-      assert(!v1->type()->is_double_word() || list.at(i + 1) == NULL, "hi-word of doubleword value must be NULL");
+      assert(!v1->type()->is_double_word() || list.at(i + 1) == nullptr, "hi-word of doubleword value must be null");
 #endif
       if (v0->type()->is_double_word()) i++;
     }
@@ -149,7 +149,7 @@ void ValueStack::values_do(ValueVisitor* f) {
   for_each_state(state) {
     apply(state->_locals, f);
     apply(state->_stack, f);
-    if (state->_locks != NULL) {
+    if (state->_locks != nullptr) {
       apply(*state->_locks, f);
     }
   }
@@ -176,7 +176,7 @@ int ValueStack::total_locks_size() const {
 }
 
 int ValueStack::lock(Value obj) {
-  if (_locks == NULL) {
+  if (_locks == nullptr) {
     _locks = new Values();
   }
   _locks->push(obj);
@@ -194,17 +194,17 @@ int ValueStack::unlock() {
 
 
 void ValueStack::setup_phi_for_stack(BlockBegin* b, int index) {
-  assert(stack_at(index)->as_Phi() == NULL || stack_at(index)->as_Phi()->block() != b, "phi function already created");
+  assert(stack_at(index)->as_Phi() == nullptr || stack_at(index)->as_Phi()->block() != b, "phi function already created");
 
   ValueType* t = stack_at(index)->type();
   Value phi = new Phi(t, b, -index - 1);
   _stack.at_put(index, phi);
 
-  assert(!t->is_double_word() || _stack.at(index + 1) == NULL, "hi-word of doubleword value must be NULL");
+  assert(!t->is_double_word() || _stack.at(index + 1) == nullptr, "hi-word of doubleword value must be null");
 }
 
 void ValueStack::setup_phi_for_local(BlockBegin* b, int index) {
-  assert(local_at(index)->as_Phi() == NULL || local_at(index)->as_Phi()->block() != b, "phi function already created");
+  assert(local_at(index)->as_Phi() == nullptr || local_at(index)->as_Phi()->block() != b, "phi function already created");
 
   ValueType* t = local_at(index)->type();
   Value phi = new Phi(t, b, index);
@@ -233,7 +233,7 @@ void ValueStack::print() {
     for (int i = 0; i < locks_size(); i++) {
       Value t = lock_at(i);
       tty->print("lock %2d  ", i);
-      if (t == NULL) {
+      if (t == nullptr) {
         tty->print("this");
       } else {
         tty->print("%c%d ", t->type()->tchar(), t->id());
@@ -247,7 +247,7 @@ void ValueStack::print() {
     for (int i = 0; i < locals_size();) {
       Value l = _locals.at(i);
       tty->print("local %d ", i);
-      if (l == NULL) {
+      if (l == nullptr) {
         tty->print("null");
         i ++;
       } else {
@@ -259,15 +259,15 @@ void ValueStack::print() {
     }
   }
 
-  if (caller_state() != NULL) {
+  if (caller_state() != nullptr) {
     caller_state()->print();
   }
 }
 
 
 void ValueStack::verify() {
-  assert(scope() != NULL, "scope must exist");
-  if (caller_state() != NULL) {
+  assert(scope() != nullptr, "scope must exist");
+  if (caller_state() != nullptr) {
     assert(caller_state()->scope() == scope()->caller(), "invalid caller scope");
     caller_state()->verify();
   }
@@ -284,22 +284,22 @@ void ValueStack::verify() {
   int i;
   for (i = 0; i < stack_size(); i++) {
     Value v = _stack.at(i);
-    if (v == NULL) {
-      assert(_stack.at(i - 1)->type()->is_double_word(), "only hi-words are NULL on stack");
+    if (v == nullptr) {
+      assert(_stack.at(i - 1)->type()->is_double_word(), "only hi-words are null on stack");
     } else if (v->type()->is_double_word()) {
-      assert(_stack.at(i + 1) == NULL, "hi-word must be NULL");
+      assert(_stack.at(i + 1) == nullptr, "hi-word must be null");
     }
   }
 
   for (i = 0; i < locals_size(); i++) {
     Value v = _locals.at(i);
-    if (v != NULL && v->type()->is_double_word()) {
-      assert(_locals.at(i + 1) == NULL, "hi-word must be NULL");
+    if (v != nullptr && v->type()->is_double_word()) {
+      assert(_locals.at(i + 1) == nullptr, "hi-word must be null");
     }
   }
 
   for_each_state_value(this, v,
-    assert(v != NULL, "just test if state-iteration succeeds");
+    assert(v != nullptr, "just test if state-iteration succeeds");
   );
 }
 #endif // PRODUCT

--- a/src/hotspot/share/c1/c1_ValueStack.hpp
+++ b/src/hotspot/share/c1/c1_ValueStack.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ class ValueStack: public CompilationResourceObj {
   }
 
   Value check(ValueTag tag, Value t, Value h) {
-    assert(h == NULL, "hi-word of doubleword value must be NULL");
+    assert(h == nullptr, "hi-word of doubleword value must be null");
     return check(tag, t);
   }
 
@@ -92,24 +92,24 @@ class ValueStack: public CompilationResourceObj {
 
   int locals_size() const                        { return _locals.length(); }
   int stack_size() const                         { return _stack.length(); }
-  int locks_size() const                         { return _locks == NULL ? 0 : _locks->length(); }
+  int locks_size() const                         { return _locks == nullptr ? 0 : _locks->length(); }
   bool stack_is_empty() const                    { return _stack.is_empty(); }
-  bool no_active_locks() const                   { return _locks == NULL || _locks->is_empty(); }
+  bool no_active_locks() const                   { return _locks == nullptr || _locks->is_empty(); }
   int total_locks_size() const;
 
   // locals access
-  void clear_locals();                           // sets all locals to NULL;
+  void clear_locals();                           // sets all locals to null;
 
   void invalidate_local(int i) {
     assert(!_locals.at(i)->type()->is_double_word() ||
-           _locals.at(i + 1) == NULL, "hi-word of doubleword value must be NULL");
-    _locals.at_put(i, NULL);
+           _locals.at(i + 1) == nullptr, "hi-word of doubleword value must be null");
+    _locals.at_put(i, nullptr);
   }
 
   Value local_at(int i) const {
     Value x = _locals.at(i);
-    assert(x == NULL || !x->type()->is_double_word() ||
-           _locals.at(i + 1) == NULL, "hi-word of doubleword value must be NULL");
+    assert(x == nullptr || !x->type()->is_double_word() ||
+           _locals.at(i + 1) == nullptr, "hi-word of doubleword value must be null");
     return x;
   }
 
@@ -118,15 +118,15 @@ class ValueStack: public CompilationResourceObj {
     // double word local and kill it.
     if (i > 0) {
       Value prev = _locals.at(i - 1);
-      if (prev != NULL && prev->type()->is_double_word()) {
-        _locals.at_put(i - 1, NULL);
+      if (prev != nullptr && prev->type()->is_double_word()) {
+        _locals.at_put(i - 1, nullptr);
       }
     }
 
     _locals.at_put(i, x);
     if (x->type()->is_double_word()) {
-      // hi-word of doubleword value is always NULL
-      _locals.at_put(i + 1, NULL);
+      // hi-word of doubleword value is always null
+      _locals.at_put(i + 1, nullptr);
     }
   }
 
@@ -134,7 +134,7 @@ class ValueStack: public CompilationResourceObj {
   Value stack_at(int i) const {
     Value x = _stack.at(i);
     assert(!x->type()->is_double_word() ||
-           _stack.at(i + 1) == NULL, "hi-word of doubleword value must be NULL");
+           _stack.at(i + 1) == nullptr, "hi-word of doubleword value must be null");
     return x;
   }
 
@@ -164,8 +164,8 @@ class ValueStack: public CompilationResourceObj {
   void fpush(Value t)                            { _stack.push(check(floatTag  , t)); }
   void apush(Value t)                            { _stack.push(check(objectTag , t)); }
   void rpush(Value t)                            { _stack.push(check(addressTag, t)); }
-  void lpush(Value t)                            { _stack.push(check(longTag   , t)); _stack.push(NULL); }
-  void dpush(Value t)                            { _stack.push(check(doubleTag , t)); _stack.push(NULL); }
+  void lpush(Value t)                            { _stack.push(check(longTag   , t)); _stack.push(nullptr); }
+  void dpush(Value t)                            { _stack.push(check(doubleTag , t)); _stack.push(nullptr); }
 
   void push(ValueType* type, Value t) {
     switch (type->tag()) {
@@ -194,7 +194,7 @@ class ValueStack: public CompilationResourceObj {
       case doubleTag : return dpop();
       case objectTag : return apop();
       case addressTag: return rpop();
-      default        : ShouldNotReachHere(); return NULL;
+      default        : ShouldNotReachHere(); return nullptr;
     }
   }
 
@@ -237,7 +237,7 @@ class ValueStack: public CompilationResourceObj {
 //     do something with value and index
 //   }
 // }
-// as an invariant, state is NULL now
+// as an invariant, state is null now
 
 
 // construct a unique variable name with the line number where the macro is used
@@ -246,14 +246,14 @@ class ValueStack: public CompilationResourceObj {
 #define temp_var     temp_var2(__LINE__)
 
 #define for_each_state(state)  \
-  for (; state != NULL; state = state->caller_state())
+  for (; state != nullptr; state = state->caller_state())
 
 #define for_each_local_value(state, index, value)                                              \
   int temp_var = state->locals_size();                                                         \
   for (index = 0;                                                                              \
        index < temp_var && (value = state->local_at(index), true);                             \
-       index += (value == NULL || value->type()->is_illegal() ? 1 : value->type()->size()))    \
-    if (value != NULL)
+       index += (value == nullptr || value->type()->is_illegal() ? 1 : value->type()->size()))    \
+    if (value != nullptr)
 
 
 #define for_each_stack_value(state, index, value)                                              \
@@ -268,7 +268,7 @@ class ValueStack: public CompilationResourceObj {
   for (index = 0;                                                                              \
        index < temp_var && (value = state->lock_at(index), true);                              \
        index++)                                                                                \
-    if (value != NULL)
+    if (value != nullptr)
 
 
 // Macro definition for simple iteration of all state values of a ValueStack
@@ -318,7 +318,7 @@ class ValueStack: public CompilationResourceObj {
   {                                                                                            \
     for_each_stack_value(cur_state, cur_index, value) {                                        \
       Phi* v_phi = value->as_Phi();                                                            \
-      if (v_phi != NULL && v_phi->block() == v_block) {                                        \
+      if (v_phi != nullptr && v_phi->block() == v_block) {                                        \
         v_code;                                                                                \
       }                                                                                        \
     }                                                                                          \
@@ -326,7 +326,7 @@ class ValueStack: public CompilationResourceObj {
   {                                                                                            \
     for_each_local_value(cur_state, cur_index, value) {                                        \
       Phi* v_phi = value->as_Phi();                                                            \
-      if (v_phi != NULL && v_phi->block() == v_block) {                                        \
+      if (v_phi != nullptr && v_phi->block() == v_block) {                                        \
         v_code;                                                                                \
       }                                                                                        \
     }                                                                                          \

--- a/src/hotspot/share/c1/c1_ValueStack.hpp
+++ b/src/hotspot/share/c1/c1_ValueStack.hpp
@@ -252,7 +252,7 @@ class ValueStack: public CompilationResourceObj {
   int temp_var = state->locals_size();                                                         \
   for (index = 0;                                                                              \
        index < temp_var && (value = state->local_at(index), true);                             \
-       index += (value == nullptr || value->type()->is_illegal() ? 1 : value->type()->size()))    \
+       index += (value == nullptr || value->type()->is_illegal() ? 1 : value->type()->size())) \
     if (value != nullptr)
 
 
@@ -318,7 +318,7 @@ class ValueStack: public CompilationResourceObj {
   {                                                                                            \
     for_each_stack_value(cur_state, cur_index, value) {                                        \
       Phi* v_phi = value->as_Phi();                                                            \
-      if (v_phi != nullptr && v_phi->block() == v_block) {                                        \
+      if (v_phi != nullptr && v_phi->block() == v_block) {                                     \
         v_code;                                                                                \
       }                                                                                        \
     }                                                                                          \
@@ -326,7 +326,7 @@ class ValueStack: public CompilationResourceObj {
   {                                                                                            \
     for_each_local_value(cur_state, cur_index, value) {                                        \
       Phi* v_phi = value->as_Phi();                                                            \
-      if (v_phi != nullptr && v_phi->block() == v_block) {                                        \
+      if (v_phi != nullptr && v_phi->block() == v_block) {                                     \
         v_code;                                                                                \
       }                                                                                        \
     }                                                                                          \

--- a/src/hotspot/share/c1/c1_ValueType.cpp
+++ b/src/hotspot/share/c1/c1_ValueType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,23 +31,23 @@
 
 
 // predefined types
-VoidType*       voidType     = NULL;
-IntType*        intType      = NULL;
-LongType*       longType     = NULL;
-FloatType*      floatType    = NULL;
-DoubleType*     doubleType   = NULL;
-ObjectType*     objectType   = NULL;
-ArrayType*      arrayType    = NULL;
-InstanceType*   instanceType = NULL;
-ClassType*      classType    = NULL;
-AddressType*    addressType  = NULL;
-IllegalType*    illegalType  = NULL;
+VoidType*       voidType     = nullptr;
+IntType*        intType      = nullptr;
+LongType*       longType     = nullptr;
+FloatType*      floatType    = nullptr;
+DoubleType*     doubleType   = nullptr;
+ObjectType*     objectType   = nullptr;
+ArrayType*      arrayType    = nullptr;
+InstanceType*   instanceType = nullptr;
+ClassType*      classType    = nullptr;
+AddressType*    addressType  = nullptr;
+IllegalType*    illegalType  = nullptr;
 
 
 // predefined constants
-IntConstant*    intZero      = NULL;
-IntConstant*    intOne       = NULL;
-ObjectConstant* objectNull   = NULL;
+IntConstant*    intZero      = nullptr;
+IntConstant*    intOne       = nullptr;
+ObjectConstant* objectNull   = nullptr;
 
 
 void ValueType::initialize() {
@@ -89,15 +89,15 @@ ValueType* ValueType::meet(ValueType* y) const {
 
 ciType* ObjectConstant::exact_type() const {
   ciObject* c = constant_value();
-  return (c != NULL && !c->is_null_object()) ? c->klass() : NULL;
+  return (c != nullptr && !c->is_null_object()) ? c->klass() : nullptr;
 }
 ciType* ArrayConstant::exact_type() const {
   ciObject* c = constant_value();
-  return (c != NULL && !c->is_null_object()) ? c->klass() : NULL;
+  return (c != nullptr && !c->is_null_object()) ? c->klass() : nullptr;
 }
 ciType* InstanceConstant::exact_type() const {
   ciObject* c = constant_value();
-  return (c != NULL && !c->is_null_object()) ? c->klass() : NULL;
+  return (c != nullptr && !c->is_null_object()) ? c->klass() : nullptr;
 }
 ciType* ClassConstant::exact_type() const {
   return Compilation::current()->env()->Class_klass();

--- a/src/hotspot/share/c1/c1_ValueType.hpp
+++ b/src/hotspot/share/c1/c1_ValueType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,12 +124,12 @@ class ValueType: public CompilationResourceObj {
   bool is_long()                                 { return tag() == longTag;   }
   bool is_float()                                { return tag() == floatTag;  }
   bool is_double()                               { return tag() == doubleTag; }
-  bool is_object()                               { return as_ObjectType()   != NULL; }
-  bool is_array()                                { return as_ArrayType()    != NULL; }
-  bool is_instance()                             { return as_InstanceType() != NULL; }
-  bool is_class()                                { return as_ClassType()    != NULL; }
-  bool is_method()                               { return as_MethodType()   != NULL; }
-  bool is_address()                              { return as_AddressType()  != NULL; }
+  bool is_object()                               { return as_ObjectType()   != nullptr; }
+  bool is_array()                                { return as_ArrayType()    != nullptr; }
+  bool is_instance()                             { return as_InstanceType() != nullptr; }
+  bool is_class()                                { return as_ClassType()    != nullptr; }
+  bool is_method()                               { return as_MethodType()   != nullptr; }
+  bool is_address()                              { return as_AddressType()  != nullptr; }
   bool is_illegal()                              { return tag() == illegalTag; }
 
   bool is_int_kind() const                       { return tag() == intTag || tag() == longTag; }
@@ -140,30 +140,30 @@ class ValueType: public CompilationResourceObj {
   bool is_double_word() const                    { return _size == 2; }
 
   // casting
-  virtual VoidType*         as_VoidType()        { return NULL; }
-  virtual IntType*          as_IntType()         { return NULL; }
-  virtual LongType*         as_LongType()        { return NULL; }
-  virtual FloatType*        as_FloatType()       { return NULL; }
-  virtual DoubleType*       as_DoubleType()      { return NULL; }
-  virtual ObjectType*       as_ObjectType()      { return NULL; }
-  virtual ArrayType*        as_ArrayType()       { return NULL; }
-  virtual InstanceType*     as_InstanceType()    { return NULL; }
-  virtual ClassType*        as_ClassType()       { return NULL; }
-  virtual MetadataType*     as_MetadataType()    { return NULL; }
-  virtual MethodType*       as_MethodType()      { return NULL; }
-  virtual AddressType*      as_AddressType()     { return NULL; }
-  virtual IllegalType*      as_IllegalType()     { return NULL; }
-  virtual IntConstant*      as_IntConstant()     { return NULL; }
-  virtual LongConstant*     as_LongConstant()    { return NULL; }
-  virtual FloatConstant*    as_FloatConstant()   { return NULL; }
-  virtual DoubleConstant*   as_DoubleConstant()  { return NULL; }
-  virtual ObjectConstant*   as_ObjectConstant()  { return NULL; }
-  virtual InstanceConstant* as_InstanceConstant(){ return NULL; }
-  virtual ClassConstant*    as_ClassConstant()   { return NULL; }
-  virtual MethodConstant*   as_MethodConstant()  { return NULL; }
-  virtual ArrayConstant*    as_ArrayConstant()   { return NULL; }
-  virtual StableArrayConstant* as_StableArrayConstant()   { return NULL; }
-  virtual AddressConstant*  as_AddressConstant() { return NULL; }
+  virtual VoidType*         as_VoidType()        { return nullptr; }
+  virtual IntType*          as_IntType()         { return nullptr; }
+  virtual LongType*         as_LongType()        { return nullptr; }
+  virtual FloatType*        as_FloatType()       { return nullptr; }
+  virtual DoubleType*       as_DoubleType()      { return nullptr; }
+  virtual ObjectType*       as_ObjectType()      { return nullptr; }
+  virtual ArrayType*        as_ArrayType()       { return nullptr; }
+  virtual InstanceType*     as_InstanceType()    { return nullptr; }
+  virtual ClassType*        as_ClassType()       { return nullptr; }
+  virtual MetadataType*     as_MetadataType()    { return nullptr; }
+  virtual MethodType*       as_MethodType()      { return nullptr; }
+  virtual AddressType*      as_AddressType()     { return nullptr; }
+  virtual IllegalType*      as_IllegalType()     { return nullptr; }
+  virtual IntConstant*      as_IntConstant()     { return nullptr; }
+  virtual LongConstant*     as_LongConstant()    { return nullptr; }
+  virtual FloatConstant*    as_FloatConstant()   { return nullptr; }
+  virtual DoubleConstant*   as_DoubleConstant()  { return nullptr; }
+  virtual ObjectConstant*   as_ObjectConstant()  { return nullptr; }
+  virtual InstanceConstant* as_InstanceConstant(){ return nullptr; }
+  virtual ClassConstant*    as_ClassConstant()   { return nullptr; }
+  virtual MethodConstant*   as_MethodConstant()  { return nullptr; }
+  virtual ArrayConstant*    as_ArrayConstant()   { return nullptr; }
+  virtual StableArrayConstant* as_StableArrayConstant()   { return nullptr; }
+  virtual AddressConstant*  as_AddressConstant() { return nullptr; }
 
   // type operations
   ValueType* meet(ValueType* y) const;
@@ -286,8 +286,8 @@ class ObjectType: public ValueType {
   virtual const char tchar() const               { return 'a'; }
   virtual const char* name() const               { return "object"; }
   virtual ObjectType* as_ObjectType()            { return this; }
-  virtual ciObject* constant_value() const       { ShouldNotReachHere(); return NULL; }
-  virtual ciType* exact_type() const             { return NULL; }
+  virtual ciObject* constant_value() const       { ShouldNotReachHere(); return nullptr; }
+  virtual ciType* exact_type() const             { return nullptr; }
   bool is_loaded() const;
   jobject encoding() const;
 };
@@ -376,7 +376,7 @@ class MetadataType: public ValueType {
   virtual MetadataType* as_MetadataType()               { return this; }
   bool is_loaded() const;
   jobject encoding() const;
-  virtual ciMetadata* constant_value() const            { ShouldNotReachHere(); return NULL;  }
+  virtual ciMetadata* constant_value() const            { ShouldNotReachHere(); return nullptr;  }
 };
 
 


### PR DESCRIPTION
Hi, this PR changes all occurrences of NULL to nullptr for the subdirectory share/c1. Unfortunately the script that does the change isn't perfect, and so we need to comb through these manually to make sure nothing has gone wrong. I also review these changes but things slip past my eyes sometimes.

Here are some typical things to look out for:

1. No changes but copyright header changed (probably because I reverted some changes but forgot the copyright).
2. Macros having their NULL changed to nullptr, these are added to the script when I find them. They should be NULL.
3. nullptr in comments and logs. We try to use lower case "null" in these cases as it reads better. An exception is made when code expressions are in a comment.

An example of this:

```c++
// This function returns null
void* ret_null();
// This function returns true if *x == nullptr
bool is_nullptr(void** x);
```

Note how `nullptr` participates in a code expression here, we really are talking about the specific value `nullptr`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300086](https://bugs.openjdk.org/browse/JDK-8300086): Replace NULL with nullptr in share/c1/


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [241df265](https://git.openjdk.org/jdk/pull/14009/files/241df26519d10a266cba9a86cebe32a681bfc87a)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [241df265](https://git.openjdk.org/jdk/pull/14009/files/241df26519d10a266cba9a86cebe32a681bfc87a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14009/head:pull/14009` \
`$ git checkout pull/14009`

Update a local copy of the PR: \
`$ git checkout pull/14009` \
`$ git pull https://git.openjdk.org/jdk.git pull/14009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14009`

View PR using the GUI difftool: \
`$ git pr show -t 14009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14009.diff">https://git.openjdk.org/jdk/pull/14009.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14009#issuecomment-1549958770)