### PR TITLE
8308181: Generational ZGC: Remove CLDG_lock from old gen root scanning

### DIFF
--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -1422,13 +1422,7 @@ public:
       _cl_colored(),
       _cld_cl(&_cl_colored),
       _thread_cl(),
-      _nm_cl() {
-    ClassLoaderDataGraph_lock->lock();
-  }
-
-  ~ZRemapYoungRootsTask() {
-    ClassLoaderDataGraph_lock->unlock();
-  }
+      _nm_cl() {}
 
   virtual void work() {
     {

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -829,13 +829,7 @@ public:
       _cl_colored(),
       _cld_cl(&_cl_colored),
       _thread_cl(),
-      _nm_cl() {
-    ClassLoaderDataGraph_lock->lock();
-  }
-
-  ~ZMarkOldRootsTask() {
-    ClassLoaderDataGraph_lock->unlock();
-  }
+      _nm_cl() {}
 
   virtual void work() {
     {


### PR DESCRIPTION
We already removed the CLDG_lock from young gen root scanning, after the CLDG was made concurrently walkable with [JDK-8307106](https://bugs.openjdk.org/browse/JDK-8307106). We should remove it from the old generation root scanning code as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308181](https://bugs.openjdk.org/browse/JDK-8308181): Generational ZGC: Remove CLDG_lock from old gen root scanning


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14011/head:pull/14011` \
`$ git checkout pull/14011`

Update a local copy of the PR: \
`$ git checkout pull/14011` \
`$ git pull https://git.openjdk.org/jdk.git pull/14011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14011`

View PR using the GUI difftool: \
`$ git pr show -t 14011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14011.diff">https://git.openjdk.org/jdk/pull/14011.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14011#issuecomment-1549574779)