### PR TITLE
8308185: Update Http2TestServerConnection to use SSLSocket.startHandshake()

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -292,7 +292,7 @@ public class Http2TestServerConnection {
 
     private static void handshake(String name, SSLSocket sock) throws IOException {
         if (name == null) {
-            sock.getSession(); // awaits handshake completion
+            sock.startHandshake(); // blocks until handshake done
             return;
         } else if (name.equals("localhost")) {
             name = "localhost";
@@ -314,7 +314,7 @@ public class Http2TestServerConnection {
         List<SNIMatcher> list = List.of(matcher);
         params.setSNIMatchers(list);
         sock.setSSLParameters(params);
-        sock.getSession(); // blocks until handshake done
+        sock.startHandshake(); // blocks until handshake done
     }
 
     void closeIncoming() {


### PR DESCRIPTION
Can I please get a review of this change in the `jdk.httpclient.test.lib.http2.Http2TestServerConnection` which proposes to use the `SSLSocket.startHandshake()`  to API propogate any handshake exception back to the test that uses this test server?

This addresses https://bugs.openjdk.org/browse/JDK-8308185 and as noted in that JBS issue should help diagnoze any handshake failures in httpclient tests, a bit more easily.

tier2 testing with this change came back without any failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308185](https://bugs.openjdk.org/browse/JDK-8308185): Update Http2TestServerConnection to use SSLSocket.startHandshake()


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14012/head:pull/14012` \
`$ git checkout pull/14012`

Update a local copy of the PR: \
`$ git checkout pull/14012` \
`$ git pull https://git.openjdk.org/jdk.git pull/14012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14012`

View PR using the GUI difftool: \
`$ git pr show -t 14012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14012.diff">https://git.openjdk.org/jdk/pull/14012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14012#issuecomment-1549703802)