### PR TITLE
8144891: ToolBox should use java.nio.file.Path internally, instead of java.io.File

### DIFF
--- a/test/langtools/tools/lib/toolbox/AbstractTask.java
+++ b/test/langtools/tools/lib/toolbox/AbstractTask.java
@@ -25,13 +25,13 @@ package toolbox;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Path;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -168,9 +168,9 @@ abstract class AbstractTask<T extends AbstractTask<T>> implements Task {
             throw new IllegalStateException();
         ProcessBuilder pb = new ProcessBuilder();
         if (redirects.get(OutputKind.STDOUT) != null)
-            pb.redirectOutput(new File(redirects.get(OutputKind.STDOUT)));
+            pb.redirectOutput(Path.of(redirects.get(OutputKind.STDOUT)).toFile());
         if (redirects.get(OutputKind.STDERR) != null)
-            pb.redirectError(new File(redirects.get(OutputKind.STDERR)));
+            pb.redirectError(Path.of(redirects.get(OutputKind.STDERR)).toFile());
         pb.environment().putAll(envVars);
         return pb;
     }

--- a/test/langtools/tools/lib/toolbox/JarTask.java
+++ b/test/langtools/tools/lib/toolbox/JarTask.java
@@ -25,7 +25,6 @@ package toolbox;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
@@ -332,7 +331,7 @@ public class JarTask extends AbstractTask<JarTask> {
                         String p = base.relativize(file)
                                 .normalize()
                                 .toString()
-                                .replace(File.separatorChar, '/');
+                                .replace(ToolBox.fileSeparatorChar, '/');
                         JarEntry e = new JarEntry(p);
                             jos.putNextEntry(e);
                         try {

--- a/test/langtools/tools/lib/toolbox/JavacTask.java
+++ b/test/langtools/tools/lib/toolbox/JavacTask.java
@@ -89,7 +89,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
      * @return this task object
      */
     public JavacTask classpath(String classpath) {
-        this.classpath = Stream.of(classpath.split(File.pathSeparator))
+        this.classpath = Stream.of(classpath.split(ToolBox.pathSeparator))
                 .filter(s -> !s.isEmpty())
                 .map(s -> Paths.get(s))
                 .collect(Collectors.toList());
@@ -122,7 +122,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
      * @return this task object
      */
     public JavacTask sourcepath(String sourcepath) {
-        this.sourcepath = Stream.of(sourcepath.split(File.pathSeparator))
+        this.sourcepath = Stream.of(sourcepath.split(ToolBox.pathSeparator))
                 .filter(s -> !s.isEmpty())
                 .map(s -> Paths.get(s))
                 .collect(Collectors.toList());

--- a/test/langtools/tools/lib/toolbox/JavacTask.java
+++ b/test/langtools/tools/lib/toolbox/JavacTask.java
@@ -23,7 +23,6 @@
 
 package toolbox;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
@@ -468,7 +467,7 @@ public class JavacTask extends AbstractTask<JavacTask> {
     private String toSearchPath(List<Path> files) {
         return files.stream()
             .map(Path::toString)
-            .collect(Collectors.joining(File.pathSeparator));
+            .collect(Collectors.joining(ToolBox.pathSeparator));
     }
 
     private Iterable<? extends JavaFileObject> joinFiles(

--- a/test/langtools/tools/lib/toolbox/JavadocTask.java
+++ b/test/langtools/tools/lib/toolbox/JavadocTask.java
@@ -23,7 +23,6 @@
 
 package toolbox;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
@@ -89,7 +88,7 @@ public class JavadocTask extends AbstractTask<JavadocTask> {
      * @return this task object
      */
     public JavadocTask classpath(String classpath) {
-        this.classpath = Stream.of(classpath.split(File.pathSeparator))
+        this.classpath = Stream.of(classpath.split(ToolBox.pathSeparator))
                 .filter(s -> !s.isEmpty())
                 .map(s -> Paths.get(s))
                 .collect(Collectors.toList());
@@ -122,7 +121,7 @@ public class JavadocTask extends AbstractTask<JavadocTask> {
      * @return this task object
      */
     public JavadocTask sourcepath(String sourcepath) {
-        this.sourcepath = Stream.of(sourcepath.split(File.pathSeparator))
+        this.sourcepath = Stream.of(sourcepath.split(ToolBox.pathSeparator))
                 .filter(s -> !s.isEmpty())
                 .map(s -> Paths.get(s))
                 .collect(Collectors.toList());
@@ -397,7 +396,7 @@ public class JavadocTask extends AbstractTask<JavadocTask> {
     private String toSearchPath(List<Path> files) {
         return files.stream()
             .map(Path::toString)
-            .collect(Collectors.joining(File.pathSeparator));
+            .collect(Collectors.joining(ToolBox.pathSeparator));
     }
 
     private Iterable<? extends JavaFileObject> joinFiles(

--- a/test/langtools/tools/lib/toolbox/ModuleBuilder.java
+++ b/test/langtools/tools/lib/toolbox/ModuleBuilder.java
@@ -23,7 +23,6 @@
 
 package toolbox;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -257,7 +256,7 @@ public class ModuleBuilder {
     /**
      * Writes the source files for the module to a specified directory,
      * and then compiles them to a given directory.
-     * @param srcDir the directory in which a directory will be created
+     * @param src the directory in which a directory will be created
      *  to contain the source files for the module
      * @param modules the directory in which a directory will be created
      *    to contain the compiled class files for the module
@@ -267,7 +266,7 @@ public class ModuleBuilder {
         Path moduleSrc = write(src);
         String mp = modulePath.stream()
                 .map(Path::toString)
-                .collect(Collectors.joining(File.pathSeparator));
+                .collect(Collectors.joining(ToolBox.pathSeparator));
         new JavacTask(tb)
                 .outdir(Files.createDirectories(modules.resolve(name)))
                 .options("--module-path", mp)

--- a/test/langtools/tools/lib/toolbox/ToolBox.java
+++ b/test/langtools/tools/lib/toolbox/ToolBox.java
@@ -92,7 +92,7 @@ public class ToolBox {
     /** The platform path separator. */
     public static final String pathSeparator = System.getProperty("path.separator");
     /** The platform file separator character. */
-    public static char fileSeparatorChar = System.getProperty("file.separator").toCharArray()[0];
+    public static char fileSeparatorChar = System.getProperty("file.separator").charAt(0);
     /** The platform OS name. */
     public static final String osName = System.getProperty("os.name");
 

--- a/test/langtools/tools/lib/toolbox/ToolBox.java
+++ b/test/langtools/tools/lib/toolbox/ToolBox.java
@@ -34,8 +34,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,7 +46,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,6 +89,10 @@ import javax.tools.ToolProvider;
 public class ToolBox {
     /** The platform line separator. */
     public static final String lineSeparator = System.getProperty("line.separator");
+    /** The platform path separator. */
+    public static final String pathSeparator = System.getProperty("path.separator");
+    /** The platform file separator character. */
+    public static char fileSeparatorChar = System.getProperty("file.separator").toCharArray()[0];
     /** The platform OS name. */
     public static final String osName = System.getProperty("os.name");
 


### PR DESCRIPTION
Please review this change set that gets rid of all direct `java.io.File` usages by introducing new constants in `ToolBox`, based on system property values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8144891](https://bugs.openjdk.org/browse/JDK-8144891): ToolBox should use java.nio.file.Path internally, instead of java.io.File


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14015/head:pull/14015` \
`$ git checkout pull/14015`

Update a local copy of the PR: \
`$ git checkout pull/14015` \
`$ git pull https://git.openjdk.org/jdk.git pull/14015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14015`

View PR using the GUI difftool: \
`$ git pr show -t 14015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14015.diff">https://git.openjdk.org/jdk/pull/14015.diff</a>

</details>
