### PR TITLE
8308223: failure handler missed jcmd.vm.info command

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -33,7 +33,7 @@ onTimeout=\
         jcmd.compiler.queue \
   jcmd.vm.classloader_stats jcmd.vm.stringtable \
         jcmd.vm.symboltable jcmd.vm.uptime jcmd.vm.dynlibs \
-        jcmd.vm.system_properties \
+        jcmd.vm.system_properties jcmd.vm.info \
   jcmd.gc.heap_info jcmd.gc.class_histogram jcmd.gc.finalizer_info jcmd.thread.dump_to_file \
   jstack jhsdb.jstack.live.default jhsdb.jstack.live.mixed
 


### PR DESCRIPTION
Trivial fix that added missed useful command.
Tested by running make of failure handler and verifying results.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308223](https://bugs.openjdk.org/browse/JDK-8308223): failure handler missed jcmd.vm.info command


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14018/head:pull/14018` \
`$ git checkout pull/14018`

Update a local copy of the PR: \
`$ git checkout pull/14018` \
`$ git pull https://git.openjdk.org/jdk.git pull/14018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14018`

View PR using the GUI difftool: \
`$ git pr show -t 14018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14018.diff">https://git.openjdk.org/jdk/pull/14018.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14018#issuecomment-1550146240)