### PR TITLE
8308231: Faster MemAllocator::Allocation checks for verify/notification

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -389,12 +389,6 @@ class JvmtiExport : public AllStatic {
   static void record_vm_internal_object_allocation(oop object) NOT_JVMTI_RETURN;
   // Post objects collected by vm_object_alloc_event_collector.
   static void post_vm_object_alloc(JavaThread *thread, oop object) NOT_JVMTI_RETURN;
-  // Collects vm internal objects for later event posting.
-  inline static void vm_object_alloc_event_collector(oop object) {
-    if (should_post_vm_object_alloc()) {
-      record_vm_internal_object_allocation(object);
-    }
-  }
 
   // Used by C2 to deoptimize allocation intrinsics and post vm_object_alloc
   static int _should_notify_object_alloc;


### PR DESCRIPTION
In multi-array allocations benchmarks, there is a hot path through the native VM allocation code, which calls lots of notification methods, even when we would return immediately, because the allocation was satisfied from existing TLAB. Not calling these helper methods from `MemAllocator::Allocation` constructor/destructor looks like an incremental win for the benchmarks.

Example on M1:

```
Benchmark             (size)  Mode  Cnt        Score        Error  Units

# Before
MultiArrayAlloc.full       1  avgt   15       74,053 ±      0,869  ns/op
MultiArrayAlloc.full       2  avgt   15       87,800 ±      0,931  ns/op
MultiArrayAlloc.full       4  avgt   15      124,814 ±      0,615  ns/op
MultiArrayAlloc.full       8  avgt   15      188,562 ±      0,785  ns/op
MultiArrayAlloc.full      16  avgt   15      313,007 ±      1,108  ns/op
MultiArrayAlloc.full      32  avgt   15      640,276 ±      4,560  ns/op
MultiArrayAlloc.full      64  avgt   15     1395,220 ±      5,860  ns/op
MultiArrayAlloc.full     128  avgt   15     3417,848 ±     11,345  ns/op
MultiArrayAlloc.full     256  avgt   15     9955,360 ±    102,057  ns/op
MultiArrayAlloc.full     512  avgt   15    27738,002 ±    244,940  ns/op
MultiArrayAlloc.full    1024  avgt   15   147507,008 ±   1434,085  ns/op

# After
MultiArrayAlloc.full       1  avgt   15       70,434 ±      0,373  ns/op  ;  5% better
MultiArrayAlloc.full       2  avgt   15       82,394 ±      0,137  ns/op  ;  7% better
MultiArrayAlloc.full       4  avgt   15      108,542 ±      0,129  ns/op  ; 15% better
MultiArrayAlloc.full       8  avgt   15      170,697 ±      4,480  ns/op  ; 11% better
MultiArrayAlloc.full      16  avgt   15      272,902 ±      0,877  ns/op  ; 15% better
MultiArrayAlloc.full      32  avgt   15      524,486 ±      1,447  ns/op  ; 22% better
MultiArrayAlloc.full      64  avgt   15     1088,932 ±      2,739  ns/op  ; 17% better
MultiArrayAlloc.full     128  avgt   15     3151,144 ±     14,621  ns/op  ;  8% better
MultiArrayAlloc.full     256  avgt   15     8455,293 ±     12,656  ns/op  ; 18% better
MultiArrayAlloc.full     512  avgt   15    26060,055 ±    116,524  ns/op  ;  6% better
MultiArrayAlloc.full    1024  avgt   15   130824,480 ±    831,703  ns/op  ; 13% better
```

Additional testing:
 - [x] Ad-hoc micro-benchmarks
 - [x] Linux x86_64 fastdebug `serviceability/jvmti`
 - [x] Linux x86_64 fastdebug `jdk/jfr`
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8308231](https://bugs.openjdk.org/browse/JDK-8308231): Faster MemAllocator::Allocation checks for verify/notification (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [d189a358](https://git.openjdk.org/jdk/pull/14019/files/d189a3587c084177cbed4c4ef30c7c15eb3f6287)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14019/head:pull/14019` \
`$ git checkout pull/14019`

Update a local copy of the PR: \
`$ git checkout pull/14019` \
`$ git pull https://git.openjdk.org/jdk.git pull/14019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14019`

View PR using the GUI difftool: \
`$ git pr show -t 14019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14019.diff">https://git.openjdk.org/jdk/pull/14019.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14019#issuecomment-1551264337)