### PR TITLE
JDK-8308239: Tighten up accessibility of nested classes in java.lang.invoke

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -217,7 +217,7 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
      * it would appear that a shorter species could serve as a supertype of a
      * longer one which extends it.
      */
-    public abstract class SpeciesData {
+    abstract class SpeciesData {
         // Bootstrapping requires circular relations Class -> SpeciesData -> Class
         // Therefore, we need non-final links in the chain.  Use @Stable fields.
         private final K key;
@@ -454,7 +454,7 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
      * Code generation support for instances.
      * Subclasses can modify the behavior.
      */
-    public class Factory {
+    class Factory {
         /**
          * Constructs a factory.
          */


### PR DESCRIPTION
Tightening up accessibility of a few nested classes. There is no practical impact on source compatibility -- source uses within the package still work, but by default the ability to reflectively call methods on these classes is disabled.