### PR TITLE
8308192: Error in parsing replay file when staticfield is an array of single dimension

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1101,6 +1101,7 @@ class CompileReplay : public StackObj {
           value = oopFactory::new_longArray(length, CHECK);
         } else if (field_signature[0] == JVM_SIGNATURE_ARRAY &&
                    field_signature[1] == JVM_SIGNATURE_CLASS) {
+          parse_klass(CHECK); // eat up the array class name
           Klass* kelem = resolve_klass(field_signature + 1, CHECK);
           value = oopFactory::new_objArray(kelem, length, CHECK);
         } else {


### PR DESCRIPTION
This fixes the parsing error caused by not consuming all the tokens in the `staticfield` command in a replay file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308192](https://bugs.openjdk.org/browse/JDK-8308192): Error in parsing replay file when staticfield is an array of single dimension


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14024/head:pull/14024` \
`$ git checkout pull/14024`

Update a local copy of the PR: \
`$ git checkout pull/14024` \
`$ git pull https://git.openjdk.org/jdk.git pull/14024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14024`

View PR using the GUI difftool: \
`$ git pr show -t 14024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14024.diff">https://git.openjdk.org/jdk/pull/14024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14024#issuecomment-1550592523)