### PR TITLE
8308252: Refactor line-by-line file reading code

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -58,11 +58,11 @@ ClassListParser::ClassListParser(const char* file, ParseMode parse_mode)
   : _reader(file), _id2klass_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {
   log_info(cds)("Parsing %s%s", file,
                 (parse_mode == _parse_lambda_forms_invokers_only) ? " (lambda form invokers only)" : "");
-  _classlist_file = file;
   if (!_reader.is_opened()) {
     char errmsg[JVM_MAXPATHLEN];
     os::lasterror(errmsg, JVM_MAXPATHLEN);
-    vm_exit_during_initialization("Loading classlist failed", errmsg); // FIXME
+    log_error(cds)("Loading classlist %s failed: %s", _reader.filename(), errmsg);
+    MetaspaceShared::unrecoverable_writing_error();
   }
   _line_no = 0;
   _interfaces = new (mtClass) GrowableArray<int>(10, mtClass);
@@ -418,7 +418,7 @@ void ClassListParser::error(const char* msg, ...) {
 
   jio_fprintf(defaultStream::error_stream(),
               "An error has occurred while processing class list file %s %d:%d.\n",
-              _classlist_file, _line_no, (error_index + 1));
+              _reader.filename(), _line_no, (error_index + 1));
   jio_vfprintf(defaultStream::error_stream(), msg, ap);
 
   if (_line_len <= 0) {

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -58,10 +58,8 @@ ClassListParser::ClassListParser(const char* file, ParseMode parse_mode)
   : _reader(file), _id2klass_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE) {
   log_info(cds)("Parsing %s%s", file,
                 (parse_mode == _parse_lambda_forms_invokers_only) ? " (lambda form invokers only)" : "");
-  if (!_reader.is_opened()) {
-    char errmsg[JVM_MAXPATHLEN];
-    os::lasterror(errmsg, JVM_MAXPATHLEN);
-    log_error(cds)("Loading classlist %s failed: %s", _reader.filename(), errmsg);
+  if (!_reader.is_open()) {
+    log_error(cds)("Loading classlist %s failed: %s", _reader.filename(), os::strerror(_reader.last_errno()));
     MetaspaceShared::unrecoverable_writing_error();
   }
   _line_no = 0;

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -96,7 +96,6 @@ private:
   static const int MAX_TABLE_SIZE = 61333;
   static volatile Thread* _parsing_thread; // the thread that created _instance
   static ClassListParser* _instance; // the singleton.
-  const char* _classlist_file;
   LineReader _reader;
 
   ID2KlassTable _id2klass_table;

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -28,6 +28,7 @@
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
+#include "utilities/lineReader.hpp"
 #include "utilities/resizeableResourceHash.hpp"
 
 #define LAMBDA_PROXY_TAG "@lambda-proxy"
@@ -96,14 +97,13 @@ private:
   static volatile Thread* _parsing_thread; // the thread that created _instance
   static ClassListParser* _instance; // the singleton.
   const char* _classlist_file;
-  FILE* _file;
+  LineReader _reader;
 
   ID2KlassTable _id2klass_table;
 
   // The following field contains information from the *current* line being
   // parsed.
-  char                _line[_line_buf_size];  // The buffer that holds the current line. Some characters in
-                                              // the buffer may be overwritten by '\0' during parsing.
+  char*               _line;                  // The current input line being processed
   int                 _line_len;              // Original length of the input line.
   int                 _line_no;               // Line number for current line being parsed
   const char*         _class_name;
@@ -136,11 +136,7 @@ private:
   ~ClassListParser();
 
 public:
-  static int parse_classlist(const char* classlist_path, ParseMode parse_mode, TRAPS) {
-    ClassListParser parser(classlist_path, parse_mode);
-    return parser.parse(THREAD); // returns the number of classes loaded.
-  }
-
+  static int parse_classlist(const char* classlist_path, ParseMode parse_mode, TRAPS);
   static bool is_parsing_thread();
   static ClassListParser* instance() {
     assert(is_parsing_thread(), "call this only in the thread that created ClassListParsing::_instance");

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -147,8 +147,8 @@ class CompileReplay : public StackObj {
     _protection_domain = Handle();
     _protection_domain_initialized = false;
 
-    if (!_reader.is_opened()) {
-      fprintf(stderr, "ERROR: Can't open replay file %s\n", filename);
+    if (!_reader.is_open()) {
+      fprintf(stderr, "ERROR: Can't open replay file %s: %s\n", filename, os::strerror(_reader.last_errno()));
     }
 
     _ci_inline_records = nullptr;
@@ -181,7 +181,7 @@ class CompileReplay : public StackObj {
   }
 
   bool can_replay() {
-    return _reader.is_opened() && !had_error();
+    return _reader.is_open() && !had_error();
   }
 
   void report_error(const char* msg) {

--- a/src/hotspot/share/utilities/lineReader.cpp
+++ b/src/hotspot/share/utilities/lineReader.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.inline.hpp"
+#include "runtime/os.hpp"
+#include "utilities/lineReader.hpp"
+
+LineReader::LineReader(const char* filename) : _filename(filename), _stream(nullptr) {
+  // Use os::open() because neither fopen() nor os::fopen()
+  // can handle long path name on Windows. HMM, is this still valid today???
+  int fd = os::open(filename, O_RDONLY, S_IREAD);
+  if (fd != -1) {
+    // Obtain a File* from the file descriptor so that getc()
+    // can be used in get_line().
+    _stream = os::fdopen(fd, "r");
+    if (_stream == nullptr) {
+      ::close(fd);
+    } else {
+      // fd will be closed by fclose(_stream)
+    }
+  } else {
+    _stream = nullptr;
+  }
+
+  _buffer_length = 32;
+  _buffer = NEW_RESOURCE_ARRAY(char, _buffer_length);
+}
+
+LineReader::~LineReader() {
+  close(); // Just in case
+}
+
+void LineReader::close() {
+  if (_stream != nullptr) {
+    fclose(_stream);
+    _stream = nullptr;
+  }
+}
+
+// Returns nullptr if we have reached EOF.
+// \n is treated as the line separator
+// All occurrences of \r are stripper.
+char* LineReader::get_line() {
+  if (_stream == nullptr) {
+    return nullptr;
+  }
+  size_t buffer_pos = 0;
+  int c;
+  while ((c = getc(_stream)) != EOF) {
+    if (buffer_pos + 1 >= _buffer_length) {
+      size_t new_length = _buffer_length * 2;
+      if (new_length < _buffer_length) {
+        // This could happen on 32-bit. On 64-bit, the VM would have exited
+        // due to OOM before we ever get to here.
+        fatal("Cannot handle excessively long lines");
+      }
+      _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
+      assert(_buffer != nullptr, "OOM would have exited JVM");
+      _buffer_length = new_length;
+    }
+    if (c == '\n') {
+      break;
+    } else if (c == '\r') {
+      // skip LF
+    } else {
+      _buffer[buffer_pos++] = c;
+    }
+  }
+
+  // null terminate it, reset the pointer
+  _buffer[buffer_pos] = '\0'; // NL or EOF
+
+  if (buffer_pos == 0 && c == EOF) {
+    close();
+    return nullptr;
+  } else {
+    return _buffer;
+  }
+}

--- a/src/hotspot/share/utilities/lineReader.cpp
+++ b/src/hotspot/share/utilities/lineReader.cpp
@@ -77,7 +77,7 @@ char* LineReader::get_line() {
   while ((s = fgets(tmp, sizeof(tmp), _stream)) != nullptr) {
     char c;
     has_input = true;
-    // Get up to 127 characters, followed by '\0' (fgets always terminates the line), 
+    // Get up to 127 characters, followed by '\0' (fgets always terminates the line),
     // Iff the last character is not '\n', that means we have read a partial line
     // and should keep going.
     while ((c = *s++) != '\0') {

--- a/src/hotspot/share/utilities/lineReader.cpp
+++ b/src/hotspot/share/utilities/lineReader.cpp
@@ -27,11 +27,12 @@
 #include "runtime/os.hpp"
 #include "utilities/lineReader.hpp"
 
-LineReader::LineReader(const char* filename, size_t initial_length, size_t max_length) :
+#include <errno.h>
+
+LineReader::LineReader(const char* filename, size_t initial_length) :
   _filename(os::strdup(filename)), _stream(nullptr), _errno(0),
-  _buffer_length(initial_length), _max_buffer_length(max_length), _buffer(nullptr)
+  _buffer_length(initial_length), _buffer(nullptr)
 {
-  assert(_buffer_length < _max_buffer_length, "sanity");
   // Use os::open() because neither fopen() nor os::fopen()
   // can handle long path name on Windows. HMM, is this still valid today???
   int fd = os::open(_filename, O_RDONLY, S_IREAD);
@@ -71,48 +72,32 @@ char* LineReader::get_line() {
     return nullptr;
   }
   size_t buffer_pos = 0;
-  char tmp[128];
-  char* s;
-  bool has_input = false;
-  while ((s = fgets(tmp, sizeof(tmp), _stream)) != nullptr) {
-    char c;
-    has_input = true;
-    // Get up to 127 characters, followed by '\0' (fgets always terminates the line),
-    // Iff the last character is not '\n', that means we have read a partial line
-    // and should keep going.
-    while ((c = *s++) != '\0') {
-      // Grow buffer if necessary
-      if (buffer_pos + 1 >= _buffer_length) {
-        size_t new_length = _buffer_length * 2;
-        if (new_length < _buffer_length) {
-          // This could happen on 32-bit. On 64-bit, the VM would have exited
-          // due to OOM before we ever get to here.
-          fatal("Cannot handle excessively long lines");
-        }
-        _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
-        assert(_buffer != nullptr, "OOM would have exited JVM");
-        _buffer_length = new_length;
+  int c;
+  while ((c = getc(_stream)) != EOF) {
+    if (buffer_pos + 1 >= _buffer_length) {
+      size_t new_length = _buffer_length * 2;
+      if (new_length < _buffer_length) {
+        // This could happen on 32-bit. On 64-bit, the VM would have exited
+        // due to OOM before we ever get to here.
+        fatal("Cannot handle excessively long lines");
       }
-
-      if (c == '\n') {
-        break;
-      } else if (c == '\r') {
-        // skip LF
-      } else {
-        _buffer[buffer_pos++] = c;
-      }
+      _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
+      assert(_buffer != nullptr, "OOM would have exited JVM");
+      _buffer_length = new_length;
     }
-
     if (c == '\n') {
       break;
+    } else if (c == '\r') {
+      // skip LF
+    } else {
+      _buffer[buffer_pos++] = c;
     }
   }
 
   // null terminate it, reset the pointer
   _buffer[buffer_pos] = '\0'; // NL or EOF
 
-  if (buffer_pos == 0 && !has_input) {
-    // fgets() has not returned anything. We may have an error or EOF
+  if (buffer_pos == 0 && c == EOF) {
     _errno = errno;
     close();
     return nullptr;

--- a/src/hotspot/share/utilities/lineReader.cpp
+++ b/src/hotspot/share/utilities/lineReader.cpp
@@ -27,29 +27,33 @@
 #include "runtime/os.hpp"
 #include "utilities/lineReader.hpp"
 
-LineReader::LineReader(const char* filename) : _filename(filename), _stream(nullptr) {
+LineReader::LineReader(const char* filename, size_t initial_length, size_t max_length) :
+  _filename(os::strdup(filename)), _stream(nullptr), _errno(0),
+  _buffer_length(initial_length), _max_buffer_length(max_length), _buffer(nullptr)
+{
+  assert(_buffer_length < _max_buffer_length, "sanity");
   // Use os::open() because neither fopen() nor os::fopen()
   // can handle long path name on Windows. HMM, is this still valid today???
-  int fd = os::open(filename, O_RDONLY, S_IREAD);
-  if (fd != -1) {
+  int fd = os::open(_filename, O_RDONLY, S_IREAD);
+  if (fd == -1) {
+    _errno = errno;
+  } else {
     // Obtain a File* from the file descriptor so that getc()
     // can be used in get_line().
     _stream = os::fdopen(fd, "r");
     if (_stream == nullptr) {
+      _errno = errno;
       ::close(fd);
     } else {
       // fd will be closed by fclose(_stream)
+      _buffer = NEW_RESOURCE_ARRAY(char, _buffer_length);
     }
-  } else {
-    _stream = nullptr;
   }
-
-  _buffer_length = 32;
-  _buffer = NEW_RESOURCE_ARRAY(char, _buffer_length);
 }
 
 LineReader::~LineReader() {
   close(); // Just in case
+  FreeHeap(_filename);
 }
 
 void LineReader::close() {
@@ -67,35 +71,53 @@ char* LineReader::get_line() {
     return nullptr;
   }
   size_t buffer_pos = 0;
-  int c;
-  while ((c = getc(_stream)) != EOF) {
-    if (buffer_pos + 1 >= _buffer_length) {
-      size_t new_length = _buffer_length * 2;
-      if (new_length < _buffer_length) {
-        // This could happen on 32-bit. On 64-bit, the VM would have exited
-        // due to OOM before we ever get to here.
-        fatal("Cannot handle excessively long lines");
+  char tmp[128];
+  char* s;
+  bool has_input = false;
+  while ((s = fgets(tmp, sizeof(tmp), _stream)) != nullptr) {
+    char c;
+    has_input = true;
+    // Get up to 127 characters, followed by '\0' (fgets always terminates the line), 
+    // Iff the last character is not '\n', that means we have read a partial line
+    // and should keep going.
+    while ((c = *s++) != '\0') {
+      // Grow buffer if necessary
+      if (buffer_pos + 1 >= _buffer_length) {
+        size_t new_length = _buffer_length * 2;
+        if (new_length < _buffer_length) {
+          // This could happen on 32-bit. On 64-bit, the VM would have exited
+          // due to OOM before we ever get to here.
+          fatal("Cannot handle excessively long lines");
+        }
+        _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
+        assert(_buffer != nullptr, "OOM would have exited JVM");
+        _buffer_length = new_length;
       }
-      _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
-      assert(_buffer != nullptr, "OOM would have exited JVM");
-      _buffer_length = new_length;
+
+      if (c == '\n') {
+        break;
+      } else if (c == '\r') {
+        // skip LF
+      } else {
+        _buffer[buffer_pos++] = c;
+      }
     }
+
     if (c == '\n') {
       break;
-    } else if (c == '\r') {
-      // skip LF
-    } else {
-      _buffer[buffer_pos++] = c;
     }
   }
 
   // null terminate it, reset the pointer
   _buffer[buffer_pos] = '\0'; // NL or EOF
 
-  if (buffer_pos == 0 && c == EOF) {
+  if (buffer_pos == 0 && !has_input) {
+    // fgets() has not returned anything. We may have an error or EOF
+    _errno = errno;
     close();
     return nullptr;
   } else {
+    // If we have read an empty line: _buffer[0] == '\0'
     return _buffer;
   }
 }

--- a/src/hotspot/share/utilities/lineReader.cpp
+++ b/src/hotspot/share/utilities/lineReader.cpp
@@ -60,8 +60,8 @@ void LineReader::close() {
 }
 
 // Returns nullptr if we have reached EOF.
-// \n is treated as the line separator
-// All occurrences of \r are stripper.
+// \n is treated as the line separator.
+// All occurrences of \r are stripped.
 char* LineReader::get_line() {
   if (_stream == nullptr) {
     return nullptr;

--- a/src/hotspot/share/utilities/lineReader.hpp
+++ b/src/hotspot/share/utilities/lineReader.hpp
@@ -34,7 +34,7 @@
 class LineReader : public StackObj {
   char* _filename;
   FILE* _stream;
-  int _errno;
+  int _last_errno;
   size_t _buffer_length;
   char* _buffer;
 public:
@@ -50,7 +50,7 @@ public:
 
   // errno, if any, for the last file I/O operation performed by this LineReader
   int last_errno() {
-    return _errno;
+    return _last_errno;
   }
 };
 

--- a/src/hotspot/share/utilities/lineReader.hpp
+++ b/src/hotspot/share/utilities/lineReader.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_LINEREADER_HPP
+#define SHARE_UTILITIES_LINEREADER_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// A simple class to read lines of arbitrary length from _filename.
+// The _buffer is resource-allocated, so LineReader must be used within
+// a ResourceMark.
+class LineReader : public StackObj {
+  const char* _filename;
+  FILE* _stream;
+  size_t _buffer_length;
+  char* _buffer;
+public:
+  LineReader(const char* filename);
+  ~LineReader();
+
+  bool is_opened() const {
+    return _stream != nullptr;
+  }
+  void close();
+  char* get_line();
+};
+
+#endif // SHARE_UTILITIES_LINEREADER_HPP

--- a/src/hotspot/share/utilities/lineReader.hpp
+++ b/src/hotspot/share/utilities/lineReader.hpp
@@ -32,20 +32,27 @@
 // The _buffer is resource-allocated, so LineReader must be used within
 // a ResourceMark.
 class LineReader : public StackObj {
-  const char* _filename;
+  char* _filename;
   FILE* _stream;
+  int _errno;
   size_t _buffer_length;
+  size_t _max_buffer_length;
   char* _buffer;
 public:
-  LineReader(const char* filename);
+  LineReader(const char* filename, size_t initial_length = 160, size_t max_length = (SIZE_MAX / 2) - 1);
   ~LineReader();
 
-  bool is_opened() const {
+  bool is_open() const {
     return _stream != nullptr;
   }
   const char* filename() const { return _filename; }
   char* get_line();
   void close();
+
+  // errno, if any, for the last file I/O operation performed by this LineReader
+  int last_errno() {
+    return _errno;
+  }
 };
 
 #endif // SHARE_UTILITIES_LINEREADER_HPP

--- a/src/hotspot/share/utilities/lineReader.hpp
+++ b/src/hotspot/share/utilities/lineReader.hpp
@@ -36,10 +36,9 @@ class LineReader : public StackObj {
   FILE* _stream;
   int _errno;
   size_t _buffer_length;
-  size_t _max_buffer_length;
   char* _buffer;
 public:
-  LineReader(const char* filename, size_t initial_length = 160, size_t max_length = (SIZE_MAX / 2) - 1);
+  LineReader(const char* filename, size_t initial_length = 160);
   ~LineReader();
 
   bool is_open() const {

--- a/src/hotspot/share/utilities/lineReader.hpp
+++ b/src/hotspot/share/utilities/lineReader.hpp
@@ -43,8 +43,9 @@ public:
   bool is_opened() const {
     return _stream != nullptr;
   }
-  void close();
+  const char* filename() const { return _filename; }
   char* get_line();
+  void close();
 };
 
 #endif // SHARE_UTILITIES_LINEREADER_HPP


### PR DESCRIPTION
I extracted the `get_line()` code from `CompileReplay` and put it in a utility class so that it can be used by `ClassListParser` as well. A few notable changes:

- Simplified the API
- Changed the buffer size to a size_t
- Added size overflow and OOM checks
- Brought over the `fdopen` logic from `ClassListParser` for handling long path names on Windows. (I don't know how valid this is nowadays, but I don't want to drop it in a refactoring PR).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308252](https://bugs.openjdk.org/browse/JDK-8308252): Refactor line-by-line file reading code


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [b8a0f31e](https://git.openjdk.org/jdk/pull/14025/files/b8a0f31e3dda2cfd550941bc406b5861562a7efa)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [6530758a](https://git.openjdk.org/jdk/pull/14025/files/6530758ab7bb04a61a9c9c867810a5b6aed71838)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14025/head:pull/14025` \
`$ git checkout pull/14025`

Update a local copy of the PR: \
`$ git checkout pull/14025` \
`$ git pull https://git.openjdk.org/jdk.git pull/14025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14025`

View PR using the GUI difftool: \
`$ git pr show -t 14025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14025.diff">https://git.openjdk.org/jdk/pull/14025.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14025#issuecomment-1550658581)