### PR TITLE
8307311: Timeouts on one macOS 12.6.1 host of two Swing JTableHeader tests

### DIFF
--- a/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
+++ b/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
@@ -53,7 +53,6 @@ public class bug6889007 {
     public static void main(String[] args) throws Exception {
         try {
             robot = new Robot();
-            robot.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();

--- a/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
+++ b/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
@@ -69,6 +69,7 @@ public class bug6889007 {
                 frame.add(th);
                 frame.pack();
                 frame.setLocationRelativeTo(null);
+                frame.setAlwaysOnTop(true);
                 frame.setVisible(true);
             });
             robot.waitForIdle();
@@ -83,7 +84,7 @@ public class bug6889007 {
             int y = point.y + height/2;
             for(int i = -shift; i < width + 2*shift; i++) {
                 robot.mouseMove(x++, y);
-                robot.waitForIdle();
+                robot.delay(100);
             }
             robot.waitForIdle();
             // 9 is a magic test number
@@ -109,6 +110,8 @@ public class bug6889007 {
             Cursor cursor = Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR);
             if (oldColumn != -1 && newColumn != -1 &&
                     header.getCursor() != cursor) {
+                System.out.println("oldColumn " + oldColumn + " newColumn " + newColumn +
+                        "header.getCursor " + header.getCursor() + " cursor " + cursor);
                 try {
                     Dimension screenSize =
                                Toolkit.getDefaultToolkit().getScreenSize();


### PR DESCRIPTION
Issue was bug6889007.java was causing a timeout issue on mac system.  Although bug6889007.java fail with small test group with "Wrong cursor type" error, it could not reproduce bug6884066.java 
The hang issue might be due to waitForIdle() being called in loop which will be calling sync() so replaced with delay..

Modified fix passed the suggested small test group `desktop_timeout ` several times in all platforms 
in addition to several iterations of the test run in standalone mode in all platforms..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307311](https://bugs.openjdk.org/browse/JDK-8307311): Timeouts on one macOS 12.6.1 host of two Swing JTableHeader tests


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [85d4cf0f](https://git.openjdk.org/jdk/pull/14026/files/85d4cf0f35cf155a030c91aad5b61064cedf95c8)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14026/head:pull/14026` \
`$ git checkout pull/14026`

Update a local copy of the PR: \
`$ git checkout pull/14026` \
`$ git pull https://git.openjdk.org/jdk.git pull/14026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14026`

View PR using the GUI difftool: \
`$ git pr show -t 14026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14026.diff">https://git.openjdk.org/jdk/pull/14026.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14026#issuecomment-1550870899)