### PR TITLE
8308246: PPC64le build broken after JDK-8304913

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
@@ -50,8 +50,9 @@ public record Platform(OperatingSystem os, Architecture arch) {
         OperatingSystem os = OperatingSystem.valueOf(osName.toUpperCase(Locale.ROOT));
 
         archName = platformString.substring(index + 1);
-        // Alias architecture "amd64" to "X64"
-        archName = archName.replace("amd64", "X64");
+        // Alias architecture "amd64" to "X64" and "ppc64le" to "ppc64"
+        archName = archName.replace("amd64", "X64")
+                           .replace("ppc64le", "ppc64");
         Architecture arch = Architecture.valueOf(archName.toUpperCase(Locale.ROOT));
 
         return new Platform(os, arch);


### PR DESCRIPTION
PPC64le needs to get recognized as PPC64. Otherwise, jlink doesn't recognize the platform and throws a PluginException: ModuleTarget is malformed: No enum constant jdk.internal.util.Architecture.PPC64LE.