### PR TITLE
8308270: ARM32 build broken after JDK-8304913

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -37,6 +37,7 @@ public enum Architecture {
     X64,        // Represents AMD64 and X86_64
     X86,
     AARCH64,
+    ARM,
     RISCV64,
     S390,
     PPC64,
@@ -83,6 +84,14 @@ public enum Architecture {
     @ForceInline
     public static boolean isPPC64() {
         return PlatformProps.TARGET_ARCH_IS_PPC64;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is ARM}
+     */
+    @ForceInline
+    public static boolean isARM() {
+        return PlatformProps.TARGET_ARCH_IS_ARM;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -53,6 +53,7 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_X64     = "@@OPENJDK_TARGET_CPU@@" == "x64";
     static final boolean TARGET_ARCH_IS_X86     = "@@OPENJDK_TARGET_CPU@@" == "x86";
     static final boolean TARGET_ARCH_IS_AARCH64 = "@@OPENJDK_TARGET_CPU@@" == "aarch64";
+    static final boolean TARGET_ARCH_IS_ARM     = "@@OPENJDK_TARGET_CPU@@" == "arm";
     static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
     static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -28,6 +28,7 @@ import jdk.internal.misc.Unsafe;
 
 import static jdk.internal.util.Architecture.OTHER;
 import static jdk.internal.util.Architecture.AARCH64;
+import static jdk.internal.util.Architecture.ARM;
 import static jdk.internal.util.Architecture.PPC64;
 import static jdk.internal.util.Architecture.RISCV64;
 import static jdk.internal.util.Architecture.S390;
@@ -67,6 +68,7 @@ public class ArchTest {
             case "x86_64", "amd64" -> X64;
             case "x86", "i386" -> X86;
             case "aarch64" -> AARCH64;
+            case "arm" -> ARM;
             case "riscv64" -> RISCV64;
             case "s390x", "s390" -> S390;
             case "ppc64", "ppc64le" -> PPC64;
@@ -84,6 +86,7 @@ public class ArchTest {
                 Arguments.of(X64, Architecture.isX64()),
                 Arguments.of(X86, Architecture.isX86()),
                 Arguments.of(AARCH64, Architecture.isAARCH64()),
+                Arguments.of(ARM, Architecture.isARM()),
                 Arguments.of(RISCV64, Architecture.isRISCV64()),
                 Arguments.of(S390, Architecture.isS390()),
                 Arguments.of(PPC64, Architecture.isPPC64())


### PR DESCRIPTION
Build issue happens after https://git.openjdk.org/jdk/pull/13585:
```
$ make bundles
...
jdk.tools.jlink.plugin.PluginException: ModuleTarget is malformed: No enum constant jdk.internal.util.Architecture.ARM
	at jdk.jlink/jdk.tools.jlink.builder.DefaultImageBuilder.storeFiles(DefaultImageBuilder.java:181)
	at jdk.jlink/jdk.tools.jlink.internal.ImagePluginStack.storeFiles(ImagePluginStack.java:486)
	at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.writeImage(ImageFileCreator.java:168)
	at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.create(ImageFileCreator.java:100)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask$ImageHelper.retrieve(JlinkTask.java:860)
	at jdk.jlink/jdk.tools.jlink.internal.ImagePluginStack.operate(ImagePluginStack.java:194)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImage(JlinkTask.java:423)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:286)
	at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:56)
	at jdk.jlink/jdk.tools.jlink.internal.Main.main(Main.java:34)
```

With this PR I follow the https://github.com/openjdk/jdk/pull/13357 change to add a missing ARM32 architecture to the list of supported architectures: `X64, X86, AARCH64, RISCV64, S390, PPC64`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308270](https://bugs.openjdk.org/browse/JDK-8308270): ARM32 build broken after JDK-8304913


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14028/head:pull/14028` \
`$ git checkout pull/14028`

Update a local copy of the PR: \
`$ git checkout pull/14028` \
`$ git pull https://git.openjdk.org/jdk.git pull/14028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14028`

View PR using the GUI difftool: \
`$ git pr show -t 14028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14028.diff">https://git.openjdk.org/jdk/pull/14028.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14028#issuecomment-1551815671)