### PR TITLE
8308277: RISC-V: Improve vectorization of Match.sqrt() on floats

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7668,7 +7668,7 @@ instruct absD_reg(fRegD dst, fRegD src) %{
 %}
 
 instruct sqrtF_reg(fRegF dst, fRegF src) %{
-  match(Set dst (ConvD2F (SqrtD (ConvF2D src))));
+  match(Set dst (SqrtF src));
 
   ins_cost(FSQRT_COST);
   format %{ "fsqrt.s  $dst, $src\t#@sqrtF_reg" %}


### PR DESCRIPTION
[JDK-8190800](https://bugs.openjdk.org/browse/JDK-8190800) added `VSqrtF` and `SqrtF` nodes to support the vectorization of Match.sqrt() on floats. For riscv port, however, the scalar version of `sqrtF` still uses the old match rule that converts Float to Double first. It can be simplified to just use `SqrtF`.

The old match rule also affects the vectorization of Math.sqrt() on float. The current implementation will convert float to double with `vcvtFtoD`, then do `vsqrtD`, and finally convert the result back to float with `vcvtDtoF`. If we use the new `SqrtF` match rule, it will only use `vsqrtF` to do the conversion. Take the test (Sqrt.java) from [JDK-8190800](https://bugs.openjdk.org/browse/JDK-8190800) as an example, here is the output with `-XX:+PrintOptoAssembly` and `-XX:+UseRVV`:

before:

```
19a loadV V1, [R13] # vector (rvv)
1a2 vcvtFtoD V2, V1
1ae vfsqrt.v V1, V2 #@vsqrtD
1b6 vcvtDtoF V1, V1
1c2 storeV [R14], V1 # vector (rvv)
```

after:
```
1be loadV V1, [R12] # vector (rvv)
1c6 vfsqrt.v V1, V1 #@vsqrtF
1ce addi R12, R29, #144 # ptr, #@addP_reg_imm
1d2 storeV [R12], V1 # vector (rvv)
```

Testing:
- [x] tier1 tests on Unmatched board without `-XX:+UseRVV` (release build)
- [x] hotspot_tier1/jdk_tier1 on QEMU with `-XX:+UseRVV` (release build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308277](https://bugs.openjdk.org/browse/JDK-8308277): RISC-V: Improve vectorization of Match.sqrt() on floats


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14029/head:pull/14029` \
`$ git checkout pull/14029`

Update a local copy of the PR: \
`$ git checkout pull/14029` \
`$ git pull https://git.openjdk.org/jdk.git pull/14029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14029`

View PR using the GUI difftool: \
`$ git pr show -t 14029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14029.diff">https://git.openjdk.org/jdk/pull/14029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14029#issuecomment-1551195671)