### PR TITLE
JDK-8308285: Assert on -Xshare:dump when running with -Xlog:cds=trace

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1364,7 +1364,15 @@ BasicType java_lang_Class::primitive_type(oop java_class) {
   } else {
     assert(java_class == Universe::void_mirror(), "only valid non-array primitive");
   }
-  assert(Universe::java_mirror(type) == java_class, "must be consistent");
+#ifdef ASSERT
+  if (DumpSharedSpaces) {
+    oop mirror = Universe::java_mirror(type);
+    oop scratch_mirror = HeapShared::scratch_java_mirror(type);
+    assert(java_class == mirror || java_class == scratch_mirror, "must be consistent");
+  } else {
+    assert(Universe::java_mirror(type) == java_class, "must be consistent");
+  }
+#endif
   return type;
 }
 


### PR DESCRIPTION
We assert for `java -Xshare:dump -Xlog:cds*=trace`:

```
# assert(counter_check_mirror == java_class) failed: must be consistent
```

at

```
  29 Stack: [0x00007f8821535000,0x00007f8821635000], sp=0x00007f8821632e80, free space=1015k
  30 Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
  31 V [libjvm.so+0xda0155] java_lang_Class::primitive_type(oopDesc*)+0x13d (javaClasses.cpp:1367)
  32 V [libjvm.so+0xd9fb95] java_lang_Class::print_signature(oopDesc*, outputStream*)+0x9f (javaClasses.cpp:1284)
  33 V [libjvm.so+0xd623f5] InstanceKlass::oop_print_on(oopDesc*, outputStream*)+0x175 (instanceKlass.cpp:3652)
  34 V [libjvm.so+0x127ec71] oopDesc::print_on(outputStream*) const+0x9f (oop.cpp:47)
  35 V [libjvm.so+0xd34621] void WalkOopAndArchiveClosure::do_oop_work<narrowOop>(narrowOop*)+0x1e1 (heapShared.cpp:1124)
...
```

When tracing with at trace level, we print each copied oop in full, including the basic java mirrors. As part of the trace, we print the basic type. The utility function `BasicType java_lang_Class::primitive_type(oop java_class)` does a sanity check: the printed oop is supposed to be a class mirror for a basic type, so it must be the same as the oop resolved via (this oop)->array_klass->element_type->mirror for that type).

But at this point in the dump process, we have two variants of these basic mirrors: `Universe::_basic_type_mirrors` and `HeapShared::_scratch_basic_type_mirrors`. 

The patch loosens the assert when dumping such that the assert condition is fulfilled if the mirror is found in either of these two arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308285](https://bugs.openjdk.org/browse/JDK-8308285): Assert on -Xshare:dump when running with -Xlog:cds=trace


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14031/head:pull/14031` \
`$ git checkout pull/14031`

Update a local copy of the PR: \
`$ git checkout pull/14031` \
`$ git pull https://git.openjdk.org/jdk.git pull/14031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14031`

View PR using the GUI difftool: \
`$ git pr show -t 14031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14031.diff">https://git.openjdk.org/jdk/pull/14031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14031#issuecomment-1551297235)