### PR TITLE
8308290: Add fontconfig requirement to building.md

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -80,6 +80,7 @@ id="toc-getting-jdk-binaries">Getting JDK binaries</a></li>
 id="toc-external-library-requirements">External Library Requirements</a>
 <ul>
 <li><a href="#freetype" id="toc-freetype">FreeType</a></li>
+<li><a href="#fontconfig" id="toc-fontconfig">Fontconfig</a></li>
 <li><a href="#cups" id="toc-cups">CUPS</a></li>
 <li><a href="#x11" id="toc-x11">X11</a></li>
 <li><a href="#alsa" id="toc-alsa">ALSA</a></li>
@@ -677,6 +678,17 @@ copy.</p>
 <p>Use <code>--with-freetype-include=&lt;path&gt;</code> and
 <code>--with-freetype-lib=&lt;path&gt;</code> if <code>configure</code>
 does not automatically locate the platform FreeType files.</p>
+<h3 id="fontconfig">Fontconfig</h3>
+<p>Fontconfig from <a href="http://fontconfig.org">freedesktop.org
+Fontconfig</a> is required on all platforms except Windows and
+macOS.</p>
+<ul>
+<li>To install on an rpm-based Linux, try running
+<code>sudo yum install     fontconfig-devel</code>.</li>
+</ul>
+<p>Use <code>--with-fontconfig-include=&lt;path&gt;</code> and
+<code>--with-fontconfig=&lt;path&gt;</code> if <code>configure</code>
+does not automatically locate the platform Fontconfig files.</p>
 <h3 id="cups">CUPS</h3>
 <p>CUPS, <a href="http://www.cups.org">Common UNIX Printing System</a>
 header files are required on all platforms, except Windows. Often these

--- a/doc/building.md
+++ b/doc/building.md
@@ -471,6 +471,17 @@ rather than bundling the JDK's own copy.
 Use `--with-freetype-include=<path>` and `--with-freetype-lib=<path>`
 if `configure` does not automatically locate the platform FreeType files.
 
+### Fontconfig
+
+Fontconfig from [freedesktop.org Fontconfig](http://fontconfig.org) is required
+on all platforms except Windows and macOS.
+
+  * To install on an rpm-based Linux, try running `sudo yum install
+    fontconfig-devel`.
+
+Use `--with-fontconfig-include=<path>` and `--with-fontconfig=<path>`
+if `configure` does not automatically locate the platform Fontconfig files.
+
 ### CUPS
 
 CUPS, [Common UNIX Printing System](http://www.cups.org) header files are


### PR DESCRIPTION
After following all the commands in `building.md` I still get on Fedora 38 x86_64:

```
checking for fontconfig/fontconfig.h... no
configure: error: Could not find fontconfig!
```

Another issue is that it is all written with `yum` instead of `dnf` but people can handle it I guess.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308290](https://bugs.openjdk.org/browse/JDK-8308290): Add fontconfig requirement to building.md


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14034/head:pull/14034` \
`$ git checkout pull/14034`

Update a local copy of the PR: \
`$ git checkout pull/14034` \
`$ git pull https://git.openjdk.org/jdk.git pull/14034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14034`

View PR using the GUI difftool: \
`$ git pr show -t 14034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14034.diff">https://git.openjdk.org/jdk/pull/14034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14034#issuecomment-1551608567)