### PR TITLE
8308108: Support Unicode extension for collation settings

### DIFF
--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -230,9 +230,39 @@ public abstract class Collator
      * has the "{@code ks}" and/or the "{@code kk}"
      * <a href="https://www.unicode.org/reports/tr35/tr35-collation.html#Setting_Options">
      * Unicode collation settings</a>, the returned {@code Collator} instance
-     * will have the specified strength and/or decomposition respectively. If the specified
-     * setting value is not recognized, strength and/or decomposition will not be
-     * overridden.
+     * will have the specified strength and/or decomposition respectively. The following
+     * table describes the mappings between recognizable BCP47 values and their corresponding
+     * Collator constants.
+     * <table class="striped">
+     * <caption style="display:none">Strength/Decomposition mappings</caption>
+     * <thead>
+     * <tr><th scope="col">BCP 47 values for strength (ks)</th>
+     *     <th scope="col">Collator constants for strength</th></tr>
+     * </thead>
+     * <tbody>
+     * <tr><th scope="row" style="text-align:left">level1</th>
+     *     <td>PRIMARY</td></tr>
+     * <tr><th scope="row" style="text-align:left">level2</th>
+     *     <td>SECONDARY</td></tr>
+     * <tr><th scope="row" style="text-align:left">level3</th>
+     *     <td>TERTIARY</td></tr>
+     * <tr><th scope="row" style="text-align:left">identic</th>
+     *     <td>IDENTICAL</td></tr>
+     * </tbody>
+     * <thead>
+     * <tr><th scope="col">BCP 47 values for normalization (kk)</th>
+     *     <th scope="col">Collator constants for decomposition</th></tr>
+     * </thead>
+     * <tbody>
+     * <tr><th scope="row" style="text-align:left">true</th>
+     *     <td>CANONICAL_DECOMPOSITION</td></tr>
+     * <tr><th scope="row" style="text-align:left">false</th>
+     *     <td>NO_DECOMPOSITION</td></tr>
+     * </tbody>
+     * </table>
+     * If the specified setting value is not recognized, strength and/or
+     * decomposition will not be overridden.
+     *
      * @apiNote Implementations of {@code Collator} class may produce
      * different instances based on the "{@code co}"
      * <a href="https://www.unicode.org/reports/tr35/#UnicodeCollationIdentifier">

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -226,7 +226,13 @@ public abstract class Collator
     }
 
     /**
-     * Gets the Collator for the desired locale.
+     * Gets the Collator for the desired locale. If the desired locale
+     * has the "{@code ks}" and/or the "{@code kk}"
+     * <a href="https://www.unicode.org/reports/tr35/tr35-collation.html#Setting_Options">
+     * Unicode collation settings</a>, the returned {@code Collator} instance
+     * will have the specified strength and/or decomposition respectively. If the specified
+     * setting value is not recognized, strength and/or decomposition will not be
+     * overridden.
      * @apiNote Implementations of {@code Collator} class may produce
      * different instances based on the "{@code co}"
      * <a href="https://www.unicode.org/reports/tr35/#UnicodeCollationIdentifier">
@@ -258,6 +264,27 @@ public abstract class Collator
                 result = LocaleProviderAdapter.forJRE()
                              .getCollatorProvider().getInstance(desiredLocale);
             }
+
+            // Override strength and decomposition with `desiredLocale`, if any
+            var strength = desiredLocale.getUnicodeLocaleType("ks");
+            if (strength != null) {
+                strength = strength.toLowerCase(Locale.ROOT);
+                switch (strength) {
+                    case "level1" -> result.setStrength(PRIMARY);
+                    case "level2" -> result.setStrength(SECONDARY);
+                    case "level3" -> result.setStrength(TERTIARY);
+                    case "identic" -> result.setStrength(IDENTICAL);
+                }
+            }
+            var norm = desiredLocale.getUnicodeLocaleType("kk");
+            if (norm != null) {
+                norm = norm.toLowerCase(Locale.ROOT);
+                switch (norm) {
+                    case "true" -> result.setDecomposition(CANONICAL_DECOMPOSITION);
+                    case "false" -> result.setDecomposition(NO_DECOMPOSITION);
+                }
+            }
+
             while (true) {
                 if (ref != null) {
                     // Remove the empty SoftReference if any

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -260,8 +260,9 @@ public abstract class Collator
      *     <td>NO_DECOMPOSITION</td></tr>
      * </tbody>
      * </table>
-     * If the specified setting value is not recognized, strength and/or
-     * decomposition will not be overridden.
+     * If the specified setting value is not recognized, the strength and/or
+     * decomposition will not be overridden, as if there were no BCP 47 collation
+     * options in the desired locale.
      *
      * @apiNote Implementations of {@code Collator} class may produce
      * different instances based on the "{@code co}"

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -229,10 +229,9 @@ public abstract class Collator
      * Gets the Collator for the desired locale. If the desired locale
      * has the "{@code ks}" and/or the "{@code kk}"
      * <a href="https://www.unicode.org/reports/tr35/tr35-collation.html#Setting_Options">
-     * Unicode collation settings</a>, the returned {@code Collator} instance
-     * will have the specified strength and/or decomposition respectively. The following
-     * table describes the mappings between recognizable BCP47 values and their corresponding
-     * Collator constants.
+     * Unicode collation settings</a>, this method will call {@linkplain #setStrength(int)}
+     * and/or {@linkplain #setDecomposition(int)} on the created instance, if the specified
+     * Unicode collation settings are recognized based on the following mappings:
      * <table class="striped">
      * <caption style="display:none">Strength/Decomposition mappings</caption>
      * <thead>

--- a/test/jdk/sun/text/resources/Collator/CollationSettingsTests.java
+++ b/test/jdk/sun/text/resources/Collator/CollationSettingsTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308108
+ * @summary Tests for BCP 47 collation settings
+ * @run junit CollationSettingsTests
+ */
+
+import java.text.Collator;
+import java.util.Locale;
+import java.util.stream.Stream;
+import static java.text.Collator.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CollationSettingsTests {
+    private static final Collator ENG_DEF =  Collator.getInstance(Locale.ENGLISH);
+
+    private static Stream<Arguments> strengthData() {
+        return Stream.of(
+            Arguments.of(Locale.forLanguageTag("en-u-ks-level1"), PRIMARY),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-level2"), SECONDARY),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-level3"), TERTIARY),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-identic"), IDENTICAL),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-LEVEL1"), PRIMARY),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-LEVEL2"), SECONDARY),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-LEVEL3"), TERTIARY),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-IDENTIC"), IDENTICAL),
+            // unrecognized setting value
+            Arguments.of(Locale.forLanguageTag("en-u-ks-foo"), ENG_DEF.getStrength()),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-level4"), ENG_DEF.getStrength()),
+            Arguments.of(Locale.forLanguageTag("en-u-ks-identical"), ENG_DEF.getStrength())
+        );
+    }
+
+    private static Stream<Arguments> decompData() {
+        return Stream.of(
+            Arguments.of(Locale.forLanguageTag("en-u-kk-true"), CANONICAL_DECOMPOSITION),
+            Arguments.of(Locale.forLanguageTag("en-u-kk-false"), NO_DECOMPOSITION),
+            Arguments.of(Locale.forLanguageTag("en-u-kk-TRUE"), CANONICAL_DECOMPOSITION),
+            Arguments.of(Locale.forLanguageTag("en-u-kk-FALSE"), NO_DECOMPOSITION),
+            // unrecognized setting value
+            Arguments.of(Locale.forLanguageTag("en-u-kk-foo"), ENG_DEF.getDecomposition()),
+            Arguments.of(Locale.forLanguageTag("en-u-kk-truetrue"), ENG_DEF.getDecomposition())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("strengthData")
+    public void testStrength(Locale l, int expected) {
+        assertEquals(expected, Collator.getInstance(l).getStrength());
+    }
+
+    @ParameterizedTest
+    @MethodSource("decompData")
+    public void testDecomposition(Locale l, int expected) {
+        assertEquals(expected, Collator.getInstance(l).getDecomposition());
+    }
+}

--- a/test/jdk/sun/text/resources/Collator/CollationSettingsTests.java
+++ b/test/jdk/sun/text/resources/Collator/CollationSettingsTests.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CollationSettingsTests {
-    private static final Collator ENG_DEF =  Collator.getInstance(Locale.ENGLISH);
+    private static final Collator ENG_DEF = Collator.getInstance(Locale.ENGLISH);
 
     private static Stream<Arguments> strengthData() {
         return Stream.of(


### PR DESCRIPTION
This change intends to interpret the BCP47 U extension wrt collation settings in the given `Locale`, then applies them to the created instances in the 1-arg factory method in `Collator`. A corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308243](https://bugs.openjdk.org/browse/JDK-8308243) to be approved

### Issues
 * [JDK-8308108](https://bugs.openjdk.org/browse/JDK-8308108): Support Unicode extension for collation settings
 * [JDK-8308243](https://bugs.openjdk.org/browse/JDK-8308243): Support Unicode extension for collation settings (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [88a93839](https://git.openjdk.org/jdk/pull/14040/files/88a9383999f70ac43c2d5fbdfefe82a00a750b13)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [627b78b3](https://git.openjdk.org/jdk/pull/14040/files/627b78b375a25b3a5b9ab9f580c021bf8c09eb62)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [627b78b3](https://git.openjdk.org/jdk/pull/14040/files/627b78b375a25b3a5b9ab9f580c021bf8c09eb62)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14040/head:pull/14040` \
`$ git checkout pull/14040`

Update a local copy of the PR: \
`$ git checkout pull/14040` \
`$ git pull https://git.openjdk.org/jdk.git pull/14040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14040`

View PR using the GUI difftool: \
`$ git pr show -t 14040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14040.diff">https://git.openjdk.org/jdk/pull/14040.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14040#issuecomment-1551959300)