### PR TITLE
8308342: Remove MetaspaceClosure::Ref::keep_after_pushing()

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -135,13 +135,7 @@ private:
     SourceObjInfo(MetaspaceClosure::Ref* ref, bool read_only, FollowMode follow_mode) :
       _ptrmap_start(0), _ptrmap_end(0), _read_only(read_only), _follow_mode(follow_mode),
       _size_in_bytes(ref->size() * BytesPerWord), _msotype(ref->msotype()),
-      _source_addr(ref->obj()) {
-      if (follow_mode == point_to_it) {
-        _buffered_addr = ref->obj();
-      } else {
-        _buffered_addr = nullptr;
-      }
-    }
+      _source_addr(ref->obj()), _buffered_addr(nullptr) {}
 
     bool should_copy() const { return _follow_mode == make_a_copy; }
     void set_buffered_addr(address addr)  {
@@ -157,7 +151,12 @@ private:
     bool read_only()      const    { return _read_only;    }
     int size_in_bytes()   const    { return _size_in_bytes; }
     address source_addr() const    { return _source_addr; }
-    address buffered_addr() const  { return _buffered_addr; }
+    address buffered_addr() const  {
+      if (should_copy()) {
+        assert(_buffered_addr != nullptr, "must be initialized");
+      }
+      return _buffered_addr;
+    }
     MetaspaceObj::Type msotype() const { return _msotype; }
   };
 

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -123,20 +123,17 @@ public:
 
 private:
   class SourceObjInfo {
-    MetaspaceClosure::Ref* _ref; // The object that's copied into the buffer
     uintx _ptrmap_start;     // The bit-offset of the start of this object (inclusive)
     uintx _ptrmap_end;       // The bit-offset of the end   of this object (exclusive)
     bool _read_only;
     FollowMode _follow_mode;
     int _size_in_bytes;
     MetaspaceObj::Type _msotype;
-    address _source_addr;    // The value of the source object (_ref->obj()) when this
-                             // SourceObjInfo was created. Note that _ref->obj() may change
-                             // later if _ref is relocated.
-    address _buffered_addr;  // The copy of _ref->obj() insider the buffer.
+    address _source_addr;    // The source object to be copied.
+    address _buffered_addr;  // The copy of this object insider the buffer.
   public:
     SourceObjInfo(MetaspaceClosure::Ref* ref, bool read_only, FollowMode follow_mode) :
-      _ref(ref), _ptrmap_start(0), _ptrmap_end(0), _read_only(read_only), _follow_mode(follow_mode),
+      _ptrmap_start(0), _ptrmap_end(0), _read_only(read_only), _follow_mode(follow_mode),
       _size_in_bytes(ref->size() * BytesPerWord), _msotype(ref->msotype()),
       _source_addr(ref->obj()) {
       if (follow_mode == point_to_it) {
@@ -147,7 +144,6 @@ private:
     }
 
     bool should_copy() const { return _follow_mode == make_a_copy; }
-    MetaspaceClosure::Ref* ref() const { return  _ref; }
     void set_buffered_addr(address addr)  {
       assert(should_copy(), "must be");
       assert(_buffered_addr == nullptr, "cannot be copied twice");
@@ -163,9 +159,6 @@ private:
     address source_addr() const    { return _source_addr; }
     address buffered_addr() const  { return _buffered_addr; }
     MetaspaceObj::Type msotype() const { return _msotype; }
-
-    // convenience accessor
-    address obj() const { return ref()->obj(); }
   };
 
   class SourceObjList {
@@ -185,14 +178,6 @@ private:
 
     // convenience accessor
     SourceObjInfo* at(int i) const { return objs()->at(i); }
-  };
-
-  class SrcObjTableCleaner {
-  public:
-    bool do_entry(address key, const SourceObjInfo& value) {
-      delete value.ref();
-      return true;
-    }
   };
 
   class CDSMapLogger;

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -135,7 +135,13 @@ private:
     SourceObjInfo(MetaspaceClosure::Ref* ref, bool read_only, FollowMode follow_mode) :
       _ptrmap_start(0), _ptrmap_end(0), _read_only(read_only), _follow_mode(follow_mode),
       _size_in_bytes(ref->size() * BytesPerWord), _msotype(ref->msotype()),
-      _source_addr(ref->obj()), _buffered_addr(nullptr) {}
+      _source_addr(ref->obj()) {
+      if (follow_mode == point_to_it) {
+        _buffered_addr = ref->obj();
+      } else {
+        _buffered_addr = nullptr;
+      }
+    }
 
     bool should_copy() const { return _follow_mode == make_a_copy; }
     void set_buffered_addr(address addr)  {
@@ -152,7 +158,7 @@ private:
     int size_in_bytes()   const    { return _size_in_bytes; }
     address source_addr() const    { return _source_addr; }
     address buffered_addr() const  {
-      if (should_copy()) {
+      if (_follow_mode != set_to_null) {
         assert(_buffered_addr != nullptr, "must be initialized");
       }
       return _buffered_addr;

--- a/src/hotspot/share/memory/metaspaceClosure.cpp
+++ b/src/hotspot/share/memory/metaspaceClosure.cpp
@@ -35,9 +35,7 @@ void MetaspaceClosure::Ref::update(address new_loc) const {
 void MetaspaceClosure::push_impl(MetaspaceClosure::Ref* ref) {
   if (_nest_level < MAX_NEST_LEVEL) {
     do_push(ref);
-    if (!ref->keep_after_pushing()) {
-      delete ref;
-    }
+    delete ref;
   } else {
     do_pending_ref(ref);
     ref->set_next(_pending_refs);
@@ -80,9 +78,7 @@ void MetaspaceClosure::finish() {
     Ref* ref = _pending_refs;
     _pending_refs = _pending_refs->next();
     do_push(ref);
-    if (!ref->keep_after_pushing()) {
-      delete ref;
-    }
+    delete ref;
   }
 }
 

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -106,14 +106,13 @@ public:
   // [2] All Array<T> dimensions are statically declared.
   class Ref : public CHeapObj<mtMetaspace> {
     Writability _writability;
-    bool _keep_after_pushing;
     Ref* _next;
     void* _user_data;
     NONCOPYABLE(Ref);
 
   protected:
     virtual void** mpp() const = 0;
-    Ref(Writability w) : _writability(w), _keep_after_pushing(false), _next(nullptr), _user_data(nullptr) {}
+    Ref(Writability w) : _writability(w), _next(nullptr), _user_data(nullptr) {}
   public:
     virtual bool not_null() const = 0;
     virtual int size() const = 0;
@@ -134,8 +133,6 @@ public:
     void update(address new_loc) const;
 
     Writability writability() const { return _writability; };
-    void set_keep_after_pushing()   { _keep_after_pushing = true; }
-    bool keep_after_pushing()       { return _keep_after_pushing; }
     void set_user_data(void* data)  { _user_data = data; }
     void* user_data()               { return _user_data; }
     void set_next(Ref* n)           { _next = n; }


### PR DESCRIPTION
More CDS clean up:

- Remove the field `SourceObjInfo::_ref` since we have already cached its contents in fields such as `SourceObjInfo::_msotype` and `SourceObjInfo::_source_addr` 
- Since there's no need to keep the `_ref` around, we can remove the `Ref::keep_after_pushing()` API.
- Also `ArchiveBuilder::clean_up_src_obj_table()` is no longer necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308342](https://bugs.openjdk.org/browse/JDK-8308342): Remove MetaspaceClosure::Ref::keep_after_pushing()


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14042/head:pull/14042` \
`$ git checkout pull/14042`

Update a local copy of the PR: \
`$ git checkout pull/14042` \
`$ git pull https://git.openjdk.org/jdk.git pull/14042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14042`

View PR using the GUI difftool: \
`$ git pr show -t 14042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14042.diff">https://git.openjdk.org/jdk/pull/14042.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14042#issuecomment-1552428464)