### PR TITLE
8308347: [s390x]  build broken after JDK-8304913

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
@@ -53,6 +53,7 @@ public record Platform(OperatingSystem os, Architecture arch) {
         // Alias architecture names, if needed
         archName = archName.replace("amd64", "X64");
         archName = archName.replace("ppc64le", "PPC64");
+        archName = archName.replace("s390x", "S390");
         Architecture arch = Architecture.valueOf(archName.toUpperCase(Locale.ROOT));
 
         return new Platform(os, arch);


### PR DESCRIPTION
s390x needs to be recognised as `S390`. After [JDK-8304913](https://bugs.openjdk.org/browse/JDK-8304913) during build I was getting this PluginException: 
```
jdk.tools.jlink.plugin.PluginException: ModuleTarget is malformed: No enum constant jdk.internal.util.Architecture.S390X
        at jdk.jlink/jdk.tools.jlink.builder.DefaultImageBuilder.storeFiles(DefaultImageBuilder.java:181)
        at jdk.jlink/jdk.tools.jlink.internal.ImagePluginStack.storeFiles(ImagePluginStack.java:486)
        at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.writeImage(ImageFileCreator.java:168)
        at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.create(ImageFileCreator.java:100)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask$ImageHelper.retrieve(JlinkTask.java:860)
        at jdk.jlink/jdk.tools.jlink.internal.ImagePluginStack.operate(ImagePluginStack.java:194)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImage(JlinkTask.java:423)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:286)
        at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:56)
        at jdk.jlink/jdk.tools.jlink.internal.Main.main(Main.java:34)
```

Builds tested :`fastdebug, release`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308347](https://bugs.openjdk.org/browse/JDK-8308347): [s390x]  build broken after JDK-8304913


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14043/head:pull/14043` \
`$ git checkout pull/14043`

Update a local copy of the PR: \
`$ git checkout pull/14043` \
`$ git pull https://git.openjdk.org/jdk.git pull/14043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14043`

View PR using the GUI difftool: \
`$ git pr show -t 14043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14043.diff">https://git.openjdk.org/jdk/pull/14043.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14043#issuecomment-1552501737)