### PR TITLE
JDK-8308245: Add -proc:full to describe current default annotation processing policy

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
@@ -285,7 +285,7 @@ public enum Option {
         }
     },
 
-    PROC("-proc:", "opt.proc.none.only", STANDARD, BASIC,  ONEOF, "none", "only"),
+    PROC("-proc:", "opt.proc.none.only", STANDARD, BASIC, ONEOF, "none", "only", "full"),
 
     PROCESSOR("-processor", "opt.arg.class.list", "opt.processor", STANDARD, BASIC),
 

--- a/test/langtools/tools/javac/processing/environment/round/TestContext.java
+++ b/test/langtools/tools/javac/processing/environment/round/TestContext.java
@@ -31,7 +31,7 @@
  *          jdk.compiler/com.sun.tools.javac.processing
  *          jdk.compiler/com.sun.tools.javac.util
  * @build JavacTestingAbstractProcessor TestContext
- * @compile/process -processor TestContext -XprintRounds TestContext
+ * @compile/process -processor TestContext -XprintRounds -proc:full TestContext
  */
 
 import java.io.*;

--- a/test/langtools/tools/javac/processing/options/TestProcOption.java
+++ b/test/langtools/tools/javac/processing/options/TestProcOption.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308245
+ * @summary Test trivial handling of -proc:full option
+ * @compile -proc:full TestProcOption.java
+ * @run main TestProcOption
+ */
+
+/*
+ * The test verifies that compilation takes place when -proc:full is used.
+ */
+public class TestProcOption {
+    private TestProcOption(){};
+
+    public static void main(String... args) {
+        ; // do nothing
+    }
+}


### PR DESCRIPTION
Quick note on this PR: it proposes to add "-proc:full" as a recognized option to explicitly name the current default policy of performing both annotation processing and subsequent compilation.

(It is possible that in a future release, the default will change, in which case having the -proc:full as an option now will was any transition to a new default.)

I tried to write regressions tests to verify that "-proc:none,full" was rejected by javac; it was duly rejected, but rejected with an Error such that the usual compile/fail jtreg tags to did allow the case to pass.

As "-proc:full" corresponds to the current default, there is no new implementation of this policy in the body of the compiler.

Please also review the CSR [JDK-8308346](https://bugs.openjdk.org/browse/JDK-8308346); the CSR lists proposed updates to the javac "man page."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8308346](https://bugs.openjdk.org/browse/JDK-8308346) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8308245](https://bugs.openjdk.org/browse/JDK-8308245): Add -proc:full to describe current default annotation processing policy
 * [JDK-8308346](https://bugs.openjdk.org/browse/JDK-8308346): Add -proc:full to describe current default annotation processing policy (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14044/head:pull/14044` \
`$ git checkout pull/14044`

Update a local copy of the PR: \
`$ git checkout pull/14044` \
`$ git pull https://git.openjdk.org/jdk.git pull/14044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14044`

View PR using the GUI difftool: \
`$ git pr show -t 14044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14044.diff">https://git.openjdk.org/jdk/pull/14044.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14044#issuecomment-1552516369)