### PR TITLE
JDK-8308350: Increase buffer size for jspawnhelper arguments

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -487,7 +487,7 @@ static pid_t
 spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     pid_t resultPid;
     int i, offset, rval, bufsize, magic;
-    char *buf, buf1[16];
+    char *buf, buf1[(2 * 11) + 2]; // "%d:%d\0"
     char *hlpargs[2];
     SpawnInfo sp;
 


### PR DESCRIPTION
Trivial fix for a small problem.

jspawnhelper gets handed several file descriptors as arguments. The buffer size for this string is too small (7 chars per fd) to print out every conceivable int. This will overun the buffer if we happen to have fds larger than (printed size) 7 characters. This could lead to crashes or malfunctions if the parent VM has opened a large amount of file descriptors.

Note that on Linux, this can normally not happen since the kernel limits the number of open file descriptors per process to 1M, and these fds are still printable within the limits of this buffer. It is possible to get more fds per process, but only via kernel patch. But we still should not rely on that. And there is also still MacOS using the same mechanism.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308350](https://bugs.openjdk.org/browse/JDK-8308350): Increase buffer size for jspawnhelper arguments


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14045/head:pull/14045` \
`$ git checkout pull/14045`

Update a local copy of the PR: \
`$ git checkout pull/14045` \
`$ git pull https://git.openjdk.org/jdk.git pull/14045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14045`

View PR using the GUI difftool: \
`$ git pr show -t 14045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14045.diff">https://git.openjdk.org/jdk/pull/14045.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14045#issuecomment-1552626932)