### PR TITLE
8305225: A service broken error despite annotation processor generating it if directives listed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1093,6 +1093,9 @@ public class Modules extends JCTree.Visitor {
                     it = attr.attribType(implName, env, syms.objectType);
                 } finally {
                     env.info.visitingServiceImplementation = prevVisitingServiceImplementation;
+                }
+                if (!it.hasTag(CLASS)) {
+                    continue;
                 }
                 ClassSymbol impl = (ClassSymbol) it.tsym;
                 if ((impl.flags_field & PUBLIC) == 0) {

--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8133884 8162711 8133896 8172158 8172262 8173636 8175119 8189747 8236842 8254023 8263432
+ * @bug 8133884 8162711 8133896 8172158 8172262 8173636 8175119 8189747 8236842 8254023 8263432 8305225
  * @summary Verify that annotation processing works.
  * @library /tools/lib
  * @modules
@@ -2129,6 +2129,94 @@ public class AnnotationProcessing extends ModuleTestBase {
         @Override
         public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
             return false;
+        }
+
+    }
+
+    @Test
+    public void testCreateProvidesWithAP(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path m1 = src.resolve("m");
+
+        tb.writeJavaFiles(m1,
+                          """
+                          module m {
+                              provides api1.Api with test.Test;
+                              uses api1.Api;
+                              uses api2.Api;
+                          }
+                          """);
+
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+
+        List<String> expectedErrors = List.of(
+                "module-info.java:2:18: compiler.err.doesnt.exist: api1",
+                "module-info.java:2:32: compiler.err.doesnt.exist: test",
+                "module-info.java:3:14: compiler.err.doesnt.exist: api1",
+                "module-info.java:4:14: compiler.err.doesnt.exist: api2",
+                "4 errors");
+        List<String> actualErrors = new JavacTask(tb)
+                .options("-XDrawDiagnostics")
+                .outdir(classes)
+                .files(findJavaFiles(m1))
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(expectedErrors, actualErrors);
+
+        new JavacTask(tb)
+                .options("-processor", CreateProvidesWithAP.class.getName())
+                .outdir(classes)
+                .files(findJavaFiles(m1))
+                .run()
+                .writeAll();
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static final class CreateProvidesWithAP extends AbstractProcessor {
+
+        int round;
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            processingEnv.getElementUtils().getModuleElement("m").getDirectives();
+            if (round++ == 0) {
+                try (Writer w = processingEnv.getFiler().createSourceFile("test.Test").openWriter()) {
+                    w.append("""
+                             package test;
+                             public class Test implements api1.Api {
+                             }
+                             """);
+                } catch (IOException ex) {
+                    throw new IllegalStateException(ex);
+                }
+                try (Writer w = processingEnv.getFiler().createSourceFile("api1.Api").openWriter()) {
+                    w.append("""
+                             package api1;
+                             public interface Api {
+                             }
+                             """);
+                } catch (IOException ex) {
+                    throw new IllegalStateException(ex);
+                }
+                try (Writer w = processingEnv.getFiler().createSourceFile("api2.Api").openWriter()) {
+                    w.append("""
+                             package api2;
+                             public interface Api {
+                             }
+                             """);
+                } catch (IOException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latest();
         }
 
     }


### PR DESCRIPTION
Consider code like:
```
module m {
     provides api.Api with impl.Impl; //impl.Impl is not in sources, but is generated by an annotation processor
}
```

This works fine, until the processor asks for the given module's directives, in which case the build fails with an error like:
```
testCreateProvidesWithAP/src/m/module-info.java:2: error: the service implementation does not have a default constructor: Test
    provides api.Api with test.Test;
```

The cause for this error is that when the directive is analyzed, the `test.Test` is attributed (and any errors from that are delayed due to the annotation processing), but even though it attributes to an erroneous type, it will still be checked whether it has the appropriate constructor, etc.

The proposal is to skip the additional checks when the type is an erroneous type. Errors for it should have been reported and handled appropriately (i.e. ignored if resolved by an AP, or reported if not), there does not seem to be any reason to produce any further errors related to the missing type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305225](https://bugs.openjdk.org/browse/JDK-8305225): A service broken error despite annotation processor generating it if directives listed


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14046/head:pull/14046` \
`$ git checkout pull/14046`

Update a local copy of the PR: \
`$ git checkout pull/14046` \
`$ git pull https://git.openjdk.org/jdk.git pull/14046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14046`

View PR using the GUI difftool: \
`$ git pr show -t 14046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14046.diff">https://git.openjdk.org/jdk/pull/14046.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14046#issuecomment-1553056361)