### PR TITLE
8308235: ThreadContainer registry accumulates weak refs

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/ThreadContainers.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadContainers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class ThreadContainers {
      */
     public static Object registerContainer(ThreadContainer container) {
         expungeStaleEntries();
-        var ref = new WeakReference<>(container);
+        var ref = new WeakReference<>(container, QUEUE);
         CONTAINER_REGISTRY.add(ref);
         return ref;
     }

--- a/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
+++ b/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308235
+ * @summary Unreference ExecutorService objects returned by the Executors without shutdown
+ *    and termination, this should not leak memory
+ * @run main/othervm -Xmx32m Leak
+ */
+
+import java.util.concurrent.Executors;
+
+public class UnreferencedExecutor {
+    public static void main(String[] args) throws Exception {
+        int ncores = Runtime.getRuntime().availableProcessors();
+        long start = System.currentTimeMillis();
+        while (System.currentTimeMillis() - start < 5000) {
+            Executors.newFixedThreadPool(ncores);
+            Executors.newCachedThreadPool();
+            Executors.newVirtualThreadPerTaskExecutor();
+            Executors.newWorkStealingPool(ncores);
+        }
+    }
+}
+
+

--- a/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
+++ b/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
@@ -26,7 +26,7 @@
  * @bug 8308235
  * @summary Unreference ExecutorService objects returned by the Executors without shutdown
  *    and termination, this should not leak memory
- * @run main/othervm -Xmx32m Leak
+ * @run main/othervm -Xmx32m UnreferencedExecutor
  */
 
 import java.util.concurrent.Executors;
@@ -43,5 +43,3 @@ public class UnreferencedExecutor {
         }
     }
 }
-
-

--- a/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
+++ b/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
@@ -29,13 +29,18 @@
  * @run main/othervm -Xmx32m UnreferencedExecutor
  */
 
+import java.time.Duration;
 import java.util.concurrent.Executors;
 
 public class UnreferencedExecutor {
+
+    private static final int DURATION_IN_SECONDS = 5;
+
     public static void main(String[] args) throws Exception {
         int ncores = Runtime.getRuntime().availableProcessors();
-        long start = System.currentTimeMillis();
-        while (System.currentTimeMillis() - start < 5000) {
+        long durationNanos = Duration.ofSeconds(DURATION_IN_SECONDS).toNanos();
+        long start = System.nanoTime();
+        while (System.nanoTime() - start < durationNanos) {
             Executors.newFixedThreadPool(ncores);
             Executors.newCachedThreadPool();
             Executors.newVirtualThreadPerTaskExecutor();


### PR DESCRIPTION
ThreadContainers is an internal class used to make thread pools and other groupings of threads discoverable for observability. Some refactoring in 2021 (in the loom repo, and before integration) accidentally changed the creation of a weak reference so that it no longer associated with the reference queue. The result is that stale refs aren't expunged from a CHM, leading to a memory leak. The change to fix the issue is trivial.

Tests for memory leaks can be problematic, often more trouble than they are worth. I started with a test that polls the size of the internal CHM but decided to ditch it. Instead, the test is simple. It just runs for a few seconds creating ExecuorService implementations (including TPE, TPPE, and FJP), unreferencing them without shutdown (so they don't terminate and unregister). This is enough to causes OOME with product builds a small heap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308235](https://bugs.openjdk.org/browse/JDK-8308235): ThreadContainer registry accumulates weak refs


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [89475604](https://git.openjdk.org/jdk/pull/14047/files/89475604c6aa97880c57839e9d4ce9f6610ec4d3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14047/head:pull/14047` \
`$ git checkout pull/14047`

Update a local copy of the PR: \
`$ git checkout pull/14047` \
`$ git pull https://git.openjdk.org/jdk.git pull/14047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14047`

View PR using the GUI difftool: \
`$ git pr show -t 14047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14047.diff">https://git.openjdk.org/jdk/pull/14047.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14047#issuecomment-1554214633)