### PR TITLE
8308187: jdi/EventSet/resume/resume008 failed with "EventHandler> Unexpected event: ThreadStartEvent in thread resume008-thread0"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -339,7 +339,7 @@ public class EventFilters
                 "JFR request timer",
                 "Reference Handler",
                 "VirtualThread-unparker",
-                "Common-",
+                "Cleaner-",
                 "Common-Cleaner",
                 "FinalizerThread",
                 "ForkJoinPool"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -339,6 +339,7 @@ public class EventFilters
                 "JFR request timer",
                 "Reference Handler",
                 "VirtualThread-unparker",
+                "Common-",
                 "Common-Cleaner",
                 "FinalizerThread",
                 "ForkJoinPool"


### PR DESCRIPTION
resume008 test is failing because of an unexpected Cleaner-1 thread being created:

` # ERROR: debugger> ERROR: ThreadStartEvent is not for expected thread: Cleaner-1 `

Threads like Cleaner-1 are suppose to be filtered out so the test doesn't see them. Cleaner-1 had been missed by the filter since it never turned up in testing before. For some reason it started turning up 3 days ago. I'm not sure why, but it doesn't really matter since it should be filtered.

Testing

- Ran test 200 times. Before fix failed 13 times in 200 runs.
- Ran  all the tier5 svc tests, which is where this issue has been turning up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308187](https://bugs.openjdk.org/browse/JDK-8308187): jdi/EventSet/resume/resume008 failed with "EventHandler&gt; Unexpected event: ThreadStartEvent in thread resume008-thread0"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14048/head:pull/14048` \
`$ git checkout pull/14048`

Update a local copy of the PR: \
`$ git checkout pull/14048` \
`$ git pull https://git.openjdk.org/jdk.git pull/14048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14048`

View PR using the GUI difftool: \
`$ git pr show -t 14048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14048.diff">https://git.openjdk.org/jdk/pull/14048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14048#issuecomment-1553334204)