### PR TITLE
8308370: Fix build failures related to the java.awt.Robot documentation

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -430,7 +430,7 @@ public class Robot {
      * to capture screen content, and the required permissions are not granted,
      * then a {@code SecurityException} may be thrown,
      * or the content of the returned {@code Color} is undefined.
-     * <p>
+     * </p>
      * @apiNote It is recommended to avoid calling this method on
      * the AWT Event Dispatch Thread since screen capture may be a lengthy
      * operation, particularly if acquiring permissions is needed and involves
@@ -457,7 +457,7 @@ public class Robot {
      * to capture screen content, and the required permissions are not granted,
      * then a {@code SecurityException} may be thrown,
      * or the contents of the returned {@code BufferedImage} are undefined.
-     * <p>
+     * </p>
      * @apiNote It is recommended to avoid calling this method on
      * the AWT Event Dispatch Thread since screen capture may be a lengthy
      * operation, particularly if acquiring permissions is needed and involves


### PR DESCRIPTION
Fix a typo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308370](https://bugs.openjdk.org/browse/JDK-8308370): Fix build failures related to the java.awt.Robot documentation


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14050/head:pull/14050` \
`$ git checkout pull/14050`

Update a local copy of the PR: \
`$ git checkout pull/14050` \
`$ git pull https://git.openjdk.org/jdk.git pull/14050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14050`

View PR using the GUI difftool: \
`$ git pr show -t 14050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14050.diff">https://git.openjdk.org/jdk/pull/14050.diff</a>

</details>
