### PR TITLE
JDK-8308300: enhance exceptions in MappedMemoryUtils.c

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -185,6 +185,16 @@ JNU_ThrowIOExceptionWithLastError(JNIEnv *env, const char *defaultDetail)
     JNU_ThrowByNameWithLastError(env, "java/io/IOException", defaultDetail);
 }
 
+/*
+ * Convenience method.
+ * Call JNU_ThrowByNameWithMessageAndLastError for java.io.IOException.
+ */
+JNIEXPORT void JNICALL
+JNU_ThrowIOExceptionWithMessageAndLastError(JNIEnv *env, const char *message)
+{
+    JNU_ThrowByNameWithMessageAndLastError(env, "java/io/IOException", message);
+}
+
 
 JNIEXPORT jvalue JNICALL
 JNU_CallStaticMethodByName(JNIEnv *env,

--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -176,7 +176,7 @@ JNU_ThrowByNameWithMessageAndLastError
 }
 
 /*
- * Convenience method.
+ * Convenience function.
  * Call JNU_ThrowByNameWithLastError for java.io.IOException.
  */
 JNIEXPORT void JNICALL
@@ -186,8 +186,8 @@ JNU_ThrowIOExceptionWithLastError(JNIEnv *env, const char *defaultDetail)
 }
 
 /*
- * Convenience method.
- * Call JNU_ThrowByNameWithMessageAndLastError for java.io.IOException.
+ * Throw java.io.IOException using a given message and the string
+ * returned by getLastErrorString to construct the detail string.
  */
 JNIEXPORT void JNICALL
 JNU_ThrowIOExceptionWithMessageAndLastError(JNIEnv *env, const char *message)

--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -92,6 +92,9 @@ JNU_ThrowByNameWithMessageAndLastError
 JNIEXPORT void JNICALL
 JNU_ThrowIOExceptionWithLastError(JNIEnv *env, const char *defaultDetail);
 
+JNIEXPORT void JNICALL
+JNU_ThrowIOExceptionWithMessageAndLastError(JNIEnv *env, const char *message);
+
 /* Convert between Java strings and i18n C strings */
 JNIEXPORT const char *
 GetStringPlatformChars(JNIEnv *env, jstring jstr, jboolean *isCopy);

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
     char *a = (char *)jlong_to_ptr(address);
     int result = madvise((caddr_t)a, (size_t)len, MADV_WILLNEED);
     if (result == -1) {
-        JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with parameter MADV_WILLNEED failed");
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with advise MADV_WILLNEED failed");
     }
 }
 
@@ -121,7 +121,7 @@ Java_java_nio_MappedMemoryUtils_unload0(JNIEnv *env, jobject obj, jlong address,
     char *a = (char *)jlong_to_ptr(address);
     int result = madvise((caddr_t)a, (size_t)len, MADV_DONTNEED);
     if (result == -1) {
-        JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with parameter MADV_DONTNEED failed");
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with advise MADV_DONTNEED failed");
     }
 }
 

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -110,7 +110,7 @@ Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
     char *a = (char *)jlong_to_ptr(address);
     int result = madvise((caddr_t)a, (size_t)len, MADV_WILLNEED);
     if (result == -1) {
-        JNU_ThrowIOExceptionWithLastError(env, "madvise failed");
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with parameter MADV_WILLNEED failed");
     }
 }
 
@@ -121,7 +121,7 @@ Java_java_nio_MappedMemoryUtils_unload0(JNIEnv *env, jobject obj, jlong address,
     char *a = (char *)jlong_to_ptr(address);
     int result = madvise((caddr_t)a, (size_t)len, MADV_DONTNEED);
     if (result == -1) {
-        JNU_ThrowIOExceptionWithLastError(env, "madvise failed");
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with parameter MADV_DONTNEED failed");
     }
 }
 
@@ -132,6 +132,6 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
     void* a = (void *)jlong_to_ptr(address);
     int result = msync(a, (size_t)len, MS_SYNC);
     if (result == -1) {
-        JNU_ThrowIOExceptionWithLastError(env, "msync failed");
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed");
     }
 }


### PR DESCRIPTION
MappedMemoryUtils.c can generate exceptions like those :
java.io.UncheckedIOException: java.io.IOException: Invalid argument
       at java.base/java.nio.MappedMemoryUtils.force(MappedMemoryUtils.java:105)
       at java.base/java.nio.Buffer$2.force(Buffer.java:890)
       at java.base/jdk.internal.misc.ScopedMemoryAccess.forceInternal(ScopedMemoryAccess.java:317)
       at java.base/jdk.internal.misc.ScopedMemoryAccess.force(ScopedMemoryAccess.java:305)
       at java.base/jdk.internal.foreign.MappedMemorySegmentImpl.force(MappedMemorySegmentImpl.java:92)
       at TestByteBuffer.testMappedSegmentAsByteBuffer(TestByteBuffer.java:327)

(we see this for example on AIX); there is some room for improvement, at least the info should be added that msync failed and caused this exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308300](https://bugs.openjdk.org/browse/JDK-8308300): enhance exceptions in MappedMemoryUtils.c


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14054/head:pull/14054` \
`$ git checkout pull/14054`

Update a local copy of the PR: \
`$ git checkout pull/14054` \
`$ git pull https://git.openjdk.org/jdk.git pull/14054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14054`

View PR using the GUI difftool: \
`$ git pr show -t 14054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14054.diff">https://git.openjdk.org/jdk/pull/14054.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14054#issuecomment-1554119440)