### PR TITLE
8308403: [s390x] separate remaining_cargs from z_abi_160

### DIFF
--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -96,15 +96,15 @@
 
   // ABI_160:
 
-  // REMARK: This structure should reflect the "minimal" ABI frame
-  // layout, but it doesn't. There is an extra field at the end of the
+  // REMARK: z_abi_160_base structure reflect the "minimal" ABI frame
+  // layout. There is an field in the z_abi_160
   // structure that marks the area where arguments are passed, when
   // the argument registers "overflow". Thus, sizeof(z_abi_160)
   // doesn't yield the expected (and desired) result. Therefore, as
   // long as we do not provide extra infrastructure, one should use
   // either z_abi_160_size, or _z_abi(remaining_cargs) instead of
   // sizeof(...).
-  struct z_abi_160 : z_native_abi {
+  struct z_abi_160_base : z_native_abi {
     uint64_t carg_1;
     uint64_t carg_2;
     uint64_t carg_3;
@@ -123,12 +123,15 @@
     uint64_t cfarg_2;
     uint64_t cfarg_3;
     uint64_t cfarg_4;
+  };
+
+  struct z_abi_160: z_abi_160_base {
     uint64_t remaining_cargs;
   };
 
   enum {
     z_native_abi_size = sizeof(z_native_abi),
-    z_abi_160_size = 160
+    z_abi_160_size = sizeof(z_abi_160_base)
   };
 
   #define _z_abi(_component) \

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -100,10 +100,9 @@
   // layout. There is a field in the z_abi_160
   // structure that marks the area where arguments are passed, when
   // the argument registers "overflow". Thus, sizeof(z_abi_160)
-  // doesn't yield the expected (and desired) result. Therefore, as
-  // long as we do not provide extra infrastructure, one should use
-  // either z_abi_160_size, or _z_abi(remaining_cargs) instead of
-  // sizeof(...).
+  // doesn't yield the expected (and desired) result.
+  // Therefore, please use sizeof(z_abi_160_base) or
+  // the enum value z_abi_160_size to find out the size of the ABI structure.
   struct z_abi_160_base : z_native_abi {
     uint64_t carg_1;
     uint64_t carg_2;

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -97,7 +97,7 @@
   // ABI_160:
 
   // REMARK: z_abi_160_base structure reflect the "minimal" ABI frame
-  // layout. There is an field in the z_abi_160
+  // layout. There is a field in the z_abi_160
   // structure that marks the area where arguments are passed, when
   // the argument registers "overflow". Thus, sizeof(z_abi_160)
   // doesn't yield the expected (and desired) result. Therefore, as


### PR DESCRIPTION
This PR split `z_abi_160` into `z_abi_160_base` and `z_abi_160`. `z_abi_160_base` will represent the minimal structure and overflowing args will be taken care by `remaining_cargs` field present in `z_abi_160`.  We're separating this field because it's causing issue in calculating the correct frame size for Vthreads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308403](https://bugs.openjdk.org/browse/JDK-8308403): [s390x] separate remaining_cargs from z_abi_160


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [e3417b09](https://git.openjdk.org/jdk/pull/14055/files/e3417b092f2f43fbda123fb4c90dfc72eafe3927)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14055/head:pull/14055` \
`$ git checkout pull/14055`

Update a local copy of the PR: \
`$ git checkout pull/14055` \
`$ git pull https://git.openjdk.org/jdk.git pull/14055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14055`

View PR using the GUI difftool: \
`$ git pr show -t 14055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14055.diff">https://git.openjdk.org/jdk/pull/14055.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14055#issuecomment-1554234474)