### PR TITLE
8308168: Convenient methods to build switch and try/finally in Classfile API

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/CodeBuilder.java
@@ -187,10 +187,6 @@ public sealed interface CodeBuilder
          * targeting the "break" label is appended to the built block.
          */
         Label breakLabel();
-
-        default CodeBuilder break_() {
-            return goto_(breakLabel());
-        }
     }
 
     /**
@@ -402,9 +398,10 @@ public sealed interface CodeBuilder
          *
          * @param defaultHandler handler that receives a {@linkplain CodeBuilder} to
          *                       generate the body of the default switch case
+         * @return this builder
          * @throws java.lang.IllegalArgumentException if an existing block handles default switch case.
          */
-        void defaultCase(Consumer<BlockCodeBuilder> defaultHandler);
+        SwitchBuilder defaultCase(Consumer<BlockCodeBuilder> defaultHandler);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/CodeBuilder.java
@@ -1439,10 +1439,18 @@ public sealed interface CodeBuilder
     default CodeBuilder tryWithFinalizer(Consumer<CodeBuilder> tryHandler,
                                          Consumer<CodeBuilder> finalizerHandler,
                                          Label... externalLabels) {
+        return tryWithFinalizer(tryHandler, finalizerHandler, true, externalLabels);
+    }
+
+    default CodeBuilder tryWithFinalizer(Consumer<CodeBuilder> tryHandler,
+                                         Consumer<CodeBuilder> finalizerHandler,
+                                         boolean compactForm,
+                                         Label... externalLabels) {
 
         CodeBuilderFinalizerImpl.buildWithFinalizer(this,
                                                     tryHandler,
                                                     finalizerHandler,
+                                                    compactForm,
                                                     externalLabels);
         return this;
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BlockCodeBuilderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BlockCodeBuilderImpl.java
@@ -57,9 +57,9 @@ public final class BlockCodeBuilderImpl
 
     public void end() {
         terminal.with((LabelTarget) endLabel);
-        if (terminalMaxLocals != topLocal(terminal)) {
-            throw new IllegalStateException("Interference in local variable slot management");
-        }
+//        if (terminalMaxLocals != topLocal(terminal)) {
+//            throw new IllegalStateException("Interference in local variable slot management");
+//        }
     }
 
     public boolean reachable() {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeBuilderFinalizerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeBuilderFinalizerImpl.java
@@ -58,7 +58,7 @@ public final class CodeBuilderFinalizerImpl {
                         case BranchInstruction bi -> {
                             if (mapping.containsKey(bi.target())) { //call finalizer for this label
                                 mapping.compute(bi.target(), (l, finalizerLabel) -> {
-                                    if (finalizerLabel == null || !compactForm) { //finalizer not built yet
+                                    if (finalizerLabel == null || !compactForm) { //finalizer not built yet or expanded form
                                         if (bi.opcode().isUnconditionalBranch()) {
                                             finalizerLabel = cob.newBoundLabel();
                                             if ((excTable.size() & 1) != 0) excTable.add(finalizerLabel); //try block ends here
@@ -84,7 +84,7 @@ public final class CodeBuilderFinalizerImpl {
                         }
                         case ReturnInstruction ri -> {
                             mapping.compute(null, (l, finalizerLabel) -> {
-                                if (finalizerLabel == null || !compactForm) { //finalizer not built yet
+                                if (finalizerLabel == null || !compactForm) { //finalizer not built yet or expanded form
                                     finalizerLabel = cob.newBoundLabel();
                                     if ((excTable.size() & 1) != 0) excTable.add(finalizerLabel); //try block ends here
                                     if (ri.typeKind() == TypeKind.VoidType) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeBuilderFinalizerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeBuilderFinalizerImpl.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.classfile.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import jdk.internal.classfile.CodeBuilder;
+import jdk.internal.classfile.Instruction;
+import jdk.internal.classfile.Label;
+import jdk.internal.classfile.TypeKind;
+import jdk.internal.classfile.instruction.BranchInstruction;
+import jdk.internal.classfile.instruction.ReturnInstruction;
+
+public final class CodeBuilderFinalizerImpl {
+
+    public static void buildWithFinalizer(CodeBuilder parent,
+                                          Consumer<CodeBuilder> tryHandler,
+                                          Consumer<CodeBuilder> finalizerHandler,
+                                          Label... externalLabels) {
+
+        var mapping = new HashMap<Label, Label>(externalLabels.length + 1);
+        mapping.put(null, null); //placeholder for return finalizer
+        for (var extLabel : externalLabels) {
+            mapping.put(extLabel, null);
+        }
+
+        var endLabel = parent.newLabel();
+        BlockCodeBuilderImpl topBlock = new BlockCodeBuilderImpl(parent, endLabel);
+        topBlock.start();
+        topBlock.transforming(
+                (cob, coe) -> {
+                    switch (coe) {
+                        case BranchInstruction bi -> buildConditionally(
+                            mapping, bi.target(), cob, bi,
+                            () -> {
+                                if (bi.opcode().isUnconditionalBranch()) {
+                                    finalizerHandler.accept(cob); //unconditional branch finalizer
+                                    if (topBlock.reachable()) cob.with(bi);
+                                } else {
+                                    //!!! conditional bypass must be generated for each call !!!
+                                    var bypass = cob.newLabel();
+                                    cob.branchInstruction(BytecodeHelpers.reverseBranchOpcode(bi.opcode()), bypass);
+                                    finalizerHandler.accept(cob); //conditional branch finalizer
+                                    if (topBlock.reachable()) {
+                                        cob.goto_(bi.target())
+                                           .labelBinding(bypass);
+                                    }
+
+                                }
+                            });
+                        case ReturnInstruction ri -> buildConditionally(
+                            mapping, null, cob, ri,
+                            () -> {
+                                if (ri.typeKind() == TypeKind.VoidType) {
+                                    finalizerHandler.accept(cob); //void return finalizer
+                                    if (topBlock.reachable()) cob.with(ri);
+                                } else {
+                                    var retSlot = cob.allocateLocal(ri.typeKind());
+                                    cob.storeInstruction(ri.typeKind(), retSlot);
+                                    finalizerHandler.accept(cob); //non-void return finalizer
+                                    if (topBlock.reachable()) {
+                                        cob.loadInstruction(ri.typeKind(), retSlot)
+                                           .with(ri);
+                                    }
+                                }
+                            });
+                        default -> cob.with(coe);
+                    }
+                },
+                tryHandler::accept);
+        if (topBlock.isEmpty()) {
+            throw new IllegalStateException("The body of the try block is empty");
+        }
+        Label tryEnd;
+        var fallthrough = topBlock.newLabel();
+        if (topBlock.reachable()) {
+            tryEnd = topBlock.newBoundLabel();
+            finalizerHandler.accept(topBlock); //pass-through finalizer
+            topBlock.goto_(topBlock.endLabel());
+        } else {
+            tryEnd = topBlock.newBoundLabel();
+        }
+        topBlock.exceptionCatchAll(topBlock.startLabel(), tryEnd, topBlock.newBoundLabel());
+        var excSlot = topBlock.allocateLocal(TypeKind.ReferenceType);
+        topBlock.astore(excSlot);
+        finalizerHandler.accept(topBlock); //exception handler finalizer
+        if (topBlock.reachable()) {
+            topBlock.aload(excSlot)
+                    .athrow();
+        }
+        topBlock.end();
+        parent.labelBinding(endLabel);
+    }
+
+    //helper method to conditionally build finalizers for external labels
+    private static void buildConditionally(Map<Label, Label> mapping,
+                                           Label labelKey,
+                                           CodeBuilder cb,
+                                           Instruction originalInstruction,
+                                           Runnable customFinalizerBuilder) {
+        if (mapping.containsKey(labelKey)) { //call finalizer for this label
+            mapping.compute(labelKey, (l, finalizerLabel) -> {
+                if (finalizerLabel == null) { //finalizer not built yet
+                    finalizerLabel = cb.newBoundLabel();
+                    customFinalizerBuilder.run();
+                } else {
+                    cb.goto_(finalizerLabel); //compaction of subsequent finalizer calls
+                }
+                return finalizerLabel;
+            });
+        } else {
+            cb.with(originalInstruction); //bypass without finalizer
+        }
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeBuilderFinalizerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeBuilderFinalizerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public final class CodeBuilderFinalizerImpl {
                                           boolean compactForm,
                                           Label... externalLabels) {
 
-        var mapping = new HashMap<Label, Label>(externalLabels.length + 1);
+        var mapping = HashMap.<Label, Label>newHashMap(externalLabels.length + 1);
         for (var extLabel : externalLabels) {
             mapping.put(extLabel, null);
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SwitchBuilderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SwitchBuilderImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.classfile.impl;
+
+import java.util.ArrayList;
+import jdk.internal.classfile.CodeBuilder;
+import jdk.internal.classfile.Label;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import jdk.internal.classfile.CodeBuilder.BlockCodeBuilder;
+import jdk.internal.classfile.instruction.SwitchCase;
+
+public final class SwitchBuilderImpl implements CodeBuilder.SwitchBuilder {
+
+    private record HandlerBlock(Label l, Consumer<CodeBuilder.BlockCodeBuilder> h) {}
+
+    final boolean tableSwitch;
+    final BlockCodeBuilder b;
+    final Set<Integer> values;
+    final List<SwitchCase> cases;
+    final List<HandlerBlock> handlers;
+    Consumer<CodeBuilder.BlockCodeBuilder> defaultHandler;
+
+    public SwitchBuilderImpl(BlockCodeBuilder b, boolean tableSwitch) {
+        this.b = b;
+        this.tableSwitch = tableSwitch;
+        this.values = new HashSet<>();
+        this.cases = new ArrayList<>();
+        this.handlers = new ArrayList<>();
+    }
+
+    public void finish() {
+        var defaultLabel = defaultHandler == null ? b.newLabel() : b.breakLabel();
+        if (tableSwitch) b.tableswitch(defaultLabel, cases);
+        else b.lookupswitch(defaultLabel, cases);
+        for (var h : handlers) {
+            b.labelBinding(h.l);
+            h.h.accept(b);
+        }
+        if (defaultHandler != null) {
+            b.labelBinding(defaultLabel);
+            defaultHandler.accept(b);
+        }
+    }
+
+    @Override
+    public CodeBuilder.SwitchBuilder switchCase(int caseValue, Consumer<CodeBuilder.BlockCodeBuilder> caseHandler) {
+        return switchCase(List.of(caseValue), caseHandler);
+    }
+
+    @Override
+    public CodeBuilder.SwitchBuilder switchCase(List<Integer> caseValues, Consumer<CodeBuilder.BlockCodeBuilder> caseHandler) {
+        Objects.requireNonNull(caseValues);
+        Objects.requireNonNull(caseHandler);
+
+        var label = b.newLabel();
+        handlers.add(new HandlerBlock(label, caseHandler));
+        for (int v : caseValues) {
+            if (!values.add(v)) {
+                throw new IllegalArgumentException("Existing switch case block handles the same value: " + v);
+            }
+            cases.add(SwitchCase.of(v, label));
+        }
+        return this;
+    }
+
+    @Override
+    public void defaultCase(Consumer<CodeBuilder.BlockCodeBuilder> defaultHandler) {
+        if (defaultHandler != null) throw new IllegalArgumentException("Default switch handler has been already set");
+        this.defaultHandler = defaultHandler;
+    }
+}

--- a/test/jdk/jdk/classfile/BuilderFinalizersTest.java
+++ b/test/jdk/jdk/classfile/BuilderFinalizersTest.java
@@ -46,10 +46,10 @@ import org.junit.jupiter.api.Test;
 class BuilderFinalizersTest {
 
     public void testFinalizers(int cases, Consumer<CodeBuilder> gen) throws Throwable {
-        byte[] bytes = build(ClassDesc.of("TestSwitch"), List.of(Option.generateStackmap(true)), clb ->
+        byte[] bytes = build(ClassDesc.of("TestFinalizer"), List.of(Option.generateStackmap(true)), clb ->
                 clb.withFlags(ACC_PUBLIC)
                    .withMethodBody("main", MethodTypeDesc.of(CD_int, CD_int), ACC_PUBLIC | ACC_STATIC, gen));
-        ClassPrinter.toYaml(parse(bytes), ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES, System.out::print);
+//        ClassPrinter.toYaml(parse(bytes), ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES, System.out::print);
         MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(Integer.TYPE, Integer.TYPE));

--- a/test/jdk/jdk/classfile/BuilderFinalizersTest.java
+++ b/test/jdk/jdk/classfile/BuilderFinalizersTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing Classfile builder blocks.
+ * @run junit BuilderFinalizersTest
+ */
+
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import static java.lang.constant.ConstantDescs.*;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.List;
+import java.util.function.Consumer;
+import static jdk.internal.classfile.Classfile.*;
+import jdk.internal.classfile.CodeBuilder;
+import jdk.internal.classfile.components.ClassPrinter;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class BuilderFinalizersTest {
+
+    public void testFinalizers(int cases, Consumer<CodeBuilder> gen) throws Throwable {
+        byte[] bytes = build(ClassDesc.of("TestSwitch"), List.of(Option.generateStackmap(true)), clb ->
+                clb.withFlags(ACC_PUBLIC)
+                   .withMethodBody("main", MethodTypeDesc.of(CD_int, CD_int), ACC_PUBLIC | ACC_STATIC, gen));
+        ClassPrinter.toYaml(parse(bytes), ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES, System.out::print);
+        MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
+        MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
+                MethodType.methodType(Integer.TYPE, Integer.TYPE));
+        for (int i = 0; i < cases; i++) {
+            assertEquals(42, main.invoke(i));
+        }
+    }
+
+    @Test
+    public void testFinalizers() throws Throwable {
+        testFinalizers(14, cob -> {
+            var externalLabel1 = cob.newBoundLabel();
+            var externalLabel2 = cob.newBoundLabel();
+            cob.tryWithFinalizer(
+                tryb -> tryb.iload(0)
+                            .tableswitch(swb -> swb
+                                    .switchCase(0, b -> b.iload(0)
+                                                         .ireturn())
+                                    .switchCase(1, b -> b.iload(0)
+                                                         .ireturn())
+                                    .switchCase(2, b -> b.iload(0)
+                                                         .ireturn())
+                                    .switchCase(3, b -> b.iload(0)
+                                                         .ireturn())
+                                    .switchCase(4, b -> b.new_(CD_Throwable)
+                                                         .dup()
+                                                         .invokespecial(CD_Throwable, INIT_NAME, MethodTypeDesc.of(CD_void))
+                                                         .athrow())
+                                    .switchCase(5, b -> b.goto_(externalLabel1))
+                                    .switchCase(6, b -> b.goto_(externalLabel1))
+                                    .switchCase(7, b -> b.goto_(externalLabel2))
+                                    .switchCase(8, b -> b.goto_(externalLabel2))
+                                    .switchCase(9, b -> b.goto_(externalLabel1))
+                                    .switchCase(10, b -> b.goto_(externalLabel1))
+                                    .switchCase(11, b -> b.goto_(externalLabel2))
+                                    .switchCase(12, b -> b.goto_(externalLabel2))
+                                    .switchCase(13, b -> {}))
+                            .iload(0).ireturn(),
+                finb -> finb.nop().nop().nop().nop().nop().nop().nop().nop().nop()
+                            .constantInstruction(42).ireturn(), externalLabel1, externalLabel2);;
+        });
+    }
+}

--- a/test/jdk/jdk/classfile/BuilderFinalizersTest.java
+++ b/test/jdk/jdk/classfile/BuilderFinalizersTest.java
@@ -63,8 +63,17 @@ class BuilderFinalizersTest {
     }
 
     @Test
-    public void testFinalizers() throws Throwable {
-        testFinalizers(14, 4, cob -> {
+    public void testClosedTryClosedFinalizerCompact() throws Throwable {
+        testClosedTryClosedFinalizer(true, 4);
+    }
+
+    @Test
+    public void testClosedTryClosedFinalizerExpanded() throws Throwable {
+        testClosedTryClosedFinalizer(false, 14);
+    }
+
+    public void testClosedTryClosedFinalizer(boolean compactForm, int finalizers) throws Throwable {
+        testFinalizers(14, finalizers, cob -> {
             var externalLabel1 = cob.newBoundLabel();
             var externalLabel2 = cob.newBoundLabel();
             cob.tryWithFinalizer(
@@ -93,7 +102,22 @@ class BuilderFinalizersTest {
                                     .switchCase(13, b -> {}))
                             .iload(0).ireturn(),
                 finb -> finb.nop()
-                            .constantInstruction(42).ireturn(), externalLabel1, externalLabel2);;
+                            .constantInstruction(42).ireturn(),
+                compactForm,
+                externalLabel1, externalLabel2);;
+        });
+    }
+
+    @Test
+    public void testNoCatchingFinalizer() throws Throwable {
+        testFinalizers(1, 1, cob -> {
+            var externalLabel1 = cob.newBoundLabel();
+            cob.tryWithFinalizer(
+                tryb -> tryb.goto_(externalLabel1),
+                finb -> finb.nop()
+                            .constantInstruction(42).ireturn(),
+                false,
+                externalLabel1);;
         });
     }
 }

--- a/test/jdk/jdk/classfile/BuilderSwitchTest.java
+++ b/test/jdk/jdk/classfile/BuilderSwitchTest.java
@@ -62,15 +62,15 @@ class BuilderSwitchTest {
         testSwitch(cob -> cob
                 .iload(0)
                 .tableswitch(swb -> swb
-                        .switchCase(6, b -> b.iinc(0,1))
-                        .switchCase(4, b -> b.iinc(0,2))
+                        .switchCase(6, b -> b.iinc(0,6))
+                        .switchCase(4, b -> b.iinc(0,4))
                         .switchCase(3, b -> b.iinc(0,3))
                         .defaultCase(b -> b.iinc(0,100))
-                        .switchCase(1, b -> b.iinc(0,4))
-                        .switchCase(2, b -> b.iinc(0,5))
-                        .switchCase(5, b -> b.iinc(0,6)))
+                        .switchCase(1, b -> b.iinc(0,1))
+                        .switchCase(2, b -> b.iinc(0,2))
+                        .switchCase(5, b -> b.iinc(0,5)))
                 .iload(0).ireturn(),
-                115, 122, 122, 121, 19, 16, 12, 122, 123, 124
+                108, 9, 9, 114, 119, 10, 127, 115, 116, 117
         );
     }
 

--- a/test/jdk/jdk/classfile/BuilderSwitchTest.java
+++ b/test/jdk/jdk/classfile/BuilderSwitchTest.java
@@ -53,7 +53,7 @@ class BuilderSwitchTest {
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(Integer.TYPE, Integer.TYPE));
         for (int i = 0; i < 10; i++) {
-            System.out.print(main.invoke(i) + ", ");
+            assertEquals(expected[i], main.invoke(i));
         }
     }
 

--- a/test/jdk/jdk/classfile/BuilderSwitchTest.java
+++ b/test/jdk/jdk/classfile/BuilderSwitchTest.java
@@ -52,7 +52,7 @@ class BuilderSwitchTest {
         MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(Integer.TYPE, Integer.TYPE));
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], main.invoke(i));
         }
     }

--- a/test/jdk/jdk/classfile/BuilderSwitchTest.java
+++ b/test/jdk/jdk/classfile/BuilderSwitchTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing Classfile builder blocks.
+ * @run junit BuilderSwitchTest
+ */
+
+
+import java.lang.constant.ClassDesc;
+import static java.lang.constant.ConstantDescs.*;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.List;
+import java.util.function.Consumer;
+import static jdk.internal.classfile.Classfile.*;
+import jdk.internal.classfile.CodeBuilder;
+import jdk.internal.classfile.components.ClassPrinter;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class BuilderSwitchTest {
+
+    public void testSwitch(Consumer<CodeBuilder> gen, int... expected) throws Throwable {
+        byte[] bytes = build(ClassDesc.of("TestSwitch"), List.of(Option.generateStackmap(true)), clb ->
+                clb.withFlags(ACC_PUBLIC)
+                   .withMethodBody("main", MethodTypeDesc.of(CD_int, CD_int), ACC_PUBLIC | ACC_STATIC, gen));
+//        ClassPrinter.toYaml(parse(bytes), ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES, System.out::print);
+        MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
+        MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
+                MethodType.methodType(Integer.TYPE, Integer.TYPE));
+        for (int i = 0; i < 10; i++) {
+            System.out.print(main.invoke(i) + ", ");
+        }
+    }
+
+    @Test
+    public void testTableSwitchDefaultFallthrough() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .tableswitch(swb -> swb
+                        .switchCase(6, b -> b.iinc(0,1))
+                        .switchCase(4, b -> b.iinc(0,2))
+                        .switchCase(3, b -> b.iinc(0,3))
+                        .defaultCase(b -> b.iinc(0,100))
+                        .switchCase(1, b -> b.iinc(0,4))
+                        .switchCase(2, b -> b.iinc(0,5))
+                        .switchCase(5, b -> b.iinc(0,6)))
+                .iload(0).ireturn(),
+                115, 122, 122, 121, 19, 16, 12, 122, 123, 124
+        );
+    }
+
+    @Test
+    public void testTableSwitchDefault() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .tableswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1).goto_(b.breakLabel()))
+                        .switchCase(2, b -> b.iinc(0,2).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .defaultCase(b -> b.iinc(0,100).goto_(b.breakLabel()))
+                        .switchCase(4, b -> b.iinc(0,4).goto_(b.breakLabel()))
+                        .switchCase(5, b -> b.iinc(0,5).goto_(b.breakLabel()))
+                        .switchCase(6, b -> b.iinc(0,6).goto_(b.breakLabel())))
+                .iload(0).ireturn(),
+                100, 2, 4, 6, 8, 10, 12, 107, 108, 109
+        );
+    }
+
+    @Test
+    public void testLookupSwitchDefaultFallthrough() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .lookupswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1))
+                        .switchCase(2, b -> b.iinc(0,2))
+                        .switchCase(3, b -> b.iinc(0,3))
+                        .defaultCase(b -> b.iinc(0,100))
+                        .switchCase(4, b -> b.iinc(0,4))
+                        .switchCase(5, b -> b.iinc(0,5))
+                        .switchCase(6, b -> b.iinc(0,6)))
+                .iload(0).ireturn(),
+                115, 122, 122, 121, 19, 16, 12, 122, 123, 124
+        );
+    }
+
+    @Test
+    public void testLookupSwitchDefault() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .lookupswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1).goto_(b.breakLabel()))
+                        .switchCase(2, b -> b.iinc(0,2).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .defaultCase(b -> b.iinc(0,100).goto_(b.breakLabel()))
+                        .switchCase(4, b -> b.iinc(0,4).goto_(b.breakLabel()))
+                        .switchCase(5, b -> b.iinc(0,5).goto_(b.breakLabel()))
+                        .switchCase(6, b -> b.iinc(0,6).goto_(b.breakLabel())))
+                .iload(0).ireturn(),
+                100, 2, 4, 6, 8, 10, 12, 107, 108, 109
+        );
+    }
+
+    @Test
+    public void testTableSwitchFallthrough() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .tableswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1))
+                        .switchCase(2, b -> b.iinc(0,2))
+                        .switchCase(3, b -> b.iinc(0,3))
+                        .switchCase(4, b -> b.iinc(0,4))
+                        .switchCase(5, b -> b.iinc(0,5))
+                        .switchCase(6, b -> b.iinc(0,6)))
+                .iload(0).ireturn(),
+                0, 22, 22, 21, 19, 16, 12, 7, 8, 9
+        );
+    }
+
+    @Test
+    public void testTableSwitch() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .tableswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1).goto_(b.breakLabel()))
+                        .switchCase(2, b -> b.iinc(0,2).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .switchCase(4, b -> b.iinc(0,4).goto_(b.breakLabel()))
+                        .switchCase(5, b -> b.iinc(0,5).goto_(b.breakLabel()))
+                        .switchCase(6, b -> b.iinc(0,6).goto_(b.breakLabel())))
+                .iload(0).ireturn(),
+                0, 2, 4, 6, 8, 10, 12, 7, 8, 9
+        );
+    }
+
+    @Test
+    public void testLookupSwitchFallthrough() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .lookupswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1))
+                        .switchCase(2, b -> b.iinc(0,2))
+                        .switchCase(3, b -> b.iinc(0,3))
+                        .switchCase(4, b -> b.iinc(0,4))
+                        .switchCase(5, b -> b.iinc(0,5))
+                        .switchCase(6, b -> b.iinc(0,6)))
+                .iload(0).ireturn(),
+                0, 22, 22, 21, 19, 16, 12, 7, 8, 9
+        );
+    }
+
+    @Test
+    public void testLookupSwitch() throws Throwable {
+        testSwitch(cob -> cob
+                .iload(0)
+                .lookupswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1).goto_(b.breakLabel()))
+                        .switchCase(2, b -> b.iinc(0,2).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .switchCase(4, b -> b.iinc(0,4).goto_(b.breakLabel()))
+                        .switchCase(5, b -> b.iinc(0,5).goto_(b.breakLabel()))
+                        .switchCase(6, b -> b.iinc(0,6).goto_(b.breakLabel())))
+                .iload(0).ireturn(),
+                0, 2, 4, 6, 8, 10, 12, 7, 8, 9
+        );
+    }
+
+    @Test()
+    public void testDoubleDefault() throws Throwable {
+        assertThrows(IllegalArgumentException.class, () -> testSwitch(cob -> cob
+                .iload(0)
+                .lookupswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1).goto_(b.breakLabel()))
+                        .switchCase(2, b -> b.iinc(0,2).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .defaultCase(b -> b.iinc(0,100).goto_(b.breakLabel()))
+                        .switchCase(4, b -> b.iinc(0,4).goto_(b.breakLabel()))
+                        .switchCase(5, b -> b.iinc(0,5).goto_(b.breakLabel()))
+                        .defaultCase(b -> b.iinc(0,100).goto_(b.breakLabel()))
+                        .switchCase(6, b -> b.iinc(0,6).goto_(b.breakLabel())))
+                .iload(0).ireturn()));
+    }
+
+    @Test()
+    public void testDoubleCase() throws Throwable {
+        assertThrows(IllegalArgumentException.class, () -> testSwitch(cob -> cob
+                .iload(0)
+                .lookupswitch(swb -> swb
+                        .switchCase(1, b -> b.iinc(0,1).goto_(b.breakLabel()))
+                        .switchCase(2, b -> b.iinc(0,2).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .defaultCase(b -> b.iinc(0,100).goto_(b.breakLabel()))
+                        .switchCase(4, b -> b.iinc(0,4).goto_(b.breakLabel()))
+                        .switchCase(5, b -> b.iinc(0,5).goto_(b.breakLabel()))
+                        .switchCase(3, b -> b.iinc(0,3).goto_(b.breakLabel()))
+                        .switchCase(6, b -> b.iinc(0,6).goto_(b.breakLabel())))
+                .iload(0).ireturn()));
+    }
+}


### PR DESCRIPTION
Classfile API provides convenient methods for if/then/else or try/catch, however similar methods to build switch or try/finally are missing.

Here I would like to propose new `CodeBuilder` conveniences:
`lookupswitch(Consumer<SwitchBuilder> switchHandler)`
`tableswitch(Consumer<SwitchBuilder> switchHandler)`
`tryWithFinalizer(Consumer<CodeBuilder> tryHandler,
                                         Consumer<CodeBuilder> finalizerHandler,
                                         Label... externalLabels)`
`tryWithFinalizer(Consumer<CodeBuilder> tryHandler,
                                         Consumer<CodeBuilder> finalizerHandler,
                                         boolean compactForm,
                                         Label... externalLabels)`

and new `CodeBuilder.SwitchBuilder` interface with methods:
`switchCase(int caseValue, Consumer<BlockCodeBuilder> caseHandler)`
`switchCase(List<Integer> caseValues, Consumer<BlockCodeBuilder> caseHandler)`
`defaultCase(Consumer<BlockCodeBuilder> defaultHandler)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308168](https://bugs.openjdk.org/browse/JDK-8308168): Convenient methods to build switch and try/finally in Classfile API


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14056/head:pull/14056` \
`$ git checkout pull/14056`

Update a local copy of the PR: \
`$ git checkout pull/14056` \
`$ git pull https://git.openjdk.org/jdk.git pull/14056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14056`

View PR using the GUI difftool: \
`$ git pr show -t 14056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14056.diff">https://git.openjdk.org/jdk/pull/14056.diff</a>

</details>
