### PR TITLE
8308408: Build failure with -Werror=maybe-uninitialized in libjli/java.c with GCC8

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1205,7 +1205,7 @@ ParseArguments(int *pargc, char ***pargv,
     int argc = *pargc;
     char **argv = *pargv;
     int mode = LM_UNKNOWN;
-    char *arg;
+    char *arg = NULL;
 
     *pret = 0;
 


### PR DESCRIPTION
May I get review for this change which fixes the build broken with GCC8?
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308408](https://bugs.openjdk.org/browse/JDK-8308408): Build failure with -Werror=maybe-uninitialized in libjli/java.c with GCC8


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14057/head:pull/14057` \
`$ git checkout pull/14057`

Update a local copy of the PR: \
`$ git checkout pull/14057` \
`$ git pull https://git.openjdk.org/jdk.git pull/14057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14057`

View PR using the GUI difftool: \
`$ git pr show -t 14057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14057.diff">https://git.openjdk.org/jdk/pull/14057.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14057#issuecomment-1554341980)