### PR TITLE
8308410: broken compilation of test\jdk\tools\launcher\exeJliLaunchTest.c

### DIFF
--- a/test/jdk/tools/launcher/exeJliLaunchTest.c
+++ b/test/jdk/tools/launcher/exeJliLaunchTest.c
@@ -36,15 +36,17 @@ int
 main(int argc, char **args)
 {
     //avoid null-terminated array of arguments to test JDK-8303669
-    char *argv[argc];
+    char **argv = malloc(sizeof(char *) * argc);
     for (int i = 0; i < argc; i++) {
         argv[i] = args[i];
     }
 
-    return JLI_Launch(argc, argv,
+    int ret = JLI_Launch(argc, argv,
                    0, NULL,
                    0, NULL,
                    "1", "0",
                    *argv, *argv,
                    0, 0, 0, 0);
+    free(argv);
+    return ret;
 }


### PR DESCRIPTION
JDK-8303669 patch to test\jdk\tools\launcher\exeJliLaunchTest.c broke compilation on windows.
Unfortunately MSVC does not support variable length arrays.
This patch fixes test\jdk\tools\launcher\exeJliLaunchTest.c to use dynamic array allocation.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308410](https://bugs.openjdk.org/browse/JDK-8308410): broken compilation of test\jdk\tools\launcher\exeJliLaunchTest.c


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14060/head:pull/14060` \
`$ git checkout pull/14060`

Update a local copy of the PR: \
`$ git checkout pull/14060` \
`$ git pull https://git.openjdk.org/jdk.git pull/14060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14060`

View PR using the GUI difftool: \
`$ git pr show -t 14060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14060.diff">https://git.openjdk.org/jdk/pull/14060.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14060#issuecomment-1554495675)