### PR TITLE
8300865: C2: product reduction in ProdRed_Double is not vectorized

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3718,10 +3718,7 @@ bool SuperWord::construct_bb() {
             // First see if we can map the reduction on the given system we are on, then
             // make a data entry operation for each reduction we see.
             BasicType bt = use->bottom_type()->basic_type();
-            // Matcher::min_vector_size may return 1 in some cases, e.g. double for x86.
-            // For vector reduction implemented check we need atleast two elements.
-            int min_vec_size = MAX2(Matcher::min_vector_size(bt), 2);
-            if (ReductionNode::implemented(use->Opcode(), min_vec_size, bt)) {
+            if (ReductionNode::implemented(use->Opcode(), Matcher::max_vector_size(bt), bt)) {
               reduction_uses++;
             }
           }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3718,7 +3718,7 @@ bool SuperWord::construct_bb() {
             // First see if we can map the reduction on the given system we are on, then
             // make a data entry operation for each reduction we see.
             BasicType bt = use->bottom_type()->basic_type();
-            if (ReductionNode::implemented(use->Opcode(), Matcher::max_vector_size(bt), bt)) {
+            if (ReductionNode::implemented(use->Opcode(), Matcher::superword_max_vector_size(bt), bt)) {
               reduction_uses++;
             }
           }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3718,7 +3718,10 @@ bool SuperWord::construct_bb() {
             // First see if we can map the reduction on the given system we are on, then
             // make a data entry operation for each reduction we see.
             BasicType bt = use->bottom_type()->basic_type();
-            if (ReductionNode::implemented(use->Opcode(), Matcher::min_vector_size(bt), bt)) {
+            // Matcher::min_vector_size may return 1 in some cases, e.g. double for x86.
+            // For vector reduction implemented check we need atleast two elements.
+            int min_vec_size = MAX2(Matcher::min_vector_size(bt), 2);
+            if (ReductionNode::implemented(use->Opcode(), min_vec_size, bt)) {
               reduction_uses++;
             }
           }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/ProdRed_Double.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/ProdRed_Double.java
@@ -82,11 +82,12 @@ public class ProdRed_Double {
         }
     }
 
-    /* Vectorization is expected but not enabled (SuperWord::implemented).
-       A positive @IR test should be added later. */
     @Test
     @IR(applyIf = {"SuperWordReductions", "false"},
         failOn = {IRNode.MUL_REDUCTION_VD})
+    @IR(applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfCPUFeature = {"sse2", "true"},
+        counts = {IRNode.MUL_REDUCTION_VD, ">= 1"})
     public static double prodReductionImplement(double[] a, double[] b, double total) {
         for (int i = 0; i < a.length; i++) {
             total *= a[i] - b[i];

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReduction.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReduction.java
@@ -46,6 +46,9 @@ public abstract class VectorReduction {
     private long[] longsB;
     private long[] longsC;
     private long[] longsD;
+    private double[] doublesA;
+    private double[] doublesB;
+    private double[] doublesC;
 
     @Param("0")
     private int seed;
@@ -63,6 +66,9 @@ public abstract class VectorReduction {
         longsB = new long[COUNT];
         longsC = new long[COUNT];
         longsD = new long[COUNT];
+        doublesA = new double[COUNT];
+        doublesB = new double[COUNT];
+        doublesC = new double[COUNT];
 
         for (int i = 0; i < COUNT; i++) {
             intsA[i] = r.nextInt();
@@ -71,6 +77,9 @@ public abstract class VectorReduction {
             longsA[i] = r.nextLong();
             longsB[i] = r.nextLong();
             longsC[i] = r.nextLong();
+            doublesA[i] = r.nextDouble();
+            doublesB[i] = r.nextDouble();
+            doublesC[i] = r.nextDouble();
         }
     }
 
@@ -132,6 +141,16 @@ public abstract class VectorReduction {
             resL ^= longsD[i];
         }
         bh.consume(resL);
+    }
+
+    @Benchmark
+    public void mulRedD(Blackhole bh) {
+        double resD = 0.0;
+        for (int i = 0; i < COUNT; i++) {
+            resD += (doublesA[i] * doublesB[i]) + (doublesA[i] * doublesC[i]) +
+                     (doublesB[i] * doublesC[i]);
+        }
+        bh.consume(resD);
     }
 
     @Benchmark


### PR DESCRIPTION
This PR fixes the problem with double reduction on x86_64. 

In the test compiler.loopopts.superword.ProdRed_Double, the product reduction loop in prodReductionImplement() was not getting vectorized when run as follows:
jtreg -XX:CompileCommand=PrintAssembly,compiler.loopopts.superword.ProdRed_Double::prodReductionImplement compiler/loopopts/superword/ProdRed_Double.java
The print assembly generated in the pid-xxx.log output in JTwork/scratch directory was not showing any vector_reduction_double node.

This was happening as the ReductionNode::implemented was passed a vector size of one element. For the vector reduction implemented we need to check with at least vector size of two elements.

With this PR the vector_reduction_double node is generated.

Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300865](https://bugs.openjdk.org/browse/JDK-8300865): C2: product reduction in ProdRed_Double is not vectorized


### Reviewers
 * [Fei Gao](https://openjdk.org/census#fgao) (@fg1417 - Committer) ⚠️ Review applies to [ba3b5dfa](https://git.openjdk.org/jdk/pull/14065/files/ba3b5dfaacb3a3429288ad96ca518609088260ed)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14065/head:pull/14065` \
`$ git checkout pull/14065`

Update a local copy of the PR: \
`$ git checkout pull/14065` \
`$ git pull https://git.openjdk.org/jdk.git pull/14065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14065`

View PR using the GUI difftool: \
`$ git pr show -t 14065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14065.diff">https://git.openjdk.org/jdk/pull/14065.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14065#issuecomment-1557588208)