### PR TITLE
8159023: Engineering notation of DecimalFormat does not work as documented

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -264,6 +264,16 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * formatted using the localized minus sign, <em>not</em> the prefix and suffix
  * from the pattern.  This allows patterns such as {@code "0.###E0 m/s"}.
  *
+ * <li>The <em>maximum integer</em> digits is the sum of '0's and '#'s
+ * prior to the decimal point. The <em>minimum integer</em> digits is the
+ * sum of the '0's prior to the decimal point. The <em>maximum fraction</em>
+ * and <em>minimum fraction</em> digits follow the same rules, but apply to the
+ * digits after the decimal point but before the exponent. For example, the
+ * following pattern: {@code "#00.0####E0"} would have a minimum number of
+ * integer digits = 2("00") and a maximum number of integer digits = 3("#00"). It
+ * would have a minimum number of fraction digits = 1("0") and a maximum number of fraction
+ * digits= 5("0####").
+ *
  * <li>The minimum and maximum number of integer digits are interpreted
  * together:
  *
@@ -282,12 +292,37 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * {@code "12.3E-4"}.
  * </ul>
  *
- * <li>The number of significant digits in the mantissa is the sum of the
- * <em>minimum integer</em> and <em>maximum fraction</em> digits, and is
- * unaffected by the maximum integer digits.  For example, 12345 formatted with
- * {@code "##0.##E0"} is {@code "12.3E3"}. To show all digits, set
- * the significant digits count to zero.  The number of significant digits
+ * <li>For a given number, the amount of significant digits in
+ * the mantissa can be calculated as such
+ *
+ * <blockquote><pre>
+ * <i>Mantissa Digits:</i>
+ *         min(max(Minimum Pattern Digits, Original Number Digits), Maximum Pattern Digits)
+ * <i>Minimum pattern Digits:</i>
+ *         <i>Minimum Integer Digits</i> + <i>Minimum Fraction Digits</i>
+ * <i>Maximum pattern Digits:</i>
+ *         <i>Maximum Integer Digits</i> + <i>Maximum Fraction Digits</i>
+ * <i>Original Number Digits:</i>
+ *         The amount of significant digits in the number to be formatted
+ * </pre></blockquote>
+ *
+ * This means that generally, a mantissa will have up to the combined maximum integer
+ * and fraction digits, if the original number itself has enough significant digits. However,
+ * if there are more minimum pattern digits than significant digits in the original number,
+ * the mantissa will have significant digits that equals the combined
+ * minimum integer and fraction digits. The number of significant digits
  * does not affect parsing.
+ *
+ * <p>It should be noted, that the integer portion of the mantissa will give
+ * any excess digits to the fraction portion, whether it be for precision or
+ * for satisfying the total amount of combined minimum digits.
+ *
+ * <p>This behavior can be observed in the following example,
+ * {@snippet lang=java :
+ *     DecimalFormat df = new DecimalFormat("#000.000##E0");
+ *     df.format(12); // returns "12.0000E0"
+ *     df.format(123456789) // returns "1.23456789E8"
+ * }
  *
  * <li>Exponential patterns may not contain grouping separators.
  * </ul>
@@ -308,8 +343,8 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <h4>Special Values</h4>
  *
- * <p>{@code NaN} is formatted as a string, which typically has a single character
- * {@code U+FFFD}.  This string is determined by the
+ * <p>Not a Number({@code NaN}) is formatted as a string, which typically has a
+ * single character {@code U+FFFD}.  This string is determined by the
  * {@code DecimalFormatSymbols} object.  This is the only value for which
  * the prefixes and suffixes are not used.
  *

--- a/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
+++ b/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8159023
+ * @summary Confirm behavior of mantissa for scientific notation in Decimal Format
+ * @run junit MantissaDigits
+ */
+
+import java.text.DecimalFormat;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MantissaDigits {
+    private static final double[] numbers = {
+            1.1, 12.1, 123.1, 1234.1, 12345.1, 123456.1,
+            -1.1, -12.1, -123.1, -1234.1, -12345.1, -123456.1,
+            1, 12, 123, 1234, 12345, 123456, 1234567,
+            -1, -12, -123, -1234, -12345, -123456, -1234567,
+            1.1234, 1.1111, 1.412, 222.333, -771.2222
+
+            // The following numbers when formatted, may produce
+            // results that have leading or trailing 0s (which ultimately,
+            // are ignored, but were "included" as significant digits)
+            // 1.101013, 1.10011, 0.00101, 0.100, -1.00130, -0.00131
+            // ie: 0.00101 formatted with #0.000##E0 gives 10.10E-4
+            // which implies there was only "4" significant digits even
+            // if the mathematical expression produced 6 significant digits.
+            // This is because the leading (or trailing) (00)10.10E-4 was
+            // stripped, but when un-stripping them, the # of significant digits
+            // still matches that of the mathematical expression. Thus, these
+            // values cannot be tested via this test, but a manual comparison
+            // of the results while keeping in mind the stripping of leading
+            // or trailing zeroes still aligns to the mathematical expression.
+            };
+
+    @ParameterizedTest
+    @MethodSource("patterns")
+    public void testMantissaDefinition(String pattern) {
+        Locale.setDefault(Locale.ENGLISH);
+        DecimalFormat df = new DecimalFormat(pattern);
+        for (double number : numbers) {
+            // Count the significant digits in the pre-formatted number
+            int originalNumDigits = String.valueOf(number)
+                    .replace(".", "")
+                    .replace("-", "")
+                    .length();
+
+            if (wholeNumber(number)) {
+                // Trailing 0 should not be counted
+                originalNumDigits--;
+            }
+
+            // Format the number, then grab the significant
+            // digits inside the mantissa
+            String formattedNum = df.format(number);
+            int mantissaDigits = formattedNum
+                    .replace(".", "")
+                    .replace("E", "")
+                    .replace("-", "")
+                    .length() - 1;
+
+            // Count the zeroes and hash symbols in the
+            // pattern, to be used in the mathematical expression
+            int zeroes = (int) (pattern.chars()
+                    // ignore exponent zero
+                    .filter(ch -> ch == '0').count() - 1);
+            int hashes = (int) pattern.chars()
+                    .filter(ch -> ch == '#').count();
+
+
+            // Test the new definition of the Mantissa
+            Integer calculatedDigits = Math
+                    .min(Math.max(zeroes, originalNumDigits), (hashes+zeroes));
+            assertEquals(mantissaDigits, calculatedDigits,
+                    String.format("%s formatted with %s gives %s, and significant " +
+                            "digit count was %s, but the formula provided %s%n",
+                            number, pattern, formattedNum, mantissaDigits, calculatedDigits));
+        }
+    }
+
+    private static Boolean wholeNumber(double number) {
+        return (int) number == number;
+    }
+
+    private static Stream<Arguments> patterns() {
+        return Stream.of(
+                Arguments.of("#0.0##E0"),
+                Arguments.of("#00.00##E0"),
+                Arguments.of("#0.000##E0"),
+                Arguments.of("#00.000##E0"),
+                Arguments.of("#000.0##E0"),
+                Arguments.of("#000.00##E0"),
+                Arguments.of("#000.000##E0"),
+                Arguments.of("000.000E0"),
+                Arguments.of("#.##E0"),
+                Arguments.of("######.######E0"),
+                Arguments.of("####00.00######E0")
+        );
+    }
+}

--- a/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
+++ b/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
@@ -42,14 +42,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MantissaDigits {
-    private static final double[] numbers = {
+    private static final double[] NUMBERS = {
             1.1, 12.1, 123.1, 1234.1, 12345.1, 123456.1,
             -1.1, -12.1, -123.1, -1234.1, -12345.1, -123456.1,
             1, 12, 123, 1234, 12345, 123456, 1234567,
             -1, -12, -123, -1234, -12345, -123456, -1234567,
             1.1234, 1.1111, 1.412, 222.333, -771.2222
             };
-    private static final DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.US);
+    private static final DecimalFormatSymbols DFS = new DecimalFormatSymbols(Locale.US);
     private static final String ERRMSG = "%s formatted with %s gives %s, and " +
             "significant digit count was %s, but the formula provided %s%n";
     // Hard coded as 1, since all test patterns only have 1 exponent digit
@@ -58,13 +58,11 @@ public class MantissaDigits {
     @ParameterizedTest
     @MethodSource("patterns")
     public void testMantissaDefinition(String pattern, int minDigits, int maxDigits) {
-        DecimalFormat df = new DecimalFormat(pattern, dfs);
-        for (double number : numbers) {
+        DecimalFormat df = new DecimalFormat(pattern, DFS);
+        for (double number : NUMBERS) {
             // Count the significant digits in the pre-formatted number
-            int originalNumDigits = String.valueOf(number)
-                    .replace(".", "")
-                    .replace("-", "")
-                    .length();
+            int originalNumDigits = (int) String.valueOf(number).chars()
+                    .filter(Character::isDigit).count();
 
             if (wholeNumber(number)) {
                 // Trailing 0 should not be counted
@@ -74,11 +72,8 @@ public class MantissaDigits {
             // Format the number, then grab the significant
             // digits inside the mantissa
             String formattedNum = df.format(number);
-            int mantissaDigits = formattedNum
-                    .replace(".", "")
-                    .replace("E", "")
-                    .replace("-", "")
-                    .length() - EXPONENTDIGITS;
+            int mantissaDigits = (int) formattedNum.chars()
+                    .filter(Character::isDigit).count() - EXPONENTDIGITS;
 
             // Test the new definition of the Mantissa
             Integer calculatedDigits = Math

--- a/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
+++ b/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
@@ -31,6 +31,7 @@
  */
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.stream.Stream;
 
@@ -48,12 +49,16 @@ public class MantissaDigits {
             -1, -12, -123, -1234, -12345, -123456, -1234567,
             1.1234, 1.1111, 1.412, 222.333, -771.2222
             };
+    private static final DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.US);
+    private static final String ERRMSG = "%s formatted with %s gives %s, and " +
+            "significant digit count was %s, but the formula provided %s%n";
+    // Hard coded as 1, since all test patterns only have 1 exponent digit
+    private static final int EXPONENTDIGITS = 1;
 
     @ParameterizedTest
     @MethodSource("patterns")
-    public void testMantissaDefinition(String pattern) {
-        Locale.setDefault(Locale.ENGLISH);
-        DecimalFormat df = new DecimalFormat(pattern);
+    public void testMantissaDefinition(String pattern, int minDigits, int maxDigits) {
+        DecimalFormat df = new DecimalFormat(pattern, dfs);
         for (double number : numbers) {
             // Count the significant digits in the pre-formatted number
             int originalNumDigits = String.valueOf(number)
@@ -73,24 +78,13 @@ public class MantissaDigits {
                     .replace(".", "")
                     .replace("E", "")
                     .replace("-", "")
-                    .length() - 1;
-
-            // Count the zeroes and hash symbols in the
-            // pattern, to be used in the mathematical expression
-            int zeroes = (int) (pattern.chars()
-                    // ignore exponent zero
-                    .filter(ch -> ch == '0').count() - 1);
-            int hashes = (int) pattern.chars()
-                    .filter(ch -> ch == '#').count();
-
+                    .length() - EXPONENTDIGITS;
 
             // Test the new definition of the Mantissa
             Integer calculatedDigits = Math
-                    .min(Math.max(zeroes, originalNumDigits), (hashes+zeroes));
-            assertEquals(mantissaDigits, calculatedDigits,
-                    String.format("%s formatted with %s gives %s, and significant " +
-                            "digit count was %s, but the formula provided %s%n",
-                            number, pattern, formattedNum, mantissaDigits, calculatedDigits));
+                    .min(Math.max(minDigits, originalNumDigits), maxDigits);
+            assertEquals(mantissaDigits, calculatedDigits, String.format(ERRMSG,
+                    number, pattern, formattedNum, mantissaDigits, calculatedDigits));
         }
     }
 
@@ -100,17 +94,17 @@ public class MantissaDigits {
 
     private static Stream<Arguments> patterns() {
         return Stream.of(
-                Arguments.of("#0.0##E0"),
-                Arguments.of("#00.00##E0"),
-                Arguments.of("#0.000##E0"),
-                Arguments.of("#00.000##E0"),
-                Arguments.of("#000.0##E0"),
-                Arguments.of("#000.00##E0"),
-                Arguments.of("#000.000##E0"),
-                Arguments.of("000.000E0"),
-                Arguments.of("#.##E0"),
-                Arguments.of("######.######E0"),
-                Arguments.of("####00.00######E0")
+                Arguments.of("#0.0##E0", 2, 5),
+                Arguments.of("#00.00##E0", 4, 7),
+                Arguments.of("#0.000##E0", 4, 7),
+                Arguments.of("#00.000##E0", 5, 8),
+                Arguments.of("#000.0##E0", 4, 7),
+                Arguments.of("#000.00##E0", 5, 8),
+                Arguments.of("#000.000##E0", 6, 9),
+                Arguments.of("000.000E0", 6, 6),
+                Arguments.of("#.##E0", 0, 3),
+                Arguments.of("######.######E0", 0, 12),
+                Arguments.of("####00.00######E0", 4, 14)
         );
     }
 }

--- a/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
+++ b/test/jdk/java/text/Format/DecimalFormat/MantissaDigits.java
@@ -47,20 +47,6 @@ public class MantissaDigits {
             1, 12, 123, 1234, 12345, 123456, 1234567,
             -1, -12, -123, -1234, -12345, -123456, -1234567,
             1.1234, 1.1111, 1.412, 222.333, -771.2222
-
-            // The following numbers when formatted, may produce
-            // results that have leading or trailing 0s (which ultimately,
-            // are ignored, but were "included" as significant digits)
-            // 1.101013, 1.10011, 0.00101, 0.100, -1.00130, -0.00131
-            // ie: 0.00101 formatted with #0.000##E0 gives 10.10E-4
-            // which implies there was only "4" significant digits even
-            // if the mathematical expression produced 6 significant digits.
-            // This is because the leading (or trailing) (00)10.10E-4 was
-            // stripped, but when un-stripping them, the # of significant digits
-            // still matches that of the mathematical expression. Thus, these
-            // values cannot be tested via this test, but a manual comparison
-            // of the results while keeping in mind the stripping of leading
-            // or trailing zeroes still aligns to the mathematical expression.
             };
 
     @ParameterizedTest


### PR DESCRIPTION
Please review this PR which updates the Scientific Notation section of Decimal Format. It aims to resolve [JDK-8159023](https://bugs.openjdk.org/browse/JDK-8159023) as well as [JDK-6282188](https://bugs.openjdk.org/browse/JDK-6282188).

**Scientific Notation** in Decimal Format contains the definition for a scientific notation formatted number's mantissa as such: _The number of significant digits in the mantissa is the sum of the minimum integer and maximum fraction digits, and is unaffected by the maximum integer digits. For example, 12345 formatted with "##0.##E0" is "12.3E3"._

Both the definition and example are incorrect, as the actual result is "12.E345". 

The following example data show that scientific notation formatted numbers do not adhere to that definition. As, according to the definition, the following numbers should have 3 significant digits, but in reality, they have up to 5.
```
123 formatted by ##0.#E0 is 123E0
1234 formatted by ##0.#E0 is 1.234E3
12345 formatted by ##0.#E0 is 12.34E3
123456 formatted by ##0.#E0 is 123.5E3
1234567 formatted by ##0.#E0 is 1.235E6
12345678 formatted by ##0.#E0 is 12.35E6
123456789 formatted by ##0.#E0 is 123.5E6 
```

The actual definition of the mantissa, as well as examples and further context are included in this change. In addition, a test has been added that tests various patterns to numbers and ensures the format follows the new definition's mathematical expression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308317](https://bugs.openjdk.org/browse/JDK-8308317) to be approved

### Issues
 * [JDK-8159023](https://bugs.openjdk.org/browse/JDK-8159023): Engineering notation of DecimalFormat does not work as documented
 * [JDK-8308317](https://bugs.openjdk.org/browse/JDK-8308317): Engineering notation of DecimalFormat does not work as documented (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14066/head:pull/14066` \
`$ git checkout pull/14066`

Update a local copy of the PR: \
`$ git checkout pull/14066` \
`$ git pull https://git.openjdk.org/jdk.git pull/14066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14066`

View PR using the GUI difftool: \
`$ git pr show -t 14066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14066.diff">https://git.openjdk.org/jdk/pull/14066.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14066#issuecomment-1555386539)