### PR TITLE
8308465: Reduce memory accesses in AArch64 MD5 intrinsic

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3332,9 +3332,37 @@ class StubGenerator: public StubCodeGenerator {
      return start;
   }
 
+  class Cached64Bytes {
+  private:
+    MacroAssembler *_masm;
+    Register _base;
+    Register _regs[8];
+
+  public:
+    Cached64Bytes(MacroAssembler *masm, Register base, RegSet rs):
+      _masm(masm), _base(base) {
+      assert(rs.size() == 8, "%u registers are used to cache 16 4-byte data", rs.size());
+      auto it = rs.begin();
+      for (int i = 0; i < 8; ++i, ++it) {
+        _regs[i] = *it;
+      }
+    }
+
+    void gen_loads() {
+      for (int i = 0; i < 8; i += 2) {
+        __ ldp(_regs[i], _regs[i + 1], Address(_base, 8 * i));
+      }
+    }
+
+    // Generate code extracting i-th unsigned word (4 bytes) from cached 64 bytes.
+    void gen_unsigned_word_extract(Register dest, int i) {
+      __ ubfx(dest, _regs[i / 2], 32 * (i % 2), 32);
+    }
+  };
+
   // Utility routines for md5.
   // Clobbers r10 and r11.
-  void md5_FF(Register buf, Register r1, Register r2, Register r3, Register r4,
+  void md5_FF(Cached64Bytes& reg_cache, Register r1, Register r2, Register r3, Register r4,
               int k, int s, int t) {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
@@ -3343,7 +3371,7 @@ class StubGenerator: public StubCodeGenerator {
     __ movw(rscratch2, t);
     __ andw(rscratch3, rscratch3, r2);
     __ addw(rscratch4, r1, rscratch2);
-    __ ldrw(rscratch1, Address(buf, k*4));
+    reg_cache.gen_unsigned_word_extract(rscratch1, k);
     __ eorw(rscratch3, rscratch3, r4);
     __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
@@ -3351,14 +3379,14 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(r1, rscratch2, r2);
   }
 
-  void md5_GG(Register buf, Register r1, Register r2, Register r3, Register r4,
+  void md5_GG(Cached64Bytes& reg_cache, Register r1, Register r2, Register r3, Register r4,
               int k, int s, int t) {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
 
     __ andw(rscratch3, r2, r4);
     __ bicw(rscratch4, r3, r4);
-    __ ldrw(rscratch1, Address(buf, k*4));
+    reg_cache.gen_unsigned_word_extract(rscratch1, k);
     __ movw(rscratch2, t);
     __ orrw(rscratch3, rscratch3, rscratch4);
     __ addw(rscratch4, r1, rscratch2);
@@ -3368,7 +3396,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(r1, rscratch2, r2);
   }
 
-  void md5_HH(Register buf, Register r1, Register r2, Register r3, Register r4,
+  void md5_HH(Cached64Bytes& reg_cache, Register r1, Register r2, Register r3, Register r4,
               int k, int s, int t) {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
@@ -3376,7 +3404,7 @@ class StubGenerator: public StubCodeGenerator {
     __ eorw(rscratch3, r3, r4);
     __ movw(rscratch2, t);
     __ addw(rscratch4, r1, rscratch2);
-    __ ldrw(rscratch1, Address(buf, k*4));
+    reg_cache.gen_unsigned_word_extract(rscratch1, k);
     __ eorw(rscratch3, rscratch3, r2);
     __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
@@ -3384,7 +3412,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(r1, rscratch2, r2);
   }
 
-  void md5_II(Register buf, Register r1, Register r2, Register r3, Register r4,
+  void md5_II(Cached64Bytes& reg_cache, Register r1, Register r2, Register r3, Register r4,
               int k, int s, int t) {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
@@ -3392,7 +3420,7 @@ class StubGenerator: public StubCodeGenerator {
     __ movw(rscratch3, t);
     __ ornw(rscratch2, r2, r4);
     __ addw(rscratch4, r1, rscratch3);
-    __ ldrw(rscratch1, Address(buf, k*4));
+    reg_cache.gen_unsigned_word_extract(rscratch1, k);
     __ eorw(rscratch3, rscratch2, r3);
     __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
@@ -3424,103 +3452,107 @@ class StubGenerator: public StubCodeGenerator {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
 
+    Register state_regs[2] = { r12, r13 };
+    RegSet saved_regs = RegSet::range(r16, r22) - r18_tls;
+    Cached64Bytes reg_cache(_masm, buf, RegSet::of(r14, r15) + saved_regs);
+
+    __ push(saved_regs, sp);
+
+    __ ldp(state_regs[0], state_regs[1], Address(state));
+    __ ubfx(a, state_regs[0],  0, 32);
+    __ ubfx(b, state_regs[0], 32, 32);
+    __ ubfx(c, state_regs[1],  0, 32);
+    __ ubfx(d, state_regs[1], 32, 32);
+
     Label md5_loop;
     __ BIND(md5_loop);
 
-    // Save hash values for addition after rounds
-    __ ldrw(a, Address(state,  0));
-    __ ldrw(b, Address(state,  4));
-    __ ldrw(c, Address(state,  8));
-    __ ldrw(d, Address(state, 12));
+    reg_cache.gen_loads();
 
     // Round 1
-    md5_FF(buf, a, b, c, d,  0,  7, 0xd76aa478);
-    md5_FF(buf, d, a, b, c,  1, 12, 0xe8c7b756);
-    md5_FF(buf, c, d, a, b,  2, 17, 0x242070db);
-    md5_FF(buf, b, c, d, a,  3, 22, 0xc1bdceee);
-    md5_FF(buf, a, b, c, d,  4,  7, 0xf57c0faf);
-    md5_FF(buf, d, a, b, c,  5, 12, 0x4787c62a);
-    md5_FF(buf, c, d, a, b,  6, 17, 0xa8304613);
-    md5_FF(buf, b, c, d, a,  7, 22, 0xfd469501);
-    md5_FF(buf, a, b, c, d,  8,  7, 0x698098d8);
-    md5_FF(buf, d, a, b, c,  9, 12, 0x8b44f7af);
-    md5_FF(buf, c, d, a, b, 10, 17, 0xffff5bb1);
-    md5_FF(buf, b, c, d, a, 11, 22, 0x895cd7be);
-    md5_FF(buf, a, b, c, d, 12,  7, 0x6b901122);
-    md5_FF(buf, d, a, b, c, 13, 12, 0xfd987193);
-    md5_FF(buf, c, d, a, b, 14, 17, 0xa679438e);
-    md5_FF(buf, b, c, d, a, 15, 22, 0x49b40821);
+    md5_FF(reg_cache, a, b, c, d,  0,  7, 0xd76aa478);
+    md5_FF(reg_cache, d, a, b, c,  1, 12, 0xe8c7b756);
+    md5_FF(reg_cache, c, d, a, b,  2, 17, 0x242070db);
+    md5_FF(reg_cache, b, c, d, a,  3, 22, 0xc1bdceee);
+    md5_FF(reg_cache, a, b, c, d,  4,  7, 0xf57c0faf);
+    md5_FF(reg_cache, d, a, b, c,  5, 12, 0x4787c62a);
+    md5_FF(reg_cache, c, d, a, b,  6, 17, 0xa8304613);
+    md5_FF(reg_cache, b, c, d, a,  7, 22, 0xfd469501);
+    md5_FF(reg_cache, a, b, c, d,  8,  7, 0x698098d8);
+    md5_FF(reg_cache, d, a, b, c,  9, 12, 0x8b44f7af);
+    md5_FF(reg_cache, c, d, a, b, 10, 17, 0xffff5bb1);
+    md5_FF(reg_cache, b, c, d, a, 11, 22, 0x895cd7be);
+    md5_FF(reg_cache, a, b, c, d, 12,  7, 0x6b901122);
+    md5_FF(reg_cache, d, a, b, c, 13, 12, 0xfd987193);
+    md5_FF(reg_cache, c, d, a, b, 14, 17, 0xa679438e);
+    md5_FF(reg_cache, b, c, d, a, 15, 22, 0x49b40821);
 
     // Round 2
-    md5_GG(buf, a, b, c, d,  1,  5, 0xf61e2562);
-    md5_GG(buf, d, a, b, c,  6,  9, 0xc040b340);
-    md5_GG(buf, c, d, a, b, 11, 14, 0x265e5a51);
-    md5_GG(buf, b, c, d, a,  0, 20, 0xe9b6c7aa);
-    md5_GG(buf, a, b, c, d,  5,  5, 0xd62f105d);
-    md5_GG(buf, d, a, b, c, 10,  9, 0x02441453);
-    md5_GG(buf, c, d, a, b, 15, 14, 0xd8a1e681);
-    md5_GG(buf, b, c, d, a,  4, 20, 0xe7d3fbc8);
-    md5_GG(buf, a, b, c, d,  9,  5, 0x21e1cde6);
-    md5_GG(buf, d, a, b, c, 14,  9, 0xc33707d6);
-    md5_GG(buf, c, d, a, b,  3, 14, 0xf4d50d87);
-    md5_GG(buf, b, c, d, a,  8, 20, 0x455a14ed);
-    md5_GG(buf, a, b, c, d, 13,  5, 0xa9e3e905);
-    md5_GG(buf, d, a, b, c,  2,  9, 0xfcefa3f8);
-    md5_GG(buf, c, d, a, b,  7, 14, 0x676f02d9);
-    md5_GG(buf, b, c, d, a, 12, 20, 0x8d2a4c8a);
+    md5_GG(reg_cache, a, b, c, d,  1,  5, 0xf61e2562);
+    md5_GG(reg_cache, d, a, b, c,  6,  9, 0xc040b340);
+    md5_GG(reg_cache, c, d, a, b, 11, 14, 0x265e5a51);
+    md5_GG(reg_cache, b, c, d, a,  0, 20, 0xe9b6c7aa);
+    md5_GG(reg_cache, a, b, c, d,  5,  5, 0xd62f105d);
+    md5_GG(reg_cache, d, a, b, c, 10,  9, 0x02441453);
+    md5_GG(reg_cache, c, d, a, b, 15, 14, 0xd8a1e681);
+    md5_GG(reg_cache, b, c, d, a,  4, 20, 0xe7d3fbc8);
+    md5_GG(reg_cache, a, b, c, d,  9,  5, 0x21e1cde6);
+    md5_GG(reg_cache, d, a, b, c, 14,  9, 0xc33707d6);
+    md5_GG(reg_cache, c, d, a, b,  3, 14, 0xf4d50d87);
+    md5_GG(reg_cache, b, c, d, a,  8, 20, 0x455a14ed);
+    md5_GG(reg_cache, a, b, c, d, 13,  5, 0xa9e3e905);
+    md5_GG(reg_cache, d, a, b, c,  2,  9, 0xfcefa3f8);
+    md5_GG(reg_cache, c, d, a, b,  7, 14, 0x676f02d9);
+    md5_GG(reg_cache, b, c, d, a, 12, 20, 0x8d2a4c8a);
 
     // Round 3
-    md5_HH(buf, a, b, c, d,  5,  4, 0xfffa3942);
-    md5_HH(buf, d, a, b, c,  8, 11, 0x8771f681);
-    md5_HH(buf, c, d, a, b, 11, 16, 0x6d9d6122);
-    md5_HH(buf, b, c, d, a, 14, 23, 0xfde5380c);
-    md5_HH(buf, a, b, c, d,  1,  4, 0xa4beea44);
-    md5_HH(buf, d, a, b, c,  4, 11, 0x4bdecfa9);
-    md5_HH(buf, c, d, a, b,  7, 16, 0xf6bb4b60);
-    md5_HH(buf, b, c, d, a, 10, 23, 0xbebfbc70);
-    md5_HH(buf, a, b, c, d, 13,  4, 0x289b7ec6);
-    md5_HH(buf, d, a, b, c,  0, 11, 0xeaa127fa);
-    md5_HH(buf, c, d, a, b,  3, 16, 0xd4ef3085);
-    md5_HH(buf, b, c, d, a,  6, 23, 0x04881d05);
-    md5_HH(buf, a, b, c, d,  9,  4, 0xd9d4d039);
-    md5_HH(buf, d, a, b, c, 12, 11, 0xe6db99e5);
-    md5_HH(buf, c, d, a, b, 15, 16, 0x1fa27cf8);
-    md5_HH(buf, b, c, d, a,  2, 23, 0xc4ac5665);
+    md5_HH(reg_cache, a, b, c, d,  5,  4, 0xfffa3942);
+    md5_HH(reg_cache, d, a, b, c,  8, 11, 0x8771f681);
+    md5_HH(reg_cache, c, d, a, b, 11, 16, 0x6d9d6122);
+    md5_HH(reg_cache, b, c, d, a, 14, 23, 0xfde5380c);
+    md5_HH(reg_cache, a, b, c, d,  1,  4, 0xa4beea44);
+    md5_HH(reg_cache, d, a, b, c,  4, 11, 0x4bdecfa9);
+    md5_HH(reg_cache, c, d, a, b,  7, 16, 0xf6bb4b60);
+    md5_HH(reg_cache, b, c, d, a, 10, 23, 0xbebfbc70);
+    md5_HH(reg_cache, a, b, c, d, 13,  4, 0x289b7ec6);
+    md5_HH(reg_cache, d, a, b, c,  0, 11, 0xeaa127fa);
+    md5_HH(reg_cache, c, d, a, b,  3, 16, 0xd4ef3085);
+    md5_HH(reg_cache, b, c, d, a,  6, 23, 0x04881d05);
+    md5_HH(reg_cache, a, b, c, d,  9,  4, 0xd9d4d039);
+    md5_HH(reg_cache, d, a, b, c, 12, 11, 0xe6db99e5);
+    md5_HH(reg_cache, c, d, a, b, 15, 16, 0x1fa27cf8);
+    md5_HH(reg_cache, b, c, d, a,  2, 23, 0xc4ac5665);
 
     // Round 4
-    md5_II(buf, a, b, c, d,  0,  6, 0xf4292244);
-    md5_II(buf, d, a, b, c,  7, 10, 0x432aff97);
-    md5_II(buf, c, d, a, b, 14, 15, 0xab9423a7);
-    md5_II(buf, b, c, d, a,  5, 21, 0xfc93a039);
-    md5_II(buf, a, b, c, d, 12,  6, 0x655b59c3);
-    md5_II(buf, d, a, b, c,  3, 10, 0x8f0ccc92);
-    md5_II(buf, c, d, a, b, 10, 15, 0xffeff47d);
-    md5_II(buf, b, c, d, a,  1, 21, 0x85845dd1);
-    md5_II(buf, a, b, c, d,  8,  6, 0x6fa87e4f);
-    md5_II(buf, d, a, b, c, 15, 10, 0xfe2ce6e0);
-    md5_II(buf, c, d, a, b,  6, 15, 0xa3014314);
-    md5_II(buf, b, c, d, a, 13, 21, 0x4e0811a1);
-    md5_II(buf, a, b, c, d,  4,  6, 0xf7537e82);
-    md5_II(buf, d, a, b, c, 11, 10, 0xbd3af235);
-    md5_II(buf, c, d, a, b,  2, 15, 0x2ad7d2bb);
-    md5_II(buf, b, c, d, a,  9, 21, 0xeb86d391);
+    md5_II(reg_cache, a, b, c, d,  0,  6, 0xf4292244);
+    md5_II(reg_cache, d, a, b, c,  7, 10, 0x432aff97);
+    md5_II(reg_cache, c, d, a, b, 14, 15, 0xab9423a7);
+    md5_II(reg_cache, b, c, d, a,  5, 21, 0xfc93a039);
+    md5_II(reg_cache, a, b, c, d, 12,  6, 0x655b59c3);
+    md5_II(reg_cache, d, a, b, c,  3, 10, 0x8f0ccc92);
+    md5_II(reg_cache, c, d, a, b, 10, 15, 0xffeff47d);
+    md5_II(reg_cache, b, c, d, a,  1, 21, 0x85845dd1);
+    md5_II(reg_cache, a, b, c, d,  8,  6, 0x6fa87e4f);
+    md5_II(reg_cache, d, a, b, c, 15, 10, 0xfe2ce6e0);
+    md5_II(reg_cache, c, d, a, b,  6, 15, 0xa3014314);
+    md5_II(reg_cache, b, c, d, a, 13, 21, 0x4e0811a1);
+    md5_II(reg_cache, a, b, c, d,  4,  6, 0xf7537e82);
+    md5_II(reg_cache, d, a, b, c, 11, 10, 0xbd3af235);
+    md5_II(reg_cache, c, d, a, b,  2, 15, 0x2ad7d2bb);
+    md5_II(reg_cache, b, c, d, a,  9, 21, 0xeb86d391);
 
-    // write hash values back in the correct order
-    __ ldrw(rscratch1, Address(state,  0));
-    __ addw(rscratch1, rscratch1, a);
-    __ strw(rscratch1, Address(state,  0));
+    __ ubfx(rscratch1, state_regs[0],  0, 32);
+    __ ubfx(rscratch2, state_regs[0], 32, 32);
+    __ ubfx(rscratch3, state_regs[1],  0, 32);
+    __ ubfx(rscratch4, state_regs[1], 32, 32);
 
-    __ ldrw(rscratch2, Address(state,  4));
-    __ addw(rscratch2, rscratch2, b);
-    __ strw(rscratch2, Address(state,  4));
+    __ addw(a, rscratch1, a);
+    __ addw(b, rscratch2, b);
+    __ addw(c, rscratch3, c);
+    __ addw(d, rscratch4, d);
 
-    __ ldrw(rscratch3, Address(state,  8));
-    __ addw(rscratch3, rscratch3, c);
-    __ strw(rscratch3, Address(state,  8));
-
-    __ ldrw(rscratch4, Address(state, 12));
-    __ addw(rscratch4, rscratch4, d);
-    __ strw(rscratch4, Address(state, 12));
+    __ orr(state_regs[0], a, b, Assembler::LSL, 32);
+    __ orr(state_regs[1], c, d, Assembler::LSL, 32);
 
     if (multi_block) {
       __ add(buf, buf, 64);
@@ -3529,6 +3561,11 @@ class StubGenerator: public StubCodeGenerator {
       __ br(Assembler::LE, md5_loop);
       __ mov(c_rarg0, ofs); // return ofs
     }
+
+    // write hash values back in the correct order
+    __ stp(state_regs[0], state_regs[1], Address(state));
+
+    __ pop(saved_regs, sp);
 
     __ ret(lr);
 


### PR DESCRIPTION
Two optimizations have been implemented in this change to reduce memory reads in AArch64 MD5 intrinsic.

**Optimization 1:** Memory loads and stores updating hash values are moved out of the loop. The final results are only written to memory once.

The original snippet loaded the value (step 3) soon after it was written to the memory (step 2). 
```
md5_loop:
    __ ldrw(a, Address(state, 0));         // step 3: load the value from memory
    ... // loop body
    __ ldrw(rscratch1, Address(state, 0)); // step 1: load the value at Address(state, 0)
    __ addw(rscratch1, rscratch1, a);
    __ strw(rscratch1, Address(state, 0)); // step 2: write the value to memory
    ...
    __ br(Assembler::LE, md5_loop);
```

The snippet is optimized to avoid memory loads and writes in the loop.
```
    __ ldp(s0, s1, Address(state,  0));    // load the value at Address(state, 0) to a register
    __ ubfx(a, s0, 0, 32);
md5_loop:
    .. // body
    __ ubfx(rscratch1, s0, 0, 32);         // step 1: extract the value from the register
    __ addw(a, rscratch1, a);
    __ orr(s0, a, b, Assembler::LSL, 32);  // step 2: preserve the value in the register
    ....
    __ br(Assembler::LE, md5_loop);
    ....
    __ str(s0, Address(state, 0));         // write the result to memory only once
```

**Optimization 2**: Redundant loads generated by `md5_GG`, `md5_HH`, and `md5_II` are removed.

The original snippet, generated by two `md5_FF`s and `md5_GG`s, read the same data repeatedly.
```
__ ldrw(rscratch1, Address(buf, 0));    // from md5_FF(.., k = 0, ..)
...
__ ldrw(rscratch1, Address(buf, 4));    // from md5_FF(.., k = 1, ..)
...
__ ldrw(rscratch1, Address(buf, 4));    // from md5_GG(.., k = 1, ..)
...
__ ldrw(rscratch1, Address(buf, 0));    // from md5_GG(.., k = 0, ..)
```

The snippet is optimized by caching the values in registers and removing the redundant loads.
```
__ ldp (buf0, buf1, Address(buf, 0));  // load both values into buf0
...
__ ubfx(rscratch1, buf0, 0, 32);       // extract the value of k = 0 from the lower 32 bits of buf0
...
__ ubfx(rscratch1, buf0, 32, 32);      // extract the value of k = 1 from the higher 32 bits of buf0
...
__ ubfx(rscratch1, buf0, 32, 32); 
...
__ ubfx(rscratch1, buf0, 0, 32);
```


**Test**
The following tests have passed.
```
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5Intrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5MultiBlockIntrinsics.java
```

**Performance**
The performance is improved by ~ 1-2% with `micro:org.openjdk.bench.java.security.MessageDigests` on larger inputs.

*MessageDigests.digest* improvement
|                   | 64         | 256     | 1,024   |  4,096 | 16,384 | bytes |
|----------- |--------|--------|--------|--------|--------|-------|
| Graviton 2 | -1.39% | 0.57%  | 1.80%  | 2.20% | 2.32% |
| Graviton 3 | -3.71% | -0.40% | 0.72% | 1.05% |  1.13% |

*MessageDigests.getAndDigest* improvement
|                   | 64         | 256      | 1,024  | 4,096  | 16,384 | bytes |
|----------- |---------|--------|-------|--------|--------|-------|
| Graviton 2 | -0.78%  | 0.32%  | 1.47% | 1.83% | 1.93%  |
| Graviton 3 | -0.06%  | 0.71%  | 1.05% | 1.15%  | 1.16%  |

Graviton 2
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score    Error   Units
---- baseline ------------------------------------------------------------------------------------------
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  3709.849 ± 30.327  ops/ms
MessageDigests.digest                   md5       256     DEFAULT  thrpt   15  1513.543 ±  0.616  ops/ms
MessageDigests.digest                   md5      1024     DEFAULT  thrpt   15   462.135 ±  0.382  ops/ms
MessageDigests.digest                   md5      4096     DEFAULT  thrpt   15   122.360 ±  0.024  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    31.037 ±  0.010  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15  2902.714 ± 92.908  ops/ms
MessageDigests.getAndDigest             md5       256     DEFAULT  thrpt   15  1395.815 ±  2.292  ops/ms
MessageDigests.getAndDigest             md5      1024     DEFAULT  thrpt   15   448.729 ±  7.343  ops/ms
MessageDigests.getAndDigest             md5      4096     DEFAULT  thrpt   15   120.616 ±  0.038  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    31.010 ±  0.007  ops/ms
---- optimized -----------------------------------------------------------------------------------------
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  3658.278 ± 43.499  ops/ms
MessageDigests.digest                   md5       256     DEFAULT  thrpt   15  1522.199 ±  2.013  ops/ms
MessageDigests.digest                   md5      1024     DEFAULT  thrpt   15   470.466 ±  0.282  ops/ms
MessageDigests.digest                   md5      4096     DEFAULT  thrpt   15   125.053 ±  0.035  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    31.757 ±  0.006  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15  2879.987 ± 88.433  ops/ms
MessageDigests.getAndDigest             md5       256     DEFAULT  thrpt   15  1400.283 ±  5.980  ops/ms
MessageDigests.getAndDigest             md5      1024     DEFAULT  thrpt   15   455.327 ±  6.663  ops/ms
MessageDigests.getAndDigest             md5      4096     DEFAULT  thrpt   15   122.828 ±  0.162  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    31.609 ±  0.010  ops/ms
```

Graviton 3
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score    Error   Units
---- baseline ------------------------------------------------------------------------------------------
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  4122.050 ±  8.495  ops/ms
MessageDigests.digest                   md5       256     DEFAULT  thrpt   15  1634.045 ±  0.341  ops/ms
MessageDigests.digest                   md5      1024     DEFAULT  thrpt   15   490.091 ±  0.072  ops/ms
MessageDigests.digest                   md5      4096     DEFAULT  thrpt   15   129.017 ±  0.007  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    32.687 ±  0.002  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15  3212.170 ± 81.253  ops/ms
MessageDigests.getAndDigest             md5       256     DEFAULT  thrpt   15  1504.159 ±  1.091  ops/ms
MessageDigests.getAndDigest             md5      1024     DEFAULT  thrpt   15   476.164 ±  3.869  ops/ms
MessageDigests.getAndDigest             md5      4096     DEFAULT  thrpt   15   126.983 ±  0.011  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    32.546 ±  0.004  ops/ms
---- optimized -----------------------------------------------------------------------------------------
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  3968.992 ± 12.005  ops/ms
MessageDigests.digest                   md5       256     DEFAULT  thrpt   15  1627.529 ±  0.857  ops/ms
MessageDigests.digest                   md5      1024     DEFAULT  thrpt   15   493.640 ±  0.050  ops/ms
MessageDigests.digest                   md5      4096     DEFAULT  thrpt   15   130.374 ±  0.010  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    33.057 ±  0.002  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15  3210.093 ± 76.102  ops/ms
MessageDigests.getAndDigest             md5       256     DEFAULT  thrpt   15  1514.893 ±  1.163  ops/ms
MessageDigests.getAndDigest             md5      1024     DEFAULT  thrpt   15   481.159 ±  3.447  ops/ms
MessageDigests.getAndDigest             md5      4096     DEFAULT  thrpt   15   128.440 ±  0.017  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    32.924 ±  0.006  ops/ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308465](https://bugs.openjdk.org/browse/JDK-8308465): Reduce memory accesses in AArch64 MD5 intrinsic


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14068/head:pull/14068` \
`$ git checkout pull/14068`

Update a local copy of the PR: \
`$ git checkout pull/14068` \
`$ git pull https://git.openjdk.org/jdk.git pull/14068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14068`

View PR using the GUI difftool: \
`$ git pr show -t 14068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14068.diff">https://git.openjdk.org/jdk/pull/14068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14068#issuecomment-1555800076)