### PR TITLE
8308469: [PPC64] Implement alternative fast-locking scheme

### DIFF
--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -114,41 +114,46 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
     bne(CCR0, slow_int);
   }
 
-  // ... and mark it unlocked.
-  ori(Rmark, Rmark, markWord::unlocked_value);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    fast_lock(Roop, Rmark, Rscratch, slow_int);
+  } else if (LockingMode == LM_LEGACY) {
+    // ... and mark it unlocked.
+    ori(Rmark, Rmark, markWord::unlocked_value);
 
-  // Save unlocked object header into the displaced header location on the stack.
-  std(Rmark, BasicLock::displaced_header_offset_in_bytes(), Rbox);
+    // Save unlocked object header into the displaced header location on the stack.
+    std(Rmark, BasicLock::displaced_header_offset_in_bytes(), Rbox);
 
-  // Compare object markWord with Rmark and if equal exchange Rscratch with object markWord.
-  assert(oopDesc::mark_offset_in_bytes() == 0, "cas must take a zero displacement");
-  cmpxchgd(/*flag=*/CCR0,
-           /*current_value=*/Rscratch,
-           /*compare_value=*/Rmark,
-           /*exchange_value=*/Rbox,
-           /*where=*/Roop/*+0==mark_offset_in_bytes*/,
-           MacroAssembler::MemBarRel | MacroAssembler::MemBarAcq,
-           MacroAssembler::cmpxchgx_hint_acquire_lock(),
-           noreg,
-           &cas_failed,
-           /*check without membar and ldarx first*/true);
-  // If compare/exchange succeeded we found an unlocked object and we now have locked it
-  // hence we are done.
+    // Compare object markWord with Rmark and if equal exchange Rscratch with object markWord.
+    assert(oopDesc::mark_offset_in_bytes() == 0, "cas must take a zero displacement");
+    cmpxchgd(/*flag=*/CCR0,
+             /*current_value=*/Rscratch,
+             /*compare_value=*/Rmark,
+             /*exchange_value=*/Rbox,
+             /*where=*/Roop/*+0==mark_offset_in_bytes*/,
+             MacroAssembler::MemBarRel | MacroAssembler::MemBarAcq,
+             MacroAssembler::cmpxchgx_hint_acquire_lock(),
+             noreg,
+             &cas_failed,
+             /*check without membar and ldarx first*/true);
+    // If compare/exchange succeeded we found an unlocked object and we now have locked it
+    // hence we are done.
+  }
   b(done);
 
   bind(slow_int);
   b(slow_case); // far
 
-  bind(cas_failed);
-  // We did not find an unlocked object so see if this is a recursive case.
-  sub(Rscratch, Rscratch, R1_SP);
-  load_const_optimized(R0, (~(os::vm_page_size()-1) | markWord::lock_mask_in_place));
-  and_(R0/*==0?*/, Rscratch, R0);
-  std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), Rbox);
-  bne(CCR0, slow_int);
+  if (LockingMode == LM_LEGACY) {
+    bind(cas_failed);
+    // We did not find an unlocked object so see if this is a recursive case.
+    sub(Rscratch, Rscratch, R1_SP);
+    load_const_optimized(R0, (~(os::vm_page_size()-1) | markWord::lock_mask_in_place));
+    and_(R0/*==0?*/, Rscratch, R0);
+    std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), Rbox);
+    bne(CCR0, slow_int);
+  }
 
   bind(done);
-
   inc_held_monitor_count(Rmark /*tmp*/);
 }
 
@@ -161,33 +166,41 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
   Address mark_addr(Roop, oopDesc::mark_offset_in_bytes());
   assert(mark_addr.disp() == 0, "cas must take a zero displacement");
 
-  // Test first if it is a fast recursive unlock.
-  ld(Rmark, BasicLock::displaced_header_offset_in_bytes(), Rbox);
-  cmpdi(CCR0, Rmark, 0);
-  beq(CCR0, done);
+  if (LockingMode != LM_LIGHTWEIGHT) {
+    // Test first if it is a fast recursive unlock.
+    ld(Rmark, BasicLock::displaced_header_offset_in_bytes(), Rbox);
+    cmpdi(CCR0, Rmark, 0);
+    beq(CCR0, done);
+  }
 
   // Load object.
   ld(Roop, in_bytes(BasicObjectLock::obj_offset()), Rbox);
   verify_oop(Roop, FILE_AND_LINE);
 
-  // Check if it is still a light weight lock, this is is true if we see
-  // the stack address of the basicLock in the markWord of the object.
-  cmpxchgd(/*flag=*/CCR0,
-           /*current_value=*/R0,
-           /*compare_value=*/Rbox,
-           /*exchange_value=*/Rmark,
-           /*where=*/Roop,
-           MacroAssembler::MemBarRel,
-           MacroAssembler::cmpxchgx_hint_release_lock(),
-           noreg,
-           &slow_int);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    ld(Rmark, oopDesc::mark_offset_in_bytes(), Roop);
+    andi_(R0, Rmark, markWord::monitor_value);
+    bne(CCR0, slow_int);
+    fast_unlock(Roop, Rmark, slow_int);
+  } else if (LockingMode == LM_LEGACY) {
+    // Check if it is still a light weight lock, this is is true if we see
+    // the stack address of the basicLock in the markWord of the object.
+    cmpxchgd(/*flag=*/CCR0,
+             /*current_value=*/R0,
+             /*compare_value=*/Rbox,
+             /*exchange_value=*/Rmark,
+             /*where=*/Roop,
+             MacroAssembler::MemBarRel,
+             MacroAssembler::cmpxchgx_hint_release_lock(),
+             noreg,
+             &slow_int);
+  }
   b(done);
   bind(slow_int);
   b(slow_case); // far
 
   // Done
   bind(done);
-
   dec_held_monitor_count(Rmark /*tmp*/);
 }
 

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2629,8 +2629,7 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
                                                Metadata* method_data,
                                                bool use_rtm, bool profile_rtm) {
   assert_different_registers(oop, box, temp, displaced_header, current_header);
-  assert(flag != CCR0, "bad condition register");
-  Label cont;
+  assert(flag == CCR0, "bad condition register");
   Label object_has_monitor;
   Label cas_failed;
   Label success, failure;
@@ -2649,7 +2648,7 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   if (UseRTMForStackLocks && use_rtm) {
     rtm_stack_locking(flag, oop, displaced_header, temp, /*temp*/ current_header,
                       stack_rtm_counters, method_data, profile_rtm,
-                      cont, object_has_monitor);
+                      success, object_has_monitor);
   }
 #endif // INCLUDE_RTM_OPT
 
@@ -2658,7 +2657,11 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   andi_(temp, displaced_header, markWord::monitor_value);
   bne(CCR0, object_has_monitor);
 
-  if (LockingMode != LM_MONITOR) {
+  if (LockingMode == LM_MONITOR) {
+    // Set NE to indicate 'failure' -> take slow-path.
+    crandc(flag, Assembler::equal, flag, Assembler::equal);
+    b(failure);
+  } else if (LockingMode == LM_LEGACY) {
     // Set displaced_header to be (markWord of object | UNLOCK_VALUE).
     ori(displaced_header, displaced_header, markWord::unlocked_value);
 
@@ -2683,27 +2686,28 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
     // If the compare-and-exchange succeeded, then we found an unlocked
     // object and we have now locked it.
     b(success);
-  } else {
-    // Set NE to indicate 'failure' -> take slow-path.
-    crandc(flag, Assembler::equal, flag, Assembler::equal);
+
+    bind(cas_failed);
+    // We did not see an unlocked object so try the fast recursive case.
+
+    // Check if the owner is self by comparing the value in the markWord of object
+    // (current_header) with the stack pointer.
+    sub(current_header, current_header, R1_SP);
+    load_const_optimized(temp, ~(os::vm_page_size()-1) | markWord::lock_mask_in_place);
+
+    and_(R0/*==0?*/, current_header, temp);
+    // If condition is true we are cont and hence we can store 0 as the
+    // displaced header in the box, which indicates that it is a recursive lock.
+    std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), box);
+
+    // Uses flag == CCR0.
+    beq(CCR0, success);
     b(failure);
+  } else {
+    assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+    fast_lock(oop, displaced_header, temp, failure);
+    b(success);
   }
-
-  bind(cas_failed);
-  // We did not see an unlocked object so try the fast recursive case.
-
-  // Check if the owner is self by comparing the value in the markWord of object
-  // (current_header) with the stack pointer.
-  sub(current_header, current_header, R1_SP);
-  load_const_optimized(temp, ~(os::vm_page_size()-1) | markWord::lock_mask_in_place);
-
-  and_(R0/*==0?*/, current_header, temp);
-  // If condition is true we are cont and hence we can store 0 as the
-  // displaced header in the box, which indicates that it is a recursive lock.
-  mcrf(flag,CCR0);
-  std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), box);
-
-  b(cont);
 
   // Handle existing monitor.
   bind(object_has_monitor);
@@ -2714,7 +2718,7 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   // Use the same RTM locking code in 32- and 64-bit VM.
   if (use_rtm) {
     rtm_inflated_locking(flag, oop, displaced_header, box, temp, /*temp*/ current_header,
-                         rtm_counters, method_data, profile_rtm, cont);
+                         rtm_counters, method_data, profile_rtm, success);
   } else {
 #endif // INCLUDE_RTM_OPT
 
@@ -2728,8 +2732,10 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
            MacroAssembler::MemBarRel | MacroAssembler::MemBarAcq,
            MacroAssembler::cmpxchgx_hint_acquire_lock());
 
-  // Store a non-null value into the box.
-  std(box, BasicLock::displaced_header_offset_in_bytes(), box);
+  if (LockingMode != LM_LIGHTWEIGHT) {
+    // Store a non-null value into the box.
+    std(box, BasicLock::displaced_header_offset_in_bytes(), box);
+  }
   beq(flag, success);
 
   // Check for recursive locking.
@@ -2746,10 +2752,8 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   } // use_rtm()
 #endif
 
-  bind(cont);
   // flag == EQ indicates success, increment held monitor count
   // flag == NE indicates failure
-  bne(flag, failure);
   bind(success);
   inc_held_monitor_count(temp);
   bind(failure);
@@ -2759,9 +2763,8 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
                                                  Register temp, Register displaced_header, Register current_header,
                                                  bool use_rtm) {
   assert_different_registers(oop, box, temp, displaced_header, current_header);
-  assert(flag != CCR0, "bad condition register");
-  Label object_has_monitor, notRecursive;
-  Label success, failure;
+  assert(flag == CCR0, "bad condition register");
+  Label success, failure, anonymous, not_anonymous, object_has_monitor, notRecursive;
 
 #if INCLUDE_RTM_OPT
   if (UseRTMForStackLocks && use_rtm) {
@@ -2776,7 +2779,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   }
 #endif
 
-  if (LockingMode != LM_MONITOR) {
+  if (LockingMode == LM_LEGACY) {
     // Find the lock address and load the displaced header from the stack.
     ld(displaced_header, BasicLock::displaced_header_offset_in_bytes(), box);
 
@@ -2792,7 +2795,11 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   andi_(R0, current_header, markWord::monitor_value);
   bne(CCR0, object_has_monitor);
 
-  if (LockingMode != LM_MONITOR) {
+  if (LockingMode == LM_MONITOR) {
+    // Set NE to indicate 'failure' -> take slow-path.
+    crandc(flag, Assembler::equal, flag, Assembler::equal);
+    b(failure);
+  } else if (LockingMode == LM_LEGACY) {
     // Check if it is still a light weight lock, this is is true if we see
     // the stack address of the basicLock in the markWord of the object.
     // Cmpxchg sets flag to cmpd(current_header, box).
@@ -2808,9 +2815,9 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
     assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
     b(success);
   } else {
-    // Set NE to indicate 'failure' -> take slow-path.
-    crandc(flag, Assembler::equal, flag, Assembler::equal);
-    b(failure);
+    assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+    fast_unlock(oop, current_header, failure);
+    b(success);
   }
 
   // Handle existing monitor.
@@ -2819,7 +2826,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   addi(current_header, current_header, -(int)markWord::monitor_value); // monitor
   ld(temp,             in_bytes(ObjectMonitor::owner_offset()), current_header);
 
-    // It's inflated.
+  // It's inflated.
 #if INCLUDE_RTM_OPT
   if (use_rtm) {
     Label L_regular_inflated_unlock;
@@ -2832,15 +2839,43 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   }
 #endif
 
-  ld(displaced_header, in_bytes(ObjectMonitor::recursions_offset()), current_header);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    // Some other platforms use a C2HandleAnonOMOwnerStub stub.
+    // This doesn't work well here, because we reach here for native wrappers, too.
+    // In addition, the stub may be out of range for conditional branches.
+    // The fixup code is not long, so we do it among other special cases below.
+
+    // If the owner is anonymous, we need to fix it.
+    andi_(R0, temp, ObjectMonitor::ANONYMOUS_OWNER);
+    bne(CCR0, anonymous);
+  }
 
   cmpd(flag, temp, R16_thread);
   bne(flag, failure);
+
+  bind(not_anonymous);
+  ld(displaced_header, in_bytes(ObjectMonitor::recursions_offset()), current_header);
 
   addic_(displaced_header, displaced_header, -1);
   blt(CCR0, notRecursive); // Not recursive if negative after decrement.
   std(displaced_header, in_bytes(ObjectMonitor::recursions_offset()), current_header);
   b(success); // flag is already EQ here.
+
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    bind(anonymous);
+    // Fix owner to be the current thread.
+    std(R16_thread, in_bytes(ObjectMonitor::owner_offset()), current_header);
+
+    // Pop owner object from lock-stack.
+    lwz(temp, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
+    addi(temp, temp, -oopSize);
+#ifdef ASSERT
+    li(R0, 0);
+    stwx(R0, temp, R16_thread);
+#endif
+    stw(temp, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
+    b(not_anonymous);
+  }
 
   bind(notRecursive);
   ld(temp,             in_bytes(ObjectMonitor::EntryList_offset()), current_header);
@@ -4410,6 +4445,7 @@ void MacroAssembler::pop_cont_fastpath() {
   bind(done);
 }
 
+// Note: Must preserve CCR0 EQ (invariant).
 void MacroAssembler::inc_held_monitor_count(Register tmp) {
   ld(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 #ifdef ASSERT
@@ -4418,11 +4454,13 @@ void MacroAssembler::inc_held_monitor_count(Register tmp) {
   bge_predict_taken(CCR0, ok);
   stop("held monitor count is negativ at increment");
   bind(ok);
+  crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Restore CCR0 EQ
 #endif
   addi(tmp, tmp, 1);
   std(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 }
 
+// Note: Must preserve CCR0 EQ (invariant).
 void MacroAssembler::dec_held_monitor_count(Register tmp) {
   ld(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 #ifdef ASSERT
@@ -4431,7 +4469,136 @@ void MacroAssembler::dec_held_monitor_count(Register tmp) {
   bgt_predict_taken(CCR0, ok);
   stop("held monitor count is <= 0 at decrement");
   bind(ok);
+  crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Restore CCR0 EQ
 #endif
   addi(tmp, tmp, -1);
   std(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
+}
+
+// Function to flip between unlocked and locked state (fast locking).
+// Branches to failed if the state is not as expected with CCR0 NE.
+// Falls through upon success with CCR0 EQ.
+// This requires fewer instructions and registers and is easier to use than the
+// cmpxchg based implementation.
+void MacroAssembler::atomically_flip_locked_state(bool is_unlock, Register obj, Register tmp, Label& failed, int semantics) {
+  assert_different_registers(obj, tmp, R0);
+  Label retry;
+
+  if (semantics & MemBarRel) {
+    release();
+  }
+
+  bind(retry);
+  STATIC_ASSERT(markWord::locked_value == 0); // Or need to change this!
+  if (!is_unlock) {
+    ldarx(tmp, obj, MacroAssembler::cmpxchgx_hint_acquire_lock());
+    xori(tmp, tmp, markWord::unlocked_value); // flip unlocked bit
+    andi_(R0, tmp, markWord::lock_mask_in_place);
+    bne(CCR0, failed); // failed if new header doesn't contain locked_value (which is 0)
+  } else {
+    ldarx(tmp, obj, MacroAssembler::cmpxchgx_hint_release_lock());
+    andi_(R0, tmp, markWord::lock_mask_in_place);
+    bne(CCR0, failed); // failed if old header doesn't contain locked_value (which is 0)
+    ori(tmp, tmp, markWord::unlocked_value); // set unlocked bit
+  }
+  stdcx_(tmp, obj);
+  bne(CCR0, retry);
+
+  if (semantics & MemBarFenceAfter) {
+    fence();
+  } else if (semantics & MemBarAcq) {
+    isync();
+  }
+}
+
+// Implements fast-locking.
+// Branches to slow upon failure to lock the object, with CCR0 NE.
+// Falls through upon success with CCR0 EQ.
+//
+//  - obj: the object to be locked
+//  - hdr: the header, already loaded from obj, will be destroyed
+//  - t1: temporary register
+void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Label& slow) {
+  assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
+  assert_different_registers(obj, hdr, t1);
+
+  // Check if we would have space on lock-stack for the object.
+  lwz(t1, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
+  cmplwi(CCR0, t1, LockStack::end_offset() - 1);
+  bgt(CCR0, slow);
+
+  // Quick check: Do not reserve cache line for atomic update if not unlocked.
+  // (Similar to contention_hint in cmpxchg solutions.)
+  xori(R0, hdr, markWord::unlocked_value); // flip unlocked bit
+  andi_(R0, R0, markWord::lock_mask_in_place);
+  bne(CCR0, slow); // failed if new header doesn't contain locked_value (which is 0)
+
+  // Note: We're not publishing anything (like the displaced header in LM_LEGACY)
+  // to other threads at this point. Hence, no release barrier, here.
+  // (The obj has been written to the BasicObjectLock at obj_offset() within the own thread stack.)
+  atomically_flip_locked_state(/* is_unlock */ false, obj, hdr, slow, MacroAssembler::MemBarAcq);
+
+  // After successful lock, push object on lock-stack
+  stdx(obj, t1, R16_thread);
+  addi(t1, t1, oopSize);
+  stw(t1, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
+}
+
+// Implements fast-unlocking.
+// Branches to slow upon failure, with CCR0 NE.
+// Falls through upon success, with CCR0 EQ.
+//
+// - obj: the object to be unlocked
+// - hdr: the (pre-loaded) header of the object, will be destroyed
+void MacroAssembler::fast_unlock(Register obj, Register hdr, Label& slow) {
+  assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
+  assert_different_registers(obj, hdr);
+
+#ifdef ASSERT
+  {
+    // Check that hdr is fast-locked.
+    Label hdr_ok;
+    andi_(R0, hdr, markWord::lock_mask_in_place);
+    beq(CCR0, hdr_ok);
+    stop("Header is not fast-locked");
+    bind(hdr_ok);
+  }
+  Register t1 = hdr; // Reuse in debug build.
+  {
+    // The following checks rely on the fact that LockStack is only ever modified by
+    // its owning thread, even if the lock got inflated concurrently; removal of LockStack
+    // entries after inflation will happen delayed in that case.
+
+    // Check for lock-stack underflow.
+    Label stack_ok;
+    lwz(t1, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
+    cmplwi(CCR0, t1, LockStack::start_offset());
+    bgt(CCR0, stack_ok);
+    stop("Lock-stack underflow");
+    bind(stack_ok);
+  }
+  {
+    // Check if the top of the lock-stack matches the unlocked object.
+    Label tos_ok;
+    addi(t1, t1, -oopSize);
+    ldx(t1, t1, R16_thread);
+    cmpd(CCR0, t1, obj);
+    beq(CCR0, tos_ok);
+    stop("Top of lock-stack does not match the unlocked object");
+    bind(tos_ok);
+  }
+#endif
+
+  // Release the lock.
+  atomically_flip_locked_state(/* is_unlock */ true, obj, hdr, slow, MacroAssembler::MemBarRel);
+
+  // After successful unlock, pop object from lock-stack
+  Register t2 = hdr;
+  lwz(t2, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
+  addi(t2, t2, -oopSize);
+#ifdef ASSERT
+  li(R0, 0);
+  stdx(R0, t2, R16_thread);
+#endif
+  stw(t2, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
 }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2862,7 +2862,10 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   addic_(displaced_header, displaced_header, -1);
   blt(CCR0, notRecursive); // Not recursive if negative after decrement.
   std(displaced_header, in_bytes(ObjectMonitor::recursions_offset()), current_header);
-  b(success); // flag is already EQ here.
+  if (flag == CCR0) { // Otherwise, flag is already EQ, here.
+    crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Set CCR0 EQ
+  }
+  b(success);
 
   if (LockingMode == LM_LIGHTWEIGHT) {
     bind(anonymous);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -606,6 +606,9 @@ class MacroAssembler: public Assembler {
   void pop_cont_fastpath();
   void inc_held_monitor_count(Register tmp);
   void dec_held_monitor_count(Register tmp);
+  void atomically_flip_locked_state(bool is_unlock, Register obj, Register tmp, Label& failed, int semantics);
+  void fast_lock(Register obj, Register hdr, Register t1, Label& slow);
+  void fast_unlock(Register obj, Register hdr, Label& slow);
 
   // allocation (for C1)
   void tlab_allocate(

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -12139,7 +12139,7 @@ instruct partialSubtypeCheck(iRegPdst result, iRegP_N2P subklass, iRegP_N2P supe
 
 // inlined locking and unlocking
 
-instruct cmpFastLock(flagsReg crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2) %{
+instruct cmpFastLock(flagsRegCR0 crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2) %{
   match(Set crx (FastLock oop box));
   effect(TEMP tmp1, TEMP tmp2);
   predicate(!Compile::current()->use_rtm());
@@ -12156,7 +12156,7 @@ instruct cmpFastLock(flagsReg crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iR
 %}
 
 // Separate version for TM. Use bound register for box to enable USE_KILL.
-instruct cmpFastLock_tm(flagsReg crx, iRegPdst oop, rarg2RegP box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
+instruct cmpFastLock_tm(flagsRegCR0 crx, iRegPdst oop, rarg2RegP box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
   match(Set crx (FastLock oop box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3, USE_KILL box);
   predicate(Compile::current()->use_rtm());
@@ -12175,7 +12175,7 @@ instruct cmpFastLock_tm(flagsReg crx, iRegPdst oop, rarg2RegP box, iRegPdst tmp1
   ins_pipe(pipe_class_compare);
 %}
 
-instruct cmpFastUnlock(flagsReg crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
+instruct cmpFastUnlock(flagsRegCR0 crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
   match(Set crx (FastUnlock oop box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
   predicate(!Compile::current()->use_rtm());
@@ -12192,7 +12192,7 @@ instruct cmpFastUnlock(flagsReg crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, 
   ins_pipe(pipe_class_compare);
 %}
 
-instruct cmpFastUnlock_tm(flagsReg crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
+instruct cmpFastUnlock_tm(flagsRegCR0 crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
   match(Set crx (FastUnlock oop box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
   predicate(Compile::current()->use_rtm());

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -12156,7 +12156,7 @@ instruct cmpFastLock(flagsRegCR0 crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1,
 %}
 
 // Separate version for TM. Use bound register for box to enable USE_KILL.
-instruct cmpFastLock_tm(flagsRegCR0 crx, iRegPdst oop, rarg2RegP box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
+instruct cmpFastLock_tm(flagsReg crx, iRegPdst oop, rarg2RegP box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
   match(Set crx (FastLock oop box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3, USE_KILL box);
   predicate(Compile::current()->use_rtm());
@@ -12192,7 +12192,7 @@ instruct cmpFastUnlock(flagsRegCR0 crx, iRegPdst oop, iRegPdst box, iRegPdst tmp
   ins_pipe(pipe_class_compare);
 %}
 
-instruct cmpFastUnlock_tm(flagsRegCR0 crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
+instruct cmpFastUnlock_tm(flagsReg crx, iRegPdst oop, iRegPdst box, iRegPdst tmp1, iRegPdst tmp2, iRegPdst tmp3) %{
   match(Set crx (FastUnlock oop box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
   predicate(Compile::current()->use_rtm());

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -394,6 +394,10 @@ void VM_Version::initialize() {
       // high lock contention. For now we do not use it by default.
       vm_exit_during_initialization("UseRTMLocking flag should be only set on command line");
     }
+    if (LockingMode != LM_LEGACY) {
+      warning("UseRTMLocking requires LockingMode = 1");
+      FLAG_SET_DEFAULT(UseRTMLocking, false);
+    }
 #else
     // Only C2 does RTM locking optimization.
     vm_exit_during_initialization("RTM locking optimization is not supported in this VM");

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1905,7 +1905,7 @@ bool Arguments::check_vm_args_consistency() {
 #endif
 
 
-#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM)
+#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64)
   if (LockingMode == LM_LIGHTWEIGHT) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
     warning("New lightweight locking not supported on this platform");


### PR DESCRIPTION
New alternative fast-locking scheme for PPC64. Mostly implemented like on other platforms.
Differences (also explained by comments in code):
- Not using C2HandleAnonOMOwnerStub because the C2 code is reused for native wrappers.
- Implemented a helper function `MacroAssembler::atomically_flip_locked_state` which makes it much easier to implement fast_lock/unlock for PPC64 (mainly because of register constraints in C1).
- Using acquire/release barriers only for locking/unlocking.

I have changed the C2 code to use ConditionRegister CR0 which fits better to the new locking code. Therefore, I have adapted the other modes to work with that, too.
Note that we don't support RTM with new locking modes. That feature will probably get removed in a future JDK version. (Already unsupported with Power10.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308469](https://bugs.openjdk.org/browse/JDK-8308469): [PPC64] Implement alternative fast-locking scheme


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**) ⚠️ Review applies to [eae93f86](https://git.openjdk.org/jdk/pull/14069/files/eae93f861b038636399e13e592d8aa055947f39d)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14069/head:pull/14069` \
`$ git checkout pull/14069`

Update a local copy of the PR: \
`$ git checkout pull/14069` \
`$ git pull https://git.openjdk.org/jdk.git pull/14069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14069`

View PR using the GUI difftool: \
`$ git pr show -t 14069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14069.diff">https://git.openjdk.org/jdk/pull/14069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14069#issuecomment-1557021306)