### PR TITLE
8307783: runtime/reflect/ReflectOutOfMemoryError.java timed out

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,6 +104,7 @@ runtime/ErrorHandling/TestDwarf.java 8305489 linux-all
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
+containers/docker/TestMemoryAwareness.java 8303470 linux-x64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8297977
  * @summary Test that throwing OOM from reflected method gets InvocationTargetException
- * @run main/othervm ReflectOutOfMemoryError
+ * @run main/othervm/timeout=150 ReflectOutOfMemoryError
  */
 import java.lang.reflect.*;
 

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -58,6 +58,8 @@ javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 w
 
 javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-x64
 
+javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
+
 ##########
 ## Tests incompatible with  with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -60,6 +60,8 @@ javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-
 
 javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
 
+java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
+
 ##########
 ## Tests incompatible with  with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -56,6 +56,8 @@ sun/tools/jstack/BasicJStackTest.java 8308033 generic-all
 
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
 
+javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-x64
+
 ##########
 ## Tests incompatible with  with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -524,6 +524,8 @@ javax/management/monitor/DerivedGaugeMonitorTest.java           8042211 generic-
 
 javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 generic-all
 
+javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8262312 linux-all
+
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
A trivial fix to increase a timeout:
[JDK-8307783](https://bugs.openjdk.org/browse/JDK-8307783) runtime/reflect/ReflectOutOfMemoryError.java timed out

Trivial fixes to ProblemList tests:
[JDK-8308468](https://bugs.openjdk.org/browse/JDK-8308468) ProblemList containers/docker/TestMemoryAwareness.java on linux-x64
[JDK-8308470](https://bugs.openjdk.org/browse/JDK-8308470) ProblemList javax/management/remote/mandatory/connection/BrokenConnectionTest.java on linux-all
[JDK-8308471](https://bugs.openjdk.org/browse/JDK-8308471) ProblemList javax/management/remote/mandatory/loading/MissingClassTest.java on windows-x64 w/ loom
[JDK-8308472](https://bugs.openjdk.org/browse/JDK-8308472) ProblemList javax/management/remote/mandatory/loading/RMIDownloadTest.java on windows-x64 w/ loom
[JDK-8308473](https://bugs.openjdk.org/browse/JDK-8308473) ProblemList java/lang/instrument/NativeMethodPrefixAgent.java with loom

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8307783](https://bugs.openjdk.org/browse/JDK-8307783): runtime/reflect/ReflectOutOfMemoryError.java timed out
 * [JDK-8308468](https://bugs.openjdk.org/browse/JDK-8308468): ProblemList containers/docker/TestMemoryAwareness.java on linux-x64
 * [JDK-8308470](https://bugs.openjdk.org/browse/JDK-8308470): ProblemList javax/management/remote/mandatory/connection/BrokenConnectionTest.java on linux-all
 * [JDK-8308471](https://bugs.openjdk.org/browse/JDK-8308471): ProblemList javax/management/remote/mandatory/loading/MissingClassTest.java on windows-x64 w/ loom
 * [JDK-8308472](https://bugs.openjdk.org/browse/JDK-8308472): ProblemList javax/management/remote/mandatory/loading/RMIDownloadTest.java on windows-x64 w/ loom
 * [JDK-8308473](https://bugs.openjdk.org/browse/JDK-8308473): ProblemList java/lang/instrument/NativeMethodPrefixAgent.java with loom


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14070/head:pull/14070` \
`$ git checkout pull/14070`

Update a local copy of the PR: \
`$ git checkout pull/14070` \
`$ git pull https://git.openjdk.org/jdk.git pull/14070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14070`

View PR using the GUI difftool: \
`$ git pr show -t 14070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14070.diff">https://git.openjdk.org/jdk/pull/14070.diff</a>

</details>
