### PR TITLE
8308458: Windows build failure with disassembler.cpp(792): warning C4267: '=': conversion from 'size_t' to 'int'

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -789,7 +789,7 @@ bool Disassembler::load_library(outputStream* st) {
   char* p = strrchr(buf, '/');
   *p = '\0';
   strcat(p, "/lib/");
-  lib_offset = jvm_offset = strlen(buf);
+  lib_offset = jvm_offset = (int)strlen(buf);
 #else
   {
     // Match "libjvm" instead of "jvm" on *nix platforms. Creates better matches.


### PR DESCRIPTION
Trivial fix with casting `strlen` return value to `int`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308458](https://bugs.openjdk.org/browse/JDK-8308458): Windows build failure with disassembler.cpp(792): warning C4267: '=': conversion from 'size_t' to 'int'


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14074/head:pull/14074` \
`$ git checkout pull/14074`

Update a local copy of the PR: \
`$ git checkout pull/14074` \
`$ git pull https://git.openjdk.org/jdk.git pull/14074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14074`

View PR using the GUI difftool: \
`$ git pr show -t 14074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14074.diff">https://git.openjdk.org/jdk/pull/14074.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14074#issuecomment-1556489225)