### PR TITLE
8308500: ZStatSubPhase::register_start should not call register_gc_phase_start if ZAbort::should_abort()

### DIFF
--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -808,7 +808,7 @@ ZStatSubPhase::ZStatSubPhase(const char* name, ZGenerationId id)
   : ZStatPhase(id == ZGenerationId::young ? "Young Subphase" : "Old Subphase", name) {}
 
 void ZStatSubPhase::register_start(ConcurrentGCTimer* timer, const Ticks& start) const {
-  if (timer != nullptr) {
+  if (timer != nullptr && !ZAbort::should_abort()) {
     assert(!Thread::current()->is_Worker_thread(), "Unexpected timer value");
     timer->register_gc_phase_start(name(), start);
   }


### PR DESCRIPTION
`ZStatSubPhase::register_start` should not call `register_gc_phase_start` if `ZAbort::should_abort()` is true. This will cause an unbalanced push and pop behaviour of the phase stack as `ZStatSubPhase::register_end` stops popping (and sending events) after the aborting has started. This will create an issue if more subsequent sub-phases are added in-between two abort points as the phase stack may overflow. 

Simply avoid pushing new phases when aborting has started solves this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308500](https://bugs.openjdk.org/browse/JDK-8308500): ZStatSubPhase::register_start should not call register_gc_phase_start if ZAbort::should_abort()


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14075/head:pull/14075` \
`$ git checkout pull/14075`

Update a local copy of the PR: \
`$ git checkout pull/14075` \
`$ git pull https://git.openjdk.org/jdk.git pull/14075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14075`

View PR using the GUI difftool: \
`$ git pr show -t 14075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14075.diff">https://git.openjdk.org/jdk/pull/14075.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14075#issuecomment-1556706162)