### PR TITLE
8308093: Disable language preview features use in JDK

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -110,7 +110,6 @@ JAVA_WARNINGS_ARE_ERRORS ?= -Werror
 JAVADOC_OPTIONS := -use -keywords -notimestamp \
     -encoding ISO-8859-1 -docencoding UTF-8 -breakiterator \
     -splitIndex --system none -javafx --expand-requires transitive \
-    --enable-preview -source $(JDK_SOURCE_TARGET_VERSION) \
     --override-methods=summary \
     --no-external-specs-page
 
@@ -118,7 +117,6 @@ JAVADOC_OPTIONS := -use -keywords -notimestamp \
 # development cycle.
 REFERENCE_OPTIONS := -XDignore.symbol.file=true -use -keywords -notimestamp \
     -encoding ISO-8859-1 -breakiterator -splitIndex --system none \
-    --enable-preview -source $(JDK_SOURCE_TARGET_VERSION) \
     -html5 -javafx --expand-requires transitive \
     --no-external-specs-page
 

--- a/make/modules/java.base/Java.gmk
+++ b/make/modules/java.base/Java.gmk
@@ -27,9 +27,7 @@ DISABLED_WARNINGS_java += this-escape
 
 DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:java.*,javax.*'
-JAVAC_FLAGS += -XDstringConcat=inline \
-    --enable-preview
-DISABLED_WARNINGS_java += preview
+JAVAC_FLAGS += -XDstringConcat=inline
 COPY += .icu .dat .spp .nrm content-types.properties \
     hijrah-config-Hijrah-umalqura_islamic-umalqura.properties
 CLEAN += intrinsic.properties

--- a/make/modules/jdk.jartool/Java.gmk
+++ b/make/modules/jdk.jartool/Java.gmk
@@ -25,5 +25,3 @@
 
 DISABLED_WARNINGS_java += missing-explicit-ctor
 JAVAC_FLAGS += -XDstringConcat=inline
-JAVAC_FLAGS += --enable-preview
-DISABLED_WARNINGS_java += preview

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -150,7 +150,6 @@ module java.base {
         java.compiler,
         jdk.compiler,
         jdk.incubator.vector, // participates in preview features
-        jdk.jartool, // participates in preview features
         jdk.jshell;
     exports jdk.internal.access to
         java.desktop,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -106,8 +106,6 @@ public class ClassWriter extends ClassFile {
     /** Type utilities. */
     private Types types;
 
-    private Symtab syms;
-
     private Check check;
 
     /**
@@ -174,7 +172,6 @@ public class ClassWriter extends ClassFile {
         target = Target.instance(context);
         source = Source.instance(context);
         types = Types.instance(context);
-        syms = Symtab.instance(context);
         check = Check.instance(context);
         fileManager = context.get(JavaFileManager.class);
         poolWriter = Gen.instance(context).poolWriter;
@@ -1676,9 +1673,7 @@ public class ClassWriter extends ClassFile {
         acount += writeExtraAttributes(c);
 
         poolbuf.appendInt(JAVA_MAGIC);
-        if (preview.isEnabled() && preview.usesPreview(c.sourcefile)
-                // do not write PREVIEW_MINOR_VERSION for classes participating in preview
-                && !preview.participatesInPreview(syms, c, syms.java_base.unnamedPackage)) {
+        if (preview.isEnabled() && preview.usesPreview(c.sourcefile)) {
             poolbuf.appendChar(ClassFile.PREVIEW_MINOR_VERSION);
         } else {
             poolbuf.appendChar(target.minorVersion);

--- a/src/jdk.jartool/share/classes/module-info.java
+++ b/src/jdk.jartool/share/classes/module-info.java
@@ -23,8 +23,6 @@
  * questions.
  */
 
-import jdk.internal.javac.ParticipatesInPreview;
-
 /**
  * Defines tools for manipulating Java Archive (JAR) files,
  * including the <em>{@index jar jar tool}</em> and
@@ -49,7 +47,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module jdk.jartool {
     requires jdk.internal.opt;
 

--- a/test/jdk/jdk/classfile/TEST.properties
+++ b/test/jdk/jdk/classfile/TEST.properties
@@ -1,5 +1,4 @@
 maxOutputSize = 2500000
-enablePreview = true
 modules = \
     java.base/jdk.internal.classfile \
     java.base/jdk.internal.classfile.attribute \
@@ -8,6 +7,5 @@ modules = \
     java.base/jdk.internal.classfile.impl \
     java.base/jdk.internal.classfile.impl.verifier \
     java.base/jdk.internal.classfile.components \
-    java.base/jdk.internal.classfile.util \
     java.base/jdk.internal.org.objectweb.asm \
     java.base/jdk.internal.org.objectweb.asm.tree

--- a/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
@@ -46,7 +46,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 2)
 @Measurement(iterations = 4)
 @Fork(value = 1, jvmArgsAppend = {
-        "--enable-preview",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",

--- a/test/micro/org/openjdk/bench/jdk/classfile/GenerateStackMaps.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/GenerateStackMaps.java
@@ -56,7 +56,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgsAppend = {
-        "--enable-preview",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.attribute=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED",

--- a/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
@@ -40,7 +40,6 @@ import org.openjdk.jmh.annotations.*;
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgsAppend = {
-        "--enable-preview",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.instruction=ALL-UNNAMED"})

--- a/test/micro/org/openjdk/bench/jdk/classfile/RepeatedModelTraversal.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RepeatedModelTraversal.java
@@ -39,7 +39,6 @@ import org.openjdk.jmh.annotations.*;
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgsAppend = {
-        "--enable-preview",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.components=ALL-UNNAMED"})
 @Warmup(iterations = 3)

--- a/test/micro/org/openjdk/bench/jdk/classfile/Write.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Write.java
@@ -66,7 +66,6 @@ import static jdk.internal.org.objectweb.asm.Opcodes.V12;
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
 @Fork(value = 1, jvmArgsAppend = {
-        "--enable-preview",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",


### PR DESCRIPTION
This patch disables temporary use of language preview features in JDK.
Temporary enabled language preview features (to allow Pattern Matching for switch use in the Classfile API library) are no more necessary.
All redundant use of --enable-preview in the Classfile API tests are also removed.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308093](https://bugs.openjdk.org/browse/JDK-8308093): Disable language preview features use in JDK


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14076/head:pull/14076` \
`$ git checkout pull/14076`

Update a local copy of the PR: \
`$ git checkout pull/14076` \
`$ git pull https://git.openjdk.org/jdk.git pull/14076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14076`

View PR using the GUI difftool: \
`$ git pr show -t 14076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14076.diff">https://git.openjdk.org/jdk/pull/14076.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14076#issuecomment-1556939618)