### PR TITLE
8308507: G1: GClocker induced GCs can starve threads requiring memory leading to OOME

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -70,6 +70,10 @@ G1Allocator::~G1Allocator() {
 #ifdef ASSERT
 bool G1Allocator::has_mutator_alloc_region() {
   uint node_index = current_node_index();
+  return has_mutator_alloc_region(node_index);
+}
+
+bool G1Allocator::has_mutator_alloc_region(uint node_index) {
   return mutator_alloc_region(node_index)->get() != nullptr;
 }
 #endif

--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -67,11 +67,6 @@ G1Allocator::~G1Allocator() {
   FREE_C_HEAP_ARRAY(SurvivorGCAllocRegion, _survivor_gc_alloc_regions);
 }
 
-#ifdef ASSERT
-bool G1Allocator::has_mutator_alloc_region(uint node_index) {
-  return mutator_alloc_region(node_index)->get() != nullptr;
-}
-#endif
 
 void G1Allocator::init_mutator_alloc_regions() {
   for (uint i = 0; i < _num_alloc_regions; i++) {

--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -68,11 +68,6 @@ G1Allocator::~G1Allocator() {
 }
 
 #ifdef ASSERT
-bool G1Allocator::has_mutator_alloc_region() {
-  uint node_index = current_node_index();
-  return has_mutator_alloc_region(node_index);
-}
-
 bool G1Allocator::has_mutator_alloc_region(uint node_index) {
   return mutator_alloc_region(node_index)->get() != nullptr;
 }

--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -97,11 +97,6 @@ public:
   // Node index of current thread.
   inline uint current_node_index() const;
 
-#ifdef ASSERT
-  // Do we currently have an active mutator region to allocate into?
-  bool has_mutator_alloc_region(uint node_index);
-#endif
-
   void init_mutator_alloc_regions();
   void release_mutator_alloc_regions();
 

--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -99,7 +99,6 @@ public:
 
 #ifdef ASSERT
   // Do we currently have an active mutator region to allocate into?
-  bool has_mutator_alloc_region();
   bool has_mutator_alloc_region(uint node_index);
 #endif
 

--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -88,18 +88,19 @@ private:
                                    size_t desired_word_size,
                                    size_t* actual_word_size);
 
-  // Node index of current thread.
-  inline uint current_node_index() const;
-
 public:
   G1Allocator(G1CollectedHeap* heap);
   ~G1Allocator();
 
   uint num_nodes() { return (uint)_num_alloc_regions; }
 
+  // Node index of current thread.
+  inline uint current_node_index() const;
+
 #ifdef ASSERT
   // Do we currently have an active mutator region to allocate into?
   bool has_mutator_alloc_region();
+  bool has_mutator_alloc_region(uint node_index);
 #endif
 
   void init_mutator_alloc_regions();
@@ -120,6 +121,7 @@ public:
   // This is to be called when holding an appropriate lock. It first tries in the
   // current allocation region, and then attempts an allocation using a new region.
   inline HeapWord* attempt_allocation_locked(size_t word_size);
+  inline HeapWord* attempt_allocation_locked(size_t word_size, uint node_index);
 
   inline HeapWord* attempt_allocation_force(size_t word_size);
 

--- a/src/hotspot/share/gc/g1/g1Allocator.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.inline.hpp
@@ -64,6 +64,10 @@ inline HeapWord* G1Allocator::attempt_allocation(size_t min_word_size,
 
 inline HeapWord* G1Allocator::attempt_allocation_locked(size_t word_size) {
   uint node_index = current_node_index();
+  return attempt_allocation_locked(word_size, node_index);
+}
+
+inline HeapWord* G1Allocator::attempt_allocation_locked(size_t word_size, uint node_index) {
   HeapWord* result = mutator_alloc_region(node_index)->attempt_allocation_locked(word_size);
 
   assert(result != nullptr || mutator_alloc_region(node_index)->get() == nullptr,

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2538,11 +2538,7 @@ bool G1CollectedHeap::do_collection_pause_at_safepoint() {
     return false;
   }
 
-  // FIXME: Rest allocated but not yet used.
-  {
-    log_debug(gc, alloc) ("Reset called at G1CollectedHeap::do_collection_pause_at_safepoint()");
-    reset_allocation_requests();
-  }
+  reset_allocation_requests();
 
   do_collection_pause_at_safepoint_helper();
   return true;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -955,6 +955,20 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
   return nullptr;
 }
 
+bool G1CollectedHeap::is_unclaimed_allocation(HeapWord *obj) {
+  if (!has_satisfied_allocations()) {
+    return false;
+  }
+
+  for(StalledAllocReq* alloc_req : _satisfied_allocations) {
+    if (alloc_req->state() == StalledAllocReq::AllocationState::Success &&
+        alloc_req->result() == obj) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool G1CollectedHeap::satisfy_failed_allocations(bool* gc_succeeded) {
   assert_at_safepoint_on_vm_thread();
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -402,13 +402,13 @@ G1CollectedHeap::mem_allocate(size_t word_size,
   return attempt_allocation(word_size, word_size, &dummy);
 }
 
-void G1CollectedHeap::attempt_allocation_after_gc(StalledAllocReq* req,
+void G1CollectedHeap::attempt_allocation_after_gc(size_t word_size,
                                                   uint gc_count_before,
                                                   bool should_try_gc,
                                                   GCCause::Cause gc_cause) {
 
   if (should_try_gc) {
-    do_collection_pause(req->size(), gc_count_before, gc_cause);
+    do_collection_pause(word_size, gc_count_before, gc_cause);
   } else {
     log_trace(gc, alloc)("%s: Stall until clear", Thread::current()->name());
     // The GCLocker is either active or the GCLocker initiated
@@ -475,7 +475,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
       gc_count_before = total_collections();
     }
 
-    attempt_allocation_after_gc(&request, gc_count_before, should_try_gc, GCCause::_g1_inc_collection_pause);
+    attempt_allocation_after_gc(request.size(), gc_count_before, should_try_gc, GCCause::_g1_inc_collection_pause);
 
     if (request.pending()) {
       // GC Safepoint did not handle our allocation request. We should retry.
@@ -701,7 +701,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
       gc_count_before = total_collections();
     }
 
-    attempt_allocation_after_gc(&request, gc_count_before, should_try_gc, GCCause::_g1_humongous_allocation);
+    attempt_allocation_after_gc(request.size(), gc_count_before, should_try_gc, GCCause::_g1_humongous_allocation);
 
     if (request.pending()) {
       // GC Safepoint did not handle our allocation request. We should retry.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -74,6 +74,7 @@
 #include "gc/g1/heapRegion.inline.hpp"
 #include "gc/g1/heapRegionRemSet.inline.hpp"
 #include "gc/g1/heapRegionSet.inline.hpp"
+#include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/concurrentGCBreakpoints.hpp"
 #include "gc/shared/gcBehaviours.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
@@ -113,6 +114,7 @@
 #include "utilities/align.hpp"
 #include "utilities/autoRestore.hpp"
 #include "utilities/bitMap.inline.hpp"
+#include "utilities/doublyLinkedList.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/stack.inline.hpp"
 
@@ -400,6 +402,53 @@ G1CollectedHeap::mem_allocate(size_t word_size,
   return attempt_allocation(word_size, word_size, &dummy);
 }
 
+bool G1CollectedHeap::attempt_allocation_after_gc(size_t word_size,
+                                                  uint gc_count_before,
+                                                  bool should_try_gc,
+                                                  HeapWord** result,
+                                                  GCCause::Cause gc_cause) {
+
+  StalledAllocReq request(word_size, _allocator->current_node_index());
+
+  {
+    MutexLocker ml(&_alloc_request_lock, Mutex::_no_safepoint_check_flag);
+    _stalled_allocations.insert_last(&request);
+  }
+
+  if (should_try_gc) {
+    bool succeeded = false;
+    do_collection_pause(word_size, gc_count_before, &succeeded, gc_cause);
+  } else {
+    log_trace(gc, alloc)("%s: Stall until clear", Thread::current()->name());
+    // The GCLocker is either active or the GCLocker initiated
+    // GC has not yet been performed. Stall until it is completed.
+    GCLocker::stall_until_clear();
+  }
+
+  {
+    MutexLocker ml(&_alloc_request_lock, Mutex::_no_safepoint_check_flag);
+    if (request.state() == StalledAllocReq::AllocationState::Pending) {
+      // GC Safepoint did not handle our allocation request. We should retry.
+      _stalled_allocations.remove(&request);
+      return false;
+    } else {
+      _satisfied_allocations.remove(&request);
+    }
+  }
+
+  if (request.state() == StalledAllocReq::AllocationState::Success) {
+    *result = request.result();
+  } else {
+    assert(request.state() == StalledAllocReq::AllocationState::Failed, "Sanity check!");
+    // VM successfully scheduled a collection which failed to allocate. No
+    // point in trying to allocate further. We'll just return null.
+    log_debug(gc, alloc)("%s: Failed to allocate "
+                         SIZE_FORMAT " words", Thread::current()->name(), word_size);
+    *result = nullptr;
+  }
+  return true;
+}
+
 HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
   ResourceMark rm; // For retrieving the thread names in log messages.
 
@@ -417,7 +466,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
   // fails to perform the allocation. b) is the only case when we'll
   // return null.
   HeapWord* result = nullptr;
-  for (uint try_count = 1, gclocker_retry_count = 0; /* we'll return */; try_count += 1) {
+  while (true) {
     bool should_try_gc;
     uint gc_count_before;
 
@@ -451,59 +500,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
       gc_count_before = total_collections();
     }
 
-    if (should_try_gc) {
-      bool succeeded;
-      result = do_collection_pause(word_size, gc_count_before, &succeeded, GCCause::_g1_inc_collection_pause);
-      if (result != nullptr) {
-        assert(succeeded, "only way to get back a non-null result");
-        log_trace(gc, alloc)("%s: Successfully scheduled collection returning " PTR_FORMAT,
-                             Thread::current()->name(), p2i(result));
-        return result;
-      }
-
-      if (succeeded) {
-        // We successfully scheduled a collection which failed to allocate. No
-        // point in trying to allocate further. We'll just return null.
-        log_trace(gc, alloc)("%s: Successfully scheduled collection failing to allocate "
-                             SIZE_FORMAT " words", Thread::current()->name(), word_size);
-        return nullptr;
-      }
-      log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating " SIZE_FORMAT " words",
-                           Thread::current()->name(), word_size);
-    } else {
-      // Failed to schedule a collection.
-      if (gclocker_retry_count > GCLockerRetryAllocationCount) {
-        log_warning(gc, alloc)("%s: Retried waiting for GCLocker too often allocating "
-                               SIZE_FORMAT " words", Thread::current()->name(), word_size);
-        return nullptr;
-      }
-      log_trace(gc, alloc)("%s: Stall until clear", Thread::current()->name());
-      // The GCLocker is either active or the GCLocker initiated
-      // GC has not yet been performed. Stall until it is and
-      // then retry the allocation.
-      GCLocker::stall_until_clear();
-      gclocker_retry_count += 1;
-    }
-
-    // We can reach here if we were unsuccessful in scheduling a
-    // collection (because another thread beat us to it) or if we were
-    // stalled due to the GC locker. In either can we should retry the
-    // allocation attempt in case another thread successfully
-    // performed a collection and reclaimed enough space. We do the
-    // first attempt (without holding the Heap_lock) here and the
-    // follow-on attempt will be at the start of the next loop
-    // iteration (after taking the Heap_lock).
-    size_t dummy = 0;
-    result = _allocator->attempt_allocation(word_size, word_size, &dummy);
-    if (result != nullptr) {
+    if (attempt_allocation_after_gc(word_size, gc_count_before, should_try_gc, &result, GCCause::_g1_inc_collection_pause)) {
       return result;
-    }
-
-    // Give a warning if we seem to be looping forever.
-    if ((QueuedAllocationWarningCount > 0) &&
-        (try_count % QueuedAllocationWarningCount == 0)) {
-      log_warning(gc, alloc)("%s:  Retried allocation %u times for " SIZE_FORMAT " words",
-                             Thread::current()->name(), try_count, word_size);
     }
   }
 
@@ -686,10 +684,9 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
   // fails to perform the allocation. b) is the only case when we'll
   // return null.
   HeapWord* result = nullptr;
-  for (uint try_count = 1, gclocker_retry_count = 0; /* we'll return */; try_count += 1) {
+  while (true) {
     bool should_try_gc;
     uint gc_count_before;
-
 
     {
       MutexLocker x(Heap_lock);
@@ -713,57 +710,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
       gc_count_before = total_collections();
     }
 
-    if (should_try_gc) {
-      bool succeeded;
-      result = do_collection_pause(word_size, gc_count_before, &succeeded, GCCause::_g1_humongous_allocation);
-      if (result != nullptr) {
-        assert(succeeded, "only way to get back a non-null result");
-        log_trace(gc, alloc)("%s: Successfully scheduled collection returning " PTR_FORMAT,
-                             Thread::current()->name(), p2i(result));
-        size_t size_in_regions = humongous_obj_size_in_regions(word_size);
-        policy()->old_gen_alloc_tracker()->
-          record_collection_pause_humongous_allocation(size_in_regions * HeapRegion::GrainBytes);
-        return result;
-      }
-
-      if (succeeded) {
-        // We successfully scheduled a collection which failed to allocate. No
-        // point in trying to allocate further. We'll just return null.
-        log_trace(gc, alloc)("%s: Successfully scheduled collection failing to allocate "
-                             SIZE_FORMAT " words", Thread::current()->name(), word_size);
-        return nullptr;
-      }
-      log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating " SIZE_FORMAT "",
-                           Thread::current()->name(), word_size);
-    } else {
-      // Failed to schedule a collection.
-      if (gclocker_retry_count > GCLockerRetryAllocationCount) {
-        log_warning(gc, alloc)("%s: Retried waiting for GCLocker too often allocating "
-                               SIZE_FORMAT " words", Thread::current()->name(), word_size);
-        return nullptr;
-      }
-      log_trace(gc, alloc)("%s: Stall until clear", Thread::current()->name());
-      // The GCLocker is either active or the GCLocker initiated
-      // GC has not yet been performed. Stall until it is and
-      // then retry the allocation.
-      GCLocker::stall_until_clear();
-      gclocker_retry_count += 1;
-    }
-
-
-    // We can reach here if we were unsuccessful in scheduling a
-    // collection (because another thread beat us to it) or if we were
-    // stalled due to the GC locker. In either can we should retry the
-    // allocation attempt in case another thread successfully
-    // performed a collection and reclaimed enough space.
-    // Humongous object allocation always needs a lock, so we wait for the retry
-    // in the next iteration of the loop, unlike for the regular iteration case.
-    // Give a warning if we seem to be looping forever.
-
-    if ((QueuedAllocationWarningCount > 0) &&
-        (try_count % QueuedAllocationWarningCount == 0)) {
-      log_warning(gc, alloc)("%s: Retried allocation %u times for " SIZE_FORMAT " words",
-                             Thread::current()->name(), try_count, word_size);
+    if (attempt_allocation_after_gc(word_size, gc_count_before, should_try_gc, &result, GCCause::_g1_humongous_allocation)) {
+      return result;
     }
   }
 
@@ -772,13 +720,14 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
 }
 
 HeapWord* G1CollectedHeap::attempt_allocation_at_safepoint(size_t word_size,
+                                                           uint node_index,
                                                            bool expect_null_mutator_alloc_region) {
   assert_at_safepoint_on_vm_thread();
-  assert(!_allocator->has_mutator_alloc_region() || !expect_null_mutator_alloc_region,
+  assert(!_allocator->has_mutator_alloc_region(node_index) || !expect_null_mutator_alloc_region,
          "the current alloc region was unexpectedly found to be non-null");
 
   if (!is_humongous(word_size)) {
-    return _allocator->attempt_allocation_locked(word_size);
+    return _allocator->attempt_allocation_locked(word_size, node_index);
   } else {
     HeapWord* result = humongous_obj_allocate(word_size);
     if (result != nullptr && policy()->need_to_start_conc_mark("STW humongous allocation")) {
@@ -788,6 +737,13 @@ HeapWord* G1CollectedHeap::attempt_allocation_at_safepoint(size_t word_size,
   }
 
   ShouldNotReachHere();
+}
+
+HeapWord* G1CollectedHeap::attempt_allocation_at_safepoint(size_t word_size,
+                                                           bool expect_null_mutator_alloc_region) {
+  assert_at_safepoint_on_vm_thread();
+  uint node_index = _allocator->current_node_index();
+  return attempt_allocation_at_safepoint(word_size, expect_null_mutator_alloc_region, node_index);
 }
 
 class PostCompactionPrinterClosure: public HeapRegionClosure {
@@ -947,6 +903,9 @@ void G1CollectedHeap::do_full_collection(bool clear_all_soft_refs) {
 
 bool G1CollectedHeap::upgrade_to_full_collection() {
   GCCauseSetter compaction(this, GCCause::_g1_compaction_pause);
+  // Reset any allocated but yet claimed allocation requests.
+  reset_allocation_requests();
+
   log_info(gc, ergo)("Attempting full compaction clearing soft references");
   bool success = do_full_collection(true  /* clear_all_soft_refs */,
                                     false /* do_maximal_compaction */);
@@ -972,14 +931,12 @@ void G1CollectedHeap::resize_heap_if_necessary() {
 }
 
 HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
-                                                            bool do_gc,
-                                                            bool maximal_compaction,
-                                                            bool expect_null_mutator_alloc_region,
-                                                            bool* gc_succeeded) {
-  *gc_succeeded = true;
+                                                            uint node_index,
+                                                            bool expect_null_mutator_alloc_region) {
   // Let's attempt the allocation first.
   HeapWord* result =
     attempt_allocation_at_safepoint(word_size,
+                                    node_index,
                                     expect_null_mutator_alloc_region);
   if (result != nullptr) {
     return result;
@@ -989,82 +946,153 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
   // incremental pauses.  Therefore, at least for now, we'll favor
   // expansion over collection.  (This might change in the future if we can
   // do something smarter than full collection to satisfy a failed alloc.)
-  result = expand_and_allocate(word_size);
-  if (result != nullptr) {
-    return result;
-  }
+  if (expand(word_size)) {
+    return attempt_allocation_at_safepoint(word_size,
+                                           node_index,
+                                           expect_null_mutator_alloc_region);
 
-  if (do_gc) {
-    GCCauseSetter compaction(this, GCCause::_g1_compaction_pause);
-    // Expansion didn't work, we'll try to do a Full GC.
-    // If maximal_compaction is set we clear all soft references and don't
-    // allow any dead wood to be left on the heap.
-    if (maximal_compaction) {
-      log_info(gc, ergo)("Attempting maximal full compaction clearing soft references");
-    } else {
-      log_info(gc, ergo)("Attempting full compaction");
-    }
-    *gc_succeeded = do_full_collection(maximal_compaction /* clear_all_soft_refs */ ,
-                                       maximal_compaction /* do_maximal_compaction */);
   }
-
   return nullptr;
 }
 
-HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size,
-                                                     bool* succeeded) {
+bool G1CollectedHeap::satisfy_failed_allocations(bool* gc_succeeded) {
   assert_at_safepoint_on_vm_thread();
 
-  // Attempts to allocate followed by Full GC.
-  HeapWord* result =
-    satisfy_failed_allocation_helper(word_size,
-                                     true,  /* do_gc */
-                                     false, /* maximum_collection */
-                                     false, /* expect_null_mutator_alloc_region */
-                                     succeeded);
+  bool success = handle_allocation_requests(false /* expect_null_mutator_alloc_region*/);
 
-  if (result != nullptr || !*succeeded) {
-    return result;
+  if (success) {
+   return success;
   }
 
-  // Attempts to allocate followed by Full GC that will collect all soft references.
-  result = satisfy_failed_allocation_helper(word_size,
-                                            true, /* do_gc */
-                                            true, /* maximum_collection */
-                                            true, /* expect_null_mutator_alloc_region */
-                                            succeeded);
+  // Attempt to satisfy allocation requests failed; reset the requests, execute a full-gc,
+  // then try again
+  reset_allocation_requests();
 
-  if (result != nullptr || !*succeeded) {
-    return result;
+  *gc_succeeded = do_full_collection(false /* clear_all_soft_refs */, false /* do_maximal_compaction */);
+
+  if (!*gc_succeeded) {
+    return false;
   }
 
-  // Attempts to allocate, no GC
-  result = satisfy_failed_allocation_helper(word_size,
-                                            false, /* do_gc */
-                                            false, /* maximum_collection */
-                                            true,  /* expect_null_mutator_alloc_region */
-                                            succeeded);
+  success = handle_allocation_requests(true /* expect_null_mutator_alloc_region*/);
 
-  if (result != nullptr) {
-    return result;
+  if (success) {
+   return success;
+  }
+
+  // Attempt to satisfy allocation requests after full-gc also failed. We reset the allocation requests
+  // then execute a maximal compaction full-gc before retrying the allocations
+
+  reset_allocation_requests();
+
+  *gc_succeeded = do_full_collection(true /* clear_all_soft_refs */, true /* do_maximal_compaction */);;
+
+  if (!*gc_succeeded) {
+    return false;
+  }
+
+  success = handle_allocation_requests(true /* expect_null_mutator_alloc_region*/);
+
+  if (success) {
+   return success;
+  }
+
+  // Even after maximal compaction full gc, we failed to satisfy all the pending allocation requests.
+  // We can declare the pending requests as failed.
+  DoublyLinkedList<StalledAllocReq>::RemoveIterator iter(&_stalled_allocations);
+
+  for (StalledAllocReq* alloc_req; iter.next(&alloc_req);) {
+    _satisfied_allocations.insert_last(alloc_req);
+    alloc_req->set_state(StalledAllocReq::AllocationState::Failed);
   }
 
   assert(!soft_ref_policy()->should_clear_all_soft_refs(),
          "Flag should have been handled and cleared prior to this point");
-
-  // What else?  We might try synchronous finalization later.  If the total
-  // space available is large enough for the allocation, then a more
-  // complete compaction phase than we've tried so far might be
-  // appropriate.
-  return nullptr;
+  return false;
 }
 
-// Attempting to expand the heap sufficiently
-// to support an allocation of the given "word_size".  If
-// successful, perform the allocation and return the address of the
-// allocated block, or else null.
+void G1CollectedHeap::reset_allocation_requests() {
+  assert_at_safepoint_on_vm_thread();
 
-HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
+  DoublyLinkedList<StalledAllocReq> prev_allocations;
+
+  prev_allocations.swap(_satisfied_allocations);
+
+  assert(_satisfied_allocations.is_empty(), "Sanity check!");
+
+  DoublyLinkedList<StalledAllocReq>::RemoveIterator iter(&prev_allocations);
+
+  for (StalledAllocReq* alloc_req; iter.next(&alloc_req);) {
+    if (alloc_req->state() == StalledAllocReq::AllocationState::Failed) {
+      // If an allocation request was declared failed, we maintain the failed state.
+      // This prevents requests from flip-floping between Pending->Failed->Pending states.
+      // Once any allocation attempt declares a request as failed, that request will not be re-attempted.
+      _satisfied_allocations.insert_first(alloc_req);
+    } else {
+      alloc_req->set_state(StalledAllocReq::AllocationState::Pending);
+      _stalled_allocations.insert_first(alloc_req);
+    }
+  }
+}
+
+bool G1CollectedHeap::handle_allocation_requests(bool expect_null_mutator_alloc_region) {
+  assert_at_safepoint_on_vm_thread();
+
+  const uint active_numa_nodes = G1NUMA::numa()->num_active_nodes();
+  bool *expect_null_alloc_regions = (bool *)alloca(active_numa_nodes * sizeof(bool));
+  for (uint i = 0; i < active_numa_nodes; i++) {
+    expect_null_alloc_regions[i] = expect_null_mutator_alloc_region;
+  }
+
+  while(true) {
+    StalledAllocReq* alloc_req = _stalled_allocations.first();
+    if (alloc_req == nullptr) {
+      // No more pending requests, all allocations succeeded
+      return true;
+    }
+
+    HeapWord* result =
+      satisfy_failed_allocation_helper(alloc_req->size(),
+                                       alloc_req->node_index(),
+                                       expect_null_alloc_regions[alloc_req->node_index()]
+                                       );
+
+    if (result == nullptr) {
+      // Failed to allocate, give up.
+      return false;
+    }
+
+    expect_null_alloc_regions[alloc_req->node_index()] = false;
+
+    // Allocation succeeded, update the state and result of the allocation request
+    alloc_req->set_state(StalledAllocReq::AllocationState::Success, result);
+
+    if (is_humongous(alloc_req->size())) {
+      // Calculate payload size and initialize the humongous object with a fillerArray
+      size_t words = alloc_req->size();
+
+      const size_t payload_size = words - CollectedHeap::filler_array_hdr_size();
+      const size_t len = payload_size * HeapWordSize / sizeof(jint);
+      assert((int)len >= 0, "size too large " SIZE_FORMAT " becomes %d", words, (int)len);
+
+      ObjArrayAllocator allocator(Universe::fillerArrayKlassObj(), words, (int)len, /* do_zero */ false);
+      allocator.initialize(result);
+
+      size_t size_in_regions = humongous_obj_size_in_regions(alloc_req->size());
+      policy()->old_gen_alloc_tracker()->
+          record_collection_pause_humongous_allocation(size_in_regions * HeapRegion::GrainBytes);
+    } else {
+      // Fill the allocated memory with filler objects
+      CollectedHeap::fill_with_objects(result, alloc_req->size());
+    }
+
+    // Move the allocation request from stalled to satisfied list
+    _stalled_allocations.remove(alloc_req);
+    _satisfied_allocations.insert_last(alloc_req);
+  }
+}
+
+bool G1CollectedHeap::expand(size_t word_size) {
   assert_at_safepoint_on_vm_thread();
 
   _verifier->verify_region_sets_optional();
@@ -1073,10 +1101,22 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
   log_debug(gc, ergo, heap)("Attempt heap expansion (allocation request failed). Allocation request: " SIZE_FORMAT "B",
                             word_size * HeapWordSize);
 
-
   if (expand(expand_bytes, _workers)) {
     _hrm.verify_optional();
     _verifier->verify_region_sets_optional();
+    return true;
+  }
+  return false;
+}
+
+// Attempting to expand the heap sufficiently
+// to support an allocation of the given "word_size". If
+// successful, perform the allocation and return the address of the
+// allocated block, or else null.
+HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
+  assert_at_safepoint_on_vm_thread();
+
+  if (expand(word_size)) {
     return attempt_allocation_at_safepoint(word_size,
                                            false /* expect_null_mutator_alloc_region */);
   }
@@ -1220,6 +1260,9 @@ public:
 
 G1CollectedHeap::G1CollectedHeap() :
   CollectedHeap(),
+  _alloc_request_lock(Mutex::nosafepoint, "G1 Stalled Allocation List"),
+  _stalled_allocations(),
+  _satisfied_allocations(),
   _service_thread(nullptr),
   _periodic_gc_task(nullptr),
   _free_arena_memory_task(nullptr),
@@ -2493,6 +2536,12 @@ bool G1CollectedHeap::do_collection_pause_at_safepoint() {
 
   if (GCLocker::check_active_before_gc()) {
     return false;
+  }
+
+  // FIXME: Rest allocated but not yet used.
+  {
+    log_debug(gc, alloc) ("Reset called at G1CollectedHeap::do_collection_pause_at_safepoint()");
+    reset_allocation_requests();
   }
 
   do_collection_pause_at_safepoint_helper();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -903,7 +903,7 @@ void G1CollectedHeap::do_full_collection(bool clear_all_soft_refs) {
 
 bool G1CollectedHeap::upgrade_to_full_collection() {
   GCCauseSetter compaction(this, GCCause::_g1_compaction_pause);
-  // Reset any allocated but unclaimed allocation requests.
+
   reset_allocation_requests();
 
   log_info(gc, ergo)("Attempting full compaction clearing soft references");
@@ -978,8 +978,8 @@ bool G1CollectedHeap::satisfy_failed_allocations(bool* gc_succeeded) {
     return alloc_succeeded;
   }
 
-  // Attempt to satisfy allocation requests failed; reset the requests, execute a full-gc,
-  // then try again
+  // Attempt to satisfy allocation requests failed; reset the requests, execute a full gc,
+  // then try again.
   reset_allocation_requests();
 
   *gc_succeeded = do_full_collection(false /* clear_all_soft_refs */, false /* do_maximal_compaction */);
@@ -994,11 +994,11 @@ bool G1CollectedHeap::satisfy_failed_allocations(bool* gc_succeeded) {
     return alloc_succeeded;
   }
 
-  // Attempt to satisfy allocation requests after full-gc also failed. We reset the allocation requests
-  // then execute a maximal compaction full-gc before retrying the allocations
+  // Attempt to satisfy allocation requests after full gc also failed. We reset the allocation requests
+  // then execute a maximal compaction full gc before retrying the allocations.
   reset_allocation_requests();
 
-  *gc_succeeded = do_full_collection(true /* clear_all_soft_refs */, true /* do_maximal_compaction */);;
+  *gc_succeeded = do_full_collection(true /* clear_all_soft_refs */, true /* do_maximal_compaction */);
 
   if (!*gc_succeeded) {
     return false;
@@ -1060,7 +1060,7 @@ bool G1CollectedHeap::handle_allocation_requests(bool expect_null_mutator_alloc_
   while (true) {
     StalledAllocReq* alloc_req = _stalled_allocations.first();
     if (alloc_req == nullptr) {
-      // No more pending requests, all allocations succeeded
+      // No more pending requests, all allocations succeeded.
       return true;
     }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -919,8 +919,7 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
                                                             uint node_index) {
   // Let's attempt the allocation first.
   HeapWord* result =
-    attempt_allocation_at_safepoint(word_size,
-                                    node_index);
+    attempt_allocation_at_safepoint(word_size, node_index);
   if (result != nullptr) {
     return result;
   }
@@ -930,8 +929,7 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
   // expansion over collection.  (This might change in the future if we can
   // do something smarter than full collection to satisfy a failed alloc.)
   if (expand(word_size)) {
-    return attempt_allocation_at_safepoint(word_size,
-                                           node_index);
+    return attempt_allocation_at_safepoint(word_size, node_index);
 
   }
   return nullptr;
@@ -1026,8 +1024,7 @@ bool G1CollectedHeap::handle_allocation_requests(bool expect_null_mutator_alloc_
      }
 
     HeapWord* result =
-      satisfy_failed_allocation_helper(alloc_req->size(),
-                                       alloc_req->node_index());
+      satisfy_failed_allocation_helper(alloc_req->size(), alloc_req->node_index());
 
     if (result == nullptr) {
       // Failed to allocate, give up.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -543,7 +543,7 @@ private:
   // potentially schedule a GC pause.
   HeapWord* attempt_allocation_humongous(size_t word_size);
 
-  void attempt_allocation_after_gc(StalledAllocReq* req,
+  void attempt_allocation_after_gc(size_t word_size,
                                    uint gc_count_before,
                                    bool should_try_gc,
                                    GCCause::Cause gc_cause);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -250,6 +250,10 @@ private:
   G1BlockOffsetTable* _bot;
 
 public:
+
+  bool has_satisfied_allocations() { return !_satisfied_allocations.is_empty(); }
+  bool is_unclaimed_allocation(HeapWord *obj);
+
   void rebuild_free_region_list();
   // Start a new incremental collection set for the next pause.
   void start_new_collection_set();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -197,7 +197,7 @@ class G1CollectedHeap : public CollectedHeap {
       _state(AllocationState::Pending)
     { }
 
-    StalledAllocReq() : StalledAllocReq(0, 0) {}
+    StalledAllocReq() : StalledAllocReq(0, 0) { }
 
     size_t size() { return _size; }
 
@@ -519,18 +519,15 @@ private:
   HeapWord* attempt_allocation_humongous(size_t word_size);
 
   bool attempt_allocation_after_gc(size_t word_size,
-                                  uint gc_count_before,
-                                  bool should_try_gc,
-                                  HeapWord** result,
-                                  GCCause::Cause gc_cause);
+                                   uint gc_count_before,
+                                   bool should_try_gc,
+                                   HeapWord** result,
+                                   GCCause::Cause gc_cause);
 
   // Allocation attempt that should be called during safepoints (e.g.,
-  // at the end of a successful GC). expect_null_mutator_alloc_region
-  // specifies whether the mutator alloc region is expected to be null
-  // or not.
-  HeapWord* attempt_allocation_at_safepoint(size_t word_size,
-                                            bool expect_null_mutator_alloc_region);
-
+  // at the end of a successful GC). node_index speficies the memory node
+  // to use for allocation. expect_null_mutator_alloc_region specifies
+  // whether the mutator alloc region is expected to be null or not.
   HeapWord* attempt_allocation_at_safepoint(size_t word_size,
                                             uint node_index,
                                             bool expect_null_mutator_alloc_region);
@@ -571,6 +568,7 @@ private:
 
   // Reset any allocated but unclaimed allocation requests.
   void reset_allocation_requests();
+
   // Internal helpers used during full GC to split it up to
   // increase readability.
   bool abort_concurrent_cycle();
@@ -581,15 +579,12 @@ private:
   void verify_after_full_collection();
   void print_heap_after_full_collection();
 
-  // Helper method for satisfy_failed_allocation()
+  // Helper method for handle_allocation_requests()
   HeapWord* satisfy_failed_allocation_helper(size_t word_size,
                                              uint node_index,
                                              bool expect_null_mutator_alloc_region);
 
-  // Attempts to expand the heap sufficiently to support an allocation of the
-  // given "word_size". If successful, perform the allocation and return the address
-  // of the allocated block, or else null.
-  HeapWord* expand_and_allocate(size_t word_size);
+  // Attempts to expand the heap by "word_size" words.
   bool expand(size_t word_size);
 
   void verify_numa_regions(const char* desc);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -190,7 +190,7 @@ class G1CollectedHeap : public CollectedHeap {
       Failed,
     };
 
-    StalledAllocReq(size_t size, uint numa_node, G1CollectedHeap* g1h = G1CollectedHeap::heap()) :
+    StalledAllocReq(size_t size, uint numa_node, G1CollectedHeap* g1h) :
       _size(size),
       _result(nullptr),
       _node_index(numa_node),
@@ -201,8 +201,6 @@ class G1CollectedHeap : public CollectedHeap {
         _g1h->enqueue_req(this);
       }
     }
-
-    StalledAllocReq() : StalledAllocReq(0, 0, nullptr) { }
 
     ~StalledAllocReq() {
       if (_g1h != nullptr) {
@@ -229,9 +227,9 @@ class G1CollectedHeap : public CollectedHeap {
 
   private:
     const size_t _size;
-    HeapWord* _result;
+    HeapWord* volatile _result;
     const uint _node_index;
-    AllocationState _state;
+    volatile AllocationState _state;
     G1CollectedHeap* _g1h;
   };
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -185,9 +185,9 @@ class G1CollectedHeap : public CollectedHeap {
   public:
 
     enum class AllocationState {
+      Pending,
       Success,
       Failed,
-      Pending,
     };
 
     StalledAllocReq(size_t size, uint numa_node) :
@@ -563,7 +563,7 @@ private:
   // This function does everything necessary/possible to satisfy a
   // failed allocation request (including collection, expansion, etc.)
   bool satisfy_failed_allocations(bool* gc_succeeded);
-  bool handle_allocation_requests(bool expect_null_mutator_alloc_region);
+  bool handle_allocation_requests(bool expand_heap);
 
   // Reset any allocated but unclaimed allocation requests.
   void reset_allocation_requests();
@@ -579,7 +579,9 @@ private:
   void print_heap_after_full_collection();
 
   // Helper method for handle_allocation_requests()
-  HeapWord* satisfy_failed_allocation_helper(size_t word_size, uint node_index);
+  HeapWord* satisfy_failed_allocation_helper(size_t word_size,
+                                             uint node_index,
+                                             bool expand_heap);
 
   // Attempts to expand the heap by "word_size" words.
   bool expand(size_t word_size);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -209,6 +209,9 @@ class G1CollectedHeap : public CollectedHeap {
     }
 
     AllocationState state() { return _state; }
+    bool failed() { return _state == AllocationState::Failed; }
+    bool succeeded() { return _state == AllocationState::Success; }
+    bool pending() { return _state == AllocationState::Pending; }
 
     HeapWord* result() { return _result; }
 
@@ -221,7 +224,6 @@ class G1CollectedHeap : public CollectedHeap {
 
   Mutex _alloc_request_lock;
   DoublyLinkedList<StalledAllocReq> _stalled_allocations;
-  DoublyLinkedList<StalledAllocReq> _satisfied_allocations;
 
 private:
   G1ServiceThread* _service_thread;
@@ -251,7 +253,7 @@ private:
 
 public:
 
-  bool has_satisfied_allocations() { return !_satisfied_allocations.is_empty(); }
+  bool has_stalled_allocations() { return !_stalled_allocations.is_empty(); }
   bool is_unclaimed_allocation(HeapWord *obj);
 
   void rebuild_free_region_list();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -528,11 +528,9 @@ private:
 
   // Allocation attempt that should be called during safepoints (e.g.,
   // at the end of a successful GC). node_index speficies the memory node
-  // to use for allocation. expect_null_mutator_alloc_region specifies
-  // whether the mutator alloc region is expected to be null or not.
+  // to use for allocation.
   HeapWord* attempt_allocation_at_safepoint(size_t word_size,
-                                            uint node_index,
-                                            bool expect_null_mutator_alloc_region);
+                                            uint node_index);
 
   // These methods are the "callbacks" from the G1AllocRegion class.
 
@@ -583,8 +581,7 @@ private:
 
   // Helper method for handle_allocation_requests()
   HeapWord* satisfy_failed_allocation_helper(size_t word_size,
-                                             uint node_index,
-                                             bool expect_null_mutator_alloc_region);
+                                             uint node_index);
 
   // Attempts to expand the heap by "word_size" words.
   bool expand(size_t word_size);
@@ -801,18 +798,14 @@ private:
   void shrink_helper(size_t expand_bytes);
 
   // Schedule the VM operation that will do an evacuation pause to
-  // satisfy an allocation request of word_size. *succeeded will
-  // return whether the VM operation was successful (it did do an
-  // evacuation pause) or not (another thread beat us to it or the GC
-  // locker was active). Given that we should not be holding the
-  // Heap_lock when we enter this method, we will pass the
-  // gc_count_before (i.e., total_collections()) as a parameter since
+  // satisfy any pending allocation requests. Given that we should
+  // not be holding the Heap_lock when we enter this method, we will pass
+  // the gc_count_before (i.e., total_collections()) as a parameter since
   // it has to be read while holding the Heap_lock. Currently, both
   // methods that call do_collection_pause() release the Heap_lock
   // before the call, so it's easy to read gc_count_before just before.
   HeapWord* do_collection_pause(size_t         word_size,
                                 uint           gc_count_before,
-                                bool*          succeeded,
                                 GCCause::Cause gc_cause);
 
   // Perform an incremental collection at a safepoint, possibly

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -529,8 +529,7 @@ private:
   // Allocation attempt that should be called during safepoints (e.g.,
   // at the end of a successful GC). node_index speficies the memory node
   // to use for allocation.
-  HeapWord* attempt_allocation_at_safepoint(size_t word_size,
-                                            uint node_index);
+  HeapWord* attempt_allocation_at_safepoint(size_t word_size, uint node_index);
 
   // These methods are the "callbacks" from the G1AllocRegion class.
 
@@ -580,8 +579,7 @@ private:
   void print_heap_after_full_collection();
 
   // Helper method for handle_allocation_requests()
-  HeapWord* satisfy_failed_allocation_helper(size_t word_size,
-                                             uint node_index);
+  HeapWord* satisfy_failed_allocation_helper(size_t word_size, uint node_index);
 
   // Attempts to expand the heap by "word_size" words.
   bool expand(size_t word_size);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -518,11 +518,11 @@ private:
   // potentially schedule a GC pause.
   HeapWord* attempt_allocation_humongous(size_t word_size);
 
-bool attempt_allocation_after_gc(size_t word_size,
-                                 uint gc_count_before,
-                                 bool should_try_gc,
-                                 HeapWord** result,
-                                 GCCause::Cause gc_cause);
+  bool attempt_allocation_after_gc(size_t word_size,
+                                  uint gc_count_before,
+                                  bool should_try_gc,
+                                  HeapWord** result,
+                                  GCCause::Cause gc_cause);
 
   // Allocation attempt that should be called during safepoints (e.g.,
   // at the end of a successful GC). expect_null_mutator_alloc_region
@@ -568,6 +568,8 @@ bool attempt_allocation_after_gc(size_t word_size,
   // failed allocation request (including collection, expansion, etc.)
   bool satisfy_failed_allocations(bool* gc_succeeded);
   bool handle_allocation_requests(bool expect_null_mutator_alloc_region);
+
+  // Reset any allocated but unclaimed allocation requests.
   void reset_allocation_requests();
   // Internal helpers used during full GC to split it up to
   // increase readability.

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1106,8 +1106,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
 
       bool selected_for_rebuild;
       if (hr->is_humongous()) {
-        oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
-        if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed.
+        if (_g1h->is_unclaimed_allocation(hr->humongous_start_region()->bottom())) {
           return;
         }
         bool const is_live = _cm->contains_live_object(hr->humongous_start_region()->hrm_index());
@@ -1159,8 +1158,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
                "Should not have live bytes %zu in continues humongous region %u (%s)",
                marked_bytes, region_idx, hr->get_type_str());
         if (hr->is_starts_humongous()) {
-          oop obj = cast_to_oop(hr->bottom());
-          if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed.
+          if (_g1h->is_unclaimed_allocation(hr->humongous_start_region()->bottom())) {
             return;
           }
           distribute_marked_bytes(hr, marked_bytes);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1107,7 +1107,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
       bool selected_for_rebuild;
       if (hr->is_humongous()) {
         oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
-        if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed
+        if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed.
           return;
         }
         bool const is_live = _cm->contains_live_object(hr->humongous_start_region()->hrm_index());
@@ -1160,7 +1160,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
                marked_bytes, region_idx, hr->get_type_str());
         if (hr->is_starts_humongous()) {
           oop obj = cast_to_oop(hr->bottom());
-          if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed
+          if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed.
             return;
           }
           distribute_marked_bytes(hr, marked_bytes);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1106,6 +1106,10 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
 
       bool selected_for_rebuild;
       if (hr->is_humongous()) {
+        oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
+        if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed
+          return;
+        }
         bool const is_live = _cm->contains_live_object(hr->humongous_start_region()->hrm_index());
         selected_for_rebuild = tracking_policy->update_humongous_before_rebuild(hr, is_live);
       } else {
@@ -1155,6 +1159,10 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
                "Should not have live bytes %zu in continues humongous region %u (%s)",
                marked_bytes, region_idx, hr->get_type_str());
         if (hr->is_starts_humongous()) {
+          oop obj = cast_to_oop(hr->bottom());
+          if (G1CollectedHeap::is_obj_filler(obj)) { // Object allocated, but not well-formed
+            return;
+          }
           distribute_marked_bytes(hr, marked_bytes);
         }
       } else {

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -135,7 +135,7 @@ void VM_G1CollectForAllocation::doit() {
   // If any allocation has been requested, try to do that first.
   bool has_allocation_requests = !g1h->_stalled_allocations.is_empty();
   if (has_allocation_requests) {
-    bool alloc_succeeded = g1h->handle_allocation_requests(false /* expect_null_mutator_alloc_region*/);
+    bool alloc_succeeded = g1h->handle_allocation_requests(false /* expand_heap */);
 
     if (alloc_succeeded) {
       return;

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -133,7 +133,7 @@ void VM_G1CollectForAllocation::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
   // Only if operation was really triggered by an allocation.
-  if (_word_size) {
+  if (_word_size > 0) {
     bool alloc_succeeded = g1h->handle_allocation_requests(false /* expand_heap */);
 
     if (alloc_succeeded) {

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -132,9 +132,8 @@ VM_G1CollectForAllocation::VM_G1CollectForAllocation(size_t         word_size,
 void VM_G1CollectForAllocation::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-  // If any allocation has been requested, try to do that first.
-  bool has_allocation_requests = !g1h->_stalled_allocations.is_empty();
-  if (has_allocation_requests) {
+  // Only if operation was really triggered by an allocation.
+  if (_word_size) {
     bool alloc_succeeded = g1h->handle_allocation_requests(false /* expand_heap */);
 
     if (alloc_succeeded) {
@@ -154,9 +153,7 @@ void VM_G1CollectForAllocation::doit() {
     return;
   }
 
-  has_allocation_requests = !g1h->_stalled_allocations.is_empty();
-
-  if (has_allocation_requests) {
+  if (!g1h->_stalled_allocations.is_empty()) {
     g1h->satisfy_failed_allocations(&_gc_succeeded);
   } else if (g1h->should_upgrade_to_full_gc()) {
     // There has been a request to perform a GC to free some space. We have no

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -426,14 +426,6 @@ size_t CollectedHeap::max_tlab_size() const {
   return align_down(max_int_size, MinObjAlignment);
 }
 
-size_t CollectedHeap::filler_array_hdr_size() {
-  return align_object_offset(arrayOopDesc::header_size(T_INT)); // align to Long
-}
-
-size_t CollectedHeap::filler_array_min_size() {
-  return align_object_size(filler_array_hdr_size()); // align to MinObjAlignment
-}
-
 void CollectedHeap::zap_filler_array_with(HeapWord* start, size_t words, juint value) {
   Copy::fill_to_words(start + filler_array_hdr_size(),
                       words - filler_array_hdr_size(), value);

--- a/src/hotspot/share/gc/shared/collectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.inline.hpp
@@ -46,4 +46,12 @@ inline oop CollectedHeap::class_allocate(Klass* klass, size_t size, TRAPS) {
   return allocator.allocate();
 }
 
+size_t CollectedHeap::filler_array_hdr_size() {
+  return align_object_offset(arrayOopDesc::header_size(T_INT)); // align to Long
+}
+
+size_t CollectedHeap::filler_array_min_size() {
+  return align_object_size(filler_array_hdr_size()); // align to MinObjAlignment
+}
+
 #endif // SHARE_GC_SHARED_COLLECTEDHEAP_INLINE_HPP

--- a/src/hotspot/share/gc/shared/collectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.inline.hpp
@@ -47,11 +47,11 @@ inline oop CollectedHeap::class_allocate(Klass* klass, size_t size, TRAPS) {
 }
 
 size_t CollectedHeap::filler_array_hdr_size() {
-  return align_object_offset(arrayOopDesc::header_size(T_INT)); // align to Long
+  return align_object_offset(arrayOopDesc::header_size(T_INT)); // Align to INT.
 }
 
 size_t CollectedHeap::filler_array_min_size() {
-  return align_object_size(filler_array_hdr_size()); // align to MinObjAlignment
+  return align_object_size(filler_array_hdr_size()); // Align to MinObjAlignment.
 }
 
 #endif // SHARE_GC_SHARED_COLLECTEDHEAP_INLINE_HPP

--- a/src/hotspot/share/utilities/doublyLinkedList.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/doublyLinkedList.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.hpp
@@ -67,13 +67,10 @@ public:
 //
 template <typename T>
 class DoublyLinkedList {
-  static_assert(std::is_default_constructible<T>::value,
-                "DoublyLinkedList requires default-constructible elements");
-
   static_assert(std::is_base_of<DoublyLinkedListNode, T>::value,
                 "DoublyLinkedList requires elements derived from DoublyLinkedListNode");
 
-  T _head;
+  DoublyLinkedListNode _head;
   size_t _size;
 
   NONCOPYABLE(DoublyLinkedList);

--- a/src/hotspot/share/utilities/doublyLinkedList.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.hpp
@@ -30,7 +30,7 @@
 template <typename T>
 class DoublyLinkedList;
 
-// Element in a doubly linked list
+// Element in a doubly linked list.
 
 class DoublyLinkedListNode {
   template<typename T>

--- a/src/hotspot/share/utilities/doublyLinkedList.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.hpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef SHARE_UTILITIES_DOUBLYLINKEDLIST_HPP
+#define SHARE_UTILITIES_DOUBLYLINKEDLIST_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+template <typename T>
+class DoublyLinkedList;
+
+// Element in a doubly linked list
+
+class DoublyLinkedListNode {
+  template<typename T>
+  friend class DoublyLinkedList;
+
+  DoublyLinkedListNode* _next;
+  DoublyLinkedListNode* _prev;
+
+  NONCOPYABLE(DoublyLinkedListNode);
+
+  void swap(DoublyLinkedListNode* rhs);
+
+  void verify_links() const;
+  void verify_links_linked() const;
+  void verify_links_unlinked() const;
+
+protected:
+  ~DoublyLinkedListNode();
+
+public:
+  DoublyLinkedListNode();
+};
+
+//
+// The DoublyLinkedList template provides efficient insertion, removal, and traversal of elements in a doubly linked list structure.
+// Each node in the list contains an element of type T, and the nodes are connected bidirectionally.
+// The class supports forward and backward traversal, as well as insertion and removal operations at the beginning, end,
+// or any position within the list.
+//
+// \tparam T The type of elements stored in the linked list. It must be default-constructible and derived from DoublyLinkedListNode.
+//
+// Note: The DoublyLinkedList class does not perform memory allocation or deallocation for the elements.
+//       Therefore, it is the responsibility of the class template users to manage the memory of the elements added or removed from the list.
+//
+template <typename T>
+class DoublyLinkedList {
+  static_assert(std::is_default_constructible<T>::value,
+                "DoublyLinkedList requires default-constructible elements");
+
+  static_assert(std::is_base_of<DoublyLinkedListNode, T>::value,
+                "DoublyLinkedList requires elements derived from DoublyLinkedListNode");
+
+  T _head;
+  size_t _size;
+
+  NONCOPYABLE(DoublyLinkedList);
+
+  void verify_head() const;
+
+  void insert(DoublyLinkedListNode* before, DoublyLinkedListNode* node);
+
+  T* cast_to_outer(DoublyLinkedListNode* node) const;
+
+  T* next(T* elem) const;
+  T* prev(T* elem) const;
+
+public:
+  DoublyLinkedList();
+
+  size_t size() const;
+  bool is_empty() const;
+
+  T* first() const;
+  T* last() const;
+
+  void insert_first(T* elem);
+  void insert_last(T* elem);
+  void insert_before(T* before, T* elem);
+  void insert_after(T* after, T* elem);
+
+  void remove(T* elem);
+  T* remove_first();
+  T* remove_last();
+
+  void swap(DoublyLinkedList& other);
+
+  class Iterator;
+
+  class RemoveIterator;
+
+  Iterator begin();
+  Iterator end();
+};
+
+template <typename T>
+class DoublyLinkedList<T>::Iterator : public StackObj {
+  friend class DoublyLinkedList<T>;
+
+  const DoublyLinkedList<T>* const _list;
+  T* _cur_node;
+
+  Iterator(const DoublyLinkedList<T>* list, T* start) :
+    _list(list),
+    _cur_node(start)
+  { }
+
+public:
+  Iterator& operator++() {
+    _cur_node = _list->next(_cur_node);
+    return *this;
+  }
+
+  Iterator operator++(int) {
+    Iterator tmp = *this;
+    ++(*this);
+    return tmp;
+  }
+
+  Iterator& operator--() {
+    assert(_cur_node != nullptr, "Sanity");
+    _cur_node = _list->prev(_cur_node);
+    return *this;
+  }
+
+  Iterator operator--(int) {
+    Iterator tmp = *this;
+    --(*this);
+    return tmp;
+  }
+
+  T* operator*() { return _cur_node; }
+
+  bool operator==(const Iterator& rhs) {
+    assert(_list == rhs._list, "iterator belongs to different List");
+    return _cur_node == rhs._cur_node;
+  }
+
+  bool operator!=(const Iterator& rhs) {
+    assert(_list == rhs._list, "iterator belongs to different List");
+    return _cur_node != rhs._cur_node;
+  }
+};
+
+template <typename T>
+class DoublyLinkedList<T>::RemoveIterator : public StackObj {
+private:
+  DoublyLinkedList<T>* const _list;
+  const bool _forward;
+
+public:
+  explicit RemoveIterator(DoublyLinkedList<T>* list, bool forward_iterate = true);
+
+  bool next(T** elem);
+};
+
+#endif // SHARE_UTILITIES_DOUBLYLINKEDLIST_HPP

--- a/src/hotspot/share/utilities/doublyLinkedList.inline.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.inline.hpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef SHARE_UTILITIES_DOUBLYLINKEDLIST_INLINE_HPP
+#define SHARE_UTILITIES_DOUBLYLINKEDLIST_INLINE_HPP
+
+#include "utilities/doublyLinkedList.hpp"
+#include "utilities/debug.hpp"
+
+inline DoublyLinkedListNode::DoublyLinkedListNode() :
+    _next(this),
+    _prev(this) {}
+
+inline DoublyLinkedListNode::~DoublyLinkedListNode() {
+  verify_links_unlinked();
+}
+
+inline void DoublyLinkedListNode::swap(DoublyLinkedListNode* rhs) {
+  if (this == rhs) {
+    return;
+  }
+
+  if (this->_next != this) {
+    if (rhs->_next != rhs) {
+      ::swap(this->_next, rhs->_next);
+      ::swap(this->_prev,rhs->_prev);
+      this->_next->_prev = this->_prev->_next = this;
+      rhs->_next->_prev = rhs->_prev->_next = rhs;
+    } else {
+      rhs->_next = this->_next;
+      rhs->_prev = this->_prev;
+      rhs->_next->_prev = rhs->_prev->_next = rhs;
+      this->_next = this->_prev = this;
+    }
+  } else if (rhs->_next != rhs) {
+    this->_next = rhs->_next;
+    this->_prev = rhs->_prev;
+    this->_next->_prev = this->_prev->_next = this;
+    rhs->_next = rhs->_prev = rhs;
+  }
+}
+
+inline void DoublyLinkedListNode::verify_links() const {
+  assert(_next->_prev == this, "Corrupt list node");
+  assert(_prev->_next == this, "Corrupt list node");
+}
+
+inline void DoublyLinkedListNode::verify_links_linked() const {
+  assert(_next != this, "Should be in a list");
+  assert(_prev != this, "Should be in a list");
+  verify_links();
+}
+
+inline void DoublyLinkedListNode::verify_links_unlinked() const {
+  assert(_next == this, "Should not be in a list");
+  assert(_prev == this, "Should not be in a list");
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::verify_head() const {
+  _head.verify_links();
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::insert(DoublyLinkedListNode* before, DoublyLinkedListNode* node) {
+  verify_head();
+
+  before->verify_links();
+  node->verify_links_unlinked();
+
+  node->_prev = before;
+  node->_next = before->_next;
+  before->_next = node;
+  node->_next->_prev = node;
+
+  before->verify_links_linked();
+  node->verify_links_linked();
+
+  _size++;
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::cast_to_outer(DoublyLinkedListNode* node) const {
+  return static_cast<T*>(node);
+}
+
+template <typename T>
+inline DoublyLinkedList<T>::DoublyLinkedList() :
+    _head(),
+    _size(0) {
+  verify_head();
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::swap(DoublyLinkedList& other) {
+
+  _head.swap(&other._head);
+  ::swap(this->_size, other._size);
+
+  other.verify_head();
+  verify_head();
+}
+
+template <typename T>
+inline size_t DoublyLinkedList<T>::size() const {
+  verify_head();
+  return _size;
+}
+
+template <typename T>
+inline bool DoublyLinkedList<T>::is_empty() const {
+  return size() == 0;
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::first() const {
+  return is_empty() ? nullptr : cast_to_outer(_head._next);
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::last() const {
+  return is_empty() ? nullptr : cast_to_outer(_head._prev);
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::next(T* elem) const {
+  verify_head();
+
+  return cast_to_outer(elem->_next);
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::prev(T* elem) const {
+  verify_head();
+
+  return cast_to_outer(elem->_prev);
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::insert_first(T* elem) {
+  insert(&_head, elem);
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::insert_last(T* elem) {
+  insert(_head._prev, elem);
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::insert_before(T* before, T* elem) {
+  insert(before->_prev, elem);
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::insert_after(T* after, T* elem) {
+  insert(after, elem);
+}
+
+template <typename T>
+inline void DoublyLinkedList<T>::remove(T* elem) {
+  verify_head();
+
+  elem->verify_links_linked();
+
+  DoublyLinkedListNode* const next = elem->_next;
+  DoublyLinkedListNode* const prev = elem->_prev;
+  next->verify_links_linked();
+  prev->verify_links_linked();
+
+  elem->_next = prev->_next;
+  elem->_prev = next->_prev;
+  elem->verify_links_unlinked();
+
+  next->_prev = prev;
+  prev->_next = next;
+  next->verify_links();
+  prev->verify_links();
+
+  assert(_size > 0, "Sanity check!");
+  _size--;
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::remove_first() {
+  T* elem = first();
+  if (elem != nullptr) {
+    remove(elem);
+  }
+  return elem;
+}
+
+template <typename T>
+inline T* DoublyLinkedList<T>::remove_last() {
+  T* elem = last();
+  if (elem != nullptr) {
+    remove(elem);
+  }
+  return elem;
+}
+
+template <typename T>
+inline typename DoublyLinkedList<T>::Iterator DoublyLinkedList<T>::begin() {
+ return Iterator(this, cast_to_outer(_head._next));
+}
+
+template <typename T>
+inline typename DoublyLinkedList<T>::Iterator DoublyLinkedList<T>::end() {
+ return Iterator(this, &_head);
+}
+
+template <typename T>
+inline DoublyLinkedList<T>::RemoveIterator::RemoveIterator(DoublyLinkedList<T>* list, bool forward_iterate):
+    _list(list),
+    _forward(forward_iterate) {}
+
+
+template <typename T>
+inline bool DoublyLinkedList<T>::RemoveIterator::next(T** elem) {
+  *elem = _forward ? _list->remove_first() : _list->remove_last();
+  return *elem != nullptr;
+}
+
+#endif // SHARE_UTILITIES_DOUBLYLINKEDLIST_INLINE_HPP

--- a/src/hotspot/share/utilities/doublyLinkedList.inline.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.inline.hpp
@@ -225,7 +225,7 @@ inline typename DoublyLinkedList<T>::Iterator DoublyLinkedList<T>::begin() {
 
 template <typename T>
 inline typename DoublyLinkedList<T>::Iterator DoublyLinkedList<T>::end() {
- return Iterator(this, &_head);
+ return Iterator(this, cast_to_outer(&_head));
 }
 
 template <typename T>

--- a/test/hotspot/jtreg/gc/TestAllocHumongousFragment.java
+++ b/test/hotspot/jtreg/gc/TestAllocHumongousFragment.java
@@ -172,8 +172,7 @@
  * @requires vm.gc.G1
  * @library /test/lib
  *
- * @run main/othervm -Xlog:gc+region=trace -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
- *      -XX:VerifyGCType=full -XX:+VerifyDuringGC -XX:+VerifyAfterGC
+ * @run main/othervm -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      TestAllocHumongousFragment
  */
 

--- a/test/hotspot/jtreg/gc/TestAllocHumongousFragment.java
+++ b/test/hotspot/jtreg/gc/TestAllocHumongousFragment.java
@@ -172,7 +172,8 @@
  * @requires vm.gc.G1
  * @library /test/lib
  *
- * @run main/othervm -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
+ * @run main/othervm -Xlog:gc+region=trace -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
+ *      -XX:VerifyGCType=full -XX:+VerifyDuringGC -XX:+VerifyAfterGC
  *      TestAllocHumongousFragment
  */
 


### PR DESCRIPTION
Please review this change which fixes the thread starvation problem during allocation for G1.

The starvation problem is not limited to GCLocker, however, currently, it manifests as an OOME only when GCLocker is active. In other cases, the starvation only affects the "starved" thread as it may loop indefinitely. 

Starvation with an active GCLocker happens as below:

1. Thread A tries to allocate memory as normal, and tries to start a GC; the GCLocker is active and so the thread gets stalled waiting for the GC.
2. GCLocker induced GC executes and frees some memory.
3. Thread A does not get any of that memory, but other threads also waiting for memory.
4. Goto 1 until the gclocker retry count has been reached.

In this change, we take the general approach to solving starvation problems with announcement tables (request queues). On slow allocation, a thread that wishes to complete an Allocation GC and then attempt an allocation, announces its allocation request before proceeding to participate in a race to execute a GC safepoint. Whichever thread succeeds in executing the Allocation GC safepoint will be tasked with completing all allocation requests that were announced before the safepoint. This guarantees that all announced allocation requests are either satisfied during the safepoint, or failed in case there is not enough memory to complete all requests. This effectively deals with the starvation issue and reduces the number of allocation GCs triggered.

Note: The change also adopts ZList from ZGC and makes it available under utilities as DoublyLinkedList with slight modifications. 

Testing: Tier 1-7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8308507](https://bugs.openjdk.org/browse/JDK-8308507): G1: GClocker induced GCs can starve threads requiring memory leading to OOME (**Bug** - P3)(⚠️ The fixVersion in this issue is [22] but the fixVersion in .jcheck/conf is 21, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [51fcf016](https://git.openjdk.org/jdk/pull/14077/files/51fcf01632bacf8ff618b714b150efb6886fe76e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14077/head:pull/14077` \
`$ git checkout pull/14077`

Update a local copy of the PR: \
`$ git checkout pull/14077` \
`$ git pull https://git.openjdk.org/jdk.git pull/14077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14077`

View PR using the GUI difftool: \
`$ git pr show -t 14077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14077.diff">https://git.openjdk.org/jdk/pull/14077.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14077#issuecomment-1557079522)