### PR TITLE
8302218: CHeapBitMap::free frees with incorrect size

### DIFF
--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -131,7 +131,7 @@ CHeapBitMap::CHeapBitMap(idx_t size_in_bits, MEMFLAGS flags, bool clear)
 }
 
 CHeapBitMap::~CHeapBitMap() {
-  free(map(), size());
+  free(map(), size_in_words());
 }
 
 bm_word_t* CHeapBitMap::allocate(idx_t size_in_words) const {


### PR DESCRIPTION
This patch should fix [JDK-8302218](https://bugs.openjdk.org/browse/JDK-8302218).

In destructor of `CHeapBitMap`, it invokes `free()` to free allocated memory:
https://github.com/openjdk/jdk/blob/b3cb82b859d22b18343d125349a5aebc0afb8576/src/hotspot/share/utilities/bitMap.cpp#L133-L135

`free()`'s argument should be size in words, according to:
https://github.com/openjdk/jdk/blob/b3cb82b859d22b18343d125349a5aebc0afb8576/src/hotspot/share/utilities/bitMap.cpp#L141-L143

But the destructor pass the argument of `size()` (which returns `_size`). It is "size in bits" according to
https://github.com/openjdk/jdk/blob/b3cb82b859d22b18343d125349a5aebc0afb8576/src/hotspot/share/utilities/bitMap.hpp#L63-L65

Instead, it should use the return value of `size_in_words()` to invoke `free()`.

Once `ArrayAllocatorMallocLimit` option is set, `munmap()` may be used by `free()`, which does use the size argument and this may cause crash.

I have tested this patch for tier 1-3 on x86-64 linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302218](https://bugs.openjdk.org/browse/JDK-8302218): CHeapBitMap::free frees with incorrect size


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14079/head:pull/14079` \
`$ git checkout pull/14079`

Update a local copy of the PR: \
`$ git checkout pull/14079` \
`$ git pull https://git.openjdk.org/jdk.git pull/14079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14079`

View PR using the GUI difftool: \
`$ git pr show -t 14079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14079.diff">https://git.openjdk.org/jdk/pull/14079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14079#issuecomment-1557111579)