### PR TITLE
8308544: Fix compilation regression from JDK-8306983 on musl libc

### DIFF
--- a/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
@@ -113,8 +113,8 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
     env->SetIntField(result, c_line, data.c_line);
     jbyteArray c_ccValue = (jbyteArray) env->GetObjectField(result, c_cc);
     env->SetByteArrayRegion(c_ccValue, 0, NCCS, (signed char *) data.c_cc);//TODO: cast?
-    env->SetIntField(result, c_ispeed, data.c_ispeed);
-    env->SetIntField(result, c_ospeed, data.c_ospeed);
+    env->SetIntField(result, c_ispeed, cfgetispeed(&data));
+    env->SetIntField(result, c_ospeed, cfgetospeed(&data));
 }
 
 /*
@@ -133,8 +133,8 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
     data.c_line = env->GetIntField(input, c_line);
     jbyteArray c_ccValue = (jbyteArray) env->GetObjectField(input, c_cc);
     env->GetByteArrayRegion(c_ccValue, 0, NCCS, (jbyte *) data.c_cc);
-    data.c_ispeed = env->GetIntField(input, c_ispeed);
-    data.c_ospeed = env->GetIntField(input, c_ospeed);
+    cfsetispeed(&data, env->GetIntField(input, c_ispeed));
+    cfsetospeed(&data, env->GetIntField(input, c_ospeed));
 
     if (tcsetattr(fd, cmd, &data) != 0) {
         throw_errno(env);


### PR DESCRIPTION
Since [JDK-8306983](https://bugs.openjdk.org/browse/JDK-8306983) compilation on Alpine Linux using musl libc:
```
../src/jdk.internal.le/linux/native/lible/CLibrary.cpp: In function 'void Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_tcgetattr(JNIEnv*, jobject, jint, jobject)':
../src/jdk.internal.le/linux/native/lible/CLibrary.cpp:116:45: error: 'struct termios' has no member named 'c_ispeed'; did you mean '__c_ispeed'?
  116 | env->SetIntField(result, c_ispeed, data.c_ispeed);
      | ^~~~~~~~
      | __c_ispeed
../src/jdk.internal.le/linux/native/lible/CLibrary.cpp:117:45: error: 'struct termios' has no member named 'c_ospeed'; did you mean '__c_ospeed'?
  117 | env->SetIntField(result, c_ospeed, data.c_ospeed);
      | ^~~~~~~~
      | __c_ospeed
../src/jdk.internal.le/linux/native/lible/CLibrary.cpp: In function 'void Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_tcsetattr(JNIEnv*, jobject, jint, jint, jobject)':
../src/jdk.internal.le/linux/native/lible/CLibrary.cpp:136:10: error: 'struct termios' has no member named 'c_ispeed'; did you mean '__c_ispeed'?
  136 | data.c_ispeed = env->GetIntField(input, c_ispeed);
      | ^~~~~~~~
      | __c_ispeed
../src/jdk.internal.le/linux/native/lible/CLibrary.cpp:137:10: error: 'struct termios' has no member named 'c_ospeed'; did you mean '__c_ospeed'?
   ... (rest of output omitted)
```
