### PR TITLE
8308545

### DIFF
--- a/test/jdk/java/net/httpclient/ShutdownNow.java
+++ b/test/jdk/java/net/httpclient/ShutdownNow.java
@@ -134,6 +134,8 @@ public class ShutdownNow implements HttpServerAdapters {
         if (message.equals("closed")) return true;
         // exception from selmgr.abort
         if (message.equals("shutdownNow")) return true;
+        // exception from cancelling an HTTP/2 stream
+        if (message.matches("stream [0-9]+ cancelled")) return true;
         return false;
     }
 


### PR DESCRIPTION
The test `test/jdk/java/net/httpclient/ShutdownNow.java` has been observed failing intermittently (though rarely) with an assertion error: `java.lang.AssertionError: 0: Unexpected exception: java.io.IOException: Stream 1 cancelled` caused by  

```
java.io.IOException: Stream 1 cancelled
at java.net.http/jdk.internal.net.http.Stream.cancel(Stream.java:1285) 
```

Given the nature of the test - which interrupts / cancel all operations asynchronously, then a "stream %d cancelled" exception should count as an acceptable result. 