### PR TITLE
8308540: On Kerberos TGT referral, if krb5.conf is missing realm, bad exception message

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -1255,7 +1255,7 @@ public class Config {
             if (defaultKDC != null) {
                 return defaultKDC;
             }
-            KrbException ke = new KrbException("Cannot locate KDC");
+            KrbException ke = new KrbException("Cannot locate KDC for " + realm);
             if (cause != null) {
                 ke.initCause(cause);
             }

--- a/test/jdk/sun/security/krb5/auto/ReferralsTest.java
+++ b/test/jdk/sun/security/krb5/auto/ReferralsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Red Hat, Inc.
+ * Copyright (c) 2019, 2023, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,12 @@
 
 /*
  * @test
- * @bug 8215032
+ * @bug 8215032 8308540
  * @library /test/lib
  * @run main/othervm/timeout=120 -Dsun.security.krb5.debug=true ReferralsTest
  * @summary Test Kerberos cross-realm referrals (RFC 6806)
  */
 
-import java.io.File;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -51,6 +50,8 @@ public class ReferralsTest {
     private static final String krbConfigName = "krb5-localkdc.conf";
     private static final String krbConfigNameNoCanonicalize =
             "krb5-localkdc-nocanonicalize.conf";
+    private static final String krbConfigNameOnlyOne =
+            "krb5-localkdc-onlyone.conf";
     private static final String realmKDC1 = "RABBIT.HOLE";
     private static final String realmKDC2 = "DEV.RABBIT.HOLE";
     private static final char[] password = "123qwe@Z".toCharArray();
@@ -98,16 +99,13 @@ public class ReferralsTest {
             PrincipalName.NAME_REALM_SEPARATOR_STR + realmKDC2;
 
     public static void main(String[] args) throws Exception {
-        try {
-            initializeKDCs();
-            testSubjectCredentials();
-            testDelegation();
-            testImpersonation();
-            testDelegationWithReferrals();
-            testNoCanonicalize();
-        } finally {
-            cleanup();
-        }
+        initializeKDCs();
+        testSubjectCredentials();
+        testDelegation();
+        testImpersonation();
+        testDelegationWithReferrals();
+        testNoCanonicalize();
+        testOnlyOne();
     }
 
     private static void initializeKDCs() throws Exception {
@@ -147,18 +145,9 @@ public class ReferralsTest {
                 "forwardable=true", "canonicalize=true");
         KDC.saveConfig(krbConfigNameNoCanonicalize, kdc1, kdc2,
                 "forwardable=true");
+        KDC.saveConfig(krbConfigNameOnlyOne, kdc1,
+                "forwardable=true", "canonicalize=true");
         System.setProperty("java.security.krb5.conf", krbConfigName);
-    }
-
-    private static void cleanup() {
-        String[] configFiles = new String[]{krbConfigName,
-                krbConfigNameNoCanonicalize};
-        for (String configFile : configFiles) {
-            File f = new File(configFile);
-            if (f.exists()) {
-                f.delete();
-            }
-        }
     }
 
     /*
@@ -373,6 +362,23 @@ public class ReferralsTest {
             throw new Exception("should not succeed");
         } catch (LoginException e) {
             // expected
+        }
+    }
+
+    // For JDK-8308540. When a KDC is not found, provide better error info.
+    private static void testOnlyOne() throws Exception {
+        System.setProperty("java.security.krb5.conf", krbConfigNameOnlyOne);
+        Config.refresh();
+        Context c = Context.fromUserPass(userKDC1Name, password, false);
+        c.startAsClient(serviceName, GSSUtil.GSS_KRB5_MECH_OID);
+        try {
+            Context.handshake(c, null);
+            throw new RuntimeException("Should not succeed");
+        } catch (Exception le) {
+            if (le.getMessage().contains("Cannot locate KDC for DEV.RABBIT.HOLE")) {
+                return;
+            }
+            throw le;
         }
     }
 }


### PR DESCRIPTION
Add realm name to the exception message, and make it the primary exception (retry exception added suppressed).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308540](https://bugs.openjdk.org/browse/JDK-8308540): On Kerberos TGT referral, if krb5.conf is missing realm, bad exception message (**Enhancement** - P4)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14086/head:pull/14086` \
`$ git checkout pull/14086`

Update a local copy of the PR: \
`$ git checkout pull/14086` \
`$ git pull https://git.openjdk.org/jdk.git pull/14086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14086`

View PR using the GUI difftool: \
`$ git pr show -t 14086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14086.diff">https://git.openjdk.org/jdk/pull/14086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14086#issuecomment-1557397864)