### PR TITLE
8307814: In the case of two methods with Record Patterns, the second one contains a line number from the first method

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -298,7 +298,7 @@ public class TransPatterns extends TreeTranslator {
         BindingSymbol tempBind = new BindingSymbol(Flags.SYNTHETIC,
             names.fromString(target.syntheticNameChar() + "b" + target.syntheticNameChar() + variableIndex++), recordType,
                              currentMethodSym);
-        JCVariableDecl recordBindingVar = make.VarDef(tempBind, null);
+        JCVariableDecl recordBindingVar = make.at(recordPattern.pos()).VarDef(tempBind, null);
 
         VarSymbol recordBinding = recordBindingVar.sym;
         List<? extends RecordComponent> components = recordPattern.record.getRecordComponents();
@@ -331,7 +331,7 @@ public class TransPatterns extends TreeTranslator {
                                             types.boxedTypeOrType(types.erasure(nestedBinding.type)));
             }
             JCMethodInvocation componentAccessor =
-                    make.App(make.Select(convert(make.Ident(recordBinding), recordBinding.type), //TODO - cast needed????
+                    make.at(recordPattern.pos()).App(make.Select(convert(make.Ident(recordBinding), recordBinding.type),
                              component.accessor)).setType(types.erasure(component.accessor.getReturnType()));
             if (deconstructorCalls == null) {
                 deconstructorCalls = Collections.newSetFromMap(new IdentityHashMap<>());

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/MultipleRecordPatterns.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/MultipleRecordPatterns.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8307814
+ * @summary Verify correct LineNumberTable is generated for unrolled record patterns.
+ * @library /tools/lib /tools/javac/lib ../lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox InMemoryFileManager TestBase
+ * @build LineNumberTestBase TestCase
+ * @run main MultipleRecordPatterns
+ */
+
+import java.util.List;
+
+public class MultipleRecordPatterns extends LineNumberTestBase {
+    public static void main(String[] args) throws Exception {
+        new MultipleRecordPatterns().test();
+    }
+
+    public void test() throws Exception {
+        test(List.of(TEST_CASE));
+    }
+
+    private static final TestCase[] TEST_CASE = new TestCase[] {
+        new TestCase("""
+                     public class Patterns {                     // 1
+                         private void test1(Object o) {          // 2
+                             if (o instanceof R(var v)) {        // 3
+                                 System.err.println(v);          // 4
+                             }                                   // 5
+                         }                                       // 6
+                         private void test2(Object o) {          // 7
+                             if (o instanceof R(var v)) {        // 8
+                                 System.err.println(v);          // 9
+                             }                                   //10
+                         }                                       //11
+                         record R(int i) {}                      //12
+                     }                                           //13
+                     """,
+                     "Patterns",
+                     new TestCase.MethodData("test1", List.of(3, 4, 6), true),
+                     new TestCase.MethodData("test2", List.of(8, 9, 11), true))
+    };
+
+}

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/TestCase.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/TestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 
 /**
  * TestCase contains source code to be compiled
@@ -32,28 +32,53 @@ import java.util.Set;
  */
 public class TestCase {
     public final String src;
-    public final Set<Integer> expectedLines;
-    public final boolean exactLines;
     public final List<String> extraCompilerOptions;
 
 
     private final String name;
+    private final MethodData[] methodData;
 
     public String getName() {
         return name;
     }
 
     public TestCase(String src, Collection<Integer> expectedLines, String name) {
-        this(src, expectedLines, false, List.of(), name);
+        this(src, name, new MethodData(null, expectedLines, false));
+    }
+
+    public TestCase(String src, String name, MethodData... methodData) {
+        this(src, List.of(), name, methodData);
     }
 
     public TestCase(String src, Collection<Integer> expectedLines,
                     boolean exactLines, List<String> extraCompilerOptions,
                     String name) {
+        this(src, extraCompilerOptions, name, new MethodData(null, expectedLines, exactLines));
+    }
+
+    public TestCase(String src, List<String> extraCompilerOptions,
+                    String name, MethodData... methodData) {
         this.src = src;
-        this.expectedLines = new HashSet<>(expectedLines);
-        this.exactLines = exactLines;
         this.extraCompilerOptions = extraCompilerOptions;
         this.name = name;
+        this.methodData = methodData;
+    }
+
+    public MethodData findData(String methodName) {
+        for (MethodData md : methodData) {
+            if (Objects.equals(md.methodName(), methodName)) {
+                return md;
+            }
+        }
+
+        return null;
+    }
+
+    record MethodData(String methodName, Collection<Integer> expectedLines, boolean exactLines) {
+
+        public MethodData {
+            expectedLines = new HashSet<>(expectedLines);
+        }
+
     }
 }


### PR DESCRIPTION
`TransPatterns` is not setting the position for `TreeMaker` when unrolling record patterns, leading to weird content of the `LineNumberTable`. The proposal is to set the position.

For tests, it attempts to make the tests more general/allow more strict checks on the LNT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307814](https://bugs.openjdk.org/browse/JDK-8307814): In the case of two methods with Record Patterns, the second one contains a line number from the first method


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Evgeny Mandrikov](https://openjdk.org/census#godin) (@Godin - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14087/head:pull/14087` \
`$ git checkout pull/14087`

Update a local copy of the PR: \
`$ git checkout pull/14087` \
`$ git pull https://git.openjdk.org/jdk.git pull/14087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14087`

View PR using the GUI difftool: \
`$ git pr show -t 14087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14087.diff">https://git.openjdk.org/jdk/pull/14087.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14087#issuecomment-1557414737)