### PR TITLE
8308565: HttpClient: Sanitize logging while stopping

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -57,8 +57,7 @@ class Http2ClientImpl {
 
     private final HttpClientImpl client;
 
-    // only accessed from within synchronized blocks
-    private boolean stopping;
+    private volatile boolean stopping;
 
     Http2ClientImpl(HttpClientImpl client) {
         this.client = client;
@@ -292,5 +291,9 @@ class Http2ClientImpl {
                 "jdk.httpclient.maxframesize",
                 16 * K, 16 * K * K -1, 16 * K));
         return frame;
+    }
+
+    public boolean stopping() {
+        return stopping;
     }
 }


### PR DESCRIPTION
When the HttpClient is stopping many exception stack traces may be logged, in particular if the Http2Connection attempts to send a GOAWAY frame after the underlying TCP connection or the selector have been closed.

The Http2Connection should look at the Http2ClientImpl state before logging the exception as an error. If the Http2ClientImpl is stopping, a simple debug message should be enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308565](https://bugs.openjdk.org/browse/JDK-8308565): HttpClient: Sanitize logging while stopping


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14089/head:pull/14089` \
`$ git checkout pull/14089`

Update a local copy of the PR: \
`$ git checkout pull/14089` \
`$ git pull https://git.openjdk.org/jdk.git pull/14089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14089`

View PR using the GUI difftool: \
`$ git pr show -t 14089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14089.diff">https://git.openjdk.org/jdk/pull/14089.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14089#issuecomment-1557473998)