### PR TITLE
8308291: compiler/jvmci/meta/ProfilingInfoTest.java fails with -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/meta/ProfilingInfoTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/meta/ProfilingInfoTest.java
@@ -30,6 +30,7 @@
  * @test
  * @requires vm.jvmci
  * @requires vm.compMode != "Xcomp"
+ * @requires vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel > 1
  * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler -Xbootclasspath/a:. compiler.jvmci.meta.ProfilingInfoTest


### PR DESCRIPTION
adjust requires declaration

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308291](https://bugs.openjdk.org/browse/JDK-8308291): compiler/jvmci/meta/ProfilingInfoTest.java fails with -XX:TieredStopAtLevel=1


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14091/head:pull/14091` \
`$ git checkout pull/14091`

Update a local copy of the PR: \
`$ git checkout pull/14091` \
`$ git pull https://git.openjdk.org/jdk.git pull/14091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14091`

View PR using the GUI difftool: \
`$ git pr show -t 14091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14091.diff">https://git.openjdk.org/jdk/pull/14091.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14091#issuecomment-1557636412)