### PR TITLE
8308655: Narrow types of ConstantPool and ConstMethod returns

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2672,7 +2672,7 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
   m->set_constants(_cp);
   m->set_name_index(name_index);
   m->set_signature_index(signature_index);
-  m->compute_from_signature(cp->symbol_at(signature_index));
+  m->constMethod()->compute_from_signature(cp->symbol_at(signature_index), access_flags.is_static());
   assert(args_size < 0 || args_size == m->size_of_parameters(), "");
 
   // Fill in code attribute information

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1345,8 +1345,7 @@ void ClassLoader::record_result(JavaThread* current, InstanceKlass* ik,
   const char* const file_name = file_name_for_class_name(class_name,
                                                          ik->name()->utf8_length());
   assert(file_name != nullptr, "invariant");
-
-  ClassLoaderExt::record_result(classpath_index, ik, redefined);
+  ClassLoaderExt::record_result(checked_cast<s2>(classpath_index), ik, redefined);
 }
 #endif // INCLUDE_CDS
 

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -66,7 +66,8 @@ void ClassLoaderExt::append_boot_classpath(ClassPathEntry* new_entry) {
 
 void ClassLoaderExt::setup_app_search_path(JavaThread* current) {
   Arguments::assert_is_dumping_archive();
-  _app_class_paths_start_index = ClassLoader::num_boot_classpath_entries();
+  int start_index = ClassLoader::num_boot_classpath_entries();
+  _app_class_paths_start_index = checked_cast<jshort>(start_index);
   char* app_class_path = os::strdup_check_oom(Arguments::get_appclasspath(), mtClass);
 
   if (strcmp(app_class_path, ".") == 0) {
@@ -116,8 +117,9 @@ void ClassLoaderExt::process_module_table(JavaThread* current, ModuleEntryTable*
 
 void ClassLoaderExt::setup_module_paths(JavaThread* current) {
   Arguments::assert_is_dumping_archive();
-  _app_module_paths_start_index = ClassLoader::num_boot_classpath_entries() +
-                              ClassLoader::num_app_classpath_entries();
+  int start_index = ClassLoader::num_boot_classpath_entries() +
+                    ClassLoader::num_app_classpath_entries();
+  _app_module_paths_start_index = checked_cast<jshort>(start_index);
   Handle system_class_loader (current, SystemDictionary::java_system_loader());
   ModuleEntryTable* met = Modules::get_module_entry_table(system_class_loader);
   process_module_table(current, met);

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -903,8 +903,8 @@ static Method* new_method(
   m->set_constants(nullptr); // This will get filled in later
   m->set_name_index(cp->utf8(name));
   m->set_signature_index(cp->utf8(sig));
-  m->compute_from_signature(sig);
-  m->set_size_of_parameters(params);
+  m->constMethod()->compute_from_signature(sig, flags.is_static());
+  assert(m->size_of_parameters() == params, "should be computed above");
   m->set_max_stack(max_stack);
   m->set_max_locals(params);
   m->constMethod()->set_stackmap_data(nullptr);

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
       // Set new class file stream using JVMTI agent modified class file data.
       ClassLoaderData* loader_data =
         ClassLoaderData::class_loader_data(class_loader());
-      int path_index = ik->shared_classpath_index();
+      s2 path_index = ik->shared_classpath_index();
       ClassFileStream* stream = new ClassFileStream(ptr,
                                                     end_ptr - ptr,
                                                     cfs->source(),

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1182,7 +1182,7 @@ void SystemDictionary::load_shared_class_misc(InstanceKlass* ik, ClassLoaderData
   // For boot loader, ensure that GetSystemPackage knows that a class in this
   // package was loaded.
   if (loader_data->is_the_null_class_loader_data()) {
-    int path_index = ik->shared_classpath_index();
+    s2 path_index = ik->shared_classpath_index();
     ik->set_classpath_index(path_index);
   }
 

--- a/src/hotspot/share/memory/iterator.inline.hpp
+++ b/src/hotspot/share/memory/iterator.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ private:
     }
 
   public:
-    FunctionType _function[KLASS_KIND_COUNT];
+    FunctionType _function[Klass::KLASS_KIND_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -202,7 +202,7 @@ private:
     }
 
   public:
-    FunctionType _function[KLASS_KIND_COUNT];
+    FunctionType _function[Klass::KLASS_KIND_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -265,7 +265,7 @@ private:
     }
 
   public:
-    FunctionType _function[KLASS_KIND_COUNT];
+    FunctionType _function[Klass::KLASS_KIND_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();

--- a/src/hotspot/share/oops/constMethod.hpp
+++ b/src/hotspot/share/oops/constMethod.hpp
@@ -450,18 +450,18 @@ public:
   void compute_from_signature(Symbol* sig, bool is_static);
 
   // max stack
-  int  max_stack() const                         { return _max_stack; }
+  u2   max_stack() const                         { return _max_stack; }
   void set_max_stack(int size)                   { _max_stack = checked_cast<u2>(size); }
 
   // max locals
-  int  max_locals() const                        { return _max_locals; }
+  u2  max_locals() const                         { return _max_locals; }
   void set_max_locals(int size)                  { _max_locals = checked_cast<u2>(size); }
 
   // size of parameters
   u2 size_of_parameters() const                  { return _size_of_parameters; }
 
   // Number of arguments passed on the stack even when compiled
-  int  num_stack_arg_slots() const               { return _num_stack_arg_slots; }
+  u2 num_stack_arg_slots() const                 { return _num_stack_arg_slots; }
 
   // result type (basic type of return value)
   BasicType result_type() const                  { assert(_result_type >= T_BOOLEAN, "Must be set");

--- a/src/hotspot/share/oops/constMethod.hpp
+++ b/src/hotspot/share/oops/constMethod.hpp
@@ -213,6 +213,11 @@ private:
               InlineTableSizes* sizes,
               MethodType is_overpass,
               int size);
+
+  void set_size_of_parameters(int size)          { _size_of_parameters = checked_cast<u2>(size); }
+  void set_num_stack_arg_slots(int n)            { _num_stack_arg_slots = checked_cast<u2>(n); }
+  void set_result_type(BasicType rt)             { assert(rt < 16, "result type too large");
+                                                   _result_type = (u1)rt; }
 public:
 
   static ConstMethod* allocate(ClassLoaderData* loader_data,
@@ -283,22 +288,22 @@ public:
   }
 
   // name
-  int name_index() const                         { return _name_index; }
-  void set_name_index(int index)                 { _name_index = index; }
+  u2 name_index() const                          { return _name_index; }
+  void set_name_index(int index)                 { _name_index = checked_cast<u2>(index); }
 
   // signature
-  int signature_index() const                    { return _signature_index; }
-  void set_signature_index(int index)            { _signature_index = index; }
+  u2 signature_index() const                     { return _signature_index; }
+  void set_signature_index(int index)            { _signature_index = checked_cast<u2>(index); }
 
   // generics support
-  int generic_signature_index() const            {
+  u2 generic_signature_index() const             {
     if (has_generic_signature()) {
       return *generic_signature_index_addr();
     } else {
       return 0;
     }
   }
-  void set_generic_signature_index(u2 index)    {
+  void set_generic_signature_index(u2 index)     {
     assert(has_generic_signature(), "");
     u2* addr = generic_signature_index_addr();
     *addr = index;
@@ -324,7 +329,7 @@ public:
     assert(max_method_code_size < (1 << 16),
            "u2 is too small to hold method code size in general");
     assert(0 <= size && size <= max_method_code_size, "invalid code size");
-    _code_size = size;
+    _code_size = (u2)size;
   }
 
   // linenumber table - note that length is unknown until decompression,
@@ -337,15 +342,15 @@ public:
   u2* method_parameters_length_addr() const;
 
   // checked exceptions
-  int checked_exceptions_length() const;
+  u2 checked_exceptions_length() const;
   CheckedExceptionElement* checked_exceptions_start() const;
 
   // localvariable table
-  int localvariable_table_length() const;
+  u2 localvariable_table_length() const;
   LocalVariableTableElement* localvariable_table_start() const;
 
   // exception table
-  int exception_table_length() const;
+  u2 exception_table_length() const;
   ExceptionTableElement* exception_table_start() const;
 
   // method parameters table
@@ -441,28 +446,27 @@ public:
   u2 orig_method_idnum() const                   { return _orig_method_idnum; }
   void set_orig_method_idnum(u2 idnum)           { _orig_method_idnum = idnum; }
 
+  // Derive stuff from the signature at load time.
+  void compute_from_signature(Symbol* sig, bool is_static);
+
   // max stack
   int  max_stack() const                         { return _max_stack; }
-  void set_max_stack(int size)                   { _max_stack = size; }
+  void set_max_stack(int size)                   { _max_stack = checked_cast<u2>(size); }
 
   // max locals
   int  max_locals() const                        { return _max_locals; }
-  void set_max_locals(int size)                  { _max_locals = size; }
+  void set_max_locals(int size)                  { _max_locals = checked_cast<u2>(size); }
 
   // size of parameters
-  int  size_of_parameters() const                { return _size_of_parameters; }
-  void set_size_of_parameters(int size)          { _size_of_parameters = size; }
+  u2 size_of_parameters() const                  { return _size_of_parameters; }
 
   // Number of arguments passed on the stack even when compiled
   int  num_stack_arg_slots() const               { return _num_stack_arg_slots; }
-  void set_num_stack_arg_slots(int n)            { _num_stack_arg_slots = n; }
 
   // result type (basic type of return value)
   BasicType result_type() const                  { assert(_result_type >= T_BOOLEAN, "Must be set");
                                                    return (BasicType)_result_type; }
 
-  void set_result_type(BasicType rt)             { assert(rt < 16, "result type too large");
-                                                   _result_type = (u1)rt; }
   // Deallocation for RedefineClasses
   void deallocate_contents(ClassLoaderData* loader_data);
   bool is_klass() const { return false; }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -711,7 +711,7 @@ u2 ConstantPool::uncached_name_and_type_ref_index_at(int cp_index)  {
   return extract_high_short_from_int(ref_index);
 }
 
-int ConstantPool::name_and_type_ref_index_at(int index, Bytecodes::Code code) {
+u2 ConstantPool::name_and_type_ref_index_at(int index, Bytecodes::Code code) {
   return uncached_name_and_type_ref_index_at(to_cp_index(index, code));
 }
 
@@ -729,7 +729,7 @@ u2 ConstantPool::uncached_klass_ref_index_at(int cp_index) {
   return extract_low_short_from_int(ref_index);
 }
 
-int ConstantPool::klass_ref_index_at(int index, Bytecodes::Code code) {
+u2 ConstantPool::klass_ref_index_at(int index, Bytecodes::Code code) {
   guarantee(!ConstantPool::is_invokedynamic_index(index),
             "an invokedynamic instruction does not have a klass");
   assert(code != Bytecodes::_invokedynamic,

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -448,7 +448,7 @@ bool ConstantPool::maybe_archive_resolved_klass_at(int cp_index) {
 
 int ConstantPool::cp_to_object_index(int cp_index) {
   // this is harder don't do this so much.
-  int i = reference_map()->find(cp_index);
+  int i = reference_map()->find(checked_cast<u2>(cp_index));
   // We might not find the index for jsr292 call.
   return (i < 0) ? _no_index_sentinel : i;
 }
@@ -699,9 +699,9 @@ int ConstantPool::to_cp_index(int index, Bytecodes::Code code) {
   }
 }
 
-int ConstantPool::uncached_name_and_type_ref_index_at(int cp_index)  {
+u2 ConstantPool::uncached_name_and_type_ref_index_at(int cp_index)  {
   if (tag_at(cp_index).has_bootstrap()) {
-    int pool_index = bootstrap_name_and_type_ref_index_at(cp_index);
+    u2 pool_index = bootstrap_name_and_type_ref_index_at(cp_index);
     assert(tag_at(pool_index).is_name_and_type(), "");
     return pool_index;
   }
@@ -723,7 +723,7 @@ constantTag ConstantPool::tag_ref_at(int which, Bytecodes::Code code) {
   return tag_at(pool_index);
 }
 
-int ConstantPool::uncached_klass_ref_index_at(int cp_index) {
+u2 ConstantPool::uncached_klass_ref_index_at(int cp_index) {
   assert(tag_at(cp_index).is_field_or_method(), "Corrupted constant pool");
   jint ref_index = *int_at_addr(cp_index);
   return extract_low_short_from_int(ref_index);
@@ -756,13 +756,13 @@ void ConstantPool::verify_constant_pool_resolve(const constantPoolHandle& this_c
 }
 
 
-int ConstantPool::name_ref_index_at(int which_nt) {
+u2 ConstantPool::name_ref_index_at(int which_nt) {
   jint ref_index = name_and_type_at(which_nt);
   return extract_low_short_from_int(ref_index);
 }
 
 
-int ConstantPool::signature_ref_index_at(int which_nt) {
+u2 ConstantPool::signature_ref_index_at(int which_nt) {
   jint ref_index = name_and_type_at(which_nt);
   return extract_high_short_from_int(ref_index);
 }
@@ -2182,14 +2182,14 @@ int ConstantPool::copy_cpool_bytes(int cpool_size,
       }
       case JVM_CONSTANT_ClassIndex: {
         *bytes = JVM_CONSTANT_Class;
-        idx1 = klass_index_at(idx);
+        idx1 = checked_cast<u2>(klass_index_at(idx));
         Bytes::put_Java_u2((address) (bytes+1), idx1);
         DBG(printf("JVM_CONSTANT_ClassIndex: %hd", idx1));
         break;
       }
       case JVM_CONSTANT_StringIndex: {
         *bytes = JVM_CONSTANT_String;
-        idx1 = string_index_at(idx);
+        idx1 = checked_cast<u2>(string_index_at(idx));
         Bytes::put_Java_u2((address) (bytes+1), idx1);
         DBG(printf("JVM_CONSTANT_StringIndex: %hd", idx1));
         break;
@@ -2198,7 +2198,7 @@ int ConstantPool::copy_cpool_bytes(int cpool_size,
       case JVM_CONSTANT_MethodHandleInError: {
         *bytes = JVM_CONSTANT_MethodHandle;
         int kind = method_handle_ref_kind_at(idx);
-        idx1 = method_handle_index_at(idx);
+        idx1 = checked_cast<u2>(method_handle_index_at(idx));
         *(bytes+1) = (unsigned char) kind;
         Bytes::put_Java_u2((address) (bytes+2), idx1);
         DBG(printf("JVM_CONSTANT_MethodHandle: %d %hd", kind, idx1));
@@ -2207,7 +2207,7 @@ int ConstantPool::copy_cpool_bytes(int cpool_size,
       case JVM_CONSTANT_MethodType:
       case JVM_CONSTANT_MethodTypeInError: {
         *bytes = JVM_CONSTANT_MethodType;
-        idx1 = method_type_index_at(idx);
+        idx1 = checked_cast<u2>(method_type_index_at(idx));
         Bytes::put_Java_u2((address) (bytes+1), idx1);
         DBG(printf("JVM_CONSTANT_MethodType: %hd", idx1));
         break;
@@ -2284,7 +2284,7 @@ void ConstantPool::set_on_stack(const bool value) {
   } else {
     // Clearing is done single-threadedly.
     if (!is_shared()) {
-      _flags &= ~_on_stack;
+      _flags &= (u2)(~_on_stack);
     }
   }
 }

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -259,7 +259,7 @@ class ConstantPool : public Metadata {
   // Given the per-instruction index of an indy instruction, report the
   // main constant pool entry for its bootstrap specifier.
   // From there, uncached_name/signature_ref_at will get the name/type.
-  int invokedynamic_bootstrap_ref_index_at(int indy_index) const {
+  u2 invokedynamic_bootstrap_ref_index_at(int indy_index) const {
     return cache()->resolved_indy_entry_at(decode_invokedynamic_index(indy_index))->constant_pool_index();
   }
 
@@ -507,7 +507,7 @@ class ConstantPool : public Metadata {
     int member = method_handle_index_at(which);
     return uncached_signature_ref_at(member);
   }
-  int method_handle_klass_index_at(int which) {
+  u2 method_handle_klass_index_at(int which) {
     int member = method_handle_index_at(which);
     return uncached_klass_ref_index_at(member);
   }
@@ -516,11 +516,11 @@ class ConstantPool : public Metadata {
     return symbol_at(sym);
   }
 
-  int bootstrap_name_and_type_ref_index_at(int which) {
+  u2 bootstrap_name_and_type_ref_index_at(int which) {
     assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
     return extract_high_short_from_int(*int_at_addr(which));
   }
-  int bootstrap_methods_attribute_index(int which) {
+  u2 bootstrap_methods_attribute_index(int which) {
     assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
     return extract_low_short_from_int(*int_at_addr(which));
   }
@@ -668,8 +668,8 @@ class ConstantPool : public Metadata {
     return symbol_at(signature_index);
   }
 
-  int klass_ref_index_at(int which, Bytecodes::Code code);
-  int name_and_type_ref_index_at(int which, Bytecodes::Code code);
+  u2 klass_ref_index_at(int which, Bytecodes::Code code);
+  u2 name_and_type_ref_index_at(int which, Bytecodes::Code code);
 
   int remap_instruction_operand_from_cache(int operand);  // operand must be biased by CPCACHE_INDEX_TAG
 
@@ -678,8 +678,8 @@ class ConstantPool : public Metadata {
   int to_cp_index(int which, Bytecodes::Code code);
 
   // Lookup for entries consisting of (name_index, signature_index)
-  int name_ref_index_at(int which_nt);            // ==  low-order jshort of name_and_type_at(which_nt)
-  int signature_ref_index_at(int which_nt);       // == high-order jshort of name_and_type_at(which_nt)
+  u2 name_ref_index_at(int which_nt);            // ==  low-order jshort of name_and_type_at(which_nt)
+  u2 signature_ref_index_at(int which_nt);       // == high-order jshort of name_and_type_at(which_nt)
 
   BasicType basic_type_for_signature_at(int which) const;
 
@@ -786,8 +786,8 @@ class ConstantPool : public Metadata {
     int signature_index = signature_ref_index_at(uncached_name_and_type_ref_index_at(cp_index));
     return symbol_at(signature_index);
   }
-  int       uncached_klass_ref_index_at(int cp_index);
-  int       uncached_name_and_type_ref_index_at(int cp_index);
+  u2 uncached_klass_ref_index_at(int cp_index);
+  u2 uncached_name_and_type_ref_index_at(int cp_index);
 
   // Sharing
   int pre_resolve_shared_klasses(TRAPS);

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -64,11 +64,11 @@ void ConstantPoolCacheEntry::initialize_entry(int index) {
   assert(constant_pool_index() == index, "");
 }
 
-int ConstantPoolCacheEntry::make_flags(TosState state,
+intx ConstantPoolCacheEntry::make_flags(TosState state,
                                        int option_bits,
                                        int field_index_or_method_params) {
   assert(state < number_of_states, "Invalid state in make_flags");
-  int f = ((int)state << tos_state_shift) | option_bits | field_index_or_method_params;
+  intx f = ((int)state << tos_state_shift) | option_bits | field_index_or_method_params;
   // Preserve existing flag bit values
   // The low bits are a field offset, or else the method parameter size.
 #ifdef ASSERT

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -159,7 +159,7 @@ class ConstantPoolCacheEntry {
     assert(is_vfinal(), "flags must be set");
     set_f2((intx)f2);
   }
-  int make_flags(TosState state, int option_bits, int field_index_or_method_params);
+  intx make_flags(TosState state, int option_bits, int field_index_or_method_params);
   void set_flags(intx flags)                     { _flags = flags; }
   void set_field_flags(TosState field_type, int option_bits, int field_index) {
     assert((field_index & field_index_mask) == field_index, "field_index in range");
@@ -308,8 +308,8 @@ class ConstantPoolCacheEntry {
   bool is_resolved(Bytecodes::Code code) const;
 
   // Accessors
-  int indices() const                            { return _indices; }
-  int indices_ord() const;
+  intx indices() const                           { return _indices; }
+  intx indices_ord() const;
   int constant_pool_index() const                { return (indices() & cp_index_mask); }
   Bytecodes::Code bytecode_1() const;
   Bytecodes::Code bytecode_2() const;

--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -30,7 +30,7 @@
 #include "oops/oopHandle.inline.hpp"
 #include "runtime/atomic.hpp"
 
-inline int ConstantPoolCacheEntry::indices_ord() const { return Atomic::load_acquire(&_indices); }
+inline intx ConstantPoolCacheEntry::indices_ord() const { return Atomic::load_acquire(&_indices); }
 
 inline Bytecodes::Code ConstantPoolCacheEntry::bytecode_1() const {
   return Bytecodes::cast((indices_ord() >> bytecode_1_shift) & bytecode_1_mask);

--- a/src/hotspot/share/oops/fieldInfo.cpp
+++ b/src/hotspot/share/oops/fieldInfo.cpp
@@ -86,7 +86,7 @@ Array<u1>* FieldInfoStream::create_FieldInfoStream(GrowableArray<FieldInfo>* fie
 
 #ifdef ASSERT
   FieldInfoReader r(fis);
-  u2 jfc = r.next_uint();
+  int jfc = r.next_uint();
   assert(jfc == java_fields, "Must be");
   int ifc = r.next_uint();
   assert(ifc == injected_fields, "Must be");

--- a/src/hotspot/share/oops/fieldInfo.inline.hpp
+++ b/src/hotspot/share/oops/fieldInfo.inline.hpp
@@ -98,23 +98,23 @@ inline FieldInfoReader::FieldInfoReader(const Array<u1>* fi)
 
 inline void FieldInfoReader::read_field_info(FieldInfo& fi) {
   fi._index = _next_index++;
-  fi._name_index = next_uint();
-  fi._signature_index = next_uint();
+  fi._name_index = checked_cast<u2>(next_uint());
+  fi._signature_index = checked_cast<u2>(next_uint());
   fi._offset = next_uint();
   fi._access_flags = AccessFlags(next_uint());
   fi._field_flags = FieldInfo::FieldFlags(next_uint());
   if (fi._field_flags.is_initialized()) {
-    fi._initializer_index = next_uint();
+    fi._initializer_index = checked_cast<u2>(next_uint());
   } else {
     fi._initializer_index = 0;
   }
   if (fi._field_flags.is_generic()) {
-    fi._generic_signature_index = next_uint();
+    fi._generic_signature_index = checked_cast<u2>(next_uint());
   } else {
     fi._generic_signature_index = 0;
   }
   if (fi._field_flags.is_contended()) {
-    fi._contention_group = next_uint();
+    fi._contention_group = checked_cast<u2>(next_uint());
   } else {
     fi._contention_group = 0;
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2511,7 +2511,9 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   if (itable_length() > 0) {
     itableOffsetEntry* ioe = (itableOffsetEntry*)start_of_itable();
     int method_table_offset_in_words = ioe->offset()/wordSize;
-    int nof_interfaces = (method_table_offset_in_words - itable_offset_in_words())
+    int itable_offset_in_words = (int)(start_of_itable() - (intptr_t*)this);
+
+    int nof_interfaces = (method_table_offset_in_words - itable_offset_in_words)
                          / itableOffsetEntry::size();
 
     for (int i = 0; i < nof_interfaces; i ++, ioe ++) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -944,7 +944,6 @@ public:
 
   inline intptr_t* start_of_itable() const;
   inline intptr_t* end_of_itable() const;
-  inline int itable_offset_in_words() const;
   inline oop static_field_base_raw();
 
   inline OopMapBlock* start_of_nonstatic_oop_maps() const;

--- a/src/hotspot/share/oops/instanceKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceKlass.inline.hpp
@@ -41,8 +41,6 @@
 inline intptr_t* InstanceKlass::start_of_itable()   const { return (intptr_t*)start_of_vtable() + vtable_length(); }
 inline intptr_t* InstanceKlass::end_of_itable()     const { return start_of_itable() + itable_length(); }
 
-inline int InstanceKlass::itable_offset_in_words() const { return start_of_itable() - (intptr_t*)this; }
-
 inline oop InstanceKlass::static_field_base_raw() { return java_mirror(); }
 
 inline Symbol* InstanceKlass::field_name(int index) const { return field(index).name(constants()); }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -261,7 +261,7 @@ void Klass::initialize_supers(Klass* k, Array<InstanceKlass*>* transitive_interf
       // Overflow of the primary_supers array forces me to be secondary.
       super_check_cell = &_secondary_super_cache;
     }
-    set_super_check_offset((address)super_check_cell - (address) this);
+    set_super_check_offset(u4((address)super_check_cell - (address) this));
 
 #ifdef ASSERT
     {

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -76,7 +76,7 @@ class Klass : public Metadata {
     InstanceStackChunkKlassKind,
     TypeArrayKlassKind,
     ObjArrayKlassKind,
-    Unknown
+    UnknownKlassKind
   };
 
   static const uint KLASS_KIND_COUNT = ObjArrayKlassKind + 1;
@@ -195,7 +195,7 @@ protected:
 
   // Constructor
   Klass(KlassKind kind);
-  Klass() : _kind(Unknown) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
+  Klass() : _kind(UnknownKlassKind) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
   void* operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, TRAPS) throw();
 

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -37,19 +37,6 @@
 #include "jfr/support/jfrTraceIdExtension.hpp"
 #endif
 
-// Klass Kinds for all subclasses of Klass
-enum KlassKind {
-  InstanceKlassKind,
-  InstanceRefKlassKind,
-  InstanceMirrorKlassKind,
-  InstanceClassLoaderKlassKind,
-  InstanceStackChunkKlassKind,
-  TypeArrayKlassKind,
-  ObjArrayKlassKind
-};
-
-const uint KLASS_KIND_COUNT = ObjArrayKlassKind + 1;
-
 //
 // A Klass provides:
 //  1: language level class object (method dictionary etc.)
@@ -79,7 +66,22 @@ class vtableEntry;
 class Klass : public Metadata {
   friend class VMStructs;
   friend class JVMCIVMStructs;
+ public:
+  // Klass Kinds for all subclasses of Klass
+  enum KlassKind {
+    InstanceKlassKind,
+    InstanceRefKlassKind,
+    InstanceMirrorKlassKind,
+    InstanceClassLoaderKlassKind,
+    InstanceStackChunkKlassKind,
+    TypeArrayKlassKind,
+    ObjArrayKlassKind,
+    Unknown
+  };
+
+  static const uint KLASS_KIND_COUNT = ObjArrayKlassKind + 1;
  protected:
+
   // If you add a new field that points to any metaspace object, you
   // must add this field to Klass::metaspace_pointers_do().
 
@@ -170,7 +172,7 @@ private:
   // associate this class with the JAR file where it's loaded from during
   // dump time. If a class is not loaded from the shared archive, this field is
   // -1.
-  jshort _shared_class_path_index;
+  s2 _shared_class_path_index;
 
 #if INCLUDE_CDS
   // Various attributes for shared classes. Should be zero for a non-shared class.
@@ -193,7 +195,7 @@ protected:
 
   // Constructor
   Klass(KlassKind kind);
-  Klass() : _kind(KlassKind(-1)) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
+  Klass() : _kind(Unknown) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
   void* operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, TRAPS) throw();
 
@@ -303,11 +305,11 @@ protected:
   ClassLoaderData* class_loader_data() const               { return _class_loader_data; }
   void set_class_loader_data(ClassLoaderData* loader_data) {  _class_loader_data = loader_data; }
 
-  int shared_classpath_index() const   {
+  s2 shared_classpath_index() const   {
     return _shared_class_path_index;
   };
 
-  void set_shared_classpath_index(int index) {
+  void set_shared_classpath_index(s2 index) {
     _shared_class_path_index = index;
   };
 
@@ -322,7 +324,7 @@ protected:
     CDS_ONLY(_shared_class_flags |= _archived_lambda_proxy_is_available;)
   }
   void clear_lambda_proxy_is_available() {
-    CDS_ONLY(_shared_class_flags &= ~_archived_lambda_proxy_is_available;)
+    CDS_ONLY(_shared_class_flags &= (u2)(~_archived_lambda_proxy_is_available);)
   }
   bool lambda_proxy_is_available() const {
     CDS_ONLY(return (_shared_class_flags & _archived_lambda_proxy_is_available) != 0;)
@@ -333,7 +335,7 @@ protected:
     CDS_ONLY(_shared_class_flags |= _has_value_based_class_annotation;)
   }
   void clear_has_value_based_class_annotation() {
-    CDS_ONLY(_shared_class_flags &= ~_has_value_based_class_annotation;)
+    CDS_ONLY(_shared_class_flags &= (u2)(~_has_value_based_class_annotation);)
   }
   bool has_value_based_class_annotation() const {
     CDS_ONLY(return (_shared_class_flags & _has_value_based_class_annotation) != 0;)

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1118,9 +1118,9 @@ klassItable::klassItable(InstanceKlass* klass) {
       intptr_t* method_entry  = (intptr_t *)(((address)klass) + offset_entry->offset());
       intptr_t* end         = klass->end_of_itable();
 
-      _table_offset      = (intptr_t*)offset_entry - (intptr_t*)klass;
-      _size_offset_table = (method_entry - ((intptr_t*)offset_entry)) / itableOffsetEntry::size();
-      _size_method_table = (end - method_entry)                  / itableMethodEntry::size();
+      _table_offset      = int((intptr_t*)offset_entry - (intptr_t*)klass);
+      _size_offset_table = int((method_entry - ((intptr_t*)offset_entry)) / itableOffsetEntry::size());
+      _size_method_table = int((end - method_entry)                  / itableMethodEntry::size());
       assert(_table_offset >= 0 && _size_offset_table >= 0 && _size_method_table >= 0, "wrong computation");
       return;
     }
@@ -1497,7 +1497,7 @@ class SetupItableClosure : public InterfaceVisiterClosure  {
   itableMethodEntry* method_entry() const { return _method_entry; }
 
   void doit(InstanceKlass* intf, int method_count) {
-    int offset = ((address)_method_entry) - _klass_begin;
+    int offset = int(((address)_method_entry) - _klass_begin);
     _offset_entry->initialize(intf, offset);
     _offset_entry++;
     _method_entry += method_count;

--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -52,7 +52,8 @@ class klassVtable {
 
  public:
   klassVtable(Klass* klass, void* base, int length) : _klass(klass) {
-    _tableOffset = (address)base - (address)klass; _length = length;
+    _tableOffset = int((address)base - (address)klass);
+    _length = length;
   }
 
   // accessors

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -142,18 +142,17 @@ class Method : public Metadata {
 
   // name
   Symbol* name() const                           { return constants()->symbol_at(name_index()); }
-  int name_index() const                         { return constMethod()->name_index();         }
+  u2 name_index() const                          { return constMethod()->name_index();         }
   void set_name_index(int index)                 { constMethod()->set_name_index(index);       }
 
   // signature
   Symbol* signature() const                      { return constants()->symbol_at(signature_index()); }
-  int signature_index() const                    { return constMethod()->signature_index();         }
+  u2 signature_index() const                     { return constMethod()->signature_index();         }
   void set_signature_index(int index)            { constMethod()->set_signature_index(index);       }
 
   // generics support
   Symbol* generic_signature() const              { int idx = generic_signature_index(); return ((idx != 0) ? constants()->symbol_at(idx) : nullptr); }
-  int generic_signature_index() const            { return constMethod()->generic_signature_index(); }
-  void set_generic_signature_index(int index)    { constMethod()->set_generic_signature_index(index); }
+  u2 generic_signature_index() const             { return constMethod()->generic_signature_index(); }
 
   // annotations support
   AnnotationArray* annotations() const           {
@@ -298,12 +297,7 @@ class Method : public Metadata {
     }
   }
 
-  // Derive stuff from the signature at load time.
-  void compute_from_signature(Symbol* sig);
-
-  // size of parameters (receiver if any + arguments)
-  int  size_of_parameters() const                { return constMethod()->size_of_parameters(); }
-  void set_size_of_parameters(int size)          { constMethod()->set_size_of_parameters(size); }
+  u2 size_of_parameters() const { return constMethod()->size_of_parameters(); }
 
   bool has_stackmap_table() const {
     return constMethod()->has_stackmap_table();
@@ -320,7 +314,7 @@ class Method : public Metadata {
   // exception handler table
   bool has_exception_handler() const
                              { return constMethod()->has_exception_table(); }
-  int exception_table_length() const
+  u2 exception_table_length() const
                              { return constMethod()->exception_table_length(); }
   ExceptionTableElement* exception_table_start() const
                              { return constMethod()->exception_table_start(); }
@@ -933,8 +927,6 @@ public:
   // Inlined elements
   address* native_function_addr() const          { assert(is_native(), "must be native"); return (address*) (this+1); }
   address* signature_handler_addr() const        { return native_function_addr() + 1; }
-
-  void set_num_stack_arg_slots(int n) { constMethod()->set_num_stack_arg_slots(n); }
 };
 
 

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -69,7 +69,7 @@ inline void CompressedLineNumberWriteStream::write_pair_inline(int bci, int line
   // Check if bci is 5-bit and line number 3-bit unsigned.
   if (((bci_delta & ~0x1F) == 0) && ((line_delta & ~0x7) == 0)) {
     // Compress into single byte.
-    jubyte value = ((jubyte) bci_delta << 3) | (jubyte) line_delta;
+    jubyte value = (jubyte)((bci_delta << 3) | line_delta);
     // Check that value doesn't match escape character.
     if (value != 0xFF) {
       write_byte(value);

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,9 +105,9 @@ class MethodCounters : public Metadata {
   void set_rate(float rate)                      { _rate = rate; }
 
   int highest_comp_level() const                 { return _highest_comp_level;  }
-  void set_highest_comp_level(int level)         { _highest_comp_level = level; }
+  void set_highest_comp_level(int level)         { _highest_comp_level = (u1)level; }
   int highest_osr_comp_level() const             { return _highest_osr_comp_level;  }
-  void set_highest_osr_comp_level(int level)     { _highest_osr_comp_level = level; }
+  void set_highest_osr_comp_level(int level)     { _highest_osr_comp_level = (u1)level; }
 
   // invocation counter
   InvocationCounter* invocation_counter() { return &_invocation_counter; }

--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -55,7 +55,7 @@ uint32_t Symbol::pack_hash_and_refcount(short hash, int refcount) {
 
 Symbol::Symbol(const u1* name, int length, int refcount) {
   _hash_and_refcount =  pack_hash_and_refcount((short)os::random(), refcount);
-  _length = length;
+  _length = (u2)length;
   // _body[0..1] are allocated in the header just by coincidence in the current
   // implementation of Symbol. They are read by identity_hash(), so make sure they
   // are initialized.
@@ -215,7 +215,7 @@ const char* Symbol::as_klass_external_name() const {
 static void print_class(outputStream *os, const SignatureStream& ss) {
   int sb = ss.raw_symbol_begin(), se = ss.raw_symbol_end();
   for (int i = sb; i < se; ++i) {
-    int ch = ss.raw_char_at(i);
+    char ch = ss.raw_char_at(i);
     if (ch == JVM_SIGNATURE_SLASH) {
       os->put(JVM_SIGNATURE_DOT);
     } else {
@@ -359,7 +359,7 @@ void Symbol::make_permanent() {
       fatal("refcount underflow");
       return;
     } else {
-      int hash = extract_hash(old_value);
+      short hash = extract_hash(old_value);
       found = Atomic::cmpxchg(&_hash_and_refcount, old_value, pack_hash_and_refcount(hash, PERM_REFCOUNT));
       if (found == old_value) {
         return;  // successfully updated.

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -211,7 +211,7 @@ class Symbol : public MetaspaceObj {
   bool starts_with(const char* prefix) const {
     return starts_with(prefix, (int) strlen(prefix));
   }
-  bool starts_with(int prefix_char) const {
+  bool starts_with(char prefix_char) const {
     return contains_byte_at(0, prefix_char);
   }
   // Tests if the symbol ends with the given suffix.
@@ -221,7 +221,7 @@ class Symbol : public MetaspaceObj {
   bool ends_with(const char* suffix) const {
     return ends_with(suffix, (int) strlen(suffix));
   }
-  bool ends_with(int suffix_char) const {
+  bool ends_with(char suffix_char) const {
     return contains_byte_at(utf8_length() - 1, suffix_char);
   }
 

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -3642,7 +3642,7 @@ void VM_RedefineClasses::set_new_constant_pool(
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-generic_signature_index change: %d to %d", method->generic_signature_index(), new_index);
-      method->set_generic_signature_index(new_index);
+      method->constMethod()->set_generic_signature_index(new_index);
     }
 
     // Update constant pool indices in the method's checked exception

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1176,15 +1176,15 @@ inline intx byte_size(void* from, void* to) {
 
 // Pack and extract shorts to/from ints:
 
-inline int extract_low_short_from_int(jint x) {
-  return x & 0xffff;
+inline u2 extract_low_short_from_int(u4 x) {
+  return u2(x & 0xffff);
 }
 
-inline int extract_high_short_from_int(jint x) {
-  return (x >> 16) & 0xffff;
+inline u2 extract_high_short_from_int(u4 x) {
+  return u2((x >> 16) & 0xffff);
 }
 
-inline int build_int_from_shorts( jushort low, jushort high ) {
+inline int build_int_from_shorts( u2 low, u2 high ) {
   return ((int)((unsigned int)high << 16) | (unsigned int)low);
 }
 


### PR DESCRIPTION
This change uses a number of ways to eliminate -Wconversion warnings in the metadata files in the oops directory. 

1. narrow return types to u2 if the accessor is for a field or value that's u2 (u2 is most common for constMethod fields and constant pool indices)
2. Use checked_cast<type> for places where we know the int value is u2 or s2 but propagating these types is too much fan out.
3. Use plain casts where it's obvious that the int value fits in the casted-to type.
4. Moved KlassKind to be contained in Klass to add the Unknown enum value to use instead of -1.
5. Moved the compute_from_signature function into ConstMethod as it sets values in ConstMethod and the parameters are changed in the set functions.  Removed some pass through functions in Method.

Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308655](https://bugs.openjdk.org/browse/JDK-8308655): Narrow types of ConstantPool and ConstMethod returns


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) ⚠️ Review applies to [7398e225](https://git.openjdk.org/jdk/pull/14092/files/7398e2252a348ab8114916f90aa05fa287b0b81b)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [7398e225](https://git.openjdk.org/jdk/pull/14092/files/7398e2252a348ab8114916f90aa05fa287b0b81b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14092/head:pull/14092` \
`$ git checkout pull/14092`

Update a local copy of the PR: \
`$ git checkout pull/14092` \
`$ git pull https://git.openjdk.org/jdk.git pull/14092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14092`

View PR using the GUI difftool: \
`$ git pr show -t 14092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14092.diff">https://git.openjdk.org/jdk/pull/14092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14092#issuecomment-1559639022)