### PR TITLE
8308503: AArch64: SIGILL when running with -XX:UseBranchProtection=pac-ret on hardware without PAC feature

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -458,14 +458,14 @@ void VM_Version::initialize() {
     // Enable ROP-protection if
     // 1) this code has been built with branch-protection,
     // 2) the CPU/OS supports it, and
-    // 3) incompatible virtual threads feature isn't enabled.
+    // 3) incompatible VMContinuations isn't enabled.
 #ifdef __ARM_FEATURE_PAC_DEFAULT
     if (!VM_Version::supports_paca()) {
       // Disable PAC to prevent illegal instruction crashes.
       warning("ROP-protection specified, but not supported on this CPU. Disabling ROP-protection.");
     } else if (VMContinuations) {
       // Not currently compatible with continuation freeze/thaw.
-      warning("ROP-protection is incompatible with virtual threads feature. Disabling ROP-protection.");
+      warning("ROP-protection is incompatible with VMContinuations. Disabling ROP-protection.");
     } else {
       _rop_protection = true;
     }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -455,15 +455,17 @@ void VM_Version::initialize() {
   } else if (strcmp(UseBranchProtection, "standard") == 0 ||
              strcmp(UseBranchProtection, "pac-ret") == 0) {
     _rop_protection = false;
-    // Enable PAC if this code has been built with branch-protection, the CPU/OS
-    // supports it, and incompatible preview features aren't enabled.
+    // Enable ROP-protection if
+    // 1) this code has been built with branch-protection,
+    // 2) the CPU/OS supports it, and
+    // 3) incompatible virtual threads feature isn't enabled.
 #ifdef __ARM_FEATURE_PAC_DEFAULT
     if (!VM_Version::supports_paca()) {
       // Disable PAC to prevent illegal instruction crashes.
       warning("ROP-protection specified, but not supported on this CPU. Disabling ROP-protection.");
-    } else if (Arguments::enable_preview()) {
+    } else if (VMContinuations) {
       // Not currently compatible with continuation freeze/thaw.
-      warning("ROP-protection is incompatible with virtual threads preview feature. Disabling ROP-protection.");
+      warning("ROP-protection is incompatible with virtual threads feature. Disabling ROP-protection.");
     } else {
       _rop_protection = true;
     }


### PR DESCRIPTION
When revisiting the behavior of UseBranchProtection [1], we get one SIGILL error when running with -XX:UseBranchProtection=pac-ret on hardware without PAC.

Problem:

We build and run `java --version` with the following configuration matrix `Config X VMoption X Machine`.

```
  Config = {--enable-branch-protection, null}
  VMoption = {-XX:UseBranchProtection=pac-ret, -XX:UseBranchProtection=standard}
  Machine = {w/ PAC, w/o PAC}
```

VM crashes with SIGILL error for configure `Config=null, VMoption=pac-ret, Machine=w/o PAC`. The unrecognized instruction is `pacia x30, x29`, i.e. `pacia(lr, rfp)` generated by function `MacroAssembler::protect_return_address()`. [2]

Root cause:

1. Instruction `pacia` is not in the NOP space. That's why `Config=null, VMoption=pac-ret` passes on `hardware w/ PAC`, but fails on `hardware w/o PAC`.

2. -XX:UseBranchProtection=pac-ret behaves differently from the document [3], i.e.

```
  In order to use Branch Protection features in the VM,
  --enable-branch-protection must be used
```

`_rop_protection` is not turned off for `Config=null`. That's why `VMoption=pac-ret, Machine=w/o PAC` passes with
`Config=--enable-branch-protection` but fails with `Config=null`.

Fix:

This patch refines the parsing of -XX:UseBranchProtection=pac-ret:

1. We handle "pac-ret" and "standard" in the same way, since only one type of branch protection is implemented for now, i.e. "pac-ret". We may update "standard" in the future if "bti" protection is added.

2. `_rop_protection` is not turned on unless all the three conditions are satisfied [4]. Otherwise, it's kept off and one warning message is emitted.

```
// Enable PAC if this code has been built with branch-protection, the
// CPU/OS supports it, and incompatible preview features aren't enabled.
```

[1] https://bugs.openjdk.org/browse/JDK-8287325?focusedCommentId=14581099&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14581099
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L5976
[3] https://github.com/openjdk/jdk/blob/master/doc/building.md#branch-protection
[4] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp#L457

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308503](https://bugs.openjdk.org/browse/JDK-8308503): AArch64: SIGILL when running with -XX:UseBranchProtection=pac-ret on hardware without PAC feature


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [fbbf86a8](https://git.openjdk.org/jdk/pull/14095/files/fbbf86a85e4069e0f12fa0a8236dc7d1a60a3b16)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14095/head:pull/14095` \
`$ git checkout pull/14095`

Update a local copy of the PR: \
`$ git checkout pull/14095` \
`$ git pull https://git.openjdk.org/jdk.git pull/14095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14095`

View PR using the GUI difftool: \
`$ git pr show -t 14095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14095.diff">https://git.openjdk.org/jdk/pull/14095.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14095#issuecomment-1558548225)