### PR TITLE
JDK-8308627: JDK-8306983 breaks Alpine

### DIFF
--- a/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
@@ -113,8 +113,16 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
     env->SetIntField(result, c_line, data.c_line);
     jbyteArray c_ccValue = (jbyteArray) env->GetObjectField(result, c_cc);
     env->SetByteArrayRegion(c_ccValue, 0, NCCS, (signed char *) data.c_cc);//TODO: cast?
+#ifdef _HAVE_STRUCT_TERMIOS_C_ISPEED
     env->SetIntField(result, c_ispeed, data.c_ispeed);
+#else
+    env->SetIntField(result, c_ispeed, 0);
+#endif
+#ifdef _HAVE_STRUCT_TERMIOS_C_OSPEED
     env->SetIntField(result, c_ospeed, data.c_ospeed);
+#else
+    env->SetIntField(result, c_ospeed, 0);
+#endif
 }
 
 /*
@@ -133,9 +141,12 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
     data.c_line = env->GetIntField(input, c_line);
     jbyteArray c_ccValue = (jbyteArray) env->GetObjectField(input, c_cc);
     env->GetByteArrayRegion(c_ccValue, 0, NCCS, (jbyte *) data.c_cc);
+#ifdef _HAVE_STRUCT_TERMIOS_C_ISPEED
     data.c_ispeed = env->GetIntField(input, c_ispeed);
+#endif
+#ifdef _HAVE_STRUCT_TERMIOS_C_OSPEED
     data.c_ospeed = env->GetIntField(input, c_ospeed);
-
+#endif
     if (tcsetattr(fd, cmd, &data) != 0) {
         throw_errno(env);
     }


### PR DESCRIPTION
Trivial fix to get Alpine to build again after https://bugs.openjdk.org/browse/JDK-8306983

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308627](https://bugs.openjdk.org/browse/JDK-8308627): JDK-8306983 breaks Alpine


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14097/head:pull/14097` \
`$ git checkout pull/14097`

Update a local copy of the PR: \
`$ git checkout pull/14097` \
`$ git pull https://git.openjdk.org/jdk.git pull/14097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14097`

View PR using the GUI difftool: \
`$ git pr show -t 14097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14097.diff">https://git.openjdk.org/jdk/pull/14097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14097#issuecomment-1558863436)