### PR TITLE
JDK-8264488: Improve warning for module names ending with digits

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1861,7 +1861,7 @@ compiler.warn.finally.cannot.complete=\
 
 # 0: name
 compiler.warn.poor.choice.for.module.name=\
-    module name component {0} ends with a digit. Module names should not encode version information in module names should avoid terminal digits
+    module name component {0} ends with a digit. Module names should not encode version information in module names
 
 # 0: string
 compiler.warn.incubating.modules=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1861,7 +1861,7 @@ compiler.warn.finally.cannot.complete=\
 
 # 0: name
 compiler.warn.poor.choice.for.module.name=\
-    module name component {0} should avoid terminal digits
+    module name component {0} ends with a digit. Module names should not encode version information in module names should avoid terminal digits
 
 # 0: string
 compiler.warn.incubating.modules=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1861,7 +1861,7 @@ compiler.warn.finally.cannot.complete=\
 
 # 0: name
 compiler.warn.poor.choice.for.module.name=\
-    module name component {0} ends with a digit. Module names should not encode version information in module names
+    terminal digits in module name {0} look like a version number
 
 # 0: string
 compiler.warn.incubating.modules=\


### PR DESCRIPTION
Since this is a rather trivial change, I didn't start a new discussion, as I deem this sufficiently discussed [back in early 2021](https://mail.openjdk.org/pipermail/discuss/2021-March/005779.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264488](https://bugs.openjdk.org/browse/JDK-8264488): Improve warning for module names ending with digits (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14099/head:pull/14099` \
`$ git checkout pull/14099`

Update a local copy of the PR: \
`$ git checkout pull/14099` \
`$ git pull https://git.openjdk.org/jdk.git pull/14099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14099`

View PR using the GUI difftool: \
`$ git pr show -t 14099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14099.diff">https://git.openjdk.org/jdk/pull/14099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14099#issuecomment-1559639326)