### PR TITLE
8307738: JFR: EventStream.openRepository() drops events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,7 @@ public final class ChunkParser {
     private ParserConfiguration configuration;
     private MetadataDescriptor previousMetadata;
     private MetadataDescriptor metadata;
+    private long lastFlush;
     private boolean staleMetadata = true;
 
     public ChunkParser(RecordingInput input, ParserState ps) throws IOException {
@@ -254,7 +255,7 @@ public final class ChunkParser {
                 // Not accepted by filter
             } else {
                 if (typeId == 1) { // checkpoint event
-                    if (CheckpointType.FLUSH.is(parseCheckpointType())) {
+                    if ((parseFlushCheckpoint())) {
                         input.position(pos + size);
                         return FLUSH_MARKER;
                     }
@@ -269,11 +270,15 @@ public final class ChunkParser {
         return null;
     }
 
-    private byte parseCheckpointType() throws IOException {
-        input.readLong(); // timestamp
+    private boolean parseFlushCheckpoint() throws IOException {
+        long timestamp = input.readLong();
         input.readLong(); // duration
         input.readLong(); // delta
-        return input.readByte();
+        if (CheckpointType.FLUSH.is(input.readByte())) {
+            lastFlush = timeConverter.convertTimestamp(timestamp);
+            return true;
+        }
+        return false;
     }
 
     private boolean awaitUpdatedHeader(long absoluteChunkEnd, long filterEnd) throws IOException {
@@ -480,6 +485,10 @@ public final class ChunkParser {
 
     public long getEndNanos() {
         return getStartNanos() + getChunkDuration();
+    }
+
+    public long getLastFlush() {
+        return lastFlush;
     }
 
     public void setStaleMetadata(boolean stale) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,9 +166,7 @@ public final class EventDirectoryStream extends AbstractEventStream {
                         processUnordered(disp);
                     }
                     currentParser.resetCache();
-                    long endNanos = currentParser.getStartNanos() + currentParser.getChunkDuration();
-                    // same conversion as in RecordingInfo
-                    if (endNanos > filterEnd) {
+                    if (currentParser.getLastFlush() > filterEnd) {
                         return;
                     }
                 }


### PR DESCRIPTION
Could I have a review that prevents events to be dropped in case an end time has been set for a stream.

Testing: jdk/jdk/jfr

Thanks
Erik