### PR TITLE
8303215: Make thread stacks not use huge pages

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -929,7 +929,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   // Add an additional page to the stack size to reduce its chances of getting large page aligned
   // so that the stack does not get backed by a transparent huge page.
-  if (stack_size >= os::Linux::_default_large_page_size && is_aligned(stack_size, os::Linux::_default_large_page_size)) {
+  if (stack_size >= os::Linux::default_large_page_size() && is_aligned(stack_size, os::Linux::default_large_page_size())) {
     stack_size += os::vm_page_size();
   }
 
@@ -3625,7 +3625,7 @@ static void set_coredump_filter(CoredumpFilterBit bit) {
 
 static size_t _large_page_size = 0;
 
-size_t os::Linux::scan_default_large_page_size() {
+static size_t scan_default_large_page_size() {
   size_t default_large_page_size = 0;
 
   // large_page_size on Linux is used to round up heap size. x86 uses either
@@ -3752,7 +3752,7 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
 
 void os::large_page_init() {
   // Scan default large page size
-  size_t default_large_page_size = os::Linux::scan_default_large_page_size();
+  size_t default_large_page_size = scan_default_large_page_size();
   os::Linux::_default_large_page_size = default_large_page_size;
 
   // 1) Handle the case where we do not want to use huge pages and hence

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -930,10 +930,10 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   // Add an additional page to the stack size to reduce its chances of getting large page aligned
   // so that the stack does not get backed by a transparent huge page.
   size_t default_large_page_size = os::Linux::default_large_page_size();
-  if (default_large_page_size != 0) {
-    if (stack_size >= default_large_page_size && is_aligned(stack_size, default_large_page_size)) {
-      stack_size += os::vm_page_size();
-    }
+  if (default_large_page_size != 0 &&
+      stack_size >= default_large_page_size &&
+      is_aligned(stack_size, default_large_page_size)) {
+    stack_size += os::vm_page_size();
   }
 
   int status = pthread_attr_setstacksize(&attr, stack_size);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -927,11 +927,9 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   }
   assert(is_aligned(stack_size, os::vm_page_size()), "stack_size not aligned");
 
-  size_t default_large_page_size = os::Linux::scan_default_large_page_size();
-
   // Add an additional page to the stack size to reduce its chances of getting large page aligned
   // so that the stack does not get backed by a transparent huge page.
-  if (stack_size >= default_large_page_size && is_aligned(stack_size, default_large_page_size)) {
+  if (stack_size >= os::Linux::_default_large_page_size && is_aligned(stack_size, os::Linux::_default_large_page_size)) {
     stack_size += os::vm_page_size();
   }
 
@@ -3753,6 +3751,10 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
 }
 
 void os::large_page_init() {
+  // Scan default large page size
+  size_t default_large_page_size = os::Linux::scan_default_large_page_size();
+  os::Linux::_default_large_page_size = default_large_page_size;
+
   // 1) Handle the case where we do not want to use huge pages and hence
   //    there is no need to scan the OS for related info
   if (!UseLargePages &&
@@ -3772,9 +3774,7 @@ void os::large_page_init() {
     return;
   }
 
-  // 2) Scan OS info
-  size_t default_large_page_size = os::Linux::scan_default_large_page_size();
-  os::Linux::_default_large_page_size = default_large_page_size;
+  // 2) check if large pages are configured
   if (default_large_page_size == 0) {
     // No large pages configured, return.
     warn_no_large_pages_configured();

--- a/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
@@ -31,11 +31,13 @@
 
 define_pd_global(bool, DontYieldALot,            false);
 
-// set default stack sizes < 2MB so as to prevent stacks from getting
+// Set default stack sizes < 2MB so as to prevent stacks from getting
 // large-page aligned and backed by THPs on systems where 2MB is the
-// default huge page size. For non-JavaThreads, glibc adds an additional
+// default huge page size. For non-JavaThreads, glibc may add an additional
 // guard page to the total stack size, so to keep the default sizes same
-// for all the following flags, we set them to 2 pages less than 2MB.
+// for all the following flags, we set them to 2 pages less than 2MB. On
+// systems where 2MB is the default large page size, 4KB is most commonly
+// the regular page size.
 define_pd_global(intx, ThreadStackSize,          2040); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2040);
 

--- a/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
@@ -30,6 +30,12 @@
 // (see globals.hpp)
 
 define_pd_global(bool, DontYieldALot,            false);
+
+// set default stack sizes < 2MB so as to prevent stacks from getting
+// large-page aligned and backed by THPs on systems where 2MB is the
+// default huge page size. For non-JavaThreads, glibc adds an additional
+// guard page to the total stack size, so to keep the default sizes same
+// for all the following flags, we set them to 2 pages less than 2MB.
 define_pd_global(intx, ThreadStackSize,          2040); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2040);
 

--- a/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
@@ -30,10 +30,10 @@
 // (see globals.hpp)
 
 define_pd_global(bool, DontYieldALot,            false);
-define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
-define_pd_global(intx, VMThreadStackSize,        2048);
+define_pd_global(intx, ThreadStackSize,          2040); // 0 => use system default
+define_pd_global(intx, VMThreadStackSize,        2040);
 
-define_pd_global(intx, CompilerThreadStackSize,  2048);
+define_pd_global(intx, CompilerThreadStackSize,  2040);
 
 define_pd_global(uintx,JVMInvokeMethodSlack,     8192);
 


### PR DESCRIPTION
When a system has Transparent Huge Pages (THP) enabled (/sys/kernel/mm/transparent_hugepage/enabled is set to 'always'), thread stacks can have significantly more resident set size (RSS) than they actually require. This occurs when the stack size is 2MB or larger, which makes the memory range of the stack more likely to be aligned on a Large Page Size boundary (2MB on most systems). This in turn makes the stack eligible to be backed by transparent huge pages resulting in more memory consumption than it would otherwise when standard small pages are used. This issue is more apparent on AArch64 platforms where the default stack size is 2MB. 

```
Example mapping from smaps illustrating this issue:
fffced200000-fffced204000 ---p 00000000 00:00 0 
Size:                16 kB     # guard pages
KernelPageSize:       4 kB
MMUPageSize:          4 kB
...
fffced204000-fffced400000 rw-p 00000000 00:00 0 
Size:              2032 kB    # stack space
KernelPageSize:       4 kB
MMUPageSize:          4 kB
Rss:               2032 kB    # entire stack resident in memory
```

This fix addresses this issue with the following two main changes:

1. Change the default stack size to 2040KB, which is 2 pages less than 2MB. This ensures that stacks don't get 2MB aligned. And why 2 pages less than 2MB, because for non-JavaThreads, glibc adds an additional guard page to the total stack size. To keep it simple and to keep the default stack size value for  all options - ThreadStackSize, CompilerThreadStackSize, and VMThreadStackSize same, we use the default value as 2040K.

Example mapping for a JavaThread:
```
ffff6e913000-ffff6e917000 ---p 00000000 00:00 0 
Size:                 16 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
...
ffff6e917000-ffff6eb11000 rw-p 00000000 00:00 0 
Size:               2024 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                  92 kB
```
Example Mapping for a non-JavaThread (WatcherThread):
```
ffff6eb11000-ffff6eb12000 ---p 00000000 00:00 0 
Size:                  4 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
...
ffff6eb12000-ffff6ed10000 rw-p 00000000 00:00 0 
Size:               2040 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                  12 kB
```

2. If the requested stack size is greater than or equal to the default large page size (2MB on most systems) and can be large-page aligned, then add an additional page to the stack size. This reduces the chances of stacks getting large page aligned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215): Make thread stacks not use huge pages


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [a4698247](https://git.openjdk.org/jdk/pull/14105/files/a46982470c7c3c4f7e3d12aaa2a0b9d6dfb7e8a5)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14105/head:pull/14105` \
`$ git checkout pull/14105`

Update a local copy of the PR: \
`$ git checkout pull/14105` \
`$ git pull https://git.openjdk.org/jdk.git pull/14105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14105`

View PR using the GUI difftool: \
`$ git pr show -t 14105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14105.diff">https://git.openjdk.org/jdk/pull/14105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14105#issuecomment-1559921231)