### PR TITLE
8308716: ProblemList java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java with genzgc on windows-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -42,3 +42,7 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8307462 generic-all
 
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
+
+vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 windows-x64
+vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_a/TestDescription.java 8308367 windows-x64
+vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 8308367 windows-x64

--- a/test/jdk/ProblemList-generational-zgc.txt
+++ b/test/jdk/ProblemList-generational-zgc.txt
@@ -39,3 +39,4 @@ sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8307393   generic-all
 
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8298066 generic-all
 com/sun/jdi/ThreadMemoryLeakTest.java          8307402 generic-all
+java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java 8308047 windows-x64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -458,6 +458,7 @@ java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,wi
 java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
+java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
Trivial fixes to ProblemList some tests:
[JDK-8308716](https://bugs.openjdk.org/browse/JDK-8308716) ProblemList java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java with genzgc on windows-x64
[JDK-8308718](https://bugs.openjdk.org/browse/JDK-8308718) ProblemList three mlvm/indy/func/jvmti tests on windows-x64 in Xcomp mode
[JDK-8308720](https://bugs.openjdk.org/browse/JDK-8308720) ProblemList java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java on macosx-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8308716](https://bugs.openjdk.org/browse/JDK-8308716): ProblemList java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java with genzgc on windows-x64
 * [JDK-8308718](https://bugs.openjdk.org/browse/JDK-8308718): ProblemList three mlvm/indy/func/jvmti tests on windows-x64 in Xcomp mode
 * [JDK-8308720](https://bugs.openjdk.org/browse/JDK-8308720): ProblemList java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java on macosx-x64


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14106/head:pull/14106` \
`$ git checkout pull/14106`

Update a local copy of the PR: \
`$ git checkout pull/14106` \
`$ git pull https://git.openjdk.org/jdk.git pull/14106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14106`

View PR using the GUI difftool: \
`$ git pr show -t 14106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14106.diff">https://git.openjdk.org/jdk/pull/14106.diff</a>

</details>
