### PR TITLE
8299665: /proc/self/stat parsing in libmanagement broken by execname with spaces

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -346,7 +346,7 @@ JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getCommittedVirtualMemorySize0
   (JNIEnv *env, jobject mbean)
 {
-   unsigned long vsize;
+    unsigned long vsize;
     if (read_vmem_usage("/proc/self/stat", &vsize) == -1) {
         throw_internal_error(env, "Unable to get virtual memory usage");
     }

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#include "jni_util.h"
-
 #include <stdio.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -38,6 +36,8 @@
 #include <dlfcn.h>
 #include <pthread.h>
 #include <inttypes.h>
+
+#include "management_ext.h"
 #include "com_sun_management_internal_OperatingSystemImpl.h"
 
 #include <assert.h>
@@ -72,13 +72,6 @@ static int next_line(FILE *f) {
     } while (c != '\n' && c != EOF);
 
     return c;
-}
-
-static void throw_internal_error(JNIEnv* env, const char* msg) {
-    char errmsg[128];
-
-    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
-    JNU_ThrowInternalError(env, errmsg);
 }
 
 /**

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -35,6 +35,13 @@ const JmmInterface* jmm_interface_management_ext = NULL;
 static JavaVM* jvm = NULL;
 jint jmm_version_management_ext = 0;
 
+void throw_internal_error(JNIEnv* env, const char* msg) {
+    char errmsg[128];
+
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
+    JNU_ThrowInternalError(env, errmsg);
+}
+
 JNIEXPORT jint JNICALL
    DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
     JNIEnv* env;

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.h
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.h
@@ -37,4 +37,6 @@
 extern const JmmInterface* jmm_interface_management_ext;
 extern jint jmm_version_management_ext;
 
+void throw_internal_error(JNIEnv* env, const char* msg);
+
 #endif

--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -61,10 +61,6 @@
 #include <libperfstat.h>
 #endif
 
-#if defined(__linux__)
-#include <string.h>
-#endif
-
 static jlong page_size = 0;
 
 #if defined(_ALLBSD_SOURCE) || defined(_AIX)

--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -86,13 +86,6 @@ static jlong page_size = 0;
   #define closedir closedir64
 #endif
 
-static void throw_internal_error(JNIEnv* env, const char* msg) {
-    char errmsg[128];
-
-    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
-    JNU_ThrowInternalError(env, errmsg);
-}
-
 // true = get available swap in bytes
 // false = get total swap in bytes
 static jlong get_total_or_available_swap_space_size(JNIEnv* env, jboolean available) {
@@ -133,7 +126,7 @@ Java_com_sun_management_internal_OperatingSystemImpl_initialize0
     page_size = sysconf(_SC_PAGESIZE);
 }
 
-// Linux-specific implementation is in UnixOperatingSystem.c 
+// Linux-specific implementation is in UnixOperatingSystem.c
 #if !defined(__linux__)
 JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getCommittedVirtualMemorySize0


### PR DESCRIPTION
Code that parses /proc/self/stat may be broken if the executable name contains spaces.

We have code that does this correctly, and code that does not.
UnixOperatingSystem.c is Linux-specific OS code, and has vread_statdata which correctly uses strrchr to find the last ) and parses from there.

OperatingSystemImpl.c the generic, not Linux-specific code, is not OK, as Java_com_sun_management_internal_OperatingSystemImpl_getCommittedVirtualMemorySize0 has a problematic fscanf call. 
But the problematic fscanf call is Linux-specific: we use ifdef to create OS-specific implementations.


Need to change the fscanf of /proc/self/stat to do the same buffered read as read_ticks in UnixOperatingSystem.c (the Linux-specific code), with strrchr to read past the ) of the execname.

Moving the actually-Linux-specific getCommittedVirtualMemorySize0 to be with the other Linux-specific code means it can just use the existing method for accessing /proc/self/stat.

It does however call throw_internal_error, which is then not accessible.  So that function can be shared in the libmanagement_ext.h/.c for both uses.

The call to throw_internal_error is working: if I change the code to fail, it reports a java.lang.InternalError as it would before.

Existing tests still pass: 
i.e. test/jdk/com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299665](https://bugs.openjdk.org/browse/JDK-8299665): /proc/self/stat parsing in libmanagement broken by execname with spaces


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14107/head:pull/14107` \
`$ git checkout pull/14107`

Update a local copy of the PR: \
`$ git checkout pull/14107` \
`$ git pull https://git.openjdk.org/jdk.git pull/14107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14107`

View PR using the GUI difftool: \
`$ git pr show -t 14107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14107.diff">https://git.openjdk.org/jdk/pull/14107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14107#issuecomment-1560941244)