### PR TITLE
8290499: new File(parent, "/") breaks normalization – creates File with slash at the end

### DIFF
--- a/src/java.base/unix/classes/java/io/UnixFileSystem.java
+++ b/src/java.base/unix/classes/java/io/UnixFileSystem.java
@@ -101,15 +101,23 @@ final class UnixFileSystem extends FileSystem {
         return pathname.startsWith("/") ? 1 : 0;
     }
 
+    // Remove trailing '/' if present and there are at least two characters
+    private static String trimSeparator(String s) {
+        int len = s.length();
+        if (len > 1 && s.charAt(len - 1) == '/')
+            return s.substring(0, len - 1);
+        return s;
+    }
+
     @Override
     public String resolve(String parent, String child) {
         if (child.isEmpty()) return parent;
         if (child.charAt(0) == '/') {
             if (parent.equals("/")) return child;
-            return parent + child;
+            return trimSeparator(parent + child);
         }
-        if (parent.equals("/")) return parent + child;
-        return parent + '/' + child;
+        if (parent.equals("/")) return trimSeparator(parent + child);
+        return trimSeparator(parent + '/' + child);
     }
 
     @Override

--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -285,6 +285,13 @@ final class WinNTFileSystem extends FileSystem {
             theChars[parentEnd] = slash;
             child.getChars(childStart, cn, theChars, parentEnd + 1);
         }
+
+        // if present, strip trailing name separator unless after a ':'
+        if (theChars.length > 1
+            && theChars[theChars.length - 1] == slash
+            && theChars[theChars.length - 2] != ':')
+            return new String(theChars, 0, theChars.length - 1);
+
         return new String(theChars);
     }
 

--- a/test/jdk/java/io/File/Cons.java
+++ b/test/jdk/java/io/File/Cons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
-   @bug 4131169 4168988
+   @bug 4131169 4168988 8290499
    @summary Basic File constructor tests
  */
 
@@ -251,11 +251,17 @@ public class Cons {
         /* Two-arg constructors cases, string parent */
         if (!old) {
             ck2("//foo", "bar", "/foo", "bar", "/foo/bar");
+            ck2("/foo", "/", "/", "foo", "/foo");
+            ck2("//foo", "/", "/", "foo", "/foo");
+            ck2("/foo", "//", "/", "foo", "/foo");
         }
 
         /* Two-arg constructor cases, File parent */
         if (!old) {
             ck2f("//foo", "bar", "/foo", "bar", "/foo/bar");
+            ck2f("/foo", "/", "/", "foo", "/foo");
+            ck2f("//foo", "/", "/", "foo", "/foo");
+            ck2f("/foo", "//", "/", "foo", "/foo");
         }
 
         File f = new File("/foo");
@@ -296,10 +302,17 @@ public class Cons {
             ck2("z:/", "//foo", "z:/", "foo", "z:/foo");
             ck2("z:/", "foo/", "z:/", "foo", "z:/foo");
             ck2("//foo", "bar", "//foo", "bar", "//foo/bar");
+            ck2("z:", "", null, "", "z:");
+            ck2("z:/", "/", null, "", "z:/");
+            ck2("z:/", "a/b/c", "z:/a/b", "c", "z:/a/b/c");
+            ck2("z:/", "a/b/c/", "z:/a/b", "c", "z:/a/b/c");
 
             /* Two-arg constructor cases, File parent */
             ck2f("//foo", "bar", "//foo", "bar", "//foo/bar");
-
+            ck2f("z:", "", null, "", "z:");
+            ck2f("z:/", "/", null, "", "z:/");
+            ck2f("z:/", "a/b/c", "z:/a/b", "c", "z:/a/b/c");
+            ck2f("z:/", "a/b/c/", "z:/a/b", "c", "z:/a/b/c");
         }
     }
 


### PR DESCRIPTION
In `java.io.File`, change the constructors `File(File,String)` and `File(String,String)` so that they do not for typical cases return a `File` whose path has a trailing name separator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290499](https://bugs.openjdk.org/browse/JDK-8290499): new File(parent, "/") breaks normalization – creates File with slash at the end


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14109/head:pull/14109` \
`$ git checkout pull/14109`

Update a local copy of the PR: \
`$ git checkout pull/14109` \
`$ git pull https://git.openjdk.org/jdk.git pull/14109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14109`

View PR using the GUI difftool: \
`$ git pr show -t 14109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14109.diff">https://git.openjdk.org/jdk/pull/14109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14109#issuecomment-1560232453)