### PR TITLE
8174722: Wrong behavior of DecimalFormat with RoundingMode.UP in special case

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -393,46 +393,26 @@ final class DigitList implements Cloneable {
      }
 
     /**
-     * Determine if a number should create a 1 in the least significant location
-     * if truncating the representation to the given number of digits would
-     * violate the current RoundingMode contract.
-     * @param maximumDigits The maximum number of digits to be shown.
+     * This method sets the Digit List to a state that is either
+     * equivalent to zero, or a state with a 1 in the least significant location
+     * if an underflow to zero would violate the current RoundingMode contract.
      *
-     * Upon return, count will either be one or zero.
+     * This method does not return any value, and instead adjusts
+     * the instance variables that the Digit List is composed of.
+     *
+     * @param maximumDigits The maximum number of digits to be shown.
      */
     private void underflowToZero(int maximumDigits) {
-        switch(roundingMode) {
-            case UP:
-                // RoundingMode.UP can not decrease the magnitude of the value
-                // whether negative or positive.
-                decimalAt = -maximumDigits + 1;
-                digits[0] = '1';
-                count = 1;
-                break;
-            case CEILING:
-                // RoundingMode.CEILING follows RoundingMode.UP behavior when
-                // the value is positive
-                if (!isNegative) {
-                    decimalAt = -maximumDigits + 1;
-                    digits[0] = '1';
-                    count = 1;
-                } else {
-                    count = 0;
-                }
-                break;
-            case FLOOR:
-                // RoundingMode.FLOOR can not increase the value
-                // when negative
-                if (isNegative) {
-                    decimalAt = -maximumDigits + 1;
-                    digits[0] = '1';
-                    count = 1;
-                } else {
-                    count = 0;
-                }
-                break;
-            default:
-                count = 0;
+        // These modes under the right conditions should not
+        // decrease the magnitude of the formatted value
+        if (roundingMode == RoundingMode.UP
+                || (roundingMode == RoundingMode.CEILING && !isNegative)
+                || (roundingMode == RoundingMode.FLOOR && isNegative)) {
+            decimalAt = -maximumDigits + 1;
+            digits[0] = '1';
+            count = 1;
+        } else {
+            count = 0;
         }
     }
 

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -395,7 +395,7 @@ final class DigitList implements Cloneable {
     /**
      * Determine if a number should create a 1 in the least significant location
      * if truncating the representation to the given number of digits would
-     * violate the current RoundingMode contract
+     * violate the current RoundingMode contract.
      * @param maximumDigits The maximum number of digits to be shown.
      *
      * Upon return, count will either be one or zero.

--- a/test/jdk/java/text/Format/DecimalFormat/UnderflowToZero.java
+++ b/test/jdk/java/text/Format/DecimalFormat/UnderflowToZero.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+* @test
+* @bug 8174722
+* @summary Tests underflow for rounding values < abs(0.1) in DecimalFormat
+* @run junit UnderflowToZero
+*/
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UnderflowToZero {
+    private static final RoundingMode[] MODES = {RoundingMode.DOWN,
+            RoundingMode.HALF_EVEN, RoundingMode.HALF_UP, RoundingMode.HALF_DOWN,
+            RoundingMode.FLOOR, RoundingMode.CEILING, RoundingMode.UP};
+    private static final String ERRMSG = "%f formatted with pattern %s and mode " +
+            "%s gives %s but %f formatted with the same pattern and mode gives %s";
+
+    @ParameterizedTest
+    @MethodSource("patternAndNumbers")
+    public void testModes(double bigger, double smaller, String pattern) {
+        DecimalFormat df = new DecimalFormat();
+        df.applyPattern(pattern);
+        for (RoundingMode mode : MODES) {
+            testFormat(bigger, smaller, pattern, mode, df);
+        }
+    }
+
+    @Test
+    public void testZero() {
+        DecimalFormat df = new DecimalFormat();
+        df.applyPattern("0.0");
+        for (RoundingMode mode : MODES) {
+            df.setRoundingMode(mode);
+            String decimalFormatted = df.format(0.0000);
+            assertEquals(decimalFormatted, "0.0");
+        }
+    }
+
+    // Ensure formatting values less than abs(.1) adheres
+    // to contracts of rounding modes. To ensure this, we can compare
+    // the fractional portion of the result to the fractional portion
+    // of the same value + 1;
+    private void testFormat(double bigger, double smaller, String pattern,
+                            RoundingMode mode, DecimalFormat df) {
+        df.setRoundingMode(mode);
+        // Compare the fractional part of both numbers
+        // Eg: Compare 1.(0001) to 0.(0001)
+        String biggerFormatted = df.format(bigger).split("\\.")[1];
+        String smallerFormatted = df.format(smaller).split("\\.")[1];
+        assertEquals(biggerFormatted, smallerFormatted, String.format(ERRMSG, bigger, pattern,
+                mode, df.format(bigger), smaller, df.format(smaller)));
+    }
+
+    private static Stream<Arguments> patternAndNumbers() {
+        return Stream.of(
+                Arguments.of(1.0001, 0.0001, "0.0"),
+                Arguments.of(1.0001, 0.0001, "0.00"),
+                Arguments.of(1.0001, 0.0001, "0.000"),
+
+                Arguments.of(-1.0001, -0.0001, "0.0"),
+                Arguments.of(-1.0001, -0.0001, "0.00"),
+                Arguments.of(-1.0001, -0.0001, "0.000"),
+
+                Arguments.of(1.0009, 0.0009, "0.0"),
+                Arguments.of(1.0009, 0.0009, "0.00"),
+                Arguments.of(1.0009, 0.0009, "0.000"),
+
+                Arguments.of(-1.0009, -0.0009, "0.0"),
+                Arguments.of(-1.0009, -0.0009, "0.00"),
+                Arguments.of(-1.0009, -0.0009, "0.000"),
+
+                Arguments.of(1.0004545, 0.0004545, "0.0"),
+                Arguments.of(1.0004545, 0.0004545, "0.00"),
+                Arguments.of(1.0004545, 0.0004545, "0.000"),
+
+                Arguments.of(-1.0004545, -0.0004545, "0.0"),
+                Arguments.of(-1.0004545, -0.0004545, "0.00"),
+                Arguments.of(-1.0004545, -0.0004545, "0.000")
+        );
+    }
+}

--- a/test/jdk/java/text/Format/DecimalFormat/UnderflowToZero.java
+++ b/test/jdk/java/text/Format/DecimalFormat/UnderflowToZero.java
@@ -77,7 +77,7 @@ public class UnderflowToZero {
     // Ensure formatting values less than abs(.1) adheres
     // to contracts of rounding modes. To ensure this, we can compare
     // the fractional portion of the result to the fractional portion
-    // of the same value + 1;
+    // of the same value +- 1;
     private void testFormat(double bigger, double smaller, String pattern,
                             RoundingMode mode, DecimalFormat df) {
         df.setRoundingMode(mode);

--- a/test/jdk/java/text/Format/DecimalFormat/UnderflowToZero.java
+++ b/test/jdk/java/text/Format/DecimalFormat/UnderflowToZero.java
@@ -32,6 +32,9 @@
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -41,11 +44,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UnderflowToZero {
-    private static final RoundingMode[] MODES = {RoundingMode.DOWN,
-            RoundingMode.HALF_EVEN, RoundingMode.HALF_UP, RoundingMode.HALF_DOWN,
-            RoundingMode.FLOOR, RoundingMode.CEILING, RoundingMode.UP};
+    private static final List<RoundingMode> MODES;
     private static final String ERRMSG = "%f formatted with pattern %s and mode " +
             "%s gives %s but %f formatted with the same pattern and mode gives %s";
+
+    static {
+        MODES = new ArrayList<>(Arrays.asList(RoundingMode.values()));
+        MODES.remove(RoundingMode.UNNECESSARY);
+    }
 
     @ParameterizedTest
     @MethodSource("patternAndNumbers")


### PR DESCRIPTION
Please review this PR, which addresses a case where Decimal Format would violate certain RoundingMode contracts given the right pattern and double. Note that this fix is intended only to address the edge case in the implementation, and the lack of specification regarding rounding will be addressed in [JDK-8313434](https://bugs.openjdk.org/browse/JDK-8313434).

For example,

```
DecimalFormat df = new DecimalFormat();
df.setRoundingMode(RoundingMode.UP);
double small = 0.0001;
double big = 1.0001;
df.applyPattern("0.00");
df.format(small); // returns 0.00, which violates UP
df.format(big); // returns 1.01, which does not violate UP
```

In this example `0.0001` becomes `0.00`, a decrease in magnitude. This violates the RoundingMode.UP contract as RoundingMode.UP states "Note that this rounding mode never decreases the magnitude of the calculated value."

The Decimal Format implementation makes an assumption that under-flowing to zero can be made if the pattern allows for it, skipping the consideration of RoundingMode. This is a result of when the pattern has less fractional digits than fractional leading zeroes in the numerical representation of the given double, and the double is less than .1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8308798](https://bugs.openjdk.org/browse/JDK-8308798) to be approved

### Issues
 * [JDK-8174722](https://bugs.openjdk.org/browse/JDK-8174722): Wrong behavior of DecimalFormat with RoundingMode.UP in special case (**Bug** - P4)
 * [JDK-8308798](https://bugs.openjdk.org/browse/JDK-8308798): Wrong behavior of DecimalFormat with RoundingMode.UP in special case (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14110/head:pull/14110` \
`$ git checkout pull/14110`

Update a local copy of the PR: \
`$ git checkout pull/14110` \
`$ git pull https://git.openjdk.org/jdk.git pull/14110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14110`

View PR using the GUI difftool: \
`$ git pr show -t 14110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14110.diff">https://git.openjdk.org/jdk/pull/14110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14110#issuecomment-1560250979)