### PR TITLE
8308751: Create new switch to print error reporting output to both hs_err_pid file and stdout/stderr

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2775,6 +2775,12 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       if (FLAG_SET_CMDLINE(ErrorFileToStdout, false) != JVMFlag::SUCCESS) {
         return JNI_EINVAL;
       }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStderr, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStdout, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
       if (FLAG_SET_CMDLINE(ErrorFileToStderr, true) != JVMFlag::SUCCESS) {
         return JNI_EINVAL;
       }
@@ -2782,7 +2788,39 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       if (FLAG_SET_CMDLINE(ErrorFileToStderr, false) != JVMFlag::SUCCESS) {
         return JNI_EINVAL;
       }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStderr, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStdout, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
       if (FLAG_SET_CMDLINE(ErrorFileToStdout, true) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+    } else if (match_option(option, "-XX:+ErrorFileWithStderr")) {
+      if (FLAG_SET_CMDLINE(ErrorFileToStderr, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileToStdout, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStdout, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStderr, true) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+    } else if (match_option(option, "-XX:+ErrorFileWithStdout")) {
+      if (FLAG_SET_CMDLINE(ErrorFileToStderr, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileToStdout, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStderr, false) != JVMFlag::SUCCESS) {
+        return JNI_EINVAL;
+      }
+      if (FLAG_SET_CMDLINE(ErrorFileWithStdout, true) != JVMFlag::SUCCESS) {
         return JNI_EINVAL;
       }
     } else if (match_option(option, "--finalization=", &tail)) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1053,6 +1053,12 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, ErrorFileToStdout, false,                                   \
           "If true, error data is printed to stdout instead of a file")     \
                                                                             \
+  product(bool, ErrorFileWithStderr, false,                                 \
+          "If true, error data is printed to stderr and a file")            \
+                                                                            \
+  product(bool, ErrorFileWithStdout, false,                                 \
+          "If true, error data is printed to stdout and a file")            \
+                                                                            \
   develop(bool, UseHeavyMonitors, false,                                    \
           "(Deprecated) Use heavyweight instead of lightweight Java "       \
           "monitors")                                                       \

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1712,7 +1712,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     }
   }
 
-  // Part 1: print to screen
+  // Part 1: print to stdout/stderr
   if (!out_done) {
     // print an abbreviated version (the '#' section) to stdout by default.
     // full error log is printed if the print option to stdout and stderr is specified

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1712,40 +1712,43 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     }
   }
 
-  // Part 1: print an abbreviated version (the '#' section) to stdout.
+  // Part 1: print to screen
   if (!out_done) {
-    // Suppress this output if we plan to print Part 2 to stdout too.
-    // No need to have the "#" section twice.
-    if (!(ErrorFileToStdout && out.fd() == 1)) {
-      report(&out, false);
+    // print an abbreviated version (the '#' section) to stdout by default.
+    // full error log is printed if the print option to stdout and stderr is specified
+    bool verbose = false;
+    if (ErrorFileToStdout || ErrorFileToStderr || ErrorFileWithStdout || ErrorFileWithStderr) {
+      verbose = true;
+    }
+    if (ErrorFileToStderr || ErrorFileWithStderr) {
+      out.set_fd(2);
     }
 
+    report(&out, verbose);
+
     out_done = true;
+    out.set_fd(fd_out);
 
     _current_step = 0;
     _current_step_info = "";
   }
 
-  // Part 2: print a full error log file (optionally to stdout or stderr).
-  // print to error log file
-  if (!log_done) {
+  // Part 2: print a full error log file
+  if (!log_done && !ErrorFileToStdout && !ErrorFileToStderr) {
     // see if log file is already open
     if (!log.is_open()) {
       // open log file
-      if (ErrorFileToStdout) {
-        fd_log = 1;
-      } else if (ErrorFileToStderr) {
-        fd_log = 2;
-      } else {
-        fd_log = prepare_log_file(ErrorFile, "hs_err_pid%p.log", true,
-                 buffer, sizeof(buffer));
-        if (fd_log != -1) {
-          out.print_raw("# An error report file with more information is saved as:\n# ");
-          out.print_raw_cr(buffer);
-        } else {
-          out.print_raw_cr("# Can not save log file, dump to screen..");
-          fd_log = 1;
+      fd_log = prepare_log_file(ErrorFile, "hs_err_pid%p.log", true, buffer, sizeof(buffer));
+      if (fd_log != -1) {
+        out.print_raw("# An error report file ");
+        if (!ErrorFileWithStdout && !ErrorFileWithStderr) {
+          out.print_raw("with more information ");
         }
+        out.print_raw("is saved as:\n# ");
+        out.print_raw_cr(buffer);
+      } else {
+        out.print_raw_cr("# Can not save log file, dump to screen..");
+        fd_log = 1;
       }
       log.set_fd(fd_log);
     }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileWithRedirectTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileWithRedirectTest.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug #######
+ * @bug 8308751
  * @summary Test ErrorFileWithStderr and ErrorFileWithStdout
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
I think it makes sense to add the ErrorFileWithStdout and ErrorFileWithStderr for troubleshooting.
I would appriciate if someone could review it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8308947](https://bugs.openjdk.org/browse/JDK-8308947) to be approved

### Issues
 * [JDK-8308751](https://bugs.openjdk.org/browse/JDK-8308751): Create new switch to print error reporting output to both hs_err_pid file and stdout/stderr (**Enhancement** - P4)
 * [JDK-8308947](https://bugs.openjdk.org/browse/JDK-8308947): Create new switch to print error reporting output to both hs_err_pid file and stdout/stderr (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14114/head:pull/14114` \
`$ git checkout pull/14114`

Update a local copy of the PR: \
`$ git checkout pull/14114` \
`$ git pull https://git.openjdk.org/jdk.git pull/14114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14114`

View PR using the GUI difftool: \
`$ git pr show -t 14114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14114.diff">https://git.openjdk.org/jdk/pull/14114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14114#issuecomment-1560668271)