### PR TITLE
8308758: Problemlist compiler/c2/irTests/TestVectorConditionalMove.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,6 +69,8 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
 
+compiler/c2/irTests/TestVectorConditionalMove.java 8306922 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
In order to reduce the noise in the JDK 21 CI, I'm problemlisting:

compiler/c2/irTests/TestVectorConditionalMove.java

which fails intermittently but with high frequency on multiple platforms after [JDK-8306302](https://bugs.openjdk.org/browse/JDK-8306302).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308758](https://bugs.openjdk.org/browse/JDK-8308758): Problemlist compiler/c2/irTests/TestVectorConditionalMove.java


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14115/head:pull/14115` \
`$ git checkout pull/14115`

Update a local copy of the PR: \
`$ git checkout pull/14115` \
`$ git pull https://git.openjdk.org/jdk.git pull/14115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14115`

View PR using the GUI difftool: \
`$ git pr show -t 14115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14115.diff">https://git.openjdk.org/jdk/pull/14115.diff</a>

</details>
