### PR TITLE
8308748: JNU_GetStringPlatformChars may write to String's internal memory array

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -915,7 +915,7 @@ getStringUTF8(JNIEnv *env, jstring jstr, jboolean strict)
     // we need two bytes for each latin-1 char above 127 (negative jbytes)
     for (i = 0; i < len; i++) {
         if (strict && str[i] == 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, value, str, 0);
+            (*env)->ReleasePrimitiveArrayCritical(env, value, str, JNI_ABORT);
             JNU_ThrowIllegalArgumentException(env, "NUL character not allowed in platform string");
             return NULL;
         }
@@ -926,7 +926,7 @@ getStringUTF8(JNIEnv *env, jstring jstr, jboolean strict)
 
     result = MALLOC_MIN4(rlen);
     if (result == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, value, str, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, value, str, JNI_ABORT);
         JNU_ThrowOutOfMemoryError(env, "requested array size exceeds VM limit");
         return NULL;
     }
@@ -940,7 +940,7 @@ getStringUTF8(JNIEnv *env, jstring jstr, jboolean strict)
             result[ri++] = c;
         }
     }
-    (*env)->ReleasePrimitiveArrayCritical(env, value, str, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, value, str, JNI_ABORT);
     result[rlen] = '\0';
     return result;
 }


### PR DESCRIPTION
This change prevents the contents of the internal string array from being copied back when releasing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308748](https://bugs.openjdk.org/browse/JDK-8308748): JNU_GetStringPlatformChars may write to String's internal memory array


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14117/head:pull/14117` \
`$ git checkout pull/14117`

Update a local copy of the PR: \
`$ git checkout pull/14117` \
`$ git pull https://git.openjdk.org/jdk.git pull/14117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14117`

View PR using the GUI difftool: \
`$ git pr show -t 14117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14117.diff">https://git.openjdk.org/jdk/pull/14117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14117#issuecomment-1564582016)