### PR TITLE
8194823: Serial GC does not account GCs caused by TLAB allocation in GC overhead limit

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -170,7 +170,8 @@ HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose) {
 
 HeapWord* EpsilonHeap::allocate_new_tlab(size_t min_size,
                                          size_t requested_size,
-                                         size_t* actual_size) {
+                                         size_t* actual_size,
+                                         bool* gc_overhead_limit_was_exceeded) {
   Thread* thread = Thread::current();
 
   // Defaults in case elastic paths are not taken

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -95,7 +95,8 @@ public:
   HeapWord* mem_allocate(size_t size, bool* gc_overhead_limit_was_exceeded) override;
   HeapWord* allocate_new_tlab(size_t min_size,
                               size_t requested_size,
-                              size_t* actual_size) override;
+                              size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
 
   // TLAB allocation
   size_t tlab_capacity(Thread* thr)         const override { return capacity();     }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -381,7 +381,8 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
 
 HeapWord* G1CollectedHeap::allocate_new_tlab(size_t min_size,
                                              size_t requested_size,
-                                             size_t* actual_size) {
+                                             size_t* actual_size,
+                                             bool* gc_overhead_limit_was_exceeded) {
   assert_heap_not_locked_and_not_at_safepoint();
   assert(!is_humongous(requested_size), "we do not allow humongous TLABs");
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -438,7 +438,8 @@ private:
 
   HeapWord* allocate_new_tlab(size_t min_size,
                               size_t requested_size,
-                              size_t* actual_size) override;
+                              size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
 
   HeapWord* mem_allocate(size_t word_size,
                          bool*  gc_overhead_limit_was_exceeded) override;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -514,7 +514,8 @@ size_t ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread* thr) const {
   return young_gen()->eden_space()->unsafe_max_tlab_alloc(thr);
 }
 
-HeapWord* ParallelScavengeHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) {
+HeapWord* ParallelScavengeHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+                                                  bool* gc_overhead_limit_was_exceeded) {
   HeapWord* result = young_gen()->allocate(requested_size);
   if (result != nullptr) {
     *actual_size = requested_size;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -514,7 +514,9 @@ size_t ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread* thr) const {
   return young_gen()->eden_space()->unsafe_max_tlab_alloc(thr);
 }
 
-HeapWord* ParallelScavengeHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+HeapWord* ParallelScavengeHeap::allocate_new_tlab(size_t min_size,
+                                                  size_t requested_size,
+                                                  size_t* actual_size,
                                                   bool* gc_overhead_limit_was_exceeded) {
   HeapWord* result = young_gen()->allocate(requested_size);
   if (result != nullptr) {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -102,7 +102,9 @@ class ParallelScavengeHeap : public CollectedHeap {
   HeapWord* allocate_old_gen_and_record(size_t word_size);
 
  protected:
-  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+  HeapWord* allocate_new_tlab(size_t min_size,
+                              size_t requested_size,
+                              size_t* actual_size,
                               bool* gc_overhead_limit_was_exceeded) override;
 
   inline bool should_alloc_in_eden(size_t size) const;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -102,7 +102,8 @@ class ParallelScavengeHeap : public CollectedHeap {
   HeapWord* allocate_old_gen_and_record(size_t word_size);
 
  protected:
-  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) override;
+  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
 
   inline bool should_alloc_in_eden(size_t size) const;
   inline void death_march_check(HeapWord* const result, size_t size);

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -522,7 +522,8 @@ void CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, bool 
 
 HeapWord* CollectedHeap::allocate_new_tlab(size_t min_size,
                                            size_t requested_size,
-                                           size_t* actual_size) {
+                                           size_t* actual_size,
+                                           bool* gc_overhead_limit_was_exceeded) {
   guarantee(false, "thread-local allocation buffers not supported");
   return nullptr;
 }

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -151,7 +151,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // returned in actual_size.
   virtual HeapWord* allocate_new_tlab(size_t min_size,
                                       size_t requested_size,
-                                      size_t* actual_size);
+                                      size_t* actual_size,
+                                      bool* gc_overhead_limit_was_exceeded);
 
   // Reinitialize tlabs before resuming mutators.
   virtual void resize_all_tlabs();

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -934,11 +934,11 @@ size_t GenCollectedHeap::unsafe_max_tlab_alloc(Thread* thr) const {
 
 HeapWord* GenCollectedHeap::allocate_new_tlab(size_t min_size,
                                               size_t requested_size,
-                                              size_t* actual_size) {
-  bool gc_overhead_limit_was_exceeded;
+                                              size_t* actual_size,
+                                              bool* gc_overhead_limit_was_exceeded) {
   HeapWord* result = mem_allocate_work(requested_size /* size */,
                                        true /* is_tlab */,
-                                       &gc_overhead_limit_was_exceeded);
+                                       gc_overhead_limit_was_exceeded);
   if (result != nullptr) {
     *actual_size = requested_size;
   }

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -238,7 +238,8 @@ public:
   size_t unsafe_max_tlab_alloc(Thread* thr) const override;
   HeapWord* allocate_new_tlab(size_t min_size,
                               size_t requested_size,
-                              size_t* actual_size) override;
+                              size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
 
   // The "requestor" generation is performing some garbage collection
   // action for which it would be useful to have scratch space.  The

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -321,7 +321,9 @@ HeapWord* MemAllocator::mem_allocate_inside_tlab_slow(Allocation& allocation) co
   // Allocate a new TLAB requesting new_tlab_size. Any size
   // between minimal and new_tlab_size is accepted.
   size_t min_tlab_size = ThreadLocalAllocBuffer::compute_min_size(_word_size);
-  mem = Universe::heap()->allocate_new_tlab(min_tlab_size, new_tlab_size, &allocation._allocated_tlab_size,
+  mem = Universe::heap()->allocate_new_tlab(min_tlab_size,
+                                            new_tlab_size,
+                                            &allocation._allocated_tlab_size,
                                             &allocation._overhead_limit_exceeded);
   if (mem == nullptr) {
     assert(allocation._allocated_tlab_size == 0,

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -321,7 +321,8 @@ HeapWord* MemAllocator::mem_allocate_inside_tlab_slow(Allocation& allocation) co
   // Allocate a new TLAB requesting new_tlab_size. Any size
   // between minimal and new_tlab_size is accepted.
   size_t min_tlab_size = ThreadLocalAllocBuffer::compute_min_size(_word_size);
-  mem = Universe::heap()->allocate_new_tlab(min_tlab_size, new_tlab_size, &allocation._allocated_tlab_size);
+  mem = Universe::heap()->allocate_new_tlab(min_tlab_size, new_tlab_size, &allocation._allocated_tlab_size,
+                                            &allocation._overhead_limit_exceeded);
   if (mem == nullptr) {
     assert(allocation._allocated_tlab_size == 0,
            "Allocation failed, but actual size was updated. min: " SIZE_FORMAT

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -793,7 +793,8 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
 
 HeapWord* ShenandoahHeap::allocate_new_tlab(size_t min_size,
                                             size_t requested_size,
-                                            size_t* actual_size) {
+                                            size_t* actual_size,
+                                            bool* gc_overhead_limit_was_exceeded) {
   ShenandoahAllocRequest req = ShenandoahAllocRequest::for_tlab(min_size, requested_size);
   HeapWord* res = allocate_memory(req);
   if (res != nullptr) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -531,7 +531,9 @@ public:
 
   void notify_mutator_alloc_words(size_t words, bool waste);
 
-  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+  HeapWord* allocate_new_tlab(size_t min_size,
+                              size_t requested_size,
+                              size_t* actual_size,
                               bool* gc_overhead_limit_was_exceeded) override;
   size_t tlab_capacity(Thread *thr) const override;
   size_t unsafe_max_tlab_alloc(Thread *thread) const override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -531,7 +531,8 @@ public:
 
   void notify_mutator_alloc_words(size_t words, bool waste);
 
-  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) override;
+  HeapWord* allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
   size_t tlab_capacity(Thread *thr) const override;
   size_t unsafe_max_tlab_alloc(Thread *thread) const override;
   size_t max_tlab_size() const override;

--- a/src/hotspot/share/gc/x/xCollectedHeap.cpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.cpp
@@ -146,7 +146,8 @@ bool XCollectedHeap::requires_barriers(stackChunkOop obj) const {
   return false;
 }
 
-HeapWord* XCollectedHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) {
+HeapWord* XCollectedHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+                                            bool* gc_overhead_limit_was_exceeded) {
   const size_t size_in_bytes = XUtils::words_to_bytes(align_object_size(requested_size));
   const uintptr_t addr = _heap.alloc_tlab(size_in_bytes);
 

--- a/src/hotspot/share/gc/x/xCollectedHeap.cpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.cpp
@@ -146,7 +146,9 @@ bool XCollectedHeap::requires_barriers(stackChunkOop obj) const {
   return false;
 }
 
-HeapWord* XCollectedHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+HeapWord* XCollectedHeap::allocate_new_tlab(size_t min_size,
+                                            size_t requested_size,
+                                            size_t* actual_size,
                                             bool* gc_overhead_limit_was_exceeded) {
   const size_t size_in_bytes = XUtils::words_to_bytes(align_object_size(requested_size));
   const uintptr_t addr = _heap.alloc_tlab(size_in_bytes);

--- a/src/hotspot/share/gc/x/xCollectedHeap.hpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.hpp
@@ -53,7 +53,8 @@ private:
 
   HeapWord* allocate_new_tlab(size_t min_size,
                               size_t requested_size,
-                              size_t* actual_size) override;
+                              size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
 
 public:
   static XCollectedHeap* heap();

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -141,7 +141,8 @@ bool ZCollectedHeap::requires_barriers(stackChunkOop obj) const {
   return ZContinuation::requires_barriers(&_heap, obj);
 }
 
-HeapWord* ZCollectedHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size) {
+HeapWord* ZCollectedHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+                                            bool* gc_overhead_limit_was_exceeded) {
   const size_t size_in_bytes = ZUtils::words_to_bytes(align_object_size(requested_size));
   const zaddress addr = ZAllocator::eden()->alloc_tlab(size_in_bytes);
 

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -141,7 +141,9 @@ bool ZCollectedHeap::requires_barriers(stackChunkOop obj) const {
   return ZContinuation::requires_barriers(&_heap, obj);
 }
 
-HeapWord* ZCollectedHeap::allocate_new_tlab(size_t min_size, size_t requested_size, size_t* actual_size,
+HeapWord* ZCollectedHeap::allocate_new_tlab(size_t min_size,
+                                            size_t requested_size,
+                                            size_t* actual_size,
                                             bool* gc_overhead_limit_was_exceeded) {
   const size_t size_in_bytes = ZUtils::words_to_bytes(align_object_size(requested_size));
   const zaddress addr = ZAllocator::eden()->alloc_tlab(size_in_bytes);

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -54,7 +54,8 @@ private:
 
   HeapWord* allocate_new_tlab(size_t min_size,
                               size_t requested_size,
-                              size_t* actual_size) override;
+                              size_t* actual_size,
+                              bool* gc_overhead_limit_was_exceeded) override;
 
 public:
   static ZCollectedHeap* heap();


### PR DESCRIPTION
Hi all,

This patch enables the gc overhead limit when allocating TLAB in serial gc.
The main modification is at `GenCollectedHeap::allocate_new_tlab` and the other 
files only adjust the parameters of the method `allocate_new_tlab`.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8194823](https://bugs.openjdk.org/browse/JDK-8194823): Serial GC does not account GCs caused by TLAB allocation in GC overhead limit


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [f19d3213](https://git.openjdk.org/jdk/pull/14120/files/f19d32132467c13727f0a1082fa1885601e12461)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14120/head:pull/14120` \
`$ git checkout pull/14120`

Update a local copy of the PR: \
`$ git checkout pull/14120` \
`$ git pull https://git.openjdk.org/jdk.git pull/14120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14120`

View PR using the GUI difftool: \
`$ git pr show -t 14120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14120.diff">https://git.openjdk.org/jdk/pull/14120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14120#issuecomment-1560912818)