### PR TITLE
8308009: Generational ZGC: OOM before clearing all SoftReferences

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -302,6 +302,14 @@ static bool should_preclean_young(GCCause::Cause cause) {
     return true;
   }
 
+  // It is important that when soft references are cleared, we also pre-clean the young
+  // generation, as we might otherwise throw premature OOM. Therefore, all causes that
+  // trigger soft ref cleaning must also trigger pre-cleaning of young gen. If allocations
+  // stalled when checking for soft ref cleaning, then since we hold the driver locker all
+  // the way until we check for young gen pre-cleaning, we can be certain that we should
+  // catch that above and perform young gen pre-cleaning.
+  assert(!should_clear_soft_references(cause), "Clearing soft references without pre-cleaning young gen");
+
   // Preclean young if implied by configuration
   return ScavengeBeforeFullGC;
 }

--- a/src/hotspot/share/gc/z/zDriver.hpp
+++ b/src/hotspot/share/gc/z/zDriver.hpp
@@ -112,7 +112,7 @@ private:
 
   void collect_old();
   void gc(const ZDriverRequest& request);
-  void handle_alloc_stalls() const;
+  void handle_alloc_stalls(bool cleared_soft_refs) const;
 
 protected:
   virtual void run_thread();

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -111,7 +111,7 @@ public:
   bool is_alloc_stalling() const;
   bool is_alloc_stalling_for_old() const;
   void handle_alloc_stalling_for_young();
-  void handle_alloc_stalling_for_old();
+  void handle_alloc_stalling_for_old(bool cleared_soft_refs);
 
   // Continuations
   bool is_allocating(zaddress addr) const;

--- a/src/hotspot/share/gc/z/zHeap.inline.hpp
+++ b/src/hotspot/share/gc/z/zHeap.inline.hpp
@@ -86,8 +86,8 @@ inline void ZHeap::handle_alloc_stalling_for_young() {
   _page_allocator.handle_alloc_stalling_for_young();
 }
 
-inline void ZHeap::handle_alloc_stalling_for_old() {
-  _page_allocator.handle_alloc_stalling_for_old();
+inline void ZHeap::handle_alloc_stalling_for_old(bool cleared_soft_refs) {
+  _page_allocator.handle_alloc_stalling_for_old(cleared_soft_refs);
 }
 
 inline bool ZHeap::is_oop(uintptr_t addr) const {

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -985,9 +985,11 @@ void ZPageAllocator::handle_alloc_stalling_for_young() {
   restart_gc();
 }
 
-void ZPageAllocator::handle_alloc_stalling_for_old() {
+void ZPageAllocator::handle_alloc_stalling_for_old(bool cleared_soft_refs) {
   ZLocker<ZLock> locker(&_lock);
-  notify_out_of_memory();
+  if (cleared_soft_refs) {
+    notify_out_of_memory();
+  }
   restart_gc();
 }
 

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -163,7 +163,7 @@ public:
   bool is_alloc_stalling() const;
   bool is_alloc_stalling_for_old() const;
   void handle_alloc_stalling_for_young();
-  void handle_alloc_stalling_for_old();
+  void handle_alloc_stalling_for_old(bool cleared_soft_refs);
 
   void threads_do(ThreadClosure* tc) const;
 };


### PR DESCRIPTION
When a major GC in generational ZGC with a different cause that doesn’t pre-clean and doesn’t clear soft references, we ask if there are allocations stalled on old. And part of that condition is to check if we are not stalled on young. So if an allocation request comes in just before such a “weak” major GC, we will say we won’t clear soft references. But after that major collection we will satisfy all the constraints to throw OOM as both an YC and OC has passed since the allocation request was installed.
The solution is to let the driver remember if it cleared soft references or not, and only throw OOM if it cleared soft references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308009](https://bugs.openjdk.org/browse/JDK-8308009): Generational ZGC: OOM before clearing all SoftReferences


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [45b2b269](https://git.openjdk.org/jdk/pull/14122/files/45b2b26964978c40b435094de173b8549f973d84)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14122/head:pull/14122` \
`$ git checkout pull/14122`

Update a local copy of the PR: \
`$ git checkout pull/14122` \
`$ git pull https://git.openjdk.org/jdk.git pull/14122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14122`

View PR using the GUI difftool: \
`$ git pr show -t 14122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14122.diff">https://git.openjdk.org/jdk/pull/14122.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14122#issuecomment-1561028876)