### PR TITLE
8300491: SymbolLookup::libraryLookup accepts strings with terminators

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -95,6 +95,7 @@ public final class SystemLookup implements SymbolLookup {
             final SymbolLookup finalLookup = lookup;
             lookup = name -> {
                 Objects.requireNonNull(name);
+                if (Utils.containsNullChars(name)) return Optional.empty();
                 return finalLookup.find(name).or(() -> fallbackLookup.apply(name));
             };
         }
@@ -106,6 +107,7 @@ public final class SystemLookup implements SymbolLookup {
         NativeLibrary lib = loader.apply(RawNativeLibraries.newInstance(MethodHandles.lookup()));
         return name -> {
             Objects.requireNonNull(name);
+            if (Utils.containsNullChars(name)) return Optional.empty();
             try {
                 long addr = lib.lookup(name);
                 return addr == 0 ?

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -251,4 +251,8 @@ public final class Utils {
     public static boolean isPowerOfTwo(long value) {
         return (value & (value - 1)) == 0L;
     }
+
+    public static boolean containsNullChars(String s) {
+        return s.indexOf('\u0000') >= 0;
+    }
 }

--- a/test/jdk/java/foreign/LibraryLookupTest.java
+++ b/test/jdk/java/foreign/LibraryLookupTest.java
@@ -67,6 +67,21 @@ public class LibraryLookupTest {
         callFunc(addr);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void testLoadLibraryBadName() {
+        try (Arena arena = Arena.ofConfined()) {
+            SymbolLookup.libraryLookup(LIB_PATH.toString() + "\u0000", arena);
+        }
+    }
+
+    @Test
+    void testLoadLibraryBadLookupName() {
+        try (Arena arena = Arena.ofConfined()) {
+            SymbolLookup lookup = SymbolLookup.libraryLookup(LIB_PATH, arena);
+            assertTrue(lookup.find("inc\u0000foobar").isEmpty());
+        }
+    }
+
     private static MemorySegment loadLibrary(Arena session) {
         SymbolLookup lib = SymbolLookup.libraryLookup(LIB_PATH, session);
         MemorySegment addr = lib.find("inc").get();

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -134,6 +134,11 @@ public class StdLibTest extends NativeTestHelper {
         assertEquals(found, expected.length());
     }
 
+    @Test
+    void testSystemLibraryBadLookupName() {
+        assertTrue(LINKER.defaultLookup().find("strlen\u0000foobar").isEmpty());
+    }
+
     static class StdLibHelper {
 
         final static MethodHandle strcat = abi.downcallHandle(abi.defaultLookup().find("strcat").get(),

--- a/test/jdk/java/foreign/TestClassLoaderFindNative.java
+++ b/test/jdk/java/foreign/TestClassLoaderFindNative.java
@@ -28,6 +28,7 @@
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestClassLoaderFindNative
  */
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 import org.testng.annotations.Test;
@@ -59,5 +60,10 @@ public class TestClassLoaderFindNative {
     public void testVariableSymbolLookup() {
         MemorySegment segment = SymbolLookup.loaderLookup().find("c").get().reinterpret(1);
         assertEquals(segment.get(JAVA_BYTE, 0), 42);
+    }
+
+    @Test
+    void testLoadLibraryBadLookupName() {
+        assertTrue(SymbolLookup.loaderLookup().find("f\u0000foobar").isEmpty());
     }
 }


### PR DESCRIPTION
There is a difference in behavior between `System::loadLibrary` and `SymbolLookup::libraryLookup(String)`. While the former catches library names containing NULL chars (because, internally it uses Path/File logic, which reject those), `SymbolLookup` does not. As a result, it is possible to load libraries such as `libGL.so\0foobar`, because the string is passed directly to `dlopen`.

A similar issue arises when we consider `SymbolLookup::find`, as the name is again sent unmodified to `dlopen`. In reality, some filtering *does* happen in that case, as the native code calls `GetStringUTFChars`:

https://docs.oracle.com/en/java/javase/20/docs/specs/jni/functions.html#getstringutfchars

Which encodes the NULL chars in a different form:

https://docs.oracle.com/en/java/javase/20/docs/specs/jni/types.html#modified-utf-8-strings

So, in practice, even if the input is not validated, a call to `find` with one or more NULL chars is unlikely to succeed.

In this patch I have added several checks to make sure that:
* the name of library passed to `libraryLookup(String)` does not contain `\0` and, if so, throw `IllegalArgumentException` (which is already covered by current spec;
* the name of a symbol passed to `SymbolLookup::find` does not contain `\0` and, if so, return empty optional. This required changes on all the lookups we implement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300491](https://bugs.openjdk.org/browse/JDK-8300491): SymbolLookup::libraryLookup accepts strings with terminators


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14126/head:pull/14126` \
`$ git checkout pull/14126`

Update a local copy of the PR: \
`$ git checkout pull/14126` \
`$ git pull https://git.openjdk.org/jdk.git pull/14126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14126`

View PR using the GUI difftool: \
`$ git pr show -t 14126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14126.diff">https://git.openjdk.org/jdk/pull/14126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14126#issuecomment-1561382183)