### PR TITLE
8308073: ClassLoaderExt::append_boot_classpath should handle dynamic archive

### DIFF
--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "cds/cds_globals.hpp"
+#include "cds/dynamicArchive.hpp"
 #include "cds/filemap.hpp"
 #include "cds/heapShared.hpp"
 #include "classfile/classFileParser.hpp"
@@ -60,6 +61,9 @@ void ClassLoaderExt::append_boot_classpath(ClassPathEntry* new_entry) {
   if (UseSharedSpaces) {
     warning("Sharing is only supported for boot loader classes because bootstrap classpath has been appended");
     FileMapInfo::current_info()->set_has_platform_or_app_classes(false);
+    if (DynamicArchive::is_mapped()) {
+      FileMapInfo::dynamic_info()->set_has_platform_or_app_classes(false);
+    }
   }
   ClassLoader::add_to_boot_append_entries(new_entry);
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/JvmtiAddPath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JvmtiAddPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,9 +81,7 @@ public class JvmtiAddPath {
         run(check_appcds_enabled, appJar, "-Xlog:class+load", "JvmtiApp", "noadd"); // appcds should be enabled
 
         System.out.println("Test case 2: add to boot classpath only - should find Hello.class in boot loader");
-        String[] toCheck = (TestCommon.isDynamicArchive()) ? check_appcds_enabled
-                                                           : check_appcds_disabled;
-        run(toCheck, appJar, "-Xlog:class+load", "JvmtiApp", "bootonly", addbootJar); // appcds should be disabled
+        run(check_appcds_disabled, appJar, "-Xlog:class+load", "JvmtiApp", "bootonly", addbootJar); // appcds should be disabled
 
         System.out.println("Test case 3: add to app classpath only - should find Hello.class in app loader");
         run(appJar, "JvmtiApp", "apponly", addappJar);

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/JvmtiAddPath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/JvmtiAddPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,9 +119,7 @@ public class JvmtiAddPath {
             "-Xlog:class+load", "JvmtiApp", "noadd", MAIN_CLASS); // appcds should be enabled
 
         System.out.println("Test case 2: add to boot classpath only - should find Hello.class in boot loader");
-        String[] toCheck = TestCommon.isDynamicArchive() ? check_appcds_enabled :
-                           check_appcds_disabled;
-        run(toCheck, appJar,
+        run(check_appcds_disabled, appJar,
             "-Xlog:class+load=trace",
             modulePath,
             "JvmtiApp", "bootonly", addbootJar, MAIN_CLASS); // appcds should be disabled


### PR DESCRIPTION
Please review this simple fix for setting the `_has_platform_or_app_classes` flag for the dynamic archive case. The flag will be set to `false` in case the boot class path is appended via JVM TI.
Also adjusting two related JvmtiAddPath.java tests accordingly.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308073](https://bugs.openjdk.org/browse/JDK-8308073): ClassLoaderExt::append_boot_classpath should handle dynamic archive


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14127/head:pull/14127` \
`$ git checkout pull/14127`

Update a local copy of the PR: \
`$ git checkout pull/14127` \
`$ git pull https://git.openjdk.org/jdk.git pull/14127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14127`

View PR using the GUI difftool: \
`$ git pr show -t 14127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14127.diff">https://git.openjdk.org/jdk/pull/14127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14127#issuecomment-1561553127)