### PR TITLE
8304375: jdk/jfr/api/consumer/filestream/TestOrdered.java failed with "Expected at least some events to be out of order! Reuse = false"

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
@@ -66,6 +66,11 @@ public class TestOrdered {
                 e.printStackTrace();
                 throw new Error("Unexpected exception in barrier");
             }
+            Instant timestamp = Instant.now();
+            // Wait for clock to increment
+            while (Instant.now().equals(timestamp)) {
+                ;
+            }
             OrderedEvent e2 = new OrderedEvent();
             e2.commit();
         }
@@ -108,6 +113,7 @@ public class TestOrdered {
                 es.setOrdered(false);
                 es.onEvent(e -> {
                     Instant endTime = e.getEndTime();
+                    System.out.println("testSetOrderedFalse: endTime: " + endTime);
                     if (endTime.isBefore(timestamp.get())) {
                         unoreded.set(true);
                         es.close();


### PR DESCRIPTION
Could I have a review of a test fix.

Not sure why the test fails. The only way I can see is if several events get the exactly the same timestamp. Seems unlikely, but I added a loop to ensure the clock advances on every thread/core and logged the timestamp, so if it fails again, we have more information.

Testing: jdk/jfr/api/consumer/filestream/TestOrdered.java 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304375](https://bugs.openjdk.org/browse/JDK-8304375): jdk/jfr/api/consumer/filestream/TestOrdered.java failed with "Expected at least some events to be out of order! Reuse = false"


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14128/head:pull/14128` \
`$ git checkout pull/14128`

Update a local copy of the PR: \
`$ git checkout pull/14128` \
`$ git pull https://git.openjdk.org/jdk.git pull/14128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14128`

View PR using the GUI difftool: \
`$ git pr show -t 14128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14128.diff">https://git.openjdk.org/jdk/pull/14128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14128#issuecomment-1561787410)