### PR TITLE
8308727: Compiler should accept final unnamed variables in try-with-resources

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3843,7 +3843,7 @@ public class JavacParser implements Parser {
         if (token.kind == FINAL || token.kind == MONKEYS_AT) {
             JCModifiers mods = optFinal(0);
             JCExpression t = parseType(true);
-            return variableDeclaratorRest(token.pos, mods, t, ident(), true, null, true, false, false);
+            return variableDeclaratorRest(token.pos, mods, t, identOrUnderscore(), true, null, true, false, false);
         }
         JCExpression t = term(EXPR | TYPE);
         if (wasTypeMode() && LAX_IDENTIFIER.test(token.kind)) {

--- a/test/langtools/tools/javac/patterns/Unnamed.java
+++ b/test/langtools/tools/javac/patterns/Unnamed.java
@@ -31,6 +31,10 @@
  */
 
 import java.util.Objects;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 public class Unnamed {
     public static void main(String[] args) throws Throwable {
@@ -89,6 +93,9 @@ public class Unnamed {
                 } catch (Exception _) {}
             }
         }
+        try (final Lock _ = null) { }
+        try (@Foo Lock _ = null) { }
+
         String[] strs = new String[] { "str1", "str2" };
         for (var _ : strs) {
             for (var _ : strs) {
@@ -290,6 +297,9 @@ public class Unnamed {
         public int run(int a, int b);
     }
     record R(Object o) {}
+    @Target(ElementType.LOCAL_VARIABLE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Foo { }
 
     sealed abstract class Base permits R1, R2, R3, R4 { }
     final  class R1  extends Base { }


### PR DESCRIPTION
This PR addresses the bug with `final` but also with annotations on local variables within try-with-resources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308727](https://bugs.openjdk.org/browse/JDK-8308727): Compiler should accept final unnamed variables in try-with-resources


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14130/head:pull/14130` \
`$ git checkout pull/14130`

Update a local copy of the PR: \
`$ git checkout pull/14130` \
`$ git pull https://git.openjdk.org/jdk.git pull/14130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14130`

View PR using the GUI difftool: \
`$ git pr show -t 14130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14130.diff">https://git.openjdk.org/jdk/pull/14130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14130#issuecomment-1561703324)