### PR TITLE
8308335 JFR: Remove @Experimental from Virtual Threads events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadEndEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadEndEvent.java
@@ -26,7 +26,6 @@
 package jdk.jfr.events;
 
 import jdk.jfr.Category;
-import jdk.jfr.Experimental;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.internal.MirrorEvent;

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadEndEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadEndEvent.java
@@ -35,7 +35,6 @@ import jdk.jfr.internal.MirrorEvent;
 @Label("Virtual Thread End")
 @Name("jdk.VirtualThreadEnd")
 @MirrorEvent(className = "jdk.internal.event.VirtualThreadEndEvent")
-@Experimental
 public final class VirtualThreadEndEvent extends AbstractJDKEvent {
 
     @Label("Thread Id")

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadPinnedEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadPinnedEvent.java
@@ -35,6 +35,5 @@ import jdk.jfr.internal.MirrorEvent;
 @Label("Virtual Thread Pinned")
 @Name("jdk.VirtualThreadPinned")
 @MirrorEvent(className = "jdk.internal.event.VirtualThreadPinnedEvent")
-@Experimental
 public final class VirtualThreadPinnedEvent extends AbstractJDKEvent {
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadPinnedEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadPinnedEvent.java
@@ -26,7 +26,6 @@
 package jdk.jfr.events;
 
 import jdk.jfr.Category;
-import jdk.jfr.Experimental;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.internal.MirrorEvent;

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadStartEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadStartEvent.java
@@ -26,7 +26,6 @@
 package jdk.jfr.events;
 
 import jdk.jfr.Category;
-import jdk.jfr.Experimental;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.internal.MirrorEvent;

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadStartEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadStartEvent.java
@@ -35,7 +35,6 @@ import jdk.jfr.internal.MirrorEvent;
 @Label("Virtual Thread Start")
 @Name("jdk.VirtualThreadStart")
 @MirrorEvent(className = "jdk.internal.event.VirtualThreadStartEvent")
-@Experimental
 public final class VirtualThreadStartEvent extends AbstractJDKEvent {
 
     @Label("Thread Id")

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadSubmitFailedEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadSubmitFailedEvent.java
@@ -27,7 +27,6 @@ package jdk.jfr.events;
 
 import jdk.jfr.Category;
 import jdk.jfr.Description;
-import jdk.jfr.Experimental;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.internal.MirrorEvent;

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadSubmitFailedEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/VirtualThreadSubmitFailedEvent.java
@@ -37,7 +37,6 @@ import jdk.jfr.internal.MirrorEvent;
 @Name("jdk.VirtualThreadSubmitFailed")
 @Description("Submit of task for virtual thread failed")
 @MirrorEvent(className = "jdk.internal.event.VirtualThreadSubmitFailedEvent")
-@Experimental
 public final class VirtualThreadSubmitFailedEvent extends AbstractJDKEvent {
 
     @Label("Thread Id")

--- a/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
@@ -77,6 +77,9 @@ public class TestLookForUntestedEvents {
             "ContainerConfiguration", "ContainerCPUUsage", "ContainerCPUThrottling",
             "ContainerMemoryUsage", "ContainerIOUsage")
     );
+    // These events are tested in test/jdk/java/lang/Thread/virtual/JfrEvents.java
+    private static final Set<String> coveredVirtualThreadEvents = Set.of(
+        "VirtualThreadPinned", "VirtualThreadSubmitFailed");
 
     // This is a "known failure list" for this test.
     // NOTE: if the event is not covered, a bug should be open, and bug number
@@ -85,16 +88,8 @@ public class TestLookForUntestedEvents {
     );
 
     // Experimental events
-    private static final Set<String> experimentalEvents = new HashSet<>(
-        Arrays.asList(
-            "Flush",
-            "SyncOnValueBasedClass",
-            "VirtualThreadStart",
-            "VirtualThreadEnd",
-            "VirtualThreadPinned",
-            "VirtualThreadSubmitFailed")
-    );
-
+    private static final Set<String> experimentalEvents = Set.of(
+        "Flush", "SyncOnValueBasedClass");
 
     public static void main(String[] args) throws Exception {
         for (EventType type : FlightRecorder.getFlightRecorder().getEventTypes()) {
@@ -127,6 +122,7 @@ public class TestLookForUntestedEvents {
         // Account for hard-to-test, experimental and GC tested events
         eventsNotCoveredByTest.removeAll(hardToTestEvents);
         eventsNotCoveredByTest.removeAll(coveredGcEvents);
+        eventsNotCoveredByTest.removeAll(coveredVirtualThreadEvents);
         eventsNotCoveredByTest.removeAll(coveredContainerEvents);
         eventsNotCoveredByTest.removeAll(knownNotCoveredEvents);
 


### PR DESCRIPTION
Virtual threads is no longer in preview and experimental annotation should be removed.

Testing: test/jdk/jdk/jfr

Thanks
erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308335](https://bugs.openjdk.org/browse/JDK-8308335): JFR: Remove @Experimental from Virtual Threads events


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [4c035bd9](https://git.openjdk.org/jdk/pull/14133/files/4c035bd99125bd6aaa2cec7d6de0600c9e683084)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14133/head:pull/14133` \
`$ git checkout pull/14133`

Update a local copy of the PR: \
`$ git checkout pull/14133` \
`$ git pull https://git.openjdk.org/jdk.git pull/14133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14133`

View PR using the GUI difftool: \
`$ git pr show -t 14133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14133.diff">https://git.openjdk.org/jdk/pull/14133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14133#issuecomment-1561787660)