### PR TITLE
8308803: Improve java/util/UUID/UUIDTest.java

### DIFF
--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,27 @@
  */
 
 /* @test
- * @bug 4173528 5068772 8148936 8196334
+ * @bug 4173528 5068772 8148936 8196334 8308803
  * @summary Unit tests for java.util.UUID
  * @key randomness
- * @run main/othervm -XX:+CompactStrings UUIDTest
- * @run main/othervm -XX:-CompactStrings UUIDTest
+ * @run main/othervm -Xmx1g -XX:+CompactStrings UUIDTest
+ * @run main/othervm -Xmx1g -XX:-CompactStrings UUIDTest
  */
 
 import java.util.*;
+import java.util.stream.IntStream;
 
 public class UUIDTest {
 
-    static Random generator = new Random();
+    // Single UUID instance is ~32 bytes, 1M instances take ~256M in the set
+    private static final int COUNT = 1_000_000;
+
+    static final Random generator = new Random();
 
     public static void main(String[] args) throws Exception {
-        containsTest();
+        negativeTest();
         randomUUIDTest();
+        randomUUIDTest_Multi();
         nameUUIDFromBytesTest();
         stringTest();
         versionTest();
@@ -49,56 +54,76 @@ public class UUIDTest {
         compareTo();
     }
 
-    // Verify that list.contains detects UUID collisons
-    private static void containsTest() throws Exception {
-        List list = new LinkedList();
-        list.add(new UUID(4,4));
-        if (!list.contains(new UUID(4,4)))
-            throw new Exception("contains test did not work as expected");
-    }
-
-    private static void randomUUIDTest() throws Exception {
-        List list = new LinkedList();
-        for (int i=0; i<100; i++) {
-            UUID u1 = UUID.randomUUID();
-            if (4 != u1.version()) {
-                throw new Exception("bad version");
-            }
-            if (2 != u1.variant()) {
-                throw new Exception("bad variant");
-            }
-            if (list.contains(u1))
-                throw new Exception("random UUID collision very unlikely");
-            list.add(u1);
+    private static void negativeTest() throws Exception {
+        Set<UUID> set = new HashSet<>();
+        set.add(new UUID(4, 4));
+        if (set.add(new UUID(4, 4))) {
+            throw new Exception("Contains test does not work as expected");
         }
     }
 
+    private static void randomUUIDTest() throws Exception {
+        Set<UUID> set = new HashSet<>();
+        for (int i = 0; i < COUNT; i++) {
+            UUID u = UUID.randomUUID();
+            if (u.version() != 4) {
+                throw new Exception("Bad version: " + u);
+            }
+            if (u.variant() != 2) {
+                throw new Exception("Bad variant: " + u);
+            }
+            if (!set.add(u)) {
+                throw new Exception("UUID collision: " + u);
+            }
+        }
+    }
+
+    private static void randomUUIDTest_Multi() throws Exception {
+        List<UUID> uuids = IntStream.range(0, COUNT).parallel()
+                                    .mapToObj(i -> UUID.randomUUID())
+                                    .toList();
+
+        Set<UUID> set = new HashSet<>();
+        for (UUID u : uuids) {
+            if (u.version() != 4) {
+                throw new Exception("Bad version: " + u);
+            }
+            if (u.variant() != 2) {
+                throw new Exception("Bad variant: " + u);
+            }
+            if (!set.add(u)) {
+                throw new Exception("UUID collision: " + u);
+            }
+        }
+    }
+
+
     private static void nameUUIDFromBytesTest() throws Exception {
-        Random byteSource = new Random();
         byte[] someBytes = new byte[12];
-        List list = new LinkedList();
-        for (int i=0; i<100; i++) {
-            byteSource.nextBytes(someBytes);
-            UUID u1 = UUID.nameUUIDFromBytes(someBytes);
-            if (3 != u1.version()) {
-                throw new Exception("bad version");
+        Set<UUID> set = new HashSet<>();
+        for (int i = 0; i < COUNT; i++) {
+            generator.nextBytes(someBytes);
+            UUID u = UUID.nameUUIDFromBytes(someBytes);
+            if (u.version() != 3) {
+                throw new Exception("Bad version: " + u);
             }
-            if (2 != u1.variant()) {
-                throw new Exception("bad variant");
+            if (u.variant() != 2) {
+                throw new Exception("Bad variant: " + u);
             }
-            if (list.contains(u1))
-                throw new Exception("byte UUID collision very unlikely");
-            list.add(u1);
+            if (!set.add(u)) {
+                throw new Exception("UUID collision: " + u);
+            }
         }
     }
 
     private static void stringTest() throws Exception {
-        for (int i=0; i<100; i++) {
+        for (int i = 0; i < COUNT; i++) {
             UUID u1 = UUID.randomUUID();
             UUID u2 = UUID.fromString(u1.toString().toLowerCase());
             UUID u3 = UUID.fromString(u1.toString().toUpperCase());
-            if (!u1.equals(u2) || !u1.equals(u3))
-                throw new Exception("UUID -> string -> UUID failed");
+            if (!u1.equals(u2) || !u1.equals(u3)) {
+                throw new Exception("UUID -> string -> UUID failed: " + u1 + " -> " + u2 + " -> " + u3);
+            }
         }
 
         testFromStringError("-0");
@@ -121,62 +146,90 @@ public class UUIDTest {
 
     private static void versionTest() throws Exception {
         UUID test = UUID.randomUUID();
-        if (test.version() != 4)
-            throw new Exception("randomUUID not type 4");
-        Random byteSource = new Random();
+        if (test.version() != 4) {
+            throw new Exception("randomUUID not type 4: " + test);
+        }
+
         byte[] someBytes = new byte[12];
-        byteSource.nextBytes(someBytes);
+        generator.nextBytes(someBytes);
         test = UUID.nameUUIDFromBytes(someBytes);
-        if (test.version() != 3)
-            throw new Exception("nameUUIDFromBytes not type 3");
+        if (test.version() != 3) {
+            throw new Exception("nameUUIDFromBytes not type 3: " + test);
+        }
+
         test = UUID.fromString("9835451d-e2e0-1e41-8a5a-be785f17dcda");
-        if (test.version() != 1)
+        if (test.version() != 1) {
             throw new Exception("wrong version fromString 1");
+        }
+
         test = UUID.fromString("9835451d-e2e0-2e41-8a5a-be785f17dcda");
-        if (test.version() != 2)
+        if (test.version() != 2) {
             throw new Exception("wrong version fromString 2");
+        }
+
         test = UUID.fromString("9835451d-e2e0-3e41-8a5a-be785f17dcda");
-        if (test.version() != 3)
+        if (test.version() != 3) {
             throw new Exception("wrong version fromString 3");
+        }
+
         test = UUID.fromString("9835451d-e2e0-4e41-8a5a-be785f17dcda");
-        if (test.version() != 4)
+        if (test.version() != 4) {
             throw new Exception("wrong version fromString 4");
+        }
+
         test = new UUID(0x0000000000001000L, 55L);
-        if (test.version() != 1)
+        if (test.version() != 1) {
             throw new Exception("wrong version from bit set to 1");
+        }
+
         test = new UUID(0x0000000000002000L, 55L);
-        if (test.version() != 2)
+        if (test.version() != 2) {
             throw new Exception("wrong version from bit set to 2");
+        }
+
         test = new UUID(0x0000000000003000L, 55L);
-        if (test.version() != 3)
+        if (test.version() != 3) {
             throw new Exception("wrong version from bit set to 3");
+        }
+
         test = new UUID(0x0000000000004000L, 55L);
-        if (test.version() != 4)
+        if (test.version() != 4) {
             throw new Exception("wrong version from bit set to 4");
+        }
     }
 
     private static void variantTest() throws Exception {
         UUID test = UUID.randomUUID();
-        if (test.variant() != 2)
+        if (test.variant() != 2) {
             throw new Exception("randomUUID not variant 2");
-        Random byteSource = new Random();
+        }
+
         byte[] someBytes = new byte[12];
-        byteSource.nextBytes(someBytes);
+        generator.nextBytes(someBytes);
         test = UUID.nameUUIDFromBytes(someBytes);
-        if (test.variant() != 2)
+        if (test.variant() != 2) {
             throw new Exception("nameUUIDFromBytes not variant 2");
+        }
+
         test = new UUID(55L, 0x0000000000001000L);
-        if (test.variant() != 0)
+        if (test.variant() != 0) {
             throw new Exception("wrong variant from bit set to 0");
+        }
+
         test = new UUID(55L, 0x8000000000001000L);
-        if (test.variant() != 2)
+        if (test.variant() != 2) {
             throw new Exception("wrong variant from bit set to 2");
-       test = new UUID(55L, 0xc000000000001000L);
-        if (test.variant() != 6)
+        }
+
+        test = new UUID(55L, 0xc000000000001000L);
+        if (test.variant() != 6) {
             throw new Exception("wrong variant from bit set to 6");
-       test = new UUID(55L, 0xe000000000001000L);
-        if (test.variant() != 7)
+        }
+
+        test = new UUID(55L, 0xe000000000001000L);
+        if (test.variant() != 7) {
             throw new Exception("wrong variant from bit set to 7");
+        }
     }
 
     private static void timestampTest() throws Exception {
@@ -187,15 +240,21 @@ public class UUIDTest {
         } catch (UnsupportedOperationException uoe) {
             // Correct result
         }
+
         test = UUID.fromString("00000001-0000-1000-8a5a-be785f17dcda");
-        if (test.timestamp() != 1)
+        if (test.timestamp() != 1) {
             throw new Exception("Incorrect timestamp");
+        }
+
         test = UUID.fromString("00000400-0000-1000-8a5a-be785f17dcda");
-        if (test.timestamp() != 1024)
+        if (test.timestamp() != 1024) {
             throw new Exception("Incorrect timestamp");
+        }
+
         test = UUID.fromString("FFFFFFFF-FFFF-1FFF-8a5a-be785f17dcda");
-        if (test.timestamp() != Long.MAX_VALUE>>3)
+        if (test.timestamp() != (Long.MAX_VALUE >> 3)) {
             throw new Exception("Incorrect timestamp");
+        }
     }
 
     private static void clockSequenceTest() throws Exception {
@@ -206,18 +265,26 @@ public class UUIDTest {
         } catch (UnsupportedOperationException uoe) {
             // Correct result
         }
+
         test = UUID.fromString("00000001-0000-1000-8001-be785f17dcda");
-        if (test.clockSequence() != 1)
+        if (test.clockSequence() != 1) {
             throw new Exception("Incorrect sequence");
+        }
+
         test = UUID.fromString("00000001-0000-1000-8002-be785f17dcda");
-        if (test.clockSequence() != 2)
+        if (test.clockSequence() != 2) {
             throw new Exception("Incorrect sequence");
+        }
+
         test = UUID.fromString("00000001-0000-1000-8010-be785f17dcda");
-        if (test.clockSequence() != 16)
+        if (test.clockSequence() != 16) {
             throw new Exception("Incorrect sequence");
+        }
+
         test = UUID.fromString("00000001-0000-1000-bFFF-be785f17dcda");
-        if (test.clockSequence() != ((2L<<13)-1)) // 2^14 - 1
+        if (test.clockSequence() != ((1L << 14) - 1)) {
             throw new Exception("Incorrect sequence");
+        }
     }
 
     private static void nodeTest() throws Exception {
@@ -228,32 +295,39 @@ public class UUIDTest {
         } catch (UnsupportedOperationException uoe) {
             // Correct result
         }
+
         test = UUID.fromString("00000001-0000-1000-8001-000000000001");
-        if (test.node() != 1)
+        if (test.node() != 1) {
             throw new Exception("Incorrect node");
+        }
+
         test = UUID.fromString("00000001-0000-1000-8002-FFFFFFFFFFFF");
-        if (test.node() != ((2L<<47)-1)) // 2^48 - 1
+        if (test.node() != ((1L << 48) - 1)) {
             throw new Exception("Incorrect node");
+        }
     }
 
     private static void hashCodeEqualsTest() throws Exception {
         // If two UUIDs are equal they must have the same hashCode
-        for (int i=0; i<100; i++) {
+        for (int i = 0; i < COUNT; i++) {
             UUID u1 = UUID.randomUUID();
             UUID u2 = UUID.fromString(u1.toString());
-            if (u1.hashCode() != u2.hashCode())
-                throw new Exception("Equal UUIDs with different hashcodes");
+            if (u1.hashCode() != u2.hashCode()) {
+                throw new Exception("Equal UUIDs with different hash codes: " + u1 + " and " + u2);
+            }
         }
+
         // Test equality of UUIDs with tampered bits
-        for (int i=0; i<1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             long l = generator.nextLong();
             long l2 = generator.nextLong();
             int position = generator.nextInt(64);
             UUID u1 = new UUID(l, l2);
             l = l ^ (1L << position);
             UUID u2 = new UUID(l, l2);
-            if (u1.equals(u2))
-                throw new Exception("UUIDs with different bits equal");
+            if (u1.equals(u2)) {
+                throw new Exception("UUIDs with different bits equal: " + u1 + " and " + u2);
+            }
         }
     }
 
@@ -267,18 +341,20 @@ public class UUIDTest {
         if ((id.compareTo(id2) >= 0) ||
             (id2.compareTo(id3) >= 0) ||
             (id3.compareTo(id4) >= 0) ||
-            (id4.compareTo(id5) >= 0))
+            (id4.compareTo(id5) >= 0)) {
             throw new RuntimeException("compareTo failure");
+        }
 
         if ((id5.compareTo(id4) <= 0) ||
             (id4.compareTo(id3) <= 0) ||
             (id3.compareTo(id2) <= 0) ||
-            (id2.compareTo(id) <= 0))
+            (id2.compareTo(id) <= 0)) {
             throw new RuntimeException("compareTo failure");
+        }
 
-        if (id.compareTo(id) != 0)
+        if (id.compareTo(id) != 0) {
             throw new RuntimeException("compareTo failure");
-
+        }
     }
 
 }

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -66,6 +66,8 @@ public class UUIDTest {
     }
 
     private static void randomUUIDTest() throws Exception {
+        List<UUID> collisions = new ArrayList<>();
+
         Set<UUID> set = new HashSet<>();
         for (int i = 0; i < COUNT; i++) {
             UUID u = UUID.randomUUID();
@@ -76,8 +78,15 @@ public class UUIDTest {
                 throw new Exception("Bad variant: " + u);
             }
             if (!set.add(u)) {
-                throw new Exception("UUID collision: " + u);
+                collisions.add(u);
             }
+        }
+
+        if (!collisions.isEmpty()) {
+           // This is extremely unlikely to happen. If you see this failure,
+           // this highly likely points to the implementation bug, rather than
+           // the odd chance.
+           throw new Exception("UUID collisions detected: " + collisions);
         }
     }
 
@@ -85,6 +94,8 @@ public class UUIDTest {
         List<UUID> uuids = IntStream.range(0, COUNT).parallel()
                                     .mapToObj(i -> UUID.randomUUID())
                                     .toList();
+
+        List<UUID> collisions = new ArrayList<>();
 
         Set<UUID> set = new HashSet<>();
         for (UUID u : uuids) {
@@ -95,13 +106,22 @@ public class UUIDTest {
                 throw new Exception("Bad variant: " + u);
             }
             if (!set.add(u)) {
-                throw new Exception("UUID collision: " + u);
+                collisions.add(u);
             }
+        }
+
+        if (!collisions.isEmpty()) {
+           // This is extremely unlikely to happen. If you see this failure,
+           // this highly likely points to the implementation bug, rather than
+           // the odd chance.
+           throw new Exception("UUID collisions detected: " + collisions);
         }
     }
 
 
     private static void nameUUIDFromBytesTest() throws Exception {
+        List<UUID> collisions = new ArrayList<>();
+
         byte[] someBytes = new byte[12];
         Set<UUID> set = new HashSet<>();
         for (int i = 0; i < COUNT; i++) {
@@ -114,8 +134,15 @@ public class UUIDTest {
                 throw new Exception("Bad variant: " + u);
             }
             if (!set.add(u)) {
-                throw new Exception("UUID collision: " + u);
+                collisions.add(u);
             }
+        }
+
+        if (!collisions.isEmpty()) {
+           // This is extremely unlikely to happen. If you see this failure,
+           // this highly likely points to the implementation bug, rather than
+           // the odd chance.
+           throw new Exception("UUID collisions detected: " + collisions);
         }
     }
 

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -25,19 +25,22 @@
  * @bug 4173528 5068772 8148936 8196334 8308803
  * @summary Unit tests for java.util.UUID
  * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
  * @run main/othervm -Xmx1g -XX:+CompactStrings UUIDTest
  * @run main/othervm -Xmx1g -XX:-CompactStrings UUIDTest
  */
 
 import java.util.*;
 import java.util.stream.IntStream;
+import jdk.test.lib.RandomFactory;
 
 public class UUIDTest {
 
     // Single UUID instance is ~32 bytes, 1M instances take ~256M in the set
     private static final int COUNT = 1_000_000;
 
-    static final Random generator = new Random();
+    static final Random generator = RandomFactory.getRandom();
 
     public static void main(String[] args) throws Exception {
         negativeTest();
@@ -313,7 +316,8 @@ public class UUIDTest {
             UUID u1 = UUID.randomUUID();
             UUID u2 = UUID.fromString(u1.toString());
             if (u1.hashCode() != u2.hashCode()) {
-                throw new Exception("Equal UUIDs with different hash codes: " + u1 + " and " + u2);
+                throw new Exception("Equal UUIDs with different hash codes: " + u1 + "(" + u1.hashCode() + ") " +
+                                    "and " + u2 + "(" + u2.hashCode() + ")");
             }
         }
 


### PR DESCRIPTION
UUID is very important class that is used to track identities of objects in large scale systems. Yet, the coverage in JDK test is disappointing: it tests only 100 of UUID instances per test, which is way too small to detect collisions due to the bad randomness for example.

I have some pending work to improve UUID performance, and tests should be improved. 

The improved test still runs in less than 5 seconds on my laptop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308803](https://bugs.openjdk.org/browse/JDK-8308803): Improve java/util/UUID/UUIDTest.java


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [48d6bc5c](https://git.openjdk.org/jdk/pull/14134/files/48d6bc5c531532921be819fa34bfb0bc70384ce2)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14134/head:pull/14134` \
`$ git checkout pull/14134`

Update a local copy of the PR: \
`$ git checkout pull/14134` \
`$ git pull https://git.openjdk.org/jdk.git pull/14134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14134`

View PR using the GUI difftool: \
`$ git pr show -t 14134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14134.diff">https://git.openjdk.org/jdk/pull/14134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14134#issuecomment-1561811751)