### PR TITLE
8308771: Redundant header file in interp_masm_<archs>.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -26,7 +26,6 @@
 #ifndef CPU_AARCH64_INTERP_MASM_AARCH64_HPP
 #define CPU_AARCH64_INTERP_MASM_AARCH64_HPP
 
-#include "interpreter/invocationCounter.hpp"
 #include "runtime/frame.hpp"
 
 // This file specializes the assembler with interpreter-specific macros

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -26,7 +26,6 @@
 #ifndef CPU_AARCH64_INTERP_MASM_AARCH64_HPP
 #define CPU_AARCH64_INTERP_MASM_AARCH64_HPP
 
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 #include "runtime/frame.hpp"
 
@@ -35,7 +34,6 @@
 typedef ByteSize (*OffsetFunction)(uint);
 
 class InterpreterMacroAssembler: public MacroAssembler {
- protected:
 
  protected:
   // Interpreter specific version of call_VM_base

--- a/src/hotspot/cpu/arm/interp_masm_arm.hpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.hpp
@@ -25,7 +25,6 @@
 #ifndef CPU_ARM_INTERP_MASM_ARM_HPP
 #define CPU_ARM_INTERP_MASM_ARM_HPP
 
-#include "interpreter/invocationCounter.hpp"
 #include "oops/method.hpp"
 #include "runtime/frame.hpp"
 #include "prims/jvmtiExport.hpp"

--- a/src/hotspot/cpu/arm/interp_masm_arm.hpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.hpp
@@ -25,7 +25,6 @@
 #ifndef CPU_ARM_INTERP_MASM_ARM_HPP
 #define CPU_ARM_INTERP_MASM_ARM_HPP
 
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 #include "oops/method.hpp"
 #include "runtime/frame.hpp"

--- a/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
@@ -26,7 +26,6 @@
 #ifndef CPU_PPC_INTERP_MASM_PPC_HPP
 #define CPU_PPC_INTERP_MASM_PPC_HPP
 
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 
 // This file specializes the assembler with interpreter-specific macros.

--- a/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
@@ -26,8 +26,6 @@
 #ifndef CPU_PPC_INTERP_MASM_PPC_HPP
 #define CPU_PPC_INTERP_MASM_PPC_HPP
 
-#include "interpreter/invocationCounter.hpp"
-
 // This file specializes the assembler with interpreter-specific macros.
 
 

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -37,7 +37,6 @@
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vm_version.hpp"
-#include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 // Implementation of InterpreterMacroAssembler.

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -27,7 +27,6 @@
 #ifndef CPU_RISCV_INTERP_MASM_RISCV_HPP
 #define CPU_RISCV_INTERP_MASM_RISCV_HPP
 
-#include "interpreter/invocationCounter.hpp"
 #include "runtime/frame.hpp"
 
 // This file specializes the assembler with interpreter-specific macros

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -27,7 +27,6 @@
 #ifndef CPU_RISCV_INTERP_MASM_RISCV_HPP
 #define CPU_RISCV_INTERP_MASM_RISCV_HPP
 
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 #include "runtime/frame.hpp"
 

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -42,7 +42,6 @@
 #include "runtime/javaThread.hpp"
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/sharedRuntime.hpp"
-#include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 // Implementation of InterpreterMacroAssembler.

--- a/src/hotspot/cpu/s390/interp_masm_s390.hpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.hpp
@@ -26,7 +26,6 @@
 #ifndef CPU_S390_INTERP_MASM_S390_HPP
 #define CPU_S390_INTERP_MASM_S390_HPP
 
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 
 // This file specializes the assembler with interpreter-specific macros.

--- a/src/hotspot/cpu/s390/interp_masm_s390.hpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.hpp
@@ -26,8 +26,6 @@
 #ifndef CPU_S390_INTERP_MASM_S390_HPP
 #define CPU_S390_INTERP_MASM_S390_HPP
 
-#include "interpreter/invocationCounter.hpp"
-
 // This file specializes the assembler with interpreter-specific macros.
 
 class InterpreterMacroAssembler: public MacroAssembler {

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -25,7 +25,6 @@
 #ifndef CPU_X86_INTERP_MASM_X86_HPP
 #define CPU_X86_INTERP_MASM_X86_HPP
 
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 #include "oops/method.hpp"
 #include "runtime/frame.hpp"

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -25,6 +25,7 @@
 #ifndef CPU_X86_INTERP_MASM_X86_HPP
 #define CPU_X86_INTERP_MASM_X86_HPP
 
+#include "asm/macroAssembler.hpp"
 #include "oops/method.hpp"
 #include "runtime/frame.hpp"
 

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -25,7 +25,6 @@
 #ifndef CPU_X86_INTERP_MASM_X86_HPP
 #define CPU_X86_INTERP_MASM_X86_HPP
 
-#include "interpreter/invocationCounter.hpp"
 #include "oops/method.hpp"
 #include "runtime/frame.hpp"
 

--- a/src/hotspot/cpu/zero/interp_masm_zero.hpp
+++ b/src/hotspot/cpu/zero/interp_masm_zero.hpp
@@ -27,7 +27,6 @@
 #define CPU_ZERO_INTERP_MASM_ZERO_HPP
 
 #include "asm/codeBuffer.hpp"
-#include "interpreter/invocationCounter.hpp"
 
 // This file specializes the assembler with interpreter-specific macros
 

--- a/src/hotspot/cpu/zero/interp_masm_zero.hpp
+++ b/src/hotspot/cpu/zero/interp_masm_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,7 +27,6 @@
 #define CPU_ZERO_INTERP_MASM_ZERO_HPP
 
 #include "asm/codeBuffer.hpp"
-#include "asm/macroAssembler.hpp"
 #include "interpreter/invocationCounter.hpp"
 
 // This file specializes the assembler with interpreter-specific macros

--- a/src/hotspot/share/interpreter/interp_masm.hpp
+++ b/src/hotspot/share/interpreter/interp_masm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #define SHARE_INTERPRETER_INTERP_MASM_HPP
 
 #include "asm/macroAssembler.hpp"
+#include "interpreter/invocationCounter.hpp"
 #include "utilities/macros.hpp"
 
 #include CPU_HEADER(interp_masm)


### PR DESCRIPTION
`asm/macroAssembler` and `interpreter/invocationCounter.hpp` can be sorted out in `interp_masm_<arch>.hpp` files. I have tested these changes for `s390x`, `ppc`,  `arch64-M1 Pro` for `release` and `fastdebug` build. Builds are good. 

For other archs(`arm`, `risc-v`) I haven't performed any testing because I don't have access to such hardwares. 

I've restored the changes for x86 as it seemed to break the build, not sure why.

__Reviews and comments are welcomed__

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308771](https://bugs.openjdk.org/browse/JDK-8308771): Redundant header file in interp_masm_&lt;archs&gt;.hpp (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14137/head:pull/14137` \
`$ git checkout pull/14137`

Update a local copy of the PR: \
`$ git checkout pull/14137` \
`$ git pull https://git.openjdk.org/jdk.git pull/14137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14137`

View PR using the GUI difftool: \
`$ git pr show -t 14137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14137.diff">https://git.openjdk.org/jdk/pull/14137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14137#issuecomment-1562197278)