### PR TITLE
8308817: RISC-V: Support VectorTest node for Vector API

### DIFF
--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -168,7 +168,7 @@
 
   // BoolTest mask for vector test intrinsics
   static constexpr BoolTest::mask vectortest_mask(bool is_alltrue, bool is_predicate, int vlen) {
-    return BoolTest::illegal;
+    return is_alltrue ? BoolTest::eq : BoolTest::ne;
   }
 
   // Returns pre-selection estimated size of a vector operation.

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4280,3 +4280,110 @@ instruct vmask_fromlong(vRegMask dst, iRegL src) %{
   %}
   ins_pipe(pipe_slow);
 %}
+
+// ------------------------------ VectorTest -----------------------------------
+
+// anytrue
+
+// Not matched. Condition is negated and value zero is moved to the right side in CMoveINode::Ideal.
+
+// instruct cmovI_vtest_anytrue(iRegINoSp dst, cmpOp cop, vRegMask op1, vRegMask op2, immI0 zero, immI_1 one) %{
+//   predicate(n->in(1)->in(1)->as_Bool()->_test._test == BoolTest::ne &&
+//             static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
+//   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary zero one)));
+//   format %{ "CMove $dst, (vectortest $cop $op1 $op2), zero, one\t#@cmovI_vtest_anytrue"  %}
+//   ins_encode %{
+//     BasicType bt = Matcher::vector_element_basic_type(this, $op1);
+//     uint vector_length = Matcher::vector_length(this, $op1);
+//     __ vsetvli_helper(bt, vector_length);
+//     __ vcpop_m($dst$$Register, as_VectorRegister($op1$$reg));
+//     __ snez($dst$$Register, $dst$$Register);
+//   %}
+//   ins_pipe(pipe_slow);
+// %}
+
+instruct cmovI_vtest_anytrue_negate(iRegINoSp dst, cmpOp cop, vRegMask op1, vRegMask op2, immI0 zero, immI_1 one) %{
+  predicate(n->in(1)->in(1)->as_Bool()->_test._test == BoolTest::eq &&
+            static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
+  match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary one zero)));
+  format %{ "CMove $dst, (vectortest $cop $op1 $op2), zero, one\t#@cmovI_vtest_anytrue_negate"  %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
+    uint vector_length = Matcher::vector_length(this, $op1);
+    __ vsetvli_helper(bt, vector_length);
+    __ vcpop_m($dst$$Register, as_VectorRegister($op1$$reg));
+    __ snez($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// alltrue
+
+// Not matched. Condition is negated and value zero is moved to the right side in CMoveINode::Ideal.
+
+// instruct cmovI_vtest_alltrue(iRegINoSp dst, cmpOp cop, vRegMask op1, vRegMask op2, immI0 zero, immI_1 one) %{
+//   predicate(n->in(1)->in(1)->as_Bool()->_test._test == BoolTest::eq &&
+//             static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
+//   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary zero one)));
+//   format %{ "CMove $dst, (vectortest $cop $op1 $op2), zero, one\t#@cmovI_vtest_alltrue"  %}
+//   ins_encode %{
+//     BasicType bt = Matcher::vector_element_basic_type(this, $op1);
+//     uint vector_length = Matcher::vector_length(this, $op1);
+//     __ vsetvli_helper(bt, vector_length);
+//     __ vcpop_m($dst$$Register, as_VectorRegister($op1$$reg));
+//     __ sub($dst$$Register, $dst$$Register, vector_length);
+//     __ seqz($dst$$Register, $dst$$Register);
+//   %}
+//   ins_pipe(pipe_slow);
+// %}
+
+instruct cmovI_vtest_alltrue_negate(iRegINoSp dst, cmpOp cop, vRegMask op1, vRegMask op2, immI0 zero, immI_1 one) %{
+  predicate(n->in(1)->in(1)->as_Bool()->_test._test == BoolTest::ne &&
+            static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
+  match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary one zero)));
+  format %{ "CMove $dst, (vectortest $cop $op1 $op2), zero, one\t#@cmovI_vtest_alltrue_negate"  %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
+    uint vector_length = Matcher::vector_length(this, $op1);
+    __ vsetvli_helper(bt, vector_length);
+    __ vcpop_m($dst$$Register, as_VectorRegister($op1$$reg));
+    __ sub($dst$$Register, $dst$$Register, vector_length);
+    __ seqz($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// anytrue
+
+instruct vtest_anytrue_branch(cmpOpEqNe cop, vRegMask op1, vRegMask op2, label lbl) %{
+  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
+  match(If cop (VectorTest op1 op2));
+  effect(USE lbl);
+  format %{ "b$cop (vectortest ne $op1, $op2) $lbl\t#@vtest_anytrue_branch" %}
+  ins_encode %{
+    uint vector_length = Matcher::vector_length(this, $op1);
+    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
+    __ vsetvli_helper(bt, vector_length);
+    __ vcpop_m(t0, as_VectorRegister($op1$$reg));
+    __ enc_cmpEqNe_imm0_branch($cop$$cmpcode, t0, *($lbl$$label), /* is_far */ true);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// alltrue
+
+instruct vtest_alltrue_branch(cmpOpEqNe cop, vRegMask op1, vRegMask op2, label lbl) %{
+  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
+  match(If cop (VectorTest op1 op2));
+  effect(USE lbl);
+  format %{ "b$cop (vectortest overflow $op1, $op2) $lbl\t#@vtest_alltrue_branch" %}
+  ins_encode %{
+    uint vector_length = Matcher::vector_length(this, $op1);
+    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
+    __ vsetvli_helper(bt, vector_length);
+    __ vcpop_m(t0, as_VectorRegister($op1$$reg));
+    __ sub(t0, t0, vector_length);
+    __ enc_cmpEqNe_imm0_branch($cop$$cmpcode, t0, *($lbl$$label), /* is_far */ true);
+  %}
+  ins_pipe(pipe_slow);
+%}


### PR DESCRIPTION
Hi,

we have added VectorTest node, It was implemented by referring to RVV v1.0 [1]. please take a look and have some reviews. Thanks a lot.
We can use the Int256VectorTests.java[2] to print the compilation log, verify and observe the generation of nodes.

For example, we can use the following command to print the compilation log of a jtreg test case:
```
/home/zifeihan/jdk-tools/jtreg/bin/jtreg \
-v:default \
-concurrency:16 -timeout:50 \
-javaoption:-XX:+UnlockExperimentalVMOptions \
-javaoption:-XX:+UseRVV \
-javaoption:-XX:+PrintOptoAssembly \
-javaoption:-XX:LogFile=/home/zifeihan/jdk-rvv/Int256VectorTests_PrintOptoAssembly_20230525.log \
-jdk:/home/zifeihan/jdk-rvv/build/linux-riscv64-server-fastdebug/jdk \
-compilejdk:/home/zifeihan/jdk-rvv/build/linux-x86_64-server-release/images/jdk \
/home/zifeihan/jdk/test/jdk/jdk/incubator/vector/Int256VectorTests.java
```

Also here's a more concise test case, VectorTestDemo:

```
import jdk.incubator.vector.ByteVector;
import jdk.incubator.vector.VectorMask;

public class VectorTestDemo {
    static boolean[] d = new boolean[]{true, false, false, false, false, false, false, false};
    static VectorMask<Byte> avmask = VectorMask.fromArray(ByteVector.SPECIES_64, d, 0);

    public static void main(String[] args) {
        for (int i = 0; i < 300000; i++) {
            
            final boolean alltrue = alltrue();
            if (alltrue != false) {
                throw new RuntimeException("alltrue");
            }
            final boolean anytrue = anytrue();
            if (anytrue != true) {
                throw new RuntimeException("anytrue");
            }
        }
    }

    public static boolean anytrue() {
        return avmask.anyTrue();
    }

    public static boolean alltrue() {
        return avmask.allTrue();
    }
}

```
We can compile `VectorTestDemo.java` using `javac --add-modules jdk.incubator.vector VectorTestDemo.java`, and use `./java -XX:-TieredCompilation -XX:+UnlockExperimentalVMOptions -XX:+UseRVV -XX:+PrintOptoAssembly -XX:+LogCompilation -XX:LogFile=compile.log VectorTestDemo > aaa.log` to start the test case, we can observe the specified compilation log `compile.log`, which contains the VectorTest node for the PR implementation.
Some of the compilation logs of VectorTestDemo#anytrue method are as follows.
```
05e lwu R28, [R7, #12] # loadN, compressed ptr, #@loadN ! Field: jdk/internal/vm/vector/VectorSupport$VectorPayload.payload (constant)
062 decode_heap_oop R7, R28 #@decodeHeapOop
066 addi R7, R7, #16 # ptr, #@addP_reg_imm
068 loadV V1, [R7] # vector (rvv)
070 vloadmask V0, V1
078 CMove R10, (vectortest eq V0 V0), zero, one #@cmovI_vtest_anytrue_negate
```
Some of the compilation logs of the VectorTestDemo#alltrue method are as follows.
```
05e lwu R28, [R7, #12] # loadN, compressed ptr, #@loadN ! Field: jdk/internal/vm/vector/VectorSupport$VectorPayload.payload (constant)
062 decode_heap_oop R7, R28 #@decodeHeapOop
066 addi R7, R7, #16 # ptr, #@addP_reg_imm
068 loadV V1, [R7] # vector (rvv)
070 vloadmask V0, V1
078 CMove R10, (vectortest ne V0 V0), zero, one #@cmovI_vtest_alltrue_negate
```
Some of the compilation logs of VectorTest#main method are as follows.
```
0b2 decode_heap_oop R7, R7 #@decodeHeapOop
0b4 addi R7, R7, #16 # ptr, #@addP_reg_imm
0b6 loadV V1, [R7] # vector (rvv)
0be vloadmask V0, V1
0c6 CMove R28, (vectortest eq V0 V0), zero, one #@cmovI_vtest_anytrue_negate
0d2 beq (vectortest overflow V0, V0) B8 #@vtest_alltrue_branch P=0.000001 C=-1.000000
```
As comment in the PR in cmovI_vtest_anytrue instruct, cmpOp is negated in CMoveINode::Ideal. So we keep this version for better understanding of the code change.

[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc
[2] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/incubator/vector/Int256VectorTests.java

### Testing:
qemu with UseRVV:

- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308817](https://bugs.openjdk.org/browse/JDK-8308817): RISC-V: Support VectorTest node for Vector API


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Dingli Zhang `<dingli@iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14138/head:pull/14138` \
`$ git checkout pull/14138`

Update a local copy of the PR: \
`$ git checkout pull/14138` \
`$ git pull https://git.openjdk.org/jdk.git pull/14138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14138`

View PR using the GUI difftool: \
`$ git pr show -t 14138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14138.diff">https://git.openjdk.org/jdk/pull/14138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14138#issuecomment-1562205667)