### PR TITLE
8308746: C2 IR test failures for TestFpMinMaxReductions.java with SSE2

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxReductions.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxReductions.java
@@ -29,7 +29,7 @@
  *          tests complement those in TestFpMinMaxIntrinsics, which focus more
  *          on correctness aspects.
  * @library /test/lib /
- * @requires os.simpleArch == "x64"& (vm.opt.UseAVX == "null" | vm.opt.UseAVX > 0)
+ * @requires os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*"
  * @run driver compiler.intrinsics.math.TestFpMinMaxReductions
  */
 


### PR DESCRIPTION
`TestFpMinMaxReductions.java` requires `UseAVX > 0` to enforce that floating-point min/max computations are matched by specialized implementations in x64 (see [x86.ad](https://github.com/openjdk/jdk/blob/2a18e537d60c88c015bea738764eef2ca610abf1/src/hotspot/cpu/x86/x86.ad#L1539)). This changeset guards the test file with an `avx.*` CPU feature instead, which is more robust because it reflects the final AVX configuration after all flags are processed (including flags such as `UseSSE` that might affect the final AVX configuration).

#### Testing

- `TestFpMinMaxReductions.java` in tier1-5 (windows-x64, linux-x64, and macosx-x64).
- `TestFpMinMaxReductions.java` with all possible combinations of `UseAVX` and `UseSSE`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308746](https://bugs.openjdk.org/browse/JDK-8308746): C2 IR test failures for TestFpMinMaxReductions.java with SSE2


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Contributors
 * Jatin Bhateja `<jbhateja@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14141/head:pull/14141` \
`$ git checkout pull/14141`

Update a local copy of the PR: \
`$ git checkout pull/14141` \
`$ git pull https://git.openjdk.org/jdk.git pull/14141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14141`

View PR using the GUI difftool: \
`$ git pr show -t 14141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14141.diff">https://git.openjdk.org/jdk/pull/14141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14141#issuecomment-1562594183)