### PR TITLE
8308807: MulticastSocket cannot join IPv4 multicast group when IPv6 is enabled (aix)

### DIFF
--- a/src/java.base/share/classes/java/net/DatagramSocket.java
+++ b/src/java.base/share/classes/java/net/DatagramSocket.java
@@ -32,6 +32,7 @@ import java.nio.channels.MulticastChannel;
 import java.util.Objects;
 import java.util.Set;
 import sun.nio.ch.DefaultSelectorProvider;
+import java.net.InetSocketAddress;
 
 /**
  * This class represents a socket for sending and receiving datagram packets.
@@ -1394,6 +1395,10 @@ public class DatagramSocket implements java.io.Closeable {
         boolean multicast = (type == MulticastSocket.class);
         DatagramSocket delegate = null;
         boolean initialized = false;
+        ProtocolFamily family = null;
+        if (bindaddr instanceof InetSocketAddress inetSocketAddress) {
+            family = inetSocketAddress.getAddress() instanceof Inet6Address ? StandardProtocolFamily.INET6 : StandardProtocolFamily.INET;
+        }
         try {
             DatagramSocketImplFactory factory = DatagramSocket.factory;
             if (factory != null) {
@@ -1406,7 +1411,7 @@ public class DatagramSocket implements java.io.Closeable {
             } else {
                 // create NIO adaptor
                 delegate = DefaultSelectorProvider.get()
-                        .openUninterruptibleDatagramChannel()
+                        .openUninterruptibleDatagramChannel(family)
                         .socket();
             }
 

--- a/src/java.base/share/classes/sun/nio/ch/SelectorProviderImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelectorProviderImpl.java
@@ -54,6 +54,12 @@ public abstract class SelectorProviderImpl
         return new DatagramChannelImpl(this, /*interruptible*/false);
     }
 
+    public DatagramChannel openUninterruptibleDatagramChannel(ProtocolFamily family) throws IOException {
+    if(family == null)
+       return openUninterruptibleDatagramChannel();
+       return new DatagramChannelImpl(this, family, /*interruptible*/false);
+    }
+
     @Override
     public DatagramChannel openDatagramChannel(ProtocolFamily family) throws IOException {
         return new DatagramChannelImpl(this, family, /*interruptible*/true);

--- a/src/java.base/share/classes/sun/nio/ch/SelectorProviderImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelectorProviderImpl.java
@@ -55,7 +55,7 @@ public abstract class SelectorProviderImpl
     }
 
     public DatagramChannel openUninterruptibleDatagramChannel(ProtocolFamily family) throws IOException {
-    if(family == null)
+    if (family == null)
        return openUninterruptibleDatagramChannel();
        return new DatagramChannelImpl(this, family, /*interruptible*/false);
     }


### PR DESCRIPTION
DatagramSocket delegates to an inner DatagramSocket object. Irrespective of whether datagramSocket is IPv4 or IPv6, we create an IPv6 datagramChannel as its's delegate. So, This can cause problems with operations like joinGroup. 

On AIX, IPv6 datagramSocket can not join an IPv4 multicast group.

These failures can be fixed by making sure that the delegate created for a datagram socket has the same protocol family. 




Reported Issue : [JDK-8308807](https://bugs.openjdk.org/browse/JDK-8308807)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8308807 is used in problem lists: [test/jdk/ProblemList.txt]

### Issue
 * [JDK-8308807](https://bugs.openjdk.org/browse/JDK-8308807): MulticastSocket cannot join IPv4 multicast group when IPv6 is enabled (aix) (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14142/head:pull/14142` \
`$ git checkout pull/14142`

Update a local copy of the PR: \
`$ git checkout pull/14142` \
`$ git pull https://git.openjdk.org/jdk.git pull/14142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14142`

View PR using the GUI difftool: \
`$ git pr show -t 14142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14142.diff">https://git.openjdk.org/jdk/pull/14142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14142#issuecomment-1562407930)