### PR TITLE
8308844: ProblemList gc/z/TestHighUsage.java with Generational ZGC on windows x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -115,3 +115,5 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
+
+gc/z/TestHighUsage.java                                       8308843 windows-x64


### PR DESCRIPTION
The test fails intermittently in early tiers on Windows x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308844](https://bugs.openjdk.org/browse/JDK-8308844): ProblemList gc/z/TestHighUsage.java with Generational ZGC on windows x64


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14144/head:pull/14144` \
`$ git checkout pull/14144`

Update a local copy of the PR: \
`$ git checkout pull/14144` \
`$ git pull https://git.openjdk.org/jdk.git pull/14144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14144`

View PR using the GUI difftool: \
`$ git pr show -t 14144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14144.diff">https://git.openjdk.org/jdk/pull/14144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14144#issuecomment-1562848370)