### PR TITLE
8232722: G1 archive region deallocation may shrink the heap below -Xms

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2199,7 +2199,7 @@ bool FileMapInfo::map_heap_region_impl() {
   char* base = os::map_memory(_fd, _full_path, r->file_offset(),
                               addr, _mapped_heap_memregion.byte_size(), r->read_only(),
                               r->allow_exec());
-  if (UseNewCode || base == nullptr || base != addr) {
+  if (base == nullptr || base != addr) {
     dealloc_heap_region(regions_committed);
     log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
                   INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -548,7 +548,7 @@ public:
   bool  validate_boot_class_paths() NOT_CDS_RETURN_(false);
   bool  validate_app_class_paths(int shared_app_paths_len) NOT_CDS_RETURN_(false);
   bool  map_heap_region_impl() NOT_CDS_JAVA_HEAP_RETURN_(false);
-  void  dealloc_heap_region() NOT_CDS_JAVA_HEAP_RETURN;
+  void  dealloc_heap_region(uint regions_committed) NOT_CDS_JAVA_HEAP_RETURN;
   bool  can_use_heap_region();
   bool  load_heap_region() NOT_CDS_JAVA_HEAP_RETURN_(false);
   bool  map_heap_region() NOT_CDS_JAVA_HEAP_RETURN_(false);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -607,7 +607,7 @@ void G1CollectedHeap::dealloc_archive_regions(MemRegion range, uint regions_comm
          p2i(start_address), p2i(last_address));
   size_used += range.byte_size();
 
-  // Free, empty and uncommit regions with CDS archive content.
+  // Free, empty and optionally uncommit regions with CDS archive content.
   uint shrink_count = 0;
   auto dealloc_archive_region = [&] (HeapRegion* r, bool is_last) {
     guarantee(r->is_old(), "Expected old region at index %u", r->hrm_index());

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -714,7 +714,7 @@ public:
 
   // Commit the appropriate G1 region(s) containing the specified range
   // and mark them as 'old' region(s).
-  bool alloc_archive_regions(MemRegion range);
+  bool alloc_archive_regions(MemRegion range, uint& regions_committed);
 
   // Populate the G1BlockOffsetTablePart for archived regions with the given
   // memory range.
@@ -724,7 +724,7 @@ public:
   // which had been allocated by alloc_archive_regions. This should be called
   // at JVM init time if the archive heap's contents cannot be used (e.g., if
   // CRC check fails).
-  void dealloc_archive_regions(MemRegion range);
+  void dealloc_archive_regions(MemRegion range, uint regions_committed);
 
 private:
 

--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -551,8 +551,9 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
   return G1_NO_HRM_INDEX;
 }
 
-bool HeapRegionManager::allocate_containing_regions(MemRegion range, size_t* commit_count, WorkerThreads* pretouch_workers) {
-  size_t commits = 0;
+bool HeapRegionManager::allocate_containing_regions(MemRegion range, uint* commit_count, uint* allocate_count, WorkerThreads* pretouch_workers) {
+  uint commits = 0;
+  uint allocated = 0;
   uint start_index = (uint)_regions.get_index_by_address(range.start());
   uint last_index = (uint)_regions.get_index_by_address(range.last());
 
@@ -567,10 +568,12 @@ bool HeapRegionManager::allocate_containing_regions(MemRegion range, size_t* com
     if (!curr_region->is_free()) {
       return false;
     }
+    allocated++;
   }
 
   allocate_free_regions_starting_at(start_index, (last_index - start_index) + 1);
   *commit_count = commits;
+  *allocate_count = allocated;
   return true;
 }
 

--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -263,8 +263,9 @@ public:
 
   // Allocate the regions that contain the address range specified, committing the
   // regions if necessary. Return false if any of the regions is already committed
-  // and not free, and return the number of regions newly committed in commit_count.
-  bool allocate_containing_regions(MemRegion range, size_t* commit_count, WorkerThreads* pretouch_workers);
+  // and not free, and return the number of regions newly committed in commit_count,
+  // allocated in allocate_count.
+  bool allocate_containing_regions(MemRegion range, uint* commit_count, uint* allocate_count, WorkerThreads* pretouch_workers);
 
   // Apply blk->do_heap_region() on all committed regions in address order,
   // terminating the iteration early if do_heap_region() returns true.


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that properly deallocates/uncommits CDS archive regions when failing to load the CDS archive?

In particular this caused the nuisance mentioned in the CR where even if -Xms==-Xmx, g1 uncommitted the heap memory anyway.

Testing: gha, manual testing as below

There is no (existing) way to induce CDS load errors easily, so what I did was adding `-XX:+UseNewCode` in `filemap.cpp:2202` to simulate failures when enabled. Obviously I removed the flag in this change.

Here's the problematic case:

```
$java -XX:GCCardSizeInBytes=128 -Xmx128m -Xms128m -Xlog:gc+region=trace,gc+ergo+heap=debug -XX:+UseNewCode -version

[0.050s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000ffe00000, 0x00000000fff00000, 0x00000000fff00000]
[0.050s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000fff00000, 0x00000000fff06278, 0x0000000100000000]
[0.050s][trace][gc,region   ] G1HR INACTIVE(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.050s][trace][gc,region   ] G1HR INACTIVE(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.050s][debug][gc,ergo,heap] Attempt heap shrinking (CDS archive regions). Total size: 2097152B
[0.050s][trace][gc,region   ] G1HR UNCOMMIT(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.050s][trace][gc,region   ] G1HR UNCOMMIT(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.057s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffd00000, 0x00000000ffd00000, 0x00000000ffe00000]
[0.129s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffc00000, 0x00000000ffc00000, 0x00000000ffd00000]
openjdk version "21-internal" 2023-09-19
```

(The `GCCardSizeInBytes` option is there to decrease the minimum heap alignment to 512kb/1M so that setting `-Xms` to an odd value in a later test works)

I.e. the CDS regions are unconditionally uncommitted even through `-Xms == -Xmx`.

The next case just illustrates current (pre-existing) behavior with `-Xms != -Xmx`, showing that CDS regions are always committed, leading to higher than `-Xms` memory usage. I will file an enhancement here, as it is acceptable behavior (to me).

```
$ java -XX:GCCardSizeInBytes=128 -Xmx128m -Xms126m -Xlog:gc+region=trace,gc+ergo+heap=debug -XX:+UseNewCode -version

[0.048s][trace][gc,region   ] G1HR COMMIT(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.048s][trace][gc,region   ] G1HR ACTIVE(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.048s][debug][gc,ergo,heap] Allocate CDS archive regions. Allocated 2 Committed 2
[0.048s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000ffe00000, 0x00000000fff00000, 0x00000000fff00000]
[0.048s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000fff00000, 0x00000000fff05f50, 0x0000000100000000]
[0.063s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffd00000, 0x00000000ffd00000, 0x00000000ffe00000]
```

I.e. CDS allocation just commits the last few regions without caring about other existing mappings to not fragment the heap.

The next case is the new behavior:
```
java -XX:GCCardSizeInBytes=128 -Xmx128m -Xms128m -Xlog:gc+region=trace,gc+ergo+heap=debug -XX:+UseNewCode -version

[0.047s][trace][gc,region   ] G1HR ACTIVE(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.047s][trace][gc,region   ] G1HR ACTIVE(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.048s][debug][gc,ergo,heap] Allocate CDS archive regions. Allocated 2 Committed 0
[0.048s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000ffe00000, 0x00000000fff00000, 0x00000000fff00000]
[0.048s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000fff00000, 0x00000000fff05f50, 0x0000000100000000]
[0.049s][trace][gc,region   ] G1HR CLEANUP(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.050s][trace][gc,region   ] G1HR CLEANUP(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.050s][debug][gc,ergo,heap] Deallocate CDS archive regions. Freed 2 Uncommitted 0 regions.
[0.057s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.131s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
openjdk version "21-internal" 2023-09-19
```
G1 does not uncommit the region blindly any more.

The next test case shows that if `-Xms` is lower than `-Xmx`, the code still properly uncommits (and no only frees the region).
```
java -XX:GCCardSizeInBytes=128 -Xmx128m -Xms126m -Xlog:gc+region=trace,gc+ergo+heap=debug -XX:+UseNewCode -version

[0.048s][trace][gc,region   ] G1HR COMMIT(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.048s][trace][gc,region   ] G1HR ACTIVE(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.048s][trace][gc,region   ] G1HR COMMIT(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.048s][trace][gc,region   ] G1HR ACTIVE(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.048s][debug][gc,ergo,heap] Allocate CDS archive regions. Allocated 2 Committed 2
[0.048s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000ffe00000, 0x00000000fff00000, 0x00000000fff00000]
[0.048s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000fff00000, 0x00000000fff05f50, 0x0000000100000000]
[0.048s][trace][gc,region   ] G1HR INACTIVE(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.049s][trace][gc,region   ] G1HR INACTIVE(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.049s][debug][gc,ergo,heap] Deallocate CDS archive regions. Freed 2 Uncommitted 2 regions.
[0.049s][trace][gc,region   ] G1HR UNCOMMIT(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.049s][trace][gc,region   ] G1HR UNCOMMIT(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.056s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffd00000, 0x00000000ffd00000, 0x00000000ffe00000]
[0.124s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffc00000, 0x00000000ffc00000, 0x00000000ffd00000]
openjdk version "21-internal" 2023-09-19
```

And finally a "mixed" case where to allocate the CDS archive G1 uses a mix of already allocated regions and committed regions, and uncommits/gives back regions as expected.

```
java -XX:GCCardSizeInBytes=128 -Xmx128m -Xms127m -Xlog:gc+region=trace,gc+ergo+heap=debug -XX:+UseNewCode -version

[0.053s][trace][gc,region   ] G1HR COMMIT(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.053s][trace][gc,region   ] G1HR ACTIVE(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.053s][debug][gc,ergo,heap] Allocate CDS archive regions. Allocated 2 Committed 1
[0.053s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000ffe00000, 0x00000000fff00000, 0x00000000fff00000]
[0.053s][trace][gc,region   ] G1HR ALLOC(OLD) [0x00000000fff00000, 0x00000000fff05f50, 0x0000000100000000]
[0.053s][trace][gc,region   ] G1HR INACTIVE(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.054s][trace][gc,region   ] G1HR CLEANUP(FREE) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.054s][debug][gc,ergo,heap] Deallocate CDS archive regions. Freed 2 Uncommitted 1 regions.
[0.054s][trace][gc,region   ] G1HR UNCOMMIT(FREE) [0x00000000ffe00000, 0x00000000ffe00000, 0x00000000fff00000]
[0.061s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000fff00000, 0x00000000fff00000, 0x0000000100000000]
[0.138s][trace][gc,region   ] G1HR ALLOC(EDEN) [0x00000000ffd00000, 0x00000000ffd00000, 0x00000000ffe00000]
openjdk version "21-internal" 2023-09-19
```

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232722](https://bugs.openjdk.org/browse/JDK-8232722): G1 archive region deallocation may shrink the heap below -Xms


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14145/head:pull/14145` \
`$ git checkout pull/14145`

Update a local copy of the PR: \
`$ git checkout pull/14145` \
`$ git pull https://git.openjdk.org/jdk.git pull/14145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14145`

View PR using the GUI difftool: \
`$ git pr show -t 14145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14145.diff">https://git.openjdk.org/jdk/pull/14145.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14145#issuecomment-1562614745)