### PR TITLE
8307057 JFR: Enable -XX:+DebugNonSafepoints when JFR starts

### DIFF
--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -373,6 +373,13 @@ bool JfrRecorder::create_event_throttler() {
   return JfrEventThrottler::create();
 }
 
+void JfrRecorder::enable_debug_non_safepoints() {
+  if (FLAG_IS_DEFAULT(DebugNonSafepoints)) {
+    DebugNonSafepoints = true;
+    log_debug(jfr)("DebugNonSafepoints enabled");
+  }
+}
+
 void JfrRecorder::destroy_components() {
   JfrJvmtiAgent::destroy();
   if (_post_box != nullptr) {
@@ -431,6 +438,7 @@ void JfrRecorder::on_recorder_thread_exit() {
 }
 
 void JfrRecorder::start_recording() {
+  enable_debug_non_safepoints();
   _post_box->post(MSG_START);
 }
 

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
@@ -55,6 +55,7 @@ class JfrRecorder : public JfrCHeapObj {
   static bool create_thread_sampling();
   static bool create_event_throttler();
   static bool create_components();
+  static void enable_debug_non_safepoints();
   static void destroy_components();
   static void on_recorder_thread_exit();
 


### PR DESCRIPTION
Could I have review of a change that enables DebugNonSafepoints when JFR starts.

Testing: tier1, tier2, tier3, tier4

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307057](https://bugs.openjdk.org/browse/JDK-8307057): JFR: Enable  -XX:+DebugNonSafepoints when JFR starts (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14147/head:pull/14147` \
`$ git checkout pull/14147`

Update a local copy of the PR: \
`$ git checkout pull/14147` \
`$ git pull https://git.openjdk.org/jdk.git pull/14147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14147`

View PR using the GUI difftool: \
`$ git pr show -t 14147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14147.diff">https://git.openjdk.org/jdk/pull/14147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14147#issuecomment-1562921063)