### PR TITLE
8308856: jdk.internal.classfile.impl.EntryMap::nextPowerOfTwo math problem

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/EntryMap.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/EntryMap.java
@@ -174,7 +174,7 @@ public abstract class EntryMap<T> {
     }
 
     public static long nextPowerOfTwo( long x ) {
-        return 1l << -Long.numberOfLeadingZeros(x - 1);
+        return 1L << -Long.numberOfLeadingZeros(x - 1);
     }
 
     public static int arraySize( final int expected, final float f ) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/EntryMap.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/EntryMap.java
@@ -174,8 +174,7 @@ public abstract class EntryMap<T> {
     }
 
     public static long nextPowerOfTwo( long x ) {
-        x = -1 >>> Long.numberOfLeadingZeros(x - 1);
-        return x + 1;
+        return 1l << -Long.numberOfLeadingZeros(x - 1);
     }
 
     public static int arraySize( final int expected, final float f ) {


### PR DESCRIPTION
Fix of jdk.internal.classfile.impl.EntryMap::nextPowerOfTwo returning correct zero power of two.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308856](https://bugs.openjdk.org/browse/JDK-8308856): jdk.internal.classfile.impl.EntryMap::nextPowerOfTwo math problem


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14148/head:pull/14148` \
`$ git checkout pull/14148`

Update a local copy of the PR: \
`$ git checkout pull/14148` \
`$ git pull https://git.openjdk.org/jdk.git pull/14148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14148`

View PR using the GUI difftool: \
`$ git pr show -t 14148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14148.diff">https://git.openjdk.org/jdk/pull/14148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14148#issuecomment-1562826193)