### PR TITLE
8308589: gc/cslocker/TestCSLocker.java timed out

### DIFF
--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -32,6 +32,13 @@ import static gc.testlibrary.Allocation.blackHole;
  * @summary This short test check RFE 6186200 changes. One thread locked
  * @summary completely in JNI CS, while other is trying to allocate memory
  * @summary provoking GC. OOM means FAIL, deadlock means PASS.
+ *
+ * @comment This test assumes that no allocation happens during the sleep loop,   \
+ *          which is something that we can't guarantee. With Generational ZGC we  \
+ *          see test timeouts because the main thread allocates and waits for the \
+ *          GC, which waits for the CSLocker, which waits for the main thread.    \
+ * @requires !vm.opt.final.ZGenerational
+ *
  * @run main/native/othervm -Xmx256m gc.cslocker.TestCSLocker
  */
 


### PR DESCRIPTION
We have found that this test is flawed and will cause deadlocks if allocations wait for a GC to complete. We tried to fix this issue by removing one source of allocations (see JDK-8308043), but that there are still more reasons why the JVM might allocate memory in the test. The test has a history of causing timeouts (likely caused by deadlocks), but we're currently only seeing hangs with Generational ZGC. I propose that we turn off this test for Generational ZGC, and if the test still cause problems in other configurations then we'll reevaluate if this should be handled some other way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308589](https://bugs.openjdk.org/browse/JDK-8308589): gc/cslocker/TestCSLocker.java timed out


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14150/head:pull/14150` \
`$ git checkout pull/14150`

Update a local copy of the PR: \
`$ git checkout pull/14150` \
`$ git pull https://git.openjdk.org/jdk.git pull/14150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14150`

View PR using the GUI difftool: \
`$ git pr show -t 14150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14150.diff">https://git.openjdk.org/jdk/pull/14150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14150#issuecomment-1562948118)