### PR TITLE
JDK-8308872: enhance logging and some exception in krb5/Config.java

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -671,6 +671,9 @@ public class Config {
     private List<String> loadConfigFile(final String fileName)
             throws IOException, KrbException {
 
+        if (DEBUG) {
+            System.out.println("Loading config file from " + fileName);
+        }
         List<String> result = new ArrayList<>();
         List<String> raw = new ArrayList<>();
         Set<Path> dupsCheck = new HashSet<>();
@@ -781,6 +784,9 @@ public class Config {
             throws KrbException {
         Hashtable<String,Object> current = stanzaTable;
         for (String line: v) {
+            if (DEBUG) {
+                System.out.println(line);
+            }
             // There are only 3 kinds of lines
             // 1. a = b
             // 2. a = {
@@ -979,16 +985,22 @@ public class Config {
         String default_enctypes;
         default_enctypes = get("libdefaults", configName);
         if (default_enctypes == null && !configName.equals("permitted_enctypes")) {
+            if (DEBUG) {
+                System.out.println("Getting permitted_enctypes from libdefaults");
+            }
             default_enctypes = get("libdefaults", "permitted_enctypes");
         }
         int[] etype;
         if (default_enctypes == null) {
             if (DEBUG) {
-                System.out.println("Using builtin default etypes for " +
+                System.out.println("default_enctypes were null, using builtin default etypes for configuration " +
                     configName);
             }
             etype = EType.getBuiltInDefaults();
         } else {
+            if (DEBUG) {
+                System.out.println("default_enctypes:" + default_enctypes);
+            }
             String delim = " ";
             StringTokenizer st;
             for (int j = 0; j < default_enctypes.length(); j++) {
@@ -1010,7 +1022,7 @@ public class Config {
                 }
             }
             if (ls.isEmpty()) {
-                throw new KrbException("no supported default etypes for "
+                throw new KrbException("no supported default etypes for configuration "
                         + configName);
             } else {
                 etype = new int[ls.size()];

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -1022,7 +1022,8 @@ public class Config {
                 }
             }
             if (ls.isEmpty()) {
-                throw new KrbException("no supported default etypes for configuration "
+                throw new KrbException("out of " + len +
+                        " default etypes no supported etypes found for configuration "
                         + configName);
             } else {
                 etype = new int[ls.size()];


### PR DESCRIPTION
There exists already some logging in krb5/Config.java (enabled by -Dsun.security.krb5.debug=true), this could be enhanced for easier analysis of problems. Additionally some exception(s) might be slightly adjusted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308872](https://bugs.openjdk.org/browse/JDK-8308872): enhance logging and some exception in krb5/Config.java


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14151/head:pull/14151` \
`$ git checkout pull/14151`

Update a local copy of the PR: \
`$ git checkout pull/14151` \
`$ git pull https://git.openjdk.org/jdk.git pull/14151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14151`

View PR using the GUI difftool: \
`$ git pr show -t 14151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14151.diff">https://git.openjdk.org/jdk/pull/14151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14151#issuecomment-1563025119)