### PR TITLE
8308814: extend SetLocalXXX minimal support for virtual threads

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -5826,9 +5826,8 @@ class C2 extends C1 implements I2 {
       The <code>GetLocalXXX</code> functions may be used to retrieve the value of
       a local variable contained in the frame of a virtual thread.
       The <code>SetLocalXXX</code> functions may be used to set the value of a
-      local variable in the topmost frame of a virtual thread suspended at a
-      breakpoint or single step event. An implementation may support setting locals
-      in other cases.
+      local variable in the topmost frame of a virtual thread suspended at an event.
+      An implementation may support setting locals in other cases.
     </intro>
 
     <function id="GetLocalObject" num="21">
@@ -6205,7 +6204,7 @@ class C2 extends C1 implements I2 {
           Not a visible frame
         </error>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
-          The thread is a virtual thread and the implementation does not support
+          The thread is a suspended virtual thread and the implementation does not support
           setting the value of locals in the frame of the given depth.
           See <internallink id="local">Local Variables</internallink>.
         </error>
@@ -6269,7 +6268,7 @@ class C2 extends C1 implements I2 {
           Not a visible frame
         </error>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
-          The thread is a virtual thread and the implementation does not support
+          The thread is a suspended virtual thread and the implementation does not support
           setting the value of locals in the frame of the given depth.
           See <internallink id="local">Local Variables</internallink>.
         </error>
@@ -6328,7 +6327,7 @@ class C2 extends C1 implements I2 {
           Not a visible frame
         </error>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
-          The thread is a virtual thread and the implementation does not support
+          The thread is a suspended virtual thread and the implementation does not support
           setting the value of locals in the frame of the given depth.
           See <internallink id="local">Local Variables</internallink>.
         </error>
@@ -6387,7 +6386,7 @@ class C2 extends C1 implements I2 {
           Not a visible frame
         </error>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
-          The thread is a virtual thread and the implementation does not support
+          The thread is a suspended virtual thread and the implementation does not support
           setting the value of locals in the frame of the given depth.
           See <internallink id="local">Local Variables</internallink>.
         </error>
@@ -6446,7 +6445,7 @@ class C2 extends C1 implements I2 {
           Not a visible frame
         </error>
         <error id="JVMTI_ERROR_OPAQUE_FRAME">
-          The thread is a virtual thread and the implementation does not support
+          The thread is a suspended virtual thread and the implementation does not support
           setting the value of locals in the frame of the given depth.
           See <internallink id="local">Local Variables</internallink>.
         </error>


### PR DESCRIPTION
Currently, the `SetLocalXXX` minimal support for virtual threads is defined for a virtual threads suspended at a breakpoint or single step event. This enhancement is to extend to virtual threads suspended any event. This make `SetLocalXXX` spec consistent with specs of the `StopThread`, `PopFrame` and `ForceEarlyReturnXXX`.

It does not look that any implementation update is needed as it is already supporting any suspended and mounted virtual thread which includes suspended at an event cases.

The CSR (already reviewed) is:
  [8308815](https://bugs.openjdk.org/browse/JDK-8308815): extend `SetLocalXXX` minimal support for virtual threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308815](https://bugs.openjdk.org/browse/JDK-8308815) to be approved

### Issues
 * [JDK-8308814](https://bugs.openjdk.org/browse/JDK-8308814): extend SetLocalXXX minimal support for virtual threads
 * [JDK-8308815](https://bugs.openjdk.org/browse/JDK-8308815): extend SetLocalXXX minimal support for virtual threads (**CSR**)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14153/head:pull/14153` \
`$ git checkout pull/14153`

Update a local copy of the PR: \
`$ git checkout pull/14153` \
`$ git pull https://git.openjdk.org/jdk.git pull/14153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14153`

View PR using the GUI difftool: \
`$ git pr show -t 14153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14153.diff">https://git.openjdk.org/jdk/pull/14153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14153#issuecomment-1563057016)