### PR TITLE
8308881: Strong CLD oop handle roots are demoted to non-roots concurrently

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -194,6 +194,8 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   Dictionary* create_dictionary();
 
+  void demote_strong_roots();
+
   void initialize_name(Handle class_loader);
 
  public:


### PR DESCRIPTION
It is illegal to remove strong roots concurrently without clearing them first. A SATB collector with concurrent root scanning assumes that when strong roots disappear from the object graph, they are cleared first, which makes SATB notice the root. All global strong roots do this. Except CLD strong roots, which are turned into non-roots by decrementing the keep_alive counter to 0, when bootstrapping weak hidden class CLDs. This is not valid behaviour. This patch tries to treat these oops like we do any other global strong handles that are unlinked from the system: clear them when they stop being strong roots.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308881](https://bugs.openjdk.org/browse/JDK-8308881): Strong CLD oop handle roots are demoted to non-roots concurrently


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [b75fce32](https://git.openjdk.org/jdk/pull/14154/files/b75fce3261c5c49d3f1dee07daa66d8fd3766c5f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14154/head:pull/14154` \
`$ git checkout pull/14154`

Update a local copy of the PR: \
`$ git checkout pull/14154` \
`$ git pull https://git.openjdk.org/jdk.git pull/14154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14154`

View PR using the GUI difftool: \
`$ git pr show -t 14154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14154.diff">https://git.openjdk.org/jdk/pull/14154.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14154#issuecomment-1563135343)