### PR TITLE
8308876 JFR: Deserialization of EventTypeInfo uses incorrect attribute names

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/EventTypeInfo.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/EventTypeInfo.java
@@ -44,7 +44,7 @@ import jdk.jfr.SettingDescriptor;
  * @since 9
  */
 public final class EventTypeInfo {
-    private final List<SettingDescriptorInfo> settings;
+    private final List<SettingDescriptorInfo> settingDescriptors;
     private final long id;
     private final String name;
     private final String description;
@@ -53,7 +53,7 @@ public final class EventTypeInfo {
 
     // package private
     EventTypeInfo(EventType eventType) {
-        this.settings = creatingSettingDescriptorInfos(eventType);
+        this.settingDescriptors = creatingSettingDescriptorInfos(eventType);
         this.id = eventType.getId();
         this.name = eventType.getName();
         this.label = eventType.getLabel();
@@ -62,12 +62,20 @@ public final class EventTypeInfo {
     }
 
     private EventTypeInfo(CompositeData cd) {
-        this.settings = createSettings(cd.get("settings"));
+        if (cd.containsKey("settings")) {
+            this.settingDescriptors = createSettingDescriptors(cd.get("settings"));
+        } else {
+            this.settingDescriptors = createSettingDescriptors(cd.get("settingDescriptors")); 
+        }
         this.id = (long) cd.get("id");
         this.name = (String) cd.get("name");
         this.label = (String) cd.get("label");
         this.description = (String) cd.get("description");
-        this.categoryNames = createCategoryNames((Object[]) cd.get("category"));
+        if (cd.containsKey("category")) {
+            this.categoryNames = createCategoryNames((Object[]) cd.get("category"));
+        } else {
+            this.categoryNames = createCategoryNames((Object[]) cd.get("categoryNames"));
+        }
     }
 
     private static List<String> createCategoryNames(Object[] array) {
@@ -87,7 +95,7 @@ public final class EventTypeInfo {
         return Collections.unmodifiableList(settingDescriptorInfos);
     }
 
-    private static List<SettingDescriptorInfo> createSettings(Object settings) {
+    private static List<SettingDescriptorInfo> createSettingDescriptors(Object settings) {
         if (settings instanceof Object[] settingsArray) {
             List<SettingDescriptorInfo> list = new ArrayList<>(settingsArray.length);
             for (Object element : settingsArray) {
@@ -174,7 +182,7 @@ public final class EventTypeInfo {
      * @see EventType#getSettingDescriptors()
      */
     public List<SettingDescriptorInfo> getSettingDescriptors() {
-        return settings;
+        return settingDescriptors;
     }
 
     /**
@@ -229,11 +237,11 @@ public final class EventTypeInfo {
      * <td>{@code String}</td>
      * </tr>
      * <tr>
-     * <th scope="row">category</th>
+     * <th scope="row">categoryNames</th>
      * <td><code>ArrayType(1, SimpleType.STRING)</code></td>
      * </tr>
      * <tr>
-     * <th scope="row">settings</th>
+     * <th scope="row">settingDescriptors</th>
      * <td>{@code javax.management.openmbean.CompositeData[]} whose element type
      * is the mapped type for {@link SettingDescriptorInfo} as specified in the
      * {@link SettingDescriptorInfo#from} method.</td>

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/EventTypeInfo.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/EventTypeInfo.java
@@ -65,7 +65,7 @@ public final class EventTypeInfo {
         if (cd.containsKey("settings")) {
             this.settingDescriptors = createSettingDescriptors(cd.get("settings"));
         } else {
-            this.settingDescriptors = createSettingDescriptors(cd.get("settingDescriptors")); 
+            this.settingDescriptors = createSettingDescriptors(cd.get("settingDescriptors"));
         }
         this.id = (long) cd.get("id");
         this.name = (String) cd.get("name");

--- a/test/jdk/jdk/jfr/jmx/info/TestEventTypeInfo.java
+++ b/test/jdk/jdk/jfr/jmx/info/TestEventTypeInfo.java
@@ -42,13 +42,14 @@ import jdk.test.lib.Asserts;
  * @summary Test for EventTypeInfo
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.jmx.info.TestEventTypeInfo
+ * @run main/othervm -Djdk.attach.allowAttachSelf=true -Dcom.sun.management.jmxremote jdk.jfr.jmx.info.TestEventTypeInfo
  */
 public class TestEventTypeInfo {
     public static void main(String[] args) throws Throwable {
         FlightRecorder jfr = FlightRecorder.getFlightRecorder();
 
-        FlightRecorderMXBean bean = JmxHelper.getFlighteRecorderMXBean();
+        long selfPID = JmxHelper.getPID();
+        FlightRecorderMXBean bean = JmxHelper.getFlighteRecorderMXBean(selfPID);
         List<EventTypeInfo> typeInfos = bean.getEventTypes();
 
         Map<String, EventType> types = new HashMap<>();


### PR DESCRIPTION
Could I have a review of a bug when deserialzing EventTypeInfo. For details, see CSR.

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8308877](https://bugs.openjdk.org/browse/JDK-8308877) to be approved

### Issues
 * [JDK-8308876](https://bugs.openjdk.org/browse/JDK-8308876): JFR: Deserialization of EventTypeInfo uses incorrect attribute names
 * [JDK-8308877](https://bugs.openjdk.org/browse/JDK-8308877): JFR: Deserialization of EventTypeInfo uses incorrect attribute names (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14155/head:pull/14155` \
`$ git checkout pull/14155`

Update a local copy of the PR: \
`$ git checkout pull/14155` \
`$ git pull https://git.openjdk.org/jdk.git pull/14155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14155`

View PR using the GUI difftool: \
`$ git pr show -t 14155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14155.diff">https://git.openjdk.org/jdk/pull/14155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14155#issuecomment-1563207094)