### PR TITLE
8308678: (fs) UnixPath::toRealPath needs additional permissions when running with SM (macOS)

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -906,7 +906,7 @@ class UnixPath implements Path {
             final UnixFileKey elementKey = attrs.fileKey();
 
             // Obtain the directory stream pointer. It will be closed by
-            // UnixDirectoryStream::closeImpl.
+            // UnixDirectoryStream::close.
             long dp = -1;
             try {
                 dp = opendir(path);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -782,12 +782,12 @@ class UnixPath implements Path {
         return open(this, flags, 0);
     }
 
-    private static boolean canRead(UnixPath path) {
+    private boolean canRead() {
         @SuppressWarnings("removal")
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             try {
-                sm.checkRead(path.getPathForPermissionCheck());
+                sm.checkRead(getPathForPermissionCheck());
                 return true;
             } catch (SecurityException ignore) {
                 return false;
@@ -896,7 +896,7 @@ class UnixPath implements Path {
         // If SM and no read permission, then fall back to result derived so
         // far with case possibly not retained
         UnixPath path = fs.rootDirectory();
-        if (!canRead(path))
+        if (!path.canRead())
             return result;
 
         // Traverse the result obtained above from the root downward, leaving

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -917,7 +917,6 @@ class UnixPath implements Path {
             // Obtain the stream of entries in the directory corresponding
             // to the path constructed thus far, and extract the entry whose
             // key is equal to the key of the current element
-            FileSystemProvider provider = getFileSystem().provider();
             DirectoryStream.Filter<Path> filter = (p) -> { return true; };
             try (DirectoryStream<Path> entries = new UnixDirectoryStream(path, dp, filter)) {
                 boolean found = false;

--- a/test/jdk/java/nio/file/Path/MacToRealPath.policy
+++ b/test/jdk/java/nio/file/Path/MacToRealPath.policy
@@ -1,0 +1,4 @@
+grant {
+    permission java.io.FilePermission "${java.io.tmpdir}", "read,write";
+    permission java.io.FilePermission "${java.io.tmpdir}/-", "read,write,delete";
+};

--- a/test/jdk/java/nio/file/Path/MacToRealPathWithSM.java
+++ b/test/jdk/java/nio/file/Path/MacToRealPathWithSM.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8308678
+ * @requires (os.family == "mac")
+ * @summary Verify UnixPath::toRealPath falls back if no perms on macOS
+ * @run main/othervm -Djava.security.manager=allow MacToRealPathWithSM MacToRealPath.policy
+ */
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+public class MacToRealPathWithSM {
+    public static void main(String[] args) throws Exception {
+        String policyFile = args[0];
+        String testSrc = System.getProperty("test.src");
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        if (testSrc == null || tmpDir == null)
+            throw new RuntimeException("This test must be run by jtreg");
+        System.out.println("testSrc: " + testSrc);
+        System.out.println("tmpDir: " + tmpDir);
+
+        Path src = Path.of(testSrc);
+        Path tmp = Path.of(tmpDir);
+
+        Path path = Files.createTempFile(tmp, "bonjour", ".txt");
+        path.toFile().deleteOnExit();
+
+        // Write to the path
+        Files.writeString(path, "\nBonjour, tout le monde!\n");
+        System.out.println(Files.readString(path));
+
+        // Install security manager with the given policy file
+        System.setProperty("java.security.policy",
+            src.resolve(policyFile).toString());
+        System.setSecurityManager(new SecurityManager());
+
+        // Derive real path
+        System.out.printf("real path: %s%n", path.toRealPath());
+        System.out.printf("real path no follow: %s%n",
+                          path.toRealPath(LinkOption.NOFOLLOW_LINKS));
+    }
+}


### PR DESCRIPTION
When not resolving links and the case retention algorithm cannot be run due to a security manager being in place with no read permissions for the tree to be traversed, then fall back to the result obtained without case correction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308678](https://bugs.openjdk.org/browse/JDK-8308678): (fs) UnixPath::toRealPath needs additional permissions when running with SM (macOS)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14157/head:pull/14157` \
`$ git checkout pull/14157`

Update a local copy of the PR: \
`$ git checkout pull/14157` \
`$ git pull https://git.openjdk.org/jdk.git pull/14157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14157`

View PR using the GUI difftool: \
`$ git pr show -t 14157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14157.diff">https://git.openjdk.org/jdk/pull/14157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14157#issuecomment-1563250836)