### PR TITLE
8307488: Incorrect weight of the first ObjectAllocationSample JFR event

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -132,18 +132,18 @@ class ClearObjectAllocationSampling : public ThreadClosure {
 };
 
 template <typename Iterator>
-static inline void iterate(Iterator& it, ClearObjectAllocationSampling& robs) {
+static inline void iterate(Iterator& it, ClearObjectAllocationSampling& coas) {
   while (it.has_next()) {
-    robs.do_thread(it.next());
+    coas.do_thread(it.next());
   }
 }
 
 static void clear_object_allocation_sampling() {
-  ClearObjectAllocationSampling robs;
+  ClearObjectAllocationSampling coas;
   JfrJavaThreadIterator jit;
-  iterate(jit, robs);
+  iterate(jit, coas);
   JfrNonJavaThreadIterator njit;
-  iterate(njit, robs);
+  iterate(njit, coas);
 }
 
 template <typename Instance, size_t(Instance::*func)()>

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -41,6 +41,7 @@
 #include "jfr/recorder/storage/jfrStorageControl.hpp"
 #include "jfr/recorder/stringpool/jfrStringPool.hpp"
 #include "jfr/utilities/jfrAllocation.hpp"
+#include "jfr/utilities/jfrThreadIterator.hpp"
 #include "jfr/utilities/jfrTime.hpp"
 #include "jfr/writers/jfrJavaEventWriter.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
@@ -120,6 +121,30 @@ class JfrRotationLock : public StackObj {
 const Thread* JfrRotationLock::_owner_thread = nullptr;
 const int JfrRotationLock::retry_wait_millis = 10;
 volatile int JfrRotationLock::_lock = 0;
+
+// Reset thread local state used for object allocation sampling.
+class ClearObjectAllocationSampling : public ThreadClosure {
+ public:
+  void do_thread(Thread* t) {
+    assert(t != nullptr, "invariant");
+    t->jfr_thread_local()->clear_last_allocated_bytes();
+  }
+};
+
+template <typename Iterator>
+static inline void iterate(Iterator& it, ClearObjectAllocationSampling& robs) {
+  while (it.has_next()) {
+    robs.do_thread(it.next());
+  }
+}
+
+static void clear_object_allocation_sampling() {
+  ClearObjectAllocationSampling robs;
+  JfrJavaThreadIterator jit;
+  iterate(jit, robs);
+  JfrNonJavaThreadIterator njit;
+  iterate(njit, robs);
+}
 
 template <typename Instance, size_t(Instance::*func)()>
 class Content {
@@ -435,6 +460,7 @@ void JfrRecorderService::clear() {
 }
 
 void JfrRecorderService::pre_safepoint_clear() {
+  clear_object_allocation_sampling();
   _string_pool.clear();
   _storage.clear();
   JfrStackTraceRepository::clear();

--- a/src/hotspot/share/jfr/support/jfrObjectAllocationSample.cpp
+++ b/src/hotspot/share/jfr/support/jfrObjectAllocationSample.cpp
@@ -27,33 +27,18 @@
 #include "gc/shared/tlab_globals.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "jfr/support/jfrObjectAllocationSample.hpp"
+#include "jfr/support/jfrThreadLocal.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-static THREAD_LOCAL int64_t _last_allocated_bytes = 0;
-
-inline void send_allocation_sample(const Klass* klass, int64_t allocated_bytes) {
-  assert(allocated_bytes > 0, "invariant");
+inline bool send_allocation_sample(const Klass* klass, int64_t allocated_bytes, JfrThreadLocal* tl) {
   EventObjectAllocationSample event;
   if (event.should_commit()) {
-    const int64_t weight = allocated_bytes - _last_allocated_bytes;
+    const int64_t weight = allocated_bytes - tl->last_allocated_bytes();
     assert(weight > 0, "invariant");
     event.set_objectClass(klass);
     event.set_weight(weight);
     event.commit();
-    _last_allocated_bytes = allocated_bytes;
-  }
-}
-
-inline bool send_allocation_sample_with_result(const Klass* klass, int64_t allocated_bytes) {
-  assert(allocated_bytes > 0, "invariant");
-  EventObjectAllocationSample event;
-  if (event.should_commit()) {
-    const int64_t weight = allocated_bytes - _last_allocated_bytes;
-    assert(weight > 0, "invariant");
-    event.set_objectClass(klass);
-    event.set_weight(weight);
-    event.commit();
-    _last_allocated_bytes = allocated_bytes;
+    tl->set_last_allocated_bytes(allocated_bytes);
     return true;
   }
   return false;
@@ -66,35 +51,27 @@ inline int64_t estimate_tlab_size_bytes(Thread* thread) {
   return static_cast<int64_t>(desired_tlab_size_bytes - alignment_reserve_bytes);
 }
 
-inline int64_t load_allocated_bytes(Thread* thread) {
-  assert(thread != nullptr, "invariant");
+inline int64_t load_allocated_bytes(JfrThreadLocal* tl, Thread* thread) {
   const int64_t allocated_bytes = thread->allocated_bytes();
-  if (allocated_bytes < _last_allocated_bytes) {
-    // A hw thread can detach and reattach to the VM, and when it does,
-    // it gets a new JavaThread representation. The thread local variable
-    // tracking _last_allocated_bytes is mapped to the existing hw thread,
-    // so it needs to be reset.
-    _last_allocated_bytes = 0;
-  }
-  return allocated_bytes == _last_allocated_bytes ? 0 : allocated_bytes;
+  return allocated_bytes == tl->last_allocated_bytes() ? 0 : allocated_bytes;
 }
 
 // To avoid large objects from being undersampled compared to the regular TLAB samples,
 // the data amount is normalized as if it was a TLAB, giving a number of TLAB sampling attempts to the large object.
-static void normalize_as_tlab_and_send_allocation_samples(const Klass* klass, int64_t obj_alloc_size_bytes, Thread* thread) {
-  const int64_t allocated_bytes = load_allocated_bytes(thread);
+static void normalize_as_tlab_and_send_allocation_samples(const Klass* klass, int64_t obj_alloc_size_bytes, JfrThreadLocal* tl, Thread* thread) {
+  const int64_t allocated_bytes = load_allocated_bytes(tl, thread);
   assert(allocated_bytes > 0, "invariant"); // obj_alloc_size_bytes is already attributed to allocated_bytes at this point.
   if (!UseTLAB) {
-    send_allocation_sample(klass, allocated_bytes);
+    send_allocation_sample(klass, allocated_bytes, tl);
     return;
   }
   const int64_t tlab_size_bytes = estimate_tlab_size_bytes(thread);
-  if (allocated_bytes - _last_allocated_bytes < tlab_size_bytes) {
+  if (allocated_bytes - tl->last_allocated_bytes() < tlab_size_bytes) {
     return;
   }
   assert(obj_alloc_size_bytes > 0, "invariant");
   do {
-    if (send_allocation_sample_with_result(klass, allocated_bytes)) {
+    if (send_allocation_sample(klass, allocated_bytes, tl)) {
       return;
     }
     obj_alloc_size_bytes -= tlab_size_bytes;
@@ -102,13 +79,16 @@ static void normalize_as_tlab_and_send_allocation_samples(const Klass* klass, in
 }
 
 void JfrObjectAllocationSample::send_event(const Klass* klass, size_t alloc_size, bool outside_tlab, Thread* thread) {
+  assert(thread != nullptr, "invariant");
+  JfrThreadLocal* const tl = thread->jfr_thread_local();
+  assert(tl != nullptr, "invariant");
   if (outside_tlab) {
-    normalize_as_tlab_and_send_allocation_samples(klass, static_cast<int64_t>(alloc_size), thread);
+    normalize_as_tlab_and_send_allocation_samples(klass, static_cast<int64_t>(alloc_size), tl, thread);
     return;
   }
-  const int64_t allocated_bytes = load_allocated_bytes(thread);
+  const int64_t allocated_bytes = load_allocated_bytes(tl, thread);
   if (allocated_bytes == 0) {
     return;
   }
-  send_allocation_sample(klass, allocated_bytes);
+  send_allocation_sample(klass, allocated_bytes, tl);
 }

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -64,6 +64,7 @@ JfrThreadLocal::JfrThreadLocal() :
   _data_lost(0),
   _stack_trace_id(max_julong),
   _parent_trace_id(0),
+  _last_allocated_bytes(0),
   _user_time(0),
   _cpu_time(0),
   _wallclock_time(os::javaTimeNanos()),

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -58,6 +58,7 @@ class JfrThreadLocal {
   u8 _data_lost;
   traceid _stack_trace_id;
   traceid _parent_trace_id;
+  int64_t _last_allocated_bytes;
   jlong _user_time;
   jlong _cpu_time;
   jlong _wallclock_time;
@@ -147,6 +148,18 @@ class JfrThreadLocal {
 
   void set_stackdepth(u4 depth) {
     _stackdepth = depth;
+  }
+
+  int64_t last_allocated_bytes() const {
+    return _last_allocated_bytes;
+  }
+
+  void set_last_allocated_bytes(int64_t allocated_bytes) {
+    _last_allocated_bytes = allocated_bytes;
+  }
+
+  void clear_last_allocated_bytes() {
+    set_last_allocated_bytes(0);
   }
 
   // Contextually defined thread id that is volatile,


### PR DESCRIPTION
Greetings,

this PR fixes the problem with incorrect weights attribution for the initial ObjectAllocationSample event.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307488](https://bugs.openjdk.org/browse/JDK-8307488): Incorrect weight of the first ObjectAllocationSample JFR event


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14158/head:pull/14158` \
`$ git checkout pull/14158`

Update a local copy of the PR: \
`$ git checkout pull/14158` \
`$ git pull https://git.openjdk.org/jdk.git pull/14158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14158`

View PR using the GUI difftool: \
`$ git pr show -t 14158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14158.diff">https://git.openjdk.org/jdk/pull/14158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14158#issuecomment-1563286469)