### PR TITLE
8308906: Make CIPrintCompilerName a diagnostic flag

### DIFF
--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -210,10 +210,6 @@ void CompileTask::print_line_on_error(outputStream* st, char* buf, int buflen) {
 // CompileTask::print_tty
 void CompileTask::print_tty() {
   ttyLocker ttyl;  // keep the following output all in one block
-  // print compiler name if requested
-  if (CIPrintCompilerName) {
-    tty->print("%s:", CompileBroker::compiler_name(comp_level()));
-  }
   print(tty);
 }
 

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -50,7 +50,7 @@
                                                                             \
   /* compiler interface */                                                  \
                                                                             \
-  develop(bool, CIPrintCompilerName, false,                                 \
+  product(bool, CIPrintCompilerName, false, DIAGNOSTIC,                     \
           "when CIPrint is active, print the name of the active compiler")  \
                                                                             \
   product(bool, CIPrintCompileQueue, false, DIAGNOSTIC,                     \


### PR DESCRIPTION
Please review a very simple change. This makes it easy to see which JIT compiler is used to compile each method:

```
java -XX:+UnlockDiagnosticVMOptions -XX:+PrintCompilation -XX:+CIPrintCompilerName  -jar MyApp.java
```

CSR is not needed because this is a diagnostic VM option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308906](https://bugs.openjdk.org/browse/JDK-8308906): Make CIPrintCompilerName a diagnostic flag


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14161/head:pull/14161` \
`$ git checkout pull/14161`

Update a local copy of the PR: \
`$ git checkout pull/14161` \
`$ git pull https://git.openjdk.org/jdk.git pull/14161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14161`

View PR using the GUI difftool: \
`$ git pr show -t 14161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14161.diff">https://git.openjdk.org/jdk/pull/14161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14161#issuecomment-1563496209)