### PR TITLE
8307144: namedParams in XECParameters and EdDSAParameters can be private final

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -41,8 +41,7 @@ public class XECParameters {
 
     static final XECParameters X25519;
     static final XECParameters X448;
-    
-    static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+
     private final static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
 
     // Naming/identification parameters

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -42,7 +42,7 @@ public class XECParameters {
     static final XECParameters X25519;
     static final XECParameters X448;
 
-    private final ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+    static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
 
     // Naming/identification parameters
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -42,7 +42,7 @@ public class XECParameters {
     static final XECParameters X25519;
     static final XECParameters X448;
 
-    private final static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+    private static final ParametersMap<XECParameters> namedParams = new ParametersMap<>();
 
     // Naming/identification parameters
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -41,12 +41,9 @@ public class XECParameters {
 
     static final XECParameters X25519;
     static final XECParameters X448;
-
-<<<<<<< Updated upstream
+    
     static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
-=======
     private final static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
->>>>>>> Stashed changes
 
     // Naming/identification parameters
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,8 @@ public class XECParameters {
     static final XECParameters X25519;
     static final XECParameters X448;
 
-    private static final ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+    private static final ParametersMap<XECParameters> namedParams =
+        new ParametersMap<>();
 
     // Naming/identification parameters
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -42,7 +42,7 @@ public class XECParameters {
     static final XECParameters X25519;
     static final XECParameters X448;
 
-    static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+    private final ParametersMap<XECParameters> namedParams = new ParametersMap<>();
 
     // Naming/identification parameters
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -42,7 +42,11 @@ public class XECParameters {
     static final XECParameters X25519;
     static final XECParameters X448;
 
+<<<<<<< Updated upstream
     static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+=======
+    private final static ParametersMap<XECParameters> namedParams = new ParametersMap<>();
+>>>>>>> Stashed changes
 
     // Naming/identification parameters
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,8 @@ public class EdDSAParameters {
         }
     }
 
-    private static final ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
+    private static final ParametersMap<EdDSAParameters> namedParams =
+        new ParametersMap<>();
 
     private final String name;
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -147,7 +147,11 @@ public class EdDSAParameters {
         }
     }
 
+<<<<<<< Updated upstream
     static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
+=======
+    private final static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
+>>>>>>> Stashed changes
 
     private final String name;
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -147,7 +147,6 @@ public class EdDSAParameters {
         }
     }
 
-    static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
     private final static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
 
     private final String name;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -147,7 +147,7 @@ public class EdDSAParameters {
         }
     }
 
-    private final static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
+    private static final ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
 
     private final String name;
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -147,11 +147,8 @@ public class EdDSAParameters {
         }
     }
 
-<<<<<<< Updated upstream
     static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
-=======
     private final static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
->>>>>>> Stashed changes
 
     private final String name;
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -147,7 +147,7 @@ public class EdDSAParameters {
         }
     }
 
-    static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
+    private final ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
 
     private final String name;
     private final ObjectIdentifier oid;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAParameters.java
@@ -147,7 +147,7 @@ public class EdDSAParameters {
         }
     }
 
-    private final ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
+    static ParametersMap<EdDSAParameters> namedParams = new ParametersMap<>();
 
     private final String name;
     private final ObjectIdentifier oid;


### PR DESCRIPTION
Changed `namedParams` in XECParameters and EdDSAParameters to be `private final`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307144](https://bugs.openjdk.org/browse/JDK-8307144): namedParams in XECParameters and EdDSAParameters can be private final (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to [f870eec4](https://git.openjdk.org/jdk/pull/14162/files/f870eec4105802c626e78134c57fa65d0990d06d)
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to [f870eec4](https://git.openjdk.org/jdk/pull/14162/files/f870eec4105802c626e78134c57fa65d0990d06d)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14162/head:pull/14162` \
`$ git checkout pull/14162`

Update a local copy of the PR: \
`$ git checkout pull/14162` \
`$ git pull https://git.openjdk.org/jdk.git pull/14162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14162`

View PR using the GUI difftool: \
`$ git pr show -t 14162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14162.diff">https://git.openjdk.org/jdk/pull/14162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14162#issuecomment-1579544057)