### PR TITLE
8308907: ProblemList java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -625,6 +625,7 @@ javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
 javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,macosx-aarch64
 javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
+javax/sound/sampled/Clip/ClipIsRunningAfterStop.java 8307574 linux-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -460,6 +460,7 @@ java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-a
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64
 java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java 8308875 linux-x64
+sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8301177 linux-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -459,6 +459,7 @@ java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64
+java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java 8308875 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
Trivial fixes to ProblemList a few tests:
[JDK-8308907](https://bugs.openjdk.org/browse/JDK-8308907) ProblemList java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java on linux-x64
[JDK-8308908](https://bugs.openjdk.org/browse/JDK-8308908) ProblemList javax/sound/sampled/Clip/ClipIsRunningAfterStop.java on linux-x64
[JDK-8308909](https://bugs.openjdk.org/browse/JDK-8308909) ProblemList sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java on linux-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8308907](https://bugs.openjdk.org/browse/JDK-8308907): ProblemList java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java on linux-x64
 * [JDK-8308908](https://bugs.openjdk.org/browse/JDK-8308908): ProblemList javax/sound/sampled/Clip/ClipIsRunningAfterStop.java on linux-x64
 * [JDK-8308909](https://bugs.openjdk.org/browse/JDK-8308909): ProblemList sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java on linux-x64


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14163/head:pull/14163` \
`$ git checkout pull/14163`

Update a local copy of the PR: \
`$ git checkout pull/14163` \
`$ git pull https://git.openjdk.org/jdk.git pull/14163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14163`

View PR using the GUI difftool: \
`$ git pr show -t 14163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14163.diff">https://git.openjdk.org/jdk/pull/14163.diff</a>

</details>
