### PR TITLE
8308594: Use atomic bitset function for PackageEntry::_defined_by_cds_in_class_path

### DIFF
--- a/src/hotspot/share/classfile/packageEntry.hpp
+++ b/src/hotspot/share/classfile/packageEntry.hpp
@@ -225,12 +225,7 @@ public:
   }
   void set_defined_by_cds_in_class_path(int idx) {
     assert(idx < max_index_for_defined_in_class_path(), "sanity");
-    int old_val = 0;
-    int new_val = 0;
-    do {
-      old_val = Atomic::load(&_defined_by_cds_in_class_path);
-      new_val = old_val | ((int)1 << idx);
-    } while (Atomic::cmpxchg(&_defined_by_cds_in_class_path, old_val, new_val) != old_val);
+    Atomic::fetch_then_or(&_defined_by_cds_in_class_path, ((int)1 << idx));
   }
 };
 


### PR DESCRIPTION
Please review this simple fix for replacing the implementation in `PackageEntry::set_defined_by_cds_in_class_path()` with `Atomic::fetch_then_or()`.

Passed tier1 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308594](https://bugs.openjdk.org/browse/JDK-8308594): Use atomic bitset function for PackageEntry::_defined_by_cds_in_class_path


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14164/head:pull/14164` \
`$ git checkout pull/14164`

Update a local copy of the PR: \
`$ git checkout pull/14164` \
`$ git pull https://git.openjdk.org/jdk.git pull/14164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14164`

View PR using the GUI difftool: \
`$ git pr show -t 14164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14164.diff">https://git.openjdk.org/jdk/pull/14164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14164#issuecomment-1563569101)