### PR TITLE
8308917: C2 SuperWord::output: assert before bailout with CountedLoopReserveKit

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2664,6 +2664,7 @@ bool SuperWord::output() {
     // Create a vector mask node for post loop, bail out if not created
     vmask = create_post_loop_vmask();
     if (vmask == nullptr) {
+      assert(false, "rce post loop vmask was not created");
       return false; // and reverse to backup IG
     }
   }
@@ -2718,6 +2719,7 @@ bool SuperWord::output() {
         if (val == nullptr) {
           if (do_reserve_copy()) {
             NOT_PRODUCT(if(is_trace_loop_reverse() || TraceLoopOpts) {tty->print_cr("SWPointer::output: val should not be null, exiting SuperWord");})
+            assert(false, "input to vector store was not created");
             return false; //and reverse to backup IG
           }
           ShouldNotReachHere();
@@ -2857,6 +2859,7 @@ bool SuperWord::output() {
           if (in1 == nullptr) {
             if (do_reserve_copy()) {
               NOT_PRODUCT(if(is_trace_loop_reverse() || TraceLoopOpts) {tty->print_cr("SWPointer::output: in1 should not be null, exiting SuperWord");})
+              assert(false, "input in1 to vector operand was not created");
               return false; //and reverse to backup IG
             }
             ShouldNotReachHere();
@@ -2866,6 +2869,7 @@ bool SuperWord::output() {
         if (in2 == nullptr) {
           if (do_reserve_copy()) {
             NOT_PRODUCT(if(is_trace_loop_reverse() || TraceLoopOpts) {tty->print_cr("SWPointer::output: in2 should not be null, exiting SuperWord");})
+            assert(false, "input in2 to vector operand was not created");
             return false; //and reverse to backup IG
           }
           ShouldNotReachHere();
@@ -2939,6 +2943,7 @@ bool SuperWord::output() {
       } else {
         if (do_reserve_copy()) {
           NOT_PRODUCT(if(is_trace_loop_reverse() || TraceLoopOpts) {tty->print_cr("SWPointer::output: Unhandled scalar opcode (%s), ShouldNotReachHere, exiting SuperWord", NodeClassNames[opc]);})
+          assert(false, "Unhandled scalar opcode (%s)", NodeClassNames[opc]);
           return false; //and reverse to backup IG
         }
         ShouldNotReachHere();

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2664,7 +2664,7 @@ bool SuperWord::output() {
     // Create a vector mask node for post loop, bail out if not created
     vmask = create_post_loop_vmask();
     if (vmask == nullptr) {
-      assert(false, "rce post loop vmask was not created");
+      // create_post_loop_vmask checks many conditions, any of them could fail
       return false; // and reverse to backup IG
     }
   }


### PR DESCRIPTION
In SuperWord::output we create a CountedLoopReserveKit, so that we can reverse edits to the loop, in case something goes wrong. As far as I understand all of these conditions should never occur, prior condition checking in SuperWord should have already verified that. We should at least add asserts so that we can catch such failures and fix them, and do not just silently bail out of SuperWord (reverse the graph to before SuperWord and continue compilation).

`DoReserveCopyInSuperWord` enables `do_reserve_copy()`. It is a product flag and default true. If it is disabled, and there is such a failure we just hit a `ShouldNotReachHere()`.

There was one occurance I could not assert for: `vmask = create_post_loop_vmask();`. Read more below, there is actually a but there.

**Testing**

TODO testing up to tier6 plus stress testing.
(it already passed tier3 and stress testing)

**Discussion**

Do we really want to keep the `DoReserveCopyInSuperWord` flag (product, always true), which enables the use of `CountedLoopReserveKit`? It means that we always duplicate the loop (and the loops can be rather large because they were unrolled before SuperWord). It seems a bit of an edge case to want to bail out of SuperWord, but not of the whole compilation.
We can later decide if it makes sense to clone the whole loop via CountedLoopReserveKit (the loops can be large!), or if we should just have a regular compilation bailout instead (could simplify the code and reduce overhead of loop cloning).

Plus: it seems the checks and bailouts are very selectively applied. I don't see why we would nullptr check some "vector_opd" but not all of them. So if we decide to keep it, we should probably apply it more consistently.

What do you think?

------

**Bug: bad combination of -XX:+PostLoopMultiversioning -XX:-DoReserveCopyInSuperWord**

I filed it here: [JDK-8308949](https://bugs.openjdk.org/browse/JDK-8308949)

`PostLoopMultiversioning` unrolls the post-loop with the use of a vmask. Read more about post-loop vectorization here https://github.com/openjdk/jdk/pull/6828. But in `create_post_loop_vmask` we have some conditions which have to hold, and if they fail we get a `nullptr`, and bail out of SuperWord, via `CountedLoopReserveKit`.

But if we turn off `DoReserveCopyInSuperWord`, this is not cought, and we hit an assert.

Generally, this looks a bit unclean, what we have now: we should do the checks of `create_post_loop_vmask` before `SuperWord::output`, so before we make any changes to the IR. Maybe that could be the bug-fix there.

This bug is a bit of a hint that we should not have too many product flags like `DoReserveCopyInSuperWord`, which we rarely to never test. I wonder if anybody even ever uses it?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308917](https://bugs.openjdk.org/browse/JDK-8308917): C2 SuperWord::output: assert before bailout with CountedLoopReserveKit


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14168/head:pull/14168` \
`$ git checkout pull/14168`

Update a local copy of the PR: \
`$ git checkout pull/14168` \
`$ git pull https://git.openjdk.org/jdk.git pull/14168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14168`

View PR using the GUI difftool: \
`$ git pr show -t 14168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14168.diff">https://git.openjdk.org/jdk/pull/14168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14168#issuecomment-1563812953)