### PR TITLE
8308875: java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java failed with 'Cannot invoke "sun.awt.X11GraphicsDevice.getInsets()" because "device" is null'

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -887,18 +887,22 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
 
     @Override
     public Insets getScreenInsets(final GraphicsConfiguration gc) {
-        final X11GraphicsDevice device = (X11GraphicsDevice) gc.getDevice();
-        Insets insets = device.getInsets();
-        if (insets == null) {
-            synchronized (device) {
-                insets = device.getInsets();
-                if (insets == null) {
-                    insets = getScreenInsetsImpl(gc);
-                    device.setInsets(insets);
+        final GraphicsDevice gd = gc.getDevice();
+        if (gd instanceof X11GraphicsDevice x11Device) {
+            Insets insets = x11Device.getInsets();
+            if (insets == null) {
+                synchronized (x11Device) {
+                    insets = x11Device.getInsets();
+                    if (insets == null) {
+                        insets = getScreenInsetsImpl(gc);
+                        x11Device.setInsets(insets);
+                    }
                 }
             }
+            return (Insets) insets.clone();
+        } else {
+            return super.getScreenInsets(gc);
         }
-        return (Insets) insets.clone();
     }
 
     /*

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -459,7 +459,6 @@ java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64
-java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java 8308875 linux-x64
 sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8301177 linux-x64
 
 ############################################################################


### PR DESCRIPTION
8308875 is a regression after the recent [fix for 8305578](https://github.com/openjdk/jdk/commit/d7245f70) that effectively undid a part of [another, older, change](https://github.com/openjdk/jdk/commit/40f6d697d25293282e3d3ee695ef8cd9a5494799), the one made to fix [8233573](https://bugs.openjdk.org/browse/JDK-8233573).

This commits brings that part back and passes the test `java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java` on Linux, so the test is also removed from the ProblemList file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308875](https://bugs.openjdk.org/browse/JDK-8308875): java/awt/Toolkit/GetScreenInsetsCustomGC/GetScreenInsetsCustomGC.java failed with 'Cannot invoke "sun.awt.X11GraphicsDevice.getInsets()" because "device" is null'


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14170/head:pull/14170` \
`$ git checkout pull/14170`

Update a local copy of the PR: \
`$ git checkout pull/14170` \
`$ git pull https://git.openjdk.org/jdk.git pull/14170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14170`

View PR using the GUI difftool: \
`$ git pr show -t 14170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14170.diff">https://git.openjdk.org/jdk/pull/14170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14170#issuecomment-1564006309)