### PR TITLE
8308935: jdk.management.jfr.RecordingInfo.toString() lacks test coverage

### DIFF
--- a/test/jdk/jdk/jfr/jmx/info/TestRecordingInfo.java
+++ b/test/jdk/jdk/jfr/jmx/info/TestRecordingInfo.java
@@ -35,6 +35,7 @@ import jdk.jfr.RecordingState;
 import jdk.management.jfr.FlightRecorderMXBean;
 import jdk.management.jfr.RecordingInfo;
 import jdk.test.lib.jfr.CommonHelper;
+import jdk.test.lib.Asserts;
 
 /**
  * @test
@@ -62,6 +63,16 @@ public class TestRecordingInfo {
         FlightRecorderMXBean bean = JmxHelper.getFlighteRecorderMXBean();
         RecordingInfo info = JmxHelper.verifyExists(recording.getId(), bean.getRecordings());
 
+        String text = info.toString();
+        assertContains(text, "name");
+        assertContains(text, String.valueOf(info.getName()));
+        assertContains(text, "id");
+        assertContains(text, String.valueOf(info.getId()));
+        assertContains(text, "maxAge");
+        assertContains(text, String.valueOf(info.getMaxAge()));
+        assertContains(text, "maxSize");
+        assertContains(text, String.valueOf(info.getMaxSize()));
+
         System.out.println(JmxHelper.asString(recording));
         System.out.println(JmxHelper.asString(info));
         JmxHelper.verifyEquals(info, recording);
@@ -70,4 +81,9 @@ public class TestRecordingInfo {
         recording.close();
     }
 
+    private static void assertContains(String text, String match) {
+        if (!text.contains(match)) {
+            Asserts.fail("Expected '" + text + "' to contain '" + match + '"');
+        }
+    }
 }


### PR DESCRIPTION
Could I have a review of test fix that adds test coverage for the RecordingInfo.toString() method.

Testing: jdk/jdk/jfr/jmx/info/TestRecordingInfo.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308935](https://bugs.openjdk.org/browse/JDK-8308935): jdk.management.jfr.RecordingInfo.toString() lacks test coverage


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14171/head:pull/14171` \
`$ git checkout pull/14171`

Update a local copy of the PR: \
`$ git checkout pull/14171` \
`$ git pull https://git.openjdk.org/jdk.git pull/14171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14171`

View PR using the GUI difftool: \
`$ git pr show -t 14171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14171.diff">https://git.openjdk.org/jdk/pull/14171.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14171#issuecomment-1564130252)