### PR TITLE
8308930: [JVMCI] TestUncaughtErrorInCompileMethod times out

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,8 +71,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/c2/irTests/TestVectorConditionalMove.java 8306922 generic-all
 
-compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8308930 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/jvmci/TestUncaughtErrorInCompileMethod.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestUncaughtErrorInCompileMethod.java
@@ -67,7 +67,9 @@ public class TestUncaughtErrorInCompileMethod extends JVMCIServiceLocator {
         } else {
             int total = 0;
             while (!compilerCreationErrorOccurred) {
+                // Do some random work to trigger compilation
                 total += getTime();
+                total += String.valueOf(total).hashCode();
             }
             System.out.println(total);
         }


### PR DESCRIPTION
This PR makes TestUncaughtErrorInCompileMethod more robust against HotSpot compilation scheduling variability which should prevent timeouts in this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308930](https://bugs.openjdk.org/browse/JDK-8308930): [JVMCI] TestUncaughtErrorInCompileMethod times out


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [8faf2b2e](https://git.openjdk.org/jdk/pull/14173/files/8faf2b2ee82fb2ff41c0eefe4d03cb2698ce64e9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14173/head:pull/14173` \
`$ git checkout pull/14173`

Update a local copy of the PR: \
`$ git checkout pull/14173` \
`$ git pull https://git.openjdk.org/jdk.git pull/14173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14173`

View PR using the GUI difftool: \
`$ git pr show -t 14173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14173.diff">https://git.openjdk.org/jdk/pull/14173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14173#issuecomment-1564579527)