### PR TITLE
8308479: [s390x] Implement alternative fast-locking scheme

### DIFF
--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -83,60 +83,63 @@ void C1_MacroAssembler::verified_entry(bool breakAtEntry) {
   if (breakAtEntry) z_illtrap(0xC1);
 }
 
-void C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr, Label& slow_case) {
+void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox, Label& slow_case) {
   const int hdr_offset = oopDesc::mark_offset_in_bytes();
-  assert_different_registers(hdr, obj, disp_hdr);
 
-  verify_oop(obj, FILE_AND_LINE);
+  const Register tmp   = Z_R1_scratch;
+
+  assert_different_registers(Rmark, Roop, Rbox, tmp);
+
+  verify_oop(Roop, FILE_AND_LINE);
 
   // Load object header.
-  z_lg(hdr, Address(obj, hdr_offset));
+  z_lg(Rmark, Address(Roop, hdr_offset));
 
   // Save object being locked into the BasicObjectLock...
-  z_stg(obj, Address(disp_hdr, BasicObjectLock::obj_offset()));
+  z_stg(Roop, Address(Rbox, BasicObjectLock::obj_offset()));
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
-    load_klass(Z_R1_scratch, obj);
-    testbit(Address(Z_R1_scratch, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+    load_klass(tmp, Roop);
+    testbit(Address(tmp, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
     z_btrue(slow_case);
   }
 
   assert(LockingMode != LM_MONITOR, "LM_MONITOR is already handled, by emit_lock()");
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    Unimplemented();
+    fast_lock(Roop, Rmark, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     NearLabel done;
     // and mark it as unlocked.
-    z_oill(hdr, markWord::unlocked_value);
+    z_oill(Rmark, markWord::unlocked_value);
     // Save unlocked object header into the displaced header location on the stack.
-    z_stg(hdr, Address(disp_hdr, (intptr_t) 0));
+    z_stg(Rmark, Address(Rbox, BasicLock::displaced_header_offset_in_bytes()));
     // Test if object header is still the same (i.e. unlocked), and if so, store the
     // displaced header address in the object header. If it is not the same, get the
     // object header instead.
-    z_csg(hdr, disp_hdr, hdr_offset, obj);
+    z_csg(Rmark, Rbox, hdr_offset, Roop);
     // If the object header was the same, we're done.
     branch_optimized(Assembler::bcondEqual, done);
-    // If the object header was not the same, it is now in the hdr register.
+    // If the object header was not the same, it is now in the Rmark register.
     // => Test if it is a stack pointer into the same stack (recursive locking), i.e.:
     //
-    // 1) (hdr & markWord::lock_mask_in_place) == 0
-    // 2) rsp <= hdr
-    // 3) hdr <= rsp + page_size
+    // 1) (Rmark & markWord::lock_mask_in_place) == 0
+    // 2) rsp <= Rmark
+    // 3) Rmark <= rsp + page_size
     //
     // These 3 tests can be done by evaluating the following expression:
     //
-    // (hdr - Z_SP) & (~(page_size-1) | markWord::lock_mask_in_place)
+    // (Rmark - Z_SP) & (~(page_size-1) | markWord::lock_mask_in_place)
     //
     // assuming both the stack pointer and page_size have their least
     // significant 2 bits cleared and page_size is a power of 2
-    z_sgr(hdr, Z_SP);
+    z_sgr(Rmark, Z_SP);
 
     load_const_optimized(Z_R0_scratch, (~(os::vm_page_size() - 1) | markWord::lock_mask_in_place));
-    z_ngr(hdr, Z_R0_scratch); // AND sets CC (result eq/ne 0).
+    z_ngr(Rmark, Z_R0_scratch); // AND sets CC (result eq/ne 0).
     // For recursive locking, the result is zero. => Save it in the displaced header
-    // location (null in the displaced hdr location indicates recursive locking).
-    z_stg(hdr, Address(disp_hdr, (intptr_t) 0));
+    // location (null in the displaced Rmark location indicates recursive locking).
+    z_stg(Rmark, Address(Rbox, BasicLock::displaced_header_offset_in_bytes()));
     // Otherwise we don't care about the result and handle locking via runtime call.
     branch_optimized(Assembler::bcondNotZero, slow_case);
     // done
@@ -144,35 +147,41 @@ void C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hd
   }
 }
 
-void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_hdr, Label& slow_case) {
-  const int aligned_mask = BytesPerWord -1;
+void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rbox, Label& slow_case) {
   const int hdr_offset = oopDesc::mark_offset_in_bytes();
-  assert_different_registers(hdr, obj, disp_hdr);
+
+  assert_different_registers(Rmark, Roop, Rbox);
+
   NearLabel done;
 
   if (LockingMode != LM_LIGHTWEIGHT) {
     // Load displaced header.
-    z_ltg(hdr, Address(disp_hdr, (intptr_t) 0));
-    // If the loaded hdr is null we had recursive locking, and we are done.
+    z_ltg(Rmark, Address(Rbox, BasicLock::displaced_header_offset_in_bytes()));
+    // If the loaded Rmark is null we had recursive locking, and we are done.
     z_bre(done);
   }
 
   // Load object.
-  z_lg(obj, Address(disp_hdr, BasicObjectLock::obj_offset()));
-  verify_oop(obj, FILE_AND_LINE);
+  z_lg(Roop, Address(Rbox, BasicObjectLock::obj_offset()));
+  verify_oop(Roop, FILE_AND_LINE);
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    Unimplemented();
-  } else {
+    const Register tmp = Z_R1_scratch;
+    z_lg(Rmark, Address(Roop, hdr_offset));
+    z_lgr(tmp, Rmark);
+    z_nill(tmp, markWord::monitor_value);
+    z_brnz(slow_case);
+    fast_unlock(Roop, Rmark, tmp, slow_case);
+  } else if (LockingMode == LM_LEGACY) {
     // Test if object header is pointing to the displaced header, and if so, restore
     // the displaced header in the object. If the object header is not pointing to
     // the displaced header, get the object header instead.
-    z_csg(disp_hdr, hdr, hdr_offset, obj);
+    z_csg(Rbox, Rmark, hdr_offset, Roop);
     // If the object header was not pointing to the displaced header,
     // we do unlocking via runtime call.
     branch_optimized(Assembler::bcondNotEqual, slow_case);
-    // done
   }
+  // done
   bind(done);
 }
 

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.hpp
@@ -51,6 +51,7 @@
   // hdr     : Used to hold original markWord to be CASed back into obj, contents destroyed.
   // obj     : Must point to the object to lock, contents preserved.
   // disp_hdr: Must point to the displaced header location, contents destroyed.
+  // Z_R0_scratch will be killed as well
   void unlock_object(Register hdr, Register obj, Register lock, Label& slow_case);
 
   void initialize_object(

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -977,9 +977,10 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
 // lock object
 //
 // Registers alive
-//   monitor - Address of the BasicObjectLock to be used for locking,
+//   monitor (Z_R10) - Address of the BasicObjectLock to be used for locking,
 //             which must be initialized with the object to lock.
-//   object  - Address of the object to be locked.
+//   object  (Z_R11, Z_R2) - Address of the object to be locked.
+//  templateTable (monitorenter) is using Z_R2 for object
 void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
 
   if (LockingMode == LM_MONITOR) {
@@ -987,7 +988,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
     return;
   }
 
-  // template code:
+  // template code: (for LM_LEGACY)
   //
   // markWord displaced_header = obj->mark().set_unlocked();
   // monitor->lock()->set_displaced_header(displaced_header);
@@ -1001,68 +1002,77 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   //   InterpreterRuntime::monitorenter(THREAD, monitor);
   // }
 
-  const Register displaced_header = Z_ARG5;
+  const int hdr_offset = oopDesc::mark_offset_in_bytes();
+
+  const Register header           = Z_ARG5;
   const Register object_mark_addr = Z_ARG4;
   const Register current_header   = Z_ARG5;
+  const Register tmp              = Z_R1_scratch;
 
-  NearLabel done;
-  NearLabel slow_case;
+  NearLabel done, slow_case;
 
-  // markWord displaced_header = obj->mark().set_unlocked();
+  // markWord header = obj->mark().set_unlocked();
 
-  // Load markWord from object into displaced_header.
-  z_lg(displaced_header, oopDesc::mark_offset_in_bytes(), object);
+  // Load markWord from object into header.
+  z_lg(header, hdr_offset, object);
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
-    load_klass(Z_R1_scratch, object);
-    testbit(Address(Z_R1_scratch, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+    load_klass(tmp, object);
+    testbit(Address(tmp, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
     z_btrue(slow_case);
   }
 
-  // Set displaced_header to be (markWord of object | UNLOCK_VALUE).
-  z_oill(displaced_header, markWord::unlocked_value);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    fast_lock(object, /* mark word */ header, tmp, slow_case);
+  } else if (LockingMode == LM_LEGACY) {
 
-  // monitor->lock()->set_displaced_header(displaced_header);
+    // Set header to be (markWord of object | UNLOCK_VALUE).
+    // This will not change anything if it was unlocked before.
+    z_oill(header, markWord::unlocked_value);
 
-  // Initialize the box (Must happen before we update the object mark!).
-  z_stg(displaced_header, in_bytes(BasicObjectLock::lock_offset()) +
-                          BasicLock::displaced_header_offset_in_bytes(), monitor);
+    // monitor->lock()->set_displaced_header(displaced_header);
+    const int lock_offset = in_bytes(BasicObjectLock::lock_offset());
+    const int mark_offset = lock_offset + BasicLock::displaced_header_offset_in_bytes();
 
-  // if (Atomic::cmpxchg(/*addr*/obj->mark_addr(), /*cmp*/displaced_header, /*ex=*/monitor) == displaced_header) {
+    // Initialize the box (Must happen before we update the object mark!).
+    z_stg(header, mark_offset, monitor);
 
-  // Store stack address of the BasicObjectLock (this is monitor) into object.
-  add2reg(object_mark_addr, oopDesc::mark_offset_in_bytes(), object);
+    // if (Atomic::cmpxchg(/*addr*/obj->mark_addr(), /*cmp*/displaced_header, /*ex=*/monitor) == displaced_header) {
 
-  z_csg(displaced_header, monitor, 0, object_mark_addr);
-  assert(current_header==displaced_header, "must be same register"); // Identified two registers from z/Architecture.
+    // not necessary, use offset in instruction directly.
+    // add2reg(object_mark_addr, hdr_offset, object);
 
-  z_bre(done);
+    // Store stack address of the BasicObjectLock (this is monitor) into object.
+    z_csg(header, monitor, hdr_offset, object);
+    assert(current_header == header,
+           "must be same register"); // Identified two registers from z/Architecture.
 
-  // } else if (THREAD->is_lock_owned((address)displaced_header))
-  //   // Simple recursive case.
-  //   monitor->lock()->set_displaced_header(nullptr);
+    z_bre(done);
 
-  // We did not see an unlocked object so try the fast recursive case.
+    // } else if (THREAD->is_lock_owned((address)displaced_header))
+    //   // Simple recursive case.
+    //   monitor->lock()->set_displaced_header(nullptr);
 
-  // Check if owner is self by comparing the value in the markWord of object
-  // (current_header) with the stack pointer.
-  z_sgr(current_header, Z_SP);
+    // We did not see an unlocked object so try the fast recursive case.
 
-  assert(os::vm_page_size() > 0xfff, "page size too small - change the constant");
+    // Check if owner is self by comparing the value in the markWord of object
+    // (current_header) with the stack pointer.
+    z_sgr(current_header, Z_SP);
 
-  // The prior sequence "LGR, NGR, LTGR" can be done better
-  // (Z_R1 is temp and not used after here).
-  load_const_optimized(Z_R0, (~(os::vm_page_size()-1) | markWord::lock_mask_in_place));
-  z_ngr(Z_R0, current_header); // AND sets CC (result eq/ne 0)
+    assert(os::vm_page_size() > 0xfff, "page size too small - change the constant");
 
-  // If condition is true we are done and hence we can store 0 in the displaced
-  // header indicating it is a recursive lock and be done.
-  z_brne(slow_case);
-  z_release();  // Membar unnecessary on zarch AND because the above csg does a sync before and after.
-  z_stg(Z_R0/*==0!*/, in_bytes(BasicObjectLock::lock_offset()) +
-                      BasicLock::displaced_header_offset_in_bytes(), monitor);
+    // The prior sequence "LGR, NGR, LTGR" can be done better
+    // (Z_R1 is temp and not used after here).
+    load_const_optimized(Z_R0, (~(os::vm_page_size() - 1) | markWord::lock_mask_in_place));
+    z_ngr(Z_R0, current_header); // AND sets CC (result eq/ne 0)
+
+    // If condition is true we are done and hence we can store 0 in the displaced
+    // header indicating it is a recursive lock and be done.
+    z_brne(slow_case);
+    z_release();  // Member unnecessary on zarch AND because the above csg does a sync before and after.
+    z_stg(Z_R0/*==0!*/, mark_offset, monitor);
+  }
   z_bru(done);
-
   // } else {
   //   // Slow path.
   //   InterpreterRuntime::monitorenter(THREAD, monitor);
@@ -1070,8 +1080,16 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   // None of the above fast optimizations worked so we have to get into the
   // slow case of monitor enter.
   bind(slow_case);
-  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter), monitor);
-
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    // for fast locking we need to use monitorenter_obj, see interpreterRuntime.cpp
+    call_VM(noreg,
+            CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter_obj),
+            object);
+  } else {
+    call_VM(noreg,
+            CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter),
+            monitor);
+  }
   // }
 
   bind(done);
@@ -1092,7 +1110,7 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
   }
 
 // else {
-  // template code:
+  // template code: (for LM_LEGACY):
   //
   // if ((displaced_header = monitor->displaced_header()) == nullptr) {
   //   // Recursive unlock. Mark the monitor unlocked by setting the object field to null.
@@ -1105,10 +1123,12 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
   //   InterpreterRuntime::monitorexit(monitor);
   // }
 
-  const Register displaced_header = Z_ARG4;
-  const Register current_header   = Z_R1;
+  const int hdr_offset = oopDesc::mark_offset_in_bytes();
+
+  const Register header         = Z_ARG4;
+  const Register current_header = Z_R1_scratch;
   Address obj_entry(monitor, BasicObjectLock::obj_offset());
-  Label done;
+  Label done, slow_case;
 
   if (object == noreg) {
     // In the template interpreter, we must assure that the object
@@ -1118,35 +1138,63 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
     z_lg(object, obj_entry);
   }
 
-  assert_different_registers(monitor, object, displaced_header, current_header);
+  assert_different_registers(monitor, object, header, current_header);
 
   // if ((displaced_header = monitor->displaced_header()) == nullptr) {
   //   // Recursive unlock. Mark the monitor unlocked by setting the object field to null.
   //   monitor->set_obj(nullptr);
 
-  clear_mem(obj_entry, sizeof(oop));
+  // monitor->lock()->set_displaced_header(displaced_header);
+  const int lock_offset = in_bytes(BasicObjectLock::lock_offset());
+  const int mark_offset = lock_offset + BasicLock::displaced_header_offset_in_bytes();
 
-  // Test first if we are in the fast recursive case.
-  MacroAssembler::load_and_test_long(displaced_header,
-                                     Address(monitor, in_bytes(BasicObjectLock::lock_offset()) +
-                                                      BasicLock::displaced_header_offset_in_bytes()));
-  z_bre(done); // displaced_header == 0 -> goto done
+  clear_mem(obj_entry, sizeof(oop));
+  if (LockingMode != LM_LIGHTWEIGHT) {
+    // Test first if we are in the fast recursive case.
+    MacroAssembler::load_and_test_long(header, Address(monitor, mark_offset));
+    z_bre(done); // header == 0 -> goto done
+  }
 
   // } else if (Atomic::cmpxchg(obj->mark_addr(), monitor, displaced_header) == monitor) {
   //   // We swapped the unlocked mark in displaced_header into the object's mark word.
   //   monitor->set_obj(nullptr);
 
   // If we still have a lightweight lock, unlock the object and be done.
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    // Check for non-symmetric locking. This is allowed by the spec and the interpreter
+    // must handle it.
 
-  // The markword is expected to be at offset 0.
-  assert(oopDesc::mark_offset_in_bytes() == 0, "unlock_object: review code below");
+    Register tmp = current_header;
 
-  // We have the displaced header in displaced_header. If the lock is still
-  // lightweight, it will contain the monitor address and we'll store the
-  // displaced header back into the object's mark word.
-  z_lgr(current_header, monitor);
-  z_csg(current_header, displaced_header, 0, object);
-  z_bre(done);
+    // First check for lock-stack underflow.
+    z_lgf(tmp, Address(Z_thread, JavaThread::lock_stack_top_offset()));
+    compareU32_and_branch(tmp, (unsigned)LockStack::start_offset(), Assembler::bcondNotHigh, slow_case);
+
+    // Then check if the top of the lock-stack matches the unlocked object.
+    z_afi(tmp, -oopSize);
+    z_lg(tmp, Address(Z_thread, tmp));
+    z_cgrj(tmp, object, Assembler::bcondNotEqual, slow_case);
+
+    z_lg(header, Address(object, hdr_offset));
+    z_lgr(tmp, header);
+    z_nill(tmp, markWord::monitor_value);
+    z_brne(slow_case);
+
+    fast_unlock(object, header, tmp, slow_case);
+
+    z_bru(done);
+  } else {
+    // The markword is expected to be at offset 0.
+    // This is not required on s390, at least not here.
+    assert(hdr_offset == 0, "unlock_object: review code below");
+
+    // We have the displaced header in header. If the lock is still
+    // lightweight, it will contain the monitor address and we'll store the
+    // displaced header back into the object's mark word.
+    z_lgr(current_header, monitor);
+    z_csg(current_header, header, hdr_offset, object);
+    z_bre(done);
+  }
 
   // } else {
   //   // Slow path.
@@ -1154,6 +1202,7 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
 
   // The lock has been converted into a heavy lock and hence
   // we need to get into the slow case.
+  bind(slow_case);
   z_stg(object, obj_entry);   // Restore object entry, has been cleared above.
   call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), monitor);
 
@@ -2214,6 +2263,6 @@ void InterpreterMacroAssembler::pop_interpreter_frame(Register return_pc, Regist
 
 void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) {
   if (VerifyFPU) {
-    unimplemented("verfiyFPU");
+    unimplemented("verifyFPU");
   }
 }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3277,6 +3277,11 @@ void MacroAssembler::compiler_fast_unlock_object(Register oop, Register box, Reg
     z_bru(done); // csg sets CR as desired.
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+
+    z_lg(temp, hdr_offset, oop);
+    z_nill(temp, markWord::monitor_value);
+    z_brne(object_has_monitor);
+
     z_lg(currentHeader, hdr_offset, oop);
     fast_unlock(oop, currentHeader, temp, done);
     z_bru(done);

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3277,9 +3277,7 @@ void MacroAssembler::compiler_fast_unlock_object(Register oop, Register box, Reg
     z_bru(done); // csg sets CR as desired.
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-
     z_lg(currentHeader, hdr_offset, oop);
-
     fast_unlock(oop, currentHeader, temp, done);
     z_bru(done);
   }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -722,6 +722,8 @@ class MacroAssembler: public Assembler {
 
   void compiler_fast_lock_object(Register oop, Register box, Register temp1, Register temp2);
   void compiler_fast_unlock_object(Register oop, Register box, Register temp1, Register temp2);
+  void fast_lock(Register obj, Register hdr, Register tmp, Label& slow);
+  void fast_unlock(Register obj, Register hdr, Register tmp, Label& slow);
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1904,8 +1904,7 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
-
-#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64)
+#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64) && !defined(S390)
   if (LockingMode == LM_LIGHTWEIGHT) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
     warning("New lightweight locking not supported on this platform");


### PR DESCRIPTION
This PR implements new fast-locking scheme for s390x. Additionally few parameters have been renamed to be in sync with PPC.

Testing done:
All `test/jdk/java/util/concurrent` test with parameters:
* LockingMode=2 
* LockingMode=2 with -Xint
* LockingMode=2 with -XX:TieredStopAtLevel=1
* LockingMode=2 with -XX:-TieredCompilation

Result is consistently similar to Aarch(MacOS) and PPC, All of 124 tests are passing except `MapLoops.java` because in the 2nd part for this testcase, jvm is started with `HeavyMonitors` which conflict with `LockingMode=2`

**Review & Comments are Most Welcomed**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308479](https://bugs.openjdk.org/browse/JDK-8308479): [s390x] Implement alternative fast-locking scheme (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14174/head:pull/14174` \
`$ git checkout pull/14174`

Update a local copy of the PR: \
`$ git checkout pull/14174` \
`$ git pull https://git.openjdk.org/jdk.git pull/14174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14174`

View PR using the GUI difftool: \
`$ git pr show -t 14174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14174.diff">https://git.openjdk.org/jdk/pull/14174.diff</a>

</details>
