### PR TITLE
8308948: Remove unimplemented ThreadLocalAllocBuffer::reset

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
@@ -87,9 +87,6 @@ private:
 
   size_t remaining();
 
-  // Make parsable and release it.
-  void reset();
-
   void invariants() const { assert(top() >= start() && top() <= end(), "invalid tlab"); }
 
   void initialize(HeapWord* start, HeapWord* top, HeapWord* end);


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308948](https://bugs.openjdk.org/browse/JDK-8308948): Remove unimplemented ThreadLocalAllocBuffer::reset


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14175/head:pull/14175` \
`$ git checkout pull/14175`

Update a local copy of the PR: \
`$ git checkout pull/14175` \
`$ git pull https://git.openjdk.org/jdk.git pull/14175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14175`

View PR using the GUI difftool: \
`$ git pr show -t 14175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14175.diff">https://git.openjdk.org/jdk/pull/14175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14175#issuecomment-1564267129)