### PR TITLE
8308943: jdk.internal.le build fails on AIX

### DIFF
--- a/src/jdk.internal.le/linux/classes/jdk/internal/org/jline/terminal/impl/jna/linux/LinuxJnaNativePtyProvider.java
+++ b/src/jdk.internal.le/linux/classes/jdk/internal/org/jline/terminal/impl/jna/linux/LinuxJnaNativePtyProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.org.jline.terminal.impl.jna.linux;
+
+import java.io.IOException;
+import jdk.internal.org.jline.terminal.Attributes;
+import jdk.internal.org.jline.terminal.Size;
+import jdk.internal.org.jline.terminal.impl.jna.JnaNativePty;
+import jdk.internal.org.jline.terminal.impl.jna.JnaNativePtyProvider;
+import jdk.internal.org.jline.terminal.spi.TerminalProvider;
+
+public class LinuxJnaNativePtyProvider implements JnaNativePtyProvider {
+
+    public LinuxJnaNativePtyProvider() {}
+
+    public JnaNativePty current(TerminalProvider.Stream console) throws IOException {
+        return LinuxNativePty.current(console);
+    }
+
+    public JnaNativePty open(Attributes attr, Size size) throws IOException {
+        return LinuxNativePty.open(attr, size);
+    }
+
+    public int isatty(int fd) {
+        return LinuxNativePty.isatty(fd);
+    }
+
+    public String ttyname(int fd) {
+        return LinuxNativePty.ttyname(fd);
+    }
+
+}

--- a/src/jdk.internal.le/linux/classes/module-info.java.extra
+++ b/src/jdk.internal.le/linux/classes/module-info.java.extra
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+uses jdk.internal.org.jline.terminal.impl.jna.JnaNativePtyProvider;
+provides jdk.internal.org.jline.terminal.impl.jna.JnaNativePtyProvider with
+        jdk.internal.org.jline.terminal.impl.jna.linux.LinuxJnaNativePtyProvider;

--- a/src/jdk.internal.le/macosx/classes/jdk/internal/org/jline/terminal/impl/jna/osx/OsXJnaNativePtyProvider.java
+++ b/src/jdk.internal.le/macosx/classes/jdk/internal/org/jline/terminal/impl/jna/osx/OsXJnaNativePtyProvider.java
@@ -22,29 +22,32 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.internal.org.jline.terminal.impl.jna;
+package jdk.internal.org.jline.terminal.impl.jna.osx;
 
 import java.io.IOException;
 import jdk.internal.org.jline.terminal.Attributes;
 import jdk.internal.org.jline.terminal.Size;
-import jdk.internal.org.jline.terminal.impl.jna.osx.OsXNativePty;
+import jdk.internal.org.jline.terminal.impl.jna.JnaNativePty;
+import jdk.internal.org.jline.terminal.impl.jna.JnaNativePtyProvider;
 import jdk.internal.org.jline.terminal.spi.TerminalProvider;
 
-class JDKNativePty {
+public class OsXJnaNativePtyProvider implements JnaNativePtyProvider {
 
-    static JnaNativePty current(TerminalProvider.Stream console) throws IOException {
+    public OsXJnaNativePtyProvider() {}
+
+    public JnaNativePty current(TerminalProvider.Stream console) throws IOException {
         return OsXNativePty.current(console);
     }
 
-    static JnaNativePty open(Attributes attr, Size size) throws IOException {
+    public JnaNativePty open(Attributes attr, Size size) throws IOException {
         return OsXNativePty.open(attr, size);
     }
 
-    static int isatty(int fd) {
+    public int isatty(int fd) {
         return OsXNativePty.isatty(fd);
     }
 
-    static String ttyname(int fd) {
+    public String ttyname(int fd) {
         return OsXNativePty.ttyname(fd);
     }
 

--- a/src/jdk.internal.le/macosx/classes/module-info.java.extra
+++ b/src/jdk.internal.le/macosx/classes/module-info.java.extra
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+uses jdk.internal.org.jline.terminal.impl.jna.JnaNativePtyProvider;
+provides jdk.internal.org.jline.terminal.impl.jna.JnaNativePtyProvider with
+        jdk.internal.org.jline.terminal.impl.jna.osx.OsXJnaNativePtyProvider;

--- a/src/jdk.internal.le/unix/classes/jdk/internal/org/jline/terminal/impl/jna/JnaNativePty.java
+++ b/src/jdk.internal.le/unix/classes/jdk/internal/org/jline/terminal/impl/jna/JnaNativePty.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
+import java.util.ServiceLoader;
 
 //import com.sun.jna.Platform;
 import jdk.internal.org.jline.terminal.Attributes;
@@ -52,7 +53,7 @@ public abstract class JnaNativePty extends AbstractPty implements Pty {
 //        } else {
 //            throw new UnsupportedOperationException();
 //        }
-        return JDKNativePty.current(console);
+        return getProvider().current(console);
     }
 
     public static JnaNativePty open(Attributes attr, Size size) throws IOException {
@@ -67,7 +68,7 @@ public abstract class JnaNativePty extends AbstractPty implements Pty {
 //        } else {
 //            throw new UnsupportedOperationException();
 //        }
-        return JDKNativePty.open(attr, size);
+        return getProvider().open(attr, size);
     }
 
     protected JnaNativePty(int master, FileDescriptor masterFD, int slave, FileDescriptor slaveFD, String name) {
@@ -183,7 +184,7 @@ public abstract class JnaNativePty extends AbstractPty implements Pty {
 //        } else {
 //            return false;
 //        }
-        return JDKNativePty.isatty(fd) == 1;
+        return getProvider().isatty(fd) == 1;
     }
 
     private static String ttyname(int fd) {
@@ -198,7 +199,15 @@ public abstract class JnaNativePty extends AbstractPty implements Pty {
 //        } else {
 //            return null;
 //        }
-        return JDKNativePty.ttyname(fd);
+        return getProvider().ttyname(fd);
     }
 
+    private static JnaNativePtyProvider getProvider() {
+        for (JnaNativePtyProvider p :
+                ServiceLoader.load(JnaNativePtyProvider.class, JnaNativePty.class.getClassLoader())) {
+            return p;
+        }
+
+        throw new UnsupportedOperationException("No JnaNativePtyProvider found!");
+    }
 }

--- a/src/jdk.internal.le/unix/classes/jdk/internal/org/jline/terminal/impl/jna/JnaNativePtyProvider.java
+++ b/src/jdk.internal.le/unix/classes/jdk/internal/org/jline/terminal/impl/jna/JnaNativePtyProvider.java
@@ -27,25 +27,16 @@ package jdk.internal.org.jline.terminal.impl.jna;
 import java.io.IOException;
 import jdk.internal.org.jline.terminal.Attributes;
 import jdk.internal.org.jline.terminal.Size;
-import jdk.internal.org.jline.terminal.impl.jna.linux.LinuxNativePty;
 import jdk.internal.org.jline.terminal.spi.TerminalProvider;
 
-class JDKNativePty {
+public interface JnaNativePtyProvider {
 
-    static JnaNativePty current(TerminalProvider.Stream console) throws IOException {
-        return LinuxNativePty.current(console);
-    }
+    public JnaNativePty current(TerminalProvider.Stream console) throws IOException;
 
-    static JnaNativePty open(Attributes attr, Size size) throws IOException {
-        return LinuxNativePty.open(attr, size);
-    }
+    public JnaNativePty open(Attributes attr, Size size) throws IOException;
 
-    static int isatty(int fd) {
-        return LinuxNativePty.isatty(fd);
-    }
+    public int isatty(int fd);
 
-    static String ttyname(int fd) {
-        return LinuxNativePty.ttyname(fd);
-    }
+    public String ttyname(int fd);
 
 }


### PR DESCRIPTION
Build of `jdk.internal.le` fails on AIX, because code in the `unix` directory expects `jdk.internal.org.jline.terminal.impl.jna.JDKNativePty` for each platform (unix-like), but it does not for AIX.

We could add a stub of this class into the `aix` directory (methods could throw an exception, which would automatically switch JLine into the "external executable" mode, if enabled). But, it might be better to use the `ServiceLoader`, and simply register a platform-specific provider as a service. This patch is attempting to do the latter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308943](https://bugs.openjdk.org/browse/JDK-8308943): jdk.internal.le build fails on AIX


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14176/head:pull/14176` \
`$ git checkout pull/14176`

Update a local copy of the PR: \
`$ git checkout pull/14176` \
`$ git pull https://git.openjdk.org/jdk.git pull/14176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14176`

View PR using the GUI difftool: \
`$ git pr show -t 14176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14176.diff">https://git.openjdk.org/jdk/pull/14176.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14176#issuecomment-1564280643)