### PR TITLE
8308336: Test java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java failed: java.net.BindException: Address already in use

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -73,7 +73,7 @@ public class HttpURLConnectionExpectContinueTest {
 
         control.serverSocket = new ServerSocket();
         control.serverSocket.setReuseAddress(true);
-        control.serverSocket.bind(new InetSocketAddress("127.0.0.1", 54321));
+        control.serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
         Runnable runnable = () -> {
             while (!control.stop) {
                 try {

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -425,7 +425,7 @@ public class HttpURLConnectionExpectContinueTest {
     private HttpURLConnection createConnection() throws Exception {
         URL url = URIBuilder.newBuilder()
                 .scheme("http")
-                .host(InetAddress.getLoopbackAddress())
+                .loopback()
                 .port(control.serverSocket.getLocalPort())
                 .toURL();
 

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -27,8 +27,8 @@
  * @summary Verify that expect 100-continue doesn't hang
  * @library /test/lib
  * @run junit/othervm HttpURLConnectionExpectContinueTest
- * @run junit/othervm -Djava.net.preferIPv4Stack=True HttpURLConnectionExpectContinueTest
- * @run junit/othervm -Djava.net.preferIPv6Addresses=True HttpURLConnectionExpectContinueTest
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true HttpURLConnectionExpectContinueTest
+ * @run junit/othervm -Djava.net.preferIPv6Addresses=true HttpURLConnectionExpectContinueTest
  */
 
 import jdk.test.lib.net.URIBuilder;

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -27,8 +27,11 @@
  * @summary Verify that expect 100-continue doesn't hang
  * @library /test/lib
  * @run junit/othervm HttpURLConnectionExpectContinueTest
+ * @run junit/othervm -Djava.net.preferIPv4Stack=True HttpURLConnectionExpectContinueTest
+ * @run junit/othervm -Djava.net.preferIPv6Addresses=True HttpURLConnectionExpectContinueTest
  */
 
+import jdk.test.lib.net.URIBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -73,7 +76,7 @@ public class HttpURLConnectionExpectContinueTest {
 
         control.serverSocket = new ServerSocket();
         control.serverSocket.setReuseAddress(true);
-        control.serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
+        control.serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         Runnable runnable = () -> {
             while (!control.stop) {
                 try {
@@ -419,8 +422,12 @@ public class HttpURLConnectionExpectContinueTest {
     }
 
     // Creates a connection with all the common settings used in each test
-    private HttpURLConnection createConnection() throws IOException {
-        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+    private HttpURLConnection createConnection() throws Exception {
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .host(InetAddress.getLoopbackAddress())
+                .port(control.serverSocket.getLocalPort())
+                .toURL();
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoOutput(true);


### PR DESCRIPTION
`HttpURLConnectionExpectContinueTest` was throwing an error due to port being hardcoded, updated test to let the system decide which port to use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308336](https://bugs.openjdk.org/browse/JDK-8308336): Test java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java failed: java.net.BindException: Address already in use (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14177/head:pull/14177` \
`$ git checkout pull/14177`

Update a local copy of the PR: \
`$ git checkout pull/14177` \
`$ git pull https://git.openjdk.org/jdk.git pull/14177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14177`

View PR using the GUI difftool: \
`$ git pr show -t 14177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14177.diff">https://git.openjdk.org/jdk/pull/14177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14177#issuecomment-1564365957)