### PR TITLE
8308749: C2 failed: regular loops only (counted loop inside infinite loop)

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1745,6 +1745,21 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
   // =================================================
   // ---- SUCCESS!   Found A Trip-Counted Loop!  -----
   //
+
+  if (x->Opcode() == Op_Region) {
+    // x has not yet been transformed to Loop or LongCountedLoop.
+    // This should only happen if we are inside an infinite loop.
+    // It happens like this:
+    //   build_loop_tree -> do not attach infinite loop and nested loops
+    //   beautify_loops  -> does not transform the infinite and nested loops to LoopNode, because not attached yet
+    //   build_loop_tree -> find and attach infinite and nested loops
+    //   counted_loop    -> nested Regions are not yet transformed to LoopNodes, we land here
+    assert(x->as_Region()->is_in_infinite_subgraph(),
+           "x can only be a Region and not Loop if inside infinite loop");
+    // Come back later when Region is transformed to LoopNode
+    return false;
+  }
+
   assert(x->Opcode() == Op_Loop || x->Opcode() == Op_LongCountedLoop, "regular loops only");
   C->print_method(PHASE_BEFORE_CLOOPS, 3);
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopInsideInfiniteLoop.jasm
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopInsideInfiniteLoop.jasm
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class TestCountedLoopInsideInfiniteLoop
+{
+    public Method "<init>":"()V"
+    stack 2 locals 1
+    {
+        aload_0;
+        invokespecial  Method java/lang/Object."<init>":"()V";
+        return;
+    }
+    static Method test:"(IIII)V"
+    stack 200 locals 4
+    {
+        iload      0; // arg0 == 0
+        ifeq LEND;
+
+    LOOP1: // counted loop to kick off beautify_loops
+        iload      1;
+        ifeq LOOP1;
+        iload      2;
+        ifle LOOP1;
+
+    LOOP2: // infinite loop (still Region)
+        goto LOOP2b;
+
+    LOOP2b: // counted loop (still Region)
+        iinc       3, -1;
+        iload      3;
+        ifgt LOOP2b;
+
+        iconst_0;
+        ifeq LOOP2; // always true
+        goto LOOP2b;
+
+    LEND:
+        return;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopInsideInfiniteLoopMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopInsideInfiniteLoopMain.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308749
+ * @compile TestCountedLoopInsideInfiniteLoop.jasm
+ * @summary Counted Loops inside infinite loops are only detected later,
+ *          and may still be a Region and not a LoopNode as expected.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:PerMethodTrapLimit=0
+ *      -XX:CompileCommand=compileonly,TestCountedLoopInsideInfiniteLoop::test
+ *      TestCountedLoopInsideInfiniteLoopMain
+ */
+
+public class TestCountedLoopInsideInfiniteLoopMain {
+    public static void main (String[] args) {
+        TestCountedLoopInsideInfiniteLoop.test(0, 0, 0, 0);
+    }
+}


### PR DESCRIPTION
I found this failure with my jasm fuzzer. Have not tried to reproduce it with plain java.

I added the code above the assert, the comments explain why:

https://github.com/openjdk/jdk/blob/1fd6699e44f8caea9a1c7a8b1e946b2d1ebc0f82/src/hotspot/share/opto/loopnode.cpp#L1749-L1763

Here the graph just before the assert:
![image](https://github.com/openjdk/jdk/assets/32593061/7f11875d-49fb-49df-a3d8-6d4102711b01)

`120 Loop` -> need it to kick of `beautify_loop` and a second `build_loop_tree`
`71 Region` -> inifinite loop, `NeverBranch` is inserted on first `build_loop_tree` pass. Only attached to loop tree after second `build_loop_tree`.
`x = 81 Region` -> looks like a counted loop, but is only attached to the loop tree after `beautify_loop` in the second `build_loop_tree`.

Testing up to tier6 and stress testing. Passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308749](https://bugs.openjdk.org/browse/JDK-8308749): C2 failed: regular loops only (counted loop inside infinite loop) (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14178/head:pull/14178` \
`$ git checkout pull/14178`

Update a local copy of the PR: \
`$ git checkout pull/14178` \
`$ git pull https://git.openjdk.org/jdk.git pull/14178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14178`

View PR using the GUI difftool: \
`$ git pr show -t 14178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14178.diff">https://git.openjdk.org/jdk/pull/14178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14178#issuecomment-1567943807)