### PR TITLE
JDK-8286470: Support searching for sections in class/package javadoc

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -908,62 +908,66 @@ public class TagletWriterImpl extends TagletWriter {
             HtmlId id = HtmlIds.forText(tagText, htmlWriter.indexAnchorTable);
             result = HtmlTree.SPAN(id, HtmlStyle.searchTagResult, tagContent);
             if (options.createIndex() && !tagText.isEmpty()) {
-                String holder = new SimpleElementVisitor14<String, Void>() {
-
-                    @Override
-                    public String visitModule(ModuleElement e, Void p) {
-                        return resources.getText("doclet.module")
-                                + " " + utils.getFullyQualifiedName(e);
-                    }
-
-                    @Override
-                    public String visitPackage(PackageElement e, Void p) {
-                        return resources.getText("doclet.package")
-                                + " " + utils.getFullyQualifiedName(e);
-                    }
-
-                    @Override
-                    public String visitType(TypeElement e, Void p) {
-                        return utils.getTypeElementKindName(e, true)
-                                + " " + utils.getFullyQualifiedName(e);
-                    }
-
-                    @Override
-                    public String visitExecutable(ExecutableElement e, Void p) {
-                        return utils.getFullyQualifiedName(utils.getEnclosingTypeElement(e))
-                                + "." + utils.getSimpleName(e)
-                                + utils.flatSignature(e, htmlWriter.getCurrentPageElement());
-                    }
-
-                    @Override
-                    public String visitVariable(VariableElement e, Void p) {
-                        return utils.getFullyQualifiedName(utils.getEnclosingTypeElement(e))
-                                + "." + utils.getSimpleName(e);
-                    }
-
-                    @Override
-                    public String visitUnknown(Element e, Void p) {
-                        if (e instanceof DocletElement de) {
-                            return switch (de.getSubKind()) {
-                                case OVERVIEW -> resources.getText("doclet.Overview");
-                                case DOCFILE -> getHolderName(de);
-                            };
-                        } else {
-                            return super.visitUnknown(e, p);
-                        }
-                    }
-
-                    @Override
-                    protected String defaultAction(Element e, Void p) {
-                        return utils.getFullyQualifiedName(e);
-                    }
-                }.visit(element);
+                String holder = getHolderName(element);
                 IndexItem item = IndexItem.of(element, tree, tagText, holder, desc,
                         new DocLink(htmlWriter.path, id.name()));
                 configuration.mainIndex.add(item);
             }
         }
         return result;
+    }
+
+    String getHolderName(Element element) {
+        return new SimpleElementVisitor14<String, Void>() {
+
+            @Override
+            public String visitModule(ModuleElement e, Void p) {
+                return resources.getText("doclet.module")
+                        + " " + utils.getFullyQualifiedName(e);
+            }
+
+            @Override
+            public String visitPackage(PackageElement e, Void p) {
+                return resources.getText("doclet.package")
+                        + " " + utils.getFullyQualifiedName(e);
+            }
+
+            @Override
+            public String visitType(TypeElement e, Void p) {
+                return utils.getTypeElementKindName(e, true)
+                        + " " + utils.getFullyQualifiedName(e);
+            }
+
+            @Override
+            public String visitExecutable(ExecutableElement e, Void p) {
+                return utils.getFullyQualifiedName(utils.getEnclosingTypeElement(e))
+                        + "." + utils.getSimpleName(e)
+                        + utils.flatSignature(e, htmlWriter.getCurrentPageElement());
+            }
+
+            @Override
+            public String visitVariable(VariableElement e, Void p) {
+                return utils.getFullyQualifiedName(utils.getEnclosingTypeElement(e))
+                        + "." + utils.getSimpleName(e);
+            }
+
+            @Override
+            public String visitUnknown(Element e, Void p) {
+                if (e instanceof DocletElement de) {
+                    return switch (de.getSubKind()) {
+                        case OVERVIEW -> resources.getText("doclet.Overview");
+                        case DOCFILE -> getHolderName(de);
+                    };
+                } else {
+                    return super.visitUnknown(e, p);
+                }
+            }
+
+            @Override
+            protected String defaultAction(Element e, Void p) {
+                return utils.getFullyQualifiedName(e);
+            }
+        }.visit(element);
     }
 
     private String getHolderName(DocletElement de) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -166,6 +166,7 @@ doclet.Enclosing_Class=Enclosing class:
 doclet.Enclosing_Interface=Enclosing interface:
 doclet.Inheritance_Tree=Inheritance Tree
 doclet.ReferencedIn=Referenced In
+doclet.Section=Section
 doclet.External_Specification=External Specification
 doclet.External_Specifications=External Specifications
 doclet.External_Specifications.All_Specifications=All Specifications

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -209,7 +209,7 @@ public class IndexItem {
         Objects.requireNonNull(link);
 
         switch (docTree.getKind()) {
-            case INDEX, SPEC, SYSTEM_PROPERTY -> { }
+            case INDEX, SPEC, SYSTEM_PROPERTY, START_ELEMENT -> { }
             default -> throw new IllegalArgumentException(docTree.getKind().toString());
         }
 
@@ -340,7 +340,7 @@ public class IndexItem {
 
     protected Category getCategory(DocTree docTree) {
         return switch (docTree.getKind()) {
-            case INDEX, SPEC, SYSTEM_PROPERTY -> Category.TAGS;
+            case INDEX, SPEC, SYSTEM_PROPERTY, START_ELEMENT -> Category.TAGS;
             default -> throw new IllegalArgumentException(docTree.getKind().toString());
         };
     }

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8289332
+ * @bug 8289332 8286470
  * @summary Auto-generate ids for user-defined headings
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -79,6 +79,10 @@ public class TestAutoHeaderId extends JavadocTester {
                          *
                          * <h4></h4>
                          *
+                         * <h2>  Multi-line
+                         *       heading   with extra
+                         *                 whitespace</h2>
+                         *
                          * Last sentence.
                          */
                         public class C {
@@ -121,6 +125,32 @@ public class TestAutoHeaderId extends JavadocTester {
                     """,
                 """
                     <h4 id="-heading"></h4>
-                    """);
+                    """,
+                """
+                    <h2 id="multi-line-heading-with-extra-whitespace-heading">  Multi-line
+                           heading   with extra
+                                     whitespace</h2>""");
+        checkOutput("tag-search-index.js", true,
+                """
+                    {"l":"Duplicate Text","h":"class p.C","d":"Section","u":"p/C.html#duplicate-text-heading"}""",
+                """
+                    {"l":"Duplicate Text","h":"class p.C","d":"Section","u":"p/C.html#duplicate-text-heading1"}""",
+                """
+                    {"l":"Embedded A-Tag with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-2"}""",
+                """
+                    {"l":"Embedded Code Tag","h":"class p.C","d":"Section","u":"p/C.html#embedded-code-tag-heading"}""",
+                """
+                    {"l":"Embedded Link Tag","h":"class p.C","d":"Section","u":"p/C.html#embedded-link-tag-heading"}""",
+                """
+                    {"l":"Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#extra-chars-heading"}""",
+                """
+                    {"l":"First Header","h":"class p.C","d":"Section","u":"p/C.html#first-header-heading"}""",
+                """
+                    {"l":"Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
+                """
+                    {"l":"Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
+                    #multi-line-heading-with-extra-whitespace-heading"}""",
+                """
+                    {"l":"Other attributes","h":"class p.C","d":"Section","u":"p/C.html#other-attributes-heading"}""");
     }
 }


### PR DESCRIPTION
Please review a change to generate search index entries for all HTML headings in the documentation comments and auxiliary files. The change is relatively straightforward, new code replaces and complements the code to generate `id` attributes for all headings.

JDK API docs generated with this change are available here: https://cr.openjdk.org/~hannesw/8286470/api.00/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286470](https://bugs.openjdk.org/browse/JDK-8286470): Support searching for sections in class/package javadoc


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14179/head:pull/14179` \
`$ git checkout pull/14179`

Update a local copy of the PR: \
`$ git checkout pull/14179` \
`$ git pull https://git.openjdk.org/jdk.git pull/14179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14179`

View PR using the GUI difftool: \
`$ git pr show -t 14179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14179.diff">https://git.openjdk.org/jdk/pull/14179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14179#issuecomment-1564501244)