### PR TITLE
8308969: make test-prebuilt doesn't return the correct exit code

### DIFF
--- a/make/Global.gmk
+++ b/make/Global.gmk
@@ -132,7 +132,6 @@ test-prebuilt-with-exit-code:
 
 # Alias for backwards compatibility
 run-test-prebuilt: test-prebuilt
-run-test-prebuilt-with-exit-code: test-prebuilt-with-exit-code
 
 ALL_GLOBAL_TARGETS := help print-configurations test-prebuilt run-test-prebuilt
 

--- a/make/Global.gmk
+++ b/make/Global.gmk
@@ -125,8 +125,14 @@ test-prebuilt:
 	    $(MAKE) --no-print-directory -r -R -I make/common/ -f make/RunTestsPrebuilt.gmk \
 	    test-prebuilt CUSTOM_MAKE_DIR=$(CUSTOM_MAKE_DIR) TEST="$(TEST)" )
 
+test-prebuilt-with-exit-code:
+	@( cd $(topdir) && \
+	    $(MAKE) --no-print-directory -r -R -I make/common/ -f make/RunTestsPrebuilt.gmk \
+	    test-prebuilt-with-exit-code CUSTOM_MAKE_DIR=$(CUSTOM_MAKE_DIR) TEST="$(TEST)" )
+
 # Alias for backwards compatibility
 run-test-prebuilt: test-prebuilt
+run-test-prebuilt-with-exit-code: test-prebuilt-with-exit-code
 
 ALL_GLOBAL_TARGETS := help print-configurations test-prebuilt run-test-prebuilt
 

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -294,6 +294,9 @@ test-prebuilt:
 	    SPEC=$(SPEC) FINDTESTS_STAND_ALONE=true
 	@cd $(TOPDIR) && $(MAKE) $(MAKE_ARGS) -f make/RunTests.gmk run-test \
 	    TEST="$(TEST)"
+	@if test -f $(MAKESUPPORT_OUTPUTDIR)/exit-with-error ; then \
+	  exit 1 ; \
+	fi
 
 all: test-prebuilt
 

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -294,6 +294,8 @@ test-prebuilt:
 	    SPEC=$(SPEC) FINDTESTS_STAND_ALONE=true
 	@cd $(TOPDIR) && $(MAKE) $(MAKE_ARGS) -f make/RunTests.gmk run-test \
 	    TEST="$(TEST)"
+
+test-prebuilt-with-exit-code: test-prebuilt
 	@if test -f $(MAKESUPPORT_OUTPUTDIR)/exit-with-error ; then \
 	  exit 1 ; \
 	fi


### PR DESCRIPTION
For 'make' test and 'make test-only' the existence of exit-with-error is checked in the main target in Init.gmk. Is there a better way to fix this than to check for the existence of exit-with-error in RunTestsPrebuilt.gmk?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308969](https://bugs.openjdk.org/browse/JDK-8308969): make test-prebuilt doesn't return the correct exit code


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14183/head:pull/14183` \
`$ git checkout pull/14183`

Update a local copy of the PR: \
`$ git checkout pull/14183` \
`$ git pull https://git.openjdk.org/jdk.git pull/14183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14183`

View PR using the GUI difftool: \
`$ git pr show -t 14183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14183.diff">https://git.openjdk.org/jdk/pull/14183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14183#issuecomment-1564624017)