### PR TITLE
XYZ: Fix typo in MethodHandles Javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -6484,7 +6484,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * <a id="effid"></a>
      * A parameter list {@code A} is defined to be <em>effectively identical</em> to another parameter list {@code B}
      * if {@code A} and {@code B} are identical, or if {@code A} is shorter and is identical with a proper prefix of {@code B}.
-     * When speaking of an unordered set of parameter lists, we say they the set is "effectively identical"
+     * When speaking of an unordered set of parameter lists, we say that the set is "effectively identical"
      * as a whole if the set contains a longest list, and all members of the set are effectively identical to
      * that longest list.
      * For example, any set of type sequences of the form {@code (V*)} is effectively identical,


### PR DESCRIPTION
Fix a simple typo in the MethodHandles Javadoc related to effectively identical sequences.
First PR to the openjdk; if I understand the docs correctly, someone has to create a JBS entry for this and sponsor this, right?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14184/head:pull/14184` \
`$ git checkout pull/14184`

Update a local copy of the PR: \
`$ git checkout pull/14184` \
`$ git pull https://git.openjdk.org/jdk.git pull/14184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14184`

View PR using the GUI difftool: \
`$ git pr show -t 14184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14184.diff">https://git.openjdk.org/jdk/pull/14184.diff</a>

</details>
