### PR TITLE
8306688: Support Windows serialized keystores (SST files)

### DIFF
--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
@@ -56,6 +56,13 @@ abstract class CKeyStore extends KeyStoreSpi {
 
     private static final int LOCATION_CURRENTUSER = 0;
     private static final int LOCATION_LOCALMACHINE = 1;
+    private static final int LOCATION_SST = 2;
+
+    public static final class SST extends CKeyStore {
+        public SST() {
+            super("SST", LOCATION_SST);
+        }
+    }
 
     public static final class MY extends CKeyStore {
         public MY() {
@@ -702,8 +709,12 @@ abstract class CKeyStore extends KeyStoreSpi {
      */
     public void engineLoad(InputStream stream, char[] password)
             throws IOException, NoSuchAlgorithmException, CertificateException {
-        if (stream != null && !keyStoreCompatibilityMode) {
+        if (stream != null && !getRequiresKeyStoreFromStream() && !keyStoreCompatibilityMode) {
             throw new IOException("Keystore input stream must be null");
+        }
+        else if (stream == null && getRequiresKeyStoreFromStream())
+        {
+            throw new IOException("Keystore input stream cannot be null");
         }
 
         if (password != null && !keyStoreCompatibilityMode) {
@@ -725,8 +736,15 @@ abstract class CKeyStore extends KeyStoreSpi {
 
         try {
 
-            // Load keys and/or certificate chains
-            loadKeysOrCertificateChains(getName(), getLocation());
+            if (stream != null && getRequiresKeyStoreFromStream()) {
+                // Load keys and/or certificate chains from input stream
+                byte[] blob = stream.readAllBytes();
+                loadKeysOrCertificateChainsFromMemory(blob, blob.length);
+            }
+            else {
+                // Load keys and/or certificate chains
+                loadKeysOrCertificateChains(getName(), getLocation());
+            }
 
         } catch (KeyStoreException e) {
             throw new IOException(e);
@@ -857,6 +875,13 @@ abstract class CKeyStore extends KeyStoreSpi {
     }
 
     /**
+     * Returns whether the keystore comes from a stream.
+     */
+    private boolean getRequiresKeyStoreFromStream() {
+        return storeLocation == LOCATION_SST;
+    }
+
+    /**
      * Loads keys and/or certificates from keystore into Collection.
      *
      * @param name Name of keystore.
@@ -864,6 +889,15 @@ abstract class CKeyStore extends KeyStoreSpi {
      */
     private native void loadKeysOrCertificateChains(String name,
             int location) throws KeyStoreException;
+
+    /**
+     * Load keys and/or certificates from inmemory keystore into Collection.
+     *
+     * @param keystoreBlob In memory keystore.
+     * @param keystoreBlobSize Size in bytes of in memory keystore
+     */
+    private native void loadKeysOrCertificateChainsFromMemory(byte[] keystoreBlob, 
+            int keystoreBlobSize) throws KeyStoreException;
 
     /**
      * Stores a DER-encoded certificate into the certificate store

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
@@ -896,7 +896,7 @@ abstract class CKeyStore extends KeyStoreSpi {
      * @param keystoreBlob In memory keystore.
      * @param keystoreBlobSize Size in bytes of in memory keystore
      */
-    private native void loadKeysOrCertificateChainsFromMemory(byte[] keystoreBlob, 
+    private native void loadKeysOrCertificateChainsFromMemory(byte[] keystoreBlob,
             int keystoreBlobSize) throws KeyStoreException;
 
     /**

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
@@ -99,6 +99,8 @@ public final class SunMSCAPI extends Provider {
                         return new CKeyStore.MYLocalMachine();
                     } else if (algo.equals("Windows-ROOT-LOCALMACHINE")) {
                         return new CKeyStore.ROOTLocalMachine();
+                    } else if (algo.equals("Windows-SST")) {
+                        return new CKeyStore.SST();
                     }
                 } else if (type.equals("Signature")) {
                     if (algo.equals("NONEwithRSA")) {
@@ -167,6 +169,15 @@ public final class SunMSCAPI extends Provider {
                 /*
                  * Key store
                  */
+
+                // experimental for now; especially as JCK expects all keystores to
+                // load without a file, but the SST keystore MUST have a file
+                String prop = System.getProperty("sun.security.mscapi.keyStoreSSTSupport");
+                if ("true".equals(prop)) {
+                    putService(new ProviderService(p, "KeyStore",
+                               "Windows-SST", "sun.security.mscapi.CKeyStore$SST"));
+                }
+
                 putService(new ProviderService(p, "KeyStore",
                            "Windows-MY", "sun.security.mscapi.CKeyStore$MY"));
                 putService(new ProviderService(p, "KeyStore",


### PR DESCRIPTION
Added ability to load keystores from SST files on Windows.  Example usage:

KeyStore keyStore = KeyStore.getInstance("Windows-SST");
try (FileInputStream fis = new FileInputStream("mykeystore.sst")) {
   keyStore.load(fis, null);
}

Note that its not limited to file streams, it can be any stream.

The feature is behind a runtime flag ("sun.security.mscapi.keyStoreSSTSupport") as the KeyStore must have an input stream, but the JCK tests assume an input stream is optional

tier1 tests for linux/macos/Windows for x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Issue
 * [JDK-8306688](https://bugs.openjdk.org/browse/JDK-8306688): Support Windows serialized keystores (SST files) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14187/head:pull/14187` \
`$ git checkout pull/14187`

Update a local copy of the PR: \
`$ git checkout pull/14187` \
`$ git pull https://git.openjdk.org/jdk.git pull/14187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14187`

View PR using the GUI difftool: \
`$ git pr show -t 14187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14187.diff">https://git.openjdk.org/jdk/pull/14187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14187#issuecomment-1564973973)