### PR TITLE
8308975: Fix signed integer overflow in compiler code, part 2

### DIFF
--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -169,16 +169,16 @@ int CPUPerformanceInterface::CPUPerformance::cpu_loads_process(double* pjvmUserL
   if (_total_cpu_nanos == 0 || active_processor_count != _active_processor_count) {
     // First call or change in active processor count
     result = OS_ERR;
-  }
+  } else {
+    long delta_nanos = active_processor_count * (total_cpu_nanos - _total_cpu_nanos);
+    if (delta_nanos == 0) {
+      // Avoid division by zero
+      return OS_ERR;
+    }
 
-  long delta_nanos = active_processor_count * (total_cpu_nanos - _total_cpu_nanos);
-  if (delta_nanos == 0) {
-    // Avoid division by zero
-    return OS_ERR;
+    *pjvmUserLoad = normalize((double)(jvm_user_nanos - _jvm_user_nanos)/delta_nanos);
+    *pjvmKernelLoad = normalize((double)(jvm_system_nanos - _jvm_system_nanos)/delta_nanos);
   }
-
-  *pjvmUserLoad = normalize((double)(jvm_user_nanos - _jvm_user_nanos)/delta_nanos);
-  *pjvmKernelLoad = normalize((double)(jvm_system_nanos - _jvm_system_nanos)/delta_nanos);
 
   _active_processor_count = active_processor_count;
   _total_cpu_nanos = total_cpu_nanos;

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -123,9 +123,9 @@ void Canonicalizer::do_Op2(Op2* x) {
         { jlong a = x->x()->type()->as_LongConstant()->value();
           jlong b = x->y()->type()->as_LongConstant()->value();
           switch (x->op()) {
-            case Bytecodes::_ladd: set_constant(a + b); return;
-            case Bytecodes::_lsub: set_constant(a - b); return;
-            case Bytecodes::_lmul: set_constant(a * b); return;
+            case Bytecodes::_ladd: set_constant(java_add(a, b)); return;
+            case Bytecodes::_lsub: set_constant(java_subtract(a, b)); return;
+            case Bytecodes::_lmul: set_constant(java_multiply(a, b)); return;
             case Bytecodes::_ldiv:
               if (b != 0) {
                 set_constant(SharedRuntime::ldiv(b, a));

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2245,10 +2245,11 @@ SwitchRangeArray* LIRGenerator::create_lookup_ranges(TableSwitch* x) {
   int len = x->length();
   if (len > 0) {
     BlockBegin* sux = x->sux_at(0);
-    int key = x->lo_key();
+    int low = x->lo_key();
     BlockBegin* default_sux = x->default_sux();
-    C1SwitchRange* range = new C1SwitchRange(key, sux);
-    for (int i = 0; i < len; i++, key++) {
+    C1SwitchRange* range = new C1SwitchRange(low, sux);
+    for (int i = 0; i < len; i++) {
+      int key = low + i;
       BlockBegin* new_sux = x->sux_at(i);
       if (sux == new_sux) {
         // still in same range

--- a/src/hotspot/share/ci/ciMetadata.hpp
+++ b/src/hotspot/share/ci/ciMetadata.hpp
@@ -105,7 +105,7 @@ class ciMetadata: public ciBaseObject {
 
   bool equals(ciMetadata* obj) const { return (this == obj); }
 
-  int hash() { return ident() * 31; } // ???
+  uint hash() { return ident() * 31; } // ???
 
   void print(outputStream* st);
   virtual void print_impl(outputStream* st) {}

--- a/src/hotspot/share/ci/ciObject.cpp
+++ b/src/hotspot/share/ci/ciObject.cpp
@@ -144,7 +144,7 @@ bool ciObject::equals(ciObject* obj) {
 //
 // Implementation note: we use the address of the ciObject as the
 // basis for the hash.  Use the _ident field, which is well-behaved.
-int ciObject::hash() {
+uint ciObject::hash() {
   return ident() * 31;
 }
 

--- a/src/hotspot/share/ci/ciObject.hpp
+++ b/src/hotspot/share/ci/ciObject.hpp
@@ -98,7 +98,7 @@ public:
   bool equals(ciObject* obj);
 
   // A hash value for the convenience of compilers.
-  int hash();
+  uint hash();
 
   // Tells if this oop should be made a constant.
   bool should_be_constant();

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -360,7 +360,7 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Convert "x-c0" into "x+ -c0".
   if( i &&                      // Might be bottom or top...
       i->is_con() )
-    return new AddLNode(in1, phase->longcon(-i->get_con()));
+    return new AddLNode(in1, phase->longcon(java_negate(i->get_con())));
 
   // Convert "(x+c0) - y" into (x-y) + c0"
   // Do not collapse (x+c0)-y if "+" is a loop increment or

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -413,7 +413,7 @@ const Type* Type::maybe_remove_speculative(bool include_speculative) const {
 
 //------------------------------hash-------------------------------------------
 int Type::uhash( const Type *const t ) {
-  return t->hash();
+  return (int)t->hash();
 }
 
 #define SMALLINT ((juint)3)  // a value too insignificant to consider widening
@@ -770,7 +770,7 @@ bool Type::eq( const Type * ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int Type::hash(void) const {
+uint Type::hash(void) const {
   return _base;
 }
 
@@ -1360,8 +1360,8 @@ bool TypeF::eq(const Type *t) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeF::hash(void) const {
-  return *(int*)(&_f);
+uint TypeF::hash(void) const {
+  return *(uint*)(&_f);
 }
 
 //------------------------------is_finite--------------------------------------
@@ -1470,8 +1470,8 @@ bool TypeD::eq(const Type *t) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeD::hash(void) const {
-  return *(int*)(&_d);
+uint TypeD::hash(void) const {
+  return *(uint*)(&_d);
 }
 
 //------------------------------is_finite--------------------------------------
@@ -1764,8 +1764,8 @@ bool TypeInt::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeInt::hash(void) const {
-  return java_add(java_add(_lo, _hi), java_add((jint)_widen, (jint)Type::Int));
+uint TypeInt::hash(void) const {
+  return (uint)_lo + (uint)_hi + (uint)_widen + (uint)Type::Int;
 }
 
 //------------------------------is_finite--------------------------------------
@@ -2030,8 +2030,8 @@ bool TypeLong::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeLong::hash(void) const {
-  return (int)(_lo+_hi+_widen+(int)Type::Long);
+uint TypeLong::hash(void) const {
+  return (uint)_lo + (uint)_hi + (uint)_widen + (uint)Type::Long;
 }
 
 //------------------------------is_finite--------------------------------------
@@ -2272,10 +2272,10 @@ bool TypeTuple::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeTuple::hash(void) const {
-  intptr_t sum = _cnt;
+uint TypeTuple::hash(void) const {
+  uintptr_t sum = _cnt;
   for( uint i=0; i<_cnt; i++ )
-    sum += (intptr_t)_fields[i];     // Hash on pointers directly
+    sum += (uintptr_t)_fields[i];     // Hash on pointers directly
   return sum;
 }
 
@@ -2387,8 +2387,8 @@ bool TypeAry::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeAry::hash(void) const {
-  return (intptr_t)_elem + (intptr_t)_size + (_stable ? 43 : 0);
+uint TypeAry::hash(void) const {
+  return (uint)(uintptr_t)_elem + (uint)(uintptr_t)_size + (uint)(_stable ? 43 : 0);
 }
 
 /**
@@ -2575,8 +2575,8 @@ bool TypeVect::eq(const Type *t) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeVect::hash(void) const {
-  return (intptr_t)_elem + (intptr_t)_length;
+uint TypeVect::hash(void) const {
+  return (uint)(uintptr_t)_elem + (uint)(uintptr_t)_length;
 }
 
 //------------------------------singleton--------------------------------------
@@ -2801,9 +2801,8 @@ bool TypePtr::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypePtr::hash(void) const {
-  return java_add(java_add((jint)_ptr, (jint)_offset), java_add((jint)hash_speculative(), (jint)_inline_depth));
-;
+uint TypePtr::hash(void) const {
+  return (uint)_ptr + (uint)_offset + (uint)hash_speculative() + (uint)_inline_depth;
 }
 
 /**
@@ -3235,8 +3234,8 @@ bool TypeRawPtr::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeRawPtr::hash(void) const {
-  return (intptr_t)_bits + TypePtr::hash();
+uint TypeRawPtr::hash(void) const {
+  return (uint)(uintptr_t)_bits + (uint)TypePtr::hash();
 }
 
 //------------------------------dump2------------------------------------------
@@ -3325,16 +3324,16 @@ bool TypePtr::InterfaceSet::eq(ciInstanceKlass* k) const {
 }
 
 
-int TypePtr::InterfaceSet::hash() const {
+uint TypePtr::InterfaceSet::hash() const {
   assert(_initialized, "must be");
   return _hash;
 }
 
 void TypePtr::InterfaceSet::compute_hash() {
-  int hash = 0;
+  uint hash = 0;
   for (int i = 0; i < _list.length(); i++) {
     ciKlass* k = _list.at(i);
-    hash += (jint)k->hash();
+    hash += k->hash();
   }
   _hash = hash;
 }
@@ -3846,10 +3845,11 @@ bool TypeOopPtr::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeOopPtr::hash(void) const {
+uint TypeOopPtr::hash(void) const {
   return
-    java_add(java_add((jint)(const_oop() ? const_oop()->hash() : 0), (jint)_klass_is_exact),
-             java_add((jint)_instance_id, (jint)TypePtr::hash()));
+    (uint)(const_oop() ? const_oop()->hash() : 0) +
+    (uint)_klass_is_exact +
+    (uint)_instance_id + TypePtr::hash();
 }
 
 //------------------------------dump2------------------------------------------
@@ -4483,9 +4483,8 @@ bool TypeInstPtr::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeInstPtr::hash(void) const {
-  int hash = java_add(java_add((jint)klass()->hash(), (jint)TypeOopPtr::hash()), _interfaces.hash());
-  return hash;
+uint TypeInstPtr::hash(void) const {
+  return klass()->hash() + TypeOopPtr::hash() + _interfaces.hash();
 }
 
 bool TypeInstPtr::is_java_subtype_of_helper(const TypeOopPtr* other, bool this_exact, bool other_exact) const {
@@ -4834,8 +4833,8 @@ bool TypeAryPtr::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeAryPtr::hash(void) const {
-  return (intptr_t)_ary + TypeOopPtr::hash();
+uint TypeAryPtr::hash(void) const {
+  return (uint)(uintptr_t)_ary + TypeOopPtr::hash();
 }
 
 bool TypeAryPtr::is_java_subtype_of_helper(const TypeOopPtr* other, bool this_exact, bool other_exact) const {
@@ -5219,7 +5218,7 @@ const TypePtr* TypeAryPtr::with_instance_id(int instance_id) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeNarrowPtr::hash(void) const {
+uint TypeNarrowPtr::hash(void) const {
   return _ptrtype->hash() + 7;
 }
 
@@ -5379,7 +5378,7 @@ bool TypeMetadataPtr::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeMetadataPtr::hash(void) const {
+uint TypeMetadataPtr::hash(void) const {
   return
     (metadata() ? metadata()->hash() : 0) +
     TypePtr::hash();
@@ -5619,8 +5618,8 @@ bool TypeKlassPtr::eq(const Type *t) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeKlassPtr::hash(void) const {
-  return java_add((jint)TypePtr::hash(), _interfaces.hash());
+uint TypeKlassPtr::hash(void) const {
+  return TypePtr::hash() + _interfaces.hash();
 }
 
 //------------------------------singleton--------------------------------------
@@ -5732,8 +5731,8 @@ bool TypeInstKlassPtr::eq(const Type *t) const {
     TypeKlassPtr::eq(p);
 }
 
-int TypeInstKlassPtr::hash(void) const {
-  return java_add((jint)klass()->hash(), TypeKlassPtr::hash());
+uint TypeInstKlassPtr::hash(void) const {
+  return klass()->hash() + TypeKlassPtr::hash();
 }
 
 const TypeInstKlassPtr *TypeInstKlassPtr::make(PTR ptr, ciKlass* k, const InterfaceSet& interfaces, int offset) {
@@ -6092,8 +6091,8 @@ bool TypeAryKlassPtr::eq(const Type *t) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeAryKlassPtr::hash(void) const {
-  return (intptr_t)_elem + TypeKlassPtr::hash();
+uint TypeAryKlassPtr::hash(void) const {
+  return (uint)(uintptr_t)_elem + TypeKlassPtr::hash();
 }
 
 //----------------------compute_klass------------------------------------------
@@ -6640,8 +6639,8 @@ bool TypeFunc::eq( const Type *t ) const {
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
-int TypeFunc::hash(void) const {
-  return (intptr_t)_domain + (intptr_t)_range;
+uint TypeFunc::hash(void) const {
+  return (uint)(uintptr_t)_domain + (uint)(uintptr_t)_range;
 }
 
 //------------------------------dump2------------------------------------------

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -353,7 +353,7 @@ public:
 
   // Return a hash for this type.  The hash function is public so ConNode
   // (constants) can hash on their constant, which is represented by a Type.
-  virtual int hash() const;
+  virtual uint hash() const;
 
   // Map ideal registers (machine types) to ideal types
   static const Type *mreg2type[];
@@ -491,7 +491,7 @@ class TypeF : public Type {
   TypeF( float f ) : Type(FloatCon), _f(f) {};
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 public:
@@ -522,7 +522,7 @@ class TypeD : public Type {
   TypeD( double d ) : Type(DoubleCon), _d(d) {};
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 public:
@@ -581,7 +581,7 @@ protected:
 public:
   typedef jint NativeType;
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
   const jint _lo, _hi;          // Lower bound, upper bound
@@ -647,7 +647,7 @@ protected:
 public:
   typedef jlong NativeType;
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 public:
@@ -706,7 +706,7 @@ class TypeTuple : public Type {
 
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 
@@ -756,7 +756,7 @@ class TypeAry : public Type {
       _elem(elem), _size(size), _stable(stable) {}
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 
@@ -798,7 +798,7 @@ public:
   }
 
   virtual bool eq(const Type *t) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 
@@ -884,7 +884,7 @@ protected:
   class InterfaceSet {
   private:
     GrowableArray<ciKlass*> _list;
-    int _hash;
+    uint _hash;
     ciKlass* _exact_klass;
     DEBUG_ONLY(bool _initialized;)
 
@@ -899,7 +899,7 @@ protected:
     InterfaceSet(GrowableArray<ciInstanceKlass*>* interfaces);
     bool eq(const InterfaceSet& other) const;
     bool eq(ciInstanceKlass* k) const;
-    int hash() const;
+    uint hash() const;
     void dump(outputStream* st) const;
     InterfaceSet union_with(const InterfaceSet& other) const;
     InterfaceSet intersection_with(const InterfaceSet& other) const;
@@ -1015,7 +1015,7 @@ public:
   virtual const TypePtr* add_offset(intptr_t offset) const;
   virtual const TypePtr* with_offset(intptr_t offset) const;
   virtual bool eq(const Type *t) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint  hash() const;            // Type specific hashing
 
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
@@ -1070,7 +1070,7 @@ protected:
   TypeRawPtr( PTR ptr, address bits ) : TypePtr(RawPtr,ptr,0), _bits(bits){}
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;     // Type specific hashing
+  virtual uint hash() const;    // Type specific hashing
 
   const address _bits;          // Constant value, if applicable
 
@@ -1107,7 +1107,7 @@ protected:
              const TypePtr* speculative, int inline_depth);
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint hash() const;             // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   enum {
    InstanceTop = -1,   // undefined instance
@@ -1276,7 +1276,7 @@ class TypeInstPtr : public TypeOopPtr {
   TypeInstPtr(PTR ptr, ciKlass* k, const InterfaceSet& interfaces, bool xk, ciObject* o, int offset, int instance_id,
               const TypePtr* speculative, int inline_depth);
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint hash() const;             // Type specific hashing
 
   ciKlass* exact_klass_helper() const;
 
@@ -1405,7 +1405,7 @@ class TypeAryPtr : public TypeOopPtr {
 
   }
   virtual bool eq( const Type *t ) const;
-  virtual int hash() const;     // Type specific hashing
+  virtual uint hash() const;    // Type specific hashing
   const TypeAry *_ary;          // Array we point into
   const bool     _is_autobox_cache;
 
@@ -1513,7 +1513,7 @@ protected:
   virtual const Type *filter_helper(const Type *kills, bool include_speculative) const;
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint hash() const;             // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
 
 private:
@@ -1557,7 +1557,7 @@ protected:
 
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int hash() const;
+  virtual uint hash() const;
   virtual bool singleton(void) const;    // TRUE if type is a singleton
 
 protected:
@@ -1678,7 +1678,7 @@ public:
 
   // corresponding pointer to instance, for a given class
   virtual const TypeOopPtr* as_instance_type(bool klass_change = true) const;
-  virtual int hash() const;
+  virtual uint hash() const;
   virtual bool eq(const Type *t) const;
 
   virtual const TypePtr *add_offset( intptr_t offset ) const;
@@ -1734,7 +1734,7 @@ public:
   const Type *elem() const { return _elem; }
 
   virtual bool eq(const Type *t) const;
-  virtual int hash() const;             // Type specific hashing
+  virtual uint hash() const;             // Type specific hashing
 
   virtual const TypeAryKlassPtr* cast_to_ptr_type(PTR ptr) const;
 
@@ -1779,7 +1779,7 @@ protected:
   virtual const Type *filter_helper(const Type *kills, bool include_speculative) const;
 public:
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint hash() const;             // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
 
   virtual const Type *xmeet( const Type *t ) const;
@@ -1890,7 +1890,7 @@ public:
 class TypeFunc : public Type {
   TypeFunc( const TypeTuple *domain, const TypeTuple *range ) : Type(Function),  _domain(domain), _range(range) {}
   virtual bool eq( const Type *t ) const;
-  virtual int  hash() const;             // Type specific hashing
+  virtual uint hash() const;             // Type specific hashing
   virtual bool singleton(void) const;    // TRUE if type is a singleton
   virtual bool empty(void) const;        // TRUE if type is vacuous
 


### PR DESCRIPTION
This is a followup from part 1.  I had to use java_add/subtract/multiply/negate in a few more places.
cpu_loads_process had an overflow on BSD when the first snapshot is relative to the epoch in 1970.
Use unsigned for C2 Type hash functions.
