### PR TITLE
8303451: Synchronization entry in C2 debug info is misleading

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3196,8 +3196,9 @@ void nmethod::print_code_comment_on(outputStream* st, int column, address begin,
   ScopeDesc* sd  = scope_desc_in(begin, end);
   if (sd != nullptr) {
     st->move_to(column, 6, 0);
-    if (sd->bci() == SynchronizationEntryBCI) {
-      st->print(";*synchronization entry");
+    if (sd->bci() == InvocationEntryBci) {
+      assert(SynchronizationEntryBCI == InvocationEntryBci, "should be same");
+      st->print(";* invocation entry (also synchronization entry if synchronized)");
     } else if (sd->bci() == AfterBci) {
       st->print(";* method exit (unlocked if synchronized)");
     } else if (sd->bci() == UnwindBci) {

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -131,7 +131,7 @@ CHeapBitMap::CHeapBitMap(idx_t size_in_bits, MEMFLAGS flags, bool clear)
 }
 
 CHeapBitMap::~CHeapBitMap() {
-  free(map(), size());
+  free(map(), size_in_words());
 }
 
 bm_word_t* CHeapBitMap::allocate(idx_t size_in_words) const {

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -119,7 +119,7 @@ public class TestOnSpinWaitAArch64 {
     // #           [sp+0x20]  (sp of caller)
     // 0x0000ffffa409da80:   nop
     // 0x0000ffffa409da84:   sub sp, sp, #0x20
-    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;*synchronization entry
+    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ; * invocation entry (also synchronization entry if synchronized)
     //                                                       ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@-1 (line 187)
     // 0x0000ffffa409da8c:   nop
     // 0x0000ffffa409da90:   nop


### PR DESCRIPTION
This should fix [JDK-8303451](https://bugs.openjdk.org/browse/JDK-8303451).

It is a trivial patch that fixes a misleading code comment at method entry printed by `-XX:+PrintAssembly`.

For exmple,
```asm
0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;*synchronization entry
```
will become
```asm
0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ; * invocation entry (also synchronization entry if synchronized)
```
