### PR TITLE
8303451: Synchronization entry in C2 debug info is misleading

### DIFF
--- a/src/hotspot/share/code/debugInfoRec.cpp
+++ b/src/hotspot/share/code/debugInfoRec.cpp
@@ -328,7 +328,7 @@ void DebugInformationRecorder::describe_scope(int         pc_offset,
   assert(method == nullptr ||
          (method->is_native() && bci == 0) ||
          (!method->is_native() && 0 <= bci && bci < method->code_size()) ||
-         bci == -1, "illegal bci");
+         bci == InvocationEntryBci || bci == UnwindBci, "illegal bci");
 
   // serialize the locals/expressions/monitors
   stream()->write_int((intptr_t) locals);

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3197,8 +3197,11 @@ void nmethod::print_code_comment_on(outputStream* st, int column, address begin,
   if (sd != nullptr) {
     st->move_to(column, 6, 0);
     if (sd->bci() == InvocationEntryBci) {
-      assert(SynchronizationEntryBCI == InvocationEntryBci, "should be same");
-      st->print(";* invocation entry (also synchronization entry if synchronized)");
+      if (method()->is_synchronized()) {
+        st->print(";* synchronization entry");
+      } else {
+        st->print(";* invocation entry");
+      }
     } else if (sd->bci() == AfterBci) {
       st->print(";* method exit (unlocked if synchronized)");
     } else if (sd->bci() == UnwindBci) {

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3196,8 +3196,9 @@ void nmethod::print_code_comment_on(outputStream* st, int column, address begin,
   ScopeDesc* sd  = scope_desc_in(begin, end);
   if (sd != nullptr) {
     st->move_to(column, 6, 0);
-    if (sd->bci() == SynchronizationEntryBCI) {
-      st->print(";*synchronization entry");
+    if (sd->bci() == InvocationEntryBci) {
+      assert(SynchronizationEntryBCI == InvocationEntryBci, "should be same");
+      st->print(";* invocation entry (also synchronization entry if synchronized)");
     } else if (sd->bci() == AfterBci) {
       st->print(";* method exit (unlocked if synchronized)");
     } else if (sd->bci() == UnwindBci) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -964,7 +964,7 @@ void Parse::throw_to_exit(SafePointNode* ex_map) {
 
 //------------------------------do_exits---------------------------------------
 void Parse::do_exits() {
-  set_parse_bci(InvocationEntryBci);
+  set_parse_bci(UnwindBci);
 
   // Now peephole on the return bits
   Node* region = _exits.control();

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -119,7 +119,7 @@ public class TestOnSpinWaitAArch64 {
     // #           [sp+0x20]  (sp of caller)
     // 0x0000ffffa409da80:   nop
     // 0x0000ffffa409da84:   sub sp, sp, #0x20
-    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;*synchronization entry
+    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ; * invocation entry (also synchronization entry if synchronized)
     //                                                       ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@-1 (line 187)
     // 0x0000ffffa409da8c:   nop
     // 0x0000ffffa409da90:   nop

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -119,7 +119,7 @@ public class TestOnSpinWaitAArch64 {
     // #           [sp+0x20]  (sp of caller)
     // 0x0000ffffa409da80:   nop
     // 0x0000ffffa409da84:   sub sp, sp, #0x20
-    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ; * invocation entry (also synchronization entry if synchronized)
+    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;* invocation entry (also synchronization entry if synchronized)
     //                                                       ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@-1 (line 187)
     // 0x0000ffffa409da8c:   nop
     // 0x0000ffffa409da90:   nop

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -119,7 +119,7 @@ public class TestOnSpinWaitAArch64 {
     // #           [sp+0x20]  (sp of caller)
     // 0x0000ffffa409da80:   nop
     // 0x0000ffffa409da84:   sub sp, sp, #0x20
-    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;* invocation entry (also synchronization entry if synchronized)
+    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;*synchronization entry
     //                                                       ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@-1 (line 187)
     // 0x0000ffffa409da8c:   nop
     // 0x0000ffffa409da90:   nop


### PR DESCRIPTION
This should fix [JDK-8303451](https://bugs.openjdk.org/browse/JDK-8303451).

It tries to correct some misleading code comments printed by `-XX:+PrintAssembly`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303451](https://bugs.openjdk.org/browse/JDK-8303451): Synchronization entry in C2 debug info is misleading (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14192/head:pull/14192` \
`$ git checkout pull/14192`

Update a local copy of the PR: \
`$ git checkout pull/14192` \
`$ git pull https://git.openjdk.org/jdk.git pull/14192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14192`

View PR using the GUI difftool: \
`$ git pr show -t 14192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14192.diff">https://git.openjdk.org/jdk/pull/14192.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14192#issuecomment-1565557234)