### PR TITLE
8308986: Disable svc tests failing with virtual thread factory

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -36,6 +36,7 @@ vmTestbase/nsk/jdi/ReferenceType/instances/instances001/instances001.java 830897
 vmTestbase/nsk/jdi/ReferenceType/instances/instances003/instances003.java 8308978 generic-all
 vmTestbase/nsk/jdi/ReferenceType/instances/instances004/TestDescription.java 8308978 generic-all
 vmTestbase/nsk/jdi/MonitorWaitedRequest/addThreadFilter/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jdi/VirtualMachine/instanceCounts/instancecounts002/TestDescription.java 8308978 generic-all
 vmTestbase/nsk/jdi/stress/serial/monitorEvents002/TestDescription.java 8308978 generic-all
 vmTestbase/nsk/jdi/stress/serial/heapwalking001/TestDescription.java 8308978 generic-all
 vmTestbase/nsk/jdi/stress/serial/heapwalking002/TestDescription.java 8308978 generic-all

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -31,8 +31,17 @@ serviceability/dcmd/thread/PrintConcurrentLocksTest.java 8308033 generic-all
 serviceability/dcmd/thread/PrintTest.java 8308033 generic-all
 serviceability/dcmd/thread/ThreadDumpToFileTest.java 8308033 generic-all
 serviceability/tmtools/jstack/DaemonThreadTest.java 8308033 generic-all
-vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java 8308985 generic-all
-vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java 8308985 generic-all
+vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects001/referringObjects001.java 8308978 generic-all
+vmTestbase/nsk/jdi/ReferenceType/instances/instances001/instances001.java 8308978 generic-all
+vmTestbase/nsk/jdi/ReferenceType/instances/instances003/instances003.java 8308978 generic-all
+vmTestbase/nsk/jdi/ReferenceType/instances/instances004/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jdi/MonitorWaitedRequest/addThreadFilter/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jdi/stress/serial/monitorEvents002/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jdi/stress/serial/heapwalking001/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jdi/stress/serial/heapwalking002/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jdi/stress/serial/mixed001/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java 8308978 generic-all
+vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java 8308978 generic-all
 
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -31,6 +31,8 @@ serviceability/dcmd/thread/PrintConcurrentLocksTest.java 8308033 generic-all
 serviceability/dcmd/thread/PrintTest.java 8308033 generic-all
 serviceability/dcmd/thread/ThreadDumpToFileTest.java 8308033 generic-all
 serviceability/tmtools/jstack/DaemonThreadTest.java 8308033 generic-all
+vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java 8308985 generic-all
+vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java 8308985 generic-all
 
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -61,7 +61,7 @@ java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 ##########
 ## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.
-## So any test might be added as incompatible, the bug is not required.
+## So any test might be added as incompatible, the bug id is not required.
 
 # Incorrect stack/threadgroup/exception expectations for main thread
 java/lang/StackWalker/DumpStackTest.java 0000000 generic-all

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -59,9 +59,9 @@ javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
 ##########
-## Tests incompatible with  with virtual test thread factory.
+## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.
-## So any test migth be added as incompatible, the bug is not required.
+## So any test might be added as incompatible, the bug is not required.
 
 # Incorrect stack/threadgroup/exception expectations for main thread
 java/lang/StackWalker/DumpStackTest.java 0000000 generic-all

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -72,6 +72,7 @@ java/lang/Thread/UncaughtExceptionsTest.java 0000000 generic-all
 java/lang/Thread/virtual/GetStackTraceWhenRunnable.java 0000000 generic-all
 java/lang/invoke/condy/CondyNestedResolutionTest.java 0000000 generic-all
 java/lang/ref/OOMEInReferenceHandler.java 0000000 generic-all
+java/util/concurrent/locks/Lock/OOMEInAQS.java 0000000 generic-all
 jdk/internal/vm/Continuation/Scoped.java 0000000 generic-all
 
 # The problems with permissions


### PR DESCRIPTION
Disable test
java/util/concurrent/locks/Lock/OOMEInAQS.java
Test provokes OOME and might catch it in an unexpected location. It looks like an issue similar to https://bugs.openjdk.org/browse/JDK-8298066. However, generally the OOME might be thrown mount/umount or in unparker thread. There are no plans to fix such tests to be able to pass with virtual threads now. 

Also, disable
mTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
because of https://bugs.openjdk.org/browse/JDK-8308985

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308986](https://bugs.openjdk.org/browse/JDK-8308986): Disable svc tests failing with virtual thread factory


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [5ed56e68](https://git.openjdk.org/jdk/pull/14193/files/5ed56e68fb48a6e95e62355852f94b61d3b40444)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [2c068101](https://git.openjdk.org/jdk/pull/14193/files/2c068101a033ecf79cc635db6136f1aba8c8bec4)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [5ed56e68](https://git.openjdk.org/jdk/pull/14193/files/5ed56e68fb48a6e95e62355852f94b61d3b40444)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14193/head:pull/14193` \
`$ git checkout pull/14193`

Update a local copy of the PR: \
`$ git checkout pull/14193` \
`$ git pull https://git.openjdk.org/jdk.git pull/14193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14193`

View PR using the GUI difftool: \
`$ git pr show -t 14193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14193.diff">https://git.openjdk.org/jdk/pull/14193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14193#issuecomment-1565675703)