### PR TITLE
JDK-8308987: Update java.lang.Class to use javadoc snippets

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -127,18 +127,17 @@ import sun.reflect.misc.ReflectUtil;
  * class name of an object:
  *
  * {@snippet lang="java" :
- *     void printClassName(Object obj) {
- *         System.out.println("The class of " + obj +
- *                            " is " + obj.getClass().getName());
- *     }
- * }
+ * void printClassName(Object obj) {
+ *     System.out.println("The class of " + obj +
+ *                        " is " + obj.getClass().getName());
+ * }}
  *
  * It is also possible to get the {@code Class} object for a named
  * class or interface (or for {@code void}) using a <i>class literal</i>.
  * For example:
  *
  * {@snippet lang="java" :
- *     System.out.println("The name of class Foo is: "+Foo.class.getName());
+ * System.out.println("The name of class Foo is: "+Foo.class.getName());
  * }
  *
  * <p> Some methods of class {@code Class} expose whether the declaration of
@@ -342,7 +341,7 @@ public final class Class<T> implements java.io.Serializable,
      * equivalent to:
      *
      * {@snippet lang="java" :
-     *  Class.forName(className, true, currentLoader)
+     * Class.forName(className, true, currentLoader)
      * }
      *
      * where {@code currentLoader} denotes the defining class loader of
@@ -353,7 +352,7 @@ public final class Class<T> implements java.io.Serializable,
      * {@code java.lang.Thread}:
      *
      * {@snippet lang="java" :
-     *   Class<?> t = Class.forName("java.lang.Thread")
+     * Class<?> t = Class.forName("java.lang.Thread");
      * }
      * <p>
      * A call to {@code forName("X")} causes the class named
@@ -416,13 +415,13 @@ public final class Class<T> implements java.io.Serializable,
      * <p> For example, in an instance method the expression:
      *
      * {@snippet lang="java" :
-     *  Class.forName("Foo")
+     * Class.forName("Foo")
      * }
      *
      * is equivalent to:
      *
      * {@snippet lang="java" :
-     *  Class.forName("Foo", true, this.getClass().getClassLoader())
+     * Class.forName("Foo", true, this.getClass().getClassLoader())
      * }
      *
      * Note that this method throws errors related to loading, linking

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,20 +126,20 @@ import sun.reflect.misc.ReflectUtil;
  * <p> The following example uses a {@code Class} object to print the
  * class name of an object:
  *
- * <blockquote><pre>
+ * {@snippet lang="java" :
  *     void printClassName(Object obj) {
  *         System.out.println("The class of " + obj +
  *                            " is " + obj.getClass().getName());
  *     }
- * </pre></blockquote>
+ * }
  *
  * It is also possible to get the {@code Class} object for a named
  * class or interface (or for {@code void}) using a <i>class literal</i>.
  * For example:
  *
- * <blockquote>
- *     {@code System.out.println("The name of class Foo is: "+Foo.class.getName());}
- * </blockquote>
+ * {@snippet lang="java" :
+ *     System.out.println("The name of class Foo is: "+Foo.class.getName());
+ * }
  *
  * <p> Some methods of class {@code Class} expose whether the declaration of
  * a class or interface in Java source code was <em>enclosed</em> within
@@ -341,9 +341,9 @@ public final class Class<T> implements java.io.Serializable,
      * interface with the given string name.  Invoking this method is
      * equivalent to:
      *
-     * <blockquote>
-     *  {@code Class.forName(className, true, currentLoader)}
-     * </blockquote>
+     * {@snippet lang="java" :
+     *  Class.forName(className, true, currentLoader)
+     * }
      *
      * where {@code currentLoader} denotes the defining class loader of
      * the current class.
@@ -352,9 +352,9 @@ public final class Class<T> implements java.io.Serializable,
      * runtime {@code Class} descriptor for the class named
      * {@code java.lang.Thread}:
      *
-     * <blockquote>
-     *   {@code Class t = Class.forName("java.lang.Thread")}
-     * </blockquote>
+     * {@snippet lang="java" :
+     *   Class<?> t = Class.forName("java.lang.Thread")
+     * }
      * <p>
      * A call to {@code forName("X")} causes the class named
      * {@code X} to be initialized.
@@ -415,15 +415,15 @@ public final class Class<T> implements java.io.Serializable,
      *
      * <p> For example, in an instance method the expression:
      *
-     * <blockquote>
-     *  {@code Class.forName("Foo")}
-     * </blockquote>
+     * {@snippet lang="java" :
+     *  Class.forName("Foo")
+     * }
      *
      * is equivalent to:
      *
-     * <blockquote>
-     *  {@code Class.forName("Foo", true, this.getClass().getClassLoader())}
-     * </blockquote>
+     * {@snippet lang="java" :
+     *  Class.forName("Foo", true, this.getClass().getClassLoader())
+     * }
      *
      * Note that this method throws errors related to loading, linking
      * or initializing as specified in Sections {@jls 12.2}, {@jls
@@ -607,15 +607,15 @@ public final class Class<T> implements java.io.Serializable,
      *
      * <p>The call
      *
-     * <pre>{@code
+     * {@snippet lang="java" :
      * clazz.newInstance()
-     * }</pre>
+     * }
      *
      * can be replaced by
      *
-     * <pre>{@code
+     * {@snippet lang="java" :
      * clazz.getDeclaredConstructor().newInstance()
-     * }</pre>
+     * }
      *
      * The latter sequence of calls is inferred to be able to throw
      * the additional exception types {@link
@@ -2485,7 +2485,7 @@ public final class Class<T> implements java.io.Serializable,
      * @apiNote
      * <p> The following method can be used to find the record canonical constructor:
      *
-     * <pre>{@code
+     * {@snippet lang="java" :
      * static <T extends Record> Constructor<T> getCanonicalConstructor(Class<T> cls)
      *     throws NoSuchMethodException {
      *   Class<?>[] paramTypes =
@@ -2493,7 +2493,7 @@ public final class Class<T> implements java.io.Serializable,
      *           .map(RecordComponent::getType)
      *           .toArray(Class<?>[]::new);
      *   return cls.getDeclaredConstructor(paramTypes);
-     * }}</pre>
+     * }}
      *
      * @return  An array of {@code RecordComponent} objects representing all the
      *          record components of this record class, or {@code null} if this


### PR DESCRIPTION
Straightforward doc refactoring to use snippets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308987](https://bugs.openjdk.org/browse/JDK-8308987): Update java.lang.Class to use javadoc snippets


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14194/head:pull/14194` \
`$ git checkout pull/14194`

Update a local copy of the PR: \
`$ git checkout pull/14194` \
`$ git pull https://git.openjdk.org/jdk.git pull/14194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14194`

View PR using the GUI difftool: \
`$ git pr show -t 14194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14194.diff">https://git.openjdk.org/jdk/pull/14194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14194#issuecomment-1565684921)