### PR TITLE
8308892: Bad graph detected in build_loop_late after JDK-8305635

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1799,6 +1799,9 @@ ParsePredicateNode* ParsePredicates::get_parse_predicate_or_null(Node* parse_pre
 }
 
 // Initialize the Parse Predicate projection field that matches the kind of the parent of `parse_predicate_proj`.
+// Only initialize if Parse Predicate projection itself or any of the Parse Predicate projections coming further up
+// in the graph are not already initialized (this would be a sign of repeated Parse Predicates which are not cleaned up,
+// yet).
 bool ParsePredicates::assign_predicate_proj(ParsePredicateSuccessProj* parse_predicate_proj) {
   ParsePredicateNode* parse_predicate = get_parse_predicate_or_null(parse_predicate_proj);
   assert(parse_predicate != nullptr, "must exist");
@@ -1811,13 +1814,16 @@ bool ParsePredicates::assign_predicate_proj(ParsePredicateSuccessProj* parse_pre
       _loop_predicate_proj = parse_predicate_proj;
       break;
     case Deoptimization::DeoptReason::Reason_profile_predicate:
-      if (_profiled_loop_predicate_proj != nullptr) {
+      if (_profiled_loop_predicate_proj != nullptr ||
+          _loop_predicate_proj != nullptr) {
         return false;
       }
       _profiled_loop_predicate_proj = parse_predicate_proj;
       break;
     case Deoptimization::DeoptReason::Reason_loop_limit_check:
-      if (_loop_limit_check_predicate_proj != nullptr) {
+      if (_loop_limit_check_predicate_proj != nullptr ||
+          _loop_predicate_proj != nullptr ||
+          _profiled_loop_predicate_proj != nullptr) {
         return false;
       }
       _loop_limit_check_predicate_proj = parse_predicate_proj;

--- a/test/hotspot/jtreg/compiler/predicates/TestWrongPredicateOrder.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestWrongPredicateOrder.java
@@ -69,7 +69,6 @@ public class TestWrongPredicateOrder {
             i += 3;
             iArr2[0] = 1; // Invariant check hoisted as Loop Predicate
 
-
             if (flag) {
                 // Early exit -> enables Profiled Loop Predicate creation below
                 return;
@@ -80,7 +79,6 @@ public class TestWrongPredicateOrder {
 
             // Profiled Loop Predicate for range check hit too much -> no Profiled Parse Predicate is added in re-compilation anymore
             iArr[i + iFld] = 34;
-
 
             if (iFld2 == 5555) {
                 i++; // UCT -> ensures to emit Parse Predicates twice with an If in between that is folded after parsing

--- a/test/hotspot/jtreg/compiler/predicates/TestWrongPredicateOrder.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestWrongPredicateOrder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8308892
+ * @summary Test that Parse Predicates immediately following other Parse Predicates
+            are cleaned up properly.
+ * @run main/othervm -Xbatch compiler.predicates.TestWrongPredicateOrder
+ */
+
+package compiler.predicates;
+
+public class TestWrongPredicateOrder {
+    static boolean flag;
+    static int iFld = 0;
+    static int iFld2 = 34;
+    static int iArr[] = new int[1005];
+    static int iArr2[] = new int[100000];
+
+
+    public static void main(String[] strArr) {
+        // Warmup without hitting Profiled Loop Predicate for range check
+        for (int i = 0; i < 10000; i++) {
+            flag = !flag;
+            iFld = 0;
+            test();
+        }
+
+        // Constantly hitting Profiled Loop Predicate for range check -> re-compilation without
+        for (int i = 0; i < 10000; i++) {
+            try {
+                iFld = 1000; // Ensures out of bounds access to hit Profiled Loop Predicate
+                flag = !flag;
+                test();
+            } catch (Exception e) {
+                // Expected
+            }
+        }
+    }
+
+    public static void test() {
+        // Ensure to emit Loop Limit Check Predicate which is hit too often -> no Loop Limit Check Parse Predicate is added in re-compilation anymore
+        int limit = flag ? Integer.MAX_VALUE - 1 : 1000;
+
+        int i = 0;
+        while (i < limit) {
+            i += 3;
+            iArr2[0] = 1; // Invariant check hoisted as Loop Predicate
+
+
+            if (flag) {
+                // Early exit -> enables Profiled Loop Predicate creation below
+                return;
+            }
+
+            // Data dependency on Loop Predicate for "iArr2[0] = 1", we need to hoist this (invariant) check with a Profiled Loop Predicate
+            iArr2[1] = 5;
+
+            // Profiled Range Check predicate -> hit too much -> no Profiled Parse Predicate is added in re-compilation anymore
+            iArr[i + iFld] = 34;
+
+
+            if (iFld2 == 5555) {
+                i++; // UCT -> ensures to emit parse predicates twice with an If in between that is folded after parsing
+            }
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/predicates/TestWrongPredicateOrder.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestWrongPredicateOrder.java
@@ -78,12 +78,12 @@ public class TestWrongPredicateOrder {
             // Data dependency on Loop Predicate for "iArr2[0] = 1", we need to hoist this (invariant) check with a Profiled Loop Predicate
             iArr2[1] = 5;
 
-            // Profiled Range Check predicate -> hit too much -> no Profiled Parse Predicate is added in re-compilation anymore
+            // Profiled Loop Predicate for range check hit too much -> no Profiled Parse Predicate is added in re-compilation anymore
             iArr[i + iFld] = 34;
 
 
             if (iFld2 == 5555) {
-                i++; // UCT -> ensures to emit parse predicates twice with an If in between that is folded after parsing
+                i++; // UCT -> ensures to emit Parse Predicates twice with an If in between that is folded after parsing
             }
         }
     }


### PR DESCRIPTION
The cleanup done in [JDK-8305635](https://bugs.openjdk.org/browse/JDK-8305635) wrongly identifies unrelated Parse Predicates which are not cleaned up, yet. It just walks from the entry of the loop up and tries to find each of the three Parse Predicates once but in no particular order. This order insensitive walk is wrong as seen in the following graph (from the attached replay file of this bug):

![image](https://github.com/openjdk/jdk/assets/17833009/32f73fcb-1d36-40d6-938c-2d282a98ea52)

We first find `116 Parse Predicate` for Loop Predicates, then `84 Parse Predicate` for Profiled Loop Predicates and then stop when finding `71 Parse Predicate` for Loop Predicates because we've already found a Parse Predicate for Loop Predicates already. We then wrongly create Loop Predicates (above `116 Parse Predicate`) which are below newly created Profiled Loop Predicates (above `84 Parse Predicate`). This could lead to a bad graph because of data dependencies that rely on the fact that Loop Predicates are above Profiled Loop Predicates:
https://github.com/openjdk/jdk/blob/547a8b40b324917e66c71409b31421feacce79d7/src/hotspot/share/opto/loopPredicate.cpp#L1529-L1543

The fix is straight forward to make the assignment of Parse Predicate projections in `ParsePredicates` aware of the relative ordering constraint. Note that this class will be refactored again in [JDK-8305636](https://bugs.openjdk.org/browse/JDK-8305636). But I think properly fixing this first is better than waiting for JDK-8305636 to go in.

Testing: tier1-4, hs-precheckin-comp, hs-stress-comp

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308892](https://bugs.openjdk.org/browse/JDK-8308892): Bad graph detected in build_loop_late after JDK-8305635


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**) ⚠️ Review applies to [806bdba5](https://git.openjdk.org/jdk/pull/14196/files/806bdba5c47622c1e060f041e0ea3983161770ed)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14196/head:pull/14196` \
`$ git checkout pull/14196`

Update a local copy of the PR: \
`$ git checkout pull/14196` \
`$ git pull https://git.openjdk.org/jdk.git pull/14196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14196`

View PR using the GUI difftool: \
`$ git pr show -t 14196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14196.diff">https://git.openjdk.org/jdk/pull/14196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14196#issuecomment-1566282531)