### PR TITLE
8308997: RISC-V: Sign extend when comparing 32-bit value with zero instead of testing the sign bit

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -982,7 +982,6 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
     case Bytecodes::_i2b:
       __ sign_extend(dest->as_register(), src->as_register(), 8); break;
     case Bytecodes::_l2i:
-      _masm->block_comment("FIXME: This could be a no-op");
       __ sign_extend(dest->as_register(), src->as_register_lo(), 32); break;
     case Bytecodes::_d2l:
       __ fcvt_l_d_safe(dest->as_register_lo(), src->as_double_reg()); break;

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -976,14 +976,14 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
     case Bytecodes::_i2c:
       __ zero_extend(dest->as_register(), src->as_register(), 16); break;
     case Bytecodes::_i2l:
-      __ addw(dest->as_register_lo(), src->as_register(), zr); break;
+      __ sign_extend(dest->as_register_lo(), src->as_register(), 32); break;
     case Bytecodes::_i2s:
       __ sign_extend(dest->as_register(), src->as_register(), 16); break;
     case Bytecodes::_i2b:
       __ sign_extend(dest->as_register(), src->as_register(), 8); break;
     case Bytecodes::_l2i:
-      _masm->block_comment("FIXME: This coulde be no-op");
-      __ addw(dest->as_register(), src->as_register_lo(), zr); break;
+      _masm->block_comment("FIXME: This could be a no-op");
+      __ sign_extend(dest->as_register(), src->as_register_lo(), 32); break;
     case Bytecodes::_d2l:
       __ fcvt_l_d_safe(dest->as_register_lo(), src->as_double_reg()); break;
     case Bytecodes::_f2i:
@@ -1304,7 +1304,7 @@ void LIR_Assembler::logic_op(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr
       int right_const = right->as_jint();
       if (Assembler::is_simm12(right_const)) {
         logic_op_imm(Rdst, Rleft, right_const, code);
-        __ addw(Rdst, Rdst, zr);
+        __ sign_extend(Rdst, Rdst, 32);
      } else {
         __ mv(t0, right_const);
         logic_op_reg32(Rdst, Rleft, t0, code);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -79,7 +79,6 @@ void InterpreterMacroAssembler::narrow(Register result) {
   bind(notChar);
   sign_extend(result, result, 16);
 
-  // Nothing to do for T_INT
   bind(done);
   sign_extend(result, result, 32);
 }

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -81,7 +81,7 @@ void InterpreterMacroAssembler::narrow(Register result) {
 
   // Nothing to do for T_INT
   bind(done);
-  addw(result, result, zr);
+  sign_extend(result, result, 32);
 }
 
 void InterpreterMacroAssembler::jump_to_entry(address entry) {
@@ -220,7 +220,7 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,
     // plain index.
     assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
     xori(index, index, -1);
-    addw(index, index, zr);
+    sign_extend(index, index, 32);
   } else if (index_size == sizeof(u1)) {
     load_unsigned_byte(index, Address(xbcp, bcp_offset));
   } else {
@@ -379,7 +379,7 @@ void InterpreterMacroAssembler::push_ptr(Register r) {
 
 void InterpreterMacroAssembler::push_i(Register r) {
   addi(esp, esp, -wordSize);
-  addw(r, r, zr); // signed extended
+  sign_extend(r, r, 32);
   sd(r, Address(esp, 0));
 }
 

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -172,7 +172,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void load_ptr(int n, Register val);
   void store_ptr(int n, Register val);
 
-  // Load float value from 'address'. The value is loaded onto the FPU register v0.
+  // Load float value from 'address'. The value is loaded onto the fp register f10.
   void load_float(Address src);
   void load_double(Address src);
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1644,21 +1644,21 @@ void MacroAssembler::andrw(Register Rd, Register Rs1, Register Rs2) {
   andr(Rd, Rs1, Rs2);
   // addw: The result is clipped to 32 bits, then the sign bit is extended,
   // and the result is stored in Rd
-  addw(Rd, Rd, zr);
+  sign_extend(Rd, Rd, 32);
 }
 
 void MacroAssembler::orrw(Register Rd, Register Rs1, Register Rs2) {
   orr(Rd, Rs1, Rs2);
   // addw: The result is clipped to 32 bits, then the sign bit is extended,
   // and the result is stored in Rd
-  addw(Rd, Rd, zr);
+  sign_extend(Rd, Rd, 32);
 }
 
 void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
   xorr(Rd, Rs1, Rs2);
   // addw: The result is clipped to 32 bits, then the sign bit is extended,
   // and the result is stored in Rd
-  addw(Rd, Rd, zr);
+  sign_extend(Rd, Rd, 32);
 }
 
 // Note: load_unsigned_short used to be called load_unsigned_word.
@@ -4420,7 +4420,7 @@ void MacroAssembler::move32_64(VMRegPair src, VMRegPair dst, Register tmp) {
   } else {
     if (dst.first() != src.first()) {
       // 32bits extend sign
-      addw(dst.first()->as_Register(), src.first()->as_Register(), zr);
+      sign_extend(dst.first()->as_Register(), src.first()->as_Register(), 32);
     }
   }
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1642,22 +1642,16 @@ void MacroAssembler::subw(Register Rd, Register Rn, int32_t decrement, Register 
 
 void MacroAssembler::andrw(Register Rd, Register Rs1, Register Rs2) {
   andr(Rd, Rs1, Rs2);
-  // addw: The result is clipped to 32 bits, then the sign bit is extended,
-  // and the result is stored in Rd
   sign_extend(Rd, Rd, 32);
 }
 
 void MacroAssembler::orrw(Register Rd, Register Rs1, Register Rs2) {
   orr(Rd, Rs1, Rs2);
-  // addw: The result is clipped to 32 bits, then the sign bit is extended,
-  // and the result is stored in Rd
   sign_extend(Rd, Rd, 32);
 }
 
 void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
   xorr(Rd, Rs1, Rs2);
-  // addw: The result is clipped to 32 bits, then the sign bit is extended,
-  // and the result is stored in Rd
   sign_extend(Rd, Rd, 32);
 }
 
@@ -4419,7 +4413,6 @@ void MacroAssembler::move32_64(VMRegPair src, VMRegPair dst, Register tmp) {
     sd(src.first()->as_Register(), Address(sp, reg2offset_out(dst.first())));
   } else {
     if (dst.first() != src.first()) {
-      // 32bits extend sign
       sign_extend(dst.first()->as_Register(), src.first()->as_Register(), 32);
     }
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1337,7 +1337,7 @@ public:
         sign_extend(Rt, Rt, 16);
         break;
       case T_INT    :
-        addw(Rt, Rt, zr);
+        sign_extend(Rt, Rt, 32);
         break;
       case T_LONG   : /* nothing to do */        break;
       case T_VOID   : /* nothing to do */        break;

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8219,7 +8219,7 @@ instruct convI2L_reg_reg(iRegLNoSp dst, iRegIorL2I src)
   ins_cost(ALU_COST);
   format %{ "addw  $dst, $src, zr\t#@convI2L_reg_reg" %}
   ins_encode %{
-    __ addw(as_Register($dst$$reg), as_Register($src$$reg), zr);
+    __ sign_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
   ins_pipe(ialu_reg);
 %}
@@ -8231,7 +8231,7 @@ instruct convL2I_reg(iRegINoSp dst, iRegL src) %{
   format %{ "addw  $dst, $src, zr\t#@convL2I_reg" %}
 
   ins_encode %{
-    __ addw(as_Register($dst$$reg), as_Register($src$$reg), zr);
+    __ sign_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
 
   ins_pipe(ialu_reg);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -152,7 +152,6 @@ instruct vloadmask_masked(vRegMask dst, vReg src, vRegMask_V0 v0) %{
 
 instruct vstoremask(vReg dst, vRegMask_V0 v0, immI size) %{
   match(Set dst (VectorStoreMask v0 size));
-  format %{ "vstoremask $dst, V0" %}
   format %{ "vstoremask $dst, V0 # elem size is $size byte[s]" %}
   ins_encode %{
     __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this));

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1627,7 +1627,6 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ la_patchable(t0, target, offset);
       __ lbu(t0, Address(t0, offset));
     });
-    __ addw(t0, t0, zr);
     __ bnez(t0, dtrace_method_entry);
     __ bind(dtrace_method_entry_done);
   }
@@ -2479,7 +2478,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 #endif
   // compiler left unloaded_class_index in j_rarg0 move to where the
   // runtime expects it.
-  __ addiw(c_rarg1, j_rarg0, 0);
+  __ sign_extend(c_rarg1, j_rarg0, 32);
 
   // we need to set the past SP to the stack pointer of the stub frame
   // and the pc to the address where this runtime call will return

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1858,7 +1858,7 @@ class StubGenerator: public StubCodeGenerator {
     //
 
     const Register t0_offset = t0;    // array offset
-    const Register x22_elsize = lh;   // element size
+    const Register x30_elsize = lh;   // element size
 
     // Get array_header_in_bytes()
     int lh_header_size_width = exact_log2(Klass::_lh_header_size_mask + 1);
@@ -1883,9 +1883,9 @@ class StubGenerator: public StubCodeGenerator {
     // The possible values of elsize are 0-3, i.e. exact_log2(element
     // size in bytes).  We do a simple bitwise binary search.
   __ BIND(L_copy_bytes);
-    __ test_bit(t0, x22_elsize, 1);
+    __ test_bit(t0, x30_elsize, 1);
     __ bnez(t0, L_copy_ints);
-    __ test_bit(t0, x22_elsize, 0);
+    __ test_bit(t0, x30_elsize, 0);
     __ bnez(t0, L_copy_shorts);
     __ add(from, src, src_pos); // src_addr
     __ add(to, dst, dst_pos); // dst_addr
@@ -1899,7 +1899,7 @@ class StubGenerator: public StubCodeGenerator {
     __ j(RuntimeAddress(short_copy_entry));
 
   __ BIND(L_copy_ints);
-    __ test_bit(t0, x22_elsize, 0);
+    __ test_bit(t0, x30_elsize, 0);
     __ bnez(t0, L_copy_longs);
     __ shadd(from, src_pos, src, t0, 2); // src_addr
     __ shadd(to, dst_pos, dst, t0, 2); // dst_addr
@@ -1911,10 +1911,10 @@ class StubGenerator: public StubCodeGenerator {
     {
       BLOCK_COMMENT("assert long copy {");
       Label L;
-      __ andi(lh, lh, Klass::_lh_log2_element_size_mask); // lh -> x22_elsize
+      __ andi(lh, lh, Klass::_lh_log2_element_size_mask); // lh -> x30_elsize
       __ sign_extend(lh, lh, 32);
       __ mv(t0, LogBytesPerLong);
-      __ beq(x22_elsize, t0, L);
+      __ beq(x30_elsize, t0, L);
       __ stop("must be long copy, but elsize is wrong");
       __ bind(L);
       BLOCK_COMMENT("} assert long copy done");

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1832,7 +1832,8 @@ class StubGenerator: public StubCodeGenerator {
     __ bne(t1, scratch_src_klass, L_failed);
 
     // if src->is_Array() isn't null then return -1
-    __ bgez(t0, L_failed);
+    // i.e. (lh >= 0)
+    __ bgez(lh, L_failed);
 
     // At this point, it is known to be a typeArray (array_tag 0x3).
 #ifdef ASSERT

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -704,7 +704,7 @@ void TemplateTable::index_check(Register array, Register index) {
     __ mv(x11, index);
   }
   Label ok;
-  __ addw(index, index, zr);
+  __ sign_extend(index, index, 32);
   __ bltu(index, length, ok);
   __ mv(x13, array);
   __ mv(t0, Interpreter::_throw_ArrayIndexOutOfBoundsException_entry);
@@ -722,7 +722,7 @@ void TemplateTable::iaload() {
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_INT) >> 2);
   __ shadd(x10, x11, x10, t0, 2);
   __ access_load_at(T_INT, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
-  __ addw(x10, x10, zr); // signed extended
+  __ sign_extend(x10, x10, 32);
 }
 
 void TemplateTable::laload() {
@@ -1543,7 +1543,7 @@ void TemplateTable::convert() {
       __ sign_extend(x10, x10, 16);
       break;
     case Bytecodes::_l2i:
-      __ addw(x10, x10, zr);
+      __ sign_extend(x10, x10, 32);
       break;
     case Bytecodes::_l2f:
       __ fcvt_s_l(f10, x10);
@@ -1767,7 +1767,7 @@ void TemplateTable::if_0cmp(Condition cc) {
   // assume branch is more often taken than not (loops use backward branches)
   Label not_taken;
 
-  __ addw(x10, x10, zr);
+  __ sign_extend(x10, x10, 32);
   switch (cc) {
     case equal:
       __ bnez(x10, not_taken);
@@ -1801,7 +1801,7 @@ void TemplateTable::if_icmp(Condition cc) {
   // assume branch is more often taken than not (loops use backward branches)
   Label not_taken;
   __ pop_i(x11);
-  __ addw(x10, x10, zr);
+  __ sign_extend(x10, x10, 32);
   switch (cc) {
     case equal:
       __ bne(x11, x10, not_taken);
@@ -2443,7 +2443,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   __ bnez(t0, notInt);
   // itos
   __ access_load_at(T_INT, IN_HEAP, x10, field, noreg, noreg);
-  __ addw(x10, x10, zr); // signed extended
+  __ sign_extend(x10, x10, 32);
   __ push(itos);
   // Rewrite bytecode to be faster
   if (rc == may_rewrite) {
@@ -3043,7 +3043,7 @@ void TemplateTable::fast_accessfield(TosState state) {
       break;
     case Bytecodes::_fast_igetfield:
       __ access_load_at(T_INT, IN_HEAP, x10, field, noreg, noreg);
-      __ addw(x10, x10, zr); // signed extended
+      __ sign_extend(x10, x10, 32);
       break;
     case Bytecodes::_fast_bgetfield:
       __ access_load_at(T_BYTE, IN_HEAP, x10, field, noreg, noreg);
@@ -3090,7 +3090,7 @@ void TemplateTable::fast_xaccess(TosState state) {
     case itos:
       __ add(x10, x10, x11);
       __ access_load_at(T_INT, IN_HEAP, x10, Address(x10, 0), noreg, noreg);
-      __ addw(x10, x10, zr); // signed extended
+      __ sign_extend(x10, x10, 32);
       break;
     case atos:
       __ add(x10, x10, x11);


### PR DESCRIPTION
RISC-V branch and jump instructions use 64-bit registers instead of 32-bit 
versions in RV64I. We use test_bit to test if bit 31 is zero to determine if a
32-bit register is less than zero currently.

However, there will be two instructions when we use test_bit to test bit
31/63 without Zbs extension[1], we can just use sign_extend instead, which
only use one instruction.

At the same time, we also change some 32-bit symbolic extension operations to
sign_extend for better readability.

[1] https://github.com/openjdk/jdk/blob/e21f865d84c7c861843ff568019e1ad11d280a50/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L4596-L4603

## Testing:
Unmatched:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308997](https://bugs.openjdk.org/browse/JDK-8308997): RISC-V: Sign extend when comparing 32-bit value with zero instead of testing the sign bit


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author) ⚠️ Review applies to [4bc7a903](https://git.openjdk.org/jdk/pull/14197/files/4bc7a903fb09a0401cef11f3d76e211637a96654)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * zifeihan `<caogui@iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14197/head:pull/14197` \
`$ git checkout pull/14197`

Update a local copy of the PR: \
`$ git checkout pull/14197` \
`$ git pull https://git.openjdk.org/jdk.git pull/14197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14197`

View PR using the GUI difftool: \
`$ git pr show -t 14197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14197.diff">https://git.openjdk.org/jdk/pull/14197.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14197#issuecomment-1566473429)