### PR TITLE
8309042: MemorySegment::reinterpret cleanup action is not called for all overloads

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -125,7 +125,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     public final MemorySegment reinterpret(long newSize, Arena arena, Consumer<MemorySegment> cleanup) {
         Objects.requireNonNull(arena);
         return reinterpretInternal(Reflection.getCallerClass(), newSize,
-                MemorySessionImpl.toMemorySession(arena), null);
+                MemorySessionImpl.toMemorySession(arena), cleanup);
     }
 
     @Override

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -33,7 +33,6 @@ import java.lang.foreign.*;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.lang.foreign.MemorySegment.Scope;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.List;

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -33,9 +33,11 @@ import java.lang.foreign.*;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.lang.foreign.MemorySegment.Scope;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
@@ -350,6 +352,20 @@ public class TestSegments {
         assertEquals(segment.address(), 0); // base address should be zero (no leaking of impl details)
         MemorySegment end = segment.asSlice(segment.byteSize(), 0);
         assertEquals(end.address(), segment.byteSize()); // end address should be equal to segment byte size
+    }
+
+    @Test
+    void testReinterpret() {
+        AtomicInteger counter = new AtomicInteger();
+        try (Arena arena = Arena.ofConfined()){
+            // check size
+            assertEquals(MemorySegment.ofAddress(42).reinterpret(100).byteSize(), 100);
+            assertEquals(MemorySegment.ofAddress(42).reinterpret(100, Arena.ofAuto(), null).byteSize(), 100);
+            // check scope and cleanup
+            assertEquals(MemorySegment.ofAddress(42).reinterpret(100, arena, s -> counter.incrementAndGet()).scope(), arena.scope());
+            assertEquals(MemorySegment.ofAddress(42).reinterpret(arena, s -> counter.incrementAndGet()).scope(), arena.scope());
+        }
+        assertEquals(counter.get(), 2);
     }
 
     @DataProvider(name = "badSizeAndAlignments")


### PR DESCRIPTION
There's an obvious bug in `AbstractMemorySegmentImpl::reinterpret(long, Arena, Consumer)`: this method does not pass the consumer down to the internal implementation method (it just passes `null`). As a result, the cleanup is not registered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309042](https://bugs.openjdk.org/browse/JDK-8309042): MemorySegment::reinterpret cleanup action is not called for all overloads


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14199/head:pull/14199` \
`$ git checkout pull/14199`

Update a local copy of the PR: \
`$ git checkout pull/14199` \
`$ git pull https://git.openjdk.org/jdk.git pull/14199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14199`

View PR using the GUI difftool: \
`$ git pr show -t 14199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14199.diff">https://git.openjdk.org/jdk/pull/14199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14199#issuecomment-1566949417)