### PR TITLE
8306136: [vectorapi] Intrinsics of VectorMask.laneIsSet()

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -4591,6 +4591,55 @@ instruct insertD_gt128b(vReg dst, vReg src, vRegD val, immI idx,
 %}
 
 // ------------------------------ Extract --------------------------------------
+
+// BOOLEAN
+
+instruct extractUB_ireg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp) %{
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_ireg $dst, $src, $idx\t# variable index. KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
+
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this, $src);
+    __ mov($tmp$$FloatRegister, __ B, 0, $idx$$Register);
+    if (VM_Version::use_neon_for_vector(length_in_bytes)) {
+      __ tbl($tmp$$FloatRegister, length_in_bytes == 16 ? __ T16B : __ T8B,
+             $src$$FloatRegister, 1, $tmp$$FloatRegister);
+    } else {
+      assert(UseSVE > 0, "must be sve");
+      __ sve_tbl($tmp$$FloatRegister, __ B, $src$$FloatRegister, $tmp$$FloatRegister);
+    }
+    __ smov($dst$$Register, $tmp$$FloatRegister, __ B, 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct extractUB_index_lt16(iRegINoSp dst, vReg src, immI idx) %{
+  predicate(n->in(2)->get_int() < 16);
+  match(Set dst (ExtractUB src idx));
+  format %{ "extractUB_index_lt16 $dst, $src, $idx\t# index < 16" %}
+  ins_encode %{
+    __ smov($dst$$Register, $src$$FloatRegister, __ B, (int)($idx$$constant));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct extractUB_index_ge16(iRegINoSp dst, vReg src, immI idx, vReg tmp) %{
+  predicate(n->in(2)->get_int() >= 16);
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_index_ge16 $dst, $src, $idx\t# index >=16. KILL $tmp" %}
+  ins_encode %{
+    assert(UseSVE > 0, "must be sve");
+    __ sve_extract_integral($dst$$Register, T_BYTE, $src$$FloatRegister,
+                            (int)($idx$$constant), $tmp$$FloatRegister);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // BYTE
 
 instruct extractB_index_lt16(iRegINoSp dst, vReg src, immI idx) %{

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -3122,6 +3122,34 @@ instruct extract$1_index_ge$2($3 dst, vReg src, immI idx, vReg tmp) %{
   ins_pipe(pipe_slow);
 %}')dnl
 dnl
+
+// BOOLEAN
+
+instruct extractUB_ireg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp) %{
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_ireg $dst, $src, $idx\t# variable index. KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
+
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this, $src);
+    __ mov($tmp$$FloatRegister, __ B, 0, $idx$$Register);
+    if (VM_Version::use_neon_for_vector(length_in_bytes)) {
+      __ tbl($tmp$$FloatRegister, length_in_bytes == 16 ? __ T16B : __ T8B,
+             $src$$FloatRegister, 1, $tmp$$FloatRegister);
+    } else {
+      assert(UseSVE > 0, "must be sve");
+      __ sve_tbl($tmp$$FloatRegister, __ B, $src$$FloatRegister, $tmp$$FloatRegister);
+    }
+    __ smov($dst$$Register, $tmp$$FloatRegister, __ B, 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+EXTRACT_INT_SMALL(UB, 16, iRegINoSp, smov, B)
+EXTRACT_INT_LARGE(UB, 16, iRegINoSp, T_BYTE)
+
 // BYTE
 EXTRACT_INT_SMALL(B, 16, iRegINoSp, smov, B)
 EXTRACT_INT_LARGE(B, 16, iRegINoSp, T_BYTE)

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -1086,7 +1086,7 @@ class methodHandle;
    do_signature(vector_extract_sig, "(Ljava/lang/Class;"                                                                                       \
                                      "Ljava/lang/Class;"                                                                                       \
                                      "I"                                                                                                       \
-                                     "Ljdk/internal/vm/vector/VectorSupport$Vector;"                                                           \
+                                     "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;"                                                    \
                                      "I"                                                                                                       \
                                      "Ljdk/internal/vm/vector/VectorSupport$VecExtractOp;)"                                                    \
                                      "J")                                                                                                      \

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -2518,11 +2518,12 @@ bool LibraryCallKit::inline_vector_insert() {
 }
 
 //  public static
-//  <V extends Vector<E>,
+//  <VM extends VectorPayload,
 //   E>
-//  long extract(Class<? extends V> vectorClass, Class<E> elementType, int vlen,
-//               V vec, int ix,
-//               VecExtractOp<V> defaultImpl)
+//  long extract(Class<? extends VM> vClass, Class<E> eClass,
+//               int length,
+//               VM vm, int i,
+//               VecExtractOp<VM> defaultImpl)
 bool LibraryCallKit::inline_vector_extract() {
   const TypeInstPtr* vector_klass = gvn().type(argument(0))->isa_instptr();
   const TypeInstPtr* elem_klass   = gvn().type(argument(1))->isa_instptr();
@@ -2532,13 +2533,12 @@ bool LibraryCallKit::inline_vector_extract() {
   if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || idx == nullptr) {
     return false; // dead code
   }
-  if (vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con() || !idx->is_con()) {
+  if (vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
     if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s idx=%s",
+      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
-                    NodeClassNames[argument(2)->Opcode()],
-                    NodeClassNames[argument(4)->Opcode()]);
+                    NodeClassNames[argument(2)->Opcode()]);
     }
     return false; // not enough info for intrinsification
   }
@@ -2557,51 +2557,94 @@ bool LibraryCallKit::inline_vector_extract() {
   }
   BasicType elem_bt = elem_type->basic_type();
   int num_elem = vlen->get_con();
-  int vopc = ExtractNode::opcode(elem_bt);
-  if (!arch_supports_vector(vopc, num_elem, elem_bt, VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=extract vlen=%d etype=%s ismask=no",
-                    num_elem, type2name(elem_bt));
-    }
-    return false; // not supported
-  }
 
   ciKlass* vbox_klass = vector_klass->const_oop()->as_instance()->java_lang_Class_klass();
   const TypeInstPtr* vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
 
-  Node* opd = unbox_vector(argument(3), vbox_type, elem_bt, num_elem);
-  if (opd == nullptr) {
-    return false;
+  Node* opd = nullptr;
+
+  if (is_vector_mask(vbox_klass)) {
+    // vbox_klass is mask. This is used for VectorMask.laneIsSet(int).
+
+    Node* pos = argument(4); // can be variable
+    if (arch_supports_vector(Op_ExtractUB, num_elem, elem_bt, VecMaskUseAll)) {
+      // Transform mask to vector with type of boolean and utilize ExtractUB node.
+      opd = unbox_vector(argument(3), vbox_type, elem_bt, num_elem);
+      if (opd == nullptr) {
+        return false;
+      }
+      opd = gvn().transform(VectorStoreMaskNode::make(gvn(), opd, elem_bt, num_elem));
+      opd = gvn().transform(new ExtractUBNode(opd, pos));
+      opd = gvn().transform(new ConvI2LNode(opd));
+    } else if (arch_supports_vector(Op_VectorMaskToLong, num_elem, elem_bt, VecMaskUseLoad)) {
+      opd = unbox_vector(argument(3), vbox_type, elem_bt, num_elem);
+      if (opd == nullptr) {
+        return false;
+      }
+      // VectorMaskToLongNode requires the input is either a mask or a vector with BOOLEAN type.
+      if (opd->bottom_type()->isa_vectmask() == nullptr) {
+        assert(!Matcher::has_predicated_vectors(), "should be");
+        opd = gvn().transform(VectorStoreMaskNode::make(gvn(), opd, elem_bt, num_elem));
+      }
+      // ((toLong() >>> pos) & 1L
+      opd = gvn().transform(new VectorMaskToLongNode(opd, TypeLong::LONG));
+      opd = gvn().transform(new URShiftLNode(opd, pos));
+      opd = gvn().transform(new AndLNode(opd, gvn().makecon(TypeLong::ONE)));
+    } else {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** Rejected mask extraction because architecture does not support it");
+      }
+      return false; // not supported
+    }
+  } else {
+    // vbox_klass is vector. This is used for Vector.lane(int).
+    if (!idx->is_con()) {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** missing constant: idx=%s", NodeClassNames[argument(4)->Opcode()]);
+      }
+      return false; // not enough info for intrinsification
+    }
+
+    int vopc = ExtractNode::opcode(elem_bt);
+    if (!arch_supports_vector(vopc, num_elem, elem_bt, VecMaskNotUsed)) {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** not supported: arity=1 op=extract vlen=%d etype=%s ismask=no",
+                      num_elem, type2name(elem_bt));
+      }
+      return false; // not supported
+    }
+
+    opd = unbox_vector(argument(3), vbox_type, elem_bt, num_elem);
+    if (opd == nullptr) {
+      return false;
+    }
+    ConINode* idx_con = gvn().intcon(idx->get_con())->as_ConI();
+
+    opd = gvn().transform(ExtractNode::make(opd, idx_con, elem_bt));
+    switch (elem_bt) {
+      case T_BYTE:
+      case T_SHORT:
+      case T_INT: {
+        opd = gvn().transform(new ConvI2LNode(opd));
+        break;
+      }
+      case T_FLOAT: {
+        opd = gvn().transform(new MoveF2INode(opd));
+        opd = gvn().transform(new ConvI2LNode(opd));
+        break;
+      }
+      case T_DOUBLE: {
+        opd = gvn().transform(new MoveD2LNode(opd));
+        break;
+      }
+      case T_LONG: {
+        // no conversion needed
+        break;
+      }
+      default: fatal("%s", type2name(elem_bt));
+    }
   }
-
-  ConINode* idx_con = gvn().intcon(idx->get_con())->as_ConI();
-  Node* operation = gvn().transform(ExtractNode::make(opd, idx_con, elem_bt));
-
-  Node* bits = nullptr;
-  switch (elem_bt) {
-    case T_BYTE:
-    case T_SHORT:
-    case T_INT: {
-      bits = gvn().transform(new ConvI2LNode(operation));
-      break;
-    }
-    case T_FLOAT: {
-      bits = gvn().transform(new MoveF2INode(operation));
-      bits = gvn().transform(new ConvI2LNode(bits));
-      break;
-    }
-    case T_DOUBLE: {
-      bits = gvn().transform(new MoveD2LNode(operation));
-      break;
-    }
-    case T_LONG: {
-      bits = operation; // no conversion needed
-      break;
-    }
-    default: fatal("%s", type2name(elem_bt));
-  }
-
-  set_result(bits);
+  set_result(opd);
   return true;
 }
 

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -2583,7 +2583,6 @@ bool LibraryCallKit::inline_vector_extract() {
       }
       // VectorMaskToLongNode requires the input is either a mask or a vector with BOOLEAN type.
       if (opd->bottom_type()->isa_vectmask() == nullptr) {
-        assert(!Matcher::has_predicated_vectors(), "should be");
         opd = gvn().transform(VectorStoreMaskNode::make(gvn(), opd, elem_bt, num_elem));
       }
       // ((toLong() >>> pos) & 1L

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1202,9 +1202,10 @@ int ExtractNode::opcode(BasicType bt) {
   }
 }
 
-// Extract a scalar element of vector.
+// Extract a scalar element of vector by constant position.
 Node* ExtractNode::make(Node* v, ConINode* pos, BasicType bt) {
-  assert(pos->get_int() < Matcher::max_vector_size(bt), "pos in range");
+  assert(pos->get_int() >= 0 &&
+         pos->get_int() < Matcher::max_vector_size(bt), "pos in range");
   switch (bt) {
   case T_BOOLEAN: return new ExtractUBNode(v, pos);
   case T_BYTE:    return new ExtractBNode(v, pos);

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1280,12 +1280,8 @@ class VectorLoadConstNode : public VectorNode {
 // Extract a scalar from a vector at position "pos"
 class ExtractNode : public Node {
  public:
-  ExtractNode(Node* src, ConINode* pos) : Node(nullptr, src, (Node*)pos) {
-    assert(in(2)->get_int() >= 0, "positive constants");
-  }
+  ExtractNode(Node* src, Node* pos) : Node(nullptr, src, pos) {}
   virtual int Opcode() const;
-  uint  pos() const { return in(2)->get_int(); }
-
   static Node* make(Node* v, ConINode* pos, BasicType bt);
   static int opcode(BasicType bt);
 };
@@ -1294,7 +1290,7 @@ class ExtractNode : public Node {
 // Extract a byte from a vector at position "pos"
 class ExtractBNode : public ExtractNode {
  public:
-  ExtractBNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractBNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return TypeInt::BYTE; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -1304,9 +1300,9 @@ class ExtractBNode : public ExtractNode {
 // Extract a boolean from a vector at position "pos"
 class ExtractUBNode : public ExtractNode {
  public:
-  ExtractUBNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractUBNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::UBYTE; }
+  virtual const Type* bottom_type() const { return TypeInt::BOOL; }
   virtual uint ideal_reg() const { return Op_RegI; }
 };
 
@@ -1314,7 +1310,7 @@ class ExtractUBNode : public ExtractNode {
 // Extract a char from a vector at position "pos"
 class ExtractCNode : public ExtractNode {
  public:
-  ExtractCNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractCNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return TypeInt::CHAR; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -1324,7 +1320,7 @@ class ExtractCNode : public ExtractNode {
 // Extract a short from a vector at position "pos"
 class ExtractSNode : public ExtractNode {
  public:
-  ExtractSNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractSNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return TypeInt::SHORT; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -1334,7 +1330,7 @@ class ExtractSNode : public ExtractNode {
 // Extract an int from a vector at position "pos"
 class ExtractINode : public ExtractNode {
  public:
-  ExtractINode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractINode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -1344,7 +1340,7 @@ class ExtractINode : public ExtractNode {
 // Extract a long from a vector at position "pos"
 class ExtractLNode : public ExtractNode {
  public:
-  ExtractLNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractLNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
@@ -1354,7 +1350,7 @@ class ExtractLNode : public ExtractNode {
 // Extract a float from a vector at position "pos"
 class ExtractFNode : public ExtractNode {
  public:
-  ExtractFNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractFNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return Type::FLOAT; }
   virtual uint ideal_reg() const { return Op_RegF; }
@@ -1364,7 +1360,7 @@ class ExtractFNode : public ExtractNode {
 // Extract a double from a vector at position "pos"
 class ExtractDNode : public ExtractNode {
  public:
-  ExtractDNode(Node* src, ConINode* pos) : ExtractNode(src, pos) {}
+  ExtractDNode(Node* src, Node* pos) : ExtractNode(src, pos) {}
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return Type::DOUBLE; }
   virtual uint ideal_reg() const { return Op_RegD; }

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -270,20 +270,20 @@ public class VectorSupport {
 
     /* ============================================================================ */
 
-    public interface VecExtractOp<V extends Vector<?>> {
-        long apply(V v, int i);
+    public interface VecExtractOp<VM extends VectorPayload> {
+        long apply(VM vm, int i);
     }
 
     @IntrinsicCandidate
     public static
-    <V extends Vector<E>,
+    <VM extends VectorPayload,
      E>
-    long extract(Class<? extends V> vClass, Class<E> eClass,
+    long extract(Class<? extends VM> vClass, Class<E> eClass,
                  int length,
-                 V v, int i,
-                 VecExtractOp<V> defaultImpl) {
+                 VM vm, int i,
+                 VecExtractOp<VM> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
-        return defaultImpl.apply(v, i);
+        return defaultImpl.apply(vm, i);
     }
 
     /* ============================================================================ */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -68,18 +68,6 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     }
 
     @Override
-    @ForceInline
-    public boolean laneIsSet(int i) {
-        int length = length();
-        Objects.checkIndex(i, length);
-        if (length <= Long.SIZE) {
-            return ((toLong() >>> i) & 1L) == 1;
-        } else {
-            return getBits()[i];
-        }
-    }
-
-    @Override
     public void intoArray(boolean[] bits, int i) {
         AbstractSpecies<E> vsp = (AbstractSpecies<E>) vectorSpecies();
         int laneCount = vsp.laneCount();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -755,6 +755,16 @@ final class Byte128Vector extends ByteVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Byte128Mask.class, byte.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -787,6 +787,16 @@ final class Byte256Vector extends ByteVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Byte256Mask.class, byte.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -851,6 +851,16 @@ final class Byte512Vector extends ByteVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Byte512Mask.class, byte.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -739,6 +739,16 @@ final class Byte64Vector extends ByteVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Byte64Mask.class, byte.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -725,6 +725,16 @@ final class ByteMaxVector extends ByteVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(ByteMaxMask.class, byte.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -716,6 +716,16 @@ final class Double128Vector extends DoubleVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Double128Mask.class, double.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -720,6 +720,16 @@ final class Double256Vector extends DoubleVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Double256Mask.class, double.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -728,6 +728,16 @@ final class Double512Vector extends DoubleVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Double512Mask.class, double.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -714,6 +714,16 @@ final class Double64Vector extends DoubleVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Double64Mask.class, double.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -713,6 +713,16 @@ final class DoubleMaxVector extends DoubleVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(DoubleMaxMask.class, double.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -720,6 +720,16 @@ final class Float128Vector extends FloatVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Float128Mask.class, float.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -728,6 +728,16 @@ final class Float256Vector extends FloatVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Float256Mask.class, float.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -744,6 +744,16 @@ final class Float512Vector extends FloatVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Float512Mask.class, float.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -716,6 +716,16 @@ final class Float64Vector extends FloatVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Float64Mask.class, float.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -713,6 +713,16 @@ final class FloatMaxVector extends FloatVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(FloatMaxMask.class, float.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -731,6 +731,16 @@ final class Int128Vector extends IntVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Int128Mask.class, int.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -739,6 +739,16 @@ final class Int256Vector extends IntVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Int256Mask.class, int.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -755,6 +755,16 @@ final class Int512Vector extends IntVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Int512Mask.class, int.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -727,6 +727,16 @@ final class Int64Vector extends IntVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Int64Mask.class, int.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -725,6 +725,16 @@ final class IntMaxVector extends IntVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(IntMaxMask.class, int.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -717,6 +717,16 @@ final class Long128Vector extends LongVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Long128Mask.class, long.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -721,6 +721,16 @@ final class Long256Vector extends LongVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Long256Mask.class, long.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -729,6 +729,16 @@ final class Long512Vector extends LongVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Long512Mask.class, long.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -715,6 +715,16 @@ final class Long64Vector extends LongVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Long64Mask.class, long.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -715,6 +715,16 @@ final class LongMaxVector extends LongVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(LongMaxMask.class, long.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -739,6 +739,16 @@ final class Short128Vector extends ShortVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Short128Mask.class, short.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -755,6 +755,16 @@ final class Short256Vector extends ShortVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Short256Mask.class, short.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -787,6 +787,16 @@ final class Short512Vector extends ShortVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Short512Mask.class, short.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -731,6 +731,16 @@ final class Short64Vector extends ShortVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(Short64Mask.class, short.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -725,6 +725,16 @@ final class ShortMaxVector extends ShortVector {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(ShortMaxMask.class, short.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -998,6 +998,16 @@ final class $vectortype$ extends $abstractvectortype$ {
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract($masktype$.class, $type$.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
         // Reductions
 
         @Override

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+public class VectorExtractBenchmark {
+    private int idx = 0;
+    private boolean[] res = new boolean[8];
+
+    private static final VectorMask bmask64 = VectorMask.fromLong(ByteVector.SPECIES_64, 1L);
+    private static final VectorMask bmask128 = VectorMask.fromLong(ByteVector.SPECIES_128, 1L);
+    private static final VectorMask bmask256 = VectorMask.fromLong(ByteVector.SPECIES_256, 1L);
+    private static final VectorMask bmask512 = VectorMask.fromLong(ByteVector.SPECIES_512, 1L);
+
+    private static final VectorMask smask64 = VectorMask.fromLong(ShortVector.SPECIES_64, 1L);
+    private static final VectorMask smask128 = VectorMask.fromLong(ShortVector.SPECIES_128, 1L);
+    private static final VectorMask smask256 = VectorMask.fromLong(ShortVector.SPECIES_256, 1L);
+    private static final VectorMask smask512 = VectorMask.fromLong(ShortVector.SPECIES_512, 1L);
+
+    private static final VectorMask imask64 = VectorMask.fromLong(IntVector.SPECIES_64, 1L);
+    private static final VectorMask imask128 = VectorMask.fromLong(IntVector.SPECIES_128, 1L);
+    private static final VectorMask imask256 = VectorMask.fromLong(IntVector.SPECIES_256, 1L);
+    private static final VectorMask imask512 = VectorMask.fromLong(IntVector.SPECIES_512, 1L);
+
+    private static final VectorMask lmask64 = VectorMask.fromLong(LongVector.SPECIES_64, 1L);
+    private static final VectorMask lmask128 = VectorMask.fromLong(LongVector.SPECIES_128, 1L);
+    private static final VectorMask lmask256 = VectorMask.fromLong(LongVector.SPECIES_256, 1L);
+    private static final VectorMask lmask512 = VectorMask.fromLong(LongVector.SPECIES_512, 1L);
+
+    private static final VectorMask fmask64 = VectorMask.fromLong(FloatVector.SPECIES_64, 1L);
+    private static final VectorMask fmask128 = VectorMask.fromLong(FloatVector.SPECIES_128, 1L);
+    private static final VectorMask fmask256 = VectorMask.fromLong(FloatVector.SPECIES_256, 1L);
+    private static final VectorMask fmask512 = VectorMask.fromLong(FloatVector.SPECIES_512, 1L);
+
+    private static final VectorMask dmask64 = VectorMask.fromLong(DoubleVector.SPECIES_64, 1L);
+    private static final VectorMask dmask128 = VectorMask.fromLong(DoubleVector.SPECIES_128, 1L);
+    private static final VectorMask dmask256 = VectorMask.fromLong(DoubleVector.SPECIES_256, 1L);
+    private static final VectorMask dmask512 = VectorMask.fromLong(DoubleVector.SPECIES_512, 1L);
+
+    @Benchmark
+    public void microMaskLaneIsSetByte64_con(Blackhole bh) {
+        res[0] = bmask64.laneIsSet(0);
+        res[1] = bmask64.laneIsSet(1);
+        res[2] = bmask64.laneIsSet(2);
+        res[3] = bmask64.laneIsSet(3);
+        res[4] = bmask64.laneIsSet(4);
+        res[5] = bmask64.laneIsSet(5);
+        res[6] = bmask64.laneIsSet(6);
+        res[7] = bmask64.laneIsSet(7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte64_var(Blackhole bh) {
+        res[0] = bmask64.laneIsSet(idx);
+        res[1] = bmask64.laneIsSet(idx + 1);
+        res[2] = bmask64.laneIsSet(idx + 2);
+        res[3] = bmask64.laneIsSet(idx + 3);
+        res[4] = bmask64.laneIsSet(idx + 4);
+        res[5] = bmask64.laneIsSet(idx + 5);
+        res[6] = bmask64.laneIsSet(idx + 6);
+        res[7] = bmask64.laneIsSet(idx + 7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte128_con(Blackhole bh) {
+        res[0] = bmask128.laneIsSet(0);
+        res[1] = bmask128.laneIsSet(1);
+        res[2] = bmask128.laneIsSet(2);
+        res[3] = bmask128.laneIsSet(3);
+        res[4] = bmask128.laneIsSet(12);
+        res[5] = bmask128.laneIsSet(13);
+        res[6] = bmask128.laneIsSet(14);
+        res[7] = bmask128.laneIsSet(15);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte128_var(Blackhole bh) {
+        res[0] = bmask128.laneIsSet(idx);
+        res[1] = bmask128.laneIsSet(idx + 1);
+        res[2] = bmask128.laneIsSet(idx + 2);
+        res[3] = bmask128.laneIsSet(idx + 3);
+        res[4] = bmask128.laneIsSet(idx + 12);
+        res[5] = bmask128.laneIsSet(idx + 13);
+        res[6] = bmask128.laneIsSet(idx + 14);
+        res[7] = bmask128.laneIsSet(idx + 15);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte256_con(Blackhole bh) {
+        res[0] = bmask256.laneIsSet(0);
+        res[1] = bmask256.laneIsSet(1);
+        res[2] = bmask256.laneIsSet(2);
+        res[3] = bmask256.laneIsSet(3);
+        res[4] = bmask256.laneIsSet(28);
+        res[5] = bmask256.laneIsSet(29);
+        res[6] = bmask256.laneIsSet(30);
+        res[7] = bmask256.laneIsSet(31);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte256_var(Blackhole bh) {
+        res[0] = bmask256.laneIsSet(idx);
+        res[1] = bmask256.laneIsSet(idx + 1);
+        res[2] = bmask256.laneIsSet(idx + 2);
+        res[3] = bmask256.laneIsSet(idx + 3);
+        res[4] = bmask256.laneIsSet(idx + 28);
+        res[5] = bmask256.laneIsSet(idx + 29);
+        res[6] = bmask256.laneIsSet(idx + 30);
+        res[7] = bmask256.laneIsSet(idx + 31);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte512_con(Blackhole bh) {
+        res[0] = bmask512.laneIsSet(0);
+        res[1] = bmask512.laneIsSet(1);
+        res[2] = bmask512.laneIsSet(2);
+        res[3] = bmask512.laneIsSet(3);
+        res[4] = bmask512.laneIsSet(60);
+        res[5] = bmask512.laneIsSet(61);
+        res[6] = bmask512.laneIsSet(62);
+        res[7] = bmask512.laneIsSet(63);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetByte512_var(Blackhole bh) {
+        res[0] = bmask512.laneIsSet(idx);
+        res[1] = bmask512.laneIsSet(idx + 1);
+        res[2] = bmask512.laneIsSet(idx + 2);
+        res[3] = bmask512.laneIsSet(idx + 3);
+        res[4] = bmask512.laneIsSet(idx + 60);
+        res[5] = bmask512.laneIsSet(idx + 61);
+        res[6] = bmask512.laneIsSet(idx + 62);
+        res[7] = bmask512.laneIsSet(idx + 63);
+        bh.consume(res);
+    }
+
+
+    @Benchmark
+    public void microMaskLaneIsSetShort64_con(Blackhole bh) {
+        res[0] = smask64.laneIsSet(0);
+        res[1] = smask64.laneIsSet(1);
+        res[2] = smask64.laneIsSet(2);
+        res[3] = smask64.laneIsSet(3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort64_var(Blackhole bh) {
+        res[0] = smask64.laneIsSet(idx);
+        res[1] = smask64.laneIsSet(idx + 1);
+        res[2] = smask64.laneIsSet(idx + 2);
+        res[3] = smask64.laneIsSet(idx + 3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort128_con(Blackhole bh) {
+        res[0] = smask128.laneIsSet(0);
+        res[1] = smask128.laneIsSet(1);
+        res[2] = smask128.laneIsSet(2);
+        res[3] = smask128.laneIsSet(3);
+        res[4] = smask128.laneIsSet(4);
+        res[5] = smask128.laneIsSet(5);
+        res[6] = smask128.laneIsSet(6);
+        res[7] = smask128.laneIsSet(7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort128_var(Blackhole bh) {
+        res[0] = smask128.laneIsSet(idx);
+        res[1] = smask128.laneIsSet(idx + 1);
+        res[2] = smask128.laneIsSet(idx + 2);
+        res[3] = smask128.laneIsSet(idx + 3);
+        res[4] = smask128.laneIsSet(idx + 4);
+        res[5] = smask128.laneIsSet(idx + 5);
+        res[6] = smask128.laneIsSet(idx + 6);
+        res[7] = smask128.laneIsSet(idx + 7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort256_con(Blackhole bh) {
+        res[0] = smask256.laneIsSet(0);
+        res[1] = smask256.laneIsSet(1);
+        res[2] = smask256.laneIsSet(2);
+        res[3] = smask256.laneIsSet(3);
+        res[4] = smask256.laneIsSet(12);
+        res[5] = smask256.laneIsSet(13);
+        res[6] = smask256.laneIsSet(14);
+        res[7] = smask256.laneIsSet(15);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort256_var(Blackhole bh) {
+        res[0] = smask256.laneIsSet(idx);
+        res[1] = smask256.laneIsSet(idx + 1);
+        res[2] = smask256.laneIsSet(idx + 2);
+        res[3] = smask256.laneIsSet(idx + 3);
+        res[4] = smask256.laneIsSet(idx + 12);
+        res[5] = smask256.laneIsSet(idx + 13);
+        res[6] = smask256.laneIsSet(idx + 14);
+        res[7] = smask256.laneIsSet(idx + 15);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort512_con(Blackhole bh) {
+        res[0] = smask512.laneIsSet(0);
+        res[1] = smask512.laneIsSet(1);
+        res[2] = smask512.laneIsSet(2);
+        res[3] = smask512.laneIsSet(3);
+        res[4] = smask512.laneIsSet(28);
+        res[5] = smask512.laneIsSet(29);
+        res[6] = smask512.laneIsSet(30);
+        res[7] = smask512.laneIsSet(31);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetShort512_var(Blackhole bh) {
+        res[0] = smask512.laneIsSet(idx);
+        res[1] = smask512.laneIsSet(idx + 1);
+        res[2] = smask512.laneIsSet(idx + 2);
+        res[3] = smask512.laneIsSet(idx + 3);
+        res[4] = smask512.laneIsSet(idx + 28);
+        res[5] = smask512.laneIsSet(idx + 29);
+        res[6] = smask512.laneIsSet(idx + 30);
+        res[7] = smask512.laneIsSet(idx + 31);
+        bh.consume(res);
+    }
+
+
+    @Benchmark
+    public void microMaskLaneIsSetInt64_con(Blackhole bh) {
+        res[0] = imask64.laneIsSet(0);
+        res[1] = imask64.laneIsSet(1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt64_var(Blackhole bh) {
+        res[0] = imask64.laneIsSet(idx);
+        res[1] = imask64.laneIsSet(idx + 1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt128_con(Blackhole bh) {
+        res[0] = imask128.laneIsSet(0);
+        res[1] = imask128.laneIsSet(1);
+        res[2] = imask128.laneIsSet(2);
+        res[3] = imask128.laneIsSet(3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt128_var(Blackhole bh) {
+        res[0] = imask128.laneIsSet(idx);
+        res[1] = imask128.laneIsSet(idx + 1);
+        res[2] = imask128.laneIsSet(idx + 2);
+        res[3] = imask128.laneIsSet(idx + 3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt256_con(Blackhole bh) {
+        res[0] = imask256.laneIsSet(0);
+        res[1] = imask256.laneIsSet(1);
+        res[2] = imask256.laneIsSet(2);
+        res[3] = imask256.laneIsSet(3);
+        res[4] = imask256.laneIsSet(4);
+        res[5] = imask256.laneIsSet(5);
+        res[6] = imask256.laneIsSet(6);
+        res[7] = imask256.laneIsSet(7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt256_var(Blackhole bh) {
+        res[0] = imask256.laneIsSet(idx);
+        res[1] = imask256.laneIsSet(idx + 1);
+        res[2] = imask256.laneIsSet(idx + 2);
+        res[3] = imask256.laneIsSet(idx + 3);
+        res[4] = imask256.laneIsSet(idx + 4);
+        res[5] = imask256.laneIsSet(idx + 5);
+        res[6] = imask256.laneIsSet(idx + 6);
+        res[7] = imask256.laneIsSet(idx + 7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt512_con(Blackhole bh) {
+        res[0] = imask512.laneIsSet(0);
+        res[1] = imask512.laneIsSet(1);
+        res[2] = imask512.laneIsSet(2);
+        res[3] = imask512.laneIsSet(3);
+        res[4] = imask512.laneIsSet(12);
+        res[5] = imask512.laneIsSet(13);
+        res[6] = imask512.laneIsSet(14);
+        res[7] = imask512.laneIsSet(15);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetInt512_var(Blackhole bh) {
+        res[0] = imask512.laneIsSet(idx);
+        res[1] = imask512.laneIsSet(idx + 1);
+        res[2] = imask512.laneIsSet(idx + 2);
+        res[3] = imask512.laneIsSet(idx + 3);
+        res[4] = imask512.laneIsSet(idx + 12);
+        res[5] = imask512.laneIsSet(idx + 13);
+        res[6] = imask512.laneIsSet(idx + 14);
+        res[7] = imask512.laneIsSet(idx + 15);
+        bh.consume(res);
+    }
+
+
+    @Benchmark
+    public void microMaskLaneIsSetLong64_con(Blackhole bh) {
+        res[0] = lmask64.laneIsSet(0);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong64_var(Blackhole bh) {
+        res[0] = lmask64.laneIsSet(idx);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong128_con(Blackhole bh) {
+        res[0] = lmask128.laneIsSet(0);
+        res[1] = lmask128.laneIsSet(1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong128_var(Blackhole bh) {
+        res[0] = lmask128.laneIsSet(idx);
+        res[1] = lmask128.laneIsSet(idx + 1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong256_con(Blackhole bh) {
+        res[0] = lmask256.laneIsSet(0);
+        res[1] = lmask256.laneIsSet(1);
+        res[2] = lmask256.laneIsSet(2);
+        res[3] = lmask256.laneIsSet(3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong256_var(Blackhole bh) {
+        res[0] = lmask256.laneIsSet(idx);
+        res[1] = lmask256.laneIsSet(idx + 1);
+        res[2] = lmask256.laneIsSet(idx + 2);
+        res[3] = lmask256.laneIsSet(idx + 3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong512_con(Blackhole bh) {
+        res[0] = lmask512.laneIsSet(0);
+        res[1] = lmask512.laneIsSet(1);
+        res[2] = lmask512.laneIsSet(2);
+        res[3] = lmask512.laneIsSet(3);
+        res[4] = lmask512.laneIsSet(4);
+        res[5] = lmask512.laneIsSet(5);
+        res[6] = lmask512.laneIsSet(6);
+        res[7] = lmask512.laneIsSet(7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetLong512_var(Blackhole bh) {
+        res[0] = lmask512.laneIsSet(idx);
+        res[1] = lmask512.laneIsSet(idx + 1);
+        res[2] = lmask512.laneIsSet(idx + 2);
+        res[3] = lmask512.laneIsSet(idx + 3);
+        res[4] = lmask512.laneIsSet(idx + 4);
+        res[5] = lmask512.laneIsSet(idx + 5);
+        res[6] = lmask512.laneIsSet(idx + 6);
+        res[7] = lmask512.laneIsSet(idx + 7);
+        bh.consume(res);
+    }
+
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat64_con(Blackhole bh) {
+        res[0] = fmask64.laneIsSet(0);
+        res[1] = fmask64.laneIsSet(1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat64_var(Blackhole bh) {
+        res[0] = fmask64.laneIsSet(idx);
+        res[1] = fmask64.laneIsSet(idx + 1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat128_con(Blackhole bh) {
+        res[0] = fmask128.laneIsSet(0);
+        res[1] = fmask128.laneIsSet(1);
+        res[2] = fmask128.laneIsSet(2);
+        res[3] = fmask128.laneIsSet(3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat128_var(Blackhole bh) {
+        res[0] = fmask128.laneIsSet(idx);
+        res[1] = fmask128.laneIsSet(idx + 1);
+        res[2] = fmask128.laneIsSet(idx + 2);
+        res[3] = fmask128.laneIsSet(idx + 3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat256_con(Blackhole bh) {
+        res[0] = fmask256.laneIsSet(0);
+        res[1] = fmask256.laneIsSet(1);
+        res[2] = fmask256.laneIsSet(2);
+        res[3] = fmask256.laneIsSet(3);
+        res[4] = fmask256.laneIsSet(4);
+        res[5] = fmask256.laneIsSet(5);
+        res[6] = fmask256.laneIsSet(6);
+        res[7] = fmask256.laneIsSet(7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat256_var(Blackhole bh) {
+        res[0] = fmask256.laneIsSet(idx);
+        res[1] = fmask256.laneIsSet(idx + 1);
+        res[2] = fmask256.laneIsSet(idx + 2);
+        res[3] = fmask256.laneIsSet(idx + 3);
+        res[4] = fmask256.laneIsSet(idx + 4);
+        res[5] = fmask256.laneIsSet(idx + 5);
+        res[6] = fmask256.laneIsSet(idx + 6);
+        res[7] = fmask256.laneIsSet(idx + 7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat512_con(Blackhole bh) {
+        res[0] = fmask512.laneIsSet(0);
+        res[1] = fmask512.laneIsSet(1);
+        res[2] = fmask512.laneIsSet(2);
+        res[3] = fmask512.laneIsSet(3);
+        res[4] = fmask512.laneIsSet(12);
+        res[5] = fmask512.laneIsSet(13);
+        res[6] = fmask512.laneIsSet(14);
+        res[7] = fmask512.laneIsSet(15);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetFloat512_var(Blackhole bh) {
+        res[0] = fmask512.laneIsSet(idx);
+        res[1] = fmask512.laneIsSet(idx + 1);
+        res[2] = fmask512.laneIsSet(idx + 2);
+        res[3] = fmask512.laneIsSet(idx + 3);
+        res[4] = fmask512.laneIsSet(idx + 12);
+        res[5] = fmask512.laneIsSet(idx + 13);
+        res[6] = fmask512.laneIsSet(idx + 14);
+        res[7] = fmask512.laneIsSet(idx + 15);
+        bh.consume(res);
+    }
+
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble64_con(Blackhole bh) {
+        res[0] = dmask64.laneIsSet(0);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble64_var(Blackhole bh) {
+        res[0] = dmask64.laneIsSet(idx);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble128_con(Blackhole bh) {
+        res[0] = dmask128.laneIsSet(0);
+        res[1] = dmask128.laneIsSet(1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble128_var(Blackhole bh) {
+        res[0] = dmask128.laneIsSet(idx);
+        res[1] = dmask128.laneIsSet(idx + 1);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble256_con(Blackhole bh) {
+        res[0] = dmask256.laneIsSet(0);
+        res[1] = dmask256.laneIsSet(1);
+        res[2] = dmask256.laneIsSet(2);
+        res[3] = dmask256.laneIsSet(3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble256_var(Blackhole bh) {
+        res[0] = dmask256.laneIsSet(idx);
+        res[1] = dmask256.laneIsSet(idx + 1);
+        res[2] = dmask256.laneIsSet(idx + 2);
+        res[3] = dmask256.laneIsSet(idx + 3);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble512_con(Blackhole bh) {
+        res[0] = dmask512.laneIsSet(0);
+        res[1] = dmask512.laneIsSet(1);
+        res[2] = dmask512.laneIsSet(2);
+        res[3] = dmask512.laneIsSet(3);
+        res[4] = dmask512.laneIsSet(4);
+        res[5] = dmask512.laneIsSet(5);
+        res[6] = dmask512.laneIsSet(6);
+        res[7] = dmask512.laneIsSet(7);
+        bh.consume(res);
+    }
+
+    @Benchmark
+    public void microMaskLaneIsSetDouble512_var(Blackhole bh) {
+        res[0] = dmask512.laneIsSet(idx);
+        res[1] = dmask512.laneIsSet(idx + 1);
+        res[2] = dmask512.laneIsSet(idx + 2);
+        res[3] = dmask512.laneIsSet(idx + 3);
+        res[4] = dmask512.laneIsSet(idx + 4);
+        res[5] = dmask512.laneIsSet(idx + 5);
+        res[6] = dmask512.laneIsSet(idx + 6);
+        res[7] = dmask512.laneIsSet(idx + 7);
+        bh.consume(res);
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
@@ -25,7 +25,6 @@ package org.openjdk.bench.jdk.incubator.vector;
 import java.util.concurrent.TimeUnit;
 import jdk.incubator.vector.*;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
@@ -65,7 +64,7 @@ public class VectorExtractBenchmark {
     private static final VectorMask dmask512 = VectorMask.fromLong(DoubleVector.SPECIES_512, 1L);
 
     @Benchmark
-    public void microMaskLaneIsSetByte64_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte64_con() {
         res[0] = bmask64.laneIsSet(0);
         res[1] = bmask64.laneIsSet(1);
         res[2] = bmask64.laneIsSet(2);
@@ -74,11 +73,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask64.laneIsSet(5);
         res[6] = bmask64.laneIsSet(6);
         res[7] = bmask64.laneIsSet(7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte64_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte64_var() {
         res[0] = bmask64.laneIsSet(idx);
         res[1] = bmask64.laneIsSet(idx + 1);
         res[2] = bmask64.laneIsSet(idx + 2);
@@ -87,11 +86,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask64.laneIsSet(idx + 5);
         res[6] = bmask64.laneIsSet(idx + 6);
         res[7] = bmask64.laneIsSet(idx + 7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte128_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte128_con() {
         res[0] = bmask128.laneIsSet(0);
         res[1] = bmask128.laneIsSet(1);
         res[2] = bmask128.laneIsSet(2);
@@ -100,11 +99,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask128.laneIsSet(13);
         res[6] = bmask128.laneIsSet(14);
         res[7] = bmask128.laneIsSet(15);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte128_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte128_var() {
         res[0] = bmask128.laneIsSet(idx);
         res[1] = bmask128.laneIsSet(idx + 1);
         res[2] = bmask128.laneIsSet(idx + 2);
@@ -113,11 +112,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask128.laneIsSet(idx + 13);
         res[6] = bmask128.laneIsSet(idx + 14);
         res[7] = bmask128.laneIsSet(idx + 15);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte256_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte256_con() {
         res[0] = bmask256.laneIsSet(0);
         res[1] = bmask256.laneIsSet(1);
         res[2] = bmask256.laneIsSet(2);
@@ -126,11 +125,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask256.laneIsSet(29);
         res[6] = bmask256.laneIsSet(30);
         res[7] = bmask256.laneIsSet(31);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte256_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte256_var() {
         res[0] = bmask256.laneIsSet(idx);
         res[1] = bmask256.laneIsSet(idx + 1);
         res[2] = bmask256.laneIsSet(idx + 2);
@@ -139,11 +138,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask256.laneIsSet(idx + 29);
         res[6] = bmask256.laneIsSet(idx + 30);
         res[7] = bmask256.laneIsSet(idx + 31);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte512_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte512_con() {
         res[0] = bmask512.laneIsSet(0);
         res[1] = bmask512.laneIsSet(1);
         res[2] = bmask512.laneIsSet(2);
@@ -152,11 +151,11 @@ public class VectorExtractBenchmark {
         res[5] = bmask512.laneIsSet(61);
         res[6] = bmask512.laneIsSet(62);
         res[7] = bmask512.laneIsSet(63);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetByte512_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetByte512_var() {
         res[0] = bmask512.laneIsSet(idx);
         res[1] = bmask512.laneIsSet(idx + 1);
         res[2] = bmask512.laneIsSet(idx + 2);
@@ -165,30 +164,30 @@ public class VectorExtractBenchmark {
         res[5] = bmask512.laneIsSet(idx + 61);
         res[6] = bmask512.laneIsSet(idx + 62);
         res[7] = bmask512.laneIsSet(idx + 63);
-        bh.consume(res);
+        return res;
     }
 
 
     @Benchmark
-    public void microMaskLaneIsSetShort64_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort64_con() {
         res[0] = smask64.laneIsSet(0);
         res[1] = smask64.laneIsSet(1);
         res[2] = smask64.laneIsSet(2);
         res[3] = smask64.laneIsSet(3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort64_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort64_var() {
         res[0] = smask64.laneIsSet(idx);
         res[1] = smask64.laneIsSet(idx + 1);
         res[2] = smask64.laneIsSet(idx + 2);
         res[3] = smask64.laneIsSet(idx + 3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort128_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort128_con() {
         res[0] = smask128.laneIsSet(0);
         res[1] = smask128.laneIsSet(1);
         res[2] = smask128.laneIsSet(2);
@@ -197,11 +196,11 @@ public class VectorExtractBenchmark {
         res[5] = smask128.laneIsSet(5);
         res[6] = smask128.laneIsSet(6);
         res[7] = smask128.laneIsSet(7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort128_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort128_var() {
         res[0] = smask128.laneIsSet(idx);
         res[1] = smask128.laneIsSet(idx + 1);
         res[2] = smask128.laneIsSet(idx + 2);
@@ -210,11 +209,11 @@ public class VectorExtractBenchmark {
         res[5] = smask128.laneIsSet(idx + 5);
         res[6] = smask128.laneIsSet(idx + 6);
         res[7] = smask128.laneIsSet(idx + 7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort256_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort256_con() {
         res[0] = smask256.laneIsSet(0);
         res[1] = smask256.laneIsSet(1);
         res[2] = smask256.laneIsSet(2);
@@ -223,11 +222,11 @@ public class VectorExtractBenchmark {
         res[5] = smask256.laneIsSet(13);
         res[6] = smask256.laneIsSet(14);
         res[7] = smask256.laneIsSet(15);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort256_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort256_var() {
         res[0] = smask256.laneIsSet(idx);
         res[1] = smask256.laneIsSet(idx + 1);
         res[2] = smask256.laneIsSet(idx + 2);
@@ -236,11 +235,11 @@ public class VectorExtractBenchmark {
         res[5] = smask256.laneIsSet(idx + 13);
         res[6] = smask256.laneIsSet(idx + 14);
         res[7] = smask256.laneIsSet(idx + 15);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort512_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort512_con() {
         res[0] = smask512.laneIsSet(0);
         res[1] = smask512.laneIsSet(1);
         res[2] = smask512.laneIsSet(2);
@@ -249,11 +248,11 @@ public class VectorExtractBenchmark {
         res[5] = smask512.laneIsSet(29);
         res[6] = smask512.laneIsSet(30);
         res[7] = smask512.laneIsSet(31);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetShort512_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetShort512_var() {
         res[0] = smask512.laneIsSet(idx);
         res[1] = smask512.laneIsSet(idx + 1);
         res[2] = smask512.laneIsSet(idx + 2);
@@ -262,44 +261,44 @@ public class VectorExtractBenchmark {
         res[5] = smask512.laneIsSet(idx + 29);
         res[6] = smask512.laneIsSet(idx + 30);
         res[7] = smask512.laneIsSet(idx + 31);
-        bh.consume(res);
+        return res;
     }
 
 
     @Benchmark
-    public void microMaskLaneIsSetInt64_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt64_con() {
         res[0] = imask64.laneIsSet(0);
         res[1] = imask64.laneIsSet(1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt64_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt64_var() {
         res[0] = imask64.laneIsSet(idx);
         res[1] = imask64.laneIsSet(idx + 1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt128_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt128_con() {
         res[0] = imask128.laneIsSet(0);
         res[1] = imask128.laneIsSet(1);
         res[2] = imask128.laneIsSet(2);
         res[3] = imask128.laneIsSet(3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt128_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt128_var() {
         res[0] = imask128.laneIsSet(idx);
         res[1] = imask128.laneIsSet(idx + 1);
         res[2] = imask128.laneIsSet(idx + 2);
         res[3] = imask128.laneIsSet(idx + 3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt256_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt256_con() {
         res[0] = imask256.laneIsSet(0);
         res[1] = imask256.laneIsSet(1);
         res[2] = imask256.laneIsSet(2);
@@ -308,11 +307,11 @@ public class VectorExtractBenchmark {
         res[5] = imask256.laneIsSet(5);
         res[6] = imask256.laneIsSet(6);
         res[7] = imask256.laneIsSet(7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt256_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt256_var() {
         res[0] = imask256.laneIsSet(idx);
         res[1] = imask256.laneIsSet(idx + 1);
         res[2] = imask256.laneIsSet(idx + 2);
@@ -321,11 +320,11 @@ public class VectorExtractBenchmark {
         res[5] = imask256.laneIsSet(idx + 5);
         res[6] = imask256.laneIsSet(idx + 6);
         res[7] = imask256.laneIsSet(idx + 7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt512_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt512_con() {
         res[0] = imask512.laneIsSet(0);
         res[1] = imask512.laneIsSet(1);
         res[2] = imask512.laneIsSet(2);
@@ -334,11 +333,11 @@ public class VectorExtractBenchmark {
         res[5] = imask512.laneIsSet(13);
         res[6] = imask512.laneIsSet(14);
         res[7] = imask512.laneIsSet(15);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetInt512_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetInt512_var() {
         res[0] = imask512.laneIsSet(idx);
         res[1] = imask512.laneIsSet(idx + 1);
         res[2] = imask512.laneIsSet(idx + 2);
@@ -347,56 +346,56 @@ public class VectorExtractBenchmark {
         res[5] = imask512.laneIsSet(idx + 13);
         res[6] = imask512.laneIsSet(idx + 14);
         res[7] = imask512.laneIsSet(idx + 15);
-        bh.consume(res);
+        return res;
     }
 
 
     @Benchmark
-    public void microMaskLaneIsSetLong64_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong64_con() {
         res[0] = lmask64.laneIsSet(0);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong64_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong64_var() {
         res[0] = lmask64.laneIsSet(idx);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong128_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong128_con() {
         res[0] = lmask128.laneIsSet(0);
         res[1] = lmask128.laneIsSet(1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong128_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong128_var() {
         res[0] = lmask128.laneIsSet(idx);
         res[1] = lmask128.laneIsSet(idx + 1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong256_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong256_con() {
         res[0] = lmask256.laneIsSet(0);
         res[1] = lmask256.laneIsSet(1);
         res[2] = lmask256.laneIsSet(2);
         res[3] = lmask256.laneIsSet(3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong256_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong256_var() {
         res[0] = lmask256.laneIsSet(idx);
         res[1] = lmask256.laneIsSet(idx + 1);
         res[2] = lmask256.laneIsSet(idx + 2);
         res[3] = lmask256.laneIsSet(idx + 3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong512_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong512_con() {
         res[0] = lmask512.laneIsSet(0);
         res[1] = lmask512.laneIsSet(1);
         res[2] = lmask512.laneIsSet(2);
@@ -405,11 +404,11 @@ public class VectorExtractBenchmark {
         res[5] = lmask512.laneIsSet(5);
         res[6] = lmask512.laneIsSet(6);
         res[7] = lmask512.laneIsSet(7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetLong512_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetLong512_var() {
         res[0] = lmask512.laneIsSet(idx);
         res[1] = lmask512.laneIsSet(idx + 1);
         res[2] = lmask512.laneIsSet(idx + 2);
@@ -418,44 +417,44 @@ public class VectorExtractBenchmark {
         res[5] = lmask512.laneIsSet(idx + 5);
         res[6] = lmask512.laneIsSet(idx + 6);
         res[7] = lmask512.laneIsSet(idx + 7);
-        bh.consume(res);
+        return res;
     }
 
 
     @Benchmark
-    public void microMaskLaneIsSetFloat64_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat64_con() {
         res[0] = fmask64.laneIsSet(0);
         res[1] = fmask64.laneIsSet(1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat64_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat64_var() {
         res[0] = fmask64.laneIsSet(idx);
         res[1] = fmask64.laneIsSet(idx + 1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat128_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat128_con() {
         res[0] = fmask128.laneIsSet(0);
         res[1] = fmask128.laneIsSet(1);
         res[2] = fmask128.laneIsSet(2);
         res[3] = fmask128.laneIsSet(3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat128_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat128_var() {
         res[0] = fmask128.laneIsSet(idx);
         res[1] = fmask128.laneIsSet(idx + 1);
         res[2] = fmask128.laneIsSet(idx + 2);
         res[3] = fmask128.laneIsSet(idx + 3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat256_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat256_con() {
         res[0] = fmask256.laneIsSet(0);
         res[1] = fmask256.laneIsSet(1);
         res[2] = fmask256.laneIsSet(2);
@@ -464,11 +463,11 @@ public class VectorExtractBenchmark {
         res[5] = fmask256.laneIsSet(5);
         res[6] = fmask256.laneIsSet(6);
         res[7] = fmask256.laneIsSet(7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat256_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat256_var() {
         res[0] = fmask256.laneIsSet(idx);
         res[1] = fmask256.laneIsSet(idx + 1);
         res[2] = fmask256.laneIsSet(idx + 2);
@@ -477,11 +476,11 @@ public class VectorExtractBenchmark {
         res[5] = fmask256.laneIsSet(idx + 5);
         res[6] = fmask256.laneIsSet(idx + 6);
         res[7] = fmask256.laneIsSet(idx + 7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat512_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat512_con() {
         res[0] = fmask512.laneIsSet(0);
         res[1] = fmask512.laneIsSet(1);
         res[2] = fmask512.laneIsSet(2);
@@ -490,11 +489,11 @@ public class VectorExtractBenchmark {
         res[5] = fmask512.laneIsSet(13);
         res[6] = fmask512.laneIsSet(14);
         res[7] = fmask512.laneIsSet(15);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetFloat512_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetFloat512_var() {
         res[0] = fmask512.laneIsSet(idx);
         res[1] = fmask512.laneIsSet(idx + 1);
         res[2] = fmask512.laneIsSet(idx + 2);
@@ -503,56 +502,56 @@ public class VectorExtractBenchmark {
         res[5] = fmask512.laneIsSet(idx + 13);
         res[6] = fmask512.laneIsSet(idx + 14);
         res[7] = fmask512.laneIsSet(idx + 15);
-        bh.consume(res);
+        return res;
     }
 
 
     @Benchmark
-    public void microMaskLaneIsSetDouble64_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble64_con() {
         res[0] = dmask64.laneIsSet(0);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble64_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble64_var() {
         res[0] = dmask64.laneIsSet(idx);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble128_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble128_con() {
         res[0] = dmask128.laneIsSet(0);
         res[1] = dmask128.laneIsSet(1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble128_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble128_var() {
         res[0] = dmask128.laneIsSet(idx);
         res[1] = dmask128.laneIsSet(idx + 1);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble256_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble256_con() {
         res[0] = dmask256.laneIsSet(0);
         res[1] = dmask256.laneIsSet(1);
         res[2] = dmask256.laneIsSet(2);
         res[3] = dmask256.laneIsSet(3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble256_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble256_var() {
         res[0] = dmask256.laneIsSet(idx);
         res[1] = dmask256.laneIsSet(idx + 1);
         res[2] = dmask256.laneIsSet(idx + 2);
         res[3] = dmask256.laneIsSet(idx + 3);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble512_con(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble512_con() {
         res[0] = dmask512.laneIsSet(0);
         res[1] = dmask512.laneIsSet(1);
         res[2] = dmask512.laneIsSet(2);
@@ -561,11 +560,11 @@ public class VectorExtractBenchmark {
         res[5] = dmask512.laneIsSet(5);
         res[6] = dmask512.laneIsSet(6);
         res[7] = dmask512.laneIsSet(7);
-        bh.consume(res);
+        return res;
     }
 
     @Benchmark
-    public void microMaskLaneIsSetDouble512_var(Blackhole bh) {
+    public boolean[] microMaskLaneIsSetDouble512_var() {
         res[0] = dmask512.laneIsSet(idx);
         res[1] = dmask512.laneIsSet(idx + 1);
         res[2] = dmask512.laneIsSet(idx + 2);
@@ -574,6 +573,6 @@ public class VectorExtractBenchmark {
         res[5] = dmask512.laneIsSet(idx + 5);
         res[6] = dmask512.laneIsSet(idx + 6);
         res[7] = dmask512.laneIsSet(idx + 7);
-        bh.consume(res);
+        return res;
     }
 }


### PR DESCRIPTION
VectorMask.laneIsSet() [1] is implemented based on VectorMask.toLong() [2], and it's performance highly depends on the intrinsification of toLong(). However, if `toLong()` is failed to intrinsify, on some architectures or unsupported species, it's much more expensive than pure getBits(). Besides, some CPUs (e.g. with Arm Neon) may not have efficient instructions to implementation toLong(), so we propose to intrinsify VectorMask.laneIsSet separately.

This patch optimize laneIsSet() by calling the existing intrinsic method VectorSupport.extract(), which actually does not introduce new intrinsic method. The C2 compiler intrinsification logic to support _VectorExtract has also been extended to better support laneIsSet(). It tries to extract the mask's lane value with an ExtractUB node if the hardware backend supports it. While on hardware without ExtractUB backend support , c2 will still try to generate toLong() related nodes, which behaves the same as before the patch.

Key changes in this patch:

1. Reuse intrinsic `VectorSupport.extract()` in Java side. No new intrinsic method is introduced.
2. In compiler, `ExtractUBNode` is generated if backend support is. If not, the original "toLong" pattern is generated if it's implemented. Otherwise, it uses the default Java `getBits[i]` rather than the expensive and complicated toLong() based implementation.
3. Enable `ExtractUBNode` on AArch64 to extract the lane value for a vector mask in compiler, together with changing its bottom type to TypeInt::BOOL. This helps optimize the conditional selection generated by

   ```

       public boolean laneIsSet(int i) {
           return VectorSupport.extract(..., defaultImpl) == 1L;
       }

   ```

[Test]
hotspot:compiler/vectorapi and jdk/incubator/vector passed.

[Performance]

Below shows the performance gain on 128-bit vector size Neon machine. For 64 and 128 SPECIES, the improvment caused by this intrinsics. For other SPECIES which can not be intrinfied, performance gain comes from the default Java implementation changes, i.e. getBits[i] vs. toLong().

```
Benchmark                               Gain (after/before)
microMaskLaneIsSetByte128_con           2.47
microMaskLaneIsSetByte128_var           1.82
microMaskLaneIsSetByte256_con           3.01
microMaskLaneIsSetByte256_var           3.04
microMaskLaneIsSetByte512_con           4.83
microMaskLaneIsSetByte512_var           4.86
microMaskLaneIsSetByte64_con            1.57
microMaskLaneIsSetByte64_var            1.18
microMaskLaneIsSetDouble128_con         1.19
microMaskLaneIsSetDouble128_var         1.13
microMaskLaneIsSetDouble256_con         1.33
microMaskLaneIsSetDouble256_var         1.40
microMaskLaneIsSetDouble512_con         1.62
microMaskLaneIsSetDouble512_var         1.70
microMaskLaneIsSetDouble64_con          1.18
microMaskLaneIsSetDouble64_var          1.21
microMaskLaneIsSetFloat128_con          1.56
microMaskLaneIsSetFloat128_var          1.25
microMaskLaneIsSetFloat256_con          1.63
microMaskLaneIsSetFloat256_var          1.68
microMaskLaneIsSetFloat512_con          2.13
microMaskLaneIsSetFloat512_var          2.18
microMaskLaneIsSetFloat64_con           1.21
microMaskLaneIsSetFloat64_var           1.11
microMaskLaneIsSetInt128_con            1.54
microMaskLaneIsSetInt128_var            1.24
microMaskLaneIsSetInt256_con            1.63
microMaskLaneIsSetInt256_var            1.72
microMaskLaneIsSetInt512_con            2.09
microMaskLaneIsSetInt512_var            2.19
microMaskLaneIsSetInt64_con             1.22
microMaskLaneIsSetInt64_var             1.13
microMaskLaneIsSetLong128_con           1.21
microMaskLaneIsSetLong128_var           1.08
microMaskLaneIsSetLong256_con           1.29
microMaskLaneIsSetLong256_var           1.41
microMaskLaneIsSetLong512_con           1.62
microMaskLaneIsSetLong512_var           1.67
microMaskLaneIsSetLong64_con            1.18
microMaskLaneIsSetLong64_var            1.21
microMaskLaneIsSetShort128_con          1.57
microMaskLaneIsSetShort128_var          1.19
microMaskLaneIsSetShort256_con          2.09
microMaskLaneIsSetShort256_var          2.17
microMaskLaneIsSetShort512_con          3.00
microMaskLaneIsSetShort512_var          3.08
microMaskLaneIsSetShort64_con           1.56
microMaskLaneIsSetShort64_var           1.25
```
No regression on x86.

[1] https://github.com/openjdk/jdk/blob/3d3eaed9133dbe728ca8e00a626d33f7e35ba9ff/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java#L72
[2] https://github.com/openjdk/jdk/blob/3d3eaed9133dbe728ca8e00a626d33f7e35ba9ff/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java#L726
[3] https://github.com/openjdk/jdk/blob/3d3eaed9133dbe728ca8e00a626d33f7e35ba9ff/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java#L195

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306136](https://bugs.openjdk.org/browse/JDK-8306136): [vectorapi] Intrinsics of VectorMask.laneIsSet() (**Enhancement** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14200/head:pull/14200` \
`$ git checkout pull/14200`

Update a local copy of the PR: \
`$ git checkout pull/14200` \
`$ git pull https://git.openjdk.org/jdk.git pull/14200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14200`

View PR using the GUI difftool: \
`$ git pr show -t 14200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14200.diff">https://git.openjdk.org/jdk/pull/14200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14200#issuecomment-1567049369)