### PR TITLE
8308961: Automatically find configuration matching name of checked of branch

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -243,15 +243,16 @@ ifeq ($(HAS_SPEC),)
           GIT_IS_INSIDE_WORK_TREE := $$(shell $$(GIT) rev-parse --is-inside-work-tree 2>/dev/null)
           ifeq ($$(GIT_IS_INSIDE_WORK_TREE), true)
             GIT_CURRENT_BRANCH := $$(shell $$(GIT) rev-parse --abbrev-ref HEAD)
-            GIT_BRANCH_CONF := $$(strip $$(filter $$(GIT_CURRENT_BRANCH), $$(all_confs)))
+            GIT_BRANCH_CONFS := $$(strip $$(foreach var, $$(all_confs), \
+                $$(if $$(findstring $$(GIT_CURRENT_BRANCH), $$(var)), $$(var))))
           endif
         endif
         ifeq ($$(words $$(all_spec_files)), 1)
           # We found exactly one configuration, use it
           SPECS := $$(strip $$(all_spec_files))
-        else ifeq ($$(words $$(GIT_BRANCH_CONF)), 1)
-          # We found exactly one configuration with the name of the checked out Git branch, use it
-          SPECS := $$(build_dir)/$$(GIT_BRANCH_CONF)/spec.gmk
+        else ifeq ($$(words $$(GIT_BRANCH_CONFS)), 1)
+          # We found exactly one configuration containing the name of the checked out Git branch, use it
+          SPECS := $$(build_dir)/$$(GIT_BRANCH_CONFS)/spec.gmk
         else
           $$(info Error: No CONF given, but more than one configuration found.)
           $$(info Available configurations in $$(build_dir):)

--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -238,7 +238,18 @@ ifeq ($(HAS_SPEC),)
         SPECS := $$(addsuffix /spec.gmk, $$(addprefix $$(build_dir)/, $$(matching_confs)))
       else
         # No CONF or SPEC given, check the available configurations
-        ifneq ($$(words $$(all_spec_files)), 1)
+        GIT := $$(shell command -v git 2>/dev/null)
+        ifneq ($$(GIT),)
+          GIT_CURRENT_BRANCH := $$(shell $$(GIT) rev-parse --abbrev-ref HEAD)
+          GIT_BRANCH_CONF := $$(strip $$(filter $$(GIT_CURRENT_BRANCH), $$(all_confs)))
+        endif
+        ifeq ($$(words $$(all_spec_files)), 1)
+          # We found exactly one configuration, use it
+          SPECS := $$(strip $$(all_spec_files))
+        else ifeq ($$(words $$(GIT_BRANCH_CONF)), 1)
+          # We found exactly one configuration with the name of the checked out Git branch, use it
+          SPECS := $$(build_dir)/$$(GIT_BRANCH_CONF)/spec.gmk
+        else
           $$(info Error: No CONF given, but more than one configuration found.)
           $$(info Available configurations in $$(build_dir):)
           $$(foreach var, $$(all_confs), $$(info * $$(var)))
@@ -246,9 +257,6 @@ ifeq ($(HAS_SPEC),)
           $$(info )
           $$(error Cannot continue)
         endif
-
-        # We found exactly one configuration, use it
-        SPECS := $$(strip $$(all_spec_files))
       endif
     endif
   endef

--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -240,8 +240,11 @@ ifeq ($(HAS_SPEC),)
         # No CONF or SPEC given, check the available configurations
         GIT := $$(shell command -v git 2>/dev/null)
         ifneq ($$(GIT),)
-          GIT_CURRENT_BRANCH := $$(shell $$(GIT) rev-parse --abbrev-ref HEAD)
-          GIT_BRANCH_CONF := $$(strip $$(filter $$(GIT_CURRENT_BRANCH), $$(all_confs)))
+          GIT_IS_INSIDE_WORK_TREE := $$(shell $$(GIT) rev-parse --is-inside-work-tree 2>/dev/null)
+          ifeq ($$(GIT_IS_INSIDE_WORK_TREE), true)
+            GIT_CURRENT_BRANCH := $$(shell $$(GIT) rev-parse --abbrev-ref HEAD)
+            GIT_BRANCH_CONF := $$(strip $$(filter $$(GIT_CURRENT_BRANCH), $$(all_confs)))
+          endif
         endif
         ifeq ($$(words $$(all_spec_files)), 1)
           # We found exactly one configuration, use it


### PR DESCRIPTION
Hi all,

please review this smaller patch to the build system. This patch changes what the build system will do when there are multiple configurations available and none has been selected (neither via `CONF` nor via `SPEC`). Instead of printing an error message (current behavior) the build system will instead check if the name of any configuration exactly matches the name of the checked out Git branch. If so, then that configuration will be built.

The rationale for this change is that many developers (including me) use branches to work on multiple things concurrently. Having (at least) one configuration per branch, named after the branch, is a very natural model then for setting up one's build configurations. Having the build configuration corresponding to the checked out Git branch built automatically is then very convenient (instead of typing `make CONF=$(git branch --show-current)` every time).

A couple of design considerations:
- why use `$$(shell command -v git 2>/dev/null)` instead of `$$(GIT)` from autoconf? Because we don't have a `spec.gmk` available because we haven't chosen a configuration yet, so we don't have `$$(GIT)`.
- why use `git rev-parse --abbrev-ref HEAD` instead of `git branch --show-current`? Because `git rev-parse --abbrev-ref` has been around since [2009](https://github.com/git/git/commit/a45d34691ea624e93863e95706eeb1b1909304f3) and `git branch --show-current` was introduced in Git 2.22 in 2019 (plus that `rev-parse --abbrev-ref` works with a detached `HEAD`). `git rev-parse --is-inside-work-tree` is from [2007](https://github.com/git/git/commit/892c41b98ae2e6baf3aa13901cb10db9ac67d2f3), but I think requiring a Git installation more recent than 2009 should be ok.
- why match the branch name exactly instead of a looser matching? This could be beneficial if branches are named e.g. `$(git branch --show-current)-fastdebug`, but I wanted to start out with something strict and then the matching can be made looser if needed.
- is this backwards compatible? Yes, at least I think so. Previously the build system would return an error but now it might build a configuration, that seems compatible. The patch does not interfere at all with the code paths where `CONF` or `SPEC` has been set.

### Testing
- [x] Tested locally on macOS/aarch64 and Linux/x64 with and without configurations matching the named Git branch.
- [x] Tested locally on macOS/aarch64 and Linux/x64 without a Git client.
- [x] Tested locally on macOS/aarch64 and Linux/x64 with a source directory without a `.git` directory (i.e. not a repository).

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308961](https://bugs.openjdk.org/browse/JDK-8308961): Automatically find configuration matching name of checked of branch (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14202/head:pull/14202` \
`$ git checkout pull/14202`

Update a local copy of the PR: \
`$ git checkout pull/14202` \
`$ git pull https://git.openjdk.org/jdk.git pull/14202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14202`

View PR using the GUI difftool: \
`$ git pr show -t 14202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14202.diff">https://git.openjdk.org/jdk/pull/14202.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14202#issuecomment-1567142469)