### PR TITLE
8308765: RISC-V: Expand size of stub routines for zgc only

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -758,8 +758,8 @@ void MacroAssembler::la(Register Rd, Label &label) {
   wrap_label(Rd, label, &MacroAssembler::la);
 }
 
-void MacroAssembler::li16u(Register Rd, int32_t imm) {
-  lui(Rd, imm << 12);
+void MacroAssembler::li16u(Register Rd, uint16_t imm) {
+  lui(Rd, (uint32_t)imm << 12);
   srli(Rd, Rd, 12);
 }
 
@@ -1412,8 +1412,8 @@ static int patch_imm_in_li64(address branch, address target) {
   return LI64_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }
 
-static int patch_imm_in_li16u(address branch, int32_t target) {
-  Assembler::patch(branch, 31, 12, target & 0xfffff); // patch lui only
+static int patch_imm_in_li16u(address branch, uint16_t target) {
+  Assembler::patch(branch, 31, 12, target); // patch lui only
   return NativeInstruction::instruction_size;
 }
 
@@ -1508,7 +1508,7 @@ int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
     return patch_imm_in_li32(branch, (int32_t)imm);
   } else if (NativeInstruction::is_li16u_at(branch)) {
     int64_t imm = (intptr_t)target;
-    return patch_imm_in_li16u(branch, (int32_t)imm);
+    return patch_imm_in_li16u(branch, (uint16_t)imm);
   } else {
 #ifdef ASSERT
     tty->print_cr("pd_patch_instruction_size: instruction 0x%x at " INTPTR_FORMAT " could not be patched!\n",

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -693,7 +693,7 @@ public:
   void la(Register Rd, const address dest);
   void la(Register Rd, const Address &adr);
 
-  void li16u(Register Rd, int32_t imm);
+  void li16u(Register Rd, uint16_t imm);
   void li32(Register Rd, int32_t imm);
   void li64(Register Rd, int64_t imm);
   void li  (Register Rd, int64_t imm);  // optimized load immediate

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -37,10 +37,10 @@ static bool returns_to_call_stub(address return_pc) {
 
 enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
-  _initial_stubs_code_size      = 19000,
+  _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 128000,
-  _final_stubs_code_size        = 128000
+  _compiler_stubs_code_size     = 15000 ZGC_ONLY(+5000),
+  _final_stubs_code_size        = 20000 ZGC_ONLY(+10000)
 };
 
 class riscv {


### PR DESCRIPTION
Size of stub routines is over expanded after https://bugs.openjdk.org/browse/JDK-8307058. It should return to a proper size, and only increase when zgc enabled on riscv, same as that on aarch64 and x86 port.
This PR also guarantees that li16u instructions can only accept 16 bits immediate values when patched or encoded.

The new size of stubs are tested with -XX:+UseZGC -XX:+ZGenerational -XX:-UseRVC, and checked with -Xlog:stubs.

Tier 1~3 passed on the unmatched boards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308765](https://bugs.openjdk.org/browse/JDK-8308765): RISC-V: Expand size of stub routines for zgc only


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14203/head:pull/14203` \
`$ git checkout pull/14203`

Update a local copy of the PR: \
`$ git checkout pull/14203` \
`$ git pull https://git.openjdk.org/jdk.git pull/14203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14203`

View PR using the GUI difftool: \
`$ git pr show -t 14203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14203.diff">https://git.openjdk.org/jdk/pull/14203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14203#issuecomment-1567253024)