### PR TITLE
8309054: Parsing of erroneous patterns succeeds

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -889,7 +889,11 @@ public class JavacParser implements Parser {
             } else {
                 //type test pattern:
                 int varPos = token.pos;
-                JCVariableDecl var = variableDeclaratorRest(varPos, mods, e, identOrUnderscore(), false, null, false, false, true);
+                Name name = identOrUnderscore();
+                if (Feature.UNNAMED_VARIABLES.allowedInSource(source) && name == names.underscore) {
+                    name = names.empty;
+                }
+                JCVariableDecl var = toP(F.at(varPos).VarDef(mods, name, e, null));
                 if (e == null) {
                     var.startPos = pos;
                     if (var.name == names.underscore && !allowVar) {
@@ -3618,7 +3622,7 @@ public class JavacParser implements Parser {
                                                                      T vdefs,
                                                                      boolean localDecl)
     {
-        JCVariableDecl head = variableDeclaratorRest(pos, mods, type, name, reqInit, dc, localDecl, false, false);
+        JCVariableDecl head = variableDeclaratorRest(pos, mods, type, name, reqInit, dc, localDecl, false);
         vdefs.append(head);
         while (token.kind == COMMA) {
             // All but last of multiple declarators subsume a comma
@@ -3633,7 +3637,7 @@ public class JavacParser implements Parser {
      *  ConstantDeclarator = Ident ConstantDeclaratorRest
      */
     JCVariableDecl variableDeclarator(JCModifiers mods, JCExpression type, boolean reqInit, Comment dc, boolean localDecl) {
-        return variableDeclaratorRest(token.pos, mods, type, identOrUnderscore(), reqInit, dc, localDecl, true, false);
+        return variableDeclaratorRest(token.pos, mods, type, identOrUnderscore(), reqInit, dc, localDecl, true);
     }
 
     /** VariableDeclaratorRest = BracketsOpt ["=" VariableInitializer]
@@ -3643,13 +3647,13 @@ public class JavacParser implements Parser {
      *  @param dc       The documentation comment for the variable declarations, or null.
      */
     JCVariableDecl variableDeclaratorRest(int pos, JCModifiers mods, JCExpression type, Name name,
-                                  boolean reqInit, Comment dc, boolean localDecl, boolean compound, boolean isTypePattern) {
+                                  boolean reqInit, Comment dc, boolean localDecl, boolean compound) {
         boolean declaredUsingVar = false;
-        type = bracketsOpt(type);
         JCExpression init = null;
+        type = bracketsOpt(type);
 
         if (Feature.UNNAMED_VARIABLES.allowedInSource(source) && name == names.underscore) {
-            if (!localDecl && !isTypePattern) {
+            if (!localDecl) {
                 log.error(DiagnosticFlag.SYNTAX, pos, Errors.UseOfUnderscoreNotAllowed);
             }
             name = names.empty;
@@ -3668,38 +3672,32 @@ public class JavacParser implements Parser {
             syntaxError(token.pos, Errors.Expected(EQ));
         }
 
-        JCVariableDecl result;
-        if (!isTypePattern) {
-            int startPos = Position.NOPOS;
-            JCTree elemType = TreeInfo.innermostType(type, true);
-            if (elemType.hasTag(IDENT)) {
-                Name typeName = ((JCIdent) elemType).name;
-                if (restrictedTypeNameStartingAtSource(typeName, pos, !compound && localDecl) != null) {
-                    if (typeName != names.var) {
-                        reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedHere(typeName));
-                    } else if (type.hasTag(TYPEARRAY) && !compound) {
-                        //error - 'var' and arrays
-                        reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedArray(typeName));
-                    } else {
-                        declaredUsingVar = true;
-                        if (compound)
-                            //error - 'var' in compound local var decl
-                            reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedCompound(typeName));
-                        startPos = TreeInfo.getStartPos(mods);
-                        if (startPos == Position.NOPOS)
-                            startPos = TreeInfo.getStartPos(type);
-                        //implicit type
-                        type = null;
-                    }
+        int startPos = Position.NOPOS;
+        JCTree elemType = TreeInfo.innermostType(type, true);
+        if (elemType.hasTag(IDENT)) {
+            Name typeName = ((JCIdent) elemType).name;
+            if (restrictedTypeNameStartingAtSource(typeName, pos, !compound && localDecl) != null) {
+                if (typeName != names.var) {
+                    reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedHere(typeName));
+                } else if (type.hasTag(TYPEARRAY) && !compound) {
+                    //error - 'var' and arrays
+                    reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedArray(typeName));
+                } else {
+                    declaredUsingVar = true;
+                    if (compound)
+                        //error - 'var' in compound local var decl
+                        reportSyntaxError(elemType.pos, Errors.RestrictedTypeNotAllowedCompound(typeName));
+                    startPos = TreeInfo.getStartPos(mods);
+                    if (startPos == Position.NOPOS)
+                        startPos = TreeInfo.getStartPos(type);
+                    //implicit type
+                    type = null;
                 }
             }
-            result = toP(F.at(pos).VarDef(mods, name, type, init, declaredUsingVar));
-            attach(result, dc);
-            result.startPos = startPos;
-        } else {
-            result = toP(F.at(pos).VarDef(mods, name, type, null));
         }
-
+        JCVariableDecl result = toP(F.at(pos).VarDef(mods, name, type, init, declaredUsingVar));
+        attach(result, dc);
+        result.startPos = startPos;
         return result;
     }
 
@@ -3843,12 +3841,12 @@ public class JavacParser implements Parser {
         if (token.kind == FINAL || token.kind == MONKEYS_AT) {
             JCModifiers mods = optFinal(0);
             JCExpression t = parseType(true);
-            return variableDeclaratorRest(token.pos, mods, t, identOrUnderscore(), true, null, true, false, false);
+            return variableDeclaratorRest(token.pos, mods, t, identOrUnderscore(), true, null, true, false);
         }
         JCExpression t = term(EXPR | TYPE);
         if (wasTypeMode() && LAX_IDENTIFIER.test(token.kind)) {
             JCModifiers mods = F.Modifiers(0);
-            return variableDeclaratorRest(token.pos, mods, t, identOrUnderscore(), true, null, true, false, false);
+            return variableDeclaratorRest(token.pos, mods, t, identOrUnderscore(), true, null, true, false);
         } else {
             checkSourceLevel(Feature.EFFECTIVELY_FINAL_VARIABLES_IN_TRY_WITH_RESOURCES);
             if (!t.hasTag(IDENT) && !t.hasTag(SELECT)) {

--- a/test/langtools/tools/javac/patterns/T8309054.java
+++ b/test/langtools/tools/javac/patterns/T8309054.java
@@ -1,0 +1,24 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8309054
+ * @summary Parsing of erroneous patterns succeeds
+ * @enablePreview
+ * @compile/fail/ref=T8309054.out -XDrawDiagnostics --should-stop=at=FLOW T8309054.java
+ */
+
+public class T8309054  {
+    public void test(Object obj) {
+        boolean t1 = switch (obj) {
+            case Long a[] -> true;
+            default -> false;
+        };
+        boolean t2 = switch (obj) {
+            case Double a[][][][] -> true;
+            default -> false;
+        };
+        if (obj instanceof Float a[][]) {
+        }
+        if (obj instanceof Integer a = Integer.valueOf(0)) {
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8309054.out
+++ b/test/langtools/tools/javac/patterns/T8309054.out
@@ -1,0 +1,7 @@
+T8309054.java:12:24: compiler.err.expected2: :, ->
+T8309054.java:16:26: compiler.err.expected2: :, ->
+T8309054.java:19:35: compiler.err.expected: ')'
+T8309054.java:13:13: compiler.err.switch.mixing.case.types
+T8309054.java:17:13: compiler.err.switch.mixing.case.types
+T8309054.java:21:17: compiler.err.unexpected.type: kindname.variable, kindname.value
+6 errors


### PR DESCRIPTION
Moving the logic of type test pattern detection from `parsePattern` to `variableDeclaratorRest` in #13528 made the logic of the latter too complex. The regression in this JBS would be fixed by introducing two additional if-guards (e.g., `if (!typePattern)`); conditional on whether we are detecting a local variable or a type pattern. This PR removes this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309054](https://bugs.openjdk.org/browse/JDK-8309054): Parsing of erroneous patterns succeeds


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14205/head:pull/14205` \
`$ git checkout pull/14205`

Update a local copy of the PR: \
`$ git checkout pull/14205` \
`$ git pull https://git.openjdk.org/jdk.git pull/14205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14205`

View PR using the GUI difftool: \
`$ git pr show -t 14205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14205.diff">https://git.openjdk.org/jdk/pull/14205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14205#issuecomment-1567304782)