### PR TITLE
8309060: Compilation Error in javax/swing/event/FocusEventCauseTest.java

### DIFF
--- a/test/jdk/javax/swing/event/FocusEventCauseTest.java
+++ b/test/jdk/javax/swing/event/FocusEventCauseTest.java
@@ -32,7 +32,7 @@
 
 import java.awt.Dimension;
 import java.awt.Point;
-import java.awt.Robot;;
+import java.awt.Robot;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.InputEvent;


### PR DESCRIPTION
Inadvertent extraneous semicolon causing compilation error is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309060](https://bugs.openjdk.org/browse/JDK-8309060): Compilation Error in javax/swing/event/FocusEventCauseTest.java


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14206/head:pull/14206` \
`$ git checkout pull/14206`

Update a local copy of the PR: \
`$ git checkout pull/14206` \
`$ git pull https://git.openjdk.org/jdk.git pull/14206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14206`

View PR using the GUI difftool: \
`$ git pr show -t 14206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14206.diff">https://git.openjdk.org/jdk/pull/14206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14206#issuecomment-1567325843)