### PR TITLE
JDK-8303549: [AIX] TestNativeStack.java is failing with exit value 1

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
@@ -109,7 +109,17 @@ Java_TestNativeStack_triggerJNIStackTrace
 
   warning = warn;
 
-  if ((res = pthread_create(&thread, NULL, thread_start, NULL)) != 0) {
+#ifdef AIX
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  size_t stack_size = 0x100000;
+  pthread_attr_setstacksize(&attr, stack_size);
+  res = pthread_create(&thread, &attr, thread_start, NULL);
+#else
+  res = pthread_create(&thread, NULL, thread_start, NULL);
+#endif //AIX
+
+  if (res != 0) {
     fprintf(stderr, "TEST ERROR: pthread_create failed: %s (%d)\n", strerror(res), res);
     exit(1);
   }


### PR DESCRIPTION
Stackoverflow exception has caused an exit value 1 when native thread is attaching as daemon. 
On AIX the default stack for posix thread is 192 KB. For this particular test we run thread in pthread_create() which is defined in pthread library thus not following JVM thread creation routines. Hence we have to explicitly provide stack size. 

Reported Issue :[JDK-8303549]( https://bugs.openjdk.org/browse/JDK-8303549)