### PR TITLE
8309077: Problemlist compiler/jvmci/TestUncaughtErrorInCompileMethod.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,6 +71,8 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/c2/irTests/TestVectorConditionalMove.java 8306922 generic-all
 
+compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Problem listing the test again until [JDK-8309073](https://bugs.openjdk.org/browse/JDK-8309073) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309077](https://bugs.openjdk.org/browse/JDK-8309077): Problemlist compiler/jvmci/TestUncaughtErrorInCompileMethod.java


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14210/head:pull/14210` \
`$ git checkout pull/14210`

Update a local copy of the PR: \
`$ git checkout pull/14210` \
`$ git pull https://git.openjdk.org/jdk.git pull/14210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14210`

View PR using the GUI difftool: \
`$ git pr show -t 14210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14210.diff">https://git.openjdk.org/jdk/pull/14210.diff</a>

</details>
