### PR TITLE
8289220: Locale.forLanguageTag throws NPE due to soft ref used in locale cache being cleared

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1872,6 +1872,9 @@ public final class Locale implements Cloneable, Serializable {
         InternalLocaleBuilder bldr = new InternalLocaleBuilder();
         bldr.setLanguageTag(tag);
         BaseLocale base = bldr.getBaseLocale();
+        if (base == null) {
+            return null;
+        }
         LocaleExtensions exts = bldr.getLocaleExtensions();
         if (exts == null && !base.getVariant().isEmpty()) {
             exts = getCompatibilityExtensions(base.getLanguage(), base.getScript(),

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1872,9 +1872,6 @@ public final class Locale implements Cloneable, Serializable {
         InternalLocaleBuilder bldr = new InternalLocaleBuilder();
         bldr.setLanguageTag(tag);
         BaseLocale base = bldr.getBaseLocale();
-        if (base == null) {
-            return null;
-        }
         LocaleExtensions exts = bldr.getLocaleExtensions();
         if (exts == null && !base.getVariant().isEmpty()) {
             exts = getCompatibilityExtensions(base.getLanguage(), base.getScript(),

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -36,6 +36,7 @@ import jdk.internal.misc.CDS;
 import jdk.internal.util.StaticProperty;
 import jdk.internal.vm.annotation.Stable;
 
+import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.util.StringJoiner;
 
@@ -366,7 +367,9 @@ public final class BaseLocale {
             assert (key.holder != null && key.holderRef == null);
             BaseLocale l = key.holder;
             BaseLocale locale = new BaseLocale(l.getLanguage(), l.getScript(), l.getRegion(), l.getVariant(), true);
-            return (new Key(locale)).getBaseLocale();
+            BaseLocale value = (new Key(locale)).getBaseLocale();
+            Reference.reachabilityFence(locale);
+            return value;
         }
     }
 }

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -272,6 +272,13 @@ public final class BaseLocale {
             this.hash = hashCode(locale);
         }
 
+        private Key(BaseLocale locale) {
+            this.normalized = true;
+            this.holderRef = new SoftReference<>(locale);
+            this.holder = null;
+            this.hash = hashCode(locale);
+        }
+
         public int hashCode() {
             return hash;
         }
@@ -352,7 +359,14 @@ public final class BaseLocale {
 
         @Override
         protected BaseLocale createObject(Key key) {
-            return Key.normalize(key).getBaseLocale();
+            if (key.normalized) {
+                return key.getBaseLocale();
+            }
+
+            assert (key.holder != null && key.holderRef == null);
+            BaseLocale l = key.holder;
+            BaseLocale locale = new BaseLocale(l.getLanguage(), l.getScript(), l.getRegion(), l.getVariant(), true);
+            return (new Key(locale)).getBaseLocale();
         }
     }
 }

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -367,9 +367,12 @@ public final class BaseLocale {
             assert (key.holder != null && key.holderRef == null);
             BaseLocale l = key.holder;
             BaseLocale locale = new BaseLocale(l.getLanguage(), l.getScript(), l.getRegion(), l.getVariant(), true);
-            BaseLocale value = (new Key(locale)).getBaseLocale();
-            Reference.reachabilityFence(locale);
-            return value;
+            try {
+                BaseLocale value = (new Key(locale)).getBaseLocale();
+                return value;
+            } finally {
+               Reference.reachabilityFence(locale);
+            }
         }
     }
 }

--- a/src/java.base/share/classes/sun/util/locale/LocaleObjectCache.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleObjectCache.java
@@ -57,9 +57,8 @@ public abstract class LocaleObjectCache<K, V> {
             value = entry.get();
         }
         if (value == null) {
-            key = normalizeKey(key);
             V newVal = createObject(key);
-            if (key == null || newVal == null) {
+            if (newVal == null) {
                 // subclass must return non-null key/value object
                 return null;
             }

--- a/src/java.base/share/classes/sun/util/locale/LocaleObjectCache.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleObjectCache.java
@@ -60,7 +60,7 @@ public abstract class LocaleObjectCache<K, V> {
             V newVal = createObject(key);
             if (newVal == null) {
                 // subclass must return non-null key/value object
-                return null;
+                throw new NullPointerException();
             }
 
             CacheEntry<K, V> newEntry = new CacheEntry<>(key, newVal, queue);

--- a/test/micro/org/openjdk/bench/java/util/LocaleDefaults.java
+++ b/test/micro/org/openjdk/bench/java/util/LocaleDefaults.java
@@ -60,5 +60,10 @@ public class LocaleDefaults {
     public Locale getDefaultFormat() {
         return Locale.getDefault(Locale.Category.FORMAT);
     }
+
+    @Benchmark
+    public Locale forLanguageTag() {
+        return Locale.forLanguageTag("en-US-x-lvariant-POSIX");
+    }
 }
 


### PR DESCRIPTION
command: make test CONF=fastdebug JTREG="VM_OPTIONS=-Xcomp" TEST=gc/TestAllocHumongousFragment.java
error info: 

Caused by: java.lang.NullPointerException: Cannot invoke "sun.util.locale.BaseLocale.getVariant()" because "base" is null
at java.base/java.util.Locale.forLanguageTag(Locale.java:1802)
at java.base/sun.util.cldr.CLDRBaseLocaleDataMetaInfo.<clinit>(CLDRBaseLocaleDataMetaInfo.java:41)
... 24 more

Note that the test runs with -XX:ShenandoahGCHeuristics=aggressive -XX:+ShenandoahOOMDuringEvacALot and SoftReferences are involved (LocaleObjectCache uses SoftReferences, used by printf method called in getRandomInstance(Utils.java:511)).

Maybe we have to deal with the case where the getBaseLocale() return value is null. the call stack is:

	at java.base/sun.util.locale.LocaleObjectCache.get(LocaleObjectCache.java:64)
	at java.base/sun.util.locale.BaseLocale.getInstance(BaseLocale.java:169)
	at java.base/sun.util.locale.InternalLocaleBuilder.getBaseLocale(InternalLocaleBuilder.java:524)
	at java.base/java.util.Locale.forLanguageTag(Locale.java:1874)

in LocaleObjectCache.java:64

	 62             if (key == null || newVal == null) {                                
	 63                 // subclass must return non-null key/value object               
	 64                 return null; // run here
	 65             }

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289220](https://bugs.openjdk.org/browse/JDK-8289220): Locale.forLanguageTag throws NPE due to soft ref used in locale cache being cleared (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14211/head:pull/14211` \
`$ git checkout pull/14211`

Update a local copy of the PR: \
`$ git checkout pull/14211` \
`$ git pull https://git.openjdk.org/jdk.git pull/14211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14211`

View PR using the GUI difftool: \
`$ git pr show -t 14211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14211.diff">https://git.openjdk.org/jdk/pull/14211.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14211#issuecomment-1568010173)