### PR TITLE
8309095 : Remove UTF-8 character from TaskbarPositionTest.java

### DIFF
--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -61,7 +61,7 @@ import jtreg.SkippedException;
  * @key headful
  * @summary Tests the location of the heavy weight popup portion of JComboBox,
  * JMenu and JPopupMenu.
- * The test uses Ctrl+Down Arrow (↓) which is a system shortcut on macOS,
+ * The test uses Ctrl+Down Arrow which is a system shortcut on macOS,
  * disable it in system settings, otherwise the test will fail
  * @library ../regtesthelpers
  * @library /test/lib


### PR DESCRIPTION
Hi Reviewers, 
Removed UTF-8 character (↓) from TaskbarPositionTest.java from the testcase.
Please review this
Regards,
Renjith.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309095](https://bugs.openjdk.org/browse/JDK-8309095): Remove UTF-8 character from TaskbarPositionTest.java


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14212/head:pull/14212` \
`$ git checkout pull/14212`

Update a local copy of the PR: \
`$ git checkout pull/14212` \
`$ git pull https://git.openjdk.org/jdk.git pull/14212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14212`

View PR using the GUI difftool: \
`$ git pr show -t 14212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14212.diff">https://git.openjdk.org/jdk/pull/14212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14212#issuecomment-1568275281)