### PR TITLE
8309073: [JVMCI] TestUncaughtErrorInCompileMethod still times out

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,8 +71,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/c2/irTests/TestVectorConditionalMove.java 8306922 generic-all
 
-compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309073](https://bugs.openjdk.org/browse/JDK-8309073): [JVMCI] TestUncaughtErrorInCompileMethod still times out (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14213/head:pull/14213` \
`$ git checkout pull/14213`

Update a local copy of the PR: \
`$ git checkout pull/14213` \
`$ git pull https://git.openjdk.org/jdk.git pull/14213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14213`

View PR using the GUI difftool: \
`$ git pr show -t 14213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14213.diff">https://git.openjdk.org/jdk/pull/14213.diff</a>

</details>
