### PR TITLE
8308992: New test TestHFA fails with zero

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -244,7 +244,7 @@ public final class FallbackLinker extends AbstractLinker {
             acquireCallback.accept(addrArg);
             argSeg.set(al, 0, addrArg);
         } else if (layout instanceof GroupLayout) {
-            argSeg.copyFrom((MemorySegment) arg); // by-value struct
+            MemorySegment.copy((MemorySegment) arg, 0, argSeg, 0, argSeg.byteSize()); // by-value struct
         } else {
             assert layout == null;
         }


### PR DESCRIPTION
The issue is that the fallback linker uses `copyFrom` when copying a by-value struct argument to an internal buffer, without first adjusting the size of the argument segment. This means that if the argument segment is 'too large' (i.e. larger than the layout it was linked with) we fail with an exception since the internal buffer is too small for the entire argument segment to be copied into.

The fix is simply to use an exactly-sized copy instead, just like we do in other linker implementations. (The argument segment being too large is fine, all we care about is that it's large enough).

Testing: jdk-tier5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308992](https://bugs.openjdk.org/browse/JDK-8308992): New test TestHFA fails with zero


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14215/head:pull/14215` \
`$ git checkout pull/14215`

Update a local copy of the PR: \
`$ git checkout pull/14215` \
`$ git pull https://git.openjdk.org/jdk.git pull/14215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14215`

View PR using the GUI difftool: \
`$ git pr show -t 14215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14215.diff">https://git.openjdk.org/jdk/pull/14215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14215#issuecomment-1568379157)