### PR TITLE
8309093: Underscore with brackets

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -624,6 +624,9 @@ public class JavacParser implements Parser {
                 log.warning(token.pos, Warnings.UnderscoreAsIdentifier);
             } else if (asVariable) {
                 checkSourceLevel(Feature.UNNAMED_VARIABLES);
+                if (peekToken(LBRACKET)) {
+                    log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.UseOfUnderscoreNotAllowedWithBrackets);
+                }
             } else {
                 if (preview.isEnabled() && Feature.UNNAMED_VARIABLES.allowedInSource(source)) {
                     log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.UseOfUnderscoreNotAllowed);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3162,6 +3162,9 @@ compiler.err.use.of.underscore.not.allowed=\
     as of release 21, the underscore keyword ''_'' is only allowed to declare\n\
     unnamed patterns, local variables, exception parameters or lambda parameters
 
+compiler.err.use.of.underscore.not.allowed.with.brackets=\
+    the underscore keyword ''_'' is not allowed to be followed by brackets
+
 compiler.err.enum.as.identifier=\
     as of release 5, ''enum'' is a keyword, and may not be used as an identifier
 

--- a/test/langtools/tools/javac/diags/examples/UseOfUnderscoreNotAllowedWithBrackets.java
+++ b/test/langtools/tools/javac/diags/examples/UseOfUnderscoreNotAllowedWithBrackets.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.use.of.underscore.not.allowed.with.brackets
+// key: compiler.misc.feature.unnamed.variables
+// key: compiler.warn.preview.feature.use.plural
+// options: --enable-preview -source ${jdk.version} -Xlint:preview
+
+class UseOfUnderscoreNotAllowedWithBrackets {
+    void test() {
+        int[] _[] = new int[][]{new int[]{1}, new int[]{2}};
+    }
+}

--- a/test/langtools/tools/javac/lambda/IdentifierTest21.out
+++ b/test/langtools/tools/javac/lambda/IdentifierTest21.out
@@ -29,6 +29,7 @@ IdentifierTest.java:145:15: compiler.err.use.of.underscore.not.allowed
 IdentifierTest.java:146:13: compiler.err.use.of.underscore.not.allowed
 IdentifierTest.java:151:15: compiler.err.use.of.underscore.not.allowed
 IdentifierTest.java:152:17: compiler.err.use.of.underscore.not.allowed
+IdentifierTest.java:158:16: compiler.err.use.of.underscore.not.allowed.with.brackets
 IdentifierTest.java:160:25: compiler.err.use.of.underscore.not.allowed
 IdentifierTest.java:169:5: compiler.err.use.of.underscore.not.allowed
 IdentifierTest.java:173:26: compiler.err.use.of.underscore.not.allowed
@@ -36,4 +37,4 @@ IdentifierTest.java:175:19: compiler.err.use.of.underscore.not.allowed
 IdentifierTest.java:181:11: compiler.err.use.of.underscore.not.allowed
 - compiler.note.preview.filename: IdentifierTest.java, DEFAULT
 - compiler.note.preview.recompile
-36 errors
+37 errors

--- a/test/langtools/tools/javac/patterns/UnnamedErrors.java
+++ b/test/langtools/tools/javac/patterns/UnnamedErrors.java
@@ -1,6 +1,6 @@
 /**
  * @test /nodynamiccopyright/
- * @bug 8304246
+ * @bug 8304246 8309093
  * @summary Compiler Implementation for Unnamed patterns and variables
  * @enablePreview
  * @compile/fail/ref=UnnamedErrors.out -XDrawDiagnostics -XDshould-stop.at=FLOW UnnamedErrors.java
@@ -104,6 +104,11 @@ public class UnnamedErrors {
         for (int x = 1, _; x<=1; x++) {
 
         }
+    }
+
+    void testUnderscoreWithBrackets() {
+        int _[] = new int[]{1};
+        for (int _[] : new int[][]{new int[]{1}, new int[]{2}}) { }
     }
 
     class Lock implements AutoCloseable {

--- a/test/langtools/tools/javac/patterns/UnnamedErrors.out
+++ b/test/langtools/tools/javac/patterns/UnnamedErrors.out
@@ -21,6 +21,8 @@ UnnamedErrors.java:82:58: compiler.err.expected: ';'
 UnnamedErrors.java:101:14: compiler.err.expected: =
 UnnamedErrors.java:102:22: compiler.err.expected: =
 UnnamedErrors.java:104:26: compiler.err.expected: =
+UnnamedErrors.java:110:13: compiler.err.use.of.underscore.not.allowed.with.brackets
+UnnamedErrors.java:111:18: compiler.err.use.of.underscore.not.allowed.with.brackets
 UnnamedErrors.java:11:17: compiler.err.already.defined: kindname.variable, x, kindname.class, UnnamedErrors
 UnnamedErrors.java:36:13: compiler.err.unconditional.pattern.and.default
 UnnamedErrors.java:45:18: compiler.err.pattern.dominated
@@ -32,4 +34,4 @@ UnnamedErrors.java:83:13: compiler.err.switch.mixing.case.types
 UnnamedErrors.java:90:30: compiler.err.pattern.dominated
 - compiler.note.preview.filename: UnnamedErrors.java, DEFAULT
 - compiler.note.preview.recompile
-32 errors
+34 errors


### PR DESCRIPTION
Currently `<type> _[]` passes compilation while it is prohibited by the [spec](https://cr.openjdk.org/~abimpoudis/unnamed/jep443-20230322/specs/unnamed-jls.html#jls-14.14.2). This PR addresses that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309093](https://bugs.openjdk.org/browse/JDK-8309093): Underscore with brackets


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14217/head:pull/14217` \
`$ git checkout pull/14217`

Update a local copy of the PR: \
`$ git checkout pull/14217` \
`$ git pull https://git.openjdk.org/jdk.git pull/14217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14217`

View PR using the GUI difftool: \
`$ git pr show -t 14217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14217.diff">https://git.openjdk.org/jdk/pull/14217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14217#issuecomment-1568565996)