### PR TITLE
8309110: Build failure after JDK-8307795 due to warnings in micro-benchmark StoreMaskTrueCount.java

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
@@ -47,7 +47,7 @@ public class StoreMaskTrueCount {
     }
 
     @Benchmark
-    public static int testShort() {
+    public int testShort() {
         int res = 0;
         for (int i = 0; i < LENGTH; i += S_SPECIES.length()) {
             VectorMask<Short> m = VectorMask.fromArray(S_SPECIES, ba, i);
@@ -58,7 +58,7 @@ public class StoreMaskTrueCount {
     }
 
     @Benchmark
-    public static int testInt() {
+    public int testInt() {
         int res = 0;
         for (int i = 0; i < LENGTH; i += I_SPECIES.length()) {
             VectorMask<Integer> m = VectorMask.fromArray(I_SPECIES, ba, i);
@@ -69,7 +69,7 @@ public class StoreMaskTrueCount {
     }
 
     @Benchmark
-    public static int testLong() {
+    public int testLong() {
         int res = 0;
         for (int i = 0; i < LENGTH; i += L_SPECIES.length()) {
             VectorMask<Long> m = VectorMask.fromArray(L_SPECIES, ba, i);


### PR DESCRIPTION
Just remove the `static` to fix the build failure.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309110](https://bugs.openjdk.org/browse/JDK-8309110): Build failure after JDK-8307795 due to warnings in micro-benchmark StoreMaskTrueCount.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14218/head:pull/14218` \
`$ git checkout pull/14218`

Update a local copy of the PR: \
`$ git checkout pull/14218` \
`$ git pull https://git.openjdk.org/jdk.git pull/14218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14218`

View PR using the GUI difftool: \
`$ git pr show -t 14218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14218.diff">https://git.openjdk.org/jdk/pull/14218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14218#issuecomment-1568456749)