### PR TITLE
8309111: Removing unused constructor of PerfLongCounter and PerfLongVariable

### DIFF
--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -192,14 +192,6 @@ PerfLong::PerfLong(CounterNS ns, const char* namep, Units u, Variability v)
 }
 
 PerfLongVariant::PerfLongVariant(CounterNS ns, const char* namep, Units u,
-                                 Variability v, jlong* sampled)
-                                : PerfLong(ns, namep, u, v),
-                                  _sampled(sampled), _sample_helper(nullptr) {
-
-  sample();
-}
-
-PerfLongVariant::PerfLongVariant(CounterNS ns, const char* namep, Units u,
                                  Variability v, PerfLongSampleHelper* helper)
                                 : PerfLong(ns, namep, u, v),
                                   _sampled(nullptr), _sample_helper(helper) {

--- a/src/hotspot/share/runtime/perfData.hpp
+++ b/src/hotspot/share/runtime/perfData.hpp
@@ -406,9 +406,6 @@ class PerfLongVariant : public PerfLong {
     }
 
     PerfLongVariant(CounterNS ns, const char* namep, Units u, Variability v,
-                    jlong* sampled);
-
-    PerfLongVariant(CounterNS ns, const char* namep, Units u, Variability v,
                     PerfLongSampleHelper* sample_helper);
 
     void sample();
@@ -439,9 +436,6 @@ class PerfLongCounter : public PerfLongVariant {
                    : PerfLongVariant(ns, namep, u, V_Monotonic,
                                      initial_value) { }
 
-    PerfLongCounter(CounterNS ns, const char* namep, Units u, jlong* sampled)
-                  : PerfLongVariant(ns, namep, u, V_Monotonic, sampled) { }
-
     PerfLongCounter(CounterNS ns, const char* namep, Units u,
                     PerfLongSampleHelper* sample_helper)
                    : PerfLongVariant(ns, namep, u, V_Monotonic,
@@ -463,9 +457,6 @@ class PerfLongVariable : public PerfLongVariant {
                      jlong initial_value=0)
                     : PerfLongVariant(ns, namep, u, V_Variable,
                                       initial_value) { }
-
-    PerfLongVariable(CounterNS ns, const char* namep, Units u, jlong* sampled)
-                    : PerfLongVariant(ns, namep, u, V_Variable, sampled) { }
 
     PerfLongVariable(CounterNS ns, const char* namep, Units u,
                      PerfLongSampleHelper* sample_helper)


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309111](https://bugs.openjdk.org/browse/JDK-8309111): Removing unused constructor of PerfLongCounter and PerfLongVariable


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14219/head:pull/14219` \
`$ git checkout pull/14219`

Update a local copy of the PR: \
`$ git checkout pull/14219` \
`$ git pull https://git.openjdk.org/jdk.git pull/14219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14219`

View PR using the GUI difftool: \
`$ git pr show -t 14219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14219.diff">https://git.openjdk.org/jdk/pull/14219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14219#issuecomment-1568456314)