### PR TITLE
8309120: java/net/httpclient/AsyncShutdownNow.java fails intermittently

### DIFF
--- a/test/jdk/java/net/httpclient/AsyncShutdownNow.java
+++ b/test/jdk/java/net/httpclient/AsyncShutdownNow.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8267140
+ * @bug 8267140 8309120
  * @summary Test HttpClient::shutdownNow. Any running operation will
  *          be aborted and the client should eventually exit.
  *          This test tests shutdownNow, awaitTermination, and
@@ -139,6 +139,8 @@ public class AsyncShutdownNow implements HttpServerAdapters {
         if (message.equals("closed")) return true;
         // exception from selmgr.abort
         if (message.equals("shutdownNow")) return true;
+        // exception from cancelling an HTTP/2 stream
+        if (message.matches("Stream [0-9]+ cancelled")) return true;
         return false;
     }
 

--- a/test/jdk/java/net/httpclient/ShutdownNow.java
+++ b/test/jdk/java/net/httpclient/ShutdownNow.java
@@ -135,7 +135,7 @@ public class ShutdownNow implements HttpServerAdapters {
         // exception from selmgr.abort
         if (message.equals("shutdownNow")) return true;
         // exception from cancelling an HTTP/2 stream
-        if (message.matches("stream [0-9]+ cancelled")) return true;
+        if (message.matches("Stream [0-9]+ cancelled")) return true;
         return false;
     }
 


### PR DESCRIPTION
Please find below a fix for a regression observed in the HttpClient AsyncShutdownNow test, after [JDK-8308310](https://bugs.openjdk.org/browse/JDK-8308310)

The PlainHttpConnection should have been modified to use a ReentrantLock instead of trying to perform potentially blocking actions outside of the synchronized block.

I also took this opportunity to fix the regex in the code that validate the exception message. The IOException thrown in that case has "Stream" with a capital "S".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309120](https://bugs.openjdk.org/browse/JDK-8309120): java/net/httpclient/AsyncShutdownNow.java fails intermittently


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14223/head:pull/14223` \
`$ git checkout pull/14223`

Update a local copy of the PR: \
`$ git checkout pull/14223` \
`$ git pull https://git.openjdk.org/jdk.git pull/14223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14223`

View PR using the GUI difftool: \
`$ git pr show -t 14223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14223.diff">https://git.openjdk.org/jdk/pull/14223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14223#issuecomment-1568698506)