### PR TITLE
8296972: [macos13] java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java: getExtendedState() != 6 as expected.

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -986,7 +986,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                     // let's return into the normal states first
                     // the zoom call toggles between the normal and the max states
                     unmaximize();
-                    peer.displayChanged();
+                    peer.getLWToolkit().realSync();
                 }
                 execute(CWrapper.NSWindow::miniaturize);
                 break;
@@ -994,7 +994,8 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                 if (prevWindowState == Frame.ICONIFIED) {
                     // let's return into the normal states first
                     execute(CWrapper.NSWindow::deminiaturize);
-                    peer.displayChanged();
+                    peer.getLWToolkit().realSync();
+
                 }
                 maximize();
                 break;

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -967,7 +967,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
     }
 
     private void waitForWindowState(int state) {
-        if(peer.getState() == state) {
+        if (peer.getState() == state) {
             return;
         }
 
@@ -990,7 +990,6 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                 } catch (InterruptedException ie) {}
             }
         }
-
         target.removeWindowStateListener(wsl);
     }
 

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -986,6 +986,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                     // let's return into the normal states first
                     // the zoom call toggles between the normal and the max states
                     unmaximize();
+                    peer.displayChanged();
                 }
                 execute(CWrapper.NSWindow::miniaturize);
                 break;
@@ -993,6 +994,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                 if (prevWindowState == Frame.ICONIFIED) {
                     // let's return into the normal states first
                     execute(CWrapper.NSWindow::deminiaturize);
+                    peer.displayChanged();
                 }
                 maximize();
                 break;

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -967,8 +967,12 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
     }
 
     private void waitForWindowState(int state) {
+        if(peer.getState() == state) {
+            return;
+        }
+
         Object lock = new Object();
-        target.addWindowStateListener(new WindowStateListener() {
+        WindowStateListener wsl = new WindowStateListener() {
             public void windowStateChanged(WindowEvent e) {
                 synchronized (lock) {
                     if (e.getNewState() == state) {
@@ -976,7 +980,9 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                     }
                 }
             }
-        });
+        };
+
+        target.addWindowStateListener(wsl);
         if (peer.getState() != state) {
             synchronized (lock) {
                 try {
@@ -984,6 +990,8 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                 } catch (InterruptedException ie) {}
             }
         }
+
+        target.removeWindowStateListener(wsl);
     }
 
     @Override

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -119,7 +119,6 @@ java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java 8081489 generi
 java/awt/Focus/IconifiedFrameFocusChangeTest/IconifiedFrameFocusChangeTest.java 6849364 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java 6848406 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java 6848407 generic-all
-java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java 8296972 macosx-all
 java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java 8022302 generic-all
 java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java 8286840 linux-all
 java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-all

--- a/test/jdk/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
+++ b/test/jdk/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
@@ -45,7 +45,7 @@ import java.awt.event.WindowStateListener;
 
 public class MaximizedToIconified
 {
-    static volatile int lastFrameState = Frame.NORMAL;
+    static volatile int lastFrameState;
     static volatile boolean failed = false;
     static volatile Toolkit myKit;
     private static Robot robot;
@@ -76,6 +76,8 @@ public class MaximizedToIconified
         Frame frame = new Frame("test");
         frame.setSize(200, 200);
         frame.setVisible(true);
+
+        lastFrameState = Frame.NORMAL;
 
         robot.waitForIdle();
 
@@ -114,6 +116,7 @@ public class MaximizedToIconified
         //    because Toolkit.isFrameStateSupported() method reports these states
         //    as not supported. And such states will simply be skipped.
         examineStates(new int[] {Frame.MAXIMIZED_BOTH, Frame.ICONIFIED, Frame.NORMAL});
+        System.out.println("------");
         examineStates(new int[] {Frame.ICONIFIED, Frame.MAXIMIZED_BOTH, Frame.NORMAL});
 
     }

--- a/test/jdk/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
+++ b/test/jdk/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
@@ -118,6 +118,10 @@ public class MaximizedToIconified
         examineStates(new int[] {Frame.MAXIMIZED_BOTH, Frame.ICONIFIED, Frame.NORMAL});
         System.out.println("------");
         examineStates(new int[] {Frame.ICONIFIED, Frame.MAXIMIZED_BOTH, Frame.NORMAL});
+        System.out.println("------");
+        examineStates(new int[] {Frame.NORMAL, Frame.MAXIMIZED_BOTH, Frame.ICONIFIED});
+        System.out.println("------");
+        examineStates(new int[] {Frame.NORMAL, Frame.ICONIFIED, Frame.MAXIMIZED_BOTH});
 
     }
 


### PR DESCRIPTION
added displayChanged call to CPlatformWindow when frame first needs to deiconify or unmaximize
All client tests passed after change

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296972](https://bugs.openjdk.org/browse/JDK-8296972): [macos13] java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java: getExtendedState() != 6 as expected. (**Bug** - P4)


### Reviewers
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14226/head:pull/14226` \
`$ git checkout pull/14226`

Update a local copy of the PR: \
`$ git checkout pull/14226` \
`$ git pull https://git.openjdk.org/jdk.git pull/14226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14226`

View PR using the GUI difftool: \
`$ git pr show -t 14226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14226.diff">https://git.openjdk.org/jdk/pull/14226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14226#issuecomment-1568912817)