### PR TITLE
8308152: PropertyDescriptor should work with overridden generic getter method

### DIFF
--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1158,6 +1158,8 @@ public class Introspector {
         // For overridden methods we need to find the most derived version.
         // So we start with the given class and walk up the superclass chain.
         for (Class<?> cl = start; cl != null; cl = cl.getSuperclass()) {
+            Class<?> type = null;
+            Method foundMethod = null;
             for (Method method : ClassInfo.get(cl).getMethods()) {
                 // make sure method signature matches.
                 if (method.getName().equals(methodName)) {
@@ -1177,9 +1179,16 @@ public class Introspector {
                                 }
                             }
                         }
-                        return method;
+                        Class<?> rt = method.getReturnType();
+                        if (foundMethod == null || type.isAssignableFrom(rt)) {
+                            foundMethod = method;
+                            type = rt;
+                        }
                     }
                 }
+            }
+            if (foundMethod != null) {
+                return foundMethod;
             }
         }
         // Now check any inherited interfaces.  This is necessary both when

--- a/test/jdk/java/beans/PropertyDescriptor/OverriddenGetter.java
+++ b/test/jdk/java/beans/PropertyDescriptor/OverriddenGetter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+
+import javax.swing.JPanel;
+
+/**
+ * @test
+ * @bug 8308152
+ * @summary PropertyDescriptor should work with overridden generic getter method
+ */
+public class OverriddenGetter {
+
+    static class Parent<T> {
+        private T value;
+        public T getValue() {return value;}
+        public final void setValue(T value) {this.value = value;}
+    }
+
+    static class ChildO extends Parent<Object> {
+        public ChildO() {}
+        @Override
+        public Object getValue() {return super.getValue();}
+    }
+
+    static class ChildA extends Parent<ArithmeticException> {
+        public ChildA() {}
+        @Override
+        public ArithmeticException getValue() {return super.getValue();}
+    }
+
+    static class ChildS extends Parent<String> {
+        public ChildS() {}
+        @Override
+        public String getValue() {return super.getValue();}
+    }
+
+    public static void main(String[] args) throws Exception {
+        test("UI", JPanel.class, "getUI", "setUI");
+        test("value", ChildO.class, "getValue", "setValue");
+        test("value", ChildA.class, "getValue", "setValue");
+        test("value", ChildS.class, "getValue", "setValue");
+    }
+
+    private static void test(String name, Class<?> beanClass,
+                             String read, String write) throws Exception
+    {
+        var gold = new PropertyDescriptor(name, beanClass, read, write);
+        BeanInfo beanInfo = Introspector.getBeanInfo(beanClass);
+        PropertyDescriptor[] pds = beanInfo.getPropertyDescriptors();
+        for (PropertyDescriptor pd : pds) {
+            if (pd.getName().equals(gold.getName())) {
+                if (pd.getReadMethod() != gold.getReadMethod()) {
+                    System.err.println("Expected: " + gold.getReadMethod());
+                    System.err.println("Actual: " + pd.getReadMethod());
+                    throw new RuntimeException("Wrong read method");
+                }
+                if (pd.getWriteMethod() != gold.getWriteMethod()) {
+                    System.err.println("Expected: " + gold.getWriteMethod());
+                    System.err.println("Actual: " + pd.getWriteMethod());
+                    throw new RuntimeException("Wrong write method");
+                }
+                if (pd.getPropertyType() != gold.getPropertyType()) {
+                    System.err.println("Expected: " + gold.getPropertyType());
+                    System.err.println("Actual: " + pd.getPropertyType());
+                    throw new RuntimeException("Wrong property type");
+                }
+                return;
+            }
+        }
+        throw new RuntimeException("The PropertyDescriptor is not found");
+    }
+}


### PR DESCRIPTION
Description of the bug, copied from https://github.com/openjdk/jdk/pull/7190


> In jdk 9 we started to sort the list of methods for each class for two reasons:
>  1. We had a number of bugs which state that our JavaBeans randomly does not work, examples: JDK-6807471[1] , JDK-6788525[2], the reason was that the order of methods from Class.getMethods() is not specified.
>  2. We tried to sort methods so the more specific returns types come first, this was done because our logic for selecting the correct method did not work properly. 
> 
> The second issue above was fixed by the separate change [JDK-8196373](https://bugs.openjdk.java.net/browse/JDK-8196373) so now we only need to sort the list of methods in any order and do not care about return types.
> 

Unfortunatly it was found that we have two code paths to create a PropertyDescriptor, one of them is used by the `Introspector.getBeanInfo` and was patched by the [JDK-8196373](https://bugs.openjdk.java.net/browse/JDK-8196373) and another when the PropertyDescriptor is created directly and it still affected by that bug.

The code added by this patch is the same we already use in PropertyInfo.java, see
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/com/sun/beans/introspect/PropertyInfo.java#L81

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308152](https://bugs.openjdk.org/browse/JDK-8308152): PropertyDescriptor should work with overridden generic getter method (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14228/head:pull/14228` \
`$ git checkout pull/14228`

Update a local copy of the PR: \
`$ git checkout pull/14228` \
`$ git pull https://git.openjdk.org/jdk.git pull/14228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14228`

View PR using the GUI difftool: \
`$ git pr show -t 14228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14228.diff">https://git.openjdk.org/jdk/pull/14228.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14228#issuecomment-1571046496)