### PR TITLE
JDK-8309134: Augment test/langtools/tools/javac/versions/Versions.java for JDK 21 language changes

### DIFF
--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -248,58 +248,62 @@ public class Versions {
     protected void checksrc8(List<String> args) {
         printargs("checksrc8", args);
         expectedPass(args, List.of("New7.java", "New8.java"));
-        expectedFail(args, List.of("New10.java"));
+        expectedFail(args, List.of("New10.java", "New11.java", "New14.java", "New15.java",
+                                   "New16.java", "New17.java", "New21.java"));
+
     }
 
     protected void checksrc9(List<String> args) {
         printargs("checksrc9", args);
         expectedPass(args, List.of("New7.java", "New8.java"));
-        expectedFail(args, List.of("New10.java"));
+        expectedFail(args, List.of("New10.java", "New11.java", "New14.java", "New15.java",
+                                   "New16.java", "New17.java", "New21.java"));
     }
 
     protected void checksrc10(List<String> args) {
         printargs("checksrc10", args);
         expectedPass(args, List.of("New7.java", "New8.java", "New10.java"));
-        expectedFail(args, List.of("New11.java"));
+        expectedFail(args, List.of("New11.java", "New14.java", "New15.java",
+                                   "New16.java", "New17.java", "New21.java"));
     }
 
     protected void checksrc11(List<String> args) {
         printargs("checksrc11", args);
         expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java"));
-        expectedFail(args, List.of("New14.java"));
+        expectedFail(args, List.of("New14.java", "New15.java", "New16.java", "New17.java", "New21.java"));
     }
 
     protected void checksrc12(List<String> args) {
         printargs("checksrc12", args);
         expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java"));
-        expectedFail(args, List.of("New14.java"));
+        expectedFail(args, List.of("New14.java", "New15.java", "New16.java", "New17.java", "New21.java"));
     }
 
     protected void checksrc13(List<String> args) {
         printargs("checksrc13", args);
         expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java"));
-        expectedFail(args, List.of("New14.java"));
+        expectedFail(args, List.of("New14.java", "New15.java", "New16.java", "New17.java", "New21.java"));
     }
 
     protected void checksrc14(List<String> args) {
         printargs("checksrc14", args);
         expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                    "New14.java"));
-        expectedFail(args, List.of("New15.java"));
+        expectedFail(args, List.of("New15.java", "New16.java", "New17.java", "New21.java"));
     }
 
    protected void checksrc15(List<String> args) {
        printargs("checksrc15", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java"));
-        expectedFail(args, List.of("New16.java"));
+       expectedFail(args, List.of("New16.java", "New17.java", "New21.java"));
     }
 
    protected void checksrc16(List<String> args) {
        printargs("checksrc16", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java", "New16.java"));
-        expectedFail(args, List.of("New17.java"));
+       expectedFail(args, List.of("New17.java", "New21.java"));
     }
 
    protected void checksrc17(List<String> args) {
@@ -333,7 +337,8 @@ public class Versions {
    protected void checksrc21(List<String> args) {
        printargs("checksrc21", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
-                                  "New14.java", "New15.java", "New16.java", "New17.java", "New21.java"));
+                                  "New14.java", "New15.java", "New16.java", "New17.java",
+                                  "New21.java"));
        // Add expectedFail after new language features added in a later release.
     }
 
@@ -391,7 +396,6 @@ public class Versions {
             failedCases++;
 
         }
-
     }
 
     protected void fail(List<String> args) {
@@ -578,7 +582,7 @@ public class Versions {
         );
 
         /*
-         * Create a file with a new feature in 17, not in 16 : sealed classes
+         * Create a file with a new feature in 21, not in 20 : pattern matching for switch
          */
         writeSourceFile("New21.java",
             """

--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class Versions {
         EIGHTEEN(false,  "62.0", "18", Versions::checksrc18),
         NINETEEN(false,  "63.0", "19", Versions::checksrc19),
         TWENTY(false,    "64.0", "20", Versions::checksrc20),
-        TWENTY_ONE(false,"65.0", "21", Versions::checksrc20);
+        TWENTY_ONE(false,"65.0", "21", Versions::checksrc21);
 
         private final boolean dotOne;
         private final String classFileVer;
@@ -306,27 +306,34 @@ public class Versions {
        printargs("checksrc17", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java", "New16.java", "New17.java"));
-       // Add expectedFail after new language features added in a later release.
+        expectedFail(args, List.of("New21.java"));
     }
 
    protected void checksrc18(List<String> args) {
        printargs("checksrc18", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java", "New16.java", "New17.java"));
-       // Add expectedFail after new language features added in a later release.
+       expectedFail(args, List.of("New21.java"));
     }
 
    protected void checksrc19(List<String> args) {
        printargs("checksrc19", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java", "New16.java", "New17.java"));
-       // Add expectedFail after new language features added in a later release.
+       expectedFail(args, List.of("New21.java"));
     }
 
    protected void checksrc20(List<String> args) {
        printargs("checksrc20", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java", "New16.java", "New17.java"));
+       expectedFail(args, List.of("New21.java"));
+    }
+
+   protected void checksrc21(List<String> args) {
+       printargs("checksrc21", args);
+       expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
+                                  "New14.java", "New15.java", "New16.java", "New17.java", "New21.java"));
        // Add expectedFail after new language features added in a later release.
     }
 
@@ -566,6 +573,24 @@ public class Versions {
                 public static final class Pinniped extends Seal {}
                 public static final class TaperedThread extends Seal {}
                 public static final class Wax extends Seal {}
+            }
+            """
+        );
+
+        /*
+         * Create a file with a new feature in 17, not in 16 : sealed classes
+         */
+        writeSourceFile("New21.java",
+            """
+            public class New21 {
+                public static void main(String... args) {
+                    Object o = new Object(){};
+
+                    System.out.println(switch (o) {
+                                       case Integer i -> String.format("%d", i);
+                                       default        -> o.toString();
+                                       });
+                }
             }
             """
         );

--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -310,7 +310,7 @@ public class Versions {
        printargs("checksrc17", args);
        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
                                   "New14.java", "New15.java", "New16.java", "New17.java"));
-        expectedFail(args, List.of("New21.java"));
+       expectedFail(args, List.of("New21.java"));
     }
 
    protected void checksrc18(List<String> args) {


### PR DESCRIPTION
Augment the Versions.java test in the usual way for new language changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309134](https://bugs.openjdk.org/browse/JDK-8309134): Augment test/langtools/tools/javac/versions/Versions.java for JDK 21 language changes


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [32879ef4](https://git.openjdk.org/jdk/pull/14229/files/32879ef44836674c7241c0c63656cb27fb712662)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14229/head:pull/14229` \
`$ git checkout pull/14229`

Update a local copy of the PR: \
`$ git checkout pull/14229` \
`$ git pull https://git.openjdk.org/jdk.git pull/14229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14229`

View PR using the GUI difftool: \
`$ git pr show -t 14229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14229.diff">https://git.openjdk.org/jdk/pull/14229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14229#issuecomment-1569039009)