### PR TITLE
8309138: Fix container tests for jdks with symlinked conf dir

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -26,6 +26,7 @@ package jdk.test.lib.containers.docker;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,6 +36,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
@@ -163,7 +165,7 @@ public class DockerTestUtils {
         Path jdkSrcDir = Paths.get(JDK_UNDER_TEST);
         Path jdkDstDir = buildDir.resolve("jdk");
         Files.createDirectories(jdkDstDir);
-        Files.walkFileTree(jdkSrcDir, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
+        Files.walkFileTree(jdkSrcDir, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
 
         buildImage(imageName, buildDir);
     }


### PR DESCRIPTION
Problem:
Container tests copy tested jdk into container to do testing on it. This however does not work correctly for builds, in which conf directory is symlinked (such as fedora/rhel packages), causing failures due to missing config files in container.

Solution:
Symlinks are followed when copying tested jdk.

Testing:
tier1: OK
containers and jdk/internal/platform: [OK](https://github.com/zzambers/jdk-tester/actions/runs/5082017127/jobs/9131188265)