### PR TITLE
8308593: Add Keepalive Extended Socket Options Support for Windows

### DIFF
--- a/src/jdk.net/aix/classes/jdk/net/AIXSocketOptions.java
+++ b/src/jdk.net/aix/classes/jdk/net/AIXSocketOptions.java
@@ -68,8 +68,8 @@ class AIXSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
-        setTcpkeepAliveProbes0(fd, value);
+    void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
+        setTcpKeepAliveProbes0(fd, value);
     }
 
     @Override
@@ -83,8 +83,8 @@ class AIXSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    int getTcpkeepAliveProbes(int fd) throws SocketException {
-        return getTcpkeepAliveProbes0(fd);
+    int getTcpKeepAliveProbes(int fd) throws SocketException {
+        return getTcpKeepAliveProbes0(fd);
     }
 
     @Override
@@ -117,11 +117,11 @@ class AIXSocketOptions extends PlatformSocketOptions {
         return new UnixDomainPrincipal(user, group);
     }
 
-    private static native void setTcpkeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
     private static native void setIpDontFragment0(int fd, boolean value, boolean isIPv6) throws SocketException;
-    private static native int getTcpkeepAliveProbes0(int fd) throws SocketException;
+    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
     private static native boolean getIpDontFragment0(int fd, boolean isIPv6) throws SocketException;

--- a/src/jdk.net/aix/native/libextnet/AIXSocketOptions.c
+++ b/src/jdk.net/aix/native/libextnet/AIXSocketOptions.c
@@ -150,10 +150,10 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_AIXSocketOptions_keepAliveOptionsSupport
 
 /*
  * Class:     jdk_net_AIXSocketOptions
- * Method:    setTcpkeepAliveProbes0
+ * Method:    setTcpKeepAliveProbes0
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_jdk_net_AIXSocketOptions_setTcpkeepAliveProbes0
+JNIEXPORT void JNICALL Java_jdk_net_AIXSocketOptions_setTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd, jint optval) {
     jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_KEEPCNT failed");
@@ -183,10 +183,10 @@ JNIEXPORT void JNICALL Java_jdk_net_AIXSocketOptions_setTcpKeepAliveIntvl0
 
 /*
  * Class:     jdk_net_AIXSocketOptions
- * Method:    getTcpkeepAliveProbes0
+ * Method:    getTcpKeepAliveProbes0
  * Signature: (I)I;
  */
-JNIEXPORT jint JNICALL Java_jdk_net_AIXSocketOptions_getTcpkeepAliveProbes0
+JNIEXPORT jint JNICALL Java_jdk_net_AIXSocketOptions_getTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd) {
     jint optval, rv;
     socklen_t sz = sizeof (optval);

--- a/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
+++ b/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
@@ -68,8 +68,8 @@ class LinuxSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
-        setTcpkeepAliveProbes0(fd, value);
+    void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
+        setTcpKeepAliveProbes0(fd, value);
     }
 
     @Override
@@ -83,8 +83,8 @@ class LinuxSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    int getTcpkeepAliveProbes(int fd) throws SocketException {
-        return getTcpkeepAliveProbes0(fd);
+    int getTcpKeepAliveProbes(int fd) throws SocketException {
+        return getTcpKeepAliveProbes0(fd);
     }
 
     @Override
@@ -127,11 +127,11 @@ class LinuxSocketOptions extends PlatformSocketOptions {
         return new UnixDomainPrincipal(user, group);
     }
 
-    private static native void setTcpkeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
     private static native void setIpDontFragment0(int fd, boolean value, boolean isIPv6) throws SocketException;
-    private static native int getTcpkeepAliveProbes0(int fd) throws SocketException;
+    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
     private static native boolean getIpDontFragment0(int fd, boolean isIPv6) throws SocketException;

--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -153,10 +153,10 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_keepAliveOptionsSuppo
 
 /*
  * Class:     jdk_net_LinuxSocketOptions
- * Method:    setTcpkeepAliveProbes0
+ * Method:    setTcpKeepAliveProbes0
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setTcpkeepAliveProbes0
+JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd, jint optval) {
     jint rv = setsockopt(fd, SOL_TCP, TCP_KEEPCNT, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_KEEPCNT failed");
@@ -186,10 +186,10 @@ JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setTcpKeepAliveIntvl0
 
 /*
  * Class:     jdk_net_LinuxSocketOptions
- * Method:    getTcpkeepAliveProbes0
+ * Method:    getTcpKeepAliveProbes0
  * Signature: (I)I;
  */
-JNIEXPORT jint JNICALL Java_jdk_net_LinuxSocketOptions_getTcpkeepAliveProbes0
+JNIEXPORT jint JNICALL Java_jdk_net_LinuxSocketOptions_getTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd) {
     jint optval, rv;
     socklen_t sz = sizeof (optval);

--- a/src/jdk.net/macosx/classes/jdk/net/MacOSXSocketOptions.java
+++ b/src/jdk.net/macosx/classes/jdk/net/MacOSXSocketOptions.java
@@ -49,8 +49,8 @@ class MacOSXSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
-        setTcpkeepAliveProbes0(fd, value);
+    void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
+        setTcpKeepAliveProbes0(fd, value);
     }
 
     @Override
@@ -69,8 +69,8 @@ class MacOSXSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    int getTcpkeepAliveProbes(int fd) throws SocketException {
-        return getTcpkeepAliveProbes0(fd);
+    int getTcpKeepAliveProbes(int fd) throws SocketException {
+        return getTcpKeepAliveProbes0(fd);
     }
 
     @Override
@@ -103,11 +103,11 @@ class MacOSXSocketOptions extends PlatformSocketOptions {
         return new UnixDomainPrincipal(user, group);
     }
 
-    private static native void setTcpkeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
     private static native void setIpDontFragment0(int fd, boolean value, boolean isIPv6) throws SocketException;
-    private static native int getTcpkeepAliveProbes0(int fd) throws SocketException;
+    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
     private static native boolean getIpDontFragment0(int fd, boolean isIPv6) throws SocketException;

--- a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+++ b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
@@ -96,10 +96,10 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_MacOSXSocketOptions_keepAliveOptionsSupp
 
 /*
  * Class:     jdk_net_MacOSXSocketOptions
- * Method:    setTcpkeepAliveProbes0
+ * Method:    setTcpKeepAliveProbes0
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_jdk_net_MacOSXSocketOptions_setTcpkeepAliveProbes0
+JNIEXPORT void JNICALL Java_jdk_net_MacOSXSocketOptions_setTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd, jint optval) {
     jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_KEEPCNT failed");
@@ -129,10 +129,10 @@ JNIEXPORT void JNICALL Java_jdk_net_MacOSXSocketOptions_setTcpKeepAliveIntvl0
 
 /*
  * Class:     jdk_net_MacOSXSocketOptions
- * Method:    getTcpkeepAliveProbes0
+ * Method:    getTcpKeepAliveProbes0
  * Signature: (I)I;
  */
-JNIEXPORT jint JNICALL Java_jdk_net_MacOSXSocketOptions_getTcpkeepAliveProbes0
+JNIEXPORT jint JNICALL Java_jdk_net_MacOSXSocketOptions_getTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd) {
     jint optval, rv;
     socklen_t sz = sizeof (optval);

--- a/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
+++ b/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
@@ -277,7 +277,7 @@ public final class ExtendedSocketOptions {
                 if (option == TCP_QUICKACK) {
                     setQuickAckOption(fd, (boolean) value);
                 } else if (option == TCP_KEEPCOUNT) {
-                    setTcpkeepAliveProbes(fd, (Integer) value);
+                    setTcpKeepAliveProbes(fd, (Integer) value);
                 } else if (option == IP_DONTFRAGMENT) {
                     setIpDontFragment(fd, (Boolean) value, isIPv6);
                 } else if (option == TCP_KEEPIDLE) {
@@ -307,7 +307,7 @@ public final class ExtendedSocketOptions {
                 if (option == TCP_QUICKACK) {
                     return getQuickAckOption(fd);
                 } else if (option == TCP_KEEPCOUNT) {
-                    return getTcpkeepAliveProbes(fd);
+                    return getTcpKeepAliveProbes(fd);
                 } else if (option == IP_DONTFRAGMENT) {
                     return getIpDontFragment(fd, isIPv6);
                 } else if (option == TCP_KEEPIDLE) {
@@ -343,9 +343,9 @@ public final class ExtendedSocketOptions {
         return platformSocketOptions.getQuickAck(fdAccess.get(fd));
     }
 
-    private static void setTcpkeepAliveProbes(FileDescriptor fd, int value)
+    private static void setTcpKeepAliveProbes(FileDescriptor fd, int value)
             throws SocketException {
-        platformSocketOptions.setTcpkeepAliveProbes(fdAccess.get(fd), value);
+        platformSocketOptions.setTcpKeepAliveProbes(fdAccess.get(fd), value);
     }
 
     private static void setTcpKeepAliveTime(FileDescriptor fd, int value)
@@ -363,8 +363,8 @@ public final class ExtendedSocketOptions {
         platformSocketOptions.setTcpKeepAliveIntvl(fdAccess.get(fd), value);
     }
 
-    private static int getTcpkeepAliveProbes(FileDescriptor fd) throws SocketException {
-        return platformSocketOptions.getTcpkeepAliveProbes(fdAccess.get(fd));
+    private static int getTcpKeepAliveProbes(FileDescriptor fd) throws SocketException {
+        return platformSocketOptions.getTcpKeepAliveProbes(fdAccess.get(fd));
     }
 
     private static boolean getIpDontFragment(FileDescriptor fd, boolean isIPv6) throws SocketException {
@@ -438,7 +438,7 @@ public final class ExtendedSocketOptions {
             return false;
         }
 
-        void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
+        void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
             throw new UnsupportedOperationException("unsupported TCP_KEEPCNT option");
         }
 
@@ -462,7 +462,7 @@ public final class ExtendedSocketOptions {
             throw new UnsupportedOperationException("unsupported IP_DONTFRAGMENT option");
         }
 
-        int getTcpkeepAliveProbes(int fd) throws SocketException {
+        int getTcpKeepAliveProbes(int fd) throws SocketException {
             throw new UnsupportedOperationException("unsupported TCP_KEEPCNT option");
         }
 

--- a/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
+++ b/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
+++ b/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
@@ -42,6 +42,11 @@ class WindowsSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
+    boolean keepAliveOptionsSupported() {
+        return keepAliveOptionsSupported0();
+    }
+
+    @Override
     void setIpDontFragment(int fd, final boolean value, boolean isIPv6) throws SocketException {
         setIpDontFragment0(fd, value, isIPv6);
     }
@@ -51,8 +56,45 @@ class WindowsSocketOptions extends PlatformSocketOptions {
         return getIpDontFragment0(fd, isIPv6);
     }
 
+    @Override
+    void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
+        setTcpkeepAliveProbes0(fd, value);
+    }
+
+    @Override
+    int getTcpkeepAliveProbes(int fd) throws SocketException {
+        return getTcpkeepAliveProbes0(fd);
+    }
+
+    @Override
+    void setTcpKeepAliveTime(int fd, final int value) throws SocketException {
+        setTcpKeepAliveTime0(fd, value);
+    }
+
+    @Override
+    int getTcpKeepAliveTime(int fd) throws SocketException {
+        return getTcpKeepAliveTime0(fd);
+    }
+
+    @Override
+    void setTcpKeepAliveIntvl(int fd, final int value) throws SocketException {
+        setTcpKeepAliveIntvl0(fd, value);
+    }
+
+    @Override
+    int getTcpKeepAliveIntvl(int fd) throws SocketException {
+        return getTcpKeepAliveIntvl0(fd);
+    }
+
+    private static native boolean keepAliveOptionsSupported0();
     private static native void setIpDontFragment0(int fd, boolean value, boolean isIPv6) throws SocketException;
     private static native boolean getIpDontFragment0(int fd, boolean isIPv6) throws SocketException;
+    private static native void setTcpkeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native int getTcpkeepAliveProbes0(int fd) throws SocketException;
+    private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
+    private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
+    private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
+    private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
 
     static {
         if (System.getSecurityManager() == null) {

--- a/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
+++ b/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
@@ -57,13 +57,13 @@ class WindowsSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
-        setTcpkeepAliveProbes0(fd, value);
+    void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
+        setTcpKeepAliveProbes0(fd, value);
     }
 
     @Override
-    int getTcpkeepAliveProbes(int fd) throws SocketException {
-        return getTcpkeepAliveProbes0(fd);
+    int getTcpKeepAliveProbes(int fd) throws SocketException {
+        return getTcpKeepAliveProbes0(fd);
     }
 
     @Override
@@ -89,8 +89,8 @@ class WindowsSocketOptions extends PlatformSocketOptions {
     private static native boolean keepAliveOptionsSupported0();
     private static native void setIpDontFragment0(int fd, boolean value, boolean isIPv6) throws SocketException;
     private static native boolean getIpDontFragment0(int fd, boolean isIPv6) throws SocketException;
-    private static native void setTcpkeepAliveProbes0(int fd, int value) throws SocketException;
-    private static native int getTcpkeepAliveProbes0(int fd) throws SocketException;
+    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
     private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;

--- a/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
+++ b/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
+++ b/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
@@ -34,13 +34,65 @@
 
 static void handleError(JNIEnv *env, jint rv, const char *errmsg) {
     if (rv < 0) {
-        if (errno == ENOPROTOOPT) {
+        int error = WSAGetLastError();
+        if (error == WSAENOPROTOOPT) {
             JNU_ThrowByName(env, "java/lang/UnsupportedOperationException",
                     "unsupported socket option");
         } else {
             JNU_ThrowByNameWithLastError(env, "java/net/SocketException", errmsg);
         }
     }
+}
+
+static jint socketOptionSupported(jint level, jint optname) {
+    WSADATA wsaData;
+    jint error = WSAStartup(MAKEWORD(2, 2), &wsaData);
+
+    if (error != 0) {
+        return 0;
+    }
+
+    SOCKET sock;
+    jint one = 1;
+    jint rv;
+    socklen_t sz = sizeof(one);
+
+    /* First try IPv6; fall back to IPv4. */
+    sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    if (sock == INVALID_SOCKET) {
+        error = WSAGetLastError();
+        if (error == WSAEPFNOSUPPORT || error == WSAEAFNOSUPPORT) {
+            sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+        }
+        if (sock == INVALID_SOCKET) {
+            return 0;
+        }
+    }
+
+    rv = getsockopt(sock, level, optname, (char*) &one, &sz);
+    error = WSAGetLastError();
+
+    if (rv != 0 && error == WSAENOPROTOOPT) {
+        rv = 0;
+    } else {
+        rv = 1;
+    }
+
+    closesocket(sock);
+    WSACleanup();
+
+    return rv;
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    keepAliveOptionsSupported0
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_jdk_net_WindowsSocketOptions_keepAliveOptionsSupported0
+(JNIEnv *env, jobject unused) {
+    return socketOptionSupported(IPPROTO_TCP, TCP_KEEPIDLE) && socketOptionSupported(IPPROTO_TCP, TCP_KEEPCNT)
+            && socketOptionSupported(IPPROTO_TCP, TCP_KEEPINTVL);
 }
 
 /*
@@ -101,5 +153,80 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_WindowsSocketOptions_getIpDontFragment0
         handleError(env, rv, "get option IP_DONTFRAGMENT failed");
         return optval == IP_PMTUDISC_DO ? JNI_TRUE : JNI_FALSE;
     }
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    setTcpkeepAliveProbes0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpkeepAliveProbes0
+(JNIEnv *env, jobject unused, jint fd, jint optval) {
+    jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char*) &optval, sizeof(optval));
+    handleError(env, rv, "set option TCP_KEEPCNT failed");
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    getTcpkeepAliveProbes0
+ * Signature: (I)I;
+ */
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpkeepAliveProbes0
+(JNIEnv *env, jobject unused, jint fd) {
+    jint optval, rv;
+    socklen_t sz = sizeof(optval);
+    rv = getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char*) &optval, &sz);
+    handleError(env, rv, "get option TCP_KEEPCNT failed");
+    return optval;
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    setTcpKeepAliveTime0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpKeepAliveTime0
+(JNIEnv *env, jobject unused, jint fd, jint optval) {
+    jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char*) &optval, sizeof(optval));
+    handleError(env, rv, "set option TCP_KEEPIDLE failed");
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    getTcpKeepAliveTime0
+ * Signature: (I)I;
+ */
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpKeepAliveTime0
+(JNIEnv *env, jobject unused, jint fd) {
+    jint optval, rv;
+    socklen_t sz = sizeof(optval);
+    rv = getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char*) &optval, &sz);
+    handleError(env, rv, "get option TCP_KEEPIDLE failed");
+    return optval;
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    setTcpKeepAliveIntvl0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpKeepAliveIntvl0
+(JNIEnv *env, jobject unused, jint fd, jint optval) {
+    jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (char*) &optval, sizeof(optval));
+    handleError(env, rv, "set option TCP_KEEPINTVL failed");
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    getTcpKeepAliveIntvl0
+ * Signature: (I)I;
+ */
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpKeepAliveIntvl0
+(JNIEnv *env, jobject unused, jint fd) {
+    jint optval, rv;
+    socklen_t sz = sizeof(optval);
+    rv = getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (char*) &optval, &sz);
+    handleError(env, rv, "get option TCP_KEEPINTVL failed");
+    return optval;
 }
 

--- a/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
+++ b/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
@@ -157,10 +157,10 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_WindowsSocketOptions_getIpDontFragment0
 
 /*
  * Class:     jdk_net_WindowsSocketOptions
- * Method:    setTcpkeepAliveProbes0
+ * Method:    setTcpKeepAliveProbes0
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpkeepAliveProbes0
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd, jint optval) {
     jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char*) &optval, sizeof(optval));
     handleError(env, rv, "set option TCP_KEEPCNT failed");
@@ -168,10 +168,10 @@ JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpkeepAliveProbes0
 
 /*
  * Class:     jdk_net_WindowsSocketOptions
- * Method:    getTcpkeepAliveProbes0
+ * Method:    getTcpKeepAliveProbes0
  * Signature: (I)I;
  */
-JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpkeepAliveProbes0
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd) {
     jint optval, rv;
     socklen_t sz = sizeof(optval);


### PR DESCRIPTION
The PR adds support for the keepalive extended socket options on Windows. For TCP_KEEPIDLE and TCP_KEEPINTVL, these options are supported starting from Windows 10 version 1709. TCP_KEEPCNT is supported starting from Windows 10 version 1703. Information on these socket options can be found [here](https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options).

I've also corrected the `handleError()` function. On Windows, the error needs to be retrieved using `WSAGetLastError()` and error codes are prefixed with "WSA". Information on this can be found [here](https://learn.microsoft.com/en-us/windows/win32/winsock/error-codes-errno-h-errno-and-wsagetlasterror-2).

>The error codes returned by Windows Sockets are similar to UNIX socket error code constants, but the constants are all prefixed with WSA.

>Error codes set by Windows Sockets are not made available through the errno variable.

No new tests were added as the existing tests should cover this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308593](https://bugs.openjdk.org/browse/JDK-8308593): Add KEEPALIVE Extended Socket Options Support for Windows (**Enhancement** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [2ada2207](https://git.openjdk.org/jdk/pull/14232/files/2ada2207c1f9fa16da3b1ca2977229403c712852)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14232/head:pull/14232` \
`$ git checkout pull/14232`

Update a local copy of the PR: \
`$ git checkout pull/14232` \
`$ git pull https://git.openjdk.org/jdk.git pull/14232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14232`

View PR using the GUI difftool: \
`$ git pr show -t 14232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14232.diff">https://git.openjdk.org/jdk/pull/14232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14232#issuecomment-1570719929)