### PR TITLE
8308978: regression with a deadlock involving FollowReferences

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2968,13 +2968,14 @@ void JvmtiTagMap::iterate_over_reachable_objects(jvmtiHeapRootCallback heap_root
                                                  jvmtiStackReferenceCallback stack_ref_callback,
                                                  jvmtiObjectReferenceCallback object_ref_callback,
                                                  const void* user_data) {
+  // VTMS transitions must be disabled before the EscapeBarrier.
+  JvmtiVTMSTransitionDisabler disabler;
+
   JavaThread* jt = JavaThread::current();
   EscapeBarrier eb(true, jt);
   eb.deoptimize_objects_all_threads();
   Arena dead_object_arena(mtServiceability);
   GrowableArray<jlong> dead_objects(&dead_object_arena, 10, 0, 0);
-
-  JvmtiVTMSTransitionDisabler disabler;
 
   {
     MutexLocker ml(Heap_lock);
@@ -3015,6 +3016,9 @@ void JvmtiTagMap::follow_references(jint heap_filter,
                                     const jvmtiHeapCallbacks* callbacks,
                                     const void* user_data)
 {
+  // VTMS transitions must be disabled before the EscapeBarrier.
+  JvmtiVTMSTransitionDisabler disabler;
+
   oop obj = JNIHandles::resolve(object);
   JavaThread* jt = JavaThread::current();
   Handle initial_object(jt, obj);
@@ -3026,8 +3030,6 @@ void JvmtiTagMap::follow_references(jint heap_filter,
 
   Arena dead_object_arena(mtServiceability);
   GrowableArray<jlong> dead_objects(&dead_object_arena, 10, 0, 0);
-
-  JvmtiVTMSTransitionDisabler disabler;
 
   {
     MutexLocker ml(Heap_lock);

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -31,18 +31,6 @@ serviceability/dcmd/thread/PrintConcurrentLocksTest.java 8308033 generic-all
 serviceability/dcmd/thread/PrintTest.java 8308033 generic-all
 serviceability/dcmd/thread/ThreadDumpToFileTest.java 8308033 generic-all
 serviceability/tmtools/jstack/DaemonThreadTest.java 8308033 generic-all
-vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects001/referringObjects001.java 8308978 generic-all
-vmTestbase/nsk/jdi/ReferenceType/instances/instances001/instances001.java 8308978 generic-all
-vmTestbase/nsk/jdi/ReferenceType/instances/instances003/instances003.java 8308978 generic-all
-vmTestbase/nsk/jdi/ReferenceType/instances/instances004/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jdi/MonitorWaitedRequest/addThreadFilter/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jdi/VirtualMachine/instanceCounts/instancecounts002/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jdi/stress/serial/monitorEvents002/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jdi/stress/serial/heapwalking001/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jdi/stress/serial/heapwalking002/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jdi/stress/serial/mixed001/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java 8308978 generic-all
-vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java 8308978 generic-all
 
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)


### PR DESCRIPTION
The change fixes regression from JDK-8299414.
There is a deadlock between JvmtiVTMSTransitionDisabler and EscapeBarrier when virtual threads are in mount/unmount transition:
EscapeBarrier requests deoptimization which requires thread suspension.
JvmtiVTMSTransitionDisabler ctor waits until all in progress VTMS transitions complete, but they cannot be completed as thread is suspended.
To avoid the deadlock mount/unmount transitions should be completed before EscapeBarrier stuff.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308978](https://bugs.openjdk.org/browse/JDK-8308978): regression with a deadlock involving FollowReferences


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [b2df4fd6](https://git.openjdk.org/jdk/pull/14233/files/b2df4fd68e19decbc1202ffb7524410af3fd1ed5)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14233/head:pull/14233` \
`$ git checkout pull/14233`

Update a local copy of the PR: \
`$ git checkout pull/14233` \
`$ git pull https://git.openjdk.org/jdk.git pull/14233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14233`

View PR using the GUI difftool: \
`$ git pr show -t 14233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14233.diff">https://git.openjdk.org/jdk/pull/14233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14233#issuecomment-1569250467)