### PR TITLE
JDK-8309150: Need to escape " inside attribute values

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -1073,7 +1073,7 @@ public class HtmlTree extends Content {
             out.write(key.toString());
             if (!value.isEmpty()) {
                 out.write("=\"");
-                out.write(value);
+                out.write(value.replace("\"", "&quot;"));
                 out.write("\"");
             }
         }

--- a/test/langtools/jdk/javadoc/doclet/testAttribute/TestAttribute.java
+++ b/test/langtools/jdk/javadoc/doclet/testAttribute/TestAttribute.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309150
+ * @summary Need to escape " inside attribute values
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestAttribute
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestAttribute extends JavadocTester {
+
+    public final ToolBox tb;
+    public static void main(String... args) throws Exception {
+        var tester = new TestAttribute();
+        tester.runTests();
+    }
+
+    public TestAttribute() {
+        tb = new ToolBox();
+    }
+
+    @Test
+    public void testQuote(Path base) throws IOException {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                /**
+                 * First sentence.
+                 * @spec http://example.com title with "quotes"
+                 */
+                public class C { private C() { } }""");
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        // Test some section markers and links to these markers
+        checkOutput("p/C.html", true,
+                """
+                    <a href="http://example.com"><span id="titlewith&quot;quotes&quot;" \
+                    class="search-tag-result">title with "quotes"</span></a>""");
+    }
+}

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/HtmlParser.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/HtmlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/HtmlParser.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/HtmlParser.java
@@ -341,7 +341,8 @@ public abstract class HtmlParser {
                     value = sb.toString() // hack to replace common entities
                             .replace("&lt;", "<")
                             .replace("&gt;", ">")
-                            .replace("&amp;", "&");
+                            .replace("&amp;", "&")
+                            .replace("&quot;", "\"");
                     nextChar();
                 } else {
                     StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Please review a trivial PR to escape `"` as `&quot;` when writing HTML attribute values enclosed in `"`.

A simple test is added, using a `@spec` tag to introduce a user-defined `id`.

The inverse transformation (from `&quot;` to `"`) needs to be done in the `HtmlParser` for the `JavadocTester` framework.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309150](https://bugs.openjdk.org/browse/JDK-8309150): Need to escape " inside attribute values


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [aa0cb83a](https://git.openjdk.org/jdk/pull/14234/files/aa0cb83a93296ba1b914f4f633f6a2eada8d94ec)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14234/head:pull/14234` \
`$ git checkout pull/14234`

Update a local copy of the PR: \
`$ git checkout pull/14234` \
`$ git pull https://git.openjdk.org/jdk.git pull/14234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14234`

View PR using the GUI difftool: \
`$ git pr show -t 14234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14234.diff">https://git.openjdk.org/jdk/pull/14234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14234#issuecomment-1569272148)