### PR TITLE
8309146: extend JDI StackFrame.setValue() and JDWP StackFrame.setValues minimal support for virtual threads

### DIFF
--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -2641,7 +2641,7 @@ JDWP "Java(tm) Debug Wire Protocol"
         "<p>"
         "If the thread is a virtual thread then this command can be used to set "
         "the value of local variables in the top-most frame when the thread is "
-        "suspended at a breakpoint or single step event. The target VM may support "
+        "suspended at an event. The target VM may support "
         "setting local variables in other cases."
         (Out
             (threadObject thread "The frame's thread. ")
@@ -2659,7 +2659,7 @@ JDWP "Java(tm) Debug Wire Protocol"
             (Error INVALID_THREAD)
             (Error INVALID_OBJECT)
             (Error INVALID_FRAMEID)
-            (Error OPAQUE_FRAME      "The thread is a virtual thread and the target VM "
+            (Error OPAQUE_FRAME      "The thread is a suspended virtual thread and the target VM "
                                      "does not support setting the value of local "
                                      "variables in the frame.")
             (Error VM_DEAD)

--- a/src/jdk.jdi/share/classes/com/sun/jdi/StackFrame.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/StackFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,7 +201,7 @@ public interface StackFrame extends Mirror, Locatable {
      * <p>
      * In the case of virtual threads, the target VM supports setting values
      * of local variables when this frame is the topmost frame and the thread
-     * is suspended at a breakpoint or single step event. The target VM may
+     * is suspended at an event. The target VM may
      * support setting local variables in other cases.
      * <p>
      * Object values must be assignment compatible with the variable type
@@ -224,7 +224,7 @@ public interface StackFrame extends Mirror, Locatable {
      * invalid. Once the frame's thread is resumed, the stack frame is
      * no longer valid.
      * @throws OpaqueFrameException if this frame is on the call stack of a
-     * virtual thread and the target VM does not support setting the value of
+     * suspended virtual thread, and the target VM does not support setting the value of
      * local variables in this frame.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only.
      * @see VirtualMachine#canBeModified()


### PR DESCRIPTION
The JDWP spec for StackFrame.SetValue currently states:

        "If the thread is a virtual thread then this command can be used to set "
        "the value of local variables in the top-most frame when the thread is "
        "suspended at a breakpoint or single step event. The target VM may support "
        "setting local variables in other cases."

The JDI spec for StackFrame.setValue() has similar wording. In [JDK-8308814](https://bugs.openjdk.org/browse/JDK-8308814) the JVMTI spec clarified support to be for a thread suspended at any event, not just a breakpoint or single step. That same clarification is needed in the JDWP and JDI specs. No implementation changes are needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8309149](https://bugs.openjdk.org/browse/JDK-8309149) to be approved

### Issues
 * [JDK-8309146](https://bugs.openjdk.org/browse/JDK-8309146): extend JDI StackFrame.setValue() and JDWP StackFrame.setValues minimal support for virtual threads
 * [JDK-8309149](https://bugs.openjdk.org/browse/JDK-8309149): extend JDI StackFrame.setValue() and JDWP StackFrame.setValues minimal support for virtual threads (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14235/head:pull/14235` \
`$ git checkout pull/14235`

Update a local copy of the PR: \
`$ git checkout pull/14235` \
`$ git pull https://git.openjdk.org/jdk.git pull/14235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14235`

View PR using the GUI difftool: \
`$ git pr show -t 14235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14235.diff">https://git.openjdk.org/jdk/pull/14235.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14235#issuecomment-1569288415)