### PR TITLE
8308232: nsk/jdb tests don't pass -verbose flag to the debuggee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -226,6 +226,10 @@ public class Launcher extends DebugeeBinder {
                     }
                 }
                 String cmdline = classToExecute + " " + ArgumentHandler.joinArguments(argumentHandler.getArguments(), " ");
+                cmdline += " -waittime " + argumentHandler.getWaitTime();
+                if (argumentHandler.verbose()) {
+                    cmdline += " -verbose";
+                }
                 if (System.getProperty("main.wrapper") != null) {
                     cmdline = MainWrapper.class.getName() + " " + System.getProperty("main.wrapper") +  " " + cmdline;
                 }


### PR DESCRIPTION
The nsk/jdb tests are not passing the test args on to the debuggee. I found a way to pass all of them (see the CR for details), but Windows had trouble with the parsing. It turns out the only args that the debuggee really cares about are -verbose and -waittime, so I settled on just passing these two, and Windows is happy.

Note only a handful of tests run with -verbose as the default. However, with this change at least now if you add -verbose when debugging an issue, you will see verbose log output from the debuggee. Previously you would not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232): nsk/jdb tests don't pass -verbose flag to the debuggee


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14236/head:pull/14236` \
`$ git checkout pull/14236`

Update a local copy of the PR: \
`$ git checkout pull/14236` \
`$ git pull https://git.openjdk.org/jdk.git pull/14236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14236`

View PR using the GUI difftool: \
`$ git pr show -t 14236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14236.diff">https://git.openjdk.org/jdk/pull/14236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14236#issuecomment-1569322411)