### PR TITLE
8309159: Some minor comment and code cleanup in jdk/com/sun/jdi/PopFramesTest.java

### DIFF
--- a/test/jdk/com/sun/jdi/PopFramesTest.java
+++ b/test/jdk/com/sun/jdi/PopFramesTest.java
@@ -58,14 +58,15 @@ import java.util.*;
  * NONATIVE:  there is no native frame (purposefully) present in the stack.
  *
  * In all cases the thread is suspended and errors such as IllegalArgumentException
- * and InvalidStackFrameException should not happen. The popFrames() calls  should
+ * and InvalidStackFrameException should not happen. The popFrames() calls should
  * either pass, or produce OpaqueFrameException or NativeMethodException.
  *
  * Call stacks for each test mode (and expected result):
  *  - Note in all cases the popMethod() frame is the frame passed to popFrames().
  *  - Note that Thread.sleep() usually results in the native Thread.sleep0() frame
- *    being at the top of the stack. However, for a mounted virtual thread
- *    it does not result in any native frames due to how the VM parks virtual threads.
+ *    being at the top of the stack. However, for a mounted virtual thread that is
+ *    not pinned, it does not result in any native frames due to how the VM
+ *    parks non-pinned virtual threads.
  *
  * SLEEP_NATIVE (NativeMethodException):
  *   Thread.sleep() + methods called by Thread.sleep()
@@ -266,7 +267,6 @@ public class PopFramesTest extends TestScaffold {
 
     protected void runTests() throws Exception {
         BreakpointEvent bpe = startTo("PopFramesTestTarg", "loopOrSleep", "()V");
-        ClassType targetClass = (ClassType)bpe.location().declaringType();
         ThreadReference mainThread = bpe.thread();
 
         // Resume main thread until it is in Thread.sleep() or the infinite loop.


### PR DESCRIPTION
PopFramesTest.java is a new test. It could use a couple of minor code cleanups, and there is one unused local variable that can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309159](https://bugs.openjdk.org/browse/JDK-8309159): Some minor comment and code cleanup in jdk/com/sun/jdi/PopFramesTest.java


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14237/head:pull/14237` \
`$ git checkout pull/14237`

Update a local copy of the PR: \
`$ git checkout pull/14237` \
`$ git pull https://git.openjdk.org/jdk.git pull/14237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14237`

View PR using the GUI difftool: \
`$ git pr show -t 14237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14237.diff">https://git.openjdk.org/jdk/pull/14237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14237#issuecomment-1569328596)