### PR TITLE
8308387: CLD created and unloading list sharing _next node pointer leads to concurrent YC missing CLD roots

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -148,6 +148,7 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool has_class_mirror_ho
   _jmethod_ids(nullptr),
   _deallocate_list(nullptr),
   _next(nullptr),
+  _unloading_next(nullptr),
   _class_loader_klass(nullptr), _name(nullptr), _name_and_id(nullptr) {
 
   if (!h_class_loader.is_null()) {

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -153,7 +153,27 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   GrowableArray<Metadata*>*      _deallocate_list;
 
   // Support for walking class loader data objects
-  ClassLoaderData* _next; /// Next loader_datas created
+  // The ClassLoaderDataGraph maintains two lists of CLDs, one list which
+  // contains the created CLDs, and another which contains the unloading
+  // CLDs. To enable the lock free concurrent iteration of the created
+  // CLDs list used by the GC for root scanning, it is important that unlinking
+  // CLDs from the created list upholds the invariant that all unlinked CLDs are
+  // is_unloading() and that the new tail list inserted is the same as the tail
+  // list before unlinking.
+  // That is given a list A -> B -> C -> D -> E where B and C are is_unloading()
+  // the only valid calls to set_next(ClassLoaderData*) are:
+  //   A.set_next(B),A.set_next(C),A.set_next(D)
+  //   B.set_next(C),B.set_next(D)
+  //   C.set_next(D)
+  //   D.set_next(E)
+  //   E.set_next(nullptr)
+  // Any insertions to the created CLDs list is done at the head and keeps
+  // the list tail invariant.
+  // CLDs are unlinked in ClassLoaderDataGraph::do_unloading() and released in
+  // ClassLoaderDataGraph::purge(), so some syncronization is required between
+  // the two to ensure that no unlinked CLD remains in the system leading
+  // to a use after free.
+  ClassLoaderData* _next;
   ClassLoaderData* _unloading_next;
 
   Klass*  _class_loader_klass;

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -157,18 +157,20 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // The ClassLoaderDataGraph maintains two lists to keep track of CLDs.
   //
   // The first list [_head, _next] is where new CLDs are registered. The CLDs
-  // are only inserted at the _head, and the _next pointers are never rewritten.
+  // are only inserted at the _head, and the _next pointers are only rewritten
+  // from unlink_next() which unlinks one unloading CLD by setting _next to
+  // _next->_next.
   // This allows GCs to concurrently walk the list while the CLDs are being
   // concurrently unlinked.
   //
   // The second list [_unloading_head, _unloading_next] is where dead CLDs get
   // moved to during class unloading. See: ClassLoaderDataGraph::do_unloading().
-  // This list is never modified while other threads are iterating over it. 
+  // This list is never modified while other threads are iterating over it.
   //
   // After all dead CLDs have been moved to the unloading list, there's a
   // synchronziation point (handshake) to ensure that all threads reading these
   // CLDs finish their work. This ensures that we don't have a user-after-free
-  // when we later delete the CLDs. 
+  // when we later delete the CLDs.
   //
   // And finally, when no threads are using the unloading CLDs anymore, we
   // remove them from the class unloading list and delete them. See:

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -168,7 +168,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   //
   // After all dead CLDs have been moved to the unloading list, there's a
   // synchronization point (handshake) to ensure that all threads reading these
-  // CLDs finish their work. This ensures that we don't have a user-after-free
+  // CLDs finish their work. This ensures that we don't have a use-after-free
   // when we later delete the CLDs.
   //
   // And finally, when no threads are using the unloading CLDs anymore, we

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -181,26 +181,11 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   Symbol* _name_and_id;
   JFR_ONLY(DEFINE_TRACE_ID_FIELD;)
 
-  void set_next(ClassLoaderData* next) {
-#ifdef ASSERT
-  if (this->next() != nullptr) {
-    ClassLoaderData* cld = this->next();
-    for (;;) {
-      // Next must be in the tail of the list
-      if (cld == next) {
-        break;
-      }
-      assert(cld->is_unloading(), "only remove unloading clds");
-      cld = cld->next();
-    }
-  }
-#endif
-    Atomic::store(&_next, next);
-  }
-  ClassLoaderData* next() const        { return Atomic::load(&_next); }
+  void set_next(ClassLoaderData* next);
+  ClassLoaderData* next() const;
 
-  void set_unloading_next(ClassLoaderData* unloading_next) { _unloading_next = unloading_next; }
-  ClassLoaderData* unloading_next() const                  { return _unloading_next; }
+  void set_unloading_next(ClassLoaderData* unloading_next);
+  ClassLoaderData* unloading_next() const;
 
   ClassLoaderData(Handle h_class_loader, bool has_class_mirror_holder);
   ~ClassLoaderData();

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -167,7 +167,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // This list is never modified while other threads are iterating over it.
   //
   // After all dead CLDs have been moved to the unloading list, there's a
-  // synchronziation point (handshake) to ensure that all threads reading these
+  // synchronization point (handshake) to ensure that all threads reading these
   // CLDs finish their work. This ensures that we don't have a user-after-free
   // when we later delete the CLDs.
   //

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -158,15 +158,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // CLDs. To enable the lock free concurrent iteration of the created
   // CLDs list used by the GC for root scanning, it is important that unlinking
   // CLDs from the created list upholds the invariant that all unlinked CLDs are
-  // is_unloading() and that the new tail list inserted is the same as the tail
-  // list before unlinking.
-  // That is given a list A -> B -> C -> D -> E where B and C are is_unloading()
-  // the only valid calls to set_next(ClassLoaderData*) are:
-  //   A.set_next(B),A.set_next(C),A.set_next(D)
-  //   B.set_next(C),B.set_next(D)
-  //   C.set_next(D)
-  //   D.set_next(E)
-  //   E.set_next(nullptr)
+  // is_unloading().
   // Any insertions to the created CLDs list is done at the head and keeps
   // the list tail invariant.
   // CLDs are unlinked in ClassLoaderDataGraph::do_unloading() and released in
@@ -183,6 +175,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   void set_next(ClassLoaderData* next);
   ClassLoaderData* next() const;
+  void unlink_next();
 
   void set_unloading_next(ClassLoaderData* unloading_next);
   ClassLoaderData* unloading_next() const;

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -161,7 +161,22 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   Symbol* _name_and_id;
   JFR_ONLY(DEFINE_TRACE_ID_FIELD;)
 
-  void set_next(ClassLoaderData* next) { Atomic::store(&_next, next); }
+  void set_next(ClassLoaderData* next) {
+#ifdef ASSERT
+  if (this->next() != nullptr) {
+    ClassLoaderData* cld = this->next();
+    for (;;) {
+      // Next must be in the tail of the list
+      if (cld == next) {
+        break;
+      }
+      assert(cld->is_unloading(), "only remove unloading clds");
+      cld = cld->next();
+    }
+  }
+#endif
+    Atomic::store(&_next, next);
+  }
   ClassLoaderData* next() const        { return Atomic::load(&_next); }
 
   void set_unloading_next(ClassLoaderData* unloading_next) { _unloading_next = unloading_next; }

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -159,9 +159,8 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   // The first list [_head, _next] is where new CLDs are registered. The CLDs
   // are only inserted at the _head, and the _next pointers are only rewritten
   // from unlink_next() which unlinks one unloading CLD by setting _next to
-  // _next->_next.
-  // This allows GCs to concurrently walk the list while the CLDs are being
-  // concurrently unlinked.
+  // _next->_next. This allows GCs to concurrently walk the list while the CLDs
+  // are being concurrently unlinked.
   //
   // The second list [_unloading_head, _unloading_next] is where dead CLDs get
   // moved to during class unloading. See: ClassLoaderDataGraph::do_unloading().

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -154,6 +154,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   // Support for walking class loader data objects
   ClassLoaderData* _next; /// Next loader_datas created
+  ClassLoaderData* _unloading_next;
 
   Klass*  _class_loader_klass;
   Symbol* _name;
@@ -162,6 +163,9 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   void set_next(ClassLoaderData* next) { Atomic::store(&_next, next); }
   ClassLoaderData* next() const        { return Atomic::load(&_next); }
+
+  void set_unloading_next(ClassLoaderData* unloading_next) { _unloading_next = unloading_next; }
+  ClassLoaderData* unloading_next() const                  { return _unloading_next; }
 
   ClassLoaderData(Handle h_class_loader, bool has_class_mirror_holder);
   ~ClassLoaderData();

--- a/src/hotspot/share/classfile/classLoaderData.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.inline.hpp
@@ -33,6 +33,35 @@
 #include "oops/oopHandle.inline.hpp"
 #include "oops/weakHandle.inline.hpp"
 
+inline void ClassLoaderData::set_next(ClassLoaderData* next) {
+#ifdef ASSERT
+  if (this->next() != nullptr) {
+    ClassLoaderData* cld = this->next();
+    for (;;) {
+      // Next must be in the tail of the list
+      if (cld == next) {
+        break;
+      }
+      assert(cld->is_unloading(), "only remove unloading clds");
+      cld = cld->next();
+    }
+  }
+#endif
+    Atomic::store(&_next, next);
+  }
+
+inline ClassLoaderData* ClassLoaderData::next() const {
+  return Atomic::load(&_next);
+}
+
+inline void ClassLoaderData::set_unloading_next(ClassLoaderData* unloading_next) {
+  _unloading_next = unloading_next;
+}
+
+inline ClassLoaderData* ClassLoaderData::unloading_next() const {
+  return _unloading_next;
+}
+
 inline oop ClassLoaderData::class_loader() const {
   assert(!_unloading, "This oop is not available to unloading class loader data");
   assert(_holder.is_null() || holder_no_keepalive() != nullptr , "This class loader data holder must be alive");

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -503,25 +503,23 @@ bool ClassLoaderDataGraph::do_unloading() {
     if (data->is_alive()) {
       prev = data;
       loaders_processed++;
-      continue;
-    }
-
-    // Found dead CLD.
-    loaders_removed++;
-    seen_dead_loader = true;
-    data->unload();
-
-    // Move dead CLD to unloading list.
-    if (prev != nullptr) {
-      prev->unlink_next();
     } else {
-      assert(data == _head, "sanity check");
-      // The GC might be walking this concurrently
-      Atomic::store(&_head, data->next());
-    }
-    data->set_unloading_next(_unloading_head);
-    _unloading_head = data;
+      // Found dead CLD.
+      loaders_removed++;
+      seen_dead_loader = true;
+      data->unload();
 
+      // Move dead CLD to unloading list.
+      if (prev != nullptr) {
+        prev->unlink_next();
+      } else {
+        assert(data == _head, "sanity check");
+        // The GC might be walking this concurrently
+        Atomic::store(&_head, data->next());
+      }
+      data->set_unloading_next(_unloading_head);
+      _unloading_head = data;
+    }
   }
 
   log_debug(class, loader, data)("do_unloading: loaders processed %u, loaders removed %u", loaders_processed, loaders_removed);

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -201,7 +201,7 @@ void ClassLoaderDataGraph::walk_metadata_and_clean_metaspaces() {
   clean_deallocate_lists(walk_all_metadata);
 }
 
-// GC root of class loader data created.
+// List head of all class loader data.
 ClassLoaderData* volatile ClassLoaderDataGraph::_head = nullptr;
 ClassLoaderData* ClassLoaderDataGraph::_unloading_head = nullptr;
 
@@ -269,8 +269,7 @@ inline void assert_is_safepoint_or_gc() {
          "Must be called by safepoint or GC");
 }
 
-// These are functions called by the GC, which require all of the CLDs, including the
-// unloading ones.
+// These are functions called by the GC, which require all of the CLDs, including not yet unlinked CLDs.
 void ClassLoaderDataGraph::cld_do(CLDClosure* cl) {
   assert_is_safepoint_or_gc();
   for (ClassLoaderData* cld = Atomic::load_acquire(&_head);  cld != nullptr; cld = cld->next()) {

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoaderDataGraph.inline.hpp"
 #include "classfile/dictionary.hpp"
 #include "classfile/javaClasses.hpp"

--- a/src/hotspot/share/classfile/classLoaderDataGraph.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.hpp
@@ -41,8 +41,9 @@ class ClassLoaderDataGraph : public AllStatic {
   friend class ClassLoaderDataGraphIteratorBase;
   friend class VMStructs;
  private:
-  // All CLDs (except the null CLD) can be reached by walking _head->_next->...
+  // All CLDs (except unlinked CLDs) can be reached by walking _head->_next->...
   static ClassLoaderData* volatile _head;
+  // All unlinked CLDs
   static ClassLoaderData* _unloading_head;
 
   // Set if there's anything to purge in the deallocate lists or previous versions
@@ -67,7 +68,7 @@ class ClassLoaderDataGraph : public AllStatic {
   static void clear_claimed_marks();
   static void clear_claimed_marks(int claim);
   static void verify_claimed_marks_cleared(int claim);
-  // Iteration through CLDG inside a safepoint; GC support
+  // Iteration through CLDG; GC support
   static void cld_do(CLDClosure* cl);
   static void roots_cld_do(CLDClosure* strong, CLDClosure* weak);
   static void always_strong_cld_do(CLDClosure* cl);

--- a/src/hotspot/share/classfile/classLoaderDataGraph.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.hpp
@@ -43,7 +43,7 @@ class ClassLoaderDataGraph : public AllStatic {
  private:
   // All CLDs (except the null CLD) can be reached by walking _head->_next->...
   static ClassLoaderData* volatile _head;
-  static ClassLoaderData* _unloading;
+  static ClassLoaderData* _unloading_head;
 
   // Set if there's anything to purge in the deallocate lists or previous versions
   // during a safepoint after class unloading in a full GC.

--- a/src/hotspot/share/classfile/classLoaderDataGraph.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.hpp
@@ -69,7 +69,6 @@ class ClassLoaderDataGraph : public AllStatic {
   static void verify_claimed_marks_cleared(int claim);
   // Iteration through CLDG inside a safepoint; GC support
   static void cld_do(CLDClosure* cl);
-  static void cld_unloading_do(CLDClosure* cl);
   static void roots_cld_do(CLDClosure* strong, CLDClosure* weak);
   static void always_strong_cld_do(CLDClosure* cl);
   // Iteration through CLDG not by GC.


### PR DESCRIPTION
[JDK-8307106](https://bugs.openjdk.org/browse/JDK-8307106) introduced the ability to walk the created CLDs list in the CLDG without a lock. This was primarily introduced to allow lockless concurrent CLD roots scanning for young collections in generational ZGC. However because the CLD _next node pointer is shared between the two list this can lead to a concurrent iteration of the created CLDs missing list entries. 

This change introduces a second _unloading_next node pointer which is used for the unloading CLDs list. The set_next is now maintains the invariant that it only ever unlinks is_unloading() CLDs and maintains a consistent view of the tail list for anyone reading the list concurrently.  

Testing: tier1-3 and tier1-7 with Generational ZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308387](https://bugs.openjdk.org/browse/JDK-8308387): CLD created and unloading list sharing _next node pointer leads to concurrent YC missing CLD roots


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [320be537](https://git.openjdk.org/jdk/pull/14241/files/320be5372ad4071c601ac3f1ab2ff510944df5df)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14241/head:pull/14241` \
`$ git checkout pull/14241`

Update a local copy of the PR: \
`$ git checkout pull/14241` \
`$ git pull https://git.openjdk.org/jdk.git pull/14241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14241`

View PR using the GUI difftool: \
`$ git pr show -t 14241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14241.diff">https://git.openjdk.org/jdk/pull/14241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14241#issuecomment-1569744670)