### PR TITLE
8309104: [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement test asserts wrong values with Graal

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,12 +224,12 @@ public class UnsafeGetStableArrayElement {
     }
 
     static void testMismatched(Callable<?> c, Runnable setDefaultAction) throws Exception {
-        testMismatched(c, setDefaultAction, false);
+        testMismatched(c, setDefaultAction, false, true);
     }
 
-    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray) throws Exception {
-        if (Compiler.isGraalEnabled() && !objectArray) {
-            // Graal will constant fold mismatched reads from primitive stable arrays
+    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray, boolean aligned) throws Exception {
+        if (Compiler.isGraalEnabled() && !objectArray && aligned) {
+            // Graal will constant fold mismatched reads from primitive stable arrays, except unaligned ones
             run(c, setDefaultAction, null);
         } else {
             run(c, null, setDefaultAction);
@@ -319,15 +319,15 @@ public class UnsafeGetStableArrayElement {
         testMatched(   Test::testD_D, Test::changeD);
 
         // Object[], aligned accesses
-        testMismatched(Test::testL_J, Test::changeL, true); // long & double are always as large as an OOP
-        testMismatched(Test::testL_D, Test::changeL, true);
+        testMismatched(Test::testL_J, Test::changeL, true, true); // long & double are always as large as an OOP
+        testMismatched(Test::testL_D, Test::changeL, true, true);
         testMatched(   Test::testL_L, Test::changeL);
 
         // Unaligned accesses
-        testMismatched(Test::testS_U, Test::changeS);
-        testMismatched(Test::testC_U, Test::changeC);
-        testMismatched(Test::testI_U, Test::changeI);
-        testMismatched(Test::testJ_U, Test::changeJ);
+        testMismatched(Test::testS_U, Test::changeS, false, false);
+        testMismatched(Test::testC_U, Test::changeC, false, false);
+        testMismatched(Test::testI_U, Test::changeI, false, false);
+        testMismatched(Test::testJ_U, Test::changeJ, true, false);
 
         // No way to reliably check the expected behavior:
         //   (1) OOPs change during GC;


### PR DESCRIPTION
This PR fixes the UnsafeGetStableArrayElement test when run with the Graal compiler.

In the past this test also failed with graal because it was checking for c1/c2 semantics.
JDK-8264135 introduced changes to the UnsafeGetStableArrayElement test to account for the scenario when the test is run with the Graal compiler. If Graal is used it will assert that constants are folded by asserting matching instead of mismatch.

However, we had changes in Graal since then, since JDK-8275645 Graal no longer constant folds unaligned reads.
This lets the test fail again for the unaligned cases because it asserts graal folds them.

The fix is to actually assert mismatch on unaligned accesses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309104](https://bugs.openjdk.org/browse/JDK-8309104): [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement test asserts wrong values with Graal


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to [a8044e98](https://git.openjdk.org/jdk/pull/14242/files/a8044e98abb66814326d8e520e2a109131d28418)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14242/head:pull/14242` \
`$ git checkout pull/14242`

Update a local copy of the PR: \
`$ git checkout pull/14242` \
`$ git pull https://git.openjdk.org/jdk.git pull/14242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14242`

View PR using the GUI difftool: \
`$ git pr show -t 14242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14242.diff">https://git.openjdk.org/jdk/pull/14242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14242#issuecomment-1569795570)