### PR TITLE
8309183: C2 IR-Framework: add UseKNLSetting to whitelist

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -138,6 +138,7 @@ public class TestFramework {
                     "server",
                     "UseAVX",
                     "UseSSE",
+                    "UseKNLSetting",
                     "UseSVE",
                     "UseZbb",
                     "UseRVV",


### PR DESCRIPTION
Adding `UseKNLSetting` to IR-Framework whitelist. It is comparable to `UseAVX` and `UseSSE` on intel machines.

Without whitelisting it, we would not run the IR rules if the flag was passed from the outside as an additional VM flag.
This means we could not test the KNL platform on other machines.

Testing up to tier6 and stress testing, with and without the flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8309183](https://bugs.openjdk.org/browse/JDK-8309183)

### Issue
 * [JDK-8309183](https://bugs.openjdk.org/browse/JDK-8309183): [IR Framework] Add UseKNLSetting to whitelist (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14243/head:pull/14243` \
`$ git checkout pull/14243`

Update a local copy of the PR: \
`$ git checkout pull/14243` \
`$ git pull https://git.openjdk.org/jdk.git pull/14243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14243`

View PR using the GUI difftool: \
`$ git pr show -t 14243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14243.diff">https://git.openjdk.org/jdk/pull/14243.diff</a>

</details>
