### PR TITLE
8308943: jdk.internal.le build fails on AIX

### DIFF
--- a/src/jdk.internal.le/aix/classes/jdk/internal/org/jline/terminal/impl/jna/JDKNativePty.java
+++ b/src/jdk.internal.le/aix/classes/jdk/internal/org/jline/terminal/impl/jna/JDKNativePty.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.org.jline.terminal.impl.jna;
+
+import java.io.IOException;
+import jdk.internal.org.jline.terminal.Attributes;
+import jdk.internal.org.jline.terminal.Size;
+import jdk.internal.org.jline.terminal.impl.jna.linux.LinuxNativePty;
+import jdk.internal.org.jline.terminal.spi.TerminalProvider;
+
+class JDKNativePty {
+
+    static JnaNativePty current(TerminalProvider.Stream console) throws IOException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    static JnaNativePty open(Attributes attr, Size size) throws IOException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    static int isatty(int fd) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    static String ttyname(int fd) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+}

--- a/src/jdk.internal.le/aix/classes/jdk/internal/org/jline/terminal/impl/jna/JDKNativePty.java
+++ b/src/jdk.internal.le/aix/classes/jdk/internal/org/jline/terminal/impl/jna/JDKNativePty.java
@@ -27,7 +27,6 @@ package jdk.internal.org.jline.terminal.impl.jna;
 import java.io.IOException;
 import jdk.internal.org.jline.terminal.Attributes;
 import jdk.internal.org.jline.terminal.Size;
-import jdk.internal.org.jline.terminal.impl.jna.linux.LinuxNativePty;
 import jdk.internal.org.jline.terminal.spi.TerminalProvider;
 
 class JDKNativePty {


### PR DESCRIPTION
A simpler alternative to https://github.com/openjdk/jdk/pull/14176 - it only creates a stub of `JDKNativePty` for AIX, throwing `UnsupportedOperationException`. JLine will then either use the next provider (i.e. "exec", for JShell), or dumb terminal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308943](https://bugs.openjdk.org/browse/JDK-8308943): jdk.internal.le build fails on AIX


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14247/head:pull/14247` \
`$ git checkout pull/14247`

Update a local copy of the PR: \
`$ git checkout pull/14247` \
`$ git pull https://git.openjdk.org/jdk.git pull/14247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14247`

View PR using the GUI difftool: \
`$ git pr show -t 14247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14247.diff">https://git.openjdk.org/jdk/pull/14247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14247#issuecomment-1570223919)