### PR TITLE
8309210: Extend VM Operations hs_err logging

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -238,6 +238,8 @@ class VM_HandshakeAllThreads: public VM_Operation {
  public:
   VM_HandshakeAllThreads(HandshakeOperation* op) : _op(op) {}
 
+  const char* cause() const { return _op->name(); }
+
   bool evaluate_at_safepoint() const { return false; }
 
   void doit() {

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -174,6 +174,8 @@ class VM_Operation : public StackObj {
     assert(type >= 0 && type < VMOp_Terminating, "invalid VM operation type");
     return _names[type];
   }
+  // Extra information about what triggered this operation.
+  virtual const char* cause() const { return nullptr; }
 #ifndef PRODUCT
   void print_on(outputStream* st) const { print_on_error(st); }
 #endif

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -407,7 +407,14 @@ void VMThread::inner_execute(VM_Operation* op) {
   _cur_vm_operation = op;
 
   HandleMark hm(VMThread::vm_thread());
-  EventMarkVMOperation em("Executing %sVM operation: %s", prev_vm_operation != nullptr ? "nested " : "", op->name());
+
+  const char* const cause = op->cause();
+  EventMarkVMOperation em("Executing %sVM operation: %s%s%s%s",
+      prev_vm_operation != nullptr ? "nested " : "",
+      op->name(),
+      cause != nullptr ? " (" : "",
+      cause != nullptr ? cause : "",
+      cause != nullptr ? ")" : "");
 
   log_debug(vmthread)("Evaluating %s %s VM operation: %s",
                        prev_vm_operation != nullptr ? "nested" : "",


### PR DESCRIPTION
We have a section in the hs_err file, which prints the most recently run VM operations. Sometimes a VM operation type is used from multiple places in our code and it's not obvious why the VM operation was run. For example, HandshakeAllThreads doesn't tell us why we are running the handshake. I propose that we add an option for the VM operations to tell more about why they are used.

The proposed patch enhances the Handshake VM operation and the ZGC pause VM Operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309210](https://bugs.openjdk.org/browse/JDK-8309210): Extend VM Operations hs_err logging


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14248/head:pull/14248` \
`$ git checkout pull/14248`

Update a local copy of the PR: \
`$ git checkout pull/14248` \
`$ git pull https://git.openjdk.org/jdk.git pull/14248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14248`

View PR using the GUI difftool: \
`$ git pr show -t 14248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14248.diff">https://git.openjdk.org/jdk/pull/14248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14248#issuecomment-1570371763)