### PR TITLE
8308596: Revert the "keepAlive" workaround from CDS tests

### DIFF
--- a/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
+++ b/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
@@ -32,7 +32,6 @@
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
-import java.lang.invoke.MethodHandles.Lookup.ClassOption;
 import static java.lang.invoke.MethodHandles.Lookup.ClassOption.*;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 
@@ -45,19 +44,12 @@ public class InstantiateHiddenClass {
         " } } ");
 
     public static void main(String[] args) throws Throwable {
-        // This class is also used by the appcds/dynamicArchive/RegularHiddenClass.java
-        // test which will pass the "keep-alive" argument during dynamic CDS dump
-        // for preventing from being GC'ed prior to the dumping operation.
-        boolean keepAlive = false;
-        if (args.length == 1 && args[0].equals("keep-alive")) {
-            keepAlive = true;
-        }
 
         // Test that a hidden class cannot be found through its name.
         try {
             Lookup lookup = MethodHandles.lookup();
-            Class<?> c0 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
-            Class.forName(c0.getName()).newInstance();
+            Class<?> cl = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
+            Class.forName(cl.getName()).newInstance();
             throw new RuntimeException("Expected ClassNotFoundException not thrown");
         } catch (ClassNotFoundException e ) {
             // Test passed
@@ -68,9 +60,8 @@ public class InstantiateHiddenClass {
         // Verify that the references to these objects are different and references
         // to their classes are not equal either.
         Lookup lookup = MethodHandles.lookup();
-        ClassOption classOption = keepAlive ? STRONG : NESTMATE;
-        Class<?> c1 = lookup.defineHiddenClass(klassbuf, false, classOption).lookupClass();
-        Class<?> c2 = lookup.defineHiddenClass(klassbuf, false, classOption).lookupClass();
+        Class<?> c1 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
+        Class<?> c2 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
         Object o1 = c1.newInstance();
         Object o2 = c2.newInstance();
         if (o1 == o2) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -30,12 +30,10 @@ import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class HelloUnload {
     private static String className = "CustomLoadee";
-    // Prevent the following class from being GC'ed too soon.
-    private static Class keptC = null;
 
     public static void main(String args[]) throws Exception {
-        if (args.length < 3) {
-            throw new RuntimeException("Unexpected number of arguments: expected at least 3, actual " + args.length);
+        if (args.length != 3) {
+            throw new RuntimeException("Unexpected number of arguments: expected 3, actual " + args.length);
         }
 
         String path = args[0];
@@ -64,20 +62,9 @@ public class HelloUnload {
             throw new RuntimeException("args[2] can only be either \"true\" or \"false\", actual " + args[1]);
         }
 
-        // The HelloDynamicCustom.java and PrintSharedArchiveAndExit.java tests
-        // under appcds/dynamicArchive pass the keep-alive argument for preventing
-        // the class from being GC'ed prior to dumping of the dynamic CDS archive.
-        boolean keepAlive = false;
-        if (args[args.length - 1].equals("keep-alive")) {
-            keepAlive = true;
-        }
-
         URLClassLoader urlClassLoader =
             new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
-        if (keepAlive) {
-            keptC = c;
-        }
         System.out.println(c);
         System.out.println(c.getClassLoader());
         Object o = c.newInstance();

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/OldClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/OldClassApp.java
@@ -25,12 +25,9 @@
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.HashMap;
 import jdk.test.whitebox.WhiteBox;
 
 public class OldClassApp {
-    // Prevent the classes from being GC'ed too soon.
-    static HashMap<String, Class> clsMap = new HashMap<>();
     public static void main(String args[]) throws Exception {
         String path = args[0];
         URL url = new File(path).toURI().toURL();
@@ -47,26 +44,13 @@ public class OldClassApp {
             throw new RuntimeException("args[1] can only be either \"true\" or \"false\", actual " + args[1]);
         }
 
-        // The OldClassAndInf.java test under appcds/dynamicArchive passes the keep-alive
-        // argument for preventing the classes from being GC'ed prior to dumping of
-        // the dynamic CDS archive.
-        int startIdx = 2;
-        boolean keepAlive = false;
-        if (args[2].equals("keep-alive")) {
-            keepAlive = true;
-            startIdx = 3;
-        }
-
         URLClassLoader urlClassLoader =
             new URLClassLoader("OldClassAppClassLoader", urls, null);
 
-        for (int i = startIdx; i < args.length; i++) {
+        for (int i = 2; i < args.length; i++) {
             Class c = urlClassLoader.loadClass(args[i]);
             System.out.println(c);
             System.out.println(c.getClassLoader());
-            if (keepAlive) {
-                clsMap.put(args[i], c);
-            }
 
             // [1] Check that class is defined by the correct loader
             if (c.getClassLoader() != urlClassLoader) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustom.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustom.java
@@ -64,7 +64,7 @@ public class HelloDynamicCustom extends DynamicArchiveTestBase {
             "-Xlog:cds",
             "-Xlog:cds+dynamic=debug",
             "-cp", appJar,
-            mainAppClass, customJarPath, "false", "false", "keep-alive")
+            mainAppClass, customJarPath, "false", "false")
             .assertNormalExit(output -> {
                 output.shouldContain("Written dynamic archive 0x")
                       .shouldNotContain("klasses.*=.*CustomLoadee")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java
@@ -49,7 +49,7 @@ public class LambdaCustomLoader extends DynamicArchiveTestBase {
         // 1. Host class loaded by a custom loader is initialized during dump time.
         dump(topArchiveName,
             "-Xlog:class+load,cds=debug,cds+dynamic",
-            "-cp", appJar, mainClass, appJar, "init", "keep-alive")
+            "-cp", appJar, mainClass, appJar, "init")
             .assertNormalExit(output -> {
                 output.shouldMatch("Skipping.LambHello[$][$]Lambda.*0x.*:.Hidden.class")
                       .shouldHaveExitValue(0);
@@ -67,7 +67,7 @@ public class LambdaCustomLoader extends DynamicArchiveTestBase {
         // 2. Host class loaded by a custom loader is NOT initialized during dump time.
         dump(topArchiveName,
             "-Xlog:class+load,cds=debug,cds+dynamic",
-            "-cp", appJar, mainClass, appJar, "keep-alive")
+            "-cp", appJar, mainClass, appJar)
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0);
             });

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/OldClassAndInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/OldClassAndInf.java
@@ -80,7 +80,7 @@ public class OldClassAndInf extends DynamicArchiveTestBase {
                      "-Xlog:cds",
                      "-Xlog:cds+dynamic=debug",
                      "-cp", appJar,
-                     mainAppClass, loadeesJar, inArchive, "keep-alive"),
+                     mainAppClass, loadeesJar, inArchive),
              loadees))
              .assertNormalExit(output -> {
                  output.shouldContain("Written dynamic archive 0x")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
@@ -64,7 +64,7 @@ public class PrintSharedArchiveAndExit extends DynamicArchiveTestBase {
             "-Xlog:cds",
             "-Xlog:cds+dynamic=debug",
             "-cp", appJar,
-            mainAppClass, customJarPath, "false", "false", "keep-alive")
+            mainAppClass, customJarPath, "false", "false")
             .assertNormalExit(output -> {
                 output.shouldContain("Written dynamic archive 0x")
                       .shouldNotContain("klasses.*=.*CustomLoadee")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RegularHiddenClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RegularHiddenClass.java
@@ -54,7 +54,7 @@ public class RegularHiddenClass extends DynamicArchiveTestBase {
 
         dump(topArchiveName,
             "-Xlog:class+load=debug,cds+dynamic,cds=debug",
-            "-cp", appJar, mainClass, "keep-alive")
+            "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
                 output.shouldMatch("cds.*Skipping.TestClass.0x.*Hidden.class")
                       .shouldNotMatch("cds.dynamic.*Archiving.hidden.TestClass.*")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
@@ -28,8 +28,6 @@ import java.net.URLClassLoader;
 
 public class CustomLoaderApp {
     private static String className = "LambHello";
-    // Prevent the class from being GC'ed too soon.
-    private static Class keptC = null;
 
     public static void main(String args[]) throws Exception {
         String path = args[0];
@@ -39,25 +37,13 @@ public class CustomLoaderApp {
         System.out.println(url);
 
         boolean init = false;
-        if (args.length >= 2 && args[1].equals("init")) {
+        if (args.length ==2 && args[1].equals("init")) {
             init = true;
-        }
-
-        // The dynamicArchive/LambdaCustomLoader.java test passes the keep-alive
-        // argument for preventing the class from being GC'ed prior to dumping of
-        // the dynamic CDS archive.
-        boolean keepAlive = false;
-        if (args[args.length - 1].equals("keep-alive")) {
-            keepAlive = true;
         }
 
         URLClassLoader urlClassLoader =
             new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, init, urlClassLoader);
-        if (keepAlive) {
-            keptC = c;
-        }
-
         System.out.println(c);
         System.out.println(c.getClassLoader());
         if (c.getClassLoader() != urlClassLoader) {


### PR DESCRIPTION
This fix reverts the [changeset](https://github.com/openjdk/jdk/commit/0dbe4c5d516a5e43934cb18f3becaf2a7f90999f#diff-4184777f000a8c9284612862ed6169b85030d15fe5ee54c9694e0649613f9d8c) for [JDK-8278131](https://bugs.openjdk.org/browse/JDK-8278131) which was a workaround for the more aggressive sweeping of the code cache issue in an early implementation of loom. The workaround is no longer necessary.

Testing:

- locally on linux-x64 with a promoted loom build
- tiers 1,2,4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308596](https://bugs.openjdk.org/browse/JDK-8308596): Revert the "keepAlive" workaround from CDS tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14249/head:pull/14249` \
`$ git checkout pull/14249`

Update a local copy of the PR: \
`$ git checkout pull/14249` \
`$ git pull https://git.openjdk.org/jdk.git pull/14249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14249`

View PR using the GUI difftool: \
`$ git pr show -t 14249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14249.diff">https://git.openjdk.org/jdk/pull/14249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14249#issuecomment-1570554619)