### PR TITLE
8309200: java/net/httpclient/ExecutorShutdown fails intermittently, if connection closed during upgrade

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,11 @@ class AsyncSSLConnection extends AbstractAsyncSSLConnection {
     @Override
     public void close() {
         plainConnection.close();
+    }
+
+    @Override
+    void close(Throwable cause) {
+        plainConnection.close(cause);
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLTunnelConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLTunnelConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,6 +111,11 @@ class AsyncSSLTunnelConnection extends AbstractAsyncSSLConnection {
     @Override
     public void close() {
         plainConnection.close();
+    }
+
+    @Override
+    void close(Throwable cause) {
+        plainConnection.close(cause);
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
@@ -164,7 +164,8 @@ final class Exchange<T> {
             HttpConnection connection;
             Throwable cause;
             synchronized (this) {
-                if ((cause = this.cause) == null) {
+                cause = this.cause;
+                if (cause == null) {
                     cause = this.cause = error;
                 }
                 connection = this.connection;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
@@ -142,6 +142,7 @@ final class Exchange<T> {
     static final class ConnectionAborter {
         private volatile HttpConnection connection;
         private volatile boolean closeRequested;
+        private volatile Throwable cause;
 
         void connection(HttpConnection connection) {
             boolean closeRequested;
@@ -156,20 +157,25 @@ final class Exchange<T> {
                     this.closeRequested = false;
                 }
             }
-            if (closeRequested) closeConnection(connection);
+            if (closeRequested) closeConnection(connection, cause);
         }
 
-        void closeConnection() {
+        void closeConnection(Throwable error) {
             HttpConnection connection;
+            Throwable cause;
             synchronized (this) {
+                if ((cause = this.cause) == null) {
+                    cause = this.cause = error;
+                }
                 connection = this.connection;
                 if (connection == null) {
                     closeRequested = true;
                 } else {
                     this.connection = null;
+                    this.cause = null;
                 }
             }
-            closeConnection(connection);
+            closeConnection(connection, cause);
         }
 
         HttpConnection disable() {
@@ -178,14 +184,15 @@ final class Exchange<T> {
                 connection = this.connection;
                 this.connection = null;
                 this.closeRequested = false;
+                this.cause = null;
             }
             return connection;
         }
 
-        private static void closeConnection(HttpConnection connection) {
+        private static void closeConnection(HttpConnection connection, Throwable cause) {
             if (connection != null) {
                 try {
-                    connection.close();
+                    connection.close(cause);
                 } catch (Throwable t) {
                     // ignore
                 }
@@ -264,11 +271,19 @@ final class Exchange<T> {
             impl.cancel(cause);
         } else {
             // no impl yet. record the exception
-            failed = cause;
+            IOException failed = this.failed;
+            if (failed == null) {
+                synchronized (this) {
+                    failed = this.failed;
+                    if (failed == null) {
+                        failed = this.failed = cause;
+                    }
+                }
+            }
 
             // abort/close the connection if setting up the exchange. This can
             // be important when setting up HTTP/2
-            connectionAborter.closeConnection();
+            connectionAborter.closeConnection(failed);
 
             // now call checkCancelled to recheck the impl.
             // if the failed state is set and the impl is not null, reset

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
@@ -166,11 +166,12 @@ final class Exchange<T> {
             synchronized (this) {
                 cause = this.cause;
                 if (cause == null) {
-                    cause = this.cause = error;
+                    cause = error;
                 }
                 connection = this.connection;
                 if (connection == null) {
                     closeRequested = true;
+                    this.cause = cause;
                 } else {
                     this.connection = null;
                     this.cause = null;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,10 +427,18 @@ abstract class HttpConnection implements Closeable {
     abstract ConnectionPool.CacheKey cacheKey();
 
     /**
-     * Closes this connection, by returning the socket to its connection pool.
+     * Closes this connection.
      */
     @Override
     public abstract void close();
+
+    /**
+     * Closes this connection due to the given cause.
+     * @param cause the cause for which the connection is closed, may be null
+     */
+    void close(Throwable cause) {
+        close();
+    }
 
     abstract FlowTube getConnectionFlow();
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
@@ -401,11 +401,13 @@ class PlainHttpConnection extends HttpConnection {
         return "PlainHttpConnection: " + super.toString();
     }
 
-    /**
-     * Closes this connection
-     */
     @Override
     public void close() {
+        close(null);
+    }
+
+    @Override
+    void close(Throwable cause) {
         var closed = this.closed;
         if (closed) return;
         stateLock.lock();
@@ -423,7 +425,7 @@ class PlainHttpConnection extends HttpConnection {
             }
             try {
                 chan.close();
-                tube.signalClosed();
+                tube.signalClosed(cause);
             } finally {
                 client().connectionClosed(this);
             }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/PlainTunnelingConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/PlainTunnelingConnection.java
@@ -157,7 +157,12 @@ final class PlainTunnelingConnection extends HttpConnection {
 
     @Override
     public void close() {
-        delegate.close();
+        close(null);
+    }
+
+    @Override
+    void close(Throwable cause) {
+        delegate.close(cause);
         connected = false;
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/SocketTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/SocketTube.java
@@ -149,7 +149,7 @@ final class SocketTube implements FlowTube {
     //                           Events                                      //
     // ======================================================================//
 
-    void signalClosed() {
+    void signalClosed(Throwable cause) {
         // Ensures that the subscriber will be terminated and that future
         // subscribers will be notified when the connection is closed.
         if (Log.channel()) {
@@ -157,7 +157,7 @@ final class SocketTube implements FlowTube {
                     channelDescr());
         }
         readPublisher.subscriptionImpl.signalError(
-                new IOException("connection closed locally"));
+                new IOException("connection closed locally", cause));
     }
 
     /**


### PR DESCRIPTION
The ExecutorShutdown test has been observed failing intermittently, notably if by misfortune the shutdown sequence causes a connection to get aborted while upgrading. The issue is that the `ConnectionAborter` class that allows to mark the connection as being scheduled for closing before a handle to the connection is actually available isn't forwarding the original exception for which closing the connection was requested. When the connection is eventually closed, a generic `IOException: connection closed locally` is raised at the `SocketTube` level, which unfortunately can race with the original cause. 

The fix makes it possible to relay the original cause to the place where the IOException is raised, in order to set it as the cause of the new exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309200](https://bugs.openjdk.org/browse/JDK-8309200): java/net/httpclient/ExecutorShutdown fails intermittently, if connection closed during upgrade


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) ⚠️ Review applies to [5fb0731e](https://git.openjdk.org/jdk/pull/14251/files/5fb0731ea45dcedb63319d52e9b55a7a01b6e0f2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14251/head:pull/14251` \
`$ git checkout pull/14251`

Update a local copy of the PR: \
`$ git checkout pull/14251` \
`$ git pull https://git.openjdk.org/jdk.git pull/14251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14251`

View PR using the GUI difftool: \
`$ git pr show -t 14251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14251.diff">https://git.openjdk.org/jdk/pull/14251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14251#issuecomment-1570592812)