### PR TITLE
8307887: (fs) Files.createSymbolicLink throws less specific exception when in developer mode and file already exists

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -976,15 +976,22 @@ class WindowsNativeDispatcher {
             CreateSymbolicLink0(linkBuffer.address(), targetBuffer.address(),
                                 flags);
         } catch (WindowsException x) {
+            // Retry if the privilege to create symbolic links is not held
             if (x.lastError() == ERROR_PRIVILEGE_NOT_HELD) {
                 flags |= SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
                 try {
                     CreateSymbolicLink0(linkBuffer.address(),
                                         targetBuffer.address(), flags);
                     return;
-                } catch (WindowsException ignored) {
-                    // Will fail with ERROR_INVALID_PARAMETER for Windows
-                    // builds older than 14972.
+                } catch (WindowsException y) {
+                    // Throw an exception if and only if it is not due to symbolic link creation
+                    // privilege not being held (ERROR_PRIVILEGE_NOT_HELD) nor the
+                    // SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE flag not being recognized
+                    // (ERROR_INVALID_PARAMETER). The latter will occur for Windows builds
+                    // older than 14972.
+                    int lastError = y.lastError();
+                    if (lastError != ERROR_PRIVILEGE_NOT_HELD && lastError != ERROR_INVALID_PARAMETER)
+                        throw y;
                 }
             }
             throw x;

--- a/test/jdk/java/nio/file/Files/Links.java
+++ b/test/jdk/java/nio/file/Files/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 6863864
+ * @bug 4313887 6838333 6863864 8307887
  * @summary Unit test for java.nio.file.Files createSymbolicLink,
  *     readSymbolicLink, and createLink methods
  * @library ..
@@ -48,6 +48,19 @@ public class Links {
      * Exercise createSymbolicLink and readLink methods
      */
     static void testSymLinks(Path dir) throws IOException {
+        // Check for FileAlreadyExistsException. This must be done
+        // before the check of whether symlinks are supported. 
+        Path pathLink = Files.createTempFile("link", null);
+        Path pathTarget = Files.createTempFile("target", null);
+        try {
+            Files.createSymbolicLink(pathLink, pathTarget);
+            throw new RuntimeException("Symbolic link created");
+        } catch (FileAlreadyExistsException expected) {
+        } finally {
+            Files.deleteIfExists(pathLink);
+            Files.deleteIfExists(pathTarget);
+        }
+
         final Path link = dir.resolve("link");
 
         // Check if sym links are supported


### PR DESCRIPTION
If the second attempt to create the link fails, throw the exception referring to the last error if it is anything other than due to lack of link creation privilege or failure to recognize the flag for unprivileged link creation.