### PR TITLE
8309254: Implement fast-path for ASCII-compatible CharsetEncoders on RISC-V

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -175,7 +175,7 @@
 
  void encode_iso_array_v(Register src, Register dst,
                          Register len, Register result,
-                         Register tmp);
+                         Register tmp, bool ascii);
 
  void count_positives_v(Register ary, Register len,
                         Register result, Register tmp);

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -159,7 +159,7 @@
   }
 
   // Implements a variant of EncodeISOArrayNode that encode ASCII only
-  static const bool supports_encode_ascii_array = false;
+  static const bool supports_encode_ascii_array = true;
 
   // Some architecture needs a helper to check for alltrue vector
   static constexpr bool vectortest_needs_second_argument(bool is_alltrue, bool is_predicate) {

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -2839,15 +2839,31 @@ instruct vstring_inflate(Universe dummy, iRegP_R10 src, iRegP_R11 dst, iRegI_R12
 instruct vencode_iso_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10 result,
                            vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vRegMask_V0 v0, iRegLNoSp tmp)
 %{
-  predicate(UseRVV);
+  predicate(UseRVV && !((EncodeISOArrayNode*)n)->is_ascii());
   match(Set result (EncodeISOArray src (Binary dst len)));
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
-         TEMP v1, TEMP v2, TEMP v3, TEMP tmp, TEMP v0);
+         TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
 
-  format %{ "Encode array $src,$dst,$len -> $result" %}
+  format %{ "Encode ISO array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3"%}
   ins_encode %{
     __ encode_iso_array_v($src$$Register, $dst$$Register, $len$$Register,
-                          $result$$Register, $tmp$$Register);
+                          $result$$Register, $tmp$$Register, false /* ascii */);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct vencode_ascii_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10 result,
+                             vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vRegMask_V0 v0, iRegLNoSp tmp)
+%{
+  predicate(UseRVV && ((EncodeISOArrayNode*)n)->is_ascii());
+  match(Set result (EncodeISOArray src (Binary dst len)));
+  effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
+         TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
+
+  format %{ "Encode ASCII array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3"%}
+  ins_encode %{
+    __ encode_iso_array_v($src$$Register, $dst$$Register, $len$$Register,
+                          $result$$Register, $tmp$$Register, true /* ascii */);
   %}
   ins_pipe(pipe_class_memory);
 %}
@@ -2859,7 +2875,7 @@ instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10
   predicate(UseRVV);
   match(Set result (StrCompressedCopy src (Binary dst len)));
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
-         TEMP v1, TEMP v2, TEMP v3, TEMP tmp, TEMP v0);
+         TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
 
   format %{ "String Compress $src,$dst -> $result    // KILL R11, R12, R13" %}
   ins_encode %{

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -2844,7 +2844,7 @@ instruct vencode_iso_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R1
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
          TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
 
-  format %{ "Encode ISO array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3"%}
+  format %{ "Encode ISO array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3" %}
   ins_encode %{
     __ encode_iso_array_v($src$$Register, $dst$$Register, $len$$Register,
                           $result$$Register, $tmp$$Register, false /* ascii */);
@@ -2860,7 +2860,7 @@ instruct vencode_ascii_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
          TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
 
-  format %{ "Encode ASCII array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3"%}
+  format %{ "Encode ASCII array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3" %}
   ins_encode %{
     __ encode_iso_array_v($src$$Register, $dst$$Register, $len$$Register,
                           $result$$Register, $tmp$$Register, true /* ascii */);


### PR DESCRIPTION
[JDK-8274242](https://bugs.openjdk.org/browse/JDK-8274242) propose to extend the x86 ISO-8859-1 encoding intrinsic to work 
also for ASCII-compatible encodings, which helps speeding up various 
CharsetEncoders. Implementing a similar intrinsic should be considered on 
RISC-V as well.

The instruct log with -XX:+PrintOptoAssembly output looks like:
```
06e +   Encode ISO array R12, R11, R13 -&gt; R10 # KILL R12, R11, R13, R7, V0-V3
```

## Testing:
qemu w/ UseRVV:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/hotspot/jtreg/compiler/intrinsics/string/TestEncodeIntrinsics.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309254](https://bugs.openjdk.org/browse/JDK-8309254): Implement fast-path for ASCII-compatible CharsetEncoders on RISC-V


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) ⚠️ Review applies to [00eb80b6](https://git.openjdk.org/jdk/pull/14256/files/00eb80b6950a7098287eb2a1423254cdd8878e0b)
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author) ⚠️ Review applies to [00eb80b6](https://git.openjdk.org/jdk/pull/14256/files/00eb80b6950a7098287eb2a1423254cdd8878e0b)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14256/head:pull/14256` \
`$ git checkout pull/14256`

Update a local copy of the PR: \
`$ git checkout pull/14256` \
`$ git pull https://git.openjdk.org/jdk.git pull/14256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14256`

View PR using the GUI difftool: \
`$ git pr show -t 14256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14256.diff">https://git.openjdk.org/jdk/pull/14256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14256#issuecomment-1571395555)