### PR TITLE
8281455: Change JVM options with small ranges from 64 to 32 bits, for gc_globals.hpp

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -229,7 +229,7 @@ void G1Arguments::initialize() {
 
   // By default do not let the target stack size to be more than 1/4 of the entries
   if (FLAG_IS_DEFAULT(GCDrainStackTargetSize)) {
-    FLAG_SET_ERGO(GCDrainStackTargetSize, MIN2(GCDrainStackTargetSize, (uint)TASKQUEUE_SIZE / 4));
+    FLAG_SET_ERGO(GCDrainStackTargetSize, MIN2(GCDrainStackTargetSize, TASKQUEUE_SIZE / 4));
   }
 
 #ifdef COMPILER2

--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -229,7 +229,7 @@ void G1Arguments::initialize() {
 
   // By default do not let the target stack size to be more than 1/4 of the entries
   if (FLAG_IS_DEFAULT(GCDrainStackTargetSize)) {
-    FLAG_SET_ERGO(GCDrainStackTargetSize, MIN2(GCDrainStackTargetSize, (uintx)TASKQUEUE_SIZE / 4));
+    FLAG_SET_ERGO(GCDrainStackTargetSize, MIN2(GCDrainStackTargetSize, (uint)TASKQUEUE_SIZE / 4));
   }
 
 #ifdef COMPILER2

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2308,7 +2308,7 @@ void G1CMTask::drain_local_queue(bool partially) {
   // of things to do) or totally (at the very end).
   size_t target_size;
   if (partially) {
-    target_size = MIN2((size_t)_task_queue->max_elems()/3, (size_t)GCDrainStackTargetSize);
+    target_size = MIN2((size_t)_task_queue->max_elems()/3, GCDrainStackTargetSize);
   } else {
     target_size = 0;
   }

--- a/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.cpp
+++ b/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.cpp
@@ -42,11 +42,11 @@ JVMFlag::Error ParallelGCThreadsConstraintFuncParallel(uint value, bool verbose)
   return JVMFlag::SUCCESS;
 }
 
-JVMFlag::Error InitialTenuringThresholdConstraintFuncParallel(uintx value, bool verbose) {
+JVMFlag::Error InitialTenuringThresholdConstraintFuncParallel(uint value, bool verbose) {
   // InitialTenuringThreshold is only used for ParallelGC.
   if (UseParallelGC && (value > MaxTenuringThreshold)) {
       JVMFlag::printError(verbose,
-                          "InitialTenuringThreshold (" UINTX_FORMAT ") must be "
+                          "InitialTenuringThreshold (%u) must be "
                           "less than or equal to MaxTenuringThreshold (%u)\n",
                           value, MaxTenuringThreshold);
       return JVMFlag::VIOLATES_CONSTRAINT;
@@ -54,12 +54,12 @@ JVMFlag::Error InitialTenuringThresholdConstraintFuncParallel(uintx value, bool 
   return JVMFlag::SUCCESS;
 }
 
-JVMFlag::Error MaxTenuringThresholdConstraintFuncParallel(uintx value, bool verbose) {
+JVMFlag::Error MaxTenuringThresholdConstraintFuncParallel(uint value, bool verbose) {
   // As only ParallelGC uses InitialTenuringThreshold,
   // we don't need to compare InitialTenuringThreshold with MaxTenuringThreshold.
   if (UseParallelGC && (value < InitialTenuringThreshold)) {
     JVMFlag::printError(verbose,
-                        "MaxTenuringThreshold (" UINTX_FORMAT ") must be "
+                        "MaxTenuringThreshold (%u) must be "
                         "greater than or equal to InitialTenuringThreshold (%u)\n",
                         value, InitialTenuringThreshold);
     return JVMFlag::VIOLATES_CONSTRAINT;

--- a/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.cpp
+++ b/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.cpp
@@ -47,7 +47,7 @@ JVMFlag::Error InitialTenuringThresholdConstraintFuncParallel(uintx value, bool 
   if (UseParallelGC && (value > MaxTenuringThreshold)) {
       JVMFlag::printError(verbose,
                           "InitialTenuringThreshold (" UINTX_FORMAT ") must be "
-                          "less than or equal to MaxTenuringThreshold (" UINTX_FORMAT ")\n",
+                          "less than or equal to MaxTenuringThreshold (%u)\n",
                           value, MaxTenuringThreshold);
       return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -60,7 +60,7 @@ JVMFlag::Error MaxTenuringThresholdConstraintFuncParallel(uintx value, bool verb
   if (UseParallelGC && (value < InitialTenuringThreshold)) {
     JVMFlag::printError(verbose,
                         "MaxTenuringThreshold (" UINTX_FORMAT ") must be "
-                        "greater than or equal to InitialTenuringThreshold (" UINTX_FORMAT ")\n",
+                        "greater than or equal to InitialTenuringThreshold (%u)\n",
                         value, InitialTenuringThreshold);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }

--- a/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.hpp
+++ b/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.hpp
@@ -31,8 +31,8 @@
 // Parallel Subconstraints
 #define PARALLEL_GC_CONSTRAINTS(f)                          \
   f(uint, ParallelGCThreadsConstraintFuncParallel)          \
-  f(uintx, InitialTenuringThresholdConstraintFuncParallel)  \
-  f(uintx, MaxTenuringThresholdConstraintFuncParallel)
+  f(uint, InitialTenuringThresholdConstraintFuncParallel)   \
+  f(uint, MaxTenuringThresholdConstraintFuncParallel)
 
 PARALLEL_GC_CONSTRAINTS(DECLARE_CONSTRAINT)
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -349,7 +349,7 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_eden_space_size: gc time limit"
           " gc_cost: %f "
-          " GCTimeLimit: " UINTX_FORMAT,
+          " GCTimeLimit: " UINT32_FORMAT,
           gc_cost(), GCTimeLimit);
   }
 
@@ -526,7 +526,7 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_old_gen_free_space: gc time limit"
           " gc_cost: %f "
-          " GCTimeLimit: " UINTX_FORMAT,
+          " GCTimeLimit: " UINT32_FORMAT,
           gc_cost(), GCTimeLimit);
   }
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -526,7 +526,7 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_old_gen_free_space: gc time limit"
           " gc_cost: %f "
-          " GCTimeLimit: " UINT32_FORMAT,
+          " GCTimeLimit: %u",
           gc_cost(), GCTimeLimit);
   }
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -349,7 +349,7 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_eden_space_size: gc time limit"
           " gc_cost: %f "
-          " GCTimeLimit: " UINT32_FORMAT,
+          " GCTimeLimit: %u",
           gc_cost(), GCTimeLimit);
   }
 

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -553,7 +553,7 @@ bool PSScavenge::invoke_no_policy() {
                                                            _tenuring_threshold,
                                                            survivor_limit);
 
-       log_debug(gc, age)("Desired survivor size " SIZE_FORMAT " bytes, new threshold %u (max threshold " UINTX_FORMAT ")",
+       log_debug(gc, age)("Desired survivor size " SIZE_FORMAT " bytes, new threshold %u (max threshold %u)",
                           size_policy->calculated_survivor_size_in_bytes(),
                           _tenuring_threshold, MaxTenuringThreshold);
 

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -553,7 +553,7 @@ bool PSScavenge::invoke_no_policy() {
                                                            _tenuring_threshold,
                                                            survivor_limit);
 
-       log_debug(gc, age)("Desired survivor size " SIZE_FORMAT " bytes, new threshold %u (max threshold %u)",
+       log_debug(gc, age)("Desired survivor size %zu bytes, new threshold %u (max threshold %u)",
                           size_policy->calculated_survivor_size_in_bytes(),
                           _tenuring_threshold, MaxTenuringThreshold);
 

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -99,7 +99,7 @@ uint AgeTable::compute_tenuring_threshold(size_t desired_survivor_size) {
   }
 
 
-  log_debug(gc, age)("Desired survivor size " SIZE_FORMAT " bytes, new threshold " UINTX_FORMAT " (max threshold %u)",
+  log_debug(gc, age)("Desired survivor size %zu bytes, new threshold " UINTX_FORMAT " (max threshold %u)",
                      desired_survivor_size * oopSize, (uintx) result, MaxTenuringThreshold);
 
   return result;

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -82,7 +82,7 @@ uint AgeTable::compute_tenuring_threshold(size_t desired_survivor_size) {
 
   if (AlwaysTenure || NeverTenure) {
     assert(MaxTenuringThreshold == 0 || MaxTenuringThreshold == markWord::max_age + 1,
-           "MaxTenuringThreshold should be 0 or markWord::max_age + 1, but is " UINTX_FORMAT, MaxTenuringThreshold);
+           "MaxTenuringThreshold should be 0 or markWord::max_age + 1, but is %u", MaxTenuringThreshold);
     result = MaxTenuringThreshold;
   } else {
     size_t total = 0;
@@ -99,7 +99,7 @@ uint AgeTable::compute_tenuring_threshold(size_t desired_survivor_size) {
   }
 
 
-  log_debug(gc, age)("Desired survivor size " SIZE_FORMAT " bytes, new threshold " UINTX_FORMAT " (max threshold " UINTX_FORMAT ")",
+  log_debug(gc, age)("Desired survivor size " SIZE_FORMAT " bytes, new threshold " UINTX_FORMAT " (max threshold %u)",
                      desired_survivor_size * oopSize, (uintx) result, MaxTenuringThreshold);
 
   return result;
@@ -114,7 +114,7 @@ void AgeTable::print_age_table(uint tenuring_threshold) {
 }
 
 void AgeTable::print_on(outputStream* st, uint tenuring_threshold) {
-  st->print_cr("Age table with threshold %u (max threshold " UINTX_FORMAT ")",
+  st->print_cr("Age table with threshold %u (max threshold %u)",
                tenuring_threshold, MaxTenuringThreshold);
 
   size_t total = 0;

--- a/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
@@ -95,7 +95,7 @@ void GCOverheadChecker::check_gc_overhead_limit(GCOverheadTester* time_overhead,
       reset_gc_overhead_limit_count();
     } else if (print_gc_overhead_limit_would_be_exceeded) {
       assert(_gc_overhead_limit_count > 0, "Should not be printing");
-      log_trace(gc, ergo)("GC would exceed overhead limit of %u %% %d consecutive time(s)",
+      log_trace(gc, ergo)("GC would exceed overhead limit of %u%% %d consecutive time(s)",
                           GCTimeLimit, _gc_overhead_limit_count);
     }
   }

--- a/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -91,11 +91,11 @@ void GCOverheadChecker::check_gc_overhead_limit(GCOverheadTester* time_overhead,
 
   if (UseGCOverheadLimit) {
     if (gc_overhead_limit_exceeded()) {
-      log_trace(gc, ergo)("GC is exceeding overhead limit of " UINTX_FORMAT "%%", GCTimeLimit);
+      log_trace(gc, ergo)("GC is exceeding overhead limit of %d%%", GCTimeLimit);
       reset_gc_overhead_limit_count();
     } else if (print_gc_overhead_limit_would_be_exceeded) {
       assert(_gc_overhead_limit_count > 0, "Should not be printing");
-      log_trace(gc, ergo)("GC would exceed overhead limit of " UINTX_FORMAT "%% %d consecutive time(s)",
+      log_trace(gc, ergo)("GC would exceed overhead limit of %d %% %d consecutive time(s)",
                           GCTimeLimit, _gc_overhead_limit_count);
     }
   }

--- a/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
@@ -91,11 +91,11 @@ void GCOverheadChecker::check_gc_overhead_limit(GCOverheadTester* time_overhead,
 
   if (UseGCOverheadLimit) {
     if (gc_overhead_limit_exceeded()) {
-      log_trace(gc, ergo)("GC is exceeding overhead limit of %d%%", GCTimeLimit);
+      log_trace(gc, ergo)("GC is exceeding overhead limit of %u%%", GCTimeLimit);
       reset_gc_overhead_limit_count();
     } else if (print_gc_overhead_limit_would_be_exceeded) {
       assert(_gc_overhead_limit_count > 0, "Should not be printing");
-      log_trace(gc, ergo)("GC would exceed overhead limit of %d %% %d consecutive time(s)",
+      log_trace(gc, ergo)("GC would exceed overhead limit of %u %% %d consecutive time(s)",
                           GCTimeLimit, _gc_overhead_limit_count);
     }
   }

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -166,7 +166,7 @@
           "A System.gc() request invokes a concurrent collection; "         \
           "(effective only when using concurrent collectors)")              \
                                                                             \
-  product(uint, GCLockerEdenExpansionPercent, 5,                           \
+  product(uint, GCLockerEdenExpansionPercent, 5,                            \
           "How much the GC can expand the eden by while the GC locker "     \
           "is active (as a percentage)")                                    \
           range(0, 100)                                                     \
@@ -176,16 +176,16 @@
           "blocked by the GC locker")                                       \
           range(0, max_uintx)                                               \
                                                                             \
-  product(uint, ParallelGCBufferWastePct, 10,                              \
+  product(uint, ParallelGCBufferWastePct, 10,                               \
           "Wasted fraction of parallel allocation buffer")                  \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, TargetPLABWastePct, 10,                                    \
+  product(uint, TargetPLABWastePct, 10,                                     \
           "Target wasted space in last buffer as percent of overall "       \
           "allocation")                                                     \
           range(1, 100)                                                     \
                                                                             \
-  product(uint, PLABWeight, 75,                                            \
+  product(uint, PLABWeight, 75,                                             \
           "Percentage (0-100) used to weight the current sample when "      \
           "computing exponentially decaying average for ResizePLAB")        \
           range(0, 100)                                                     \
@@ -196,7 +196,7 @@
   product(int, ParGCArrayScanChunk, 50,                                     \
           "Scan a subset of object array and push remainder, if array is "  \
           "bigger than this")                                               \
-          range(1, max_jint/3)                                              \
+          range(1, INT_MAX/3)                                               \
                                                                             \
                                                                             \
   product(bool, AlwaysPreTouch, false,                                      \
@@ -212,12 +212,12 @@
   /* where does the range max value of (max_jint - 1) come from? */         \
   product(size_t, MarkStackSizeMax, NOT_LP64(4*M) LP64_ONLY(512*M),         \
           "Maximum size of marking stack")                                  \
-          range(1, (max_jint - 1))                                          \
+          range(1, (SIZE_MAX - 1))                                          \
                                                                             \
   product(size_t, MarkStackSize, NOT_LP64(64*K) LP64_ONLY(4*M),             \
           "Size of marking stack")                                          \
           constraint(MarkStackSizeConstraintFunc,AfterErgo)                 \
-          range(1, (max_jint - 1))                                          \
+          range(1, (SIZE_MAX - 1))                                          \
                                                                             \
   product(bool, ParallelRefProcEnabled, false,                              \
           "Enable parallel reference processing whenever possible")         \
@@ -231,7 +231,7 @@
                "ParallelRefProcEnabled is true. Specify 0 to disable and "  \
                "use all threads.")                                          \
                                                                             \
-  product(uint, InitiatingHeapOccupancyPercent, 45,                        \
+  product(uint, InitiatingHeapOccupancyPercent, 45,                         \
           "The percent occupancy (IHOP) of the current old generation "     \
           "capacity above which a concurrent mark cycle will be initiated " \
           "Its value may change over time if adaptive IHOP is enabled, "    \
@@ -364,7 +364,7 @@
           "Resize the virtual spaces of the young or old generations")      \
           range(-1, 1)                                                      \
                                                                             \
-  product(uint, AdaptiveSizeThroughPutPolicy, 0,                           \
+  product(uint, AdaptiveSizeThroughPutPolicy, 0,                            \
           "Policy for changing generation size for throughput goals")       \
           range(0, 1)                                                       \
                                                                             \
@@ -392,15 +392,15 @@
                                                                             \
   product(uint, PausePadding, 1,                                            \
           "How much buffer to keep for pause time")                         \
-          range(0, max_uint)                                                \
+          range(0, UINT_MAX)                                                \
                                                                             \
   product(uint, PromotedPadding, 3,                                         \
           "How much buffer to keep for promotion failure")                  \
-          range(0, max_uint)                                                \
+          range(0, UINT_MAX)                                                \
                                                                             \
   product(uint, SurvivorPadding, 3,                                         \
           "How much buffer to keep for survivor overflow")                  \
-          range(0, max_uint)                                                \
+          range(0, UINT_MAX)                                                \
                                                                             \
   product(uint, ThresholdTolerance, 10,                                     \
           "Allowed collection cost difference between generations")         \
@@ -411,11 +411,11 @@
           "delta")                                                          \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, YoungGenerationSizeIncrement, 20,                          \
+  product(uint, YoungGenerationSizeIncrement, 20,                           \
           "Adaptive size percentage change in young generation")            \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, YoungGenerationSizeSupplement, 80,                         \
+  product(uint, YoungGenerationSizeSupplement, 80,                          \
           "Supplement to YoungedGenerationSizeIncrement used at startup")   \
           range(0, 100)                                                     \
                                                                             \
@@ -423,11 +423,11 @@
           "Decay factor to YoungedGenerationSizeSupplement")                \
           range(1, max_uintx)                                               \
                                                                             \
-  product(uint, TenuredGenerationSizeIncrement, 20,                        \
+  product(uint, TenuredGenerationSizeIncrement, 20,                         \
           "Adaptive size percentage change in tenured generation")          \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, TenuredGenerationSizeSupplement, 80,                       \
+  product(uint, TenuredGenerationSizeSupplement, 80,                        \
           "Supplement to TenuredGenerationSizeIncrement used at startup")   \
           range(0, 100)                                                     \
                                                                             \
@@ -452,7 +452,7 @@
                                                                             \
   product(uint, GCTimeRatio, 99,                                            \
           "Adaptive size policy application time to GC time ratio")         \
-          range(0, max_uint)                                                \
+          range(0, UINT_MAX)                                                \
                                                                             \
   product(uintx, AdaptiveSizeDecrementScaleFactor, 4,                       \
           "Adaptive size scale down factor for shrinking")                  \
@@ -481,12 +481,12 @@
           "Use policy to limit of proportion of time spent in GC "          \
           "before an OutOfMemory error is thrown")                          \
                                                                             \
-  product(uint, GCTimeLimit, 98,                                           \
+  product(uint, GCTimeLimit, 98,                                            \
           "Limit of the proportion of time spent in GC before "             \
           "an OutOfMemoryError is thrown (used with GCHeapFreeLimit)")      \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, GCHeapFreeLimit, 2,                                        \
+  product(uint, GCHeapFreeLimit, 2,                                         \
           "Minimum percentage of free space after a full GC before an "     \
           "OutOfMemoryError is thrown (used with GCTimeLimit)")             \
           range(0, 100)                                                     \
@@ -567,16 +567,16 @@
           "number of milliseconds")                                         \
           range(0, max_intx)                                                \
                                                                             \
-  notproduct(intx, ScavengeALotInterval,     1,                             \
+  notproduct(int, ScavengeALotInterval,     1,                              \
           "Interval between which scavenge will occur with +ScavengeALot")  \
                                                                             \
-  notproduct(intx, FullGCALotInterval,     1,                               \
+  notproduct(int, FullGCALotInterval,     1,                                \
           "Interval between which full gc will occur with +FullGCALot")     \
                                                                             \
-  notproduct(intx, FullGCALotStart,     0,                                  \
+  notproduct(int, FullGCALotStart,     0,                                   \
           "For which invocation to start FullGCAlot")                       \
                                                                             \
-  notproduct(intx, FullGCALotDummies,  32*K,                                \
+  notproduct(int, FullGCALotDummies,  32*K,                                 \
           "Dummy object allocated with +FullGCALot, forcing all objects "   \
           "to move")                                                        \
                                                                             \
@@ -642,16 +642,16 @@
           "GC invoke count where +VerifyBefore/AfterGC kicks in")           \
           range(0, max_uintx)                                               \
                                                                             \
-  product(intx, VerifyGCLevel,     0, DIAGNOSTIC,                           \
+  product(int, VerifyGCLevel,     0, DIAGNOSTIC,                            \
           "Generation level at which to start +VerifyBefore/AfterGC")       \
           range(0, 1)                                                       \
                                                                             \
-  product(uintx, MaxTenuringThreshold,    15,                               \
+  product(uint, MaxTenuringThreshold,    15,                                \
           "Maximum value for tenuring threshold")                           \
           range(0, markWord::max_age + 1)                                   \
           constraint(MaxTenuringThresholdConstraintFunc,AfterErgo)          \
                                                                             \
-  product(uintx, InitialTenuringThreshold,    7,                            \
+  product(uint, InitialTenuringThreshold,    7,                             \
           "Initial value for tenuring threshold")                           \
           range(0, markWord::max_age + 1)                                   \
           constraint(InitialTenuringThresholdConstraintFunc,AfterErgo)      \
@@ -677,15 +677,15 @@
   product(uint, MarkSweepAlwaysCompactCount,     4,                         \
           "How often should we fully compact the heap (ignoring the dead "  \
           "space parameters)")                                              \
-          range(1, max_uint)                                                \
+          range(1, UINT_MAX)                                                \
                                                                             \
   develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
           "Delay between expansion and allocation (in milliseconds)")       \
                                                                             \
-  product(uintx, GCDrainStackTargetSize, 64,                                \
+  product(uint, GCDrainStackTargetSize, 64,                                 \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, max_uint)                                                \
+          range(0, UINT_MAX)                                                \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -212,12 +212,12 @@
   /* where does the range max value of (max_jint - 1) come from? */         \
   product(size_t, MarkStackSizeMax, NOT_LP64(4*M) LP64_ONLY(512*M),         \
           "Maximum size of marking stack")                                  \
-          range(1, (SIZE_MAX - 1))                                          \
+          range(1, (INT_MAX - 1))                                          \
                                                                             \
   product(size_t, MarkStackSize, NOT_LP64(64*K) LP64_ONLY(4*M),             \
           "Size of marking stack")                                          \
           constraint(MarkStackSizeConstraintFunc,AfterErgo)                 \
-          range(1, (SIZE_MAX - 1))                                          \
+          range(1, (INT_MAX - 1))                                          \
                                                                             \
   product(bool, ParallelRefProcEnabled, false,                              \
           "Enable parallel reference processing whenever possible")         \
@@ -682,10 +682,10 @@
   develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
           "Delay between expansion and allocation (in milliseconds)")       \
                                                                             \
-  product(size_t, GCDrainStackTargetSize, 64,                               \
+  product(uintx, GCDrainStackTargetSize, 64,                                \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, SIZE_MAX)                                                \
+          range(0, max_juint)                                               \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -166,7 +166,7 @@
           "A System.gc() request invokes a concurrent collection; "         \
           "(effective only when using concurrent collectors)")              \
                                                                             \
-  product(uintx, GCLockerEdenExpansionPercent, 5,                           \
+  product(uint, GCLockerEdenExpansionPercent, 5,                           \
           "How much the GC can expand the eden by while the GC locker "     \
           "is active (as a percentage)")                                    \
           range(0, 100)                                                     \
@@ -176,16 +176,16 @@
           "blocked by the GC locker")                                       \
           range(0, max_uintx)                                               \
                                                                             \
-  product(uintx, ParallelGCBufferWastePct, 10,                              \
+  product(uint, ParallelGCBufferWastePct, 10,                              \
           "Wasted fraction of parallel allocation buffer")                  \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, TargetPLABWastePct, 10,                                    \
+  product(uint, TargetPLABWastePct, 10,                                    \
           "Target wasted space in last buffer as percent of overall "       \
           "allocation")                                                     \
           range(1, 100)                                                     \
                                                                             \
-  product(uintx, PLABWeight, 75,                                            \
+  product(uint, PLABWeight, 75,                                            \
           "Percentage (0-100) used to weight the current sample when "      \
           "computing exponentially decaying average for ResizePLAB")        \
           range(0, 100)                                                     \
@@ -231,7 +231,7 @@
                "ParallelRefProcEnabled is true. Specify 0 to disable and "  \
                "use all threads.")                                          \
                                                                             \
-  product(uintx, InitiatingHeapOccupancyPercent, 45,                        \
+  product(uint, InitiatingHeapOccupancyPercent, 45,                        \
           "The percent occupancy (IHOP) of the current old generation "     \
           "capacity above which a concurrent mark cycle will be initiated " \
           "Its value may change over time if adaptive IHOP is enabled, "    \
@@ -364,7 +364,7 @@
           "Resize the virtual spaces of the young or old generations")      \
           range(-1, 1)                                                      \
                                                                             \
-  product(uintx, AdaptiveSizeThroughPutPolicy, 0,                           \
+  product(uint, AdaptiveSizeThroughPutPolicy, 0,                           \
           "Policy for changing generation size for throughput goals")       \
           range(0, 1)                                                       \
                                                                             \
@@ -382,11 +382,11 @@
   product(bool, UseAdaptiveSizePolicyFootprintGoal, true,                   \
           "Use adaptive minimum footprint as a goal")                       \
                                                                             \
-  product(uintx, AdaptiveSizePolicyWeight, 10,                              \
+  product(uint, AdaptiveSizePolicyWeight, 10,                              \
           "Weight given to exponential resizing, between 0 and 100")        \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, AdaptiveTimeWeight,       25,                              \
+  product(uint, AdaptiveTimeWeight,       25,                              \
           "Weight given to time in adaptive policy, between 0 and 100")     \
           range(0, 100)                                                     \
                                                                             \
@@ -402,20 +402,20 @@
           "How much buffer to keep for survivor overflow")                  \
           range(0, max_juint)                                               \
                                                                             \
-  product(uintx, ThresholdTolerance, 10,                                    \
+  product(uint, ThresholdTolerance, 10,                                    \
           "Allowed collection cost difference between generations")         \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, AdaptiveSizePolicyCollectionCostMargin, 50,                \
+  product(uint, AdaptiveSizePolicyCollectionCostMargin, 50,                \
           "If collection costs are within margin, reduce both by full "     \
           "delta")                                                          \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, YoungGenerationSizeIncrement, 20,                          \
+  product(uint, YoungGenerationSizeIncrement, 20,                          \
           "Adaptive size percentage change in young generation")            \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, YoungGenerationSizeSupplement, 80,                         \
+  product(uint, YoungGenerationSizeSupplement, 80,                         \
           "Supplement to YoungedGenerationSizeIncrement used at startup")   \
           range(0, 100)                                                     \
                                                                             \
@@ -423,11 +423,11 @@
           "Decay factor to YoungedGenerationSizeSupplement")                \
           range(1, max_uintx)                                               \
                                                                             \
-  product(uintx, TenuredGenerationSizeIncrement, 20,                        \
+  product(uint, TenuredGenerationSizeIncrement, 20,                        \
           "Adaptive size percentage change in tenured generation")          \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, TenuredGenerationSizeSupplement, 80,                       \
+  product(uint, TenuredGenerationSizeSupplement, 80,                       \
           "Supplement to TenuredGenerationSizeIncrement used at startup")   \
           range(0, 100)                                                     \
                                                                             \
@@ -481,12 +481,12 @@
           "Use policy to limit of proportion of time spent in GC "          \
           "before an OutOfMemory error is thrown")                          \
                                                                             \
-  product(uintx, GCTimeLimit, 98,                                           \
+  product(uint, GCTimeLimit, 98,                                           \
           "Limit of the proportion of time spent in GC before "             \
           "an OutOfMemoryError is thrown (used with GCHeapFreeLimit)")      \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, GCHeapFreeLimit, 2,                                        \
+  product(uint, GCHeapFreeLimit, 2,                                        \
           "Minimum percentage of free space after a full GC before an "     \
           "OutOfMemoryError is thrown (used with GCTimeLimit)")             \
           range(0, 100)                                                     \
@@ -656,11 +656,11 @@
           range(0, markWord::max_age + 1)                                   \
           constraint(InitialTenuringThresholdConstraintFunc,AfterErgo)      \
                                                                             \
-  product(uintx, TargetSurvivorRatio,    50,                                \
+  product(uint, TargetSurvivorRatio,    50,                                \
           "Desired percentage of survivor space used after scavenge")       \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, MarkSweepDeadRatio,     5,                                 \
+  product(uint, MarkSweepDeadRatio,     5,                                 \
           "Percentage (0-100) of the old gen allowed as dead wood. "        \
           "Serial mark sweep treats this as both the minimum and maximum "  \
           "value. "                                                         \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -382,31 +382,31 @@
   product(bool, UseAdaptiveSizePolicyFootprintGoal, true,                   \
           "Use adaptive minimum footprint as a goal")                       \
                                                                             \
-  product(uint, AdaptiveSizePolicyWeight, 10,                              \
+  product(uint, AdaptiveSizePolicyWeight, 10,                               \
           "Weight given to exponential resizing, between 0 and 100")        \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, AdaptiveTimeWeight,       25,                              \
+  product(uint, AdaptiveTimeWeight,       25,                               \
           "Weight given to time in adaptive policy, between 0 and 100")     \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, PausePadding, 1,                                           \
+  product(uint, PausePadding, 1,                                            \
           "How much buffer to keep for pause time")                         \
-          range(0, max_juint)                                               \
+          range(0, max_uint)                                                \
                                                                             \
-  product(uintx, PromotedPadding, 3,                                        \
+  product(uint, PromotedPadding, 3,                                         \
           "How much buffer to keep for promotion failure")                  \
-          range(0, max_juint)                                               \
+          range(0, max_uint)                                                \
                                                                             \
-  product(uintx, SurvivorPadding, 3,                                        \
+  product(uint, SurvivorPadding, 3,                                         \
           "How much buffer to keep for survivor overflow")                  \
-          range(0, max_juint)                                               \
+          range(0, max_uint)                                                \
                                                                             \
-  product(uint, ThresholdTolerance, 10,                                    \
+  product(uint, ThresholdTolerance, 10,                                     \
           "Allowed collection cost difference between generations")         \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, AdaptiveSizePolicyCollectionCostMargin, 50,                \
+  product(uint, AdaptiveSizePolicyCollectionCostMargin, 50,                 \
           "If collection costs are within margin, reduce both by full "     \
           "delta")                                                          \
           range(0, 100)                                                     \
@@ -450,9 +450,9 @@
           "in millisecond")                                                 \
           range(0, max_uintx)                                               \
                                                                             \
-  product(uintx, GCTimeRatio, 99,                                           \
+  product(uint, GCTimeRatio, 99,                                            \
           "Adaptive size policy application time to GC time ratio")         \
-          range(0, max_juint)                                               \
+          range(0, max_uint)                                                \
                                                                             \
   product(uintx, AdaptiveSizeDecrementScaleFactor, 4,                       \
           "Adaptive size scale down factor for shrinking")                  \
@@ -656,11 +656,11 @@
           range(0, markWord::max_age + 1)                                   \
           constraint(InitialTenuringThresholdConstraintFunc,AfterErgo)      \
                                                                             \
-  product(uint, TargetSurvivorRatio,    50,                                \
+  product(uint, TargetSurvivorRatio,    50,                                 \
           "Desired percentage of survivor space used after scavenge")       \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, MarkSweepDeadRatio,     5,                                 \
+  product(uint, MarkSweepDeadRatio,     5,                                  \
           "Percentage (0-100) of the old gen allowed as dead wood. "        \
           "Serial mark sweep treats this as both the minimum and maximum "  \
           "value. "                                                         \
@@ -677,7 +677,7 @@
   product(uint, MarkSweepAlwaysCompactCount,     4,                         \
           "How often should we fully compact the heap (ignoring the dead "  \
           "space parameters)")                                              \
-          range(1, max_juint)                                               \
+          range(1, max_uint)                                                \
                                                                             \
   develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
           "Delay between expansion and allocation (in milliseconds)")       \
@@ -685,7 +685,7 @@
   product(uintx, GCDrainStackTargetSize, 64,                                \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, max_juint)                                               \
+          range(0, max_uint)                                                \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -682,10 +682,10 @@
   develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
           "Delay between expansion and allocation (in milliseconds)")       \
                                                                             \
-  product(uint, GCDrainStackTargetSize, 64,                                 \
+  product(size_t, GCDrainStackTargetSize, 64,                               \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, UINT_MAX)                                                \
+          range(0, SIZE_MAX)                                                \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -429,7 +429,6 @@ typedef uintptr_t uintx;
 
 const intx  min_intx  = (intx)1 << (sizeof(intx)*BitsPerByte-1);
 const intx  max_intx  = (uintx)min_intx - 1;
-const uint  max_uint  = (uint)-1;
 const uintx max_uintx = (uintx)-1;
 
 
@@ -440,6 +439,7 @@ const uintx max_uintx = (uintx)-1;
 // max_uintx            0xFFFFFFFF      0xFFFFFFFFFFFFFFFF
 
 typedef unsigned int uint;   NEEDS_CLEANUP
+const uint  max_uint  = (uint)-1;
 
 
 //----------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -431,7 +431,6 @@ const intx  min_intx  = (intx)1 << (sizeof(intx)*BitsPerByte-1);
 const intx  max_intx  = (uintx)min_intx - 1;
 const uintx max_uintx = (uintx)-1;
 
-
 // Table of values:
 //      sizeof intx         4               8
 // min_intx             0x80000000      0x8000000000000000
@@ -1076,7 +1075,7 @@ const int      badCodeHeapFreeVal = 0xDD;                   // value used to zap
 #define       badHeapWord       (::badHeapWordVal)
 
 // Default TaskQueue size is 16K (32-bit) or 128K (64-bit)
-#define TASKQUEUE_SIZE (NOT_LP64(1<<14) LP64_ONLY(1<<17))
+const size_t TASKQUEUE_SIZE = (NOT_LP64(1<<14) LP64_ONLY(1<<17));
 
 //----------------------------------------------------------------------------------------------------
 // Utility functions for bitfield manipulations

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -429,7 +429,9 @@ typedef uintptr_t uintx;
 
 const intx  min_intx  = (intx)1 << (sizeof(intx)*BitsPerByte-1);
 const intx  max_intx  = (uintx)min_intx - 1;
+const uint  max_uint  = (uint)-1;
 const uintx max_uintx = (uintx)-1;
+
 
 // Table of values:
 //      sizeof intx         4               8

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -439,8 +439,6 @@ const uintx max_uintx = (uintx)-1;
 // max_uintx            0xFFFFFFFF      0xFFFFFFFFFFFFFFFF
 
 typedef unsigned int uint;   NEEDS_CLEANUP
-const uint  max_uint  = (uint)-1;
-
 
 //----------------------------------------------------------------------------------------------------
 // Java type definitions


### PR DESCRIPTION
The `uintx/intx` options whose ranges are small enough are changed to `uint/int`, otherwise gcc complains 
when `-Wconversion` is used in build.
Their uses in printf formats are changed accordingly.

### Tests
Locally hotspot:tier1 tested on linux-x64
mach5 tiers 1-4 on Linux and Windows 64bits platforms passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281455](https://bugs.openjdk.org/browse/JDK-8281455): Change JVM options with small ranges from 64 to 32 bits, for gc_globals.hpp (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14259/head:pull/14259` \
`$ git checkout pull/14259`

Update a local copy of the PR: \
`$ git checkout pull/14259` \
`$ git pull https://git.openjdk.org/jdk.git pull/14259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14259`

View PR using the GUI difftool: \
`$ git pr show -t 14259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14259.diff">https://git.openjdk.org/jdk/pull/14259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14259#issuecomment-1580237728)