### PR TITLE
8309286: G1: Remove unused G1HeapRegionAttr::is_valid_gen

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
@@ -101,7 +101,6 @@ public:
 #ifdef ASSERT
   bool is_default() const              { return type() == NotInCSet; }
   bool is_valid() const                { return (type() >= Optional && type() < Num); }
-  bool is_valid_gen() const            { return (type() >= Young && type() <= Old); }
 #endif
 };
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309286](https://bugs.openjdk.org/browse/JDK-8309286): G1: Remove unused G1HeapRegionAttr::is_valid_gen


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14260/head:pull/14260` \
`$ git checkout pull/14260`

Update a local copy of the PR: \
`$ git checkout pull/14260` \
`$ git pull https://git.openjdk.org/jdk.git pull/14260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14260`

View PR using the GUI difftool: \
`$ git pr show -t 14260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14260.diff">https://git.openjdk.org/jdk/pull/14260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14260#issuecomment-1571909952)