### PR TITLE
8309287: Add fontconfig requirement to building.md for Debian

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -685,6 +685,8 @@ does not automatically locate the platform FreeType files.</p>
 Fontconfig</a> is required on all platforms except Windows and
 macOS.</p>
 <ul>
+<li>To install on an apt-based Linux, try running
+<code>sudo apt-get install     libfontconfig-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running
 <code>sudo yum install     fontconfig-devel</code>.</li>
 </ul>

--- a/doc/building.md
+++ b/doc/building.md
@@ -480,6 +480,8 @@ if `configure` does not automatically locate the platform FreeType files.
 Fontconfig from [freedesktop.org Fontconfig](http://fontconfig.org) is required
 on all platforms except Windows and macOS.
 
+  * To install on an apt-based Linux, try running `sudo apt-get install
+    libfontconfig-dev`.
   * To install on an rpm-based Linux, try running `sudo yum install
     fontconfig-devel`.
 


### PR DESCRIPTION
After following all the commands in `building.md` I still get on Debian 12 x86_64:

```
checking for fontconfig/fontconfig.h... no
configure: error: Could not find fontconfig! 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309287](https://bugs.openjdk.org/browse/JDK-8309287): Add fontconfig requirement to building.md for Debian


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14261/head:pull/14261` \
`$ git checkout pull/14261`

Update a local copy of the PR: \
`$ git checkout pull/14261` \
`$ git pull https://git.openjdk.org/jdk.git pull/14261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14261`

View PR using the GUI difftool: \
`$ git pr show -t 14261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14261.diff">https://git.openjdk.org/jdk/pull/14261.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14261#issuecomment-1571996373)