### PR TITLE
8309306: G1: Move is_obj_dead from HeapRegion to G1CollectedHeap

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -224,7 +224,7 @@ public:
       }
 
       o->oop_iterate(&isLive);
-      if (_hr->obj_in_unparsable_area(o, _hr->parsable_bottom())) {
+      if (!_hr->is_in_parsable_area(o)) {
         size_t obj_size = o->size();
         _live_bytes += (obj_size * HeapWordSize);
       }

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -182,10 +182,6 @@ public:
   // All allocated blocks are occupied by objects in a HeapRegion.
   bool block_is_obj(const HeapWord* p, HeapWord* pb) const;
 
-  // Returns whether the given object is dead based on the given parsable_bottom (pb).
-  // For an object to be considered dead it must be below pb and scrubbed.
-  bool is_obj_dead(oop obj, HeapWord* pb) const;
-
   // Returns the object size for all valid block starts. If parsable_bottom (pb)
   // is given, calculates the block size based on that parsable_bottom, not the
   // current value of this HeapRegion.
@@ -524,9 +520,9 @@ public:
 
   void record_surv_words_in_group(size_t words_survived);
 
-  // Determine if an object is in the parsable or the to-be-scrubbed area.
-  inline static bool obj_in_parsable_area(const HeapWord* addr, HeapWord* pb);
-  inline static bool obj_in_unparsable_area(oop obj, HeapWord* pb);
+  // Determine if an address is in the parsable or the to-be-scrubbed area.
+  inline        bool is_in_parsable_area(const void* const addr) const;
+  inline static bool is_in_parsable_area(const void* const addr, const void* const pb);
 
   bool obj_allocated_since_marking_start(oop obj) const {
     return cast_from_oop<HeapWord*>(obj) >= top_at_mark_start();


### PR DESCRIPTION
Simple refactoring around `HeapRegion::is_obj_dead`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309306](https://bugs.openjdk.org/browse/JDK-8309306): G1: Move is_obj_dead from HeapRegion to G1CollectedHeap (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14265/head:pull/14265` \
`$ git checkout pull/14265`

Update a local copy of the PR: \
`$ git checkout pull/14265` \
`$ git pull https://git.openjdk.org/jdk.git pull/14265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14265`

View PR using the GUI difftool: \
`$ git pr show -t 14265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14265.diff">https://git.openjdk.org/jdk/pull/14265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14265#issuecomment-1572245027)