### PR TITLE
8309268: C2: "assert(in_bb(n)) failed: must be" after JDK-8306302

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3707,8 +3707,12 @@ void SuperWord::compute_vector_element_type() {
       assert(nn->is_Cmp(), "always have Cmp above Bool");
     }
     if (nn->is_Cmp() && nn->in(0) == nullptr) {
-      nn = nn->in(1);
-      set_velt_type(n, velt_type(nn));
+      // One of the inputs must be in_bb, pick that velt_type
+      if (in_bb(nn->in(1))) {
+        set_velt_type(n, velt_type(nn->in(1)));
+      } else {
+        set_velt_type(n, velt_type(nn->in(2)));
+      }
     }
   }
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3707,7 +3707,7 @@ void SuperWord::compute_vector_element_type() {
       assert(nn->is_Cmp(), "always have Cmp above Bool");
     }
     if (nn->is_Cmp() && nn->in(0) == nullptr) {
-      // One of the inputs must be in_bb, pick that velt_type
+      assert(in_bb(nn->in(1)) || in_bb(nn->in(2)), "one of the inputs must be in the loop too");
       if (in_bb(nn->in(1))) {
         set_velt_type(n, velt_type(nn->in(1)));
       } else {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -871,8 +872,7 @@ public class TestVectorConditionalMove {
             Asserts.assertEquals(rD[i], cmoveDGTforD(aD[i], bD[i], cD[i], dD[i]));
         }
 
-
-        // Use some constaints in the comparison
+        // Use some constants/invariants in the comparison
         testCMoveFGTforFCmpCon1(aF[0], bF, cF, dF, rF, rF);
         for (int i = 0; i < SIZE; i++) {
             Asserts.assertEquals(rF[i], cmoveFGTforF(aF[0], bF[i], cF[i], dF[i]));

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -590,6 +590,32 @@ public class TestVectorConditionalMove {
         }
     }
 
+    // Use some constants in the comparison
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+    private static void testCMoveFGTforFCmpCon1(float a, float[] b, float[] c, float[] d, float[] r, float[] r2) {
+        for (int i = 0; i < b.length; i++) {
+            float cc = c[i];
+            float dd = d[i];
+            r2[i] = cc + dd;
+            r[i] = (a > b[i]) ? cc : dd;
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+    private static void testCMoveFGTforFCmpCon2(float[] a, float b, float[] c, float[] d, float[] r, float[] r2) {
+        for (int i = 0; i < a.length; i++) {
+            float cc = c[i];
+            float dd = d[i];
+            r2[i] = cc + dd;
+            r[i] = (a[i] > b) ? cc : dd;
+        }
+    }
+
+    // A case that is currently not supported and is not expected to vectorize
     @Test
     @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
     private static void testCMoveVDUnsupported() {
@@ -723,7 +749,9 @@ public class TestVectorConditionalMove {
                  "testCMoveDGTforI",
                  "testCMoveDGTforL",
                  "testCMoveDGTforF",
-                 "testCMoveDGTforD"})
+                 "testCMoveDGTforD",
+                 "testCMoveFGTforFCmpCon1",
+                 "testCMoveFGTforFCmpCon2"})
     private void testCMove_runner_two() {
         int[] aI = new int[SIZE];
         int[] bI = new int[SIZE];
@@ -841,6 +869,18 @@ public class TestVectorConditionalMove {
         testCMoveDGTforD(aD, bD, cD, dD, rD, rD);
         for (int i = 0; i < SIZE; i++) {
             Asserts.assertEquals(rD[i], cmoveDGTforD(aD[i], bD[i], cD[i], dD[i]));
+        }
+
+
+        // Use some constaints in the comparison
+        testCMoveFGTforFCmpCon1(aF[0], bF, cF, dF, rF, rF);
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(rF[i], cmoveFGTforF(aF[0], bF[i], cF[i], dF[i]));
+        }
+
+        testCMoveFGTforFCmpCon2(aF, bF[0], cF, dF, rF, rF);
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(rF[i], cmoveFGTforF(aF[i], bF[0], cF[i], dF[i]));
         }
     }
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestCmpInvar.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestCmpInvar.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8309268
+ * @summary Test loop invariant input to Cmp.
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestCmpInvar::test*
+ *      compiler.loopopts.superword.TestCmpInvar
+ */
+package compiler.loopopts.superword;
+
+public class TestCmpInvar {
+    static int N = 400;
+    static long myInvar;
+
+    static void test1(int limit, float fcon) {
+        boolean a[] = new boolean[1000];
+        for (int i = 0; i < limit; i++) {
+            a[i] = fcon > i;
+        }
+    }
+
+    static void test2(int limit, float fcon) {
+        boolean a[] = new boolean[1000];
+        for (int i = 0; i < limit; i++) {
+            a[i] = i > fcon;
+        }
+    }
+
+    static int test3() {
+        int[] a = new int[N];
+        int acc = 0;
+        for (int i = 1; i < 63; i++) {
+            acc += Math.min(myInvar, a[i]--);
+        }
+        return acc;
+    }
+
+    static int test4() {
+        int[] a = new int[N];
+        int acc = 0;
+        for (int i = 1; i < 63; i++) {
+            acc += Math.min(a[i]--, myInvar);
+        }
+        return acc;
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10_100; i++) {
+            test1(500, 80.1f);
+        }
+
+        for (int i = 0; i < 10_100; i++) {
+            test2(500, 80.1f);
+        }
+
+        for (int i = 0; i < 10_000; i++) {
+            test3();
+        }
+
+        for (int i = 0; i < 10_000; i++) {
+            test4();
+        }
+    }
+}


### PR DESCRIPTION
This is the fix to a regression caused in the CMoveV fix JDK-8306302.

I had implicitly assumed that all `Cmp` in the loop also have their `in(1)` inside the loop (`in_bb`). This is not always true, and hence we hit the assert.

**Solution**

However, we know that at least one of the two inputs of a `Cmp` must also be in the loop, else the `Cmp` would float outside the loop. So if `in(1)` is not in the loop then we can just pick `in(2)` for the `velt_type`.

**Testing**
I added 2 regression tests that were provided in the bug, and also extended `TestVectorConditionalMove.java` (though it is currently problemlisted because of an IR framework bug). This extension also triggered the assert, and now properly vectorizes.

I tested up to tier6 and stress testing. I ran the tests both with `TestVectorConditionalMove` problemlisted and without the problemlisting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309268](https://bugs.openjdk.org/browse/JDK-8309268): C2: "assert(in_bb(n)) failed: must be" after JDK-8306302


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14268/head:pull/14268` \
`$ git checkout pull/14268`

Update a local copy of the PR: \
`$ git checkout pull/14268` \
`$ git pull https://git.openjdk.org/jdk.git pull/14268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14268`

View PR using the GUI difftool: \
`$ git pr show -t 14268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14268.diff">https://git.openjdk.org/jdk/pull/14268.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14268#issuecomment-1573253153)