### PR TITLE
8308891: TestCDSVMCrash.java needs @requires vm.cds

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -24,6 +24,7 @@
 /*
  * @test TestCDSVMCrash
  * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
+ * @requires vm.cds
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestCDSVMCrash


### PR DESCRIPTION
The recently added CDS test, TestCDSVMCrash.java, was missing the `@requires vm.cds` tag. This patch adds the tag as originally intended. Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308891](https://bugs.openjdk.org/browse/JDK-8308891): TestCDSVMCrash.java needs @requires vm.cds


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14270/head:pull/14270` \
`$ git checkout pull/14270`

Update a local copy of the PR: \
`$ git checkout pull/14270` \
`$ git pull https://git.openjdk.org/jdk.git pull/14270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14270`

View PR using the GUI difftool: \
`$ git pr show -t 14270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14270.diff">https://git.openjdk.org/jdk/pull/14270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14270#issuecomment-1572577975)