### PR TITLE
8309295: C2: MaxNode::signed_min() returns nullptr for int operands

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -1044,13 +1044,14 @@ Node* MaxNode::build_min_max(Node* a, Node* b, bool is_max, bool is_unsigned, co
   }
   Node* res = nullptr;
   if (is_int && !is_unsigned) {
+    Node* res_new = nullptr;
     if (is_max) {
-      res =  gvn.transform(new MaxINode(a, b));
-      assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
+      res_new = new MaxINode(a, b);
     } else {
-      Node* res =  gvn.transform(new MinINode(a, b));
-      assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
+      res_new = new MinINode(a, b);
     }
+    res = gvn.transform(res_new);
+    assert(gvn.type(res)->is_int()->_lo >= t->is_int()->_lo && gvn.type(res)->is_int()->_hi <= t->is_int()->_hi, "type doesn't match");
   } else {
     Node* cmp = nullptr;
     if (is_max) {


### PR DESCRIPTION
This *trivial* changeset ensures that `MaxNode::signed_min()` returns a new `MinI` node, instead of `nullptr`, when receiving int arguments. This path is currently dead in the VM, but fixing it makes the functionality reusable (for example by JDK-8302673, currently [under review](https://github.com/openjdk/jdk/pull/13924)), more readable, and less error-prone.

#### Testing

- tier1-3 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309295](https://bugs.openjdk.org/browse/JDK-8309295): C2: MaxNode::signed_min() returns nullptr for int operands


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14272/head:pull/14272` \
`$ git checkout pull/14272`

Update a local copy of the PR: \
`$ git checkout pull/14272` \
`$ git pull https://git.openjdk.org/jdk.git pull/14272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14272`

View PR using the GUI difftool: \
`$ git pr show -t 14272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14272.diff">https://git.openjdk.org/jdk/pull/14272.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14272#issuecomment-1573113357)