### PR TITLE
JDK-8272147

### DIFF
--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -44,10 +44,10 @@ uint                    MarkSweep::_total_invocations = 0;
 Stack<oop, mtGC>              MarkSweep::_marking_stack;
 Stack<ObjArrayTask, mtGC>     MarkSweep::_objarray_stack;
 
-Stack<PreservedMark, mtGC>    MarkSweep::_preserved_overflow_stack;
+PreservedMarksSet       MarkSweep::_preserved_overflow_stack_set(false /* in_c_heap */);
 size_t                  MarkSweep::_preserved_count = 0;
 size_t                  MarkSweep::_preserved_count_max = 0;
-PreservedMark*          MarkSweep::_preserved_marks = nullptr;
+OopAndMarkWord*         MarkSweep::_preserved_marks = nullptr;
 STWGCTimer*             MarkSweep::_gc_timer        = nullptr;
 SerialOldTracer*        MarkSweep::_gc_tracer       = nullptr;
 
@@ -142,14 +142,6 @@ template <class T> void MarkSweep::follow_root(T* p) {
 void MarkSweep::FollowRootClosure::do_oop(oop* p)       { follow_root(p); }
 void MarkSweep::FollowRootClosure::do_oop(narrowOop* p) { follow_root(p); }
 
-void PreservedMark::adjust_pointer() {
-  MarkSweep::adjust_pointer(&_obj);
-}
-
-void PreservedMark::restore() {
-  _obj->set_mark(_mark);
-}
-
 // We preserve the mark which should be replaced at the end and the location
 // that it will go.  Note that the object that this markWord belongs to isn't
 // currently at that address but it will be after phase4
@@ -159,9 +151,9 @@ void MarkSweep::preserve_mark(oop obj, markWord mark) {
   // sufficient space for the marks we need to preserve but if it isn't we fall
   // back to using Stacks to keep track of the overflow.
   if (_preserved_count < _preserved_count_max) {
-    _preserved_marks[_preserved_count++] = PreservedMark(obj, mark);
+    _preserved_marks[_preserved_count++] = OopAndMarkWord(obj, mark);
   } else {
-    _preserved_overflow_stack.push(PreservedMark(obj, mark));
+    _preserved_overflow_stack_set.get()->push_if_necessary(obj, mark);
   }
 }
 
@@ -205,30 +197,27 @@ AdjustPointerClosure MarkSweep::adjust_pointer_closure;
 void MarkSweep::adjust_marks() {
   // adjust the oops we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {
-    _preserved_marks[i].adjust_pointer();
+    MarkSweep::adjust_pointer(_preserved_marks[i].get_oop_pointer());
   }
 
   // deal with the overflow stack
-  StackIterator<PreservedMark, mtGC> iter(_preserved_overflow_stack);
+  StackIterator<OopAndMarkWord, mtGC> iter(_preserved_overflow_stack_set.get()->get_stack());
   while (!iter.is_empty()) {
-    PreservedMark* p = iter.next_addr();
-    p->adjust_pointer();
+    OopAndMarkWord* p = iter.next_addr();
+    MarkSweep::adjust_pointer(p->get_oop_pointer());
   }
 }
 
 void MarkSweep::restore_marks() {
-  log_trace(gc)("Restoring " SIZE_FORMAT " marks", _preserved_count + _preserved_overflow_stack.size());
+  log_trace(gc)("Restoring " SIZE_FORMAT " marks", _preserved_count + _preserved_overflow_stack_set.get()->size());
 
   // restore the marks we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {
-    _preserved_marks[i].restore();
+    _preserved_marks[i].set_mark();
   }
 
   // deal with the overflow
-  while (!_preserved_overflow_stack.is_empty()) {
-    PreservedMark p = _preserved_overflow_stack.pop();
-    p.restore();
-  }
+  _preserved_overflow_stack_set.restore(nullptr);
 }
 
 MarkSweep::IsAliveClosure   MarkSweep::is_alive;

--- a/src/hotspot/share/gc/serial/markSweep.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SERIAL_MARKSWEEP_HPP
 
 #include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/preservedMarks.inline.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/taskqueue.hpp"
@@ -99,10 +100,10 @@ class MarkSweep : AllStatic {
   static Stack<ObjArrayTask, mtGC>             _objarray_stack;
 
   // Space for storing/restoring mark word
-  static Stack<PreservedMark, mtGC>      _preserved_overflow_stack;
+  static PreservedMarksSet               _preserved_overflow_stack_set;
   static size_t                          _preserved_count;
   static size_t                          _preserved_count_max;
-  static PreservedMark*                  _preserved_marks;
+  static OopAndMarkWord*                 _preserved_marks;
 
   static AlwaysTrueClosure               _always_true_closure;
   static ReferenceProcessor*             _ref_processor;
@@ -184,17 +185,6 @@ class AdjustPointerClosure: public BasicOopIterateClosure {
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
   virtual ReferenceIterationMode reference_iteration_mode() { return DO_FIELDS; }
-};
-
-class PreservedMark {
-private:
-  oop _obj;
-  markWord _mark;
-
-public:
-  PreservedMark(oop obj, markWord mark) : _obj(obj), _mark(mark) {}
-  void adjust_pointer();
-  void restore();
 };
 
 #endif // SHARE_GC_SERIAL_MARKSWEEP_HPP

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -34,20 +34,22 @@ class WorkerTask;
 class PreservedMarksSet;
 class WorkerThreads;
 
+class OopAndMarkWord {
+ private:
+  oop _o;
+  markWord _m;
+
+ public:
+  OopAndMarkWord(oop obj, markWord m) : _o(obj), _m(m) { }
+
+  oop get_oop() { return _o; }
+  oop* get_oop_pointer() {return &_o; }
+  inline void set_mark() const;
+  void set_oop(oop obj) { _o = obj; }
+};
+
 class PreservedMarks {
 private:
-  class OopAndMarkWord {
-  private:
-    oop _o;
-    markWord _m;
-
-  public:
-    OopAndMarkWord(oop obj, markWord m) : _o(obj), _m(m) { }
-
-    oop get_oop() { return _o; }
-    inline void set_mark() const;
-    void set_oop(oop obj) { _o = obj; }
-  };
   typedef Stack<OopAndMarkWord, mtGC> OopAndMarkWordStack;
 
   OopAndMarkWordStack _stack;
@@ -55,6 +57,7 @@ private:
   inline bool should_preserve_mark(oop obj, markWord m) const;
 
 public:
+  OopAndMarkWordStack& get_stack() { return _stack; }
   size_t size() const { return _stack.size(); }
   inline void push_if_necessary(oop obj, markWord m);
   inline void push_always(oop obj, markWord m);

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -56,7 +56,7 @@ inline PreservedMarks::PreservedMarks()
              // cache size to 0.
              0 /* max_cache_size */) { }
 
-void PreservedMarks::OopAndMarkWord::set_mark() const {
+void OopAndMarkWord::set_mark() const {
   _o->set_mark(_m);
 }
 


### PR DESCRIPTION
Hi all,

This patch removes the class `markSweep.hpp::PreservedMark` and uses the shared `PreservedMarksSet` instead.

In order to keep the meaning of the field `_preserved_marks` in `markSweep`,
I need to use `OopAndMarkWord` explicitly. So I move `OopAndMarkWord` out of `PreservedMarks`.

Tests:
`hotspot:tier1` passed locally (x86 & linux).

Thanks for the review.

Best Regards,
-- Guoxiong