### PR TITLE
8309329: com/sun/jdi/DeferredStepTest.java fails with virtual threads due to not waiting for threads to exit

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -27,7 +27,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 ## Tests failing when main() is executed in additional vthread or in vthread instead of thread
 #
 
-com/sun/jdi/DeferredStepTest.java 8285422 generic-all
 com/sun/jdi/ExceptionEvents.java 8285422 generic-all
 com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
 com/sun/jdi/JdbStepTest.java 8285422 generic-all

--- a/test/jdk/com/sun/jdi/DeferredStepTest.java
+++ b/test/jdk/com/sun/jdi/DeferredStepTest.java
@@ -74,14 +74,14 @@ class DeferredStepTestTarg {
 
         jj1 obj1 = new jj1();
         jj2 obj2 = new jj2();
-        Thread jj1 = TestScaffold.newThread(obj1, "jj1");
-        Thread jj2 = TestScaffold.newThread(obj2, "jj2");
-        jj1.start();
-        jj2.start();
+        Thread thread1 = TestScaffold.newThread(obj1, "jj1");
+        Thread thread2 = TestScaffold.newThread(obj2, "jj2");
+        thread1.start();
+        thread2.start();
         // Threads might be deamon threads, so wait here for them to complete.
         try {
-            jj1.join();
-            jj2.join();
+            thread1.join();
+            thread2.join();
         } catch (InterruptedException ie) {
             throw new RuntimeException(ie);
         }

--- a/test/jdk/com/sun/jdi/DeferredStepTest.java
+++ b/test/jdk/com/sun/jdi/DeferredStepTest.java
@@ -74,8 +74,17 @@ class DeferredStepTestTarg {
 
         jj1 obj1 = new jj1();
         jj2 obj2 = new jj2();
-        TestScaffold.newThread(obj1, "jj1").start();
-        TestScaffold.newThread(obj2, "jj2").start();
+        Thread jj1 = TestScaffold.newThread(obj1, "jj1");
+        Thread jj2 = TestScaffold.newThread(obj2, "jj2");
+        jj1.start();
+        jj2.start();
+        // Threads might be deamon threads, so wait here for them to complete.
+        try {
+            jj1.join();
+            jj2.join();
+        } catch (InterruptedException ie) {
+            throw new RuntimeException(ie);
+        }
     }
 }
 


### PR DESCRIPTION
Virtual threads are always daemon threads, so tests that previously did not explicitly wait for test threads to exit sometimes fail with virtual threads due to the test exiting before the test threads have exited. A join() for each test thread is needed to fix this issue.

com/sun/jdi/DeferredStepTest.java is one such tests. I looked at the other com/sun/jdi failures listed in [JDK-8285422](https://bugs.openjdk.org/browse/JDK-8285422) and didn't see any others that might be failing for this same reason.

I tested locally with `JTREG_TEST_THREAD_FACTORY=Virtual`. I'll also run the appropriate mach5 tier that tests com/sun/jdi with virtual threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309329](https://bugs.openjdk.org/browse/JDK-8309329): com/sun/jdi/DeferredStepTest.java fails with virtual threads due to not waiting for threads to exit


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [24dfa505](https://git.openjdk.org/jdk/pull/14275/files/24dfa505cf23702268461ad1a58d3556e6f37e7d)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14275/head:pull/14275` \
`$ git checkout pull/14275`

Update a local copy of the PR: \
`$ git checkout pull/14275` \
`$ git pull https://git.openjdk.org/jdk.git pull/14275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14275`

View PR using the GUI difftool: \
`$ git pr show -t 14275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14275.diff">https://git.openjdk.org/jdk/pull/14275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14275#issuecomment-1572905993)