### PR TITLE
8309216: Cast from jchar* to char* in test java/io/GetXSpace.java

### DIFF
--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -129,7 +129,7 @@ Java_GetXSpace_getSpace0
     }
 #else
     int len = (int)(*env)->GetStringLength(env, root);
-    char* chars = (char*)malloc(len*sizeof(char) + 1);
+    char* chars = (char*)malloc((len + 1)*sizeof(char));
     if (chars == NULL) {
         (*env)->ReleaseStringChars(env, root, strchars);
         JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -83,13 +83,12 @@ Java_GetXSpace_getSpace0
         // use GetDiskSpaceInformationW
         DISK_SPACE_INFORMATION diskSpaceInfo;
         BOOL hres = pfnGetDiskSpaceInformation(path, &diskSpaceInfo);
+        (*env)->ReleaseStringChars(env, root, strchars);
         if (FAILED(hres)) {
-            (*env)->ReleaseStringChars(env, root, strchars);
             JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                          "GetDiskSpaceInformationW");
             return totalSpaceIsEstimated;
         }
-        (*env)->ReleaseStringChars(env, root, strchars);
 
         ULONGLONG bytesPerAllocationUnit =
             diskSpaceInfo.SectorsPerAllocationUnit*diskSpaceInfo.BytesPerSector;
@@ -110,14 +109,14 @@ Java_GetXSpace_getSpace0
         ULARGE_INTEGER totalNumberOfBytes;
         ULARGE_INTEGER totalNumberOfFreeBytes;
 
-        if (GetDiskFreeSpaceExW(path, &freeBytesAvailable, &totalNumberOfBytes,
-            &totalNumberOfFreeBytes) == 0) {
-            (*env)->ReleaseStringChars(env, root, strchars);
+        BOOL hres = GetDiskFreeSpaceExW(path, &freeBytesAvailable,
+            &totalNumberOfBytes, &totalNumberOfFreeBytes);
+        (*env)->ReleaseStringChars(env, root, strchars);
+        if (FAILED(hres)) {
             JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                          "GetDiskFreeSpaceExW");
             return totalSpaceIsEstimated;
         }
-        (*env)->ReleaseStringChars(env, root, strchars);
 
         // If quotas are in effect, it is impossible to obtain the volume size,
         // so estimate it as free + used = free + (visible - available)


### PR DESCRIPTION
For Unix, copy the `jchar`s into an allocated `char` array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309216](https://bugs.openjdk.org/browse/JDK-8309216): Cast from jchar* to char* in test java/io/GetXSpace.java


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14276/head:pull/14276` \
`$ git checkout pull/14276`

Update a local copy of the PR: \
`$ git checkout pull/14276` \
`$ git pull https://git.openjdk.org/jdk.git pull/14276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14276`

View PR using the GUI difftool: \
`$ git pr show -t 14276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14276.diff">https://git.openjdk.org/jdk/pull/14276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14276#issuecomment-1572943099)