### PR TITLE
8309332: RISC-V: Improve PrintOptoAssembly output of vector nodes

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1071,7 +1071,7 @@ instruct vneg(vReg dst, vReg src) %{
   match(Set dst (NegVI src));
   match(Set dst (NegVL src));
   ins_cost(VEC_COST);
-  format %{ "vneg $dst, $src, $src" %}
+  format %{ "vneg $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1102,7 +1102,7 @@ instruct vfneg(vReg dst, vReg src) %{
   match(Set dst (NegVF src));
   match(Set dst (NegVD src));
   ins_cost(VEC_COST);
-  format %{ "vfneg $dst, $src, $src" %}
+  format %{ "vfneg $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -341,7 +341,7 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vadd_masked $dst_src1, $src2, $v0" %}
+  format %{ "vadd_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -356,7 +356,7 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vadd_fp_masked $dst_src1, $src2, $v0" %}
+  format %{ "vadd_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -407,7 +407,7 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vsub_masked $dst_src1, $src2, $v0" %}
+  format %{ "vsub_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -421,7 +421,7 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vsub_fp_masked $dst_src1, $src2, $v0" %}
+  format %{ "vsub_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -452,7 +452,7 @@ instruct vand(vReg dst, vReg src1, vReg src2) %{
 instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AndV (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vand_masked $dst_src1, $src2, $v0" %}
+  format %{ "vand_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -484,7 +484,7 @@ instruct vor(vReg dst, vReg src1, vReg src2) %{
 instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (OrV (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vor_masked $dst_src1, $src2, $v0" %}
+  format %{ "vor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -516,7 +516,7 @@ instruct vxor(vReg dst, vReg src1, vReg src2) %{
 instruct vxor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (XorV (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vxor_masked $dst_src1, $src2, $v0" %}
+  format %{ "vxor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -550,7 +550,7 @@ instruct vdiv_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (DivVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (DivVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vdiv_fp_masked $dst_src1, $src2, $v0" %}
+  format %{ "vdiv_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -753,7 +753,7 @@ instruct vfmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF dst_src1 (Binary src2 src3)));
   match(Set dst_src1 (FmaVD dst_src1 (Binary src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vfmla $dst_src1, $src2, $src3" %}
+  format %{ "vfmla $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -770,7 +770,7 @@ instruct vfmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVF (Binary dst_src1 src2) (Binary src3 v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 src2) (Binary src3 v0)));
-  format %{ "vfmadd_masked $dst_src1, $src2, $src3, $v0" %}
+  format %{ "vfmadd_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -789,7 +789,7 @@ instruct vfmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF dst_src1 (Binary (NegVF src2) src3)));
   match(Set dst_src1 (FmaVF dst_src1 (Binary src2 (NegVF src3))));
   ins_cost(VEC_COST);
-  format %{ "vfmlsF $dst_src1, $src2, $src3" %}
+  format %{ "vfmlsF $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -805,7 +805,7 @@ instruct vfmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD dst_src1 (Binary (NegVD src2) src3)));
   match(Set dst_src1 (FmaVD dst_src1 (Binary src2 (NegVD src3))));
   ins_cost(VEC_COST);
-  format %{ "vfmlsD $dst_src1, $src2, $src3" %}
+  format %{ "vfmlsD $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -821,7 +821,7 @@ instruct vfnmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVF (Binary dst_src1 (NegVF src2)) (Binary src3 v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 (NegVD src2)) (Binary src3 v0)));
-  format %{ "vfnmsub_masked $dst_src1, $src2, $src3, $v0" %}
+  format %{ "vfnmsub_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -840,7 +840,7 @@ instruct vfnmlaF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary (NegVF src2) src3)));
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary src2 (NegVF src3))));
   ins_cost(VEC_COST);
-  format %{ "vfnmlaF $dst_src1, $src2, $src3" %}
+  format %{ "vfnmlaF $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
@@ -856,7 +856,7 @@ instruct vfnmlaD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary (NegVD src2) src3)));
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary src2 (NegVD src3))));
   ins_cost(VEC_COST);
-  format %{ "vfnmlaD $dst_src1, $src2, $src3" %}
+  format %{ "vfnmlaD $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
@@ -872,7 +872,7 @@ instruct vfnmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVF (Binary dst_src1 (NegVF src2)) (Binary (NegVF src3) v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 (NegVD src2)) (Binary (NegVD src3) v0)));
-  format %{ "vfnmadd_masked $dst_src1, $src2, $src3, $v0" %}
+  format %{ "vfnmadd_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -889,7 +889,7 @@ instruct vfnmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vfnmlsF $dst_src1, $src2, $src3" %}
+  format %{ "vfnmlsF $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -903,7 +903,7 @@ instruct vfnmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vfnmlsD $dst_src1, $src2, $src3" %}
+  format %{ "vfnmlsD $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -919,7 +919,7 @@ instruct vfmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVF (Binary dst_src1 src2) (Binary (NegVF src3) v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 src2) (Binary (NegVD src3) v0)));
-  format %{ "vfmsub_masked $dst_src1, $src2, $src3, $v0" %}
+  format %{ "vfmsub_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -938,7 +938,7 @@ instruct vmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (AddVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (AddVL dst_src1 (MulVL src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vmla $dst_src1, src2, src3" %}
+  format %{ "vmla $dst_src1, $dst_src1, src2, src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -955,7 +955,7 @@ instruct vmla_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVS (Binary dst_src1 (MulVS src2 src3)) v0));
   match(Set dst_src1 (AddVI (Binary dst_src1 (MulVI src2 src3)) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 (MulVL src2 src3)) v0));
-  format %{ "vmla_masked $dst_src1, $src2, $src3, $v0" %}
+  format %{ "vmla_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -974,7 +974,7 @@ instruct vmls(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (SubVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (SubVL dst_src1 (MulVL src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vmls $dst_src1, src2, src3" %}
+  format %{ "vmls $dst_src1, $dst_src1, src2, src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -991,7 +991,7 @@ instruct vmls_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVS (Binary dst_src1 (MulVS src2 src3)) v0));
   match(Set dst_src1 (SubVI (Binary dst_src1 (MulVI src2 src3)) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 (MulVL src2 src3)) v0));
-  format %{ "vmls_masked $dst_src1, $src2, $src3, $v0" %}
+  format %{ "vmls_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1041,7 +1041,7 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVL (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vmul_masked $dst_src1, $src2, $v0" %}
+  format %{ "vmul_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1055,7 +1055,7 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vmul_fp_masked $dst_src1, $src2, $v0" %}
+  format %{ "vmul_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1375,7 +1375,7 @@ instruct reduce_addF(fRegF src1_dst, vReg src2, vReg tmp) %{
   match(Set src1_dst (AddReductionVF src1_dst src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addF $src1_dst, $src2\t# KILL $tmp" %}
+  format %{ "reduce_addF $src1_dst, $src1_dst, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
@@ -1390,7 +1390,7 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
   match(Set src1_dst (AddReductionVD src1_dst src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addD $src1_dst, $src2\t# KILL $tmp" %}
+  format %{ "reduce_addD $src1_dst, $src1_dst, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
@@ -1441,7 +1441,7 @@ instruct reduce_addF_masked(fRegF src1_dst, vReg src2, vRegMask_V0 v0, vReg tmp)
   match(Set src1_dst (AddReductionVF (Binary src1_dst src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addF_masked $src1_dst, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_addF_masked $src1_dst, $src1_dst, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
@@ -1456,7 +1456,7 @@ instruct reduce_addD_masked(fRegD src1_dst, vReg src2, vRegMask_V0 v0, vReg tmp)
   match(Set src1_dst (AddReductionVD (Binary src1_dst src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addD_masked $src1_dst, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_addD_masked $src1_dst, $src1_dst, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
@@ -2648,7 +2648,7 @@ instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (SqrtVF dst_src v0));
   match(Set dst_src (SqrtVD dst_src v0));
   ins_cost(VEC_COST);
-  format %{ "vsqrt_fp_masked $dst_src, $v0" %}
+  format %{ "vsqrt_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3100,7 +3100,7 @@ instruct vmask_xor(vRegMask dst, vRegMask src1, vRegMask src2) %{
 instruct vmaskcast(vRegMask dst_src) %{
   match(Set dst_src (VectorMaskCast dst_src));
   ins_cost(0);
-  format %{ "vmaskcast $dst_src\t# do nothing" %}
+  format %{ "vmaskcast $dst_src, $dst_src\t# do nothing" %}
   ins_encode(/* empty encoding */);
   ins_pipe(pipe_class_empty);
 %}
@@ -3411,7 +3411,7 @@ instruct reinterpret(vReg dst_src) %{
   predicate(Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst_src (VectorReinterpret dst_src));
   ins_cost(0);
-  format %{ "# reinterpret $dst_src\t# do nothing" %}
+  format %{ "# reinterpret $dst_src, $dst_src\t# do nothing" %}
   ins_encode %{
     // empty
   %}
@@ -3446,7 +3446,7 @@ instruct vmask_reinterpret_same_esize(vRegMask dst_src) %{
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst_src (VectorReinterpret dst_src));
   ins_cost(0);
-  format %{ "vmask_reinterpret_same_esize $dst_src\t# do nothing" %}
+  format %{ "vmask_reinterpret_same_esize $dst_src, $dst_src\t# do nothing" %}
   ins_encode(/* empty encoding */);
   ins_pipe(pipe_class_empty);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -241,8 +241,7 @@ instruct vabs(vReg dst, vReg src, vReg tmp) %{
   match(Set dst (AbsVL src));
   ins_cost(VEC_COST);
   effect(TEMP tmp);
-  format %{ "vrsub.vi $tmp, $src, 0\t#@vabs\n\t"
-            "vmax.vv $dst, $tmp, $src" %}
+  format %{ "vabs $dst, $src\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -256,7 +255,7 @@ instruct vabs_fp(vReg dst, vReg src) %{
   match(Set dst (AbsVF src));
   match(Set dst (AbsVD src));
   ins_cost(VEC_COST);
-  format %{ "vfsgnjx.vv $dst, $src, $src, vm\t#@vabs_fp" %}
+  format %{ "vabs_fp $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -308,7 +307,7 @@ instruct vadd(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVI src1 src2));
   match(Set dst (AddVL src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vadd.vv $dst, $src1, $src2\t#@vadd" %}
+  format %{ "vadd $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -323,7 +322,7 @@ instruct vadd_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVF src1 src2));
   match(Set dst (AddVD src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vfadd.vv $dst, $src1, $src2\t#@vadd_fp" %}
+  format %{ "vadd_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -342,7 +341,7 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vadd.vv $dst_src1, $src2, $v0\t#@vadd_masked" %}
+  format %{ "vadd_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -357,7 +356,7 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vfadd.vv $dst_src1, $src2, $v0\t#@vadd_fp_masked" %}
+  format %{ "vadd_fp_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -376,7 +375,7 @@ instruct vsub(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVI src1 src2));
   match(Set dst (SubVL src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vsub.vv $dst, $src1, $src2\t#@vsub" %}
+  format %{ "vsub $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -390,7 +389,7 @@ instruct vsub_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVF src1 src2));
   match(Set dst (SubVD src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vfsub.vv $dst, $src1, $src2\t@vsub_fp" %}
+  format %{ "vsub_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -408,7 +407,7 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vsub.vv $dst_src1, $src2, $v0\t#@vsub_masked" %}
+  format %{ "vsub_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -422,7 +421,7 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vfsub.vv $dst_src1, $src2, $v0\t#@vsub_fp_masked" %}
+  format %{ "vsub_fp_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -437,7 +436,7 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vand(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AndV src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vand.vv  $dst, $src1, $src2\t#@vand" %}
+  format %{ "vand $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -469,7 +468,7 @@ instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vor(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (OrV src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vor.vv  $dst, $src1, $src2\t#@vor" %}
+  format %{ "vor $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -501,7 +500,7 @@ instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vxor(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (XorV src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vxor.vv  $dst, $src1, $src2\t#@vxor" %}
+  format %{ "vxor $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -534,7 +533,7 @@ instruct vdiv_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (DivVF src1 src2));
   match(Set dst (DivVD src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vfdiv.vv  $dst, $src1, $src2\t#@vdiv_fp" %}
+  format %{ "vdiv_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -551,7 +550,7 @@ instruct vdiv_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (DivVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (DivVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vfdiv.vv  $dst_src1, $src2, $v0\t#@vdiv_fp_masked" %}
+  format %{ "vdiv_fp_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -569,7 +568,7 @@ instruct vmax(vReg dst, vReg src1, vReg src2) %{
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vmax.vv $dst, $src1, $src2\t#@vmax" %}
+  format %{ "vmax $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -584,7 +583,7 @@ instruct vmin(vReg dst, vReg src1, vReg src2) %{
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst (MinV src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vmin.vv $dst, $src1, $src2\t#@vmin" %}
+  format %{ "vmin $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -633,7 +632,7 @@ instruct vmaxF(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vmaxF $dst, $src1, $src2\t#@vmaxF" %}
+  format %{ "vmaxF $dst, $src1, $src2" %}
   ins_encode %{
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
@@ -647,7 +646,7 @@ instruct vmaxD(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vmaxD $dst, $src1, $src2\t#@vmaxD" %}
+  format %{ "vmaxD $dst, $src1, $src2" %}
   ins_encode %{
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
@@ -661,7 +660,7 @@ instruct vminF(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vminF $dst, $src1, $src2\t#@vminF" %}
+  format %{ "vminF $dst, $src1, $src2" %}
   ins_encode %{
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
@@ -675,7 +674,7 @@ instruct vminD(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vminD $dst, $src1, $src2\t#@vminD" %}
+  format %{ "vminD $dst, $src1, $src2" %}
   ins_encode %{
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
@@ -754,7 +753,7 @@ instruct vfmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF dst_src1 (Binary src2 src3)));
   match(Set dst_src1 (FmaVD dst_src1 (Binary src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vfmacc.vv $dst_src1, $src2, $src3\t#@vfmla" %}
+  format %{ "vfmla $dst_src1, $src2, $src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -790,7 +789,7 @@ instruct vfmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF dst_src1 (Binary (NegVF src2) src3)));
   match(Set dst_src1 (FmaVF dst_src1 (Binary src2 (NegVF src3))));
   ins_cost(VEC_COST);
-  format %{ "vfnmsac.vv $dst_src1, $src2, $src3\t#@vfmlsF" %}
+  format %{ "vfmlsF $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -806,7 +805,7 @@ instruct vfmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD dst_src1 (Binary (NegVD src2) src3)));
   match(Set dst_src1 (FmaVD dst_src1 (Binary src2 (NegVD src3))));
   ins_cost(VEC_COST);
-  format %{ "vfnmsac.vv $dst_src1, $src2, $src3\t#@vfmlsD" %}
+  format %{ "vfmlsD $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -841,7 +840,7 @@ instruct vfnmlaF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary (NegVF src2) src3)));
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary src2 (NegVF src3))));
   ins_cost(VEC_COST);
-  format %{ "vfnmacc.vv $dst_src1, $src2, $src3\t#@vfnmlaF" %}
+  format %{ "vfnmlaF $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
@@ -857,7 +856,7 @@ instruct vfnmlaD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary (NegVD src2) src3)));
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary src2 (NegVD src3))));
   ins_cost(VEC_COST);
-  format %{ "vfnmacc.vv $dst_src1, $src2, $src3\t#@vfnmlaD" %}
+  format %{ "vfnmlaD $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
@@ -890,7 +889,7 @@ instruct vfnmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vfmsac.vv $dst_src1, $src2, $src3\t#@vfnmlsF" %}
+  format %{ "vfnmlsF $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -904,7 +903,7 @@ instruct vfnmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   predicate(UseFMA);
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vfmsac.vv $dst_src1, $src2, $src3\t#@vfnmlsD" %}
+  format %{ "vfnmlsD $dst_src1, $src2, $src3" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
@@ -939,7 +938,7 @@ instruct vmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (AddVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (AddVL dst_src1 (MulVL src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vmacc.vv $dst_src1, src2, src3\t#@vmla" %}
+  format %{ "vmla $dst_src1, src2, src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -975,7 +974,7 @@ instruct vmls(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (SubVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (SubVL dst_src1 (MulVL src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vnmsac.vv $dst_src1, src2, src3\t#@vmls" %}
+  format %{ "vmls $dst_src1, src2, src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1010,7 +1009,7 @@ instruct vmul(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVI src1 src2));
   match(Set dst (MulVL src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vmul.vv $dst, $src1, $src2\t#@vmul" %}
+  format %{ "vmul $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1024,7 +1023,7 @@ instruct vmul_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVF src1 src2));
   match(Set dst (MulVD src1 src2));
   ins_cost(VEC_COST);
-  format %{ "vfmul.vv $dst, $src1, $src2\t#@vmul_fp" %}
+  format %{ "vmul_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1042,7 +1041,7 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVL (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vmul.vv $dst_src1, $src2, $v0\t#@vmul_masked" %}
+  format %{ "vmul_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1056,7 +1055,7 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVD (Binary dst_src1 src2) v0));
   ins_cost(VEC_COST);
-  format %{ "vmul.vv $dst_src1, $src2, $v0\t#@vmul_fp_masked" %}
+  format %{ "vmul_fp_masked $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1072,7 +1071,7 @@ instruct vneg(vReg dst, vReg src) %{
   match(Set dst (NegVI src));
   match(Set dst (NegVL src));
   ins_cost(VEC_COST);
-  format %{ "vrsub.vx $dst, $src, $src\t#@vneg" %}
+  format %{ "vneg $dst, $src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1103,7 +1102,7 @@ instruct vfneg(vReg dst, vReg src) %{
   match(Set dst (NegVF src));
   match(Set dst (NegVD src));
   ins_cost(VEC_COST);
-  format %{ "vfsgnjn.vv $dst, $src, $src\t#@vfneg" %}
+  format %{ "vfneg $dst, $src, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1137,9 +1136,7 @@ instruct reduce_andI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_andI\n\t"
-            "vredand.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_andI $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1154,9 +1151,7 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_andL\n\t"
-            "vredand.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_andL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1211,9 +1206,7 @@ instruct reduce_orI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_orI\n\t"
-            "vredor.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_orI $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1228,9 +1221,7 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_orL\n\t"
-            "vredor.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_orL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1285,9 +1276,7 @@ instruct reduce_xorI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_xorI\n\t"
-            "vredxor.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_xorI $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1302,9 +1291,7 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_xorL\n\t"
-            "vredxor.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_xorL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1359,9 +1346,7 @@ instruct reduce_addI(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_addI\n\t"
-            "vredsum.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_addI $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1376,9 +1361,7 @@ instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vmv.s.x $tmp, $src1\t#@reduce_addL\n\t"
-            "vredsum.vs $tmp, $src2, $tmp\n\t"
-            "vmv.x.s $dst, $tmp" %}
+  format %{ "reduce_addL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
@@ -1392,9 +1375,7 @@ instruct reduce_addF(fRegF src1_dst, vReg src2, vReg tmp) %{
   match(Set src1_dst (AddReductionVF src1_dst src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vfmv.s.f $tmp, $src1_dst\t#@reduce_addF\n\t"
-            "vfredosum.vs $tmp, $src2, $tmp\n\t"
-            "vfmv.f.s $src1_dst, $tmp" %}
+  format %{ "reduce_addF $src1_dst, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
@@ -1409,9 +1390,7 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
   match(Set src1_dst (AddReductionVD src1_dst src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "vfmv.s.f $tmp, $src1_dst\t#@reduce_addD\n\t"
-            "vfredosum.vs $tmp, $src2, $tmp\n\t"
-            "vfmv.f.s $src1_dst, $tmp" %}
+  format %{ "reduce_addD $src1_dst, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
@@ -1635,7 +1614,7 @@ instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce_maxF $dst, $src1, $src2, $tmp1, $tmp2" %}
+  format %{ "vreduce_maxF $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
@@ -1650,7 +1629,7 @@ instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce_maxD $dst, $src1, $src2, $tmp1, $tmp2" %}
+  format %{ "vreduce_maxD $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
@@ -1701,7 +1680,7 @@ instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce_minF $dst, $src1, $src2, $tmp1, $tmp2" %}
+  format %{ "vreduce_minF $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
@@ -1716,7 +1695,7 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce_minD $dst, $src1, $src2, $tmp1, $tmp2" %}
+  format %{ "vreduce_minD $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
@@ -1767,7 +1746,7 @@ instruct replicate(vReg dst, iRegIorL2I src) %{
   match(Set dst (ReplicateS src));
   match(Set dst (ReplicateI src));
   ins_cost(VEC_COST);
-  format %{ "vmv.v.x  $dst, $src\t#@replicate" %}
+  format %{ "replicate $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -1779,7 +1758,7 @@ instruct replicate(vReg dst, iRegIorL2I src) %{
 instruct replicateL(vReg dst, iRegL src) %{
   match(Set dst (ReplicateL src));
   ins_cost(VEC_COST);
-  format %{ "vmv.v.x  $dst, $src\t#@replicateL" %}
+  format %{ "replicateL $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
@@ -1792,7 +1771,7 @@ instruct replicate_imm5(vReg dst, immI5 con) %{
   match(Set dst (ReplicateS con));
   match(Set dst (ReplicateI con));
   ins_cost(VEC_COST);
-  format %{ "vmv.v.i  $dst, $con\t#@replicate_imm5" %}
+  format %{ "replicate_imm5 $dst, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length_in_bytes(this));
@@ -1804,7 +1783,7 @@ instruct replicate_imm5(vReg dst, immI5 con) %{
 instruct replicateL_imm5(vReg dst, immL5 con) %{
   match(Set dst (ReplicateL con));
   ins_cost(VEC_COST);
-  format %{ "vmv.v.i  $dst, $con\t#@replicateL_imm5" %}
+  format %{ "replicateL_imm5 $dst, $con" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
@@ -1815,7 +1794,7 @@ instruct replicateL_imm5(vReg dst, immL5 con) %{
 instruct replicateF(vReg dst, fRegF src) %{
   match(Set dst (ReplicateF src));
   ins_cost(VEC_COST);
-  format %{ "vfmv.v.f  $dst, $src\t#@replicateF" %}
+  format %{ "replicateF $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
@@ -1826,7 +1805,7 @@ instruct replicateF(vReg dst, fRegF src) %{
 instruct replicateD(vReg dst, fRegD src) %{
   match(Set dst (ReplicateD src));
   ins_cost(VEC_COST);
-  format %{ "vfmv.v.f  $dst, $src\t#@replicateD" %}
+  format %{ "replicateD $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
@@ -2223,7 +2202,7 @@ instruct vlsrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vasrB_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVB src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsra.vi $dst, $src, $shift\t#@vasrB_imm" %}
+  format %{ "vasrB_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -2241,7 +2220,7 @@ instruct vasrB_imm(vReg dst, vReg src, immI shift) %{
 instruct vasrS_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVS src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsra.vi $dst, $src, $shift\t#@vasrS_imm" %}
+  format %{ "vasrS_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -2259,7 +2238,7 @@ instruct vasrS_imm(vReg dst, vReg src, immI shift) %{
 instruct vasrI_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVI src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsrl.vi $dst, $src, $shift\t#@vasrI_imm" %}
+  format %{ "vasrI_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -2277,7 +2256,7 @@ instruct vasrL_imm(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (RShiftVL src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsrl.vi $dst, $src, $shift\t#@vasrL_imm" %}
+  format %{ "vasrL_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -2361,7 +2340,7 @@ instruct vasrL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vlsrB_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVB src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrB_imm" %}
+  format %{ "vlsrB_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -2383,7 +2362,7 @@ instruct vlsrB_imm(vReg dst, vReg src, immI shift) %{
 instruct vlsrS_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVS src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrS_imm" %}
+  format %{ "vlsrS_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -2405,7 +2384,7 @@ instruct vlsrS_imm(vReg dst, vReg src, immI shift) %{
 instruct vlsrI_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVI src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrI_imm" %}
+  format %{ "vlsrI_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -2423,7 +2402,7 @@ instruct vlsrL_imm(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (URShiftVL src (RShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsrl.vi $dst, $src, $shift\t#@vlsrL_imm" %}
+  format %{ "vlsrL_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -2515,7 +2494,7 @@ instruct vlsrL_imm_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vlslB_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVB src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsll.vi $dst, $src, $shift\t#@vlslB_imm" %}
+  format %{ "vlslB_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
@@ -2532,7 +2511,7 @@ instruct vlslB_imm(vReg dst, vReg src, immI shift) %{
 instruct vlslS_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVS src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsll.vi $dst, $src, $shift\t#@vlslS_imm" %}
+  format %{ "vlslS_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
@@ -2549,7 +2528,7 @@ instruct vlslS_imm(vReg dst, vReg src, immI shift) %{
 instruct vlslI_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVI src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsll.vi $dst, $src, $shift\t#@vlslI_imm" %}
+  format %{ "vlslI_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_INT, Matcher::vector_length(this));
@@ -2562,7 +2541,7 @@ instruct vlslL_imm(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (LShiftVL src (LShiftCntV shift)));
   ins_cost(VEC_COST);
-  format %{ "vsll.vi $dst, $src, $shift\t#@vlslL_imm" %}
+  format %{ "vlslL_imm $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -2654,7 +2633,7 @@ instruct vsqrt_fp(vReg dst, vReg src) %{
   match(Set dst (SqrtVF src));
   match(Set dst (SqrtVD src));
   ins_cost(VEC_COST);
-  format %{ "vfsqrt.v $dst, $src\t#@vsqrt_fp" %}
+  format %{ "vsqrt_fp $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -3140,7 +3119,7 @@ instruct storeV_masked(vReg src, vmemA mem, vRegMask_V0 v0) %{
 
 instruct vblend(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (VectorBlend (Binary src1 src2) v0));
-  format %{ "vmerge_vvm $dst, $src1, $src2, v0\t#@vector blend" %}
+  format %{ "vblend $dst, $src1, $src2, v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));


### PR DESCRIPTION
Hi, Currently in the vector node implementation, some of the instruction formats are part of the rvv assembly instructions, for which the assembly instructions are also incomplete, such as the missing vsetvli assembly instruction(vsetvli is used to set the element width, number, etc), This makes the compiler assembly output by -XX:+PrintOptoAssembly difficult to understand. And if every assembly instruction is reflected, it will be redundant and increase the maintenance work in the future. And referring to other CPUs, such as the ARM64, it is straightforward to use the instruct function name to simplify [1].

While this won't affect release build, we should fix this for debug build. We can use the -XX:+PrintOptoAssembly parameter to print the compiler assembly output by -XX:+PrintOptoAssembly and view the assembly logic in conjunction with the source code of the specific vector node.

[1] https://github.com/openjdk/jdk/blob/4460429d7a50b9a7a99058ef4e5ae36fb30b956f/src/hotspot/cpu/aarch64/aarch64_vector.ad#L2842-L2846

### Testing:
qemu with UseRVV:

- [ ] Tier1 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)
- [x] test/jdk/jdk/incubator/vector/Int256VectorTests.java (fastdebug with -XX:+PrintOptoAssembly)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309332](https://bugs.openjdk.org/browse/JDK-8309332): RISC-V: Improve PrintOptoAssembly output of vector nodes


### Reviewers
 * [Yanhong Zhu](https://openjdk.org/census#yzhu) (@yhzhu20 - Author) ⚠️ Review applies to [9e0430c0](https://git.openjdk.org/jdk/pull/14279/files/9e0430c0120c167d89d76f6d20a4ca468ad626df)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14279/head:pull/14279` \
`$ git checkout pull/14279`

Update a local copy of the PR: \
`$ git checkout pull/14279` \
`$ git pull https://git.openjdk.org/jdk.git pull/14279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14279`

View PR using the GUI difftool: \
`$ git pr show -t 14279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14279.diff">https://git.openjdk.org/jdk/pull/14279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14279#issuecomment-1573039669)