### PR TITLE
JDK-8309340: Provide sctpHandleSocketErrorWithMessage

### DIFF
--- a/src/jdk.sctp/unix/native/libsctp/Sctp.h
+++ b/src/jdk.sctp/unix/native/libsctp/Sctp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,5 +286,6 @@ extern sctp_bindx_func* nio_sctp_bindx;
 extern sctp_peeloff_func* nio_sctp_peeloff;
 
 extern jint sctpHandleSocketError(JNIEnv *env, jint errorValue);
+extern jint sctpHandleSocketErrorWithMessage(JNIEnv *env, jint errorValue, const char* message);
 
 #endif /* !SUN_NIO_CH_SCTP_H */


### PR DESCRIPTION
There are cases in the sctp coding where a function sctpHandleSocketErrorWithMessage would be beneficial (similar to existing handleSocketErrorWithMessage) to provide more detail what failed.

Additionally sctpHandleSocketErrorWithMessage was a bit modified (added errno handling for ENOTCONN from handleSocketErrorWithMessage).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309340](https://bugs.openjdk.org/browse/JDK-8309340): Provide sctpHandleSocketErrorWithMessage


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14280/head:pull/14280` \
`$ git checkout pull/14280`

Update a local copy of the PR: \
`$ git checkout pull/14280` \
`$ git pull https://git.openjdk.org/jdk.git pull/14280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14280`

View PR using the GUI difftool: \
`$ git pr show -t 14280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14280.diff">https://git.openjdk.org/jdk/pull/14280.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14280#issuecomment-1573331005)