### PR TITLE
JDK-8308288: Fix xlc17 clang warnings and build errors in hotspot

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -162,7 +162,7 @@ char* os::iso8601_time(jlong milliseconds_since_19700101, char* buffer, size_t b
   // No offset when dealing with UTC
   time_t UTC_to_local = 0;
   if (!utc) {
-#if defined(_ALLBSD_SOURCE) || defined(_GNU_SOURCE)
+#if (defined(_ALLBSD_SOURCE) || defined(_GNU_SOURCE)) && !defined(AIX)
     UTC_to_local = -(time_struct.tm_gmtoff);
 #elif defined(_WINDOWS)
     long zone;
@@ -878,8 +878,8 @@ bool os::print_function_and_library_name(outputStream* st,
   // this as a function descriptor for the reader (see below).
   if (!have_function_name && os::is_readable_pointer(addr)) {
     address addr2 = (address)os::resolve_function_descriptor(addr);
-    if (have_function_name = is_function_descriptor =
-        dll_address_to_function_name(addr2, p, buflen, &offset, demangle)) {
+    if ((have_function_name = is_function_descriptor =
+        dll_address_to_function_name(addr2, p, buflen, &offset, demangle))) {
       addr = addr2;
     }
   }

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -32,12 +32,22 @@
 // globally used constants & types, class (forward)
 // declarations and a few frequently used utility functions.
 
+#include <alloca.h>
 #include <ctype.h>
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+// In stdlib.h on AIX malloc is defined as a macro causing
+// compiler errors when resolving them in different depths as it
+// happens in the log tags. This avoids the macro.
+#if (defined(__VEC__) || defined(__AIXVEC)) && defined(AIX) \
+    && defined(__open_xl_version__) && __open_xl_version__ >= 17
+  #undef malloc
+  extern void *malloc(size_t) asm("vec_malloc");
+#endif
+
 #include <wchar.h>
 
 #include <math.h>


### PR DESCRIPTION
This pr is a split off from JDK-8308288 : Fix xlc17 clang warnings in shared code https://github.com/openjdk/jdk/pull/14146
It handles the part in hotspot.

It handles the error introduced by a redefine of malloc in stdlib.h resulting in the following build error:

/data/d042520/pr/jdk/src/hotspot/share/runtime/os.cpp:616:5: error: no member named '_vec_malloc' in 'LogTag'; did you mean 'vec_malloc'?
    log_warning(malloc, free)("ptr caught: " PTR_FORMAT, p2i(ptr));
    ^~~~~~~~~~~~~~~~~~~~~~~~~
/data/d042520/pr/jdk/src/hotspot/share/logging/log.hpp:46:28: note: expanded from macro 'log_warning'
#define log_warning(...) (!log_is_enabled(Warning, __VA_ARGS__)) ? (void)0 : LogImpl<LOG_TAGS(__VA_ARGS__)>::write<LogLevel::Warning>
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/d042520/pr/jdk/src/hotspot/share/logging/log.hpp:68:45: note: expanded from macro 'log_is_enabled'
#define log_is_enabled(level, ...) (LogImpl<LOG_TAGS(__VA_ARGS__)>::is_level(LogLevel::level))
                                            ^~~~~~~~~~~~~~~~~~~~~
/data/d042520/pr/jdk/src/hotspot/share/logging/logTag.hpp:221:38: note: expanded from macro 'LOG_TAGS'
#define LOG_TAGS(...) EXPAND_VARARGS(LOG_TAGS_EXPANDED(__VA_ARGS__, _NO_TAG, _NO_TAG, _NO_TAG, _NO_TAG, _NO_TAG, _NO_TAG))
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/d042520/pr/jdk/src/hotspot/share/logging/logTag.hpp:217:57: note: expanded from macro 'LOG_TAGS_EXPANDED'
#define LOG_TAGS_EXPANDED(T0, T1, T2, T3, T4, T5, ...)  PREFIX_LOG_TAG(T0), PREFIX_LOG_TAG(T1), PREFIX_LOG_TAG(T2), \
                                                        ^~~~~~~~~~~~~~~~~~
   ... (rest of output omitted)


Additionally it solves the need for an #include <alloca.h> on AIX for any usage of the alloca function, by adding the include to globalDefinitions_xlc.hpp