### PR TITLE
8309336: Incorrect switch in enum not reported properly

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1732,10 +1732,10 @@ public class Attr extends JCTree.Visitor {
                             if (!pattype.hasTag(ERROR)) {
                                 if (pattype.constValue() == null) {
                                     Symbol s = TreeInfo.symbol(expr);
-                                    if (s != null && s.kind == TYP && allowPatternSwitch) {
+                                    if (s != null && s.kind == TYP) {
                                         log.error(expr.pos(),
                                                   Errors.PatternExpected);
-                                    } else if (s == null || !s.isEnum() || !allowPatternSwitch) {
+                                    } else if (s == null || !s.isEnum()) {
                                         log.error(expr.pos(),
                                                   (stringSwitch ? Errors.StringConstReq
                                                                 : intSwitch ? Errors.ConstExprReq

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1657,9 +1657,9 @@ public class Attr extends JCTree.Visitor {
             boolean enumSwitch = (seltype.tsym.flags() & Flags.ENUM) != 0;
             boolean stringSwitch = types.isSameType(seltype, syms.stringType);
             boolean errorEnumSwitch = TreeInfo.isErrorEnumSwitch(selector, cases);
+            boolean intSwitch = types.isAssignable(seltype, syms.intType);
             boolean patternSwitch;
-            if (!enumSwitch && !stringSwitch && !errorEnumSwitch &&
-                !types.isAssignable(seltype, syms.intType)) {
+            if (!enumSwitch && !stringSwitch && !errorEnumSwitch && !intSwitch) {
                 preview.checkSourceLevel(selector.pos(), Feature.PATTERN_SWITCH);
                 patternSwitch = true;
             } else {
@@ -1735,11 +1735,13 @@ public class Attr extends JCTree.Visitor {
                                     if (s != null && s.kind == TYP && allowPatternSwitch) {
                                         log.error(expr.pos(),
                                                   Errors.PatternExpected);
-                                    } else if ((s != null && !s.isEnum()) || !allowPatternSwitch) {
+                                    } else if (s == null || !s.isEnum() || !allowPatternSwitch) {
                                         log.error(expr.pos(),
-                                                  (stringSwitch ? Errors.StringConstReq : Errors.ConstExprReq));
+                                                  (stringSwitch ? Errors.StringConstReq
+                                                                : intSwitch ? Errors.ConstExprReq
+                                                                            : Errors.PatternOrEnumReq));
                                     }
-                                } else if (!stringSwitch && !types.isAssignable(seltype, syms.intType)) {
+                                } else if (!stringSwitch && !intSwitch) {
                                     log.error(label.pos(), Errors.ConstantLabelNotCompatible(pattype, seltype));
                                 } else if (!constants.add(pattype.constValue())) {
                                     log.error(c.pos(), Errors.DuplicateCaseLabel);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1706,6 +1706,10 @@ public class Attr extends JCTree.Visitor {
                             if (sym == null) {
                                 if (allowPatternSwitch) {
                                     attribTree(expr, switchEnv, caseLabelResultInfo(seltype));
+                                    Symbol enumSym = TreeInfo.symbol(expr);
+                                    if (enumSym == null || !enumSym.isEnum() || enumSym.kind != VAR) {
+                                        log.error(expr.pos(), Errors.EnumLabelMustBeEnumConstant);
+                                    }
                                 } else {
                                     log.error(expr.pos(), Errors.EnumLabelMustBeUnqualifiedEnum);
                                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -576,6 +576,9 @@ compiler.err.enum.cant.be.instantiated=\
 compiler.err.enum.label.must.be.unqualified.enum=\
     an enum switch case label must be the unqualified name of an enumeration constant
 
+compiler.err.enum.label.must.be.enum.constant=\
+    an enum switch constant case label must be an enumeration constant
+
 compiler.err.enum.no.subclassing=\
     classes cannot directly extend java.lang.Enum
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -411,6 +411,9 @@ compiler.err.class.not.allowed=\
 compiler.err.const.expr.req=\
     constant expression required
 
+compiler.err.pattern.or.enum.req=\
+    pattern or enum constant required
+
 compiler.err.cont.outside.loop=\
     continue outside of loop
 

--- a/test/langtools/tools/javac/diags/examples/EnumLabelMustBeEnumConstant.java
+++ b/test/langtools/tools/javac/diags/examples/EnumLabelMustBeEnumConstant.java
@@ -21,48 +21,17 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 8300543 8309336
- * @summary Check switches work correctly with qualified enum constants
- * @compile/fail/ref=EnumSwitchQualifiedErrors.out -XDrawDiagnostics EnumSwitchQualifiedErrors.java
-*/
+// key: compiler.err.enum.label.must.be.enum.constant
 
-public class EnumSwitchQualifiedErrors {
+class EnumLabelMustBeEnumConstant {
+    enum E { A };
 
-    int testPatternMatchingSwitch1(I i) {
-        return switch(i) {
-            case E1.A -> 1;
-            case E2.A -> 2;
-        };
-    }
-
-    int testPatternMatchingSwitch2(E1 e) {
-        return switch(e) {
-            case E1.A -> 1;
-            case E2.A -> 4;
-        };
-    }
-
-    int testPatternMatchingSwitch3(Number n) {
-        return switch(n) {
-            case E1.A -> 1;
-            case E2.A -> 2;
-        };
-    }
-
-    int testPatternMatchingSwitch4(E1 e) {
-        return switch(e) {
-            case E1A -> 1;
-            case (E1) null -> 1;
-            case E1 -> 1;
+    void m(E e) {
+        switch (e) {
+            case EA -> {}
             default -> {}
-        };
+        }
     }
 
-    sealed interface I {}
-    enum E1 implements I { A; }
-    enum E2 { A; }
-
-    static final E1 E1A = null;
+    static final E EA;
 }

--- a/test/langtools/tools/javac/diags/examples/PatternOrEnumReq.java
+++ b/test/langtools/tools/javac/diags/examples/PatternOrEnumReq.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.pattern.or.enum.req
+
+class PatternOrEnumReq {
+    enum E { A };
+
+    void m(Object o) {
+        switch (o) {
+            case EA -> {}
+            default -> {}
+        }
+    }
+
+    static final E EA;
+}

--- a/test/langtools/tools/javac/patterns/PatternErrorRecovery-old.out
+++ b/test/langtools/tools/javac/patterns/PatternErrorRecovery-old.out
@@ -1,3 +1,3 @@
 PatternErrorRecovery.java:12:18: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.pattern.switch), 20, 21
-PatternErrorRecovery.java:11:18: compiler.err.const.expr.req
+PatternErrorRecovery.java:11:18: compiler.err.pattern.or.enum.req
 2 errors

--- a/test/langtools/tools/javac/patterns/PatternErrorRecovery-old.out
+++ b/test/langtools/tools/javac/patterns/PatternErrorRecovery-old.out
@@ -1,3 +1,3 @@
 PatternErrorRecovery.java:12:18: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.pattern.switch), 20, 21
-PatternErrorRecovery.java:11:18: compiler.err.pattern.or.enum.req
+PatternErrorRecovery.java:11:18: compiler.err.pattern.expected
 2 errors

--- a/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.java
+++ b/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.java
@@ -60,6 +60,15 @@ public class EnumSwitchQualifiedErrors {
         };
     }
 
+    int testPatternMatchingSwitch5(Object e) {
+        return switch(e) {
+            case E1A -> 1;
+            case (E1) null -> 1;
+            case E1 -> 1;
+            default -> {}
+        };
+    }
+
     sealed interface I {}
     enum E1 implements I { A; }
     enum E2 { A; }

--- a/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.out
+++ b/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.out
@@ -5,4 +5,7 @@ EnumSwitchQualifiedErrors.java:50:20: compiler.err.prob.found.req: (compiler.mis
 EnumSwitchQualifiedErrors.java:56:18: compiler.err.enum.label.must.be.enum.constant
 EnumSwitchQualifiedErrors.java:57:18: compiler.err.enum.label.must.be.enum.constant
 EnumSwitchQualifiedErrors.java:58:18: compiler.err.enum.label.must.be.enum.constant
-7 errors
+EnumSwitchQualifiedErrors.java:65:18: compiler.err.pattern.or.enum.req
+EnumSwitchQualifiedErrors.java:66:18: compiler.err.pattern.or.enum.req
+EnumSwitchQualifiedErrors.java:67:18: compiler.err.pattern.expected
+10 errors

--- a/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.out
+++ b/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.out
@@ -2,4 +2,7 @@ EnumSwitchQualifiedErrors.java:36:20: compiler.err.prob.found.req: (compiler.mis
 EnumSwitchQualifiedErrors.java:43:20: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: EnumSwitchQualifiedErrors.E2, EnumSwitchQualifiedErrors.E1)
 EnumSwitchQualifiedErrors.java:49:20: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: EnumSwitchQualifiedErrors.E1, java.lang.Number)
 EnumSwitchQualifiedErrors.java:50:20: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: EnumSwitchQualifiedErrors.E2, java.lang.Number)
-4 errors
+EnumSwitchQualifiedErrors.java:56:18: compiler.err.enum.label.must.be.enum.constant
+EnumSwitchQualifiedErrors.java:57:18: compiler.err.enum.label.must.be.enum.constant
+EnumSwitchQualifiedErrors.java:58:18: compiler.err.enum.label.must.be.enum.constant
+7 errors


### PR DESCRIPTION
As of JDK 21, enum constants may be qualified in switches. But there's a bug in the way these "constants" are attributed. Having code like:
```
class EnumLabelMustBeEnumConstant {
    enum E { A };

    void m(E e) {
        switch (e) {
            case EA -> {}
            default -> {}
        }
    }

    static final E EA;
}
```

javac will attribute `EA`, which will turn out to exist, and have the correct type (`E`), so that it will be accepted (and may crash javac later in the backend).

The proposed fix is simply to check that the given expression is an enum constant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309336](https://bugs.openjdk.org/browse/JDK-8309336): Incorrect switch in enum not reported properly


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14284/head:pull/14284` \
`$ git checkout pull/14284`

Update a local copy of the PR: \
`$ git checkout pull/14284` \
`$ git pull https://git.openjdk.org/jdk.git pull/14284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14284`

View PR using the GUI difftool: \
`$ git pr show -t 14284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14284.diff">https://git.openjdk.org/jdk/pull/14284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14284#issuecomment-1573689868)