### PR TITLE
8309346: Extend hs_err logging for all VM operations deriving from VM_GC_Operation

### DIFF
--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -68,6 +68,10 @@ VM_GC_Operation::~VM_GC_Operation() {
   ch->soft_ref_policy()->set_all_soft_refs_clear(false);
 }
 
+const char* VM_GC_Operation::cause() const {
+  return GCCause::to_string(_gc_cause);
+}
+
 // The same dtrace probe can't be inserted in two different files, so we
 // have to call it here, so it's only in one file.  Can't create new probes
 // for the other file anymore.   The dtrace probes have to remain stable.

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -137,9 +137,7 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
   }
   ~VM_GC_Operation();
 
-  virtual const char* cause() const {
-    return GCCause::to_string(_gc_cause);
-  }
+  virtual const char* cause() const;
 
   // Acquire the Heap_lock and determine if this VM operation should be executed
   // (i.e. not skipped). Return this result, and also store it in _prologue_succeeded.


### PR DESCRIPTION
This patch implements `cause()` for `VM_GC_Operation` and its derived classes. It follows [JDK-8309210](https://bugs.openjdk.org/browse/JDK-8309210) to provide more detailed info for `VM_GC_Operation`s in hs_err log file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8309346](https://bugs.openjdk.org/browse/JDK-8309346): Extend hs_err logging for all VM operations deriving from VM_GC_Operation


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14287/head:pull/14287` \
`$ git checkout pull/14287`

Update a local copy of the PR: \
`$ git checkout pull/14287` \
`$ git pull https://git.openjdk.org/jdk.git pull/14287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14287`

View PR using the GUI difftool: \
`$ git pr show -t 14287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14287.diff">https://git.openjdk.org/jdk/pull/14287.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14287#issuecomment-1573909276)