### PR TITLE
JDK-8299052 : ViewportOverlapping test fails intermittently on Win10 & Win11

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -660,7 +660,6 @@ javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
 java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
-java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64
 
 javax/swing/JColorChooser/Test6827032.java 8224968 windows-x64
 java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8288839 windows-x64

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -493,13 +493,7 @@ public abstract class OverlappingTestBase {
         Util.waitForIdle(robot);
 
         // wait for graphic effects on systems like Win7
-        Toolkit.getDefaultToolkit().sync();
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        Util.waitForIdle(robot);
+        robot.delay(500);
 
         if (!instance.performTest()) {
             fail(failMessage);

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,39 @@
  * questions.
  */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Canvas;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Scrollbar;
+import java.awt.TextField;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.peer.ComponentPeer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import javax.swing.*;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
 
 import sun.awt.AWTAccessor;
 import sun.awt.EmbeddedFrame;
-import java.io.*;
-
 import sun.awt.OSInfo;
+
 import test.java.awt.regtesthelpers.Util;
 
 /**

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -422,7 +422,7 @@ public abstract class OverlappingTestBase {
         Util.waitForIdle(robot);
         try{
             Thread.sleep(500);
-        } catch(Exception exx) {
+        } catch (Exception exx) {
             exx.printStackTrace();
         }
 
@@ -480,7 +480,7 @@ public abstract class OverlappingTestBase {
         Robot robot = null;
         try {
             robot = new Robot();
-        } catch(Exception ignored) {
+        } catch (Exception ignored) {
         }
         currentAwtControl = component;
         System.out.println("Testing " + currentAwtControl.getClass().getSimpleName());

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -26,10 +26,15 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -65,6 +70,7 @@ public class ViewportOverlapping extends OverlappingTestBase {
     private Point vLoc;
     private Point testLoc;
     private Point resizeLoc;
+    private static Robot robot;
 
     private JFrame f;
     private JPanel p;
@@ -81,7 +87,6 @@ public class ViewportOverlapping extends OverlappingTestBase {
 
         f = new JFrame();
         f.addMouseListener(new MouseAdapter() {
-
             @Override
             public void mouseClicked(MouseEvent e) {
                 frameClicked++;
@@ -99,60 +104,75 @@ public class ViewportOverlapping extends OverlappingTestBase {
     @Override
     protected boolean performTest() {
         try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                public void run() {
-                    // prepare test data
-                    frameClicked = 0;
+            SwingUtilities.invokeAndWait(() -> {
+                // prepare test data
+                frameClicked = 0;
 
-                    b.requestFocus();
+                b.requestFocus();
 
-                    scrollPane.getHorizontalScrollBar().setUnitIncrement(40);
-                    scrollPane.getVerticalScrollBar().setUnitIncrement(40);
+                scrollPane.getHorizontalScrollBar().setUnitIncrement(40);
+                scrollPane.getVerticalScrollBar().setUnitIncrement(40);
 
-                    hLoc = scrollPane.getHorizontalScrollBar().getLocationOnScreen();
-                    hLoc.translate(scrollPane.getHorizontalScrollBar().getWidth() - 3, 3);
-                    vLoc = scrollPane.getVerticalScrollBar().getLocationOnScreen();
-                    vLoc.translate(3, scrollPane.getVerticalScrollBar().getHeight() - 3);
+                hLoc = scrollPane.getHorizontalScrollBar().getLocationOnScreen();
+                hLoc.translate(scrollPane.getHorizontalScrollBar().getWidth() - 3, 3);
+                vLoc = scrollPane.getVerticalScrollBar().getLocationOnScreen();
+                vLoc.translate(3, scrollPane.getVerticalScrollBar().getHeight() - 3);
 
-                    testLoc = p.getLocationOnScreen();
-                    testLoc.translate(-3, -3);
+                testLoc = p.getLocationOnScreen();
+                testLoc.translate(-3, -3);
 
-                    resizeLoc = f.getLocationOnScreen();
-                    resizeLoc.translate(f.getWidth() - 1, f.getHeight() - 1);
-                }
+                resizeLoc = f.getLocationOnScreen();
+                resizeLoc.translate(f.getWidth() - 1, f.getHeight() - 1);
             });
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException("Problem preparing test GUI.");
         }
-        // run robot
-        Robot robot = Util.createRobot();
-        robot.setAutoDelay(ROBOT_DELAY);
 
         robot.mouseMove(hLoc.x, hLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        Util.waitForIdle(robot);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        captureScreen("Img_1.png");
 
         robot.mouseMove(vLoc.x, vLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        Util.waitForIdle(robot);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        captureScreen("Img_2.png");
 
         clickAndBlink(robot, testLoc, false);
         robot.mouseMove(resizeLoc.x, resizeLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseMove(resizeLoc.x + 5, resizeLoc.y + 5);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        Util.waitForIdle(robot);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        captureScreen("Img_3.png");
 
         clickAndBlink(robot, testLoc, false);
-        return frameClicked == 2;
+        captureScreen("Img_4.png");
+        return (frameClicked == 2);
     }
 
     // this strange plumbing stuff is required due to "Standard Test Machinery" in base class
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String args[]) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(ROBOT_DELAY);
+
         instance = new ViewportOverlapping();
         OverlappingTestBase.doMain(args);
+        captureScreen("Img_5.png");
+    }
+
+    private static void captureScreen(String filename) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        try {
+            ImageIO.write(
+                    robot.createScreenCapture(new Rectangle(0, 0, screenSize.width, screenSize.height)),
+                    "png",
+                    new File(filename)
+            );
+        } catch (IOException ignored) {
+        }
     }
 }

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -132,13 +132,13 @@ public class ViewportOverlapping extends OverlappingTestBase {
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        captureScreen("Img_1.png", "png");
+        captureScreen("Img_1");
 
         robot.mouseMove(vLoc.x, vLoc.y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        captureScreen("Img_2.png", "png");
+        captureScreen("Img_2");
 
         clickAndBlink(robot, testLoc, false);
         robot.mouseMove(resizeLoc.x, resizeLoc.y);
@@ -146,30 +146,30 @@ public class ViewportOverlapping extends OverlappingTestBase {
         robot.mouseMove(resizeLoc.x + 5, resizeLoc.y + 5);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        captureScreen("Img_3.png", "png");
+        captureScreen("Img_3");
 
         clickAndBlink(robot, testLoc, false);
-        captureScreen("Img_4.png", "png");
+        captureScreen("Img_4");
         return (frameClicked == 2);
     }
 
     // this strange plumbing stuff is required due to "Standard Test Machinery" in base class
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         robot = new Robot();
         robot.setAutoDelay(ROBOT_DELAY);
 
         instance = new ViewportOverlapping();
         OverlappingTestBase.doMain(args);
-        captureScreen("Img_5.png", "png");
+        captureScreen("Img_5");
     }
 
-    private static void captureScreen(String filename, String format) {
+    private static void captureScreen(String filename) {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         try {
             ImageIO.write(
                     robot.createScreenCapture(new Rectangle(0, 0, screenSize.width, screenSize.height)),
-                    format,
-                    new File(filename)
+                    "png",
+                    new File(filename + ".png")
             );
         } catch (IOException ignored) {
         }

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,6 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
-import test.java.awt.regtesthelpers.Util;
 
 /**
  * AWT/Swing overlapping test for viewport

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -132,13 +132,13 @@ public class ViewportOverlapping extends OverlappingTestBase {
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        captureScreen("Img_1.png");
+        captureScreen("Img_1.png", "png");
 
         robot.mouseMove(vLoc.x, vLoc.y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        captureScreen("Img_2.png");
+        captureScreen("Img_2.png", "png");
 
         clickAndBlink(robot, testLoc, false);
         robot.mouseMove(resizeLoc.x, resizeLoc.y);
@@ -146,10 +146,10 @@ public class ViewportOverlapping extends OverlappingTestBase {
         robot.mouseMove(resizeLoc.x + 5, resizeLoc.y + 5);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        captureScreen("Img_3.png");
+        captureScreen("Img_3.png", "png");
 
         clickAndBlink(robot, testLoc, false);
-        captureScreen("Img_4.png");
+        captureScreen("Img_4.png", "png");
         return (frameClicked == 2);
     }
 
@@ -160,15 +160,15 @@ public class ViewportOverlapping extends OverlappingTestBase {
 
         instance = new ViewportOverlapping();
         OverlappingTestBase.doMain(args);
-        captureScreen("Img_5.png");
+        captureScreen("Img_5.png", "png");
     }
 
-    private static void captureScreen(String filename) {
+    private static void captureScreen(String filename, String format) {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         try {
             ImageIO.write(
                     robot.createScreenCapture(new Rectangle(0, 0, screenSize.width, screenSize.height)),
-                    "png",
+                    format,
                     new File(filename)
             );
         } catch (IOException ignored) {


### PR DESCRIPTION
ViewportOverlapping test was failing intermittently during CI runs on Win10 and Win11. 

Although this intermittent issue wasn't replicable when the individual test as well as the test group was run multiple times. Hence screenshot capture has been at various points in the test to aid debugging this intermittent issue, in case it should occur again. 

PS: Only relevant code in OverlappingTestBase has been cleaned-up as required by this test. There are other parts of the base class that require code clean-up  which is best if taken up as a separate issue as it has common code across many AWT_Mixing tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299052](https://bugs.openjdk.org/browse/JDK-8299052): ViewportOverlapping test fails intermittently on Win10 &amp; Win11 (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14289/head:pull/14289` \
`$ git checkout pull/14289`

Update a local copy of the PR: \
`$ git checkout pull/14289` \
`$ git pull https://git.openjdk.org/jdk.git pull/14289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14289`

View PR using the GUI difftool: \
`$ git pr show -t 14289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14289.diff">https://git.openjdk.org/jdk/pull/14289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14289#issuecomment-1574118884)