### PR TITLE
8309391: Remove non-failing tests from test/jdk/ProblemList-Virtual.txt

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -27,17 +27,15 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 ## Tests failing when main() is executed in additional vthread or in vthread instead of thread
 #
 
-com/sun/jdi/ExceptionEvents.java 8285422 generic-all
+com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
 com/sun/jdi/JdbStepTest.java 8285422 generic-all
 com/sun/jdi/JdbStopThreadTest.java 8285422 generic-all
 com/sun/jdi/JdbStopThreadidTest.java 8285422 generic-all
 com/sun/jdi/MethodEntryExitEvents.java 8285422 generic-all
 com/sun/jdi/MultiBreakpointsTest.java 8285422 generic-all
-com/sun/jdi/RedefineCrossStart.java 8285422 generic-all
-com/sun/jdi/RedefineG.java 8285422 generic-all
+com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
 com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java 8285422 generic-all
-com/sun/jdi/RedefineTTYLineNumber.java 8285422 generic-all
 com/sun/jdi/ReferrersTest.java 8285422 generic-all
 com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/StepTest.java 8285422 generic-all


### PR DESCRIPTION
The following two tests no longer seem to be failing with the virtual thread test factory:

com/sun/jdi/RedefineG.java 8285422 generic-all
com/sun/jdi/RedefineTTYLineNumber.java 8285422 generic-all

They can be removed from the problem list. I also updated a couple of entries to refer to existing CRs that give more specific reasons for why the tests are failing.

I tested locally using JTREG_TEST_THREAD_FACTORY=Virtual. I also have a mach5 tier5 job in progress that will do all the virtual thread testing.

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309391](https://bugs.openjdk.org/browse/JDK-8309391): Remove non-failing tests from test/jdk/ProblemList-Virtual.txt


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14290/head:pull/14290` \
`$ git checkout pull/14290`

Update a local copy of the PR: \
`$ git checkout pull/14290` \
`$ git pull https://git.openjdk.org/jdk.git pull/14290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14290`

View PR using the GUI difftool: \
`$ git pr show -t 14290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14290.diff">https://git.openjdk.org/jdk/pull/14290.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14290#issuecomment-1574389847)