### PR TITLE
8309334: ProcessTools.main() does not properly set thread names when using the virtual thread wrapper

### DIFF
--- a/test/hotspot/jtreg/runtime/BootstrapMethod/TestLambdaExceptionInInitializer.java
+++ b/test/hotspot/jtreg/runtime/BootstrapMethod/TestLambdaExceptionInInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class TestLambdaExceptionInInitializer {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("TestPkg.Lambda");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
-        output.shouldContain("Exception in thread \"main\" java.lang.ExceptionInInitializerError");
+        output.shouldMatch("Exception in thread \".+\" java.lang.ExceptionInInitializerError");
 
         output.shouldContain("Caused by: java.lang.NullPointerException");
         output.shouldContain("at TestPkg.LambdaMetafactory.throwNpe(LambdaMetafactory.java:34)");

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,9 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
-com/sun/jdi/JdbStepTest.java 8285422 generic-all
-com/sun/jdi/JdbStopThreadTest.java 8285422 generic-all
-com/sun/jdi/JdbStopThreadidTest.java 8285422 generic-all
 com/sun/jdi/MethodEntryExitEvents.java 8285422 generic-all
 com/sun/jdi/MultiBreakpointsTest.java 8285422 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -879,6 +879,8 @@ public final class ProcessTools {
         }
     }
 
+    public static final String OLD_MAIN_THREAD_NAME = "old-m-a-i-n";
+
     // ProcessTools as a wrapper
     // It executes method main in a separate virtual or platform thread
     public static void main(String[] args) throws Throwable {
@@ -894,7 +896,7 @@ public final class ProcessTools {
             // MainThreadGroup used just as a container for exceptions
             // when main is executed in virtual thread
             MainThreadGroup tg = new MainThreadGroup();
-            Thread vthread = startVirtualThread(() -> {
+            Thread vthread = createVirtualThread(() -> {
                     try {
                         mainMethod.invoke(null, new Object[] { classArgs });
                     } catch (InvocationTargetException e) {
@@ -903,6 +905,9 @@ public final class ProcessTools {
                         tg.uncaughtThrowable = error;
                     }
                 });
+            Thread.currentThread().setName(OLD_MAIN_THREAD_NAME);
+            vthread.setName("main");
+            vthread.start();
             vthread.join();
             if (tg.uncaughtThrowable != null) {
                 throw tg.uncaughtThrowable;
@@ -940,12 +945,12 @@ public final class ProcessTools {
         Throwable uncaughtThrowable = null;
     }
 
-    static Thread startVirtualThread(Runnable task) {
+    static Thread createVirtualThread(Runnable task) {
         try {
             Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
             Class<?> clazz = Class.forName("java.lang.Thread$Builder");
-            Method start = clazz.getMethod("start", Runnable.class);
-            return (Thread) start.invoke(builder, task);
+            Method unstarted = clazz.getMethod("unstarted", Runnable.class);
+            return (Thread) unstarted.invoke(builder, task);
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -896,7 +896,7 @@ public final class ProcessTools {
             // MainThreadGroup used just as a container for exceptions
             // when main is executed in virtual thread
             MainThreadGroup tg = new MainThreadGroup();
-            Thread vthread = createVirtualThread(() -> {
+            Thread vthread = Thread.ofVirtual().unstarted(() -> {
                     try {
                         mainMethod.invoke(null, new Object[] { classArgs });
                     } catch (InvocationTargetException e) {
@@ -943,18 +943,5 @@ public final class ProcessTools {
             uncaughtThrowable = e;
         }
         Throwable uncaughtThrowable = null;
-    }
-
-    static Thread createVirtualThread(Runnable task) {
-        try {
-            Object builder = Thread.class.getMethod("ofVirtual").invoke(null);
-            Class<?> clazz = Class.forName("java.lang.Thread$Builder");
-            Method unstarted = clazz.getMethod("unstarted", Runnable.class);
-            return (Thread) unstarted.invoke(builder, task);
-        } catch (RuntimeException | Error e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }


### PR DESCRIPTION
Normally when a virtual thread wrapper is used to run a test, the main thread is renamed to "old-m-a-i-n" and the new virtual thread that will act as the main thread is named "main". Neither is being done by `ProcessTools.main()`. This can cause problems for tests that expect the main thread that the test is running in to be called "main". It is instead left unnamed. This is causing the following 4 tests to fail:

com/sun/jdi/JdbMethodExitTest.java
com/sun/jdi/JdbStepTest.java
com/sun/jdi/JdbStopThreadTest.java
com/sun/jdi/JdbStopThreadidTest.java

These tests also fail due to [JDK-8309397](https://bugs.openjdk.org/browse/JDK-8309397), which will be fixed after this CR, and also com/sun/jdi/JdbMethodExitTest.java fails due to [JDK-8309396](https://bugs.openjdk.org/browse/JDK-8309396), which will also subsequently be fixed.

Note this fix messed up one runtime test. It was expecting an exception message to mention the "main" thread rather than "old-m-a-i-n". Loosening the exception message matching pattern a bit solved the problem.

Testing was done by running all of tier1 and tier5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309334](https://bugs.openjdk.org/browse/JDK-8309334): ProcessTools.main() does not properly set thread names when using the virtual thread wrapper


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [de5ca147](https://git.openjdk.org/jdk/pull/14292/files/de5ca1471a4df9c19290a2c5aa4eb3c16884faaf)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [de5ca147](https://git.openjdk.org/jdk/pull/14292/files/de5ca1471a4df9c19290a2c5aa4eb3c16884faaf)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14292/head:pull/14292` \
`$ git checkout pull/14292`

Update a local copy of the PR: \
`$ git checkout pull/14292` \
`$ git pull https://git.openjdk.org/jdk.git pull/14292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14292`

View PR using the GUI difftool: \
`$ git pr show -t 14292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14292.diff">https://git.openjdk.org/jdk/pull/14292.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14292#issuecomment-1574345059)