### PR TITLE
8309397: com/sun/jdi/JdbXXX tests fail due to not being run with -Djdk.trackAllThreads

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,9 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8285422 generic-all
 com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
-com/sun/jdi/JdbStepTest.java 8285422 generic-all
-com/sun/jdi/JdbStopThreadTest.java 8285422 generic-all
-com/sun/jdi/JdbStopThreadidTest.java 8285422 generic-all
 com/sun/jdi/MethodEntryExitEvents.java 8285422 generic-all
 com/sun/jdi/MultiBreakpointsTest.java 8285422 generic-all
 com/sun/jdi/RedefineCrossStart.java 8285422 generic-all

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -553,6 +553,7 @@ abstract public class TestScaffold extends TargetAdapter {
         String mainWrapper = System.getProperty("main.wrapper");
         if (mainWrapper != null && !argInfo.targetAppCommandLine.isEmpty()) {
             argInfo.targetVMArgs += "-Dmain.wrapper=" + mainWrapper;
+            argInfo.targetVMArgs += " -Djdk.trackAllThreads" ;
             argInfo.targetAppCommandLine = TestScaffold.class.getName() + ' '
                     + mainWrapper + ' ' + argInfo.targetAppCommandLine;
         } else if ("true".equals(System.getProperty("test.enable.preview"))) {


### PR DESCRIPTION
The com/sun/jdi/JdbXXX tests rely on the jdb "threads" command output to find the main thread. If it is a virtual thread, it will not be included in the "threads" output unless the debuggee is run with -Djdk.trackAllThreads, so we need to make sure to include this option when launching the debuggee. The following tests are impacted.

com/sun/jdi/JdbMethodExitTest.java
com/sun/jdi/JdbStepTest.java
com/sun/jdi/JdbStopThreadTest.java
com/sun/jdi/JdbStopThreadidTest.java

Note that all these tests also fail due to [JDK-8309334](https://bugs.openjdk.org/browse/JDK-8309334), which needs to be fixed first. Also JdbMethodExitTest.java will fail due to [JDK-8309396](https://bugs.openjdk.org/browse/JDK-8309396), which should be fixed after this CR.

I've tested with mach5 tier5 in a workspace that has integrated the various CRs mentioned. Once JDK-8309334 is fixed, before integrating this PR I'll first merge and verify that the 3 tests being removed from the problem list by this PR also pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309397](https://bugs.openjdk.org/browse/JDK-8309397): com/sun/jdi/JdbXXX tests fail due to not being run with -Djdk.trackAllThreads


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14293/head:pull/14293` \
`$ git checkout pull/14293`

Update a local copy of the PR: \
`$ git checkout pull/14293` \
`$ git pull https://git.openjdk.org/jdk.git pull/14293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14293`

View PR using the GUI difftool: \
`$ git pr show -t 14293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14293.diff">https://git.openjdk.org/jdk/pull/14293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14293#issuecomment-1574353207)