### PR TITLE
8309170: CDS archive heap is always relocated for larger heap

### DIFF
--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -551,7 +551,7 @@ void ReservedHeapSpace::initialize_compressed_heap(const size_t size, size_t ali
     const size_t class_space = align_up(CompressedClassSpaceSize, alignment);
     // For small heaps, save some space for compressed class pointer
     // space so it can be decoded with no base.
-    if (UseCompressedClassPointers && !UseSharedSpaces &&
+    if (UseCompressedClassPointers && !UseSharedSpaces && !DumpSharedSpaces &&
         OopEncodingHeapMax <= KlassEncodingMetaspaceMax &&
         (uint64_t)(aligned_heap_base_min_address + size + class_space) <= KlassEncodingMetaspaceMax) {
       zerobased_max = (char *)OopEncodingHeapMax - class_space;


### PR DESCRIPTION
Please review this simple fix for avoiding CDS heap data relocation during runtime.

Testing:
    Passed tiers 1-4. Tier5 (in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309170](https://bugs.openjdk.org/browse/JDK-8309170): CDS archive heap is always relocated for larger heap


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14295/head:pull/14295` \
`$ git checkout pull/14295`

Update a local copy of the PR: \
`$ git checkout pull/14295` \
`$ git pull https://git.openjdk.org/jdk.git pull/14295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14295`

View PR using the GUI difftool: \
`$ git pr show -t 14295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14295.diff">https://git.openjdk.org/jdk/pull/14295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14295#issuecomment-1574510714)