### PR TITLE
8309404: Parallel: Process class loader data graph in parallel in young gc

### DIFF
--- a/src/hotspot/share/gc/parallel/psClosure.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psClosure.inline.hpp
@@ -131,7 +131,7 @@ public:
       _oop_closure.set_scanned_cld(cld);
 
       // Clean the cld since we're going to scavenge all the metadata.
-      cld->oops_do(&_oop_closure, ClassLoaderData::_claim_none, /*clear_modified_oops*/true);
+      cld->oops_do(&_oop_closure, ClassLoaderData::_claim_strong, /*clear_modified_oops*/true);
 
       _oop_closure.set_scanned_cld(nullptr);
     }

--- a/src/hotspot/share/gc/parallel/psRootType.hpp
+++ b/src/hotspot/share/gc/parallel/psRootType.hpp
@@ -34,7 +34,6 @@ public:
   // The order reflects the order these roots are to be processed,
   // We do not want any holes in the enum as we enumerate these values by incrementing them.
   enum Value {
-    class_loader_data,
     code_cache,
     //"threads" are handled in parallel as a special case
     sentinel


### PR DESCRIPTION
Hi all,

This patch parallelizes the process of the class loader data graph in young gc.

The class `ClassLoaderData` has a field `_claim` to avoid applying oop closure more than once 
and the method `ClassLoaderData::oops_do` can check if the CLD had been claimed.
The parallel full gc has already used them in `MarkFromRootsTask::work` and `PSAdjustTask::work`.

But I don't have experience to test/verify the performance improvement of the GC.
If this patch needs such test data before integrating, please guide and help me here.

Thanks for the review and guidance.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309404](https://bugs.openjdk.org/browse/JDK-8309404): Parallel: Process class loader data graph in parallel in young gc (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14297/head:pull/14297` \
`$ git checkout pull/14297`

Update a local copy of the PR: \
`$ git checkout pull/14297` \
`$ git pull https://git.openjdk.org/jdk.git pull/14297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14297`

View PR using the GUI difftool: \
`$ git pr show -t 14297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14297.diff">https://git.openjdk.org/jdk/pull/14297.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14297#issuecomment-1574828584)