### PR TITLE
8309405: RISC-V: is_deopt may produce unaligned memory read

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -624,7 +624,7 @@ class NativeDeoptInstruction: public NativeInstruction {
 
   static bool is_deopt_at(address instr) {
     assert(instr != nullptr, "");
-    uint32_t value = *(uint32_t *) instr;
+    uint32_t value = Assembler::ld_instr(instr);
     // 0xc0201073 encodes CSRRW x0, instret, x0
     return value == 0xc0201073;
   }


### PR DESCRIPTION
Please review this simple fix, a continuation of JDK-8291550.

Doing some profiling for trp_lam event (misaligned load emulation) on fpga I've found some more misaligned loads, pretty rare but still happens.
Here, is_deopt directly dereferences memory address, but with RVC enabled, a single 4-byte intruction could be 2-bytes, but not 4-bytes aligned.
So is_deopt should use ld_instr to be on safe side.

Testing: tier1 on hifive clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309405](https://bugs.openjdk.org/browse/JDK-8309405): RISC-V: is_deopt may produce unaligned memory read


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14299/head:pull/14299` \
`$ git checkout pull/14299`

Update a local copy of the PR: \
`$ git checkout pull/14299` \
`$ git pull https://git.openjdk.org/jdk.git pull/14299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14299`

View PR using the GUI difftool: \
`$ git pr show -t 14299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14299.diff">https://git.openjdk.org/jdk/pull/14299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14299#issuecomment-1574918853)