### PR TITLE
8309409: Update HttpInputStreamTest and BodyProcessorInputStreamTest to use hg.openjdk.org

### DIFF
--- a/test/jdk/java/net/httpclient/BodyProcessorInputStreamTest.java
+++ b/test/jdk/java/net/httpclient/BodyProcessorInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class BodyProcessorInputStreamTest {
     public static void main(String[] args) throws Exception {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest
-            .newBuilder(new URI("http://hg.openjdk.java.net/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
+            .newBuilder(new URI("https://hg.openjdk.org/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
             .GET()
             .build();
 

--- a/test/jdk/java/net/httpclient/HttpInputStreamTest.java
+++ b/test/jdk/java/net/httpclient/HttpInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,7 +286,7 @@ public class HttpInputStreamTest {
     public static void main(String[] args) throws Exception {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest
-            .newBuilder(new URI("http://hg.openjdk.java.net/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
+            .newBuilder(new URI("https://hg.openjdk.org/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
             .GET()
             .build();
 


### PR DESCRIPTION
Can I please get a review of this test-only change which updates these manual tests to use `https://hg.openjdk.org` instead of `http://hg.openjdk.java.net`?

I've run these manual tests locally and they now pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309409](https://bugs.openjdk.org/browse/JDK-8309409): Update HttpInputStreamTest and BodyProcessorInputStreamTest to use hg.openjdk.org


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14302/head:pull/14302` \
`$ git checkout pull/14302`

Update a local copy of the PR: \
`$ git checkout pull/14302` \
`$ git pull https://git.openjdk.org/jdk.git pull/14302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14302`

View PR using the GUI difftool: \
`$ git pr show -t 14302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14302.diff">https://git.openjdk.org/jdk/pull/14302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14302#issuecomment-1575491249)