### PR TITLE
JDK-8309416: Misstatement in semantics of methods in javax.lang.model.ElementFilter

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,13 +45,13 @@ import javax.lang.model.element.ModuleElement.UsesDirective;
 /**
  * Filters for selecting just the elements of interest from a
  * collection of elements.  The returned sets and lists are new
- * collections and do use the argument as a backing store.  The
+ * collections that do <em>not</em> use the argument collection as a backing store.  The
  * methods in this class do not make any attempts to guard against
  * concurrent modifications of the arguments.  The returned sets and
- * lists are mutable but unsafe for concurrent access.  A returned set
- * has the same iteration order as the argument set to a method.
+ * lists are mutable and unsafe for concurrent access.  A returned set
+ * from a method has the same iteration order as the argument set to the method.
  *
- * <p>If iterables and sets containing {@code null} are passed as
+ * <p>If iterables or sets containing {@code null} are passed as
  * arguments to methods in this class, a {@code NullPointerException}
  * will be thrown.
  *


### PR DESCRIPTION
Correct typo in API and make related improvements.

CSR to review: https://bugs.openjdk.org/browse/JDK-8309417

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8309417](https://bugs.openjdk.org/browse/JDK-8309417) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8309416](https://bugs.openjdk.org/browse/JDK-8309416): Misstatement in semantics of methods in javax.lang.model.ElementFilter
 * [JDK-8309417](https://bugs.openjdk.org/browse/JDK-8309417): Misstatement in semantics of methods in javax.lang.model.ElementFilter (**CSR**)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14306/head:pull/14306` \
`$ git checkout pull/14306`

Update a local copy of the PR: \
`$ git checkout pull/14306` \
`$ git pull https://git.openjdk.org/jdk.git pull/14306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14306`

View PR using the GUI difftool: \
`$ git pr show -t 14306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14306.diff">https://git.openjdk.org/jdk/pull/14306.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14306#issuecomment-1575946154)