### PR TITLE
8309420: com/sun/jdi/StepTest.java fails with virtual thread wrapper

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -35,7 +35,6 @@ com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
 com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java 8285422 generic-all
 com/sun/jdi/ReferrersTest.java 8285422 generic-all
 com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
-com/sun/jdi/StepTest.java 8285422 generic-all
 com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all


### PR DESCRIPTION
The test has two issues. The first is that it assume that once the VMStart event has arrived and one "step into" is done, it will be in the main method of the debuggee. Once there, it determines the debuggee class name by looking at the classtype of topmost frame. The problems is when using virtual threads, it is actually in TestScaffold.main() at this point, so the wrong class name is gleaned from the frame. To fix this the test just saves away the debuggee class name, which is passed to the test as the 4th argument.

The other issue is that the test assumes once it gets to the debuggee go() method, there are only two frames on the stack. It's more like 16 when using virtual threads. The test needs to account for this by counting the number of frames when go() is entered rather than assuming it will be 2.

Tested locally with and without the wrapper and by running tier5 svc tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309420](https://bugs.openjdk.org/browse/JDK-8309420): com/sun/jdi/StepTest.java fails with virtual thread wrapper (**Bug** - `"4"`)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14307/head:pull/14307` \
`$ git checkout pull/14307`

Update a local copy of the PR: \
`$ git checkout pull/14307` \
`$ git pull https://git.openjdk.org/jdk.git pull/14307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14307`

View PR using the GUI difftool: \
`$ git pr show -t 14307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14307.diff">https://git.openjdk.org/jdk/pull/14307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14307#issuecomment-1576014661)