### PR TITLE
8309419: RISC-V: Relax register constraint for AddReductionVF & AddReductionVD nodes

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1371,32 +1371,32 @@ instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct reduce_addF(fRegF src1_dst, vReg src2, vReg tmp) %{
-  match(Set src1_dst (AddReductionVF src1_dst src2));
+instruct reduce_addF(fRegF dst, fRegF src1, vReg src2, vReg tmp) %{
+  match(Set dst (AddReductionVF src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addF $src1_dst, $src1_dst, $src2\t# KILL $tmp" %}
+  format %{ "reduce_addF $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
-    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
+    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
-    __ vfmv_f_s($src1_dst$$FloatRegister, as_VectorRegister($tmp$$reg));
+    __ vfmv_f_s($dst$$FloatRegister, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
-  match(Set src1_dst (AddReductionVD src1_dst src2));
+instruct reduce_addD(fRegD dst, fRegD src1, vReg src2, vReg tmp) %{
+  match(Set dst (AddReductionVD src1 src2));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addD $src1_dst, $src1_dst, $src2\t# KILL $tmp" %}
+  format %{ "reduce_addD $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
-    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
+    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
-    __ vfmv_f_s($src1_dst$$FloatRegister, as_VectorRegister($tmp$$reg));
+    __ vfmv_f_s($dst$$FloatRegister, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1437,32 +1437,32 @@ instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   ins_pipe(pipe_slow);
 %}
 
-instruct reduce_addF_masked(fRegF src1_dst, vReg src2, vRegMask_V0 v0, vReg tmp) %{
-  match(Set src1_dst (AddReductionVF (Binary src1_dst src2) v0));
+instruct reduce_addF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+  match(Set dst (AddReductionVF (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addF_masked $src1_dst, $src1_dst, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_addF_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
-    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
+    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg), Assembler::v0_t);
-    __ vfmv_f_s($src1_dst$$FloatRegister, as_VectorRegister($tmp$$reg));
+    __ vfmv_f_s($dst$$FloatRegister, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct reduce_addD_masked(fRegD src1_dst, vReg src2, vRegMask_V0 v0, vReg tmp) %{
-  match(Set src1_dst (AddReductionVD (Binary src1_dst src2) v0));
+instruct reduce_addD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+  match(Set dst (AddReductionVD (Binary src1 src2) v0));
   effect(TEMP tmp);
   ins_cost(VEC_COST);
-  format %{ "reduce_addD_masked $src1_dst, $src1_dst, $src2, $v0\t# KILL $tmp" %}
+  format %{ "reduce_addD_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
-    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1_dst$$FloatRegister);
+    __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg), Assembler::v0_t);
-    __ vfmv_f_s($src1_dst$$FloatRegister, as_VectorRegister($tmp$$reg));
+    __ vfmv_f_s($dst$$FloatRegister, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
Hi, We note that in the C2 AddReductionVF & AddReductionVD node, the src1 and dst registers are constrained to be the same register, which is not required, so we relax the register constraint for AddReductionVF/AddReductionVD in the C2 node. For reference, other CPUs, such as x86 and arm neon, do not need the same registers either[1]. arm64 sve constrains them to be the same registers because of the use of the FADDA instruction[2], which is floating point adding all active channels of SIMD&FP scalar sources and vector sources and placing the result in SIMD&FP scalar source registers. So for arm64 sve, it is required that that the two registers be the same.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/aarch64_vector.ad#L2897-L2907 
[2] https://developer.arm.com/documentation/ddi0596/2020-12/SVE-Instructions/FADDA--Floating-point-add-strictly-ordered-reduction--accumulating-in-scalar-

### AddReductionVF/AddReductionVD
We can use Float256VectorTests.java Double256VectorTests.java  to
emit these nodes and the compilation log is as follows:
#### AddReductionVF
Before this patch:
```
0f6     B15: #	out( B61 B16 ) &lt;- in( B14 )  Freq: 55.8033
0f6     # castII of R19, #@castII
0f6     addw  R10, R19, zr	#@convI2L_reg_reg
0fa     slli  R10, R10, (#2 &amp; 0x3f)	#@lShiftL_reg_imm
0fc     add R11, R31, R10	# ptr, #@addP_reg_reg
100     addi  R11, R11, #16	# ptr, #@addP_reg_imm
102     loadV V1, [R11]	# vector (rvv)
10a     spill F0 -&gt; F1	# spill size = 32
10e     reduce_addF F1, F1, V1	# KILL V2
11e     bgeu  R19, R29, B61	#@cmpU_branch  P=0.000001 C=-1.000000
```
After this patch(Saving a spill operation):
```
0f6     B15: #	out( B61 B16 ) &lt;- in( B14 )  Freq: 55.8033
0f6     # castII of R19, #@castII
0f6     addw  R10, R19, zr	#@convI2L_reg_reg
0fa     slli  R10, R10, (#2 &amp; 0x3f)	#@lShiftL_reg_imm
0fc     add R11, R31, R10	# ptr, #@addP_reg_reg
100     addi  R11, R11, #16	# ptr, #@addP_reg_imm
102     loadV V1, [R11]	# vector (rvv)
10a     reduce_addF F1, F0, V1	# KILL V2
11a     bgeu  R19, R29, B61	#@cmpU_branch  P=0.000001 C=-1.000000
```
#### AddReductionVD
Before this patch:
```
0f4     B15: #	out( B61 B16 ) &lt;- in( B14 )  Freq: 55.8033
0f4     # castII of R9, #@castII
0f4     addw  R10, R9, zr	#@convI2L_reg_reg
0f8     slli  R10, R10, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
0fa     add R11, R30, R10	# ptr, #@addP_reg_reg
0fe     addi  R11, R11, #16	# ptr, #@addP_reg_imm
100     loadV V1, [R11]	# vector (rvv)
108     spill F0 -&gt; F1	# spill size = 64
10c     reduce_addD F1, F1, V1	# KILL V2
11c     bgeu  R9, R31, B61	#@cmpU_branch  P=0.000001 C=-1.000000
```
After this patch(Saving a spill operation):
```
0f4     B15: #	out( B61 B16 ) &lt;- in( B14 )  Freq: 55.8033
0f4     # castII of R9, #@castII
0f4     addw  R10, R9, zr	#@convI2L_reg_reg
0f8     slli  R10, R10, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
0fa     add R11, R30, R10	# ptr, #@addP_reg_reg
0fe     addi  R11, R11, #16	# ptr, #@addP_reg_imm
100     loadV V1, [R11]	# vector (rvv)
108     reduce_addD F1, F0, V1	# KILL V2
118     bgeu  R9, R31, B61	#@cmpU_branch  P=0.000001 C=-1.000000
```

- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309419](https://bugs.openjdk.org/browse/JDK-8309419): RISC-V: Relax register constraint for AddReductionVF &amp; AddReductionVD nodes


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14308/head:pull/14308` \
`$ git checkout pull/14308`

Update a local copy of the PR: \
`$ git checkout pull/14308` \
`$ git pull https://git.openjdk.org/jdk.git pull/14308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14308`

View PR using the GUI difftool: \
`$ git pr show -t 14308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14308.diff">https://git.openjdk.org/jdk/pull/14308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14308#issuecomment-1576111979)