### PR TITLE
8308537: Remove BreakAtNode

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -133,9 +133,6 @@
   notproduct(bool, OptoBreakpointOSR, false,                                \
           "insert breakpoint at osr method entry")                          \
                                                                             \
-  notproduct(uint64_t, BreakAtNode, 0,                                      \
-          "Break at construction of this Node (either _idx or _debug_idx)") \
-                                                                            \
   notproduct(bool, OptoBreakpointC2R, false,                                \
           "insert breakpoint at runtime stub entry")                        \
                                                                             \

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2472,13 +2472,6 @@ void Node::dump_orig(outputStream *st, bool print_key) const {
 
 void Node::set_debug_orig(Node* orig) {
   _debug_orig = orig;
-  if (not_a_node(orig))  orig = nullptr;
-  int trip = 10;
-  while (orig != nullptr) {
-    orig = orig->debug_orig();
-    if (not_a_node(orig))  orig = nullptr;
-    if (trip-- <= 0)  break;
-  }
 }
 #endif //ASSERT
 

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -77,10 +77,6 @@ void Node::verify_construction() {
     // Only check assert during parsing and optimization phase. Skip it while generating code.
     assert(C->live_nodes() <= C->max_node_limit(), "Live Node limit exceeded limit");
   }
-  if (BreakAtNode != 0 && (_debug_idx == BreakAtNode || (uint64_t)_idx == BreakAtNode)) {
-    tty->print_cr("BreakAtNode: _idx=%d _debug_idx=" UINT64_FORMAT, _idx, _debug_idx);
-    BREAKPOINT;
-  }
 #if OPTO_DU_ITERATOR_ASSERT
   _last_del = nullptr;
   _del_tick = 0;
@@ -2476,15 +2472,9 @@ void Node::dump_orig(outputStream *st, bool print_key) const {
 
 void Node::set_debug_orig(Node* orig) {
   _debug_orig = orig;
-  if (BreakAtNode == 0)  return;
   if (not_a_node(orig))  orig = nullptr;
   int trip = 10;
   while (orig != nullptr) {
-    if (orig->debug_idx() == BreakAtNode || (uintx)orig->_idx == BreakAtNode) {
-      tty->print_cr("BreakAtNode: _idx=%d _debug_idx=" UINT64_FORMAT " orig._idx=%d orig._debug_idx=" UINT64_FORMAT,
-                    this->_idx, this->debug_idx(), orig->_idx, orig->debug_idx());
-      BREAKPOINT;
-    }
     orig = orig->debug_orig();
     if (not_a_node(orig))  orig = nullptr;
     if (trip-- <= 0)  break;


### PR DESCRIPTION
The BreakAtNode flag was unused as its utility is now insignificant with the use of "rr" in practice. See the following discussion: https://github.com/openjdk/jdk/pull/13767#issuecomment-1541805032. I removed the BreakAtNode flag and the related parts in the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308537](https://bugs.openjdk.org/browse/JDK-8308537): Remove BreakAtNode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14311/head:pull/14311` \
`$ git checkout pull/14311`

Update a local copy of the PR: \
`$ git checkout pull/14311` \
`$ git pull https://git.openjdk.org/jdk.git pull/14311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14311`

View PR using the GUI difftool: \
`$ git pr show -t 14311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14311.diff">https://git.openjdk.org/jdk/pull/14311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14311#issuecomment-1578188365)