### PR TITLE
JDK-8309471: Limit key characters in static index pages

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -356,7 +356,7 @@ public class IndexWriter extends HtmlDocletWriter {
         content.add(new HtmlTree(TagName.BR));
         List<Content> pageLinks = Stream.of(IndexItem.Category.values())
                 .flatMap(c -> mainIndex.getItems(c).stream())
-                .filter(i -> !(i.isElementItem() || i.isTagItem()))
+                .filter(i -> !(i.isElementItem() || i.isTagItem() || i.isSectionItem()))
                 .sorted((i1,i2)-> utils.compareStrings(i1.getLabel(), i2.getLabel()))
                 .map(i -> links.createLink(pathToRoot.resolve(i.getUrl()),
                         contents.getNonBreakString(i.getLabel())))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -356,7 +356,7 @@ public class IndexWriter extends HtmlDocletWriter {
         content.add(new HtmlTree(TagName.BR));
         List<Content> pageLinks = Stream.of(IndexItem.Category.values())
                 .flatMap(c -> mainIndex.getItems(c).stream())
-                .filter(i -> !(i.isElementItem() || i.isTagItem() || i.isSectionItem()))
+                .filter(i -> !(i.isElementItem() || i.isTagItem()))
                 .sorted((i1,i2)-> utils.compareStrings(i1.getLabel(), i2.getLabel()))
                 .map(i -> links.createLink(pathToRoot.resolve(i.getUrl()),
                         contents.getNonBreakString(i.getLabel())))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -300,7 +300,14 @@ public class IndexBuilder {
     }
 
     private static Character keyCharacter(String s) {
-        return s.isEmpty() ? '*' : Character.toUpperCase(s.charAt(0));
+        // Use first valid java identifier start character as key,
+        // or '*' for strings that do not contain one.
+        for (int i = 0; i < s.length(); i++) {
+            if (Character.isJavaIdentifierStart(s.charAt(i))) {
+                return Character.toUpperCase(s.charAt(i));
+            }
+        }
+        return '*';
     }
 
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -414,14 +414,7 @@ public class IndexItem {
      * @return {@code true} if this index is for a tag in a doc comment
      */
     public boolean isTagItem() {
-        return getDocTree() != null && getDocTree().getKind().tagName != null;
-    }
-
-    /**
-     * {@return {@code true} if this index item is for a HTML heading/section in a doc comment}
-     */
-    public boolean isSectionItem() {
-        return getDocTree() != null && getDocTree().getKind() == DocTree.Kind.START_ELEMENT;
+        return getDocTree() != null;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -414,7 +414,14 @@ public class IndexItem {
      * @return {@code true} if this index is for a tag in a doc comment
      */
     public boolean isTagItem() {
-        return getDocTree() != null;
+        return getDocTree() != null && getDocTree().getKind().tagName != null;
+    }
+
+    /**
+     * {@return {@code true} if this index item is for a HTML heading/section in a doc comment}
+     */
+    public boolean isSectionItem() {
+        return getDocTree() != null && getDocTree().getKind() == DocTree.Kind.START_ELEMENT;
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -55,41 +55,41 @@ public class TestAutoHeaderId extends JavadocTester {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
                 """
-                package p;
-                /**
-                 * First sentence.
-                 *
-                 * <h2>First Header</h2>
-                 *
-                 * <h3 id="fixed-id-1">Header with ID</h3>
-                 *
-                 * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
-                 *
-                 * <h5>{@code Embedded Code Tag}</h5>
-                 *
-                 * <h6>{@linkplain C Embedded Link Tag}</h6>
-                 *
-                 * <h3>Duplicate Text</h3>
-                 *
-                 * <h4>Duplicate Text</h4>
-                 *
-                 * <h2>Extra (#*!. chars</h2>
-                 *
-                 * <h3 style="color: red;" class="some-class">Other attributes</h3>
-                 *
-                 * <h4></h4>
-                 *
-                 * <h2>  Multi-line
-                 *       heading   with extra
-                 *                 whitespace</h2>
-                 *
-                 * Last sentence.
-                 */
-                public class C {
-                    /** Comment. */
-                    C() { }
-                }
-                """);
+                        package p;
+                        /**
+                         * First sentence.
+                         *
+                         * <h2>First Header</h2>
+                         *
+                         * <h3 id="fixed-id-1">Header with ID</h3>
+                         *
+                         * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
+                         *
+                         * <h5>{@code Embedded Code Tag}</h5>
+                         *
+                         * <h6>{@linkplain C Embedded Link Tag}</h6>
+                         *
+                         * <h3>Duplicate Text</h3>
+                         *
+                         * <h4>Duplicate Text</h4>
+                         *
+                         * <h2>Extra (#*!. chars</h2>
+                         *
+                         * <h3 style="color: red;" class="some-class">Other attributes</h3>
+                         *
+                         * <h4></h4>
+                         *
+                         * <h2>  Multi-line
+                         *       heading   with extra
+                         *                 whitespace</h2>
+                         *
+                         * Last sentence.
+                         */
+                        public class C {
+                            /** Comment. */
+                            C() { }
+                        }
+                        """);
 
         javadoc("-d", base.resolve("api").toString(),
                 "-sourcepath", src.toString(),
@@ -102,39 +102,39 @@ public class TestAutoHeaderId extends JavadocTester {
     private void checkIds() {
         checkOutput("p/C.html", true,
                 """
-                <h2 id="first-header-heading">First Header</h2>
-                """,
+                    <h2 id="first-header-heading">First Header</h2>
+                    """,
                 """
-                <h3 id="fixed-id-1">Header with ID</h3>
-                """,
+                    <h3 id="fixed-id-1">Header with ID</h3>
+                    """,
                 """
-                <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
-                """,
+                    <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
+                    """,
                 """
-                <h5 id="embedded-code-tag-heading"><code>Embedded Code Tag</code></h5>
-                """,
+                    <h5 id="embedded-code-tag-heading"><code>Embedded Code Tag</code></h5>
+                    """,
                 """
-                <h6 id="embedded-link-tag-heading"><a href="C.html" title="class in p">Embedded Link Tag</a></h6>
-                """,
+                    <h6 id="embedded-link-tag-heading"><a href="C.html" title="class in p">Embedded Link Tag</a></h6>
+                    """,
                 """
-                <h3 id="duplicate-text-heading">Duplicate Text</h3>
-                """,
+                    <h3 id="duplicate-text-heading">Duplicate Text</h3>
+                    """,
                 """
-                <h4 id="duplicate-text-heading1">Duplicate Text</h4>
-                """,
+                    <h4 id="duplicate-text-heading1">Duplicate Text</h4>
+                    """,
                 """
-                <h2 id="extra-chars-heading">Extra (#*!. chars</h2>
-                """,
+                    <h2 id="extra-chars-heading">Extra (#*!. chars</h2>
+                    """,
                 """
-                <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
-                """,
+                    <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
+                    """,
                 """
-                <h4 id="-heading"></h4>
-                """,
+                    <h4 id="-heading"></h4>
+                    """,
                 """
-                <h2 id="multi-line-heading-with-extra-whitespace-heading">  Multi-line
-                       heading   with extra
-                                 whitespace</h2>""");
+                    <h2 id="multi-line-heading-with-extra-whitespace-heading">  Multi-line
+                           heading   with extra
+                                     whitespace</h2>""");
     }
 
     private void checkSearchIndex() {

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -59,9 +59,9 @@ public class TestAutoHeaderId extends JavadocTester {
                         /**
                          * First sentence.
                          *
-                         * <h2>First Header</h2>
+                         * <h2>1.0 First Header</h2>
                          *
-                         * <h3 id="fixed-id-1">Header with ID</h3>
+                         * <h3 id="fixed-id-1">1.1 Header with ID</h3>
                          *
                          * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
                          *
@@ -73,13 +73,13 @@ public class TestAutoHeaderId extends JavadocTester {
                          *
                          * <h4>Duplicate Text</h4>
                          *
-                         * <h2>Extra (#*!. chars</h2>
+                         * <h2>2.0 Extra (#*!. chars</h2>
                          *
                          * <h3 style="color: red;" class="some-class">Other attributes</h3>
                          *
                          * <h4></h4>
                          *
-                         * <h2>  Multi-line
+                         * <h2> 3.0 Multi-line
                          *       heading   with extra
                          *                 whitespace</h2>
                          *
@@ -102,10 +102,10 @@ public class TestAutoHeaderId extends JavadocTester {
     private void checkIds() {
         checkOutput("p/C.html", true,
                 """
-                    <h2 id="first-header-heading">First Header</h2>
+                    <h2 id="1-0-first-header-heading">1.0 First Header</h2>
                     """,
                 """
-                    <h3 id="fixed-id-1">Header with ID</h3>
+                    <h3 id="fixed-id-1">1.1 Header with ID</h3>
                     """,
                 """
                     <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
@@ -123,7 +123,7 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4 id="duplicate-text-heading1">Duplicate Text</h4>
                     """,
                 """
-                    <h2 id="extra-chars-heading">Extra (#*!. chars</h2>
+                    <h2 id="2-0-extra-chars-heading">2.0 Extra (#*!. chars</h2>
                     """,
                 """
                     <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
@@ -132,7 +132,7 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4 id="-heading"></h4>
                     """,
                 """
-                    <h2 id="multi-line-heading-with-extra-whitespace-heading">  Multi-line
+                    <h2 id="3-0-multi-line-heading-with-extra-whitespace-heading"> 3.0 Multi-line
                            heading   with extra
                                      whitespace</h2>""");
     }
@@ -150,21 +150,87 @@ public class TestAutoHeaderId extends JavadocTester {
                 """
                     {"l":"Embedded Link Tag","h":"class p.C","d":"Section","u":"p/C.html#embedded-link-tag-heading"}""",
                 """
-                    {"l":"Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#extra-chars-heading"}""",
+                    {"l":"2.0 Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#2-0-extra-chars-heading"}""",
                 """
-                    {"l":"First Header","h":"class p.C","d":"Section","u":"p/C.html#first-header-heading"}""",
+                    {"l":"1.0 First Header","h":"class p.C","d":"Section","u":"p/C.html#1-0-first-header-heading"}""",
                 """
-                    {"l":"Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
+                    {"l":"1.1 Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
                 """
-                    {"l":"Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
-                    #multi-line-heading-with-extra-whitespace-heading"}""",
+                    {"l":"3.0 Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
+                    #3-0-multi-line-heading-with-extra-whitespace-heading"}""",
                 """
                     {"l":"Other attributes","h":"class p.C","d":"Section","u":"p/C.html#other-attributes-heading"}""");
     }
 
     private void checkHtmlIndex() {
         // Make sure section links are not included in static index pages
-        checkOutput("index-all.html", false,
-                "Header", "heading", "Duplicate", "Embedded");
+        checkOutput("index-all.html", true,
+                """
+                    <a href="#I:C">C</a>&nbsp;<a href="#I:D">D</a>&nbsp;<a href="#I:E">E</a>&nbsp;<a href="#I\
+                    :F">F</a>&nbsp;<a href="#I:H">H</a>&nbsp;<a href="#I:M">M</a>&nbsp;<a href="#I:O">O</a>&n\
+                    bsp;<a href="#I:P">P</a>&nbsp;<br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;a\
+                    nd&nbsp;Interfaces</a><span class="vertical-separator">|</span><a href="allpackages-index\
+                    .html">All&nbsp;Packages</a>
+                    <h2 class="title" id="I:C">C</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html" class="type-name-link" title="class in p">C</a> - Class in <a href\
+                    ="p/package-summary.html">p</a></dt>
+                    <dd>
+                    <div class="block">First sentence.</div>
+                    </dd>
+                    </dl>
+                    <h2 class="title" id="I:D">D</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#duplicate-text-heading" class="search-tag-link">Duplicate Text</a> \
+                    - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#duplicate-text-heading1" class="search-tag-link">Duplicate Text</a>\
+                     - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:E">E</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#2-0-extra-chars-heading" class="search-tag-link">2.0 Extra (#*!. ch\
+                    ars</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#fixed-id-2" class="search-tag-link">Embedded A-Tag with ID</a> - Se\
+                    arch tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#embedded-code-tag-heading" class="search-tag-link">Embedded Code Ta\
+                    g</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#embedded-link-tag-heading" class="search-tag-link">Embedded Link Ta\
+                    g</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:F">F</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#1-0-first-header-heading" class="search-tag-link">1.0 First Header<\
+                    /a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:H">H</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#fixed-id-1" class="search-tag-link">1.1 Header with ID</a> - Search\
+                     tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:M">M</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#3-0-multi-line-heading-with-extra-whitespace-heading" class="search\
+                    -tag-link">3.0 Multi-line heading with extra whitespace</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:O">O</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#other-attributes-heading" class="search-tag-link">Other attributes<\
+                    /a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:P">P</h2>
+                    <dl class="index">
+                    <dt><a href="p/package-summary.html">p</a> - package p</dt>
+                    <dd>&nbsp;</dd>
+                    </dl>""");
     }
 }


### PR DESCRIPTION
Please review a simple change to avoid adding section index items (added in JDK-8286470) from appearing in the static index pages where the tend to cause trouble. 

The change is implemented by making `IndexItem.isTagItem()` behave true to its specification again and only return `true` if it actually represents a JavaDoc tag, and add a new `IndexItem.isSectionItem()` method for the new section index items. The new method is used to make sure section links are not listed in the index pages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309471](https://bugs.openjdk.org/browse/JDK-8309471): Limit key characters in static index pages (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14312/head:pull/14312` \
`$ git checkout pull/14312`

Update a local copy of the PR: \
`$ git checkout pull/14312` \
`$ git pull https://git.openjdk.org/jdk.git pull/14312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14312`

View PR using the GUI difftool: \
`$ git pr show -t 14312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14312.diff">https://git.openjdk.org/jdk/pull/14312.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14312#issuecomment-1576857895)