### PR TITLE
8309472: IGV: Add dump_igv(custom_name) for improved debugging

### DIFF
--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -661,6 +661,12 @@ class Compile : public Phase {
   void print_method(CompilerPhaseType cpt, int level, Node* n = nullptr);
 
 #ifndef PRODUCT
+  void dump_igv(const char* graph_name, int level = 3) {
+    if (should_print_igv(level)) {
+      _igv_printer->print_method(graph_name, level);
+    }
+  }
+
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);
   void igv_print_method_to_network(const char* phase_name = "Debug");
   static IdealGraphPrinter* debug_file_printer() { return _debug_file_printer; }


### PR DESCRIPTION
When debugging, I often add multiple IR dumps throughout the code to capture different states. To do that, I'm just re-using various `PHASE_XYZ` `CompilerPhaseType` enum values:
```
Compile::current()->print_method(PHASE_END, 3);
```
But this becomes confusing when using multiple such enum values and trying to remember what they actually mean. To overcome that (and to avoid creating new enum values each time), I suggest to introduce a new `dump_igv(custom_name)` method where `custom_name` can be an arbitrary string. Then we can use the following when debugging:
```
Compile::current()->dump_igv("foo");
Compile::current()->dump_igv("bar");
```
Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309472](https://bugs.openjdk.org/browse/JDK-8309472): IGV: Add dump_igv(custom_name) for improved debugging (**Enhancement** - `"4"`)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14313/head:pull/14313` \
`$ git checkout pull/14313`

Update a local copy of the PR: \
`$ git checkout pull/14313` \
`$ git pull https://git.openjdk.org/jdk.git pull/14313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14313`

View PR using the GUI difftool: \
`$ git pr show -t 14313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14313.diff">https://git.openjdk.org/jdk/pull/14313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14313#issuecomment-1576904923)