### PR TITLE
8309498: [JVMCI] race in CallSiteTargetValue recording

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotObjectConstantImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotObjectConstantImpl.java
@@ -88,13 +88,15 @@ abstract class HotSpotObjectConstantImpl implements HotSpotObjectConstant {
         if (runtime().getCallSite().isInstance(this)) {
             // For ConstantCallSites, we need to read "isFrozen" before reading "target"
             // isFullyInitializedConstantCallSite() reads "isFrozen"
-            if (!isFullyInitializedConstantCallSite()) {
-                if (assumptions == null) {
-                    return null;
-                }
-                assumptions.record(new Assumptions.CallSiteTargetValue(this, readTarget()));
+            if (isFullyInitializedConstantCallSite()) {
+                return readTarget();
             }
-            return readTarget();
+            if (assumptions == null) {
+                return null;
+            }
+            HotSpotObjectConstantImpl result = readTarget();
+            assumptions.record(new Assumptions.CallSiteTargetValue(this, result));
+            return result;
         }
         return null;
     }


### PR DESCRIPTION
intermittent failures with Graal on ContinuousCallSiteTargetChange showed that when constructing the CallSiteTargetValue Assumption we read the value twice so the dependency and the value in the program might be different leading to incorrect execution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309498](https://bugs.openjdk.org/browse/JDK-8309498): [JVMCI] race in CallSiteTargetValue recording (**Bug** - `"3"`)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14315/head:pull/14315` \
`$ git checkout pull/14315`

Update a local copy of the PR: \
`$ git checkout pull/14315` \
`$ git pull https://git.openjdk.org/jdk.git pull/14315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14315`

View PR using the GUI difftool: \
`$ git pr show -t 14315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14315.diff">https://git.openjdk.org/jdk/pull/14315.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14315#issuecomment-1577192791)