### PR TITLE
8309501: Remove workaround in bin/idea.sh for non standard JVMCI file layout

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -193,17 +193,7 @@ for root in $MODULE_ROOTS; do
       root=`wslpath -am $root`
     fi
 
-    VM_CI="jdk.internal.vm.ci/share/classes"
-    VM_COMPILER="src/jdk.internal.vm.compiler/share/classes"
-    if test "${root#*$VM_CI}" != "$root" || test "${root#*$VM_COMPILER}" != "$root"; then
-        for subdir in "$root"/*; do
-            if [ -d "$subdir" ]; then
-                SOURCES=$SOURCES" $SOURCE_PREFIX""$subdir"/src"$SOURCE_POSTFIX"
-            fi
-        done
-    else
-        SOURCES=$SOURCES" $SOURCE_PREFIX""$root""$SOURCE_POSTFIX"
-    fi
+    SOURCES=$SOURCES" $SOURCE_PREFIX""$root""$SOURCE_POSTFIX"
 done
 
 add_replacement "###SOURCE_ROOTS###" "$SOURCES"


### PR DESCRIPTION
This allows bin/idea.sh to properly see the JVMCI files again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309501](https://bugs.openjdk.org/browse/JDK-8309501): Remove workaround in bin/idea.sh for non standard JVMCI file layout


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14318/head:pull/14318` \
`$ git checkout pull/14318`

Update a local copy of the PR: \
`$ git checkout pull/14318` \
`$ git pull https://git.openjdk.org/jdk.git pull/14318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14318`

View PR using the GUI difftool: \
`$ git pr show -t 14318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14318.diff">https://git.openjdk.org/jdk/pull/14318.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14318#issuecomment-1577348644)