### PR TITLE
8309505

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,7 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
-com/sun/jdi/MethodEntryExitEvents.java 8285422 generic-all
 com/sun/jdi/MultiBreakpointsTest.java 8285422 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
 com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java 8285422 generic-all

--- a/test/jdk/com/sun/jdi/MethodEntryExitEvents.java
+++ b/test/jdk/com/sun/jdi/MethodEntryExitEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,10 +95,10 @@ public class MethodEntryExitEvents extends TestScaffold {
     boolean finishedCounting = false;
 
     /*
-     * Enter main() , then t2.<init>, then sayHello[1,2,3,4,5] 15 times 3 loops,
+     * main() is already entered, so add t2.<init>, then sayHello[1,2,3,4,5] 15 times 3 loops,
      * then loopComplete()
      */
-    final int expectedEntryCount = 1 + 1 + (15 * 3) + 1;
+    final int expectedEntryCount = 1 + (15 * 3) + 1;
     int methodEntryCount = 0;
 
     /*
@@ -220,8 +220,9 @@ public class MethodEntryExitEvents extends TestScaffold {
         waitForVMStart();
 
         // Determine main thread
-        ClassPrepareEvent e = resumeToPrepareOf("MethodEntryExitEventsDebugee");
-        mainThread = e.thread();
+        BreakpointEvent bpe = resumeTo("MethodEntryExitEventsDebugee",
+                                       "main", "([Ljava/lang/String;)V");;
+        mainThread = bpe.thread();
 
         try {
 


### PR DESCRIPTION
The test fails because it tries to determine the main debuggee thread by allowing it run until the debuggee class is loaded (it waits for the ClassPrepareEvent). Normally this would be done on the main debuggee thread. However, when using virtual threads, the main thread has yet to spawn the virtual thread to run the test on. The test is fixed by instead just waiting until the debuggee main method is entered.