### PR TITLE
8309506

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -30,7 +30,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
 com/sun/jdi/MethodEntryExitEvents.java 8285422 generic-all
-com/sun/jdi/MultiBreakpointsTest.java 8285422 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
 com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java 8285422 generic-all
 com/sun/jdi/ReferrersTest.java 8285422 generic-all

--- a/test/jdk/com/sun/jdi/MultiBreakpointsTest.java
+++ b/test/jdk/com/sun/jdi/MultiBreakpointsTest.java
@@ -60,8 +60,16 @@ import java.text.*;
 class MultiBreakpointsTarg {
 
     MultiBreakpointsTarg(int numThreads, int numHits) {
+        Thread threads[] = new Thread[numThreads];
         for (int ii = 0; ii < numThreads; ii++) {
-            console(ii, numHits);
+            threads[ii] = console(ii, numHits);
+        }
+        for (int ii = 0; ii < numThreads; ii++) {
+            try {
+                threads[ii].join();
+            } catch (InterruptedException ie) {
+                throw new RuntimeException(ie);
+            }
         }
     }
 
@@ -127,7 +135,7 @@ class MultiBreakpointsTarg {
     void bkpt28() {}
     void bkpt29() {}
 
-    void console(final int num, final int nhits) {
+    Thread console(final int num, final int nhits) {
         final InputStreamReader isr = new InputStreamReader(System.in);
         final BufferedReader    br  = new BufferedReader(isr);
 
@@ -135,8 +143,7 @@ class MultiBreakpointsTarg {
         //
         //final String threadName = "DebuggeeThread: " + num;
         final String threadName = "" + num;
-        Thread thrd = new Thread( threadName ) {
-                public void run() {
+        Thread thrd = TestScaffold.newThread(() -> {
                     synchronized( isr ) {
                         boolean done = false;
                         try {
@@ -188,9 +195,11 @@ class MultiBreakpointsTarg {
                         }
                     }
                 }
-            };
+            );
+        thrd.setName(threadName);
         thrd.setPriority(Thread.MAX_PRIORITY-1);
         thrd.start();
+        return thrd;
     }
 }
 


### PR DESCRIPTION
 The test fails when the main debuggee thread is a virtual thread, because virtual threads are always daemon threads. Because of this all the test threads that the debuggee creates are also daemon threads. The main deuggee thread immediately exits after creating the test threads, and at that point there are no non-daemon threads left running to keep the debuggee process alive, so the test threads never get a chance to do all the work that is expected of them. 

The fix is to use Thread.join() to prevent the main test thread from exiting until all the created tests threads have exited. I also updated the test so when run using the virtual test thread factory, the debuggee test threads will now be virtual threads. Previously just the main debuggee thread would be a virtual thread. This is not a bug fix, but does provide better virtual thread testing.