### PR TITLE
8309509

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -32,7 +32,6 @@ com/sun/jdi/JdbMethodExitTest.java 8285422 generic-all
 com/sun/jdi/MethodEntryExitEvents.java 8285422 generic-all
 com/sun/jdi/MultiBreakpointsTest.java 8285422 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
-com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java 8285422 generic-all
 com/sun/jdi/ReferrersTest.java 8285422 generic-all
 com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/StepTest.java 8285422 generic-all

--- a/test/jdk/com/sun/jdi/VMConnection.java
+++ b/test/jdk/com/sun/jdi/VMConnection.java
@@ -125,14 +125,16 @@ class VMConnection {
 
     VMConnection(String connectSpec, int traceFlags) {
         String nameString;
-        String argString;
+        String argString = "includevirtualthreads=y";
         int index = connectSpec.indexOf(':');
         if (index == -1) {
             nameString = connectSpec;
-            argString = "";
         } else {
             nameString = connectSpec.substring(0, index);
-            argString = connectSpec.substring(index + 1);
+            // Only append args if there are actually some args after the ':'
+            if (index < connectSpec.length() - 1) {
+                argString = argString + "," + connectSpec.substring(index + 1);
+            }
         }
 
         connector = findConnector(nameString);


### PR DESCRIPTION
The test fails with the virtual test thread factory because it tries to find the "main" thread in the list of threads returned by JDI, but "main" is a virtual thread and will only be returned by JDI if the debug agent is launched with includevirtualthreads=y. As a result the thread is not found and the test asserts:

java.lang.RuntimeException: assertTrue: expected true, was false
	at jdk.test.lib.Asserts.fail(Asserts.java:594)
	at jdk.test.lib.Asserts.assertTrue(Asserts.java:486)
	at jdk.test.lib.Asserts.assertTrue(Asserts.java:472)
	at TestNestmateAttr.checkGoodTransforms(TestNestmateAttr.java:511)
	at TestNestmateAttr.methodEntered(TestNestmateAttr.java:320)
	at TestScaffold$EventHandler.notifyEvent(TestScaffold.java:205)
	at TestScaffold$EventHandler.run(TestScaffold.java:279)
	at java.base/java.lang.Thread.run(Thread.java:1583)

The fix is to always run the debug agent with includevirtualthreads=y.

Tested by running all com/sun/jdi tests locally with and without the virtual test thread factory. Also ran tier1 and tier5 svc test tasks.