### PR TITLE
8309510: com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java no longer needs to override startUp() method

### DIFF
--- a/test/jdk/com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java
+++ b/test/jdk/com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java
@@ -211,16 +211,6 @@ public class TestNestmateAttr extends TestScaffold {
 
     static String origin;
 
-    // override this to correct a bug so arguments can be passed to
-    // the Target class
-    protected void startUp(String targetName) {
-        List<String> argList = new ArrayList<>(Arrays.asList(args));
-        argList.add(0, targetName); // pre-pend so it becomes the first "app" arg
-        println("run args: " + argList);
-        connect((String[]) argList.toArray(args));
-        waitForVMStart();
-    }
-
     TestNestmateAttr (String[] args) {
         super(args);
     }


### PR DESCRIPTION
com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java currently overrides the TestScaffold.startup() method:

    // override this to correct a bug so arguments can be passed to
    // the Target class
    protected void startUp(String targetName) {
        List<String> argList = new ArrayList<>(Arrays.asList(args));
        argList.add(0, targetName); // pre-pend so it becomes the first "app" arg
        println("run args: " + argList);
        connect((String[]) argList.toArray(args));
        waitForVMStart();
    }

This issue of passing app args was fixed recently by [JDK-8308481](https://bugs.openjdk.org/browse/JDK-8308481), so the override is no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309510](https://bugs.openjdk.org/browse/JDK-8309510): com/sun/jdi/RedefineNestmateAttr/TestNestmateAttr.java no longer needs to override startUp() method (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14325/head:pull/14325` \
`$ git checkout pull/14325`

Update a local copy of the PR: \
`$ git checkout pull/14325` \
`$ git pull https://git.openjdk.org/jdk.git pull/14325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14325`

View PR using the GUI difftool: \
`$ git pr show -t 14325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14325.diff">https://git.openjdk.org/jdk/pull/14325.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14325#issuecomment-1577734094)