### PR TITLE
8309511: Regression test ExtraImportSemicolon.java refers to the wrong bug

### DIFF
--- a/test/langtools/tools/javac/parser/ExtraImportSemicolon.java
+++ b/test/langtools/tools/javac/parser/ExtraImportSemicolon.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 5059679
+ * @bug 8027682
  * @summary Verify proper error reporting of extra semicolon before import statement
  * @compile/fail/ref=ExtraImportSemicolon.out1 -XDrawDiagnostics ExtraImportSemicolon.java
  * @compile/ref=ExtraImportSemicolon.out2 --release 20 -XDrawDiagnostics ExtraImportSemicolon.java


### PR DESCRIPTION
Please review this trivial fix for an incorrect `@bug` reference in `ExtraImportSemicolon.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309511](https://bugs.openjdk.org/browse/JDK-8309511): Regression test ExtraImportSemicolon.java refers to the wrong bug (**Bug** - P5)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14327/head:pull/14327` \
`$ git checkout pull/14327`

Update a local copy of the PR: \
`$ git checkout pull/14327` \
`$ git pull https://git.openjdk.org/jdk.git pull/14327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14327`

View PR using the GUI difftool: \
`$ git pr show -t 14327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14327.diff">https://git.openjdk.org/jdk/pull/14327.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14327#issuecomment-1577778909)