### PR TITLE
8304403: Remove unused methods in RangeCheckElimination::Bound

### DIFF
--- a/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
@@ -1337,26 +1337,6 @@ RangeCheckEliminator::Bound::Bound(Instruction::Condition cond, Value v, int con
   }
 }
 
-// Set lower
-void RangeCheckEliminator::Bound::set_lower(int value, Value v) {
-  assert(!v || !v->as_Constant() || !v->type()->as_IntConstant(), "Must not be constant!");
-  this->_lower = value;
-  this->_lower_instr = v;
-}
-
-// Set upper
-void RangeCheckEliminator::Bound::set_upper(int value, Value v) {
-  assert(!v || !v->as_Constant() || !v->type()->as_IntConstant(), "Must not be constant!");
-  this->_upper = value;
-  this->_upper_instr = v;
-}
-
-// Add constant -> no overflow may occur
-void RangeCheckEliminator::Bound::add_constant(int value) {
-  this->_lower += value;
-  this->_upper += value;
-}
-
 // or
 void RangeCheckEliminator::Bound::or_op(Bound *b) {
   // Watch out, bound is not guaranteed not to overflow!

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
@@ -97,12 +97,9 @@ public:
     void and_op(Bound *b);
     bool has_upper();
     bool has_lower();
-    void set_upper(int upper, Value upper_instr);
-    void set_lower(int lower, Value lower_instr);
     bool is_smaller(Bound *b);
     void remove_upper();
     void remove_lower();
-    void add_constant(int value);
     Bound *copy();
   };
 


### PR DESCRIPTION
Removed 3 unused methods in RangeCheckElimination:

RangeCheckEliminator::Bound::set_lower
RangeCheckEliminator::Bound::set_upper
RangeCheckEliminator::Bound::add_constant
