### PR TITLE
8309527: Improve test proxy performance

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
+++ b/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
+++ b/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
@@ -1023,13 +1023,14 @@ public class HTTPTestServer extends HTTPTest {
                 public void run() {
                     try {
                         try {
-                            int c;
-                            while ((c = is.read()) != -1) {
-                                os.write(c);
+                            int len;
+                            byte[] buf = new byte[16 * 1024];
+                            while ((len = is.read(buf)) != -1) {
+                                os.write(buf, 0, len);
                                 os.flush();
                                 // if DEBUG prints a + or a - for each transferred
                                 // character.
-                                if (DEBUG) System.out.print(tag);
+                                if (DEBUG) System.out.print(String.valueOf(tag).repeat(len));
                             }
                             is.close();
                         } finally {

--- a/test/jdk/java/net/httpclient/DigestEchoServer.java
+++ b/test/jdk/java/net/httpclient/DigestEchoServer.java
@@ -1443,18 +1443,19 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
                 @Override
                 public void run() {
                     try {
-                        int c = 0;
+                        int len = 0;
+                        byte[] buf = new byte[16 * 1024];
                         try {
-                            while ((c = is.read()) != -1) {
-                                os.write(c);
+                            while ((len = is.read(buf)) != -1) {
+                                os.write(buf, 0, len);
                                 os.flush();
                                 // if DEBUG prints a + or a - for each transferred
                                 // character.
-                                if (DEBUG) System.out.print(tag);
+                                if (DEBUG) System.out.print(String.valueOf(tag).repeat(len));
                             }
                             is.close();
                         } catch (IOException ex) {
-                            if (DEBUG || !stopped && c >  -1)
+                            if (DEBUG || !stopped && len > -1)
                                 ex.printStackTrace(System.out);
                             end.completeExceptionally(ex);
                         } finally {

--- a/test/jdk/java/net/httpclient/ProxyTest.java
+++ b/test/jdk/java/net/httpclient/ProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/ProxyTest.java
+++ b/test/jdk/java/net/httpclient/ProxyTest.java
@@ -256,13 +256,14 @@ public class ProxyTest {
                 public void run() {
                     try {
                         try {
-                            int c;
-                            while ((c = is.read()) != -1) {
-                                os.write(c);
+                            int len;
+                            byte[] buf = new byte[16 * 1024];
+                            while ((len = is.read(buf)) != -1) {
+                                os.write(buf, 0, len);
                                 os.flush();
                                 // if DEBUG prints a + or a - for each transferred
                                 // character.
-                                if (DEBUG) System.out.print(tag);
+                                if (DEBUG) System.out.print(String.valueOf(tag).repeat(len));
                             }
                             is.close();
                         } finally {

--- a/test/jdk/java/net/httpclient/http2/ProxyTest2.java
+++ b/test/jdk/java/net/httpclient/http2/ProxyTest2.java
@@ -187,13 +187,14 @@ public class ProxyTest2 {
                 public void run() {
                     try {
                         try {
-                            int c;
-                            while ((c = is.read()) != -1) {
-                                os.write(c);
+                            int len;
+                            byte[] buf = new byte[16 * 1024];
+                            while ((len = is.read(buf)) != -1) {
+                                os.write(buf, 0, len);
                                 os.flush();
                                 // if DEBUG prints a + or a - for each transferred
                                 // character.
-                                if (DEBUG) System.out.print(tag);
+                                if (DEBUG) System.out.print(String.valueOf(tag).repeat(len));
                             }
                             is.close();
                         } finally {

--- a/test/jdk/sun/net/www/http/HttpClient/B8209178.java
+++ b/test/jdk/sun/net/www/http/HttpClient/B8209178.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/net/www/http/HttpClient/B8209178.java
+++ b/test/jdk/sun/net/www/http/HttpClient/B8209178.java
@@ -214,13 +214,14 @@ public class B8209178 {
                 public void run() {
                     try {
                         try {
-                            int c;
-                            while ((c = is.read()) != -1) {
-                                os.write(c);
+                            int len;
+                            byte[] buf = new byte[16 * 1024];
+                            while ((len = is.read(buf)) != -1) {
+                                os.write(buf, 0, len);
                                 os.flush();
                                 // if DEBUG prints a + or a - for each transferred
                                 // character.
-                                if (DEBUG) System.out.print(tag);
+                                if (DEBUG) System.out.print(String.valueOf(tag).repeat(len));
                             }
                             is.close();
                         } finally {


### PR DESCRIPTION
Please review this change to introduce buffering in the tunnelling proxy implementations.

Copying network data one byte at a time is very inefficient. ProxyAuthDisabledSchemesSSL is 10 seconds faster (from 40 down to 30s) on my Windows machine with these changes.

I did not quantify the improvements in other tests affected by this change; I only verified that they continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309527](https://bugs.openjdk.org/browse/JDK-8309527): Improve test proxy performance (**Enhancement** - `"4"`)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14329/head:pull/14329` \
`$ git checkout pull/14329`

Update a local copy of the PR: \
`$ git checkout pull/14329` \
`$ git pull https://git.openjdk.org/jdk.git pull/14329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14329`

View PR using the GUI difftool: \
`$ git pr show -t 14329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14329.diff">https://git.openjdk.org/jdk/pull/14329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14329#issuecomment-1578453840)