### PR TITLE
JDK-8309534 @JEP(number=430, title="String Templates") should use default status

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -68,7 +68,7 @@ public @interface PreviewFeature {
         VIRTUAL_THREADS,
         @JEP(number=442, title="Foreign Function & Memory API", status="Third Preview")
         FOREIGN,
-        @JEP(number=430, title="String Templates", status="First Preview")
+        @JEP(number=430, title="String Templates")
         STRING_TEMPLATES,
         @JEP(number=443, title="Unnamed Patterns and Variables")
         UNNAMED,


### PR DESCRIPTION
Status was incorrectly specified as 

@JEP(number=430, title="String Templates", status="First Preview") 

Should be 

@JEP(number=430, title="String Templates)