### PR TITLE
8309543: Micro-optimize x86 assembler UseCondCardMark

### DIFF
--- a/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/cardTableBarrierSetAssembler_x86.cpp
@@ -119,7 +119,7 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
   if (UseCondCardMark) {
     Label L_already_dirty;
     __ cmpb(card_addr, dirty);
-    __ jcc(Assembler::equal, L_already_dirty);
+    __ jccb(Assembler::equal, L_already_dirty);
     __ movb(card_addr, dirty);
     __ bind(L_already_dirty);
   } else {


### PR DESCRIPTION
Noticed this while explaining a related code: there is no need to make a full jump, and a short jump would suffice. Assembler does not know about this shortening, because it is a forward branch.

Makes a slightly more compact interpreter code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309543](https://bugs.openjdk.org/browse/JDK-8309543): Micro-optimize x86 assembler UseCondCardMark (**Enhancement** - `"4"`)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14335/head:pull/14335` \
`$ git checkout pull/14335`

Update a local copy of the PR: \
`$ git checkout pull/14335` \
`$ git pull https://git.openjdk.org/jdk.git pull/14335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14335`

View PR using the GUI difftool: \
`$ git pr show -t 14335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14335.diff">https://git.openjdk.org/jdk/pull/14335.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14335#issuecomment-1578881086)