### PR TITLE
8309542: compiler/jvmci/TestEnableJVMCIProduct.java fails with "JVMCI compiler 'graal' specified by jvmci.Compiler not found"

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/TestEnableJVMCIProduct.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestEnableJVMCIProduct.java
@@ -94,13 +94,16 @@ public class TestEnableJVMCIProduct {
             for (Expectation expectation : expectations) {
                 output.stdoutShouldMatch(expectation.pattern);
             }
-            if (flag.equals("-XX:+UseGraalJIT")) {
-                output.shouldContain("jvmci.Compiler=graal");
-            }
             if (output.getExitValue() != 0) {
                 // This should only happen when JVMCI compilation is requested and the VM has no
                 // JVMCI compiler (e.g. Graal is not included in the build)
-                output.stdoutShouldMatch("No JVMCI compiler found");
+                if (flag.equals("-XX:+UseGraalJIT")) {
+                    output.shouldContain("JVMCI compiler 'graal' specified by jvmci.Compiler not found");
+                } else {
+                    output.stdoutShouldMatch("No JVMCI compiler found");
+                }
+            } else if (flag.equals("-XX:+UseGraalJIT")) {
+                output.shouldContain("jvmci.Compiler=graal");
             }
         }
     }


### PR DESCRIPTION
This PR fixes an intermittent failure in TestEnableJVMCIProduct.java that can happen when execution is slow enough such that a top-tier JIT compilation is scheduled.