### PR TITLE
8308445: Linker should check that capture state segment is big enough

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -95,6 +95,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
             FunctionDescriptor fd = linkRequest.descriptor();
             MethodType type = fd.toMethodType();
             MethodHandle handle = arrangeDowncall(type, fd, linkRequest.options());
+            handle = SharedUtils.maybeCheckCaptureSegment(handle, linkRequest.options());
             handle = SharedUtils.maybeInsertAllocator(fd, handle);
             return handle;
         });

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -78,7 +78,7 @@ public final class SharedUtils {
     private static final MethodHandle MH_BUFFER_COPY;
     private static final MethodHandle MH_REACHABILITY_FENCE;
     public static final MethodHandle MH_CHECK_SYMBOL;
-    private static final MethodHandle MH_SLICE_CAPTURE_SEGMENT;
+    private static final MethodHandle MH_CHECK_CAPTURE_SEGMENT;
 
     public static final AddressLayout C_POINTER = ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(JAVA_BYTE));
@@ -111,7 +111,7 @@ public final class SharedUtils {
                     methodType(void.class, Object.class));
             MH_CHECK_SYMBOL = lookup.findStatic(SharedUtils.class, "checkSymbol",
                     methodType(void.class, MemorySegment.class));
-            MH_SLICE_CAPTURE_SEGMENT = lookup.findStatic(SharedUtils.class, "checkCaptureSegment",
+            MH_CHECK_CAPTURE_SEGMENT = lookup.findStatic(SharedUtils.class, "checkCaptureSegment",
                     methodType(MemorySegment.class, MemorySegment.class));
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
@@ -349,7 +349,7 @@ public final class SharedUtils {
     public static MethodHandle maybeCheckCaptureSegment(MethodHandle handle, LinkerOptions options) {
         if (options.hasCapturedCallState()) {
             // (<target address>, SegmentAllocator, <capture segment>, ...) -> ...
-            handle = MethodHandles.filterArguments(handle, 2, MH_SLICE_CAPTURE_SEGMENT);
+            handle = MethodHandles.filterArguments(handle, 2, MH_CHECK_CAPTURE_SEGMENT);
         }
         return handle;
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -78,6 +78,7 @@ public final class SharedUtils {
     private static final MethodHandle MH_BUFFER_COPY;
     private static final MethodHandle MH_REACHABILITY_FENCE;
     public static final MethodHandle MH_CHECK_SYMBOL;
+    private static final MethodHandle MH_SLICE_CAPTURE_SEGMENT;
 
     public static final AddressLayout C_POINTER = ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(JAVA_BYTE));
@@ -110,6 +111,8 @@ public final class SharedUtils {
                     methodType(void.class, Object.class));
             MH_CHECK_SYMBOL = lookup.findStatic(SharedUtils.class, "checkSymbol",
                     methodType(void.class, MemorySegment.class));
+            MH_SLICE_CAPTURE_SEGMENT = lookup.findStatic(SharedUtils.class, "checkCaptureSegment",
+                    methodType(MemorySegment.class, MemorySegment.class));
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
         }
@@ -341,6 +344,23 @@ public final class SharedUtils {
             handle = insertArguments(handle, 1, THROWING_ALLOCATOR);
         }
         return handle;
+    }
+
+    public static MethodHandle maybeCheckCaptureSegment(MethodHandle handle, LinkerOptions options) {
+        if (options.hasCapturedCallState()) {
+            // (<target address>, SegmentAllocator, <capture segment>, ...) -> ...
+            handle = MethodHandles.filterArguments(handle, 2, MH_SLICE_CAPTURE_SEGMENT);
+        }
+        return handle;
+    }
+
+    @ForceInline
+    public static MemorySegment checkCaptureSegment(MemorySegment captureSegment) {
+        Objects.requireNonNull(captureSegment);
+        if (captureSegment.equals(MemorySegment.NULL)) {
+            throw new IllegalArgumentException("Capture segment is NULL: " + captureSegment);
+        }
+        return captureSegment.asSlice(0, CapturableState.LAYOUT);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.invoke.MethodHandles.foldArguments;
 
 public final class FallbackLinker extends AbstractLinker {
@@ -152,7 +151,7 @@ public final class FallbackLinker extends AbstractLinker {
 
             MemorySegment capturedState = null;
             if (invData.capturedStateMask() != 0) {
-                capturedState = (MemorySegment) args[argStart++];
+                capturedState = SharedUtils.checkCaptureSegment((MemorySegment) args[argStart++]);
                 MemorySessionImpl capturedStateImpl = ((AbstractMemorySegmentImpl) capturedState).sessionImpl();
                 capturedStateImpl.acquire0();
                 acquiredSessions.add(capturedStateImpl);

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -50,6 +50,7 @@ import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestCaptureCallState extends NativeTestHelper {
 
@@ -82,6 +83,21 @@ public class TestCaptureCallState extends NativeTestHelper {
             testCase.resultCheck().accept(result);
             int savedErrno = (int) errnoHandle.get(saveSeg);
             assertEquals(savedErrno, testValue);
+        }
+    }
+
+    @Test(dataProvider = "invalidCaptureSegmentCases")
+    public void testInvalidCaptureSegment(MemorySegment captureSegment,
+                                          Class<?> expectedExceptionType, String expectedExceptionMessage) {
+        Linker.Option stl = Linker.Option.captureCallState("errno");
+        MethodHandle handle = downcallHandle("set_errno_V", FunctionDescriptor.ofVoid(C_INT), stl);
+
+        try {
+            int testValue = 42;
+            handle.invoke(captureSegment, testValue); // should throw
+        } catch (Throwable t) {
+            assertTrue(expectedExceptionType.isInstance(t));
+            assertTrue(t.getMessage().matches(expectedExceptionMessage));
         }
     }
 
@@ -128,4 +144,13 @@ public class TestCaptureCallState extends NativeTestHelper {
         return new SaveValuesCase("set_errno_" + name, FunctionDescriptor.of(layout, JAVA_INT), "errno", check);
     }
 
+    @DataProvider
+    public static Object[][] invalidCaptureSegmentCases() {
+        return new Object[][]{
+            {Arena.ofAuto().allocate(1), IndexOutOfBoundsException.class, ".*Out of bound access on segment.*"},
+            {MemorySegment.NULL, IllegalArgumentException.class, ".*Capture segment is NULL.*"},
+            {Arena.ofAuto().allocate(Linker.Option.captureStateLayout().byteSize() + 3).asSlice(3), // misaligned
+                    IllegalArgumentException.class, ".*Target offset incompatible with alignment constraints.*"},
+        };
+    }
 }


### PR DESCRIPTION
Fix the bug mentioned in the JBS issue.

The implementation is updated to slice the capture state segment using the capture state layout. This checks both that the segment is big enough, and that it is properly aligned.

Additionally, I added a check for `MS::NULL` since this is also an illegal value we can catch early.

Test cases are added for all three invalid values.

Testing: `jdk_foreign` test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308445](https://bugs.openjdk.org/browse/JDK-8308445): Linker should check that capture state segment is big enough (**Bug** - `"3"`)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14339/head:pull/14339` \
`$ git checkout pull/14339`

Update a local copy of the PR: \
`$ git checkout pull/14339` \
`$ git pull https://git.openjdk.org/jdk.git pull/14339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14339`

View PR using the GUI difftool: \
`$ git pr show -t 14339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14339.diff">https://git.openjdk.org/jdk/pull/14339.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14339#issuecomment-1579139904)