### PR TITLE
JDK-8309550: jdk.jfr.internal.Utils::formatDataAmount method should gracefully handle amounts equal to Long.MIN_VALUE

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -123,7 +123,7 @@ public final class Utils {
 
     // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = amount == Long.MIN_VALUE ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
         char unitPrefix = "kMGTPE".charAt(exp - 1);
         return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -148,7 +148,7 @@ public final class ValueFormatter {
 
     // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = amount == Long.MIN_VALUE ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
         char unitPrefix = "kMGTPE".charAt(exp - 1);
         return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
     }


### PR DESCRIPTION
Please review this simple fix to JDK-8309550.

NB: The problem originally reported only concerned `src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java`, but since this code was duplicated in `src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java` with, as far as I understood from the bug description, with an intent to refactor it a a later time, I opted to change both occurrences of the method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309550](https://bugs.openjdk.org/browse/JDK-8309550): jdk.jfr.internal.Utils::formatDataAmount method should gracefully handle amounts equal to Long.MIN_VALUE (**Bug** - `"4"`)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [dca5b72c](https://git.openjdk.org/jdk/pull/14341/files/dca5b72c929672a7a99a7f3a678c268048645986)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14341/head:pull/14341` \
`$ git checkout pull/14341`

Update a local copy of the PR: \
`$ git checkout pull/14341` \
`$ git pull https://git.openjdk.org/jdk.git pull/14341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14341`

View PR using the GUI difftool: \
`$ git pr show -t 14341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14341.diff">https://git.openjdk.org/jdk/pull/14341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14341#issuecomment-1579319456)