### PR TITLE
8309570: ProblemList sun/security/pkcs11/Signature/TestRSAKeyLength.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -604,7 +604,7 @@ sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 gene
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
 sun/security/tools/keytool/NssTest.java                         8295343 linux-all
-sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343 linux-all
+sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343,8309569 linux-all,macosx-x64,windows-x64
 sun/security/pkcs11/rsa/TestSignatures.java                     8295343 linux-all
 sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-all
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList sun/security/pkcs11/Signature/TestRSAKeyLength.java on macosx-x64 and windows-x64.

The test is already ProblemListed on linux-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309570](https://bugs.openjdk.org/browse/JDK-8309570): ProblemList sun/security/pkcs11/Signature/TestRSAKeyLength.java (**Sub-task** - `"2"`)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14343/head:pull/14343` \
`$ git checkout pull/14343`

Update a local copy of the PR: \
`$ git checkout pull/14343` \
`$ git pull https://git.openjdk.org/jdk.git pull/14343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14343`

View PR using the GUI difftool: \
`$ git pr show -t 14343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14343.diff">https://git.openjdk.org/jdk/pull/14343.diff</a>

</details>
