### PR TITLE
JDK-8309568 javac crashes attempting to -Xprint on a class file of an unnamed class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2731,7 +2731,10 @@ public class ClassReader {
         }
         readClass(c);
         if (previewClassFile) {
-            if ((c.flags_field & SYNTHETIC) != 0 && c.isSubClass(syms.objectType.tsym, types)) {
+            if ((c.flags_field & SYNTHETIC) != 0 &&
+                    c.owner.kind == PCK &&
+                    (c.flags_field & AUXILIARY) == 0 &&
+                    (c.flags_field & FINAL) != 0) {
                 c.flags_field |= UNNAMED_CLASS;
             }
         }


### PR DESCRIPTION
Test development for [JDK-8309503](https://bugs.openjdk.org/browse/JDK-8309503) found that javac crashed attempting to -Xprint on a class file of an unnamed class. The test for ClassReader detecting of unnamed class was forcing completion of the owner class. The new code uses a flags only test.

Related test is with https://bugs.openjdk.org/browse/JDK-8309503 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309568](https://bugs.openjdk.org/browse/JDK-8309568): javac crashes attempting to -Xprint on a class file of an unnamed class (**Bug** - `"2"`)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14344/head:pull/14344` \
`$ git checkout pull/14344`

Update a local copy of the PR: \
`$ git checkout pull/14344` \
`$ git pull https://git.openjdk.org/jdk.git pull/14344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14344`

View PR using the GUI difftool: \
`$ git pr show -t 14344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14344.diff">https://git.openjdk.org/jdk/pull/14344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14344#issuecomment-1579542855)