### PR TITLE
4516654: Metalworks Demo: Window title not displayed fully in Low Vision Theme

### DIFF
--- a/src/demo/share/jfc/Metalworks/BigContrastMetalTheme.java
+++ b/src/demo/share/jfc/Metalworks/BigContrastMetalTheme.java
@@ -103,7 +103,7 @@ public class BigContrastMetalTheme extends ContrastMetalTheme {
     public void addCustomEntriesToTable(UIDefaults table) {
         super.addCustomEntriesToTable(table);
 
-        final int internalFrameIconSize = 30;
+        final int internalFrameIconSize = 24;
         table.put("InternalFrame.closeIcon", MetalIconFactory.
                 getInternalFrameCloseIcon(internalFrameIconSize));
         table.put("InternalFrame.maximizeIcon", MetalIconFactory.

--- a/src/demo/share/jfc/Metalworks/BigContrastMetalTheme.java
+++ b/src/demo/share/jfc/Metalworks/BigContrastMetalTheme.java
@@ -103,7 +103,7 @@ public class BigContrastMetalTheme extends ContrastMetalTheme {
     public void addCustomEntriesToTable(UIDefaults table) {
         super.addCustomEntriesToTable(table);
 
-        final int internalFrameIconSize = 24;
+        final int internalFrameIconSize = 30;
         table.put("InternalFrame.closeIcon", MetalIconFactory.
                 getInternalFrameCloseIcon(internalFrameIconSize));
         table.put("InternalFrame.maximizeIcon", MetalIconFactory.
@@ -125,7 +125,7 @@ public class BigContrastMetalTheme extends ContrastMetalTheme {
         table.put("TextField.border", textBorder);
         table.put("PasswordField.border", textBorder);
         table.put("TextArea.border", textBorder);
-        table.put("TextPane.font", textBorder);
+        table.put("TextPane.font", controlFont);
 
         table.put("ScrollPane.border", blackLineBorder);
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalTitlePane.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalTitlePane.java
@@ -726,7 +726,7 @@ class MetalTitlePane extends JComponent {
         int xOffset = leftToRight ? 5 : width - 5;
 
         if (getWindowDecorationStyle() == JRootPane.FRAME) {
-            xOffset += leftToRight ? IMAGE_WIDTH + 5 : - IMAGE_WIDTH - 5;
+            xOffset += leftToRight ? menuBar.getWidth() + 5 : - menuBar.getWidth() - 5;
         }
 
         String theTitle = getTitle();


### PR DESCRIPTION
In Metalworks demo in Low Vision theme, window title is not diplayed fully in this theme. The first letter of the title, that is letter "M", is cut vertically

![image](https://github.com/openjdk/jdk/assets/43534309/b122787c-8144-4771-a74a-71b60e1a63f9)

It is because the iconsize is hardcoded to be 30 and windows titlePane title is rendered at same place irrespective of theme (only font size is made bigger from normal pt 12 to 24 for Low Vision theme) so icon width overlaps the title.
Icon width is made to be 24 in demo in sync with window title font size which made it work ok

![image](https://github.com/openjdk/jdk/assets/43534309/fa61f2cb-8339-4e92-8612-b1d8d32e8b7f)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4516654](https://bugs.openjdk.org/browse/JDK-4516654): Metalworks Demo: Window title not displayed fully in Low Vision Theme (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14346/head:pull/14346` \
`$ git checkout pull/14346`

Update a local copy of the PR: \
`$ git checkout pull/14346` \
`$ git pull https://git.openjdk.org/jdk.git pull/14346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14346`

View PR using the GUI difftool: \
`$ git pr show -t 14346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14346.diff">https://git.openjdk.org/jdk/pull/14346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14346#issuecomment-1580056721)