### PR TITLE
8309474: [IR Framework] Wrong @ForceCompile link in README

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -118,7 +118,7 @@ The framework allows the use of additional compiler control annotations for help
 - [@DontInline](./DontInline.java)
 - [@ForceInline](./ForceInline.java)
 - [@DontCompile](./DontCompile.java)
-- [@ForceCompile](./DontCompile.java)
+- [@ForceCompile](./ForceCompile.java)
 - [@ForceCompileClassInitializer](./ForceCompileClassInitializer.java)
 
 ### 2.5 Framework Debug and Stress Flags


### PR DESCRIPTION
Fixed the @ForceCompile link to now actually point to the ForceCompile.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309474](https://bugs.openjdk.org/browse/JDK-8309474): [IR Framework] Wrong @ForceCompile link in README (**Bug** - `"5"`)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14347/head:pull/14347` \
`$ git checkout pull/14347`

Update a local copy of the PR: \
`$ git checkout pull/14347` \
`$ git pull https://git.openjdk.org/jdk.git pull/14347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14347`

View PR using the GUI difftool: \
`$ git pr show -t 14347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14347.diff">https://git.openjdk.org/jdk/pull/14347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14347#issuecomment-1580586369)