### PR TITLE
8309515: Stale cached data from Matcher.namedGroups() after Matcher.usePattern()

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -390,6 +390,7 @@ public final class Matcher implements MatchResult {
         if (newPattern == null)
             throw new IllegalArgumentException("Pattern cannot be null");
         parentPattern = newPattern;
+        namedGroups = null;
 
         // Reallocate state storage
         int parentGroupCount = Math.max(newPattern.capturingGroupCount, 10);

--- a/test/jdk/java/util/regex/NamedGroupsTests.java
+++ b/test/jdk/java/util/regex/NamedGroupsTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8065554
+ * @bug 8065554 8309515
  * @run main NamedGroupsTests
  */
 
@@ -86,6 +86,8 @@ public class NamedGroupsTests {
 
         testMatchResultStartEndGroupBeforeMatchOp();
         testMatchResultStartEndGroupAfterMatchOp();
+
+        testMatchResultAfterUsePattern();
     }
 
     private static void testMatchResultNoDefault() {
@@ -342,6 +344,26 @@ public class NamedGroupsTests {
     private static void testPatternNamedGroupsTwoNamedGroups() {
         if (!Pattern.compile("(?<some>.+?)(?<rest>.*)").namedGroups()
                 .equals(Map.of("some", 1, "rest", 2))) {
+            throw new RuntimeException();
+        }
+    }
+
+    private static void testMatchResultAfterUsePattern() {
+        Pattern p1 = Pattern.compile("(?<a>...)(?<b>...)");
+        Matcher m = p1.matcher("foobar");
+        if (!m.matches()) {
+            throw new RuntimeException();
+        }
+        if (!m.group("a").equals("foo")) {
+            throw new RuntimeException();
+        }
+
+        Pattern p2 = Pattern.compile("(?<b>...)(?<a>...)");
+        m.usePattern(p2);
+        if (!m.matches()) {
+            throw new RuntimeException();
+        }
+        if (!m.group("a").equals("bar")) {
             throw new RuntimeException();
         }
     }

--- a/test/jdk/java/util/regex/NamedGroupsTests.java
+++ b/test/jdk/java/util/regex/NamedGroupsTests.java
@@ -87,7 +87,7 @@ public class NamedGroupsTests {
         testMatchResultStartEndGroupBeforeMatchOp();
         testMatchResultStartEndGroupAfterMatchOp();
 
-        testMatchResultAfterUsePattern();
+        testMatchAfterUsePattern();
     }
 
     private static void testMatchResultNoDefault() {
@@ -348,7 +348,7 @@ public class NamedGroupsTests {
         }
     }
 
-    private static void testMatchResultAfterUsePattern() {
+    private static void testMatchAfterUsePattern() {
         Pattern p1 = Pattern.compile("(?<a>...)(?<b>...)");
         Matcher m = p1.matcher("foobar");
         if (!m.matches()) {

--- a/test/jdk/java/util/regex/NamedGroupsTests.java
+++ b/test/jdk/java/util/regex/NamedGroupsTests.java
@@ -352,19 +352,19 @@ public class NamedGroupsTests {
         Pattern p1 = Pattern.compile("(?<a>...)(?<b>...)");
         Matcher m = p1.matcher("foobar");
         if (!m.matches()) {
-            throw new RuntimeException();
+            throw new RuntimeException("matches() expected");
         }
         if (!m.group("a").equals("foo")) {
-            throw new RuntimeException();
+            throw new RuntimeException("\"foo\" expected for group(\"a\")");
         }
 
         Pattern p2 = Pattern.compile("(?<b>...)(?<a>...)");
         m.usePattern(p2);
         if (!m.matches()) {
-            throw new RuntimeException();
+            throw new RuntimeException("matches() expected");
         }
         if (!m.group("a").equals("bar")) {
-            throw new RuntimeException();
+            throw new RuntimeException("\"bar\" expected for group(\"a\")");
         }
     }
 


### PR DESCRIPTION
The cached `namedGroup` field must be invalidated during an invocation of `Matcher.usePattern()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309515](https://bugs.openjdk.org/browse/JDK-8309515): Stale cached data from Matcher.namedGroups() after Matcher.usePattern() (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14350/head:pull/14350` \
`$ git checkout pull/14350`

Update a local copy of the PR: \
`$ git checkout pull/14350` \
`$ git pull https://git.openjdk.org/jdk.git pull/14350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14350`

View PR using the GUI difftool: \
`$ git pr show -t 14350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14350.diff">https://git.openjdk.org/jdk/pull/14350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14350#issuecomment-1580590325)