### PR TITLE
JDK-8309594 Cleanup naming in JavacParser related to unnamed classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4051,12 +4051,12 @@ public class JavacParser implements Parser {
         }
 
         Name name = names.fromString(simplename);
-        JCModifiers anonMods = F.at(primaryPos)
+        JCModifiers unnamedMods = F.at(primaryPos)
                 .Modifiers(Flags.FINAL|Flags.SYNTHETIC|Flags.UNNAMED_CLASS, List.nil());
-        JCClassDecl anon = F.at(primaryPos).ClassDef(
-                anonMods, name, List.nil(), null, List.nil(), List.nil(),
+        JCClassDecl unnamed = F.at(primaryPos).ClassDef(
+                unnamedMods, name, List.nil(), null, List.nil(), List.nil(),
                 defs.toList());
-        topDefs.append(anon);
+        topDefs.append(unnamed);
         return topDefs.toList();
     }
 


### PR DESCRIPTION
Some residual names (anon) from early unnamed classes work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309594](https://bugs.openjdk.org/browse/JDK-8309594): Cleanup naming in JavacParser related to unnamed classes (**Task** - `"4"`)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14351/head:pull/14351` \
`$ git checkout pull/14351`

Update a local copy of the PR: \
`$ git checkout pull/14351` \
`$ git pull https://git.openjdk.org/jdk.git pull/14351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14351`

View PR using the GUI difftool: \
`$ git pr show -t 14351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14351.diff">https://git.openjdk.org/jdk/pull/14351.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14351#issuecomment-1580636312)