### PR TITLE
8309602: update JVMTI history table for jdk 21

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -15392,60 +15392,52 @@ typedef void (JNICALL *jvmtiEventVMInit)
   </change>
   <change date="13 October 2016" version="9.0.0">
       Support for modules:
-       - The majorversion is 9 now
-       - The ClassFileLoadHook events are not sent during the primordial phase anymore.
-       - Allow CompiledMethodLoad events at start phase
-       - Add new capabilities:
-          - can_generate_early_vmstart
-          - can_generate_early_class_hook_events
-       - Add new functions:
-          - GetAllModules
-          - AddModuleReads, AddModuleExports, AddModuleOpens, AddModuleUses, AddModuleProvides
-          - IsModifiableModule
-      Clarified can_redefine_any_classes, can_retransform_any_classes and IsModifiableClass API to
-      disallow some implementation defined classes.
+      The majorversion is 9 now.
+      The ClassFileLoadHook events are not sent during the primordial phase anymore.
+      Allow CompiledMethodLoad events at start phase.
+      Add new capabilities: can_generate_early_vmstart, can_generate_early_class_hook_events.
+      Add new functions: GetAllModules, AddModuleReads, AddModuleExports,
+      AddModuleOpens, AddModuleUses, AddModuleProvides, IsModifiableModule.
+      Clarified can_redefine_any_classes, can_retransform_any_classes and
+      IsModifiableClass API to disallow some implementation defined classes.
   </change>
   <change date="12 February 2017" version="9.0.0">
       Minor update for GetCurrentThread function:
-       - The function may return NULL in the start phase if the
-         can_generate_early_vmstart capability is enabled.
+      The function may return NULL in the start phase if the
+      can_generate_early_vmstart capability is enabled.
   </change>
   <change date="7 February 2018" version="11.0.0">
       Minor update for new class file NestHost and NestMembers attributes:
-        - Specify that RedefineClasses and RetransformClasses are not allowed
-          to change the class file NestHost and NestMembers attributes.
-        - Add new error JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED
-          that can be returned by RedefineClasses and RetransformClasses.
+      Specify that RedefineClasses and RetransformClasses are not allowed
+      to change the class file NestHost and NestMembers attributes;
+      Add new error JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED
+      that can be returned by RedefineClasses and RetransformClasses.
   </change>
   <change date="15 June 2018" version="11.0.0">
       Support for Low Overhead Heap Sampling:
-       - Add new capability:
-         - can_generate_sampled_object_alloc_events
-       - Add new function:
-         - SetHeapSamplingInterval
-       - Add new event type:
-         - JVMTI_EVENT_SAMPLED_OBJECT_ALLOC
+      Add new capability: can_generate_sampled_object_alloc_events.
+      Add new function: SetHeapSamplingInterval.
+      Add new event type: JVMTI_EVENT_SAMPLED_OBJECT_ALLOC.
   </change>
   <change date="20 May 2019" version="13.0.0">
       Minor spec update for the capability "can_redefine_any_class".
-      It now says:
-       "RedefineClasses can be called on any modifiable class. See IsModifiableClass.
-       (can_redefine_classes must also be set)"
+      It now says: "RedefineClasses can be called on any modifiable class."
+      See IsModifiableClass. (can_redefine_classes must also be set)
   </change>
   <change date="5 June 2019" version="13.0.0">
       Minor PopFrame spec update:
-        - The specified thread must be suspended or must be the current thread.
-          (It was not allowed to be the current thread before.)
+      The specified thread must be suspended or must be the current thread.
+     (It was not allowed to be the current thread before.)
   </change>
   <change date="10 October 2019" version="14.0.0">
       Minor update for new class file Record attribute:
-        - Specify that RedefineClasses and RetransformClasses are not allowed
-          to change the class file Record attribute.
+      Specify that RedefineClasses and RetransformClasses are not allowed
+      to change the class file Record attribute.
   </change>
   <change date="13 May 2020" version="15.0.0">
       Minor update for new class file PermittedSubclasses attribute:
-        - Specify that RedefineClasses and RetransformClasses are not allowed
-          to change the class file PermittedSubclasses attribute.
+      Specify that RedefineClasses and RetransformClasses are not allowed
+      to change the class file PermittedSubclasses attribute.
   </change>
   <change date="15 January 2021" version="17.0.0">
       Minor clarification in the section "Agent Shutdown" that says the
@@ -15457,16 +15449,10 @@ typedef void (JNICALL *jvmtiEventVMInit)
   </change>
   <change date="27 April 2022" version="19.0.0">
       Support for virtual threads (Preview):
-       - Add new capability:
-         - can_support_virtual_threads
-       - Add new functions:
-         - SuspendAllVirtualThreads
-         - ResumeAllVirtualThreads
-       - Add new event types:
-         - JVMTI_EVENT_VIRTUAL_THREAD_START
-         - JVMTI_EVENT_VIRTUAL_THREAD_END
-       - Add new error code:
-         - JVMTI_ERROR_UNSUPPORTED_OPERATION
+      Add new capability: can_support_virtual_threads.
+      Add new functions: SuspendAllVirtualThreads, ResumeAllVirtualThreads.
+      Add new event types: JVMTI_EVENT_VIRTUAL_THREAD_START, JVMTI_EVENT_VIRTUAL_THREAD_END.
+      Add new error code: JVMTI_ERROR_UNSUPPORTED_OPERATION.
   </change>
   <change date="7 June 2023" version="21.0.0">
       Virtual threads finalized to be a permanent feature.

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -15469,21 +15469,8 @@ typedef void (JNICALL *jvmtiEventVMInit)
          - JVMTI_ERROR_UNSUPPORTED_OPERATION
   </change>
   <change date="7 June 2023" version="21.0.0">
-      Permanent feature - Support for virtual threads:
-       - Add new capability:
-         - can_support_virtual_threads
-       - Add new functions:
-         - SuspendAllVirtualThreads
-         - ResumeAllVirtualThreads
-       - Add new event types:
-         - JVMTI_EVENT_VIRTUAL_THREAD_START
-         - JVMTI_EVENT_VIRTUAL_THREAD_END
-       - Add new error code:
-         - JVMTI_ERROR_UNSUPPORTED_OPERATION
-
-      Minor update with Implementation Note that dynamic loading of agents
-      into a running VM is now specified to print a warning (JEP 451).
-      See the HotSpot VM option -XX:+EnableDynamicAgentLoading.
+      Virtual threads finalized to be a permanent feature.
+      Agent start-up in the live phase now specified to print a warning.
   </change>
 </changehistory>
 

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -15456,7 +15456,7 @@ typedef void (JNICALL *jvmtiEventVMInit)
       Minor update to deprecate Heap functions 1.0.
   </change>
   <change date="27 April 2022" version="19.0.0">
-      Support for virtual threads:
+      Preview feature - Support for virtual threads:
        - Add new capability:
          - can_support_virtual_threads
        - Add new functions:
@@ -15467,6 +15467,23 @@ typedef void (JNICALL *jvmtiEventVMInit)
          - JVMTI_EVENT_VIRTUAL_THREAD_END
        - Add new error code:
          - JVMTI_ERROR_UNSUPPORTED_OPERATION
+  </change>
+  <change date="7 June 2023" version="21.0.0">
+      Permanent feature - Support for virtual threads:
+       - Add new capability:
+         - can_support_virtual_threads
+       - Add new functions:
+         - SuspendAllVirtualThreads
+         - ResumeAllVirtualThreads
+       - Add new event types:
+         - JVMTI_EVENT_VIRTUAL_THREAD_START
+         - JVMTI_EVENT_VIRTUAL_THREAD_END
+       - Add new error code:
+         - JVMTI_ERROR_UNSUPPORTED_OPERATION
+
+      Minor update with Implementation Note that dynamic loading of agents
+      into a running VM is now specified to print a warning (JEP 451).
+      See the HotSpot VM option -XX:+EnableDynamicAgentLoading.
   </change>
 </changehistory>
 

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -15456,7 +15456,7 @@ typedef void (JNICALL *jvmtiEventVMInit)
       Minor update to deprecate Heap functions 1.0.
   </change>
   <change date="27 April 2022" version="19.0.0">
-      Preview feature - Support for virtual threads:
+      Support for virtual threads (Preview):
        - Add new capability:
          - can_support_virtual_threads
        - Add new functions:


### PR DESCRIPTION
This is a minor update of the `jvmti.xml` file.
The JVM TI history table needs to be updated to list:
 - Virtual threads finalized to be a permanent feature.
 - Agent start-up in the live phase now specified to print a warning.

The JVM TI history table has no normative changes. This update does not need a CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309602](https://bugs.openjdk.org/browse/JDK-8309602): update JVMTI history table for jdk 21 (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [a9e4f8eb](https://git.openjdk.org/jdk/pull/14352/files/a9e4f8eb7c713b02c9c7782ffab8050a9251f59b)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [11db4f4f](https://git.openjdk.org/jdk/pull/14352/files/11db4f4f4f66d86d6bbf6af46e372c6e22c17eda)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14352/head:pull/14352` \
`$ git checkout pull/14352`

Update a local copy of the PR: \
`$ git checkout pull/14352` \
`$ git pull https://git.openjdk.org/jdk.git pull/14352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14352`

View PR using the GUI difftool: \
`$ git pr show -t 14352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14352.diff">https://git.openjdk.org/jdk/pull/14352.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14352#issuecomment-1580733315)