### PR TITLE
8307934 JRobot.moveMouseTo must access component on EDT

### DIFF
--- a/test/jdk/javax/swing/regtesthelpers/JRobot.java
+++ b/test/jdk/javax/swing/regtesthelpers/JRobot.java
@@ -36,11 +36,10 @@ import javax.swing.SwingUtilities;
  * JRobot is a wrapper around java.awt.Robot that provides some convenience
  * methods.
  * <p>When using jtreg you would include this class via something like:
- * <pre>
+ * <pre>{@code
  * @library ../../../regtesthelpers
  * @build JRobot
- * </pre>
- *
+ * }</pre>
  */
 
 public class JRobot extends java.awt.Robot {

--- a/test/jdk/javax/swing/regtesthelpers/JRobot.java
+++ b/test/jdk/javax/swing/regtesthelpers/JRobot.java
@@ -41,7 +41,6 @@ import javax.swing.SwingUtilities;
  * @build JRobot
  * }</pre>
  */
-
 public class JRobot extends java.awt.Robot {
     private static final int DEFAULT_DELAY = 550;
     private static final int INTERNAL_DELAY = 250;

--- a/test/jdk/javax/swing/regtesthelpers/JRobot.java
+++ b/test/jdk/javax/swing/regtesthelpers/JRobot.java
@@ -21,16 +21,6 @@
  * questions.
  */
 
-/**
- * JRobot is a wrapper around java.awt.Robot that provides some convenience
- * methods.
- * <p>When using jtreg you would include this class via something like:
- * <pre>
- * @library ../../../regtesthelpers
- * @build JRobot
- * </pre>
- *
- */
 import java.awt.AWTException;
 import java.awt.Component;
 import java.awt.EventQueue;
@@ -42,9 +32,20 @@ import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.SwingUtilities;
 
+/**
+ * JRobot is a wrapper around java.awt.Robot that provides some convenience
+ * methods.
+ * <p>When using jtreg you would include this class via something like:
+ * <pre>
+ * @library ../../../regtesthelpers
+ * @build JRobot
+ * </pre>
+ *
+ */
+
 public class JRobot extends java.awt.Robot {
-    private static int DEFAULT_DELAY = 550;
-    private static int INTERNAL_DELAY = 250;
+    final private static int DEFAULT_DELAY = 550;
+    final private static int INTERNAL_DELAY = 250;
 
     private int delay;
     private boolean delaysEnabled;
@@ -191,7 +192,7 @@ public class JRobot extends java.awt.Robot {
     /**
      * Click the first mouse button in the center of the given Component
      * <p>
-     * <b>Note:</b> This method uses EDT
+     * <b>Note:</b> This method is executed on EDT.
      *
      * @param c the Component to click on
      */
@@ -264,7 +265,7 @@ public class JRobot extends java.awt.Robot {
      * Convert a rectangle from coordinate system of Component c to
      * screen coordinate system.
      * <p>
-     * <b>Note:</b> This method uses EDT
+     * <b>Note:</b> This method is executed on EDT.
      *
      * @param r a non-null Rectangle
      * @param c a Component whose coordinate system is used for conversion

--- a/test/jdk/javax/swing/regtesthelpers/JRobot.java
+++ b/test/jdk/javax/swing/regtesthelpers/JRobot.java
@@ -37,9 +37,10 @@ import java.awt.EventQueue;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.InputEvent;
-import javax.swing.SwingUtilities;
 import java.util.concurrent.atomic.AtomicReference;
 import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.SwingUtilities;
 
 public class JRobot extends java.awt.Robot {
     private static int DEFAULT_DELAY = 550;
@@ -113,7 +114,7 @@ public class JRobot extends java.awt.Robot {
     /**
      * Move mouse cursor to the center of the Component.
      * <p>
-     * <b>Note:</b> This method is executed on EDT
+     * <b>Note:</b> This method is executed on EDT.
      *
      * @param c Component the mouse is placed over
      */
@@ -175,12 +176,12 @@ public class JRobot extends java.awt.Robot {
     }
 
     /**
-     * Click in the center of the given Component
+     * Click in the center of the given Component.
      * <p>
-     * <b>Note:</b> This method uses EDT
+     * <b>Note:</b> This method is executed on EDT.
      *
      * @param c the Component to click on
-     * @param buttons mouse button(s).
+     * @param buttons mouse button(s)
      */
     public void clickMouseOn(Component c, int buttons) {
         moveMouseTo(c);

--- a/test/jdk/javax/swing/regtesthelpers/JRobot.java
+++ b/test/jdk/javax/swing/regtesthelpers/JRobot.java
@@ -44,8 +44,8 @@ import javax.swing.SwingUtilities;
  */
 
 public class JRobot extends java.awt.Robot {
-    final private static int DEFAULT_DELAY = 550;
-    final private static int INTERNAL_DELAY = 250;
+    private static final int DEFAULT_DELAY = 550;
+    private static final int INTERNAL_DELAY = 250;
 
     private int delay;
     private boolean delaysEnabled;

--- a/test/jdk/javax/swing/regtesthelpers/JRobot.java
+++ b/test/jdk/javax/swing/regtesthelpers/JRobot.java
@@ -112,6 +112,9 @@ public class JRobot extends java.awt.Robot {
 
     /**
      * Move mouse cursor to the center of the Component.
+     * <p>
+     * <b>Note:</b> This method is executed on EDT
+     *
      * @param c Component the mouse is placed over
      */
     public void moveMouseTo(Component c) {
@@ -173,6 +176,9 @@ public class JRobot extends java.awt.Robot {
 
     /**
      * Click in the center of the given Component
+     * <p>
+     * <b>Note:</b> This method uses EDT
+     *
      * @param c the Component to click on
      * @param buttons mouse button(s).
      */
@@ -183,6 +189,9 @@ public class JRobot extends java.awt.Robot {
 
     /**
      * Click the first mouse button in the center of the given Component
+     * <p>
+     * <b>Note:</b> This method uses EDT
+     *
      * @param c the Component to click on
      */
     public void clickMouseOn(Component c) {
@@ -253,6 +262,9 @@ public class JRobot extends java.awt.Robot {
     /**
      * Convert a rectangle from coordinate system of Component c to
      * screen coordinate system.
+     * <p>
+     * <b>Note:</b> This method uses EDT
+     *
      * @param r a non-null Rectangle
      * @param c a Component whose coordinate system is used for conversion
      */


### PR DESCRIPTION
Hi Reviewers,

I have updated the JRobot.java file for enabling EDT support, along with I have removed warning BUTTON1_MASK with 'BUTTON1_DOWN_MASK'.

Regards,
Renjith

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307934](https://bugs.openjdk.org/browse/JDK-8307934): JRobot.moveMouseTo must access component on EDT (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14354/head:pull/14354` \
`$ git checkout pull/14354`

Update a local copy of the PR: \
`$ git checkout pull/14354` \
`$ git pull https://git.openjdk.org/jdk.git pull/14354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14354`

View PR using the GUI difftool: \
`$ git pr show -t 14354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14354.diff">https://git.openjdk.org/jdk/pull/14354.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14354#issuecomment-1580770197)