### PR TITLE
8309613: [Windows] hs_err files sometimes miss information about the code containing the error

### DIFF
--- a/src/hotspot/os/aix/os_aix.hpp
+++ b/src/hotspot/os/aix/os_aix.hpp
@@ -172,7 +172,7 @@ class os::Aix {
   // Returns true if ok, false if error.
   static bool get_meminfo(meminfo_t* pmi);
 
-  static bool platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size);
+  static bool platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size, address& lastpc);
   static void* resolve_function_descriptor(void* p);
 };
 

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -48,7 +48,7 @@ class os::win32 {
   static void print_uptime_info(outputStream* st);
 
   static bool platform_print_native_stack(outputStream* st, const void* context,
-                                          char *buf, int buf_size);
+                                          char *buf, int buf_size, address& lastpc);
 
   static bool register_code_area(char *low, char *high);
 

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -516,7 +516,7 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-bool os::Aix::platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size) {
+bool os::Aix::platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size, address& lastpc) {
   AixNativeCallstack::print_callstack_for_context(st, (const ucontext_t*)context, true, buf, (size_t) buf_size);
   return true;
 }

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.inline.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.inline.hpp
@@ -30,8 +30,8 @@
 
 #define HAVE_PLATFORM_PRINT_NATIVE_STACK 1
 inline bool os::platform_print_native_stack(outputStream* st, const void* context,
-                                            char *buf, int buf_size) {
-  return os::Aix::platform_print_native_stack(st, context, buf, buf_size);
+                                            char *buf, int buf_size, address& lastpc) {
+  return os::Aix::platform_print_native_stack(st, context, buf, buf_size, lastpc);
 }
 
 #define HAVE_FUNCTION_DESCRIPTORS 1

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.inline.hpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.inline.hpp
@@ -31,8 +31,8 @@
 #ifdef AMD64
 #define HAVE_PLATFORM_PRINT_NATIVE_STACK 1
 inline bool os::platform_print_native_stack(outputStream* st, const void* context,
-                                     char *buf, int buf_size) {
-  return os::win32::platform_print_native_stack(st, context, buf, buf_size);
+                                     char *buf, int buf_size, address& lastpc) {
+  return os::win32::platform_print_native_stack(st, context, buf, buf_size, lastpc);
 }
 #endif
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1008,7 +1008,7 @@ class os: AllStatic {
 
  public:
   inline static bool platform_print_native_stack(outputStream* st, const void* context,
-                                                 char *buf, int buf_size);
+                                                 char *buf, int buf_size, address& lastpc);
 
   // debugging support (mostly used by debug.cpp but also fatal error handler)
   static bool find(address pc, outputStream* st = tty); // OS specific function to make sense out of an address

--- a/src/hotspot/share/runtime/os.inline.hpp
+++ b/src/hotspot/share/runtime/os.inline.hpp
@@ -35,7 +35,7 @@
 
 #ifndef HAVE_PLATFORM_PRINT_NATIVE_STACK
 inline bool os::platform_print_native_stack(outputStream* st, const void* context,
-                                     char *buf, int buf_size) {
+                                     char *buf, int buf_size, address& lastpc) {
   return false;
 }
 #endif

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -654,7 +654,8 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
 extern "C" JNIEXPORT void pns2() { // print native stack
   Command c("pns2");
   static char buf[O_BUFLEN];
-  if (os::platform_print_native_stack(tty, nullptr, buf, sizeof(buf))) {
+  address lastpc = nullptr;
+  if (os::platform_print_native_stack(tty, nullptr, buf, sizeof(buf), lastpc)) {
     // We have printed the native stack in platform-specific code,
     // so nothing else to do in this case.
   } else {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -973,10 +973,14 @@ void VMError::report(outputStream* st, bool _verbose) {
     if (os::platform_print_native_stack(st, _context, buf, sizeof(buf), lastpc)) {
       // We have printed the native stack in platform-specific code
       // Windows/x64 needs special handling.
-      // Stack walking may got stuck. Try to print the calling code.
+      // Stack walking may get stuck. Try to print the calling code.
       if (lastpc != nullptr) {
         st->print_cr("called by the following code:");
-        print_code(st, _thread, lastpc, true, printed, printed_capacity);
+        if (print_code(st, _thread, lastpc, true, printed, printed_capacity)) {
+          printed_len++;
+        } else {
+          st->print_cr("no VM gerenated code");
+        }
       }
     } else {
       frame fr = _context ? os::fetch_frame_from_context(_context)

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -995,7 +995,7 @@ void VMError::report(outputStream* st, bool _verbose) {
       if (lastpc != nullptr) {
         const char* name = find_code_name(lastpc);
         if (name != nullptr) {
-          st->print_cr("the last pc belongs to %s (will be printed below)", name);
+          st->print_cr("The last pc belongs to %s (printed below).", name);
         }
       }
     } else {


### PR DESCRIPTION
We have seen hs_err files for errors triggered by C2 compiled methods which miss the most relevant information: the C2 method (see JBS issue for more details). I have found a possibility to add it. Please take a look and provide feedback.

Testing:
```diff
diff --git a/src/hotspot/share/opto/parse1.cpp b/src/hotspot/share/opto/parse1.cpp
index f179d3ba88d..c35a1ac595e 100644
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1210,6 +1210,12 @@ void Parse::do_method_entry() {
     make_dtrace_method_entry(method());
   }
 
+  if (UseNewCode) {
+    Node* halt = _gvn.transform(new HaltNode(control(), frameptr(), "Requested Halt!"));
+    C->root()->add_req(halt);
+    set_control(halt);
+  }
+
 #ifdef ASSERT
   // Narrow receiver type when it is too broad for the method being parsed.
   if (!method()->is_static()) {
```

"java -XX:+UseNewCode -version" shows the following output (when no hsdis lib is provided):
```
---------------  T H R E A D  ---------------

Current thread (0x0000024daebb2b30):  JavaThread "main"             [_thread_in_Java, id=30876, stack(0x000000cdacc00000,0x000000cdacd00000) (1024K)]

Stack: [0x000000cdacc00000,0x000000cdacd00000]
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [jvm.dll+0x6ca5b9]  os::win32::platform_print_native_stack+0xd9  (os_windows_x86.cpp:236)
V  [jvm.dll+0x8a3af1]  VMError::report+0xd61  (vmError.cpp:991)
V  [jvm.dll+0x8a5d6e]  VMError::report_and_die+0x5fe  (vmError.cpp:1797)
V  [jvm.dll+0x283061]  report_fatal+0x71  (debug.cpp:212)
V  [jvm.dll+0x621c3e]  MacroAssembler::debug64+0x8e  (macroAssembler_x86.cpp:829)
C  0x0000024dc1553cf4

The last pc belongs to nmethod (printed below).

Compiled method (c2)      92   16       4       java.lang.Object::<init> (1 bytes)
 total in heap  [0x0000024dc1553b10,0x0000024dc1553d50] = 576
 relocation     [0x0000024dc1553c70,0x0000024dc1553c88] = 24
 main code      [0x0000024dc1553ca0,0x0000024dc1553d00] = 96
 stub code      [0x0000024dc1553d00,0x0000024dc1553d18] = 24
 metadata       [0x0000024dc1553d18,0x0000024dc1553d20] = 8
 scopes data    [0x0000024dc1553d20,0x0000024dc1553d28] = 8
 scopes pcs     [0x0000024dc1553d28,0x0000024dc1553d48] = 32
 dependencies   [0x0000024dc1553d48,0x0000024dc1553d50] = 8

[Constant Pool (empty)]

[MachCode]
[Entry Point]
  # {method} {0x0000000800478d78} '<init>' '()V' in 'java/lang/Object'
  #           [sp+0x20]  (sp of caller)
  0x0000024dc1553ca0: 448b 5208 | 49bb 0000 | 0000 0800 | 0000 4d03 | d349 3bc2 

  0x0000024dc1553cb4: ;   {runtime_call ic_miss_stub}
  0x0000024dc1553cb4: 0f85 c6a9 | 8fff 6690 | 0f1f 4000 
[Verified Entry Point]
  0x0000024dc1553cc0: 4881 ec18 | 0000 0048 | 896c 2410 | 4181 7f20 | 0100 0000 | 0f85 1b00 

  0x0000024dc1553cd8: ;   {external_word}
  0x0000024dc1553cd8: 0000 48b9 | 98e7 0702 | fd7f 0000 | 4883 e4f0 

  0x0000024dc1553ce8: ;   {runtime_call MacroAssembler::debug64}
  0x0000024dc1553ce8: 48b8 b01b | c201 fd7f | 0000 ffd0 

  0x0000024dc1553cf4: ;   {runtime_call StubRoutines (final stubs)}
  0x0000024dc1553cf4: f4e8 0622 | 8eff e9db | ffff fff4 
[Exception Handler]
  0x0000024dc1553d00: ;   {no_reloc}
  0x0000024dc1553d00: e97b c99d | ffe8 0000 | 0000 4883 

  0x0000024dc1553d0c: ;   {runtime_call DeoptimizationBlob}
  0x0000024dc1553d0c: 2c24 05e9 | 0c40 90ff | f4f4 f4f4 
[/MachCode]


---------------  P R O C E S S  ---------------
```

Without the patch, we don't see which compiled method called this at all. An example from a real C2 bug is here: https://bugs.openjdk.org/secure/attachment/103766/hs_err_pid7652.log

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309613](https://bugs.openjdk.org/browse/JDK-8309613): [Windows] hs_err files sometimes miss information about the code containing the error (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [56a3f4c6](https://git.openjdk.org/jdk/pull/14358/files/56a3f4c69fd7272b9bd9a79873b282c27bbf897b)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [56a3f4c6](https://git.openjdk.org/jdk/pull/14358/files/56a3f4c69fd7272b9bd9a79873b282c27bbf897b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14358/head:pull/14358` \
`$ git checkout pull/14358`

Update a local copy of the PR: \
`$ git checkout pull/14358` \
`$ git pull https://git.openjdk.org/jdk.git pull/14358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14358`

View PR using the GUI difftool: \
`$ git pr show -t 14358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14358.diff">https://git.openjdk.org/jdk/pull/14358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14358#issuecomment-1580967494)