### PR TITLE
8309614: [BACKOUT] JDK-8307153 JVMTI GetThreadState on carrier should return STATE_WAITING

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -730,7 +730,7 @@ JvmtiEnvBase::get_cthread_last_java_vframe(JavaThread* jt, RegisterMap* reg_map_
 }
 
 jint
-JvmtiEnvBase::get_thread_state_base(oop thread_oop, JavaThread* jt) {
+JvmtiEnvBase::get_thread_state(oop thread_oop, JavaThread* jt) {
   jint state = 0;
 
   if (thread_oop != nullptr) {
@@ -757,19 +757,6 @@ JvmtiEnvBase::get_thread_state_base(oop thread_oop, JavaThread* jt) {
 }
 
 jint
-JvmtiEnvBase::get_thread_state(oop thread_oop, JavaThread* jt) {
-  jint state;
-
-  if (is_thread_carrying_vthread(jt, thread_oop)) {
-    state = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_WAITING |
-            JVMTI_THREAD_STATE_WAITING_INDEFINITELY;
-  } else {
-    state = get_thread_state_base(thread_oop, jt);
-  }
-  return state;
-}
-
-jint
 JvmtiEnvBase::get_vthread_state(oop thread_oop, JavaThread* java_thread) {
   jint state = 0;
   bool ext_suspended = JvmtiVTSuspender::is_vthread_suspended(thread_oop);
@@ -783,7 +770,7 @@ JvmtiEnvBase::get_vthread_state(oop thread_oop, JavaThread* java_thread) {
     jint filtered_bits = JVMTI_THREAD_STATE_SUSPENDED | JVMTI_THREAD_STATE_INTERRUPTED;
 
     // This call can trigger a safepoint, so thread_oop must not be used after it.
-    state = get_thread_state_base(ct_oop, java_thread) & ~filtered_bits;
+    state = get_thread_state(ct_oop, java_thread) & ~filtered_bits;
   } else {
     jshort vt_state = java_lang_VirtualThread::state(thread_oop);
     state = (jint)java_lang_VirtualThread::map_state_to_thread_status(vt_state);
@@ -1721,13 +1708,13 @@ JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool singl
   if (java_thread->is_hidden_from_external_view()) {
     return JVMTI_ERROR_NONE;
   }
-  bool is_thread_carrying = is_thread_carrying_vthread(java_thread, thread_h());
+  bool is_passive_cthread = is_passive_carrier_thread(java_thread, thread_h());
 
   // A case of non-virtual thread.
   if (!is_virtual) {
     // Thread.suspend() is used in some tests. It sets jt->is_suspended() only.
     if (java_thread->is_carrier_thread_suspended() ||
-        (!is_thread_carrying && java_thread->is_suspended())) {
+        (!is_passive_cthread && java_thread->is_suspended())) {
       return JVMTI_ERROR_THREAD_SUSPENDED;
     }
     java_thread->set_carrier_thread_suspended();
@@ -1741,7 +1728,7 @@ JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool singl
   // An attempt to handshake-suspend a passive carrier thread will result in
   // suspension of mounted virtual thread. So, we just mark it as suspended
   // and it will be actually suspended at virtual thread unmount transition.
-  if (!is_thread_carrying) {
+  if (!is_passive_cthread) {
     assert(thread_h() != nullptr, "sanity check");
     assert(single_suspend || thread_h()->is_a(vmClasses::BaseVirtualThread_klass()),
            "SuspendAllVirtualThreads should never suspend non-virtual threads");
@@ -1791,19 +1778,19 @@ JvmtiEnvBase::resume_thread(oop thread_oop, JavaThread* java_thread, bool single
   if (java_thread->is_hidden_from_external_view()) {
     return JVMTI_ERROR_NONE;
   }
-  bool is_thread_carrying = is_thread_carrying_vthread(java_thread, thread_h());
+  bool is_passive_cthread = is_passive_carrier_thread(java_thread, thread_h());
 
   // A case of a non-virtual thread.
   if (!is_virtual) {
     if (!java_thread->is_carrier_thread_suspended() &&
-        (is_thread_carrying || !java_thread->is_suspended())) {
+        (is_passive_cthread || !java_thread->is_suspended())) {
       return JVMTI_ERROR_THREAD_NOT_SUSPENDED;
     }
     java_thread->clear_carrier_thread_suspended();
   }
   assert(!java_thread->is_in_VTMS_transition(), "sanity check");
 
-  if (!is_thread_carrying) {
+  if (!is_passive_cthread) {
     assert(thread_h() != nullptr, "sanity check");
     assert(single_resume || thread_h()->is_a(vmClasses::BaseVirtualThread_klass()),
            "ResumeAllVirtualThreads should never resume non-virtual threads");

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -97,7 +97,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   static bool is_in_thread_list(jint count, const jthread* list, oop jt_oop);
 
   // check if thread_oop represents a passive carrier thread
-  static bool is_thread_carrying_vthread(JavaThread* java_thread, oop thread_oop) {
+  static bool is_passive_carrier_thread(JavaThread* java_thread, oop thread_oop) {
     return java_thread != nullptr && java_thread->jvmti_vthread() != nullptr
                                && java_thread->jvmti_vthread() != thread_oop
                                && java_thread->threadObj() == thread_oop;
@@ -384,8 +384,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   // get carrier thread last java vframe
   static javaVFrame* get_cthread_last_java_vframe(JavaThread* jt, RegisterMap* reg_map);
 
-  // get platform thread state
-  static jint get_thread_state_base(oop thread_oop, JavaThread* jt);
+  // get ordinary thread thread state
   static jint get_thread_state(oop thread_oop, JavaThread* jt);
 
   // get virtual thread thread state

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java
@@ -42,12 +42,8 @@ public class ThreadStateTest {
 
     private static native void setSingleSteppingMode(boolean enable);
     private static native void setMonitorContendedMode(boolean enable);
-    private static native void testGetThreadState(Thread thread);
-    private static native void testGetThreadListStackTraces(Thread thread);
 
     final Runnable FOO = () -> {
-        testGetThreadState(Thread.currentThread());
-        testGetThreadListStackTraces(Thread.currentThread());
         Thread.yield();
     };
 
@@ -63,9 +59,7 @@ public class ThreadStateTest {
 
             List<Thread> virtualThreads = new ArrayList<>();
             for (int i = 0; i < VTHREAD_COUNT; i++) {
-                Thread vt = factory.newThread(FOO);
-                vt.setName("VT-" + i);
-                virtualThreads.add(vt);
+                virtualThreads.add(factory.newThread(FOO));
             }
 
             for (Thread t : virtualThreads) {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/libThreadStateTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/libThreadStateTest.cpp
@@ -29,10 +29,6 @@
 
 // set by Agent_OnLoad
 static jvmtiEnv* jvmti = nullptr;
-static const jint EXP_VT_STATE = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_RUNNABLE;
-static const jint EXP_CT_STATE = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_WAITING |
-                                 JVMTI_THREAD_STATE_WAITING_INDEFINITELY;
-static const jint MAX_FRAME_COUNT = 32;
 
 extern "C" {
 
@@ -42,60 +38,20 @@ SingleStep(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread,
 }
 
 static void JNICALL
-MonitorContended(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread,
+MonitorContended(jvmtiEnv* jvmti, JNIEnv* jni_env, jthread thread,
                  jobject object) {
-}
-
-static void JNICALL
-check_thread_state(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jint state, jint exp_state, const char* msg) {
-  if (state != exp_state) {
-    const char* tname = get_thread_name(jvmti, jni, thread);
-
-    LOG("FAILED: %p: %s: thread state: %x expected state: %x\n",
-        (void*)thread, tname, state, exp_state);
-
-    deallocate(jvmti, jni, (void*)tname);
-    jni->FatalError(msg);
-  }
 }
 
 JNIEXPORT void JNICALL
 Java_ThreadStateTest_setSingleSteppingMode(JNIEnv* jni, jclass klass, jboolean enable) {
   jvmtiError err = jvmti->SetEventNotificationMode(enable ? JVMTI_ENABLE : JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, nullptr);
-  check_jvmti_status(jni, err, "setSingleSteppingMode: error in JVMTI SetEventNotificationMode for JVMTI_EVENT_SINGLE_STEP");
+  check_jvmti_status(jni, err, "event handler: error in JVMTI SetEventNotificationMode for event JVMTI_EVENT_SINGLE_STEP");
 }
 
 JNIEXPORT void JNICALL
 Java_ThreadStateTest_setMonitorContendedMode(JNIEnv* jni, jclass klass, jboolean enable) {
   jvmtiError err = jvmti->SetEventNotificationMode(enable ? JVMTI_ENABLE : JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, nullptr);
-  check_jvmti_status(jni, err, "setMonitorContendedMode: error in JVMTI SetEventNotificationMode for JVMTI_EVENT_MONITOR_CONTENDED_ENTER");
-}
-
-JNIEXPORT void JNICALL
-Java_ThreadStateTest_testGetThreadState(JNIEnv* jni, jclass klass, jthread vthread) {
-  jthread cthread = get_carrier_thread(jvmti, jni, vthread);
-  jint ct_state = get_thread_state(jvmti, jni, cthread);
-  jint vt_state = get_thread_state(jvmti, jni, vthread);
-
-  check_thread_state(jvmti, jni, cthread, ct_state, EXP_CT_STATE,
-                     "Failed: unexpected carrier thread state from JVMTI GetThreadState");
-  check_thread_state(jvmti, jni, vthread, vt_state, EXP_VT_STATE,
-                     "Failed: unexpected virtual thread state from JVMTI GetThreadState");
-}
-
-JNIEXPORT void JNICALL
-Java_ThreadStateTest_testGetThreadListStackTraces(JNIEnv* jni, jclass klass, jthread vthread) {
-  jthread cthread = get_carrier_thread(jvmti, jni, vthread);
-  jthread threads[2] = { cthread, vthread };
-  jvmtiStackInfo* stackInfo = NULL;
-
-  jvmtiError err = jvmti->GetThreadListStackTraces(2, threads, MAX_FRAME_COUNT, &stackInfo);
-  check_jvmti_status(jni, err, "testGetThreadState: error in JVMTI GetThreadListStackTraces");
-
-  check_thread_state(jvmti, jni, cthread, stackInfo[0].state, EXP_CT_STATE,
-                     "Failed: unexpected carrier thread state from JVMTI GetThreadListStackTraces");
-  check_thread_state(jvmti, jni, vthread, stackInfo[1].state, EXP_VT_STATE,
-                     "Failed: unexpected virtual thread state from JVMTI GetThreadListStackTraces");
+  check_jvmti_status(jni, err, "event handler: error in JVMTI SetEventNotificationMode for event JVMTI_EVENT_MONITOR_CONTENDED_ENTER");
 }
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
@@ -103,9 +59,9 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
   jvmtiCapabilities caps;
   jvmtiError err;
 
-  printf("Agent_OnLoad: started\n");
+  printf("Agent_OnLoad started\n");
   if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
-    LOG("Agent_OnLoad: error in GetEnv");
+    LOG("error in GetEnv");
     return JNI_ERR;
   }
 
@@ -116,7 +72,7 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
 
   err = jvmti->AddCapabilities(&caps);
   if (err != JVMTI_ERROR_NONE) {
-    LOG("Agent_OnLoad: error in JVMTI AddCapabilities: %d\n", err);
+    LOG("error in JVMTI AddCapabilities: %d\n", err);
   }
 
   memset(&callbacks, 0, sizeof(callbacks));
@@ -126,7 +82,6 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
   if (err != JVMTI_ERROR_NONE) {
     LOG("Agent_OnLoad: Error in JVMTI SetEventCallbacks: %d\n", err);
   }
-  printf("Agent_OnLoad: finished\n");
 
   return 0;
 }


### PR DESCRIPTION
This reverts commit 177e8327d685444d63235567f2a9bde0ec3d51cf.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309614](https://bugs.openjdk.org/browse/JDK-8309614): [BACKOUT] JDK-8307153 JVMTI GetThreadState on carrier should return STATE_WAITING (**Sub-task** - `"2"`)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14359/head:pull/14359` \
`$ git checkout pull/14359`

Update a local copy of the PR: \
`$ git checkout pull/14359` \
`$ git pull https://git.openjdk.org/jdk.git pull/14359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14359`

View PR using the GUI difftool: \
`$ git pr show -t 14359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14359.diff">https://git.openjdk.org/jdk/pull/14359.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14359#issuecomment-1580970368)