### PR TITLE
8309545: Thread.interrupted from virtual thread needlessly resets interrupt status

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -874,13 +874,14 @@ final class VirtualThread extends BaseVirtualThread {
     @Override
     boolean getAndClearInterrupt() {
         assert Thread.currentThread() == this;
-        synchronized (interruptLock) {
-            boolean oldValue = interrupted;
-            if (oldValue)
+        boolean oldValue = interrupted;
+        if (oldValue) {
+            synchronized (interruptLock) {
                 interrupted = false;
-            carrierThread.clearInterrupt();
-            return oldValue;
+                carrierThread.clearInterrupt();
+            }
         }
+        return oldValue;
     }
 
     @Override


### PR DESCRIPTION
Thread.interrupted is used to "get and clear" the current thread's interrupt status. When called from a virtual thread, the current implementation always clears the carrier's interrupt status. There is no need to do this when the interrupt status is not set, it can just read the interrupt status and return false in that case.

This was found by Sergey Kuksenko when comparing platform vs. virtual thread performance. Once CODETOOLS-7903476 is in a released version of JMH then we can start to accumulate benchmarks that execute in virtual threads.

Testing: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309545](https://bugs.openjdk.org/browse/JDK-8309545): Thread.interrupted from virtual thread needlessly resets interrupt status (**Bug** - P3)


### Reviewers
 * [Ron Pressler](https://openjdk.org/census#rpressler) (@pron - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14361/head:pull/14361` \
`$ git checkout pull/14361`

Update a local copy of the PR: \
`$ git checkout pull/14361` \
`$ git pull https://git.openjdk.org/jdk.git pull/14361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14361`

View PR using the GUI difftool: \
`$ git pr show -t 14361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14361.diff">https://git.openjdk.org/jdk/pull/14361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14361#issuecomment-1582214506)