### PR TITLE
JDK-8305645: System Tray icons get corrupted when Windows primary monitor changes

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -262,7 +262,7 @@ LRESULT CALLBACK AwtTrayIcon::TrayWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam
                 }
             }
             break;
-        case WM_DPICHANGED:
+        case WM_DISPLAYCHANGE:
             // Set the flag to update icon images, see WmTaskbarCreated
             m_bDPIChanged = true;
             break;

--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,9 @@ public class TrayIconScalingTest {
     private static TrayIcon icon;
 
     private static final String INSTRUCTIONS =
-            "This test checks if the tray icon gets updated when DPI / Scale" +
-            " is changed on the fly.\n\n" +
+            "This test checks if the tray icon gets updated correctly under 2 scenarios:\n\n" +
+            "Case 1: Single Screen - when DPI / Scale is changed on the fly.\n" +
+            "Case 2: Multi Screen - when both screens are set to different scales.\n\n" +
             "STEPS: \n\n" +
             "1. Check the system tray / notification area on Windows" +
             " taskbar, you should see a white icon which displays a" +
@@ -61,11 +62,17 @@ public class TrayIconScalingTest {
             "2. Navigate to Settings > System > Display and change the" +
             " display scale by selecting any value from" +
             " Scale & Layout dropdown.\n\n"+
-            "3. When the scale changes, check the white tray icon," +
+            "3. For Case 1, when the scale changes, check the white tray icon," +
             " there should be no distortion, it should be displayed sharp,\n" +
             " and the displayed number should correspond to the current"+
-            " scale:\n" +
-            " 100% - 16, 125% - 20, 150% - 24, 175% - 28, 200% - 32.\n\n"+
+            " scale.\n\n" +
+            "4. For Case 2, a dual monitor setup is required with 'Multiple Display'" +
+            " option under Display settings set to 'Extend the display'.\n\n" +
+            "5. Have the monitors set to different scales and toggle the" +
+            " 'Make this my main display' option under Display settings.\n\n" +
+            " In both cases, the tray icon should be displayed as a clear image" +
+            " without any distortion with the display number corresponding to the scale.\n" +
+            " 100% - 16, 125% - 20, 150% - 24, 175% - 28, 200% - 32.\n\n" +
             " If the icon is displayed sharp and without any distortion," +
             " press PASS, otherwise press FAIL.\n";
 
@@ -79,7 +86,7 @@ public class TrayIconScalingTest {
             return;
         }
         PassFailJFrame passFailJFrame = new PassFailJFrame("TrayIcon " +
-                "Test Instructions", INSTRUCTIONS, 8, 18, 85);
+                "Test Instructions", INSTRUCTIONS, 8, 25, 85);
         createAndShowGUI();
         // does not have a test window,
         // hence only the instruction frame is positioned


### PR DESCRIPTION
There are two scenarios related to tray icon distortion.

1. Single Screen - when DPI / Scale is changed on the fly - this was resolved as part of [PR#8441](https://github.com/openjdk/jdk/pull/8441)

2. Multi Screen - when screens are set to different scales and the primary display is toggled. This is a variation of scenario one. 

Earlier Windows msg - [WM_DPICHANGED](https://learn.microsoft.com/en-us/windows/win32/hidpi/wm-dpichanged) was being used to update the tray icons. This message is sent when window DPI changes. WM_DPICHANGED msg is not received when taskbar switches to primary display under multiple screen scenario, hence the tray icon was still seen distorted in case 2.
 
As [WM_DISPLAYCHANGE](https://learn.microsoft.com/en-us/windows/win32/gdi/wm-displaychange) is received in both cases, it is used as the new message to trigger tray icon update. This message also works when the main display monitor gets disconnected accidently making the other display the primary display.

TrayIconScalingTest's  instructions have been updated to include both the cases described above.