### PR TITLE
8309569: sun/security/pkcs11/Signature/TestRSAKeyLength.java fails after JDK-8301553

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -536,13 +536,14 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
     jboolean* jpTemp;
     CK_ULONG i;
 
-    *ckpLength = jArray == NULL ? 0L : (*env)->GetArrayLength(env, jArray);
-    if(*ckpLength == 0L) {
+    if (jArray == NULL) {
         *ckpArray = NULL_PTR;
+        *ckpLength = 0UL;
         return;
     }
+    *ckpLength = (*env)->GetArrayLength(env, jArray);
     jpTemp = (jboolean*) calloc(*ckpLength, sizeof(jboolean));
-    if (jpTemp == NULL) {
+    if (jpTemp == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return;
     }
@@ -552,8 +553,8 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
         return;
     }
 
-    *ckpArray = (CK_BBOOL*) calloc (*ckpLength, sizeof(CK_BBOOL));
-    if (*ckpArray == NULL) {
+    *ckpArray = (CK_BBOOL*) calloc(*ckpLength, sizeof(CK_BBOOL));
+    if (*ckpArray == NULL && *ckpLength != 0UL) {
         free(jpTemp);
         p11ThrowOutOfMemoryError(env, 0);
         return;
@@ -577,13 +578,14 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
     jbyte* jpTemp;
     CK_ULONG i;
 
-    *ckpLength = jArray == NULL ? 0L : (*env)->GetArrayLength(env, jArray);
-    if(*ckpLength == 0L) {
+    if (jArray == NULL) {
         *ckpArray = NULL_PTR;
+        *ckpLength = 0UL;
         return;
     }
+    *ckpLength = (*env)->GetArrayLength(env, jArray);
     jpTemp = (jbyte*) calloc(*ckpLength, sizeof(jbyte));
-    if (jpTemp == NULL) {
+    if (jpTemp == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return;
     }
@@ -597,8 +599,8 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
     if (sizeof(CK_BYTE) == sizeof(jbyte)) {
         *ckpArray = (CK_BYTE_PTR) jpTemp;
     } else {
-        *ckpArray = (CK_BYTE_PTR) calloc (*ckpLength, sizeof(CK_BYTE));
-        if (*ckpArray == NULL) {
+        *ckpArray = (CK_BYTE_PTR) calloc(*ckpLength, sizeof(CK_BYTE));
+        if (*ckpArray == NULL && *ckpLength != 0UL) {
             free(jpTemp);
             p11ThrowOutOfMemoryError(env, 0);
             return;
@@ -623,13 +625,14 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
     jlong* jTemp;
     CK_ULONG i;
 
-    *ckpLength = jArray == NULL ? 0L : (*env)->GetArrayLength(env, jArray);
-    if(*ckpLength == 0L) {
+    if (jArray == NULL) {
         *ckpArray = NULL_PTR;
+        *ckpLength = 0UL;
         return;
     }
+    *ckpLength = (*env)->GetArrayLength(env, jArray);
     jTemp = (jlong*) calloc(*ckpLength, sizeof(jlong));
-    if (jTemp == NULL) {
+    if (jTemp == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return;
     }
@@ -640,7 +643,7 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
     }
 
     *ckpArray = (CK_ULONG_PTR) calloc(*ckpLength, sizeof(CK_ULONG));
-    if (*ckpArray == NULL) {
+    if (*ckpArray == NULL && *ckpLength != 0UL) {
         free(jTemp);
         p11ThrowOutOfMemoryError(env, 0);
         return;
@@ -664,13 +667,14 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
     jchar* jpTemp;
     CK_ULONG i;
 
-    *ckpLength = jArray == NULL ? 0L : (*env)->GetArrayLength(env, jArray);
-    if(*ckpLength == 0L) {
+    if (jArray == NULL) {
         *ckpArray = NULL_PTR;
+        *ckpLength = 0UL;
         return;
     }
+    *ckpLength = (*env)->GetArrayLength(env, jArray);
     jpTemp = (jchar*) calloc(*ckpLength, sizeof(jchar));
-    if (jpTemp == NULL) {
+    if (jpTemp == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return;
     }
@@ -680,8 +684,8 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
         return;
     }
 
-    *ckpArray = (CK_CHAR_PTR) calloc (*ckpLength, sizeof(CK_CHAR));
-    if (*ckpArray == NULL) {
+    *ckpArray = (CK_CHAR_PTR) calloc(*ckpLength, sizeof(CK_CHAR));
+    if (*ckpArray == NULL && *ckpLength != 0UL) {
         free(jpTemp);
         p11ThrowOutOfMemoryError(env, 0);
         return;
@@ -705,13 +709,14 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
     jchar* jTemp;
     CK_ULONG i;
 
-    *ckpLength = jArray == NULL ? 0L : (*env)->GetArrayLength(env, jArray);
-    if(*ckpLength == 0L) {
+    if (jArray == NULL) {
         *ckpArray = NULL_PTR;
+        *ckpLength = 0UL;
         return;
     }
+    *ckpLength = (*env)->GetArrayLength(env, jArray);
     jTemp = (jchar*) calloc(*ckpLength, sizeof(jchar));
-    if (jTemp == NULL) {
+    if (jTemp == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return;
     }
@@ -721,7 +726,7 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
     }
 
     *ckpArray = (CK_UTF8CHAR_PTR) calloc(*ckpLength, sizeof(CK_UTF8CHAR));
-    if (*ckpArray == NULL) {
+    if (*ckpArray == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         goto cleanup;
     }
@@ -792,7 +797,7 @@ void jAttributeArrayToCKAttributeArray(JNIEnv *env, jobjectArray jArray, CK_ATTR
     jLength = (*env)->GetArrayLength(env, jArray);
     *ckpLength = jLongToCKULong(jLength);
     *ckpArray = (CK_ATTRIBUTE_PTR) calloc(*ckpLength, sizeof(CK_ATTRIBUTE));
-    if (*ckpArray == NULL) {
+    if (*ckpArray == NULL && *ckpLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return;
     }
@@ -833,7 +838,7 @@ jbyteArray ckByteArrayToJByteArray(JNIEnv *env, const CK_BYTE_PTR ckpArray, CK_U
         jpTemp = (jbyte*) ckpArray;
     } else {
         jpTemp = (jbyte*) calloc(ckLength, sizeof(jbyte));
-        if (jpTemp == NULL) {
+        if (jpTemp == NULL && ckLength != 0UL) {
             p11ThrowOutOfMemoryError(env, 0);
             return NULL;
         }
@@ -867,7 +872,7 @@ jlongArray ckULongArrayToJLongArray(JNIEnv *env, const CK_ULONG_PTR ckpArray, CK
     jlongArray jArray;
 
     jpTemp = (jlong*) calloc(ckLength, sizeof(jlong));
-    if (jpTemp == NULL) {
+    if (jpTemp == NULL && ckLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
@@ -898,7 +903,7 @@ jcharArray ckCharArrayToJCharArray(JNIEnv *env, const CK_CHAR_PTR ckpArray, CK_U
     jcharArray jArray;
 
     jpTemp = (jchar*) calloc(ckLength, sizeof(jchar));
-    if (jpTemp == NULL) {
+    if (jpTemp == NULL && ckLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }
@@ -929,7 +934,7 @@ jcharArray ckUTF8CharArrayToJCharArray(JNIEnv *env, const CK_UTF8CHAR_PTR ckpArr
     jcharArray jArray;
 
     jpTemp = (jchar*) calloc(ckLength, sizeof(jchar));
-    if (jpTemp == NULL) {
+    if (jpTemp == NULL && ckLength != 0UL) {
         p11ThrowOutOfMemoryError(env, 0);
         return NULL;
     }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -606,7 +606,7 @@ sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 gene
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
 sun/security/tools/keytool/NssTest.java                         8295343 linux-all
-sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343,8309569 linux-all,macosx-x64,windows-x64
+sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343 linux-all
 sun/security/pkcs11/rsa/TestSignatures.java                     8295343 linux-all
 sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-all
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all


### PR DESCRIPTION
We would like to propose a fix for 8309569. In this bug, a Java signature buffer of length 0 is passed to sun.security.pkcs11.wrapper.PKCS11::C_VerifyFinal to finish an ongoing signature verification operation. Notice that finishing the operation by means of C_SessionCancel was either not tried —as in software tokens implementing a standard of PKCS # 11 previous to 3— or failed, and finishing the operation with C_VerifyFinal is used as a last resort. Before calling the native C_VerifyFinal function, the signature buffer is converted from Java to native in jByteArrayToCKByteArray. Previous to 8301553, calloc was called with length 0 and, in most platforms, returns an address different from NULL. This non-NULL value was okay to the NSS Software Token [1], nothing was read because the length was 0 and the operation was finally cancelled. After 8301553, we made jByteArrayToCKByteArray to return NULL in cases of length 0 in the spirit of aligning different calloc implementations to a single path. The scope of the change is not limited to jByteArrayToCKByteArray but to other 4 analogous conversion functions in p11_util.c.

We propose to revert the behavior to the state previous to 8301553 —in other words, calling calloc in cases of length 0— but avoiding an OOM exception if calloc returns NULL because of a length 0. For implementations where calloc returns NULL upon a 0 length, an OOM exception does not reflect what really happened. In these cases, it's up to the native PKCS # 11 library to handle the case.

--
[1] - https://github.com/nss-dev/nss/blob/NSS_3_67_RTM/lib/softoken/pkcs11c.c#L3823

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309569](https://bugs.openjdk.org/browse/JDK-8309569): sun/security/pkcs11/Signature/TestRSAKeyLength.java fails after JDK-8301553 (**Bug** - P2)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Contributors
 * Martin Balao `<mbalao@openjdk.org>`
 * Francisco Ferrari Bihurriet `<fferrari@redhat.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14369/head:pull/14369` \
`$ git checkout pull/14369`

Update a local copy of the PR: \
`$ git checkout pull/14369` \
`$ git pull https://git.openjdk.org/jdk.git pull/14369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14369`

View PR using the GUI difftool: \
`$ git pr show -t 14369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14369.diff">https://git.openjdk.org/jdk/pull/14369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14369#issuecomment-1581466760)