### PR TITLE
8309499: javac fails to report compiler.err.no.java.lang with annotation processing enabled

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -978,9 +978,7 @@ public class JavaCompiler {
             }
 
             // In case an Abort was thrown before processAnnotations could be called,
-            // we could have deferred diagnostics that haven't been reported. At the
-            // time of this comment's writing, this can only ever occur through a
-            // missing java.lang error.
+            // we could have deferred diagnostics that haven't been reported.
             if (deferredDiagnosticHandler != null) {
                 deferredDiagnosticHandler.reportDeferredDiagnostics();
                 log.popDiagnosticHandler(deferredDiagnosticHandler);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -977,6 +977,14 @@ public class JavaCompiler {
                 log.printVerbose("total", Long.toString(elapsed_msec));
             }
 
+            // In case an Abort was thrown before processAnnotations could be called,
+            // we could have deferred diagnostics that haven't been reported. At the
+            // time of this comment's writing, this can only ever occur through a
+            // missing java.lang error.
+            if (deferredDiagnosticHandler != null) {
+                deferredDiagnosticHandler.reportDeferredDiagnostics();
+                log.popDiagnosticHandler(deferredDiagnosticHandler);
+            }
             reportDeferredDiagnostics();
 
             if (!log.hasDiagnosticListener()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -971,11 +971,6 @@ public class JavaCompiler {
         } catch (Abort ex) {
             if (devVerbose)
                 ex.printStackTrace(System.err);
-        } finally {
-            if (verbose) {
-                elapsed_msec = elapsed(start_msec);
-                log.printVerbose("total", Long.toString(elapsed_msec));
-            }
 
             // In case an Abort was thrown before processAnnotations could be called,
             // we could have deferred diagnostics that haven't been reported.
@@ -983,6 +978,12 @@ public class JavaCompiler {
                 deferredDiagnosticHandler.reportDeferredDiagnostics();
                 log.popDiagnosticHandler(deferredDiagnosticHandler);
             }
+        } finally {
+            if (verbose) {
+                elapsed_msec = elapsed(start_msec);
+                log.printVerbose("total", Long.toString(elapsed_msec));
+            }
+
             reportDeferredDiagnostics();
 
             if (!log.hasDiagnosticListener()) {

--- a/test/langtools/tools/javac/fatalErrors/NoJavaLangWithAnnotationProcessorTest.java
+++ b/test/langtools/tools/javac/fatalErrors/NoJavaLangWithAnnotationProcessorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309499
+ * @summary Verify that java.lang unavailable error is not swallowed when
+ *  annotation processor is used.
+ * @library /tools/lib /tools/javac/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @build NoJavaLangWithAnnotationProcessorTest JavacTestingAbstractProcessor
+ * @run main NoJavaLangWithAnnotationProcessorTest
+ */
+
+import java.nio.file.*;
+import java.util.Set;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class NoJavaLangWithAnnotationProcessorTest extends JavacTestingAbstractProcessor {
+
+    private static final String noJavaLangSrc =
+        "public class NoJavaLang {\n" +
+        "    private String s;\n" +
+        "}";
+
+    private static final String compilerErrorMessage =
+        "compiler.err.no.java.lang";
+
+    // No-Op annotation processor
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    public static void main(String[] args) throws Exception {
+        new NoJavaLangWithAnnotationProcessorTest().run();
+    }
+
+    final ToolBox tb = new ToolBox();
+
+    void run() throws Exception {
+        testCompilesNormallyWithNonEmptyBootClassPath();
+        testBootClassPath();
+        testModulePath();
+    }
+
+    // Normal case with java.lang available
+    void testCompilesNormallyWithNonEmptyBootClassPath() {
+        new JavacTask(tb)
+                .sources(noJavaLangSrc)
+                .options("-processor", "NoJavaLangWithAnnotationProcessorTest")
+                .run();
+    }
+
+
+    // test with bootclasspath, for as long as its around
+    void testBootClassPath() {
+        String[] bcpOpts = {"-XDrawDiagnostics", "-Xlint:-options", "-source", "8", "-target", "8", 
+            "-bootclasspath", ".", "-classpath", ".",
+            "-processor", "NoJavaLangWithAnnotationProcessorTest", "-processorpath", System.getProperty("test.class.path") };
+        test(bcpOpts, compilerErrorMessage);
+    }
+
+    // test with module path
+    void testModulePath() throws Exception {
+        // need to ensure there is an empty java.base to avoid different error message
+        Files.createDirectories(Paths.get("modules/java.base"));
+        new JavacTask(tb)
+                .sources("module java.base { }",
+                         "package java.lang; public class Object {}")
+                .outdir("modules/java.base")
+                .run();
+
+        Files.delete(Paths.get("modules", "java.base", "java", "lang", "Object.class"));
+
+        String[] mpOpts = {"-XDrawDiagnostics", "--system", "none", "--module-path", "modules",
+            "-processor", "NoJavaLangWithAnnotationProcessorTest", "-processorpath", System.getProperty("test.class.path") };
+        test(mpOpts, compilerErrorMessage);
+    }
+
+    private void test(String[] options, String expect) {
+        System.err.println("Testing " + java.util.Arrays.toString(options));
+
+        String out = new JavacTask(tb)
+                .options(options)
+                .sources(noJavaLangSrc)
+                .run(Task.Expect.FAIL, 1)
+                .writeAll()
+                .getOutput(Task.OutputKind.DIRECT);
+
+        if (!out.contains(expect)) {
+            throw new AssertionError("javac generated error output is not correct");
+        }
+    }
+
+}

--- a/test/langtools/tools/javac/fatalErrors/NoJavaLangWithAnnotationProcessorTest.java
+++ b/test/langtools/tools/javac/fatalErrors/NoJavaLangWithAnnotationProcessorTest.java
@@ -83,7 +83,7 @@ public class NoJavaLangWithAnnotationProcessorTest extends JavacTestingAbstractP
 
     // test with bootclasspath, for as long as its around
     void testBootClassPath() {
-        String[] bcpOpts = {"-XDrawDiagnostics", "-Xlint:-options", "-source", "8", "-target", "8", 
+        String[] bcpOpts = {"-XDrawDiagnostics", "-Xlint:-options", "-source", "8", "-target", "8",
             "-bootclasspath", ".", "-classpath", ".",
             "-processor", "NoJavaLangWithAnnotationProcessorTest", "-processorpath", System.getProperty("test.class.path") };
         test(bcpOpts, compilerErrorMessage);


### PR DESCRIPTION
Hi,

Please consider this fix for an error handling bug in javac, which causes a deferred diagnostic to be lost when an `Abort` is thrown with annotation processing enabled. See https://bugs.openjdk.org/browse/JDK-8309499 for more details.

This fix is contributed by my colleague Paula Toth paulatoth@google.com.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309499](https://bugs.openjdk.org/browse/JDK-8309499): javac fails to report compiler.err.no.java.lang with annotation processing enabled (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Contributors
 * Paula Toth `<paulatoth@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14370/head:pull/14370` \
`$ git checkout pull/14370`

Update a local copy of the PR: \
`$ git checkout pull/14370` \
`$ git pull https://git.openjdk.org/jdk.git pull/14370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14370`

View PR using the GUI difftool: \
`$ git pr show -t 14370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14370.diff">https://git.openjdk.org/jdk/pull/14370.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14370#issuecomment-1581533042)