### PR TITLE
8299825: Move StdoutLog and StderrLog to LogConfiguration

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -41,7 +41,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 LogOutput** LogConfiguration::_outputs = nullptr;
-size_t LogConfiguration::_n_outputs = 0;
+size_t      LogConfiguration::_n_outputs = 0;
 
 LogStdoutOutput* LogConfiguration::LogConfiguration::StdoutLog = nullptr;
 LogStderrOutput* LogConfiguration::LogConfiguration::StderrLog = nullptr;

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -43,8 +43,8 @@
 LogOutput** LogConfiguration::_outputs = nullptr;
 size_t      LogConfiguration::_n_outputs = 0;
 
-LogStdoutOutput* LogConfiguration::LogConfiguration::StdoutLog = nullptr;
-LogStderrOutput* LogConfiguration::LogConfiguration::StderrLog = nullptr;
+LogStdoutOutput* LogConfiguration::StdoutLog = nullptr;
+LogStderrOutput* LogConfiguration::StderrLog = nullptr;
 
 LogConfiguration::UpdateListenerFunction* LogConfiguration::_listener_callbacks = nullptr;
 size_t      LogConfiguration::_n_listener_callbacks = 0;
@@ -105,20 +105,20 @@ void LogConfiguration::post_initialize() {
 }
 
 void LogConfiguration::initialize(jlong vm_start_time) {
-  LogConfiguration::StdoutLog = new LogStdoutOutput();
-  LogConfiguration::StderrLog = new LogStderrOutput();
+  StdoutLog = new LogStdoutOutput();
+  StderrLog = new LogStderrOutput();
   LogFileOutput::set_file_name_parameters(vm_start_time);
   assert(_outputs == nullptr, "Should not initialize _outputs before this function, initialize called twice?");
   _outputs = NEW_C_HEAP_ARRAY(LogOutput*, 2, mtLogging);
-  _outputs[0] = LogConfiguration::StdoutLog;
-  _outputs[1] = LogConfiguration::StderrLog;
+  _outputs[0] = StdoutLog;
+  _outputs[1] = StderrLog;
   _n_outputs = 2;
   _outputs[0]->set_config_string("all=warning");
   _outputs[1]->set_config_string("all=off");
 
   // Set the default output to warning and error level for all new tagsets.
   for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
-    ts->set_output_level(LogConfiguration::StdoutLog, LogLevel::Default);
+    ts->set_output_level(StdoutLog, LogLevel::Default);
   }
 }
 
@@ -424,12 +424,12 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
 
   // Normally options can't be used to change an existing output
   // (parse_log_arguments() will report an error), but we make an exception for
-  // both LogConfiguration::StdoutLog and LogConfiguration::StderrLog as they're initialized automatically
+  // both StdoutLog and StderrLog as they're initialized automatically
   // very early in the boot process.
   if (output == nullptr || strlen(output) == 0 ||
       strcmp("stdout", output) == 0 || strcmp("#0", output) == 0) {
     if (!stdout_configured) {
-      success = LogConfiguration::StdoutLog->parse_options(output_options, &ss);
+      success = StdoutLog->parse_options(output_options, &ss);
       stdout_configured = true;
       // We no longer need to pass output options to parse_log_arguments().
       output_options = nullptr;
@@ -438,7 +438,7 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
     // with a warning
   } else if (strcmp("stderr", output) == 0 || strcmp("#1", output) == 0) {
     if (!stderr_configured) {
-      success = LogConfiguration::StderrLog->parse_options(output_options, &ss);
+      success = StderrLog->parse_options(output_options, &ss);
       stderr_configured = true;
       // We no longer need to pass output options to parse_log_arguments().
       output_options = nullptr;

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -24,6 +24,7 @@
 #ifndef SHARE_LOGGING_LOGCONFIGURATION_HPP
 #define SHARE_LOGGING_LOGCONFIGURATION_HPP
 
+#include "logging/logFileStreamOutput.hpp"
 #include "logging/logLevel.hpp"
 #include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -41,6 +42,8 @@ class LogConfiguration : public AllStatic {
  friend class VMError;
  friend class LogTestFixture;
  public:
+  static LogStdoutOutput* StdoutLog;
+  static LogStderrOutput* StderrLog;
   // Function for listeners
   typedef void (*UpdateListenerFunction)(void);
 

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -32,8 +32,6 @@
 #include "utilities/defaultStream.hpp"
 
 const char* const LogFileStreamOutput::FoldMultilinesOptionKey = "foldmultilines";
-LogStdoutOutput* StdoutLog = nullptr;
-LogStderrOutput* StderrLog = nullptr;
 
 bool LogFileStreamOutput::set_option(const char* key, const char* value, outputStream* errstream) {
   bool success = false;

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -87,7 +87,4 @@ class LogStderrOutput : public LogFileStreamOutput {
   }
 };
 
-extern LogStderrOutput* StderrLog;
-extern LogStdoutOutput* StdoutLog;
-
 #endif // SHARE_LOGGING_LOGFILESTREAMOUTPUT_HPP

--- a/test/hotspot/gtest/logging/test_logConfiguration.cpp
+++ b/test/hotspot/gtest/logging/test_logConfiguration.cpp
@@ -71,8 +71,8 @@ TEST_VM_F(LogConfigurationTest, describe) {
   const char* description = ss.as_string();
 
   // Verify that stdout and stderr are listed by default
-  EXPECT_PRED2(string_contains_substring, description, StdoutLog->name());
-  EXPECT_PRED2(string_contains_substring, description, StderrLog->name());
+  EXPECT_PRED2(string_contains_substring, description, LogConfiguration::StdoutLog->name());
+  EXPECT_PRED2(string_contains_substring, description, LogConfiguration::StderrLog->name());
 
   // Verify that each tag, level and decorator is listed
   for (size_t i = 0; i < LogTag::Count; i++) {
@@ -129,7 +129,7 @@ TEST_VM_F(LogConfigurationTest, update_output) {
     EXPECT_TRUE(is_described("all=info"));
 
     // Verify by iterating over tagsets
-    LogOutput* o = StdoutLog;
+    LogOutput* o = LogConfiguration::StdoutLog;
     for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
       EXPECT_TRUE(ts->has_output(o));
       EXPECT_TRUE(ts->is_level(LogLevel::Info));
@@ -181,8 +181,8 @@ TEST_VM_F(LogConfigurationTest, disable_logging) {
 
   // Verify that no tagset has logging enabled
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
-    EXPECT_FALSE(ts->has_output(StdoutLog));
-    EXPECT_FALSE(ts->has_output(StderrLog));
+    EXPECT_FALSE(ts->has_output(LogConfiguration::StdoutLog));
+    EXPECT_FALSE(ts->has_output(LogConfiguration::StderrLog));
     EXPECT_FALSE(ts->is_level(LogLevel::Error));
   }
 }
@@ -196,7 +196,7 @@ TEST_VM_F(LogConfigurationTest, disable_output) {
   EXPECT_TRUE(is_described("#0: stdout all=off"));
 
   // Verify by iterating over tagsets
-  LogOutput* o = StdoutLog;
+  LogOutput* o = LogConfiguration::StdoutLog;
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     EXPECT_FALSE(ts->has_output(o));
     EXPECT_FALSE(ts->is_level(LogLevel::Error));
@@ -336,7 +336,7 @@ TEST_VM_F(LogConfigurationTest, parse_empty_command_line_arguments) {
     bool ret = LogConfiguration::parse_command_line_arguments(cmdline);
     EXPECT_TRUE(ret) << "Error parsing command line arguments '" << cmdline << "'";
     for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
-      EXPECT_EQ(LogLevel::Unspecified, ts->level_for(StdoutLog));
+      EXPECT_EQ(LogLevel::Unspecified, ts->level_for(LogConfiguration::StdoutLog));
     }
   }
 }
@@ -418,7 +418,7 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   EXPECT_FALSE(log_is_enabled(Debug, logging));
   EXPECT_FALSE(log_is_enabled(Info, gc));
   LogTagSet* logging_ts = &LogTagSetMapping<LOG_TAGS(logging)>::tagset();
-  EXPECT_EQ(LogLevel::Info, logging_ts->level_for(StdoutLog));
+  EXPECT_EQ(LogLevel::Info, logging_ts->level_for(LogConfiguration::StdoutLog));
 
   // Enable 'gc=debug' (no wildcard), verifying no other tags are enabled
   LogConfiguration::configure_stdout(LogLevel::Debug, true, LOG_TAGS(gc));
@@ -428,9 +428,9 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     if (ts->contains(PREFIX_LOG_TAG(gc))) {
       if (ts->ntags() == 1) {
-        EXPECT_EQ(LogLevel::Debug, ts->level_for(StdoutLog));
+        EXPECT_EQ(LogLevel::Debug, ts->level_for(LogConfiguration::StdoutLog));
       } else {
-        EXPECT_EQ(LogLevel::Off, ts->level_for(StdoutLog));
+        EXPECT_EQ(LogLevel::Off, ts->level_for(LogConfiguration::StdoutLog));
       }
     }
   }
@@ -441,12 +441,12 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   EXPECT_TRUE(log_is_enabled(Trace, gc, heap));
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     if (ts->contains(PREFIX_LOG_TAG(gc))) {
-      EXPECT_EQ(LogLevel::Trace, ts->level_for(StdoutLog));
+      EXPECT_EQ(LogLevel::Trace, ts->level_for(LogConfiguration::StdoutLog));
     } else if (ts == logging_ts) {
       // Previous setting for 'logging' should remain
-      EXPECT_EQ(LogLevel::Info, ts->level_for(StdoutLog));
+      EXPECT_EQ(LogLevel::Info, ts->level_for(LogConfiguration::StdoutLog));
     } else {
-      EXPECT_EQ(LogLevel::Off, ts->level_for(StdoutLog));
+      EXPECT_EQ(LogLevel::Off, ts->level_for(LogConfiguration::StdoutLog));
     }
   }
 
@@ -457,7 +457,7 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   EXPECT_FALSE(log_is_enabled(Error, gc));
   EXPECT_FALSE(log_is_enabled(Error, gc, heap));
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
-    EXPECT_EQ(LogLevel::Off, ts->level_for(StdoutLog));
+    EXPECT_EQ(LogLevel::Off, ts->level_for(LogConfiguration::StdoutLog));
   }
 }
 

--- a/test/hotspot/gtest/logging/test_logOutputList.cpp
+++ b/test/hotspot/gtest/logging/test_logOutputList.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/logConfiguration.hpp"
 #include "logging/logFileStreamOutput.hpp"
 #include "logging/logLevel.hpp"
 #include "logging/logOutput.hpp"
@@ -174,7 +175,7 @@ TEST(LogOutputList, is_level_single_output) {
   for (size_t i = LogLevel::First; i < LogLevel::Count; i++) {
     LogLevelType level = static_cast<LogLevelType>(i);
     LogOutputList list;
-    list.set_output_level(StdoutLog, level);
+    list.set_output_level(LogConfiguration::StdoutLog, level);
     for (size_t j = LogLevel::First; j < LogLevel::Count; j++) {
       LogLevelType other = static_cast<LogLevelType>(j);
       // Verify that levels finer than the current level for stdout are reported as disabled,
@@ -202,8 +203,8 @@ TEST(LogOutputList, is_level_empty) {
 // Test is_level() on lists with two outputs on different levels
 TEST(LogOutputList, is_level_multiple_outputs) {
   for (size_t i = LogLevel::First; i < LogLevel::Count - 1; i++) {
-      LogOutput* dummy1 = StdoutLog;
-      LogOutput* dummy2 = StderrLog;
+      LogOutput* dummy1 = LogConfiguration::StdoutLog;
+      LogOutput* dummy2 = LogConfiguration::StderrLog;
       LogLevelType first = static_cast<LogLevelType>(i);
       LogLevelType second = static_cast<LogLevelType>(i + 1);
       LogOutputList list;
@@ -227,19 +228,19 @@ TEST(LogOutputList, level_for) {
   LogOutputList list;
 
   // Ask the empty list about stdout, stderr
-  EXPECT_EQ(LogLevel::Off, list.level_for(StdoutLog));
-  EXPECT_EQ(LogLevel::Off, list.level_for(StderrLog));
+  EXPECT_EQ(LogLevel::Off, list.level_for(LogConfiguration::StdoutLog));
+  EXPECT_EQ(LogLevel::Off, list.level_for(LogConfiguration::StderrLog));
 
   // Ask for level in a list with two outputs on different levels
-  list.set_output_level(StdoutLog, LogLevel::Info);
-  list.set_output_level(StderrLog, LogLevel::Trace);
-  EXPECT_EQ(LogLevel::Info, list.level_for(StdoutLog));
-  EXPECT_EQ(LogLevel::Trace, list.level_for(StderrLog));
+  list.set_output_level(LogConfiguration::StdoutLog, LogLevel::Info);
+  list.set_output_level(LogConfiguration::StderrLog, LogLevel::Trace);
+  EXPECT_EQ(LogLevel::Info, list.level_for(LogConfiguration::StdoutLog));
+  EXPECT_EQ(LogLevel::Trace, list.level_for(LogConfiguration::StderrLog));
 
   // Remove and ask again
-  list.set_output_level(StdoutLog, LogLevel::Off);
-  EXPECT_EQ(LogLevel::Off, list.level_for(StdoutLog));
-  EXPECT_EQ(LogLevel::Trace, list.level_for(StderrLog));
+  list.set_output_level(LogConfiguration::StdoutLog, LogLevel::Off);
+  EXPECT_EQ(LogLevel::Off, list.level_for(LogConfiguration::StdoutLog));
+  EXPECT_EQ(LogLevel::Trace, list.level_for(LogConfiguration::StderrLog));
 
   // Ask about an unknown output
   LogOutput* dummy = dummy_output(4711);
@@ -252,5 +253,5 @@ TEST(LogOutputList, level_for) {
   }
 
   // Make sure the stderr level is still the same
-  EXPECT_EQ(LogLevel::Trace, list.level_for(StderrLog));
+  EXPECT_EQ(LogLevel::Trace, list.level_for(LogConfiguration::StderrLog));
 }

--- a/test/hotspot/gtest/logging/test_logTagSet.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSet.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/logConfiguration.hpp"
 #include "logging/logFileStreamOutput.hpp"
 #include "logging/logLevel.hpp"
 #include "logging/logOutput.hpp"
@@ -39,18 +40,18 @@ TEST(LogTagSet, defaults) {
     EXPECT_TRUE(ts->is_level(LogLevel::Error));
     EXPECT_TRUE(ts->is_level(LogLevel::Warning));
     EXPECT_FALSE(ts->is_level(LogLevel::Info));
-    EXPECT_TRUE(ts->has_output(StdoutLog));
-    EXPECT_FALSE(ts->has_output(StderrLog));
+    EXPECT_TRUE(ts->has_output(LogConfiguration::StdoutLog));
+    EXPECT_FALSE(ts->has_output(LogConfiguration::StderrLog));
   }
 }
 
 TEST(LogTagSet, has_output) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
-  ts.set_output_level(StderrLog, LogLevel::Trace);
-  EXPECT_TRUE(ts.has_output(StderrLog));
+  ts.set_output_level(LogConfiguration::StderrLog, LogLevel::Trace);
+  EXPECT_TRUE(ts.has_output(LogConfiguration::StderrLog));
   EXPECT_FALSE(ts.has_output(NULL));
-  ts.set_output_level(StderrLog, LogLevel::Off);
-  EXPECT_FALSE(ts.has_output(StderrLog));
+  ts.set_output_level(LogConfiguration::StderrLog, LogLevel::Off);
+  EXPECT_FALSE(ts.has_output(LogConfiguration::StderrLog));
 }
 
 TEST(LogTagSet, ntags) {
@@ -63,18 +64,18 @@ TEST(LogTagSet, ntags) {
 TEST(LogTagSet, is_level) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   // Set info level on stdout and verify that is_level() reports correctly
-  ts.set_output_level(StdoutLog, LogLevel::Info);
+  ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Info);
   EXPECT_TRUE(ts.is_level(LogLevel::Error));
   EXPECT_TRUE(ts.is_level(LogLevel::Warning));
   EXPECT_TRUE(ts.is_level(LogLevel::Info));
   EXPECT_FALSE(ts.is_level(LogLevel::Debug));
   EXPECT_FALSE(ts.is_level(LogLevel::Trace));
-  ts.set_output_level(StdoutLog, LogLevel::Default);
+  ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Default);
   EXPECT_TRUE(ts.is_level(LogLevel::Default));
 }
 
 TEST(LogTagSet, level_for) {
-  LogOutput* output = StdoutLog;
+  LogOutput* output = LogConfiguration::StdoutLog;
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   for (uint i = 0; i < LogLevel::Count; i++) {
     LogLevelType level = static_cast<LogLevelType>(i);


### PR DESCRIPTION
Hi,

Please consider this small cleanup. `LogConfiguration` initializes and handles the lifetime of `StdoutLog` and `StderrLog`, therefore they should logically belong to that class. I leave the visibility as public for the time being, to change it to private would require the gtests to all be part of a fixture.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299825](https://bugs.openjdk.org/browse/JDK-8299825): Move StdoutLog and StderrLog to LogConfiguration (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14376/head:pull/14376` \
`$ git checkout pull/14376`

Update a local copy of the PR: \
`$ git checkout pull/14376` \
`$ git pull https://git.openjdk.org/jdk.git pull/14376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14376`

View PR using the GUI difftool: \
`$ git pr show -t 14376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14376.diff">https://git.openjdk.org/jdk/pull/14376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14376#issuecomment-1582452992)