### PR TITLE
8307620: [IR Framework] Readme mentions JTREG_WHITE_LIST_FLAGS instead of JTREG_WHITELIST_FLAGS

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -85,7 +85,7 @@ The [@IR](./IR.java) annotation provides two kinds of checks:
  - `counts`: A list of one or more "IR node/user-defined regex - counter" pairs which specify how often each IR node/user-defined regex should be matched on the compilation output of each compile phase.
 
 #### Disable/Enable IR Rules based on VM Flags
-One might also want to restrict the application of certain `@IR` rules depending on the used flags in the test VM. These could be flags defined by the user or by JTreg. In the latter case, the flags must be whitelisted in `JTREG_WHITE_LIST_FLAGS` in [TestFramework](./TestFramework.java) (i.e. have no unexpected impact on the IR except if the flag simulates a specific machine setup like `UseAVX={1,2,3}` etc.) to enable an IR verification by the framework. The `@IR` rules thus have an option to restrict their application:
+One might also want to restrict the application of certain `@IR` rules depending on the used flags in the test VM. These could be flags defined by the user or by JTreg. In the latter case, the flags must be whitelisted in `JTREG_WHITELIST_FLAGS` in [TestFramework](./TestFramework.java) (i.e. have no unexpected impact on the IR except if the flag simulates a specific machine setup like `UseAVX={1,2,3}` etc.) to enable an IR verification by the framework. The `@IR` rules thus have an option to restrict their application:
 
 - `applyIf`: Only apply a rule if a flag has the specified value/range of values.
 - `applyIfNot`: Only apply a rule if a flag has **not** a specified value/range of values


### PR DESCRIPTION
README now refers to JTREG_WHITELIST_FLAGS instead of JTREG_WHITE_LIST_FLAGS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307620](https://bugs.openjdk.org/browse/JDK-8307620): [IR Framework] Readme mentions JTREG_WHITE_LIST_FLAGS instead of JTREG_WHITELIST_FLAGS (**Bug** - P5)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14377/head:pull/14377` \
`$ git checkout pull/14377`

Update a local copy of the PR: \
`$ git checkout pull/14377` \
`$ git pull https://git.openjdk.org/jdk.git pull/14377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14377`

View PR using the GUI difftool: \
`$ git pr show -t 14377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14377.diff">https://git.openjdk.org/jdk/pull/14377.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14377#issuecomment-1582570087)