### PR TITLE
8309660: C2: failed: XMM register should be 0-15 (UseKNLSetting and ConvF2HF)

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1944,7 +1944,7 @@ void Assembler::vcvtdq2pd(XMMRegister dst, XMMRegister src, int vector_len) {
 
 void Assembler::vcvtps2ph(XMMRegister dst, XMMRegister src, int imm8, int vector_len) {
   assert(VM_Version::supports_evex() || VM_Version::supports_f16c(), "");
-  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /*uses_vl */ true);
+  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /*uses_vl */ false);
   int encode = vex_prefix_and_encode(src->encoding(), 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int24(0x1D, (0xC0 | encode), imm8);
 }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1944,7 +1944,7 @@ void Assembler::vcvtdq2pd(XMMRegister dst, XMMRegister src, int vector_len) {
 
 void Assembler::vcvtps2ph(XMMRegister dst, XMMRegister src, int imm8, int vector_len) {
   assert(VM_Version::supports_evex() || VM_Version::supports_f16c(), "");
-  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /*uses_vl */ false);
+  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /*uses_vl */ true);
   int encode = vex_prefix_and_encode(src->encoding(), 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int24(0x1D, (0xC0 | encode), imm8);
 }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3638,7 +3638,7 @@ instruct sqrtD_reg(regD dst) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct convF2HF_reg_reg(rRegI dst, regF src, regF tmp) %{
+instruct convF2HF_reg_reg(rRegI dst, vlRegF src, vlRegF tmp) %{
   effect(TEMP tmp);
   match(Set dst (ConvF2HF src));
   ins_cost(125);
@@ -3682,7 +3682,7 @@ instruct vconvF2HF_mem_reg(memory mem, vec src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct convHF2F_reg_reg(regF dst, rRegI src) %{
+instruct convHF2F_reg_reg(vlRegF dst, rRegI src) %{
   match(Set dst (ConvHF2F src));
   format %{ "vcvtph2ps $dst,$src" %}
   ins_encode %{

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
@@ -58,7 +58,14 @@ public class TestFloatConversionsVector {
         }
     }
 
-    @Run(test = {"test_float_float16"}, mode = RunMode.STANDALONE)
+    @Test
+    public void test_float_float16_strided(short[] sout, float[] finp) {
+        for (int i = 0; i < finp.length/2; i++) {
+            sout[i*2] = Float.floatToFloat16(finp[i*2]);
+        }
+    }
+
+    @Run(test = {"test_float_float16", "test_float_float16_strided"}, mode = RunMode.STANDALONE)
     public void kernel_test_float_float16() {
         finp = new float[ARRLEN];
         sout = new short[ARRLEN];
@@ -75,6 +82,15 @@ public class TestFloatConversionsVector {
         for (int i = 0; i < ARRLEN; i++) {
             Asserts.assertEquals(Float.floatToFloat16(finp[i]), sout[i]);
         }
+
+        for (int i = 0; i < ITERS; i++) {
+            test_float_float16_strided(sout, finp);
+        }
+
+        // Verifying the result
+        for (int i = 0; i < ARRLEN/2; i++) {
+            Asserts.assertEquals(Float.floatToFloat16(finp[i*2]), sout[i*2]);
+        }
     }
 
     @Test
@@ -85,7 +101,14 @@ public class TestFloatConversionsVector {
         }
     }
 
-    @Run(test = {"test_float16_float"}, mode = RunMode.STANDALONE)
+    @Test
+    public void test_float16_float_strided(float[] fout, short[] sinp) {
+        for (int i = 0; i < sinp.length/2; i++) {
+            fout[i*2] = Float.float16ToFloat(sinp[i*2]);
+        }
+    }
+
+    @Run(test = {"test_float16_float", "test_float16_float_strided"}, mode = RunMode.STANDALONE)
     public void kernel_test_float16_float() {
         sinp = new short[ARRLEN];
         fout = new float[ARRLEN];
@@ -101,6 +124,15 @@ public class TestFloatConversionsVector {
         // Verifying the result
         for (int i = 0; i < ARRLEN; i++) {
             Asserts.assertEquals(Float.float16ToFloat(sinp[i]), fout[i]);
+        }
+
+        for (int i = 0; i < ITERS; i++) {
+            test_float16_float_strided(fout, sinp);
+        }
+
+        // Verifying the result
+        for (int i = 0; i < ARRLEN/2; i++) {
+            Asserts.assertEquals(Float.float16ToFloat(sinp[i*2]), fout[i*2]);
         }
     }
 }


### PR DESCRIPTION
Context: `Float.floatToFloat16` -> `vcvtps2ph`.

**Problem**
```
vcvtps2ph
pre=Assembler::VEX_SIMD_66
opc=Assembler::VEX_OPCODE_0F_3A
VEX.128.66.0F3A
requires F16C
```
https://www.felixcloutier.com/x86/vcvtps2ph

So this is a non-AVX512 feature, and we should only use the registers `xmm0-15`.

There is also a AVX512 version, but it requires `AVX512VL and AVX512F`.

So on `x64`, we should only use registers `xmm0-15` if we do not have `AVX512VL`, and if we have it, then we can use `xmm0-31`.

**Suggested Solution**
As @sviswa7 suggested, we should just use the `vlRegF` instead of `regF`, see discussion in comments.

**Testing**
I simulated the patch on intel's `sde`. So now I'm confident that I don't generate code that uses `AVX512VL` registers (XMM16-31).

Running: tier1-6 + stress testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309660](https://bugs.openjdk.org/browse/JDK-8309660): C2: failed: XMM register should be 0-15 (UseKNLSetting and ConvF2HF) (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Contributors
 * Sandhya Viswanathan `<sviswanathan@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14379/head:pull/14379` \
`$ git checkout pull/14379`

Update a local copy of the PR: \
`$ git checkout pull/14379` \
`$ git pull https://git.openjdk.org/jdk.git pull/14379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14379`

View PR using the GUI difftool: \
`$ git pr show -t 14379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14379.diff">https://git.openjdk.org/jdk/pull/14379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14379#issuecomment-1584313653)