### PR TITLE
8309671: Avoid using jvmci.Compiler property to determine if Graal is enabled

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitor.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitor.java
@@ -252,10 +252,9 @@ public class HeapMonitor {
 
       VMOption enableJVMCI = bean.getVMOption("EnableJVMCI");
       VMOption useJVMCICompiler = bean.getVMOption("UseJVMCICompiler");
-      String compiler = System.getProperty("jvmci.Compiler");
 
       checkLines = !(enableJVMCI.getValue().equals("true")
-          && useJVMCICompiler.getValue().equals("true") && compiler.equals("graal"));
+          && useJVMCICompiler.getValue().equals("true"));
     } catch (Exception e) {
       // NOP.
     }

--- a/test/lib/jdk/test/whitebox/code/Compiler.java
+++ b/test/lib/jdk/test/whitebox/code/Compiler.java
@@ -63,7 +63,6 @@ public class Compiler {
      * Graal is enabled if following conditions are true:
      * - we are not in Interpreter mode
      * - UseJVMCICompiler flag is true
-     * - jvmci.Compiler variable is equal to 'graal'
      * - TieredCompilation is not used or TieredStopAtLevel is greater than 3
      * No need to check client mode because it set UseJVMCICompiler to false.
      *


### PR DESCRIPTION
HeapMonitor checks if System.getProperty("jvmci.Compiler") is graal and will not enforce checking line number derived from uncommon trap debug info. However, Graal does not set this property explicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309671](https://bugs.openjdk.org/browse/JDK-8309671): Avoid using jvmci.Compiler property to determine if Graal is enabled (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14381/head:pull/14381` \
`$ git checkout pull/14381`

Update a local copy of the PR: \
`$ git checkout pull/14381` \
`$ git pull https://git.openjdk.org/jdk.git pull/14381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14381`

View PR using the GUI difftool: \
`$ git pr show -t 14381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14381.diff">https://git.openjdk.org/jdk/pull/14381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14381#issuecomment-1583078426)