### PR TITLE
8309303: jdk/internal/misc/VM/RuntimeArguments test ignores jdk/internal/vm/options

### DIFF
--- a/test/jdk/jdk/internal/misc/VM/RuntimeArguments.java
+++ b/test/jdk/jdk/internal/misc/VM/RuntimeArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,12 @@
  * @run testng RuntimeArguments
  */
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -41,6 +47,30 @@ import static org.testng.Assert.*;
 
 public class RuntimeArguments {
     static final String TEST_CLASSES = System.getProperty("test.classes");
+    static final List<String> VM_OPTIONS = getInitialOptions();
+
+    /*
+     * Read jdk/internal/vm/options resource from the runtime image.
+     * If present, the runtime image was created with jlink --add-options and
+     * the java launcher launches the application as if
+     *   $ java @options <app>
+     * The VM options listed in the jdk/internal/vm/options resource file
+     * are passed to the VM.
+     */
+    static List<String> getInitialOptions() {
+        ModuleReference mref = ModuleFinder.ofSystem().find("java.base").orElseThrow();
+        try (ModuleReader reader = mref.open()) {
+            InputStream in = reader.open("jdk/internal/vm/options").orElse(null);
+            if (in != null) {
+                // support the simplest form for now: whitespace-separated
+                return List.of(new String(in.readAllBytes()).split("\s"));
+            } else {
+                return List.of();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 
     @DataProvider(name = "options")
     public Object[][] options() {
@@ -83,13 +113,15 @@ public class RuntimeArguments {
     @Test(dataProvider = "options")
     public void test(List<String> args, List<String> expected) throws Exception {
         // launch a test program
-        // $ java <runtime-arguments> -classpath <cpath> RuntimeArguments <expected>
-
+        // $ java <args> -classpath <cpath> RuntimeArguments <vm_options> <expected>
         Stream<String> options = Stream.concat(args.stream(),
             Stream.of("-classpath", TEST_CLASSES, "RuntimeArguments"));
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            Stream.concat(options, expected.stream())
+            // The runtime image may be created with jlink --add-options
+            // The initial VM options will be included in the result
+            // returned by VM.getRuntimeArguments()
+            Stream.concat(options, Stream.concat(VM_OPTIONS.stream(), expected.stream()))
                   .toArray(String[]::new)
         );
         ProcessTools.executeProcess(pb).shouldHaveExitValue(0);


### PR DESCRIPTION
The `RuntimeArguments` test verifies the VM arguments returned by `jdk.internal.misc.VM::getRuntimeArguments` as expected.    This test fails when running with GraalVM as it was created with `jlink --add-options` and the application will always be launched with that additional set of VM options.  This PR updates the test to read if 'jdk/internal/vm/options` is present and includle those options in the expected list.