### PR TITLE
JDK-8309686: inconsistent URL for https://www.unicode.org/reports/tr35

### DIFF
--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -275,7 +275,7 @@ public abstract class Collator
      * may return a {@code Collator} instance with the Swedish traditional sorting, which
      * gives 'v' and 'w' the same sorting order, while the {@code Collator} instance
      * for the Swedish locale without "co" identifier distinguishes 'v' and 'w'.
-     * @spec https://www.unicode.org/reports/tr35/ Unicode Locale Data Markup Language
+     * @spec https://www.unicode.org/reports/tr35 Unicode Locale Data Markup Language
      *     (LDML)
      * @param desiredLocale the desired locale.
      * @return the Collator for the desired locale.


### PR DESCRIPTION
Please review a trivial docs change to fix a URL in a `@spec` tag consistent with equivalent URLs in other tags.
(Consistency will be required when the External Specifications page is enabled.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309686](https://bugs.openjdk.org/browse/JDK-8309686): inconsistent URL for https://www.unicode.org/reports/tr35 (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14384/head:pull/14384` \
`$ git checkout pull/14384`

Update a local copy of the PR: \
`$ git checkout pull/14384` \
`$ git pull https://git.openjdk.org/jdk.git pull/14384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14384`

View PR using the GUI difftool: \
`$ git pr show -t 14384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14384.diff">https://git.openjdk.org/jdk/pull/14384.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14384#issuecomment-1583423528)