### PR TITLE
8309673: Refactor ref_at methods in SA ConstantPool

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeGetPut.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeGetPut.java
@@ -37,17 +37,17 @@ public abstract class BytecodeGetPut extends BytecodeWithCPIndex {
   // returns the name of the accessed field
   public Symbol name() {
     ConstantPool cp = method().getConstants();
-    return cp.getNameRefAt(index());
+    return cp.getNameRefAt(index(), javaCode());
   }
 
   // returns the signature of the accessed field
   public Symbol signature() {
     ConstantPool cp = method().getConstants();
-    return cp.getSignatureRefAt(index());
+    return cp.getSignatureRefAt(index(), javaCode());
   }
 
   public Field getField() {
-    return method().getConstants().getFieldRefAt(index());
+    return method().getConstants().getFieldRefAt(index(), javaCode());
   }
 
   public String toString() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeInvoke.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeInvoke.java
@@ -57,7 +57,7 @@ public class BytecodeInvoke extends BytecodeWithCPIndex {
     if (isInvokedynamic()) {
       return cp.uncachedGetNameRefAt(indexForFieldOrMethod());
     }
-    return cp.getNameRefAt(index());
+    return cp.getNameRefAt(index(), adjustedInvokeCode());
   }
 
   // returns the signature of the invoked method
@@ -66,11 +66,11 @@ public class BytecodeInvoke extends BytecodeWithCPIndex {
     if (isInvokedynamic()) {
       return cp.uncachedGetSignatureRefAt(indexForFieldOrMethod());
     }
-    return cp.getSignatureRefAt(index());
+    return cp.getSignatureRefAt(index(), adjustedInvokeCode());
   }
 
   public Method getInvokedMethod() {
-    return method().getConstants().getMethodRefAt(index());
+    return method().getConstants().getMethodRefAt(index(), adjustedInvokeCode());
   }
 
   // returns the result type (see BasicType.java) of the invoke

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -259,7 +259,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
     switch(code) {
       case Bytecodes._invokedynamic:
         int poolIndex = getCache().getIndyEntryAt(index).getConstantPoolIndex();
-        return poolIndex = invokeDynamicNameAndTypeRefIndexAt(poolIndex);
+        return invokeDynamicNameAndTypeRefIndexAt(poolIndex);
       case Bytecodes._getfield:
       case Bytecodes._getstatic:
       case Bytecodes._putfield:

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -27,6 +27,7 @@ package sun.jvm.hotspot.oops;
 import java.io.*;
 import java.util.*;
 import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.interpreter.Bytecodes;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.types.*;
 import sun.jvm.hotspot.utilities.*;
@@ -252,6 +253,31 @@ public class ConstantPool extends Metadata implements ClassConstants {
     return res;
   }
 
+  // Translate index, which could be CPCache index or Indy index, to a constant pool index
+  public int to_cp_index(int index, int code) {
+    Assert.that(getCache() != null, "'index' is a rewritten index so this class must have been rewritten");
+    switch(code) {
+      case Bytecodes._invokedynamic:
+        int poolIndex = getCache().getIndyEntryAt(index).getConstantPoolIndex();
+        return poolIndex = invokeDynamicNameAndTypeRefIndexAt(poolIndex);
+      case Bytecodes._getfield:
+      case Bytecodes._getstatic:
+      case Bytecodes._putfield:
+      case Bytecodes._putstatic:
+        // TODO: handle resolved field entries with new structure
+        // i = ....
+      case Bytecodes._invokeinterface:
+      case Bytecodes._invokehandle:
+      case Bytecodes._invokespecial:
+      case Bytecodes._invokestatic:
+      case Bytecodes._invokevirtual:
+        // TODO: handle resolved method entries with new structure
+      default:
+        // change byte-ordering and go via cache
+        return remapInstructionOperandFromCache(index);
+    }
+  }
+
   public int[] getNameAndTypeAt(int which) {
     if (Assert.ASSERTS_ENABLED) {
       Assert.that(getTagAt(which).isNameAndType(), "Corrupted constant pool: " + which + " " + getTagAt(which));
@@ -263,29 +289,23 @@ public class ConstantPool extends Metadata implements ClassConstants {
     return new int[] { extractLowShortFromInt(i), extractHighShortFromInt(i) };
   }
 
-  public Symbol getNameRefAt(int which) {
-    return implGetNameRefAt(which, false);
+  public Symbol getNameRefAt(int which, int code) {
+    int name_index = getNameRefIndexAt(getNameAndTypeRefIndexAt(which, code));
+    return getSymbolAt(name_index);
   }
 
-  public Symbol uncachedGetNameRefAt(int which) {
-    return implGetNameRefAt(which, true);
+  public Symbol uncachedGetNameRefAt(int cp_index) {
+    int name_index = getNameRefIndexAt(uncachedGetNameAndTypeRefIndexAt(cp_index));
+    return getSymbolAt(name_index);
   }
 
-  private Symbol implGetNameRefAt(int which, boolean uncached) {
-    int signatureIndex = getNameRefIndexAt(implNameAndTypeRefIndexAt(which, uncached));
+  public Symbol getSignatureRefAt(int which, int code) {
+    int signatureIndex = getSignatureRefIndexAt(getNameAndTypeRefIndexAt(which, code));
     return getSymbolAt(signatureIndex);
   }
 
-  public Symbol getSignatureRefAt(int which) {
-    return implGetSignatureRefAt(which, false);
-  }
-
-  public Symbol uncachedGetSignatureRefAt(int which) {
-    return implGetSignatureRefAt(which, true);
-  }
-
-  private Symbol implGetSignatureRefAt(int which, boolean uncached) {
-    int signatureIndex = getSignatureRefIndexAt(implNameAndTypeRefIndexAt(which, uncached));
+  public Symbol uncachedGetSignatureRefAt(int cp_index) {
+    int signatureIndex = getSignatureRefIndexAt(uncachedGetNameAndTypeRefIndexAt(cp_index));
     return getSymbolAt(signatureIndex);
   }
 
@@ -307,29 +327,20 @@ public class ConstantPool extends Metadata implements ClassConstants {
     return getCache().getEntryAt(cpCacheIndex);
   }
 
-  private int implNameAndTypeRefIndexAt(int which, boolean uncached) {
-    int i = which;
-    if (!uncached && getCache() != null) {
-      if (isInvokedynamicIndex(which)) {
-        // Invokedynamic index is index into resolved_references
-        int poolIndex = getCache().getIndyEntryAt(which).getConstantPoolIndex();
-        poolIndex = invokeDynamicNameAndTypeRefIndexAt(poolIndex);
-        Assert.that(getTagAt(poolIndex).isNameAndType(), "");
-        return poolIndex;
-      }
-      // change byte-ordering and go via cache
-      i = remapInstructionOperandFromCache(which);
-    } else {
-      if (getTagAt(which).isInvokeDynamic() || getTagAt(which).isDynamicConstant()) {
-        int poolIndex = invokeDynamicNameAndTypeRefIndexAt(which);
-        Assert.that(getTagAt(poolIndex).isNameAndType(), "");
-        return poolIndex;
-      }
+  public int uncachedGetNameAndTypeRefIndexAt(int cp_index) {
+    if (getTagAt(cp_index).isInvokeDynamic() || getTagAt(cp_index).isDynamicConstant()) {
+      int poolIndex = invokeDynamicNameAndTypeRefIndexAt(cp_index);
+      Assert.that(getTagAt(poolIndex).isNameAndType(), "");
+      return poolIndex;
     }
     // assert(tag_at(i).is_field_or_method(), "Corrupted constant pool");
     // assert(!tag_at(i).is_invoke_dynamic(), "Must be handled above");
-    int refIndex = getIntAt(i);
+    int refIndex = getIntAt(cp_index);
     return extractHighShortFromInt(refIndex);
+  }
+
+  public int getNameAndTypeRefIndexAt(int index, int code) {
+    return uncachedGetNameAndTypeRefIndexAt(to_cp_index(index, code));
   }
 
   private int remapInstructionOperandFromCache(int operand) {
@@ -370,11 +381,11 @@ public class ConstantPool extends Metadata implements ClassConstants {
   }
 
   // returns null, if not resolved.
-  public Method getMethodRefAt(int which) {
+  public Method getMethodRefAt(int which, int code) {
     Klass klass = getFieldOrMethodKlassRefAt(which);
     if (klass == null) return null;
-    Symbol name = getNameRefAt(which);
-    Symbol sig  = getSignatureRefAt(which);
+    Symbol name = getNameRefAt(which, code);
+    Symbol sig  = getSignatureRefAt(which, code);
     // Consider the super class for arrays. (java.lang.Object)
     if (klass.isArrayKlass()) {
        klass = klass.getJavaSuper();
@@ -383,16 +394,12 @@ public class ConstantPool extends Metadata implements ClassConstants {
   }
 
   // returns null, if not resolved.
-  public Field getFieldRefAt(int which) {
+  public Field getFieldRefAt(int which, int code) {
     InstanceKlass klass = (InstanceKlass)getFieldOrMethodKlassRefAt(which);
     if (klass == null) return null;
-    Symbol name = getNameRefAt(which);
-    Symbol sig  = getSignatureRefAt(which);
+    Symbol name = getNameRefAt(which, code);
+    Symbol sig  = getSignatureRefAt(which, code);
     return klass.findField(name.asString(), sig.asString());
-  }
-
-  public int getNameAndTypeRefIndexAt(int index) {
-    return implNameAndTypeRefIndexAt(index, false);
   }
 
   /** Lookup for entries consisting of (name_index, signature_index) */

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/GenerateOopMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/GenerateOopMap.java
@@ -1374,16 +1374,16 @@ public class GenerateOopMap {
     case Bytecodes._jsr:               doJsr(itr.dest());          break;
     case Bytecodes._jsr_w:             doJsr(itr.dest_w());        break;
 
-    case Bytecodes._getstatic:         doField(true,  true,  itr.getIndexU2Cpcache(), itr.bci()); break;
-    case Bytecodes._putstatic:         doField(false, true,  itr.getIndexU2Cpcache(), itr.bci()); break;
-    case Bytecodes._getfield:          doField(true,  false, itr.getIndexU2Cpcache(), itr.bci()); break;
-    case Bytecodes._putfield:          doField(false, false, itr.getIndexU2Cpcache(), itr.bci()); break;
+    case Bytecodes._getstatic:         doField(true,  true,  itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
+    case Bytecodes._putstatic:         doField(false, true,  itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
+    case Bytecodes._getfield:          doField(true,  false, itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
+    case Bytecodes._putfield:          doField(false, false, itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
 
     case Bytecodes._invokevirtual:
-    case Bytecodes._invokespecial:     doMethod(false, false, itr.getIndexU2Cpcache(), itr.bci()); break;
-    case Bytecodes._invokestatic:      doMethod(true,  false, itr.getIndexU2Cpcache(), itr.bci()); break;
-    case Bytecodes._invokedynamic:     doMethod(true,  false, itr.getIndexU4(),        itr.bci()); break;
-    case Bytecodes._invokeinterface:   doMethod(false,  true, itr.getIndexU2Cpcache(), itr.bci()); break;
+    case Bytecodes._invokespecial:     doMethod(false, false, itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
+    case Bytecodes._invokestatic:      doMethod(true,  false, itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
+    case Bytecodes._invokedynamic:     doMethod(true,  false, itr.getIndexU4(),        itr.bci(), itr.code()); break;
+    case Bytecodes._invokeinterface:   doMethod(false,  true, itr.getIndexU2Cpcache(), itr.bci(), itr.code()); break;
     case Bytecodes._newarray:
     case Bytecodes._anewarray:         ppNewRef(vCTS, itr.bci()); break;
     case Bytecodes._checkcast:         doCheckcast(); break;
@@ -1688,10 +1688,10 @@ public class GenerateOopMap {
     push(CellTypeState.makeAddr(targBCI));
   }
 
-  void  doField                             (boolean is_get, boolean is_static, int idx, int bci) {
+  void  doField                             (boolean is_get, boolean is_static, int idx, int bci, int bc) {
     // Dig up signature for field in constant pool
     ConstantPool cp        = method().getConstants();
-    int nameAndTypeIdx     = cp.getNameAndTypeRefIndexAt(idx);
+    int nameAndTypeIdx     = cp.getNameAndTypeRefIndexAt(idx, bc);
     int signatureIdx       = cp.getSignatureRefIndexAt(nameAndTypeIdx);
     Symbol signature       = cp.getSymbolAt(signatureIdx);
 
@@ -1724,10 +1724,10 @@ public class GenerateOopMap {
     pp(in, out);
   }
 
-  void  doMethod                            (boolean is_static, boolean is_interface, int idx, int bci) {
+  void  doMethod                            (boolean is_static, boolean is_interface, int idx, int bci, int bc) {
     // Dig up signature for field in constant pool
     ConstantPool cp       = _method.getConstants();
-    Symbol signature      = cp.getSignatureRefAt(idx);
+    Symbol signature      = cp.getSignatureRefAt(idx, bc);
 
     // Parse method signature
     CellTypeStateList out = new CellTypeStateList(4);


### PR DESCRIPTION
The accessor methods in constantpool.cpp were previously cleaned up to allow for different types of indices to be used, distinguishing them by the bytecode. This patch adds the same changes to the hotspot serviceability agent code. Verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309673](https://bugs.openjdk.org/browse/JDK-8309673): Refactor ref_at methods in SA ConstantPool (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [2ee60bd1](https://git.openjdk.org/jdk/pull/14385/files/2ee60bd190dd89ea836b7bb207bb183168ec1d72)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) ⚠️ Review applies to [2ee60bd1](https://git.openjdk.org/jdk/pull/14385/files/2ee60bd190dd89ea836b7bb207bb183168ec1d72)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14385/head:pull/14385` \
`$ git checkout pull/14385`

Update a local copy of the PR: \
`$ git checkout pull/14385` \
`$ git pull https://git.openjdk.org/jdk.git pull/14385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14385`

View PR using the GUI difftool: \
`$ git pr show -t 14385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14385.diff">https://git.openjdk.org/jdk/pull/14385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14385#issuecomment-1583447507)