### PR TITLE
8309702: Exclude java/lang/ScopedValue/StressStackOverflow.java from JTREG_TEST_THREAD_FACTORY=Virtual runs 

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -44,6 +44,8 @@ javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-
 
 javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
 
+java/lang/ScopedValue/StressStackOverflow.java 8309646 generic-all
+
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
 ##########


### PR DESCRIPTION
This test moved from test/jdk/jdk/incubator/concurrent to test/jdk/java/lang as part of the JEP 446 integration so it is running in a lot more configurations now. It's unstable in some configurations, including JTREG_TEST_THREAD_FACTORY=Virtual runs. The implementation may need more @DontInline/@ReservedStackAccess foo, or the test needs to made more stable. Need to temporarily exclude to reduce noise until the implementation or test is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309702](https://bugs.openjdk.org/browse/JDK-8309702): Exclude java/lang/ScopedValue/StressStackOverflow.java from JTREG_TEST_THREAD_FACTORY=Virtual runs (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14388/head:pull/14388` \
`$ git checkout pull/14388`

Update a local copy of the PR: \
`$ git checkout pull/14388` \
`$ git pull https://git.openjdk.org/jdk.git pull/14388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14388`

View PR using the GUI difftool: \
`$ git pr show -t 14388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14388.diff">https://git.openjdk.org/jdk/pull/14388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14388#issuecomment-1584146456)