### PR TITLE
JDK-8308047  java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java timed out and also had jcmd pipe errors

### DIFF
--- a/test/jdk/ProblemList-generational-zgc.txt
+++ b/test/jdk/ProblemList-generational-zgc.txt
@@ -38,5 +38,4 @@ sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java 8307393   generic-all
 sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8307393   generic-all
 
 com/sun/jdi/ThreadMemoryLeakTest.java          8307402 generic-all
-java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java 8308047 windows-x64
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8309218 generic-all

--- a/test/jdk/java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java
+++ b/test/jdk/java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 6602600
- * @run main/othervm -Xmx8m BasicCancelTest
+ * @run main/othervm -Xmx64m BasicCancelTest
  * @summary Check effectiveness of RemoveOnCancelPolicy
  */
 
@@ -76,7 +76,7 @@ public class BasicCancelTest {
         // Needed to avoid OOME
         pool.setRemoveOnCancelPolicy(true);
 
-        final long moreThanYouCanChew = Runtime.getRuntime().freeMemory() / 4;
+        final long moreThanYouCanChew = Runtime.getRuntime().maxMemory() / 4;
         System.out.printf("moreThanYouCanChew=%d%n", moreThanYouCanChew);
 
         Runnable noopTask = new Runnable() { public void run() {}};


### PR DESCRIPTION
The test used a too-small heap for generic testing, and coupled with looking at `freeMemory()` it led to a less-than-ideal determinism of execution of the test.
