### PR TITLE
JDK-8309703: AIX build fails after JDK-8280982

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -49,6 +49,11 @@ static struct PwLoopData pw = {0};
 jclass tokenStorageClass = NULL;
 jmethodID storeTokenMethodID = NULL;
 
+#if defined(AIX) && defined(__open_xl_version__) && __open_xl_version__ >= 17
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 inline void debug_screencast(
         const char *__restrict fmt,
         ...

--- a/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h
@@ -11,8 +11,14 @@ extern "C" {
 
 #include <stdint.h>
 
-#if !defined(__FreeBSD__) && !defined(__MidnightBSD__)
+#if !defined(__FreeBSD__) && !defined(__MidnightBSD__) && !defined(AIX)
 #include <endian.h>
+#endif
+
+#if defined(AIX)
+#include <sys/machine.h>
+#define __BIG_ENDIAN      4321
+#define __BYTE_ORDER      BIG_ENDIAN
 #endif
 
 /**

--- a/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #if defined(AIX)
 #include <sys/machine.h>
-#define __BIG_ENDIAN      4321
+#define __BIG_ENDIAN      BIG_ENDIAN
 #define __BYTE_ORDER      BIG_ENDIAN
 #endif
 


### PR DESCRIPTION
After
[JDK-8280982](https://bugs.openjdk.org/browse/JDK-8280982): [Wayland] [XWayland] java.awt.Robot taking screenshots
the AIX build fails.
We get

* For target support_native_java.desktop_libawt_xawt_screencast_pipewire.o:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c:33:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.h:40:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/debug/types.h:17:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/utils/type-info.h:33:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/param/type-info.h:8:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/param/param-types.h:50:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/type-info.h:8:
In file included from /aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw-types.h:18:
/aixbuild/jdk-dev/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h:15:10: fatal error: 'endian.h' file not found

I cannot find endian.h on my AIX machine.
Instead there is <sys/machine.h> which provides some info on byte order etc. instead .

Additionally we have a "warning as error"  in src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c ; xlc17 clang 15 is very picky about the vfprintf used there. I disabled the warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309703](https://bugs.openjdk.org/browse/JDK-8309703): AIX build fails after JDK-8280982 (**Bug** - P2)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14390/head:pull/14390` \
`$ git checkout pull/14390`

Update a local copy of the PR: \
`$ git checkout pull/14390` \
`$ git pull https://git.openjdk.org/jdk.git pull/14390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14390`

View PR using the GUI difftool: \
`$ git pr show -t 14390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14390.diff">https://git.openjdk.org/jdk/pull/14390.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14390#issuecomment-1584339264)