### PR TITLE
8309727: Assert privileges while reading the jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK system property

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
@@ -26,10 +26,15 @@ package jdk.incubator.vector;
 
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Objects;
 
 /*non-public*/ class VectorIntrinsics {
-    static final int VECTOR_ACCESS_OOB_CHECK = Integer.getInteger("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", 2);
+
+    @SuppressWarnings("removal")
+    static final int VECTOR_ACCESS_OOB_CHECK = AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+            Integer.getInteger("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", 2));
 
     @ForceInline
     static void requireLength(int haveLength, int length) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
@@ -31,7 +31,6 @@ import java.security.PrivilegedAction;
 import java.util.Objects;
 
 /*non-public*/ class VectorIntrinsics {
-
     @SuppressWarnings("removal")
     static final int VECTOR_ACCESS_OOB_CHECK = AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
             Integer.getInteger("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", 2));

--- a/test/jdk/jdk/incubator/vector/VectorRuns.java
+++ b/test/jdk/jdk/incubator/vector/VectorRuns.java
@@ -28,6 +28,8 @@ import java.util.stream.IntStream;
 /**
  * @test
  * @modules jdk.incubator.vector
+ * @run main VectorRuns
+ * @run main/othervm/java.security.policy=empty_security.policy VectorRuns
  */
 
 public class VectorRuns {
@@ -68,7 +70,7 @@ public class VectorRuns {
         if (r >= a.length)
             return a.length;
 
-        int length = a.length & (species.length() - 1);
+        int length = a.length & ~(species.length() - 1);
         if (length == a.length) length -= species.length();
         while (r < length) {
             IntVector vl = IntVector.fromArray(species, a, r - 1);

--- a/test/jdk/jdk/incubator/vector/VectorRuns.java
+++ b/test/jdk/jdk/incubator/vector/VectorRuns.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 
 /**
  * @test
+ * @bug 8309727
  * @modules jdk.incubator.vector
  * @run main VectorRuns
  * @run main/othervm/java.security.policy=empty_security.policy VectorRuns

--- a/test/jdk/jdk/incubator/vector/VectorRuns.java
+++ b/test/jdk/jdk/incubator/vector/VectorRuns.java
@@ -71,7 +71,7 @@ public class VectorRuns {
         if (r >= a.length)
             return a.length;
 
-        int length = a.length & ~(species.length() - 1);
+        int length = species.loopBound(a.length);
         if (length == a.length) length -= species.length();
         while (r < length) {
             IntVector vl = IntVector.fromArray(species, a, r - 1);

--- a/test/jdk/jdk/incubator/vector/empty_security.policy
+++ b/test/jdk/jdk/incubator/vector/empty_security.policy
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+// This policy is used by tests not requiring permissions, to assert that the
+// JDK implementation has the correct privileged blocks.


### PR DESCRIPTION
A trivial use of the Vector API when run with the security manager and a domain that does not grant permissions fails with java.security.AccessControlException: access denied ("java.util.PropertyPermission" "jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK" "read").

The fix it minimal, as consistent with other system property access in the JDK - just access the property while asserting privileged. Note: no explicit permission grant to the vector module is required, as it is in the boot loader.

This is the only such security manager related issue I see in this code, and I have looked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309727](https://bugs.openjdk.org/browse/JDK-8309727): Assert privileges while reading the jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK system property (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [4312aec1](https://git.openjdk.org/jdk/pull/14392/files/4312aec1bbcb0be2f65798aada38e41e26f6557d)
 * [Uwe Schindler](https://openjdk.org/census#uschindler) (@uschindler - Author) ⚠️ Review applies to [4312aec1](https://git.openjdk.org/jdk/pull/14392/files/4312aec1bbcb0be2f65798aada38e41e26f6557d)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [4312aec1](https://git.openjdk.org/jdk/pull/14392/files/4312aec1bbcb0be2f65798aada38e41e26f6557d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14392/head:pull/14392` \
`$ git checkout pull/14392`

Update a local copy of the PR: \
`$ git checkout pull/14392` \
`$ git pull https://git.openjdk.org/jdk.git pull/14392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14392`

View PR using the GUI difftool: \
`$ git pr show -t 14392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14392.diff">https://git.openjdk.org/jdk/pull/14392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14392#issuecomment-1584555845)