### PR TITLE
JDK-8309549: com/sun/tools/attach/warnings/DynamicLoadWarningTest.java fails on AIX

### DIFF
--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -119,10 +119,13 @@ class DynamicLoadWarningTest {
         test().whenRunning(loadJvmtiAgent1)
                 .stderrShouldContain(JVMTI_AGENT_WARNING);
 
-        // dynamically load loadJvmtiAgent1 twice, should be one warning
-        test().whenRunning(loadJvmtiAgent1)
-                .whenRunning(loadJvmtiAgent1)
-                .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
+        // dynamically load loadJvmtiAgent1 twice, should be one warning on platforms
+        // that can detect if an agent library was previously loaded
+        if (!Platform.isAix()) {
+            test().whenRunning(loadJvmtiAgent1)
+                    .whenRunning(loadJvmtiAgent1)
+                    .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
+        }
 
         // opt-in via command line option to allow dynamic loading of agents
         test().withOpts("-XX:+EnableDynamicAgentLoading")


### PR DESCRIPTION
On AIX ,  new jtreg test  com/sun/tools/attach/warnings/DynamicLoadWarningTest.java always failed  with the output :

----------System.err:(294/28579)----------
STARTED DynamicLoadWarningTest::testLoadJavaAgent 'testLoadJavaAgent()'
SUCCESSFUL DynamicLoadWarningTest::testLoadJavaAgent 'testLoadJavaAgent()'
STARTED DynamicLoadWarningTest::testLoadOneJvmtiAgent '[1] DynamicLoadWarningTest$$Lambda/0x000000040020bd88@600d90bb'
org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:528)
at DynamicLoadWarningTest$AppRunner.stderrShouldContain(DynamicLoadWarningTest.java:298)
at DynamicLoadWarningTest.testLoadOneJvmtiAgent(DynamicLoadWarningTest.java:125)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)

Reason seems to be the different behavior of dlopen on AIX compared to e.g. Linux 
This is what I find in the manpage of AIX 7.2 or 7.3 :
https://www.ibm.com/docs/en/aix/7.2?topic=d-dlopen-subroutine
https://www.ibm.com/docs/en/aix/7.3?topic=d-dlopen-subroutine
'If the module is already loaded, it is not loaded again, but a new, unique value will be returned by the dlopen subroutine.'

Sounds different to what Linux documents in the manpage:
https://man7.org/linux/man-pages/man3/dlopen.3.html
'If the same shared object is opened again with dlopen(), the same object handle is returned.'

We skip this special subtest on AIX .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309549](https://bugs.openjdk.org/browse/JDK-8309549): com/sun/tools/attach/warnings/DynamicLoadWarningTest.java fails on AIX (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14393/head:pull/14393` \
`$ git checkout pull/14393`

Update a local copy of the PR: \
`$ git checkout pull/14393` \
`$ git pull https://git.openjdk.org/jdk.git pull/14393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14393`

View PR using the GUI difftool: \
`$ git pr show -t 14393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14393.diff">https://git.openjdk.org/jdk/pull/14393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14393#issuecomment-1584604348)