### PR TITLE
8309692: Fix -Wconversion warnings in javaClasses

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -817,16 +817,16 @@ static void initialize_static_primitive_field(fieldDescriptor* fd, Handle mirror
   BasicType t = fd->field_type();
   switch (t) {
   case T_BYTE:
-    mirror()->byte_field_put(fd->offset(), fd->int_initial_value());
+    mirror()->byte_field_put(fd->offset(), checked_cast<jbyte>(fd->int_initial_value()));
     break;
   case T_BOOLEAN:
-    mirror()->bool_field_put(fd->offset(), fd->int_initial_value());
+    mirror()->bool_field_put(fd->offset(), checked_cast<jboolean>(fd->int_initial_value()));
     break;
   case T_CHAR:
-    mirror()->char_field_put(fd->offset(), fd->int_initial_value());
+    mirror()->char_field_put(fd->offset(), checked_cast<jchar>(fd->int_initial_value()));
     break;
   case T_SHORT:
-    mirror()->short_field_put(fd->offset(), fd->int_initial_value());
+    mirror()->short_field_put(fd->offset(), checked_cast<jshort>(fd->int_initial_value()));
     break;
   case T_INT:
     mirror()->int_field_put(fd->offset(), fd->int_initial_value());

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -325,15 +325,15 @@ inline bool java_lang_Module::is_instance(oop obj) {
 inline int Backtrace::merge_bci_and_version(int bci, int version) {
   // only store u2 for version, checking for overflow.
   if (version > USHRT_MAX || version < 0) version = USHRT_MAX;
-  assert((jushort)bci == bci, "bci should be short");
-  return build_int_from_shorts(version, bci);
+  assert((u2)bci == bci, "bci should be short");
+  return build_int_from_shorts((u2)version, (u2)bci);
 }
 
 inline int Backtrace::merge_mid_and_cpref(int mid, int cpref) {
   // only store u2 for mid and cpref, checking for overflow.
-  assert((jushort)mid == mid, "mid should be short");
-  assert((jushort)cpref == cpref, "cpref should be short");
-  return build_int_from_shorts(cpref, mid);
+  assert((u2)mid == mid, "mid should be short");
+  assert((u2)cpref == cpref, "cpref should be short");
+  return build_int_from_shorts((u2)cpref, (u2)mid);
 }
 
 inline int Backtrace::bci_at(unsigned int merged) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1274,7 +1274,7 @@ const int ObjectAlignmentInBytes = 8;
           "(0.0 means off)")                                                \
           range(0.0, (double)max_intx)                                      \
                                                                             \
-  product(intx, MaxJavaStackTraceDepth, 1024,                               \
+  product(int, MaxJavaStackTraceDepth, 1024,                                \
           "The maximum number of lines in the stack trace for Java "        \
           "exceptions (0 means all)")                                       \
           range(0, max_jint/2)                                              \


### PR DESCRIPTION
Please review this trivial patch to remove implicit integer conversions in javaClasses.inline.hpp/cpp files.
Tested tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309692](https://bugs.openjdk.org/browse/JDK-8309692): Fix -Wconversion warnings in javaClasses (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14397/head:pull/14397` \
`$ git checkout pull/14397`

Update a local copy of the PR: \
`$ git checkout pull/14397` \
`$ git pull https://git.openjdk.org/jdk.git pull/14397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14397`

View PR using the GUI difftool: \
`$ git pr show -t 14397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14397.diff">https://git.openjdk.org/jdk/pull/14397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14397#issuecomment-1584823674)