### PR TITLE
8308609: java/lang/ScopedValue/StressStackOverflow.java fails with "-XX:-VMContinuations"

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1386,7 +1386,7 @@ JVM_ENTRY(jobject, JVM_FindScopedValueBindings(JNIEnv *env, jclass cls))
     InstanceKlass* holder = method->method_holder();
     if (name == vmSymbols::runWith_method_name()) {
       if ((holder == resolver.Carrier_klass
-           || holder == vmClasses::VirtualThread_klass()
+           || holder == vmClasses::BaseVirtualThread_klass()
            || holder == vmClasses::Thread_klass())) {
         loc = 1;
       }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1385,9 +1385,8 @@ JVM_ENTRY(jobject, JVM_FindScopedValueBindings(JNIEnv *env, jclass cls))
 
     InstanceKlass* holder = method->method_holder();
     if (name == vmSymbols::runWith_method_name()) {
-      if ((holder == resolver.Carrier_klass
-           || holder == vmClasses::BaseVirtualThread_klass()
-           || holder == vmClasses::Thread_klass())) {
+      if (holder == vmClasses::Thread_klass()
+          || holder == resolver.Carrier_klass) {
         loc = 1;
       }
     }

--- a/src/java.base/share/classes/java/lang/BaseVirtualThread.java
+++ b/src/java.base/share/classes/java/lang/BaseVirtualThread.java
@@ -24,11 +24,6 @@
  */
 package java.lang;
 
-import jdk.internal.vm.annotation.ForceInline;
-import jdk.internal.vm.annotation.Hidden;
-
-import java.lang.ref.Reference;
-
 /**
  * Base class for virtual thread implementations.
  */
@@ -68,13 +63,5 @@ sealed abstract class BaseVirtualThread extends Thread
      * Makes available the parking permit to the given this virtual thread.
      */
     abstract void unpark();
-
-    @Hidden
-    @ForceInline
-    protected void runWith(Object bindings, Runnable op) {
-        ensureMaterializedForStackWalk(bindings);
-        op.run();
-        Reference.reachabilityFence(bindings);
-    }
 }
 

--- a/src/java.base/share/classes/java/lang/BaseVirtualThread.java
+++ b/src/java.base/share/classes/java/lang/BaseVirtualThread.java
@@ -24,6 +24,11 @@
  */
 package java.lang;
 
+import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.Hidden;
+
+import java.lang.ref.Reference;
+
 /**
  * Base class for virtual thread implementations.
  */
@@ -63,5 +68,13 @@ sealed abstract class BaseVirtualThread extends Thread
      * Makes available the parking permit to the given this virtual thread.
      */
     abstract void unpark();
+
+    @Hidden
+    @ForceInline
+    protected void runWith(Object bindings, Runnable op) {
+        ensureMaterializedForStackWalk(bindings);
+        op.run();
+        Reference.reachabilityFence(bindings);
+    }
 }
 

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1591,7 +1591,7 @@ public class Thread implements Runnable {
      */
     @Hidden
     @ForceInline
-    private void runWith(Object bindings, Runnable op) {
+    final void runWith(Object bindings, Runnable op) {
         ensureMaterializedForStackWalk(bindings);
         op.run();
         Reference.reachabilityFence(bindings);

--- a/src/java.base/share/classes/java/lang/ThreadBuilders.java
+++ b/src/java.base/share/classes/java/lang/ThreadBuilders.java
@@ -433,7 +433,7 @@ class ThreadBuilders {
             // run is specified to do nothing when Thread is a virtual thread
             if (Thread.currentThread() == this && !runInvoked) {
                 runInvoked = true;
-                Object bindings = scopedValueBindings();
+                Object bindings = Thread.scopedValueBindings();
                 runWith(bindings, task);
             }
         }

--- a/src/java.base/share/classes/java/lang/ThreadBuilders.java
+++ b/src/java.base/share/classes/java/lang/ThreadBuilders.java
@@ -433,7 +433,8 @@ class ThreadBuilders {
             // run is specified to do nothing when Thread is a virtual thread
             if (Thread.currentThread() == this && !runInvoked) {
                 runInvoked = true;
-                task.run();
+                Object bindings = scopedValueBindings();
+                runWith(bindings, task);
             }
         }
 

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,6 @@
  */
 package java.lang;
 
-import java.lang.ref.Reference;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Locale;
@@ -332,14 +331,6 @@ final class VirtualThread extends BaseVirtualThread {
                 setState(TERMINATED);
             }
         }
-    }
-
-    @Hidden
-    @ForceInline
-    private void runWith(Object bindings, Runnable op) {
-        ensureMaterializedForStackWalk(bindings);
-        op.run();
-        Reference.reachabilityFence(bindings);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -305,7 +305,7 @@ final class VirtualThread extends BaseVirtualThread {
             event.commit();
         }
 
-        Object bindings = scopedValueBindings();
+        Object bindings = Thread.scopedValueBindings();
         try {
             runWith(bindings, task);
         } catch (Throwable exc) {

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -53,7 +53,6 @@ import jdk.internal.vm.StackableScope;
 import jdk.internal.vm.ThreadContainer;
 import jdk.internal.vm.ThreadContainers;
 import jdk.internal.vm.annotation.ChangesCurrentThread;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Hidden;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.JvmtiMountTransition;

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -44,8 +44,6 @@ javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-
 
 javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
 
-java/lang/ScopedValue/StressStackOverflow.java 8309646 generic-all
-
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
 ##########

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -487,8 +487,6 @@ java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 
-java/lang/ScopedValue/StressStackOverflow.java                  8303498 linux-s390x
-
 ############################################################################
 
 # jdk_instrument

--- a/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
+++ b/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
@@ -21,14 +21,24 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @summary StressStackOverflow the recovery path for ScopedValue
  * @enablePreview
  * @run main/othervm/timeout=300 -XX:-TieredCompilation StressStackOverflow
  * @run main/othervm/timeout=300 -XX:TieredStopAtLevel=1 StressStackOverflow
  * @run main/othervm/timeout=300 StressStackOverflow
  */
+
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @enablePreview
+ * @run main/othervm/timeout=300 -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations StressStackOverflow
+ */
+
+
+
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;

--- a/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
+++ b/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
@@ -238,7 +238,9 @@ public class StressStackOverflow {
                 if (inheritedValue.isBound()) {
                     throw new TestFailureException("Should not be bound here");
                 }
-            } finally {
+            } catch (TestFailureException e) {
+                throw e;
+            } catch (Exception e) {
                 // ScopedValueContainer and StructuredTaskScope can
                 // throw many exceptions on stack overflow. Ignore
                 // them all.

--- a/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
+++ b/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
@@ -240,6 +240,9 @@ public class StressStackOverflow {
                 && System.nanoTime() - startTime <= 3 * MINUTES) { // 3 minutes is long enough
             try {
                 torture.run();
+                if (inheritedValue.isBound()) {
+                    throw new TestFailureException("Should not be bound here");
+                }
             } catch (TestFailureException e) {
                 throw e;
             } finally {

--- a/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
+++ b/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
@@ -37,9 +37,6 @@
  * @run main/othervm/timeout=300 -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations StressStackOverflow
  */
 
-
-
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;


### PR DESCRIPTION
Move `runWith()` from `VirtualThread` to `BaseVirtualThread`.

`BoundVirtualThread` does not use `runWith()` to run its task, so when a VM error occurs it can not recover scoped values.

Moving `runWith()` into the common subclass of both `VirtualThread` and `BoundVirtualThread` fixes the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308609](https://bugs.openjdk.org/browse/JDK-8308609): java/lang/ScopedValue/StressStackOverflow.java fails with "-XX:-VMContinuations" (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [b2663471](https://git.openjdk.org/jdk/pull/14399/files/b2663471519b031139fc9224d0fa1cc2955712e8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14399/head:pull/14399` \
`$ git checkout pull/14399`

Update a local copy of the PR: \
`$ git checkout pull/14399` \
`$ git pull https://git.openjdk.org/jdk.git pull/14399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14399`

View PR using the GUI difftool: \
`$ git pr show -t 14399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14399.diff">https://git.openjdk.org/jdk/pull/14399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14399#issuecomment-1584890249)