### PR TITLE
8309745: Problem list open client tests failing on Ubuntu_23.04

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -676,6 +676,13 @@ sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 sanity/client/SwingSet/src/EditorPaneDemoTest.java 8212240 linux-x64
 
+# jdk_swing Ubuntu 23.04 specific
+
+javax/swing/JTree/8003400/Test8003400.java 8309734 linux-all
+javax/swing/JTable/7124218/SelectEditTableCell.java 8309734 linux-all
+javax/swing/JFileChooser/JFileChooserSetLocationTest.java 8309734 linux-all
+javax/swing/JComboBox/TestComboBoxComponentRendering.java 8309734 linux-all
+
 ############################################################################
 
 # jdk_text


### PR DESCRIPTION
Several tests began to fail on Ubuntu 23.04, while passing on previous Ubuntu releases.
They also fail with JDK 20, 17.

So problem list them to reduce the noise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309745](https://bugs.openjdk.org/browse/JDK-8309745): Problem list open client tests failing on Ubuntu_23.04 (**Sub-task** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14400/head:pull/14400` \
`$ git checkout pull/14400`

Update a local copy of the PR: \
`$ git checkout pull/14400` \
`$ git pull https://git.openjdk.org/jdk.git pull/14400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14400`

View PR using the GUI difftool: \
`$ git pr show -t 14400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14400.diff">https://git.openjdk.org/jdk/pull/14400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14400#issuecomment-1584923417)