### PR TITLE
8309752: com/sun/jdi/SetLocalWhileThreadInNative.java fails with virtual test thread factory due to OpaqueFrameException

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -30,7 +30,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
 com/sun/jdi/ReferrersTest.java 8285422 generic-all
-com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all

--- a/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
+++ b/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
@@ -163,13 +163,20 @@ public class SetLocalWhileThreadInNative extends TestScaffold {
         Asserts.assertEQ(frame.location().method().toString(), "SetLocalWhileThreadInNativeTarget.dontinline_testMethod()");
         List<LocalVariable> localVars = frame.visibleVariables();
         boolean changedLocal = false;
+        boolean caughtOPE = false;
         for (LocalVariable lv : localVars) {
             if (lv.name().equals("zero")) {
-                frame.setValue(lv, vm().mirrorOf(0)); // triggers deoptimization!
-                changedLocal = true;
+                try {
+                    frame.setValue(lv, vm().mirrorOf(0)); // triggers deoptimization!
+                    changedLocal = true;
+                } catch (OpaqueFrameException e) {
+                    caughtOPE = true;
+                }
             }
         }
-        Asserts.assertTrue(changedLocal);
+        boolean isVirtualThread = "Virtual".equals(System.getProperty("main.wrapper"));
+        Asserts.assertTrue(caughtOPE == isVirtualThread);        
+        Asserts.assertTrue(changedLocal == !isVirtualThread);
 
         // signal stop
         os.write(STOP);

--- a/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
+++ b/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
@@ -163,19 +163,19 @@ public class SetLocalWhileThreadInNative extends TestScaffold {
         Asserts.assertEQ(frame.location().method().toString(), "SetLocalWhileThreadInNativeTarget.dontinline_testMethod()");
         List<LocalVariable> localVars = frame.visibleVariables();
         boolean changedLocal = false;
-        boolean caughtOPE = false;
+        boolean caughtOFE = false;
         for (LocalVariable lv : localVars) {
             if (lv.name().equals("zero")) {
                 try {
                     frame.setValue(lv, vm().mirrorOf(0)); // triggers deoptimization!
                     changedLocal = true;
                 } catch (OpaqueFrameException e) {
-                    caughtOPE = true;
+                    caughtOFE = true;
                 }
             }
         }
         boolean isVirtualThread = "Virtual".equals(System.getProperty("main.wrapper"));
-        Asserts.assertTrue(caughtOPE == isVirtualThread);
+        Asserts.assertTrue(caughtOFE == isVirtualThread);
         Asserts.assertTrue(changedLocal == !isVirtualThread);
 
         // signal stop

--- a/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
+++ b/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
@@ -175,7 +175,7 @@ public class SetLocalWhileThreadInNative extends TestScaffold {
             }
         }
         boolean isVirtualThread = "Virtual".equals(System.getProperty("main.wrapper"));
-        Asserts.assertTrue(caughtOPE == isVirtualThread);        
+        Asserts.assertTrue(caughtOPE == isVirtualThread);
         Asserts.assertTrue(changedLocal == !isVirtualThread);
 
         // signal stop


### PR DESCRIPTION
com/sun/jdi/SetLocalWhileThreadInNative.java is failing with OpaqueFrameException when using the virtual test thread factory. The reason is because JDI only supports calling StackFrame.setValue() on the topmost frame of a virtual thread. The test is calling it on the ThreadReference.frames(2), so the OpaqueFrameException is correct behavior and the test needs to adapt.

I could have chosen to just not have this test support running on a virtual thread, but it appears to be the only test we have that attempts StackFrame.setValue() on something other than the topmost frame, so it's good to have it expect the OpaqueFrameException.

Tested locally with and without the virtual thread wrapper. tier1 and tier5 svc testing tbd.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309752](https://bugs.openjdk.org/browse/JDK-8309752): com/sun/jdi/SetLocalWhileThreadInNative.java fails with virtual test thread factory due to OpaqueFrameException (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [ee21d434](https://git.openjdk.org/jdk/pull/14402/files/ee21d434259b47bcb22e828c8aad2d82c86fbbc7)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14402/head:pull/14402` \
`$ git checkout pull/14402`

Update a local copy of the PR: \
`$ git checkout pull/14402` \
`$ git pull https://git.openjdk.org/jdk.git pull/14402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14402`

View PR using the GUI difftool: \
`$ git pr show -t 14402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14402.diff">https://git.openjdk.org/jdk/pull/14402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14402#issuecomment-1585280550)