### PR TITLE
8309753: Include array classes in the output of -XX:+PrintSharedArchiveAndExit

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1357,6 +1357,10 @@ public:
     ResourceMark rm;
     _st->print_cr("%4d: %s %s", _index++, record->_klass->external_name(),
         class_loader_name_for_shared(record->_klass));
+    if (record->_klass->array_klasses() != nullptr) {
+      record->_klass->array_klasses()->cds_print_value_on(_st);
+      _st->cr();
+    }
   }
   int index() const { return _index; }
 };

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -183,6 +183,16 @@ void ArrayKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle p
     ak->restore_unshareable_info(loader_data, protection_domain, CHECK);
   }
 }
+
+void ArrayKlass::cds_print_value_on(outputStream* st) const {
+  assert(is_klass(), "must be klass");
+  st->print("      - array: %s", internal_name());
+  if (_higher_dimension != nullptr) {
+    ArrayKlass* ak = ArrayKlass::cast(higher_dimension());
+    st->cr();
+    ak->cds_print_value_on(st);
+  }
+}
 #endif // INCLUDE_CDS
 
 // Printing

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -119,6 +119,7 @@ class ArrayKlass: public Klass {
   virtual void remove_unshareable_info();
   virtual void remove_java_mirror();
   void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, TRAPS);
+  void cds_print_value_on(outputStream* st) const;
 #endif
 
   // Printing

--- a/test/hotspot/jtreg/runtime/cds/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/PrintSharedArchiveAndExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,21 +43,23 @@ public class PrintSharedArchiveAndExit {
         // (1) With a valid archive
         opts = (new CDSOptions())
             .setUseVersion(false)
-            .addSuffix( "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./" + archiveName,
+            .addSuffix("-XX:SharedArchiveFile=./" + archiveName,
                 "-XX:+PrintSharedArchiveAndExit", "-version");
         CDSTestUtils.run(opts)
             .assertNormalExit(output -> {
                 output.shouldContain("archive is valid");
+                output.shouldContain("[Ljava.lang.Object;");
                 output.shouldNotContain("java version"); // Should not print JVM version
             });
 
         opts = (new CDSOptions())
             .setUseVersion(false)
-            .addSuffix( "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./" + archiveName,
+            .addSuffix("-XX:SharedArchiveFile=./" + archiveName,
                 "-XX:+PrintSharedArchiveAndExit");
         CDSTestUtils.run(opts)
             .assertNormalExit(output -> {
                 output.shouldContain("archive is valid");
+                output.shouldContain("[Ljava.lang.Object;");
                 output.shouldNotContain("Usage:"); // Should not print JVM help message
             });
     }


### PR DESCRIPTION
Please review this simple enhancement for including the array classes names in the output of -XX:+PrintArchiveAndExit.

Before fix (portion of the output):
```
 657: java.lang.Object boot_loader
 658: java.lang.Character$CharacterCache boot_loader
 659: sun.nio.fs.LinuxFileSystem boot_loader
 660: java.lang.ThreadLocal boot_loader
 661: java.util.TreeSet boot_loader
 662: java.lang.invoke.LambdaForm$Kind boot_loader
```

After fix:
```
 657: java.lang.Object boot_loader
      - array: [Ljava.lang.Object;
      - array: [[Ljava.lang.Object;
 658: java.lang.Character$CharacterCache boot_loader
 659: sun.nio.fs.LinuxFileSystem boot_loader
 660: java.lang.ThreadLocal boot_loader
 661: java.util.TreeSet boot_loader
 662: java.lang.invoke.LambdaForm$Kind boot_loader
      - array: [Ljava.lang.invoke.LambdaForm$Kind;
```

Passed tier1 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309753](https://bugs.openjdk.org/browse/JDK-8309753): Include array classes in the output of -XX:+PrintSharedArchiveAndExit (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [b9d5ac44](https://git.openjdk.org/jdk/pull/14403/files/b9d5ac44bdc5dfe2cace83b1eb72a5279bc65806)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14403/head:pull/14403` \
`$ git checkout pull/14403`

Update a local copy of the PR: \
`$ git checkout pull/14403` \
`$ git pull https://git.openjdk.org/jdk.git pull/14403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14403`

View PR using the GUI difftool: \
`$ git pr show -t 14403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14403.diff">https://git.openjdk.org/jdk/pull/14403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14403#issuecomment-1585269812)