### PR TITLE
8307508: IndirectVarHandle.isAccessModeSupported throws NPE

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -526,8 +526,6 @@ public abstract sealed class VarHandle implements Constable
         return this;
     }
 
-    VarHandle target() { return null; }
-
     /**
      * Returns {@code true} if this VarHandle has <a href="#invoke-exact-behavior"><em>invoke-exact behavior</em></a>.
      *
@@ -2120,7 +2118,7 @@ public abstract sealed class VarHandle implements Constable
      * @return {@code true} if the given access mode is supported, otherwise
      * {@code false}.
      */
-    public final boolean isAccessModeSupported(AccessMode accessMode) {
+    public boolean isAccessModeSupported(AccessMode accessMode) {
         return vform.getMemberNameOrNull(accessMode.ordinal()) != null;
     }
 
@@ -2176,7 +2174,7 @@ public abstract sealed class VarHandle implements Constable
     MethodHandle[] methodHandleTable;
 
     @ForceInline
-    MethodHandle getMethodHandle(int mode) {
+    final MethodHandle getMethodHandle(int mode) {
         MethodHandle[] mhTable = methodHandleTable;
         if (mhTable == null) {
             mhTable = methodHandleTable = new MethodHandle[AccessMode.COUNT];
@@ -2188,7 +2186,7 @@ public abstract sealed class VarHandle implements Constable
         return mh;
     }
 
-    private final MethodHandle getMethodHandleUncached(int mode) {
+    MethodHandle getMethodHandleUncached(int mode) {
         MethodType mt = accessModeType(AccessMode.values()[mode]).
                 insertParameterTypes(0, VarHandle.class);
         MemberName mn = vform.getMemberName(mode);

--- a/test/jdk/java/lang/invoke/VarHandles/IndirectVarHandleTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/IndirectVarHandleTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8307508
+ * @summary tests for IndirectVarHandle
+ * @compile --enable-preview --release 22 IndirectVarHandleTest.java
+ * @run junit/othervm --enable-preview IndirectVarHandleTest
+ */
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.function.IntUnaryOperator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IndirectVarHandleTest {
+    @Test
+    public void testIsAccessModeTypeSupported() throws Throwable {
+        var lookup = MethodHandles.lookup();
+        var intArrayVh = MethodHandles.arrayElementVarHandle(int[].class);
+        var addOne = lookup.bind((IntUnaryOperator) a -> a + 1, "applyAsInt", MethodType.methodType(int.class, int.class));
+        var offsetIntArrayVh = MethodHandles.filterCoordinates(intArrayVh, 1, addOne);
+
+        for (var mode : VarHandle.AccessMode.values()) {
+            assertEquals(intArrayVh.isAccessModeSupported(mode), offsetIntArrayVh.isAccessModeSupported(mode), mode.toString());
+        }
+
+        var stringArrayVh = MethodHandles.arrayElementVarHandle(String[].class);
+        var offsetStringArrayVh = MethodHandles.filterCoordinates(stringArrayVh, 1, addOne);
+
+        for (var mode : VarHandle.AccessMode.values()) {
+            assertEquals(stringArrayVh.isAccessModeSupported(mode), offsetStringArrayVh.isAccessModeSupported(mode), mode.toString());
+        }
+    }
+}

--- a/test/jdk/java/lang/invoke/VarHandles/IndirectVarHandleTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/IndirectVarHandleTest.java
@@ -23,9 +23,9 @@
 
 /* @test
  * @bug 8307508
- * @summary tests for IndirectVarHandle
- * @compile --enable-preview --release 22 IndirectVarHandleTest.java
- * @run junit/othervm --enable-preview IndirectVarHandleTest
+ * @enablePreview
+ * @run junit IndirectVarHandleTest
+ * @summary Test VarHandle::isAccessModeSupported on indirect VarHandle produced by MethodHandles.filterCoordinates
  */
 import org.junit.jupiter.api.Test;
 

--- a/test/jdk/java/lang/invoke/VarHandles/IndirectVarHandleTest.java
+++ b/test/jdk/java/lang/invoke/VarHandles/IndirectVarHandleTest.java
@@ -25,7 +25,8 @@
  * @bug 8307508
  * @enablePreview
  * @run junit IndirectVarHandleTest
- * @summary Test VarHandle::isAccessModeSupported on indirect VarHandle produced by MethodHandles.filterCoordinates
+ * @summary Test VarHandle::isAccessModeSupported on indirect VarHandle
+ *          produced by MethodHandles.filterCoordinates
  */
 import org.junit.jupiter.api.Test;
 
@@ -41,18 +42,21 @@ public class IndirectVarHandleTest {
     public void testIsAccessModeTypeSupported() throws Throwable {
         var lookup = MethodHandles.lookup();
         var intArrayVh = MethodHandles.arrayElementVarHandle(int[].class);
-        var addOne = lookup.bind((IntUnaryOperator) a -> a + 1, "applyAsInt", MethodType.methodType(int.class, int.class));
+        var addOne = lookup.bind((IntUnaryOperator) a -> a + 1, "applyAsInt",
+                MethodType.methodType(int.class, int.class));
         var offsetIntArrayVh = MethodHandles.filterCoordinates(intArrayVh, 1, addOne);
 
         for (var mode : VarHandle.AccessMode.values()) {
-            assertEquals(intArrayVh.isAccessModeSupported(mode), offsetIntArrayVh.isAccessModeSupported(mode), mode.toString());
+            assertEquals(intArrayVh.isAccessModeSupported(mode),
+                    offsetIntArrayVh.isAccessModeSupported(mode), mode.toString());
         }
 
         var stringArrayVh = MethodHandles.arrayElementVarHandle(String[].class);
         var offsetStringArrayVh = MethodHandles.filterCoordinates(stringArrayVh, 1, addOne);
 
         for (var mode : VarHandle.AccessMode.values()) {
-            assertEquals(stringArrayVh.isAccessModeSupported(mode), offsetStringArrayVh.isAccessModeSupported(mode), mode.toString());
+            assertEquals(stringArrayVh.isAccessModeSupported(mode),
+                    offsetStringArrayVh.isAccessModeSupported(mode), mode.toString());
         }
     }
 }


### PR DESCRIPTION
Fixes the NPE in IndirectVarHandle.isAccessModeSupported by delegating to the target var handle. In addition, simplified the MH caching in Indirect VH and removed redundant overrides (already available via var form). This was split from #13821 as suggested by Mandy Chung, which allows easy backports to release 21 if desirable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307508](https://bugs.openjdk.org/browse/JDK-8307508): IndirectVarHandle.isAccessModeSupported throws NPE (**Bug** - P3)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [3b35edc1](https://git.openjdk.org/jdk/pull/14409/files/3b35edc144edea2f85ac01861a0b55a06e95ff09)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14409/head:pull/14409` \
`$ git checkout pull/14409`

Update a local copy of the PR: \
`$ git checkout pull/14409` \
`$ git pull https://git.openjdk.org/jdk.git pull/14409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14409`

View PR using the GUI difftool: \
`$ git pr show -t 14409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14409.diff">https://git.openjdk.org/jdk/pull/14409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14409#issuecomment-1586613415)