### PR TITLE
8309814: [IR Framework] Dump socket output string in which IR encoding was not found

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/IREncodingParser.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/IREncodingParser.java
@@ -103,7 +103,7 @@ public class IREncodingParser {
      */
     private String[] getIREncodingLines(String irEncoding) {
         Matcher matcher = IR_ENCODING_PATTERN.matcher(irEncoding);
-        TestFramework.check(matcher.find(), "Did not find IR encoding");
+        TestFramework.check(matcher.find(), "Did not find IR encoding in:" + System.lineSeparator() + irEncoding);
         String lines = matcher.group(1).trim();
         if (lines.isEmpty()) {
             // Nothing to IR match.


### PR DESCRIPTION
To better understand and analyze the low-frequency failure reported in [JDK-8309689](https://bugs.openjdk.org/browse/JDK-8309689), I suggest to additionally dump the socket output string, in which the IR encoding was not found.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309814](https://bugs.openjdk.org/browse/JDK-8309814): [IR Framework] Dump socket output string in which IR encoding was not found (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14410/head:pull/14410` \
`$ git checkout pull/14410`

Update a local copy of the PR: \
`$ git checkout pull/14410` \
`$ git pull https://git.openjdk.org/jdk.git pull/14410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14410`

View PR using the GUI difftool: \
`$ git pr show -t 14410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14410.diff">https://git.openjdk.org/jdk/pull/14410.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14410#issuecomment-1586682673)