### PR TITLE
8306281: function isWsl() returns false on WSL2

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1519,7 +1519,7 @@ var getVersionNumbers = function () {
 var isWsl = function (input) {
     return ( input.build_osenv == "wsl"
              || (input.build_os == "linux"
-                 && java.lang.System.getProperty("os.version").contains("Microsoft")));
+                 && java.lang.System.getProperty("os.version").toLowerCase().contains("microsoft")));
 }
 
 var error = function (s) {


### PR DESCRIPTION
Currently _isWsl()_ function is looking for "Microsoft" string in the _kernel release_ string (`$ uname -r`). 
That's not always true. Namely, on Ubuntu 22.04 - currently the newest Ubuntu LTS and default OS for WSL in Microsoft Store. In there `$ uname -r` command outputs "5.10.102.1-microsoft-standard-WSL2".
This makes _isWsl()_ function to return `false` in such environments and breaks JDK builds on WSL.

To correct that I made the substring search case-insensitive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306281](https://bugs.openjdk.org/browse/JDK-8306281): function isWsl() returns false on WSL2 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14413/head:pull/14413` \
`$ git checkout pull/14413`

Update a local copy of the PR: \
`$ git checkout pull/14413` \
`$ git pull https://git.openjdk.org/jdk.git pull/14413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14413`

View PR using the GUI difftool: \
`$ git pr show -t 14413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14413.diff">https://git.openjdk.org/jdk/pull/14413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14413#issuecomment-1587929872)