### PR TITLE
8309852: G1: Remove unnecessary assert_empty in G1ParScanThreadStateSet destructor

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -712,6 +712,5 @@ G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {
   assert(_flushed, "thread local state from the per thread states should have been flushed");
   FREE_C_HEAP_ARRAY(G1ParScanThreadState*, _states);
   FREE_C_HEAP_ARRAY(size_t, _surviving_young_words_total);
-  _preserved_marks_set.assert_empty();
   _preserved_marks_set.reclaim();
 }


### PR DESCRIPTION
Trivial removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309852](https://bugs.openjdk.org/browse/JDK-8309852): G1: Remove unnecessary assert_empty in G1ParScanThreadStateSet destructor (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14417/head:pull/14417` \
`$ git checkout pull/14417`

Update a local copy of the PR: \
`$ git checkout pull/14417` \
`$ git pull https://git.openjdk.org/jdk.git pull/14417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14417`

View PR using the GUI difftool: \
`$ git pr show -t 14417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14417.diff">https://git.openjdk.org/jdk/pull/14417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14417#issuecomment-1587364192)