### PR TITLE
8295555: Primitive wrapper caches could be `@Stable`

### DIFF
--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
@@ -105,9 +106,10 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
         return Optional.of(DynamicConstantDesc.ofNamed(BSM_EXPLICIT_CAST, DEFAULT_NAME, CD_byte, intValue()));
     }
 
-    private static class ByteCache {
+    private static final class ByteCache {
         private ByteCache() {}
 
+        @Stable
         static final Byte[] cache;
         static Byte[] archivedCache;
 

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
@@ -8956,9 +8957,10 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
         this.value = value;
     }
 
-    private static class CharacterCache {
+    private static final class CharacterCache {
         private CharacterCache(){}
 
+        @Stable
         static final Character[] cache;
         static Character[] archivedCache;
 

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1009,6 +1009,7 @@ public final class Integer extends Number
     private static final class IntegerCache {
         static final int low = -128;
         static final int high;
+        
         @Stable
         static final Integer[] cache;
         static Integer[] archivedCache;

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1009,7 +1009,7 @@ public final class Integer extends Number
     private static final class IntegerCache {
         static final int low = -128;
         static final int high;
-        
+
         @Stable
         static final Integer[] cache;
         static Integer[] archivedCache;

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -29,6 +29,7 @@ import jdk.internal.misc.CDS;
 import jdk.internal.misc.VM;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import java.lang.annotation.Native;
 import java.lang.constant.Constable;
@@ -1005,9 +1006,10 @@ public final class Integer extends Number
      * with new Integer object(s) after initialization.
      */
 
-    private static class IntegerCache {
+    private static final class IntegerCache {
         static final int low = -128;
         static final int high;
+        @Stable
         static final Integer[] cache;
         static Integer[] archivedCache;
 

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;
@@ -1156,9 +1157,10 @@ public final class Long extends Number
         return Long.valueOf(parseLong(s, 10));
     }
 
-    private static class LongCache {
+    private static final class LongCache {
         private LongCache() {}
 
+        @Stable
         static final Long[] cache;
         static Long[] archivedCache;
 

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
@@ -231,9 +232,10 @@ public final class Short extends Number implements Comparable<Short>, Constable 
         return Optional.of(DynamicConstantDesc.ofNamed(BSM_EXPLICIT_CAST, DEFAULT_NAME, CD_short, intValue()));
     }
 
-    private static class ShortCache {
+    private static final class ShortCache {
         private ShortCache() {}
 
+        @Stable
         static final Short[] cache;
         static Short[] archivedCache;
 


### PR DESCRIPTION
This PR proposes adding `@Stable` to certain wrapper classes' cache arrays (e.g. `Integer` and `Long`).

Comments are welcome as to how to improve the VM's handling now that the backing cache array is `@Stable`. Are there simplifications to be made or are there other optimizations we might add?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295555](https://bugs.openjdk.org/browse/JDK-8295555): Primitive wrapper caches could be `@Stable` (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14418/head:pull/14418` \
`$ git checkout pull/14418`

Update a local copy of the PR: \
`$ git checkout pull/14418` \
`$ git pull https://git.openjdk.org/jdk.git pull/14418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14418`

View PR using the GUI difftool: \
`$ git pr show -t 14418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14418.diff">https://git.openjdk.org/jdk/pull/14418.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14418#issuecomment-1587487418)