### PR TITLE
8309867: redundant class field RSAPadding.md

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,9 +102,6 @@ public final class RSAPadding {
     // maximum size of the data
     private final int maxDataSize;
 
-    // OAEP: main message digest
-    private MessageDigest md;
-
     // OAEP: MGF1
     private MGF1 mgf;
 
@@ -151,6 +148,8 @@ public final class RSAPadding {
             // sanity check, already verified in RSASignature/RSACipher
             throw new InvalidKeyException("Padded size must be at least 64");
         }
+        // OAEP: main message digest
+        MessageDigest md;
         switch (type) {
         case PAD_BLOCKTYPE_1:
         case PAD_BLOCKTYPE_2:


### PR DESCRIPTION
Hi,

May I get this simple update reviewed?

The class field RSAPadding.md can be converted to a local variable of the constructor, and save the class footprint.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309867](https://bugs.openjdk.org/browse/JDK-8309867): redundant class field RSAPadding.md (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14422/head:pull/14422` \
`$ git checkout pull/14422`

Update a local copy of the PR: \
`$ git checkout pull/14422` \
`$ git pull https://git.openjdk.org/jdk.git pull/14422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14422`

View PR using the GUI difftool: \
`$ git pr show -t 14422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14422.diff">https://git.openjdk.org/jdk/pull/14422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14422#issuecomment-1587702956)