### PR TITLE
JDK-8309870: Using -proc:full should be considered requesting explicit annotation processing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1288,7 +1288,10 @@ public class JavaCompiler {
             options.isSet(PROCESSOR_PATH) ||
             options.isSet(PROCESSOR_MODULE_PATH) ||
             options.isSet(PROC, "only") ||
+            options.isSet(PROC, "full") ||
+            options.isSet(A) ||
             options.isSet(XPRINT);
+        // Skipping -XprintRounds and -XprintProcessorInfo
     }
 
     public void setDeferredDiagnosticHandler(Log.DeferredDiagnosticHandler deferredDiagnosticHandler) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,11 @@ import static com.sun.tools.javac.main.Option.OptionKind.*;
  * or deletion without notice.</b></p>
  */
 public enum Option {
+    /*
+     * Maintenance note: when adding new annotation processing related
+     * options, the list of options regarded as requesting explicit
+     * annotation processing in JavaCompiler should be updated.
+     */
     G("-g", "opt.g", STANDARD, BASIC),
 
     G_NONE("-g:none", "opt.g.none", STANDARD, BASIC) {


### PR DESCRIPTION
Address a small omission to the recent addition of "javac -proc:full", regard "-proc:full" as explicitly requesting annotation processing. Also add "-A" to the list of options indicating explicit annotation processing was requested.

The intention is to backport this bug fix to JDK 21 too.