### PR TITLE
8308808: SunMSCAPI public keys returns internal key array

### DIFF
--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -93,7 +93,7 @@ public abstract class CPublicKey extends CKey implements PublicKey {
                     // ignore
                 }
             }
-            return encoding.clone();
+            return (encoding == null) ? null : encoding.clone();
         }
 
         @Override
@@ -179,7 +179,7 @@ public abstract class CPublicKey extends CKey implements PublicKey {
                     // ignore
                 }
             }
-            return encoding.clone();
+            return (encoding == null) ? null : encoding.clone();
         }
 
         private native byte[] getExponent(byte[] keyBlob) throws KeyException;

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -93,7 +93,10 @@ public abstract class CPublicKey extends CKey implements PublicKey {
                     // ignore
                 }
             }
-            return encoding;
+
+            byte[] safeEncoding = new byte[encoding.length];
+            System.arraycopy(encoding, 0, safeEncoding, 0, encoding.length);
+            return safeEncoding;
         }
 
         @Override

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -182,7 +182,9 @@ public abstract class CPublicKey extends CKey implements PublicKey {
                     // ignore
                 }
             }
-            return encoding;
+            byte[] safeEncoding = new byte[encoding.length];
+            System.arraycopy(encoding, 0, safeEncoding, 0, encoding.length);
+            return safeEncoding;
         }
 
         private native byte[] getExponent(byte[] keyBlob) throws KeyException;

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -87,16 +87,13 @@ public abstract class CPublicKey extends CKey implements PublicKey {
             if (encoding == null) {
                 try {
                     encoding = KeyFactory.getInstance("EC").generatePublic(
-                                new ECPublicKeySpec(getW(), getParams()))
-                            .getEncoded();
+                            new ECPublicKeySpec(getW(), getParams()))
+                        .getEncoded();
                 } catch (Exception e) {
                     // ignore
                 }
             }
-
-            byte[] safeEncoding = new byte[encoding.length];
-            System.arraycopy(encoding, 0, safeEncoding, 0, encoding.length);
-            return safeEncoding;
+            return encoding.clone();
         }
 
         @Override
@@ -182,9 +179,7 @@ public abstract class CPublicKey extends CKey implements PublicKey {
                     // ignore
                 }
             }
-            byte[] safeEncoding = new byte[encoding.length];
-            System.arraycopy(encoding, 0, safeEncoding, 0, encoding.length);
-            return safeEncoding;
+            return encoding.clone();
         }
 
         private native byte[] getExponent(byte[] keyBlob) throws KeyException;

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -6,7 +6,8 @@
  * @run main EncodingMutability
  */
 
-import java.security.*;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 
 public class EncodingMutability {
 

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -1,0 +1,27 @@
+import jdk.test.lib.Asserts;
+import jdk.test.lib.SecurityTools;
+
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.util.Arrays;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import java.security.KeyStore;
+
+public class EncodingMutability {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", "SunMSCAPI");
+        PublicKey publicKey = keyGen.generateKeyPair().getPublic();
+        byte initialByte = publicKey.getEncoded()[0];
+        publicKey.getEncoded()[0] = 0;
+        byte mutatedByte = publicKey.getEncoded()[0];
+
+        System.out.println(initialByte + " " + mutatedByte);
+
+        if (initialByte != mutatedByte) {
+            System.out.println("Was able to mutate first byte of pubkey from " + initialByte + "to " + mutatedByte);
+            throw new RuntimeException("Pubkey was mutated via getEncoded");
+        }
+    }
+}

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -1,14 +1,36 @@
 /*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+
+/*
  * @test
  * @bug 8308808
  * @requires os.family == "windows"
  * @modules jdk.crypto.mscapi
  * @run main EncodingMutability
  */
-
-import java.security.KeyPairGenerator;
-import java.security.PublicKey;
-
 public class EncodingMutability {
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -18,7 +18,7 @@ public class EncodingMutability {
         byte mutatedByte = publicKey.getEncoded()[0];
 
         if (initialByte != mutatedByte) {
-            System.out.println("Was able to mutate first byte of pubkey from " + initialByte + "to " + mutatedByte);
+            System.out.println("Was able to mutate first byte of pubkey from " + initialByte + " to " + mutatedByte);
             throw new RuntimeException("Pubkey was mutated via getEncoded");
         }
     }

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -2,7 +2,7 @@
  * @test
  * @bug 8308808
  * @requires os.family == "windows"
- * @modules jdk.crypto.mscapi/sun.security.mscapi
+ * @modules jdk.crypto.mscapi
  * @run main EncodingMutability
  */
 

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -1,12 +1,12 @@
-import jdk.test.lib.Asserts;
-import jdk.test.lib.SecurityTools;
+/*
+ * @test
+ * @bug 8308808
+ * @requires os.family == "windows"
+ * @modules jdk.crypto.mscapi/sun.security.mscapi
+ * @run main EncodingMutability
+ */
 
-import java.security.KeyPairGenerator;
-import java.security.PublicKey;
-import java.util.Arrays;
-import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
-import java.security.KeyStore;
+import java.security.*;
 
 public class EncodingMutability {
 
@@ -16,8 +16,6 @@ public class EncodingMutability {
         byte initialByte = publicKey.getEncoded()[0];
         publicKey.getEncoded()[0] = 0;
         byte mutatedByte = publicKey.getEncoded()[0];
-
-        System.out.println(initialByte + " " + mutatedByte);
 
         if (initialByte != mutatedByte) {
             System.out.println("Was able to mutate first byte of pubkey from " + initialByte + "to " + mutatedByte);


### PR DESCRIPTION
Changed `getEncoded` for both EC and RSA to return a copy of the internal key array to avoid mutability issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308808](https://bugs.openjdk.org/browse/JDK-8308808): SunMSCAPI public keys returns internal key array (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14425/head:pull/14425` \
`$ git checkout pull/14425`

Update a local copy of the PR: \
`$ git checkout pull/14425` \
`$ git pull https://git.openjdk.org/jdk.git pull/14425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14425`

View PR using the GUI difftool: \
`$ git pr show -t 14425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14425.diff">https://git.openjdk.org/jdk/pull/14425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14425#issuecomment-1587911562)