### PR TITLE
8309756: Occasional crashes with pipewire screen capture on Wayland

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -89,8 +89,10 @@ static void doCleanup() {
         struct ScreenProps *screenProps = &screenSpace.screens[i];
         if (screenProps->data) {
             if (screenProps->data->stream) {
+                fp_pw_thread_loop_lock(pw.loop);
                 fp_pw_stream_disconnect(screenProps->data->stream);
                 fp_pw_stream_destroy(screenProps->data->stream);
+                fp_pw_thread_loop_unlock(pw.loop);
                 screenProps->data->stream = NULL;
             }
             free(screenProps->data);
@@ -892,8 +894,10 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
             screenProps->captureData = NULL;
             screenProps->shouldCapture = FALSE;
 
+            fp_pw_thread_loop_lock(pw.loop);
             fp_pw_stream_set_active(screenProps->data->stream, FALSE);
             fp_pw_stream_disconnect(screenProps->data->stream);
+            fp_pw_thread_loop_unlock(pw.loop);
         }
     }
     doCleanup();


### PR DESCRIPTION
This fix seems to resolve some occasional crashes in our usage of pipewire for Wayland screen capture.
See the bug report for more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309756](https://bugs.openjdk.org/browse/JDK-8309756): Occasional crashes with pipewire screen capture on Wayland (**Bug** - P3)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14428/head:pull/14428` \
`$ git checkout pull/14428`

Update a local copy of the PR: \
`$ git checkout pull/14428` \
`$ git pull https://git.openjdk.org/jdk.git pull/14428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14428`

View PR using the GUI difftool: \
`$ git pr show -t 14428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14428.diff">https://git.openjdk.org/jdk/pull/14428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14428#issuecomment-1588134934)