### PR TITLE
8309808: BytecodeTracer prints wrong BSM for invokedynamic

### DIFF
--- a/src/hotspot/share/classfile/classPrinter.hpp
+++ b/src/hotspot/share/classfile/classPrinter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,10 +59,19 @@ public:
 
   static void print_flags_help(outputStream* os);
 
-  // flags must be OR'ed from ClassPrinter::Mode for the these two functions
+  // Parameters for print_classes() and print_methods():
+  //
+  // - The patterns are matched by StringUtils::is_star_match()
+  // - class_name_pattern matches Klass::external_name(). E.g., "java/lang/Object" or "*ang/Object"
+  // - method_pattern may optionally include the signature. E.g., "wait", "wait:()V" or "*ai*t:(*)V"
+  // - flags must be OR'ed from ClassPrinter::Mode
+  //
+  //   print_classes("java/lang/Object", 0x3, os)            -> find j.l.Object and disasm all of its methods
+  //   print_methods("*ang/Object*", "wait", 0xff, os)       -> detailed disasm of all "wait" methods in j.l.Object
+  //   print_methods("*ang/Object*", "wait:(*J*)V", 0x1, os) -> list all "wait" methods in j.l.Object that have a long parameter
   static void print_classes(const char* class_name_pattern, int flags, outputStream* os);
   static void print_methods(const char* class_name_pattern,
-                            const char* method_name_pattern, int flags, outputStream* os);
+                            const char* method_pattern, int flags, outputStream* os);
 };
 
 #endif // SHARE_CLASSFILE_CLASSPRINTER_HPP

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -302,10 +302,16 @@ bool BytecodePrinter::check_obj_index(int i, int& cp_index, outputStream* st) {
 
 
 bool BytecodePrinter::check_invokedynamic_index(int i, int& cp_index, outputStream* st) {
-  assert(ConstantPool::is_invokedynamic_index(i), "not secondary index?");
-  i = ConstantPool::decode_invokedynamic_index(i) + ConstantPool::CPCACHE_INDEX_TAG;
-
-  return check_cp_cache_index(i, cp_index, st);
+  ConstantPool* constants = _current_method->constants();
+  if (constants->cache() == nullptr) {
+    cp_index = i; // TODO: This is wrong on little-endian. See JDK-8309811.
+  } else {
+    assert(ConstantPool::is_invokedynamic_index(i), "not secondary index?");
+    i = ConstantPool::decode_invokedynamic_index(i);
+    ResolvedIndyEntry* indy_entry = constants->resolved_indy_entry_at(i);
+    cp_index = indy_entry->constant_pool_index();
+  }
+  return true;
 }
 
 void BytecodePrinter::print_constant(int i, outputStream* st) {

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -306,9 +306,9 @@ bool BytecodePrinter::check_invokedynamic_index(int i, int& cp_index, outputStre
   if (constants->cache() == nullptr) {
     cp_index = i; // TODO: This is wrong on little-endian. See JDK-8309811.
   } else {
-    assert(ConstantPool::is_invokedynamic_index(i), "not secondary index?");
-    i = ConstantPool::decode_invokedynamic_index(i);
-    ResolvedIndyEntry* indy_entry = constants->resolved_indy_entry_at(i);
+    assert(ConstantPool::is_invokedynamic_index(i), "must be");
+    int indy_index = ConstantPool::decode_invokedynamic_index(i);
+    ResolvedIndyEntry* indy_entry = constants->resolved_indy_entry_at(indy_index);
     cp_index = indy_entry->constant_pool_index();
   }
   return true;

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -31,6 +31,7 @@
 #include "cds/metaspaceShared.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/classLoaderStats.hpp"
+#include "classfile/classPrinter.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/modules.hpp"
 #include "classfile/protectionDomainCache.hpp"
@@ -1897,6 +1898,35 @@ WB_ENTRY(jint, WB_getIndyCPIndex(JNIEnv* env, jobject wb, jclass klass, jint ind
   return cp->resolved_indy_entry_at(index)->constant_pool_index();
 WB_END
 
+WB_ENTRY(jobject, WB_printClasses(JNIEnv* env, jobject wb, jstring class_name_pattern, jint flags))
+  ThreadToNativeFromVM ttnfv(thread);
+  const char* c = env->GetStringUTFChars(class_name_pattern, nullptr);
+  ResourceMark rm;
+  stringStream st;
+  {
+    ThreadInVMfromNative ttvfn(thread); // back to VM
+    ClassPrinter::print_classes(c, flags, &st);
+  }
+  jstring result = env->NewStringUTF(st.freeze());
+  CHECK_JNI_EXCEPTION_(env, nullptr);
+  return result;
+WB_END
+
+WB_ENTRY(jobject, WB_printMethods(JNIEnv* env, jobject wb, jstring class_name_pattern, jstring method_pattern, jint flags))
+  ThreadToNativeFromVM ttnfv(thread);
+  const char* c = env->GetStringUTFChars(class_name_pattern, nullptr);
+  const char* m = env->GetStringUTFChars(method_pattern, nullptr);
+  ResourceMark rm;
+  stringStream st;
+  {
+    ThreadInVMfromNative ttvfn(thread); // back to VM
+    ClassPrinter::print_methods(c, m, flags, &st);
+  }
+  jstring result = env->NewStringUTF(st.freeze());
+  CHECK_JNI_EXCEPTION_(env, nullptr);
+  return result;
+WB_END
+
 WB_ENTRY(void, WB_ClearInlineCaches(JNIEnv* env, jobject wb, jboolean preserve_static_stubs))
   VM_ClearICs clear_ics(preserve_static_stubs == JNI_TRUE);
   VMThread::execute(&clear_ics);
@@ -2737,6 +2767,8 @@ static JNINativeMethod methods[] = {
       CC"(I)I",                      (void*)&WB_ConstantPoolEncodeIndyIndex},
   {CC"getIndyInfoLength0", CC"(Ljava/lang/Class;)I",  (void*)&WB_getIndyInfoLength},
   {CC"getIndyCPIndex0",    CC"(Ljava/lang/Class;I)I", (void*)&WB_getIndyCPIndex},
+  {CC"printClasses0",      CC"(Ljava/lang/String;I)Ljava/lang/String;", (void*)&WB_printClasses},
+  {CC"printMethods0",      CC"(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;", (void*)&WB_printMethods},
   {CC"getMethodBooleanOption",
       CC"(Ljava/lang/reflect/Executable;Ljava/lang/String;)Ljava/lang/Boolean;",
                                                       (void*)&WB_GetMethodBooleaneOption},

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -534,10 +534,7 @@ extern "C" JNIEXPORT void findpc(intptr_t x) {
 }
 
 // For findmethod() and findclass():
-// - The patterns are matched by StringUtils::is_star_match()
-// - class_name_pattern matches Klass::external_name(). E.g., "java/lang/Object" or "*ang/Object"
-// - method_pattern may optionally the signature. E.g., "wait", "wait:()V" or "*ai*t:(*)V"
-// - flags must be OR'ed from ClassPrinter::Mode for findclass/findmethod
+//   See comments in classPrinter.hpp about the meanings of class_name_pattern, method_pattern and flags.
 // Examples (in gdb):
 //   call findclass("java/lang/Object", 0x3)             -> find j.l.Object and disasm all of its methods
 //   call findmethod("*ang/Object*", "wait", 0xff)       -> detailed disasm of all "wait" methods in j.l.Object

--- a/test/hotspot/jtreg/runtime/interpreter/BytecodeTracerTest.java
+++ b/test/hotspot/jtreg/runtime/interpreter/BytecodeTracerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309808 8309811
+ * @summary Test the output of the HotSpot BytecodeTracer and ClassPrinter classes.
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI BytecodeTracerTest
+ */
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class BytecodeTracerTest {
+    public static class Linked {
+        public static void doit(String args[]) {
+            System.out.println("num args = " + args.length);
+        }
+    }
+
+    public static class Unlinked implements Serializable {
+        public String toString() {
+            return "Unlinked" + this.hashCode();
+        }
+    }
+
+    static String output;
+    static int testCount = 0;
+
+    static String nextCase(String testName) {
+        ++ testCount;
+        return "======================================================================\nTest case "
+            + testCount + ": " + testName + "\n    ";
+    }
+
+    static void logOutput() throws Exception {
+        String logFileName = "log-" + testCount + ".txt";
+        System.out.println("Output saved in " + logFileName);
+        BufferedWriter writer = new BufferedWriter(new FileWriter(logFileName));
+        writer.write(output);
+        writer.close();
+    }
+
+    static void printClasses(String testName, String classNamePattern, int flags) throws Exception {
+        System.out.println(nextCase(testName) + "printClasses(\"" + classNamePattern + "\", " + flags + ")");
+        output = WhiteBox.getWhiteBox().printClasses(classNamePattern, flags);
+        logOutput();
+    }
+
+    static void printMethods(String testName, String classNamePattern, String methodPattern, int flags) throws Exception {
+        System.out.println(nextCase(testName) + "printMethods(\"" + classNamePattern + "\", \"" + methodPattern + "\", " + flags + ")");
+        output = WhiteBox.getWhiteBox().printMethods(classNamePattern, methodPattern, flags);
+        logOutput();
+    }
+
+    static void mustMatch(String pattern) {
+        Pattern p = Pattern.compile(pattern, Pattern.MULTILINE);
+        Matcher m = p.matcher(output);
+        boolean found = m.find();
+        if (!found) {
+            System.err.println("********* output ********");
+            System.err.println(output);
+            System.err.println("*************************");
+        }
+        Asserts.assertTrue(found,
+                           "Missing pattern: \"" + pattern + "\"");
+        System.out.println("Found pattern: " + pattern);
+        System.out.println("          ==>: " + m.group());
+    }
+
+    public static void main(String args[]) throws Exception {
+        Linked.doit(args); // Force "Linked" class to be linked (and rewritten);
+
+        // ======
+        printClasses("invokedynamic in linked class",
+                     "BytecodeTracerTest$Linked", 0xff);
+        mustMatch("invokedynamic bsm=[0-9]+ [0-9]+ <makeConcatWithConstants[(]I[)]Ljava/lang/String;>");
+        mustMatch("BSM: REF_invokeStatic [0-9]+ <java/lang/invoke/StringConcatFactory.makeConcatWithConstants[(]");
+
+        // ======
+        if (false) { // disabled due to JDK-8309811
+        printMethods("invokedynamic in unlinked class",
+                     "BytecodeTracerTest$Unlinked", "toString", 0xff);
+        mustMatch("invokedynamic bsm=[0-9]+ [0-9]+ <makeConcatWithConstants[(]I[)]Ljava/lang/String;>");
+        mustMatch("BSM: REF_invokeStatic [0-9]+ <java/lang/invoke/StringConcatFactory.makeConcatWithConstants[(]");
+        }
+    }
+
+    public Serializable cast(Unlinked f) {
+        // Verifying this method causes the "Unlinked" class to be loaded. However
+        // the "Unlinked" class is never used during the execution of
+        // BytecodeTracerTest.main(), so it is not linked by HotSpot.
+        return f;
+    }
+}
+

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -163,6 +163,19 @@ public class WhiteBox {
     return getIndyCPIndex0(aClass, index);
   }
 
+  private native String printClasses0(String classNamePattern, int flags);
+  public         String printClasses(String classNamePattern, int flags) {
+    Objects.requireNonNull(classNamePattern);
+    return printClasses0(classNamePattern, flags);
+  }
+
+  private native String printMethods0(String classNamePattern, String methodPattern, int flags);
+  public         String printMethods(String classNamePattern, String methodPattern, int flags) {
+    Objects.requireNonNull(classNamePattern);
+    Objects.requireNonNull(methodPattern);
+    return printMethods0(classNamePattern, methodPattern, flags);
+  }
+
   // JVMTI
   private native void addToBootstrapClassLoaderSearch0(String segment);
   public         void addToBootstrapClassLoaderSearch(String segment){


### PR DESCRIPTION
This PR fixes the tracing of invokedynamic bytecodes:

```
before: 0x00007f3aa8400385  5 invokedynamic 1 <java/lang/Object.<init>()V>
after:  0x00007f9bcc4056a5  5 invokedynamic bsm=37 13 <makeConcatWithConstants(I)Ljava/lang/String;>
```

I've also added WhiteBox functionality to make it easy to write new tests for the BytecodeTracer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309808](https://bugs.openjdk.org/browse/JDK-8309808): BytecodeTracer prints wrong BSM for invokedynamic (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [5a173e59](https://git.openjdk.org/jdk/pull/14429/files/5a173e5938921aaba0941535b52a39e5baf5c89d)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [5a173e59](https://git.openjdk.org/jdk/pull/14429/files/5a173e5938921aaba0941535b52a39e5baf5c89d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14429/head:pull/14429` \
`$ git checkout pull/14429`

Update a local copy of the PR: \
`$ git checkout pull/14429` \
`$ git pull https://git.openjdk.org/jdk.git pull/14429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14429`

View PR using the GUI difftool: \
`$ git pr show -t 14429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14429.diff">https://git.openjdk.org/jdk/pull/14429.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14429#issuecomment-1588168098)