### PR TITLE
JDK-8309883: no `@since` info in com.sun.tools.javac package-info.java, Main.java

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/Main.java
@@ -32,6 +32,8 @@ import java.io.PrintWriter;
  * compiler, javac.
  * See the <a href="{@docRoot}/jdk.compiler/module-summary.html">{@code jdk.compiler}</a>
  * module for details on replacement APIs.
+ *
+ * @since 1.5
  */
 public class Main {
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/package-info.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/package-info.java
@@ -27,5 +27,7 @@
  * This package provides a legacy entry point for the <em>javac</em> tool.
  * See the <a href="{@docRoot}/jdk.compiler/module-summary.html">{@code jdk.compiler}</a>
  * module for details on replacement APIs.
+ *
+ * @since 1.5
  */
 package com.sun.tools.javac;


### PR DESCRIPTION
Please review a trivial update to add some long-overdue `@since` tags to public API in `com.sun.tools.javac`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309883](https://bugs.openjdk.org/browse/JDK-8309883): no `@since` info in com.sun.tools.javac package-info.java, Main.java (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14431/head:pull/14431` \
`$ git checkout pull/14431`

Update a local copy of the PR: \
`$ git checkout pull/14431` \
`$ git pull https://git.openjdk.org/jdk.git pull/14431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14431`

View PR using the GUI difftool: \
`$ git pr show -t 14431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14431.diff">https://git.openjdk.org/jdk/pull/14431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14431#issuecomment-1588242646)