### PR TITLE
8309882: LinkedHashMap adds an errant serializable field

### DIFF
--- a/src/java.base/share/classes/java/util/LinkedHashMap.java
+++ b/src/java.base/share/classes/java/util/LinkedHashMap.java
@@ -330,7 +330,7 @@ public class LinkedHashMap<K,V>
     static final int PUT_NORM = 0;
     static final int PUT_FIRST = 1;
     static final int PUT_LAST = 2;
-    int putMode = PUT_NORM;
+    transient int putMode = PUT_NORM;
 
     // Called after update, but not after insertion
     void afterNodeAccess(Node<K,V> e) {


### PR DESCRIPTION
Make `putMode` be a transient field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8309885](https://bugs.openjdk.org/browse/JDK-8309885) to be approved

### Issues
 * [JDK-8309882](https://bugs.openjdk.org/browse/JDK-8309882): LinkedHashMap adds an errant serializable field (**Bug** - P3)
 * [JDK-8309885](https://bugs.openjdk.org/browse/JDK-8309885): LinkedHashMap adds an errant serializable field (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14433/head:pull/14433` \
`$ git checkout pull/14433`

Update a local copy of the PR: \
`$ git checkout pull/14433` \
`$ git pull https://git.openjdk.org/jdk.git pull/14433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14433`

View PR using the GUI difftool: \
`$ git pr show -t 14433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14433.diff">https://git.openjdk.org/jdk/pull/14433.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14433#issuecomment-1588275737)