### PR TITLE
JDK-8309884: missing @since tags in `com.sun.source.*`

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/DirectiveTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/DirectiveTree.java
@@ -27,5 +27,7 @@ package com.sun.source.tree;
 
 /**
  * A super-type for all the directives in a ModuleTree.
+ *
+ * @since 9
  */
 public interface DirectiveTree extends Tree { }

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/LambdaExpressionTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/LambdaExpressionTree.java
@@ -37,7 +37,7 @@ import java.util.List;
  *   (x,y)-> { return x + y; }
  * }</pre>
  *
- * @since 8
+ * @since 1.8
  */
 public interface LambdaExpressionTree extends ExpressionTree {
 

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/LambdaExpressionTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/LambdaExpressionTree.java
@@ -36,6 +36,8 @@ import java.util.List;
  *   (List<String> ls)->ls.size()
  *   (x,y)-> { return x + y; }
  * }</pre>
+ *
+ * @since 8
  */
 public interface LambdaExpressionTree extends ExpressionTree {
 

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/StringTemplateTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/StringTemplateTree.java
@@ -32,6 +32,7 @@ import jdk.internal.javac.PreviewFeature;
 /**
  * A tree node for a string template expression.
  *
+ * @since 21
  */
 @PreviewFeature(feature=PreviewFeature.Feature.STRING_TEMPLATES, reflective=true)
 public interface StringTemplateTree extends ExpressionTree {

--- a/src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
@@ -50,6 +50,8 @@ import com.sun.source.tree.Tree;
  * Bridges JSR 199, JSR 269, and the Tree API.
  *
  * @author Peter von der Ah&eacute;
+ *
+ * @since 1.6
  */
 public abstract class Trees {
     /**


### PR DESCRIPTION
Please review a trivial docs fix to address missing `@since` tags in `com.sun.source` API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309884](https://bugs.openjdk.org/browse/JDK-8309884): missing @since tags in `com.sun.source.*` (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [2ad464c1](https://git.openjdk.org/jdk/pull/14434/files/2ad464c1b8448bca23679edc114a288ee92607e6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14434/head:pull/14434` \
`$ git checkout pull/14434`

Update a local copy of the PR: \
`$ git checkout pull/14434` \
`$ git pull https://git.openjdk.org/jdk.git pull/14434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14434`

View PR using the GUI difftool: \
`$ git pr show -t 14434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14434.diff">https://git.openjdk.org/jdk/pull/14434.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14434#issuecomment-1588288538)