### PR TITLE
8309847: FrameForm and RegisterForm constructors should initialize all members

### DIFF
--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -31,7 +31,8 @@ int RegisterForm::_reg_ctr = 0;
 //------------------------------RegisterForm-----------------------------------
 // Constructor
 RegisterForm::RegisterForm()
-  : _regDef(cmpstr,hashstr, Form::arena),
+  : _current_ac(nullptr),
+    _regDef(cmpstr,hashstr, Form::arena),
     _regClass(cmpstr,hashstr, Form::arena),
     _allocClass(cmpstr,hashstr, Form::arena) {
 }
@@ -372,6 +373,8 @@ void CodeSnippetRegClass::declare_register_masks(FILE* fp) {
 
 //------------------------------ConditionalRegClass---------------------------
 ConditionalRegClass::ConditionalRegClass(const char *classid) : RegClass(classid), _condition_code(nullptr) {
+    _rclasses[0] = nullptr;
+    _rclasses[1] = nullptr;
 }
 
 ConditionalRegClass::~ConditionalRegClass() {
@@ -436,15 +439,20 @@ void AllocClass::output(FILE *fp) {       // Write info to output files
 //==============================Frame Handling=================================
 //------------------------------FrameForm--------------------------------------
 FrameForm::FrameForm() {
+  _sync_stack_slots = nullptr;
+  _inline_cache_reg = nullptr;
+  _interpreter_frame_pointer_reg = nullptr;
+  _cisc_spilling_operand_name = nullptr;
   _frame_pointer = nullptr;
   _c_frame_pointer = nullptr;
   _alignment = nullptr;
+  _return_addr_loc = false;
+  _c_return_addr_loc = false;
   _return_addr = nullptr;
   _c_return_addr = nullptr;
   _varargs_C_out_slots_killed = nullptr;
   _return_value = nullptr;
   _c_return_value = nullptr;
-  _interpreter_frame_pointer_reg = nullptr;
 }
 
 FrameForm::~FrameForm() {


### PR DESCRIPTION
This PR fixes missing constructor initialisations in formsopt.cpp.
This PR does not implement [CppCoreGuidelines#Rc-in-class-initializer](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer ) to keep the style consistent and minimise changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309847](https://bugs.openjdk.org/browse/JDK-8309847): FrameForm and RegisterForm constructors should initialize all members (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14435/head:pull/14435` \
`$ git checkout pull/14435`

Update a local copy of the PR: \
`$ git checkout pull/14435` \
`$ git pull https://git.openjdk.org/jdk.git pull/14435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14435`

View PR using the GUI difftool: \
`$ git pr show -t 14435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14435.diff">https://git.openjdk.org/jdk/pull/14435.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14435#issuecomment-1588525263)