### PR TITLE
8309778: java/nio/file/Files/CopyAndMove.java fails when using second test directory

### DIFF
--- a/test/jdk/java/nio/file/Files/CopyAndMove.java
+++ b/test/jdk/java/nio/file/Files/CopyAndMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/file/Files/CopyAndMove.java
+++ b/test/jdk/java/nio/file/Files/CopyAndMove.java
@@ -62,7 +62,7 @@ public class CopyAndMove {
             // Use test.dir to define second directory if possible as it might
             // be a different volume/file system and so improve test coverage.
             String testDir = System.getProperty("test.dir", ".");
-            Path dir2 = TestUtil.createTemporaryDirectory(testDir);
+            Path dir2 = TestUtil.createTemporaryDirectory(testDir).toAbsolutePath();
             FileStore fileStore2 = getFileStore(dir2);
             printDirInfo("dir2", dir2, fileStore2);
 

--- a/test/jdk/java/nio/file/Files/CopyAndMove.java
+++ b/test/jdk/java/nio/file/Files/CopyAndMove.java
@@ -62,7 +62,7 @@ public class CopyAndMove {
             // Use test.dir to define second directory if possible as it might
             // be a different volume/file system and so improve test coverage.
             String testDir = System.getProperty("test.dir", ".");
-            Path dir2 = TestUtil.createTemporaryDirectory(testDir).toAbsolutePath();
+            Path dir2 = TestUtil.createTemporaryDirectory(testDir);
             FileStore fileStore2 = getFileStore(dir2);
             printDirInfo("dir2", dir2, fileStore2);
 
@@ -909,7 +909,7 @@ public class CopyAndMove {
         if (supportsLinks) {
             source = createSourceFile(dir1);
             link = dir1.resolve("link");
-            createSymbolicLink(link, source);
+            createSymbolicLink(link, source.getFileName());
             target = getTargetFile(dir2);
             copyAndVerify(link, target);
             delete(link);


### PR DESCRIPTION
Low risk, only test changes. 
java.nio.file.NoSuchFileException: ./name1692782213124882428/link when it is a different volume/file system.
machine info:
```
文件系统       类型      容量  已用  可用 已用% 挂载点
devtmpfs       devtmpfs  7.9G     0  7.9G    0% /dev
tmpfs          tmpfs     7.9G  245M  7.7G    4% /dev/shm
tmpfs          tmpfs     7.9G  893M  7.1G   12% /run
tmpfs          tmpfs     5.0M   16K  5.0M    1% /run/lock
tmpfs          tmpfs     7.9G     0  7.9G    0% /sys/fs/cgroup
/dev/nvme0n1p3 xfs        42G   24G   18G   58% /
/dev/nvme0n1p5 xfs       147G   25G  123G   17% /data
/dev/nvme0n1p2 ext3      283M   42M  227M   16% /boot
/dev/nvme0n1p1 vfat      300M  724K  299M    1% /boot/efi
tmpfs          tmpfs     1.6G  160K  1.6G    1% /run/user/1001
/dev/sda1      ext4      1.8T  913G  827G   53% /home/loongson/test-file
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309778](https://bugs.openjdk.org/browse/JDK-8309778): java/nio/file/Files/CopyAndMove.java fails when using second test directory (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14436/head:pull/14436` \
`$ git checkout pull/14436`

Update a local copy of the PR: \
`$ git checkout pull/14436` \
`$ git pull https://git.openjdk.org/jdk.git pull/14436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14436`

View PR using the GUI difftool: \
`$ git pr show -t 14436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14436.diff">https://git.openjdk.org/jdk/pull/14436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14436#issuecomment-1588480437)