### PR TITLE
8309890: TestStringDeduplicationInterned.java waits for the wrong condition

### DIFF
--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -392,7 +392,7 @@ class TestStringDeduplicationTools {
 
             forceDeduplication(ageThreshold, FullGC);
 
-            if (!waitForDeduplication(dupString3, baseString)) {
+            if (!waitForDeduplication(dupString3, internedString)) {
                 if (getValue(dupString3) != getValue(internedString)) {
                     throw new RuntimeException("String 3 doesn't match either");
                 }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -393,9 +393,7 @@ class TestStringDeduplicationTools {
             forceDeduplication(ageThreshold, FullGC);
 
             if (!waitForDeduplication(dupString3, internedString)) {
-                if (getValue(dupString3) != getValue(internedString)) {
-                    throw new RuntimeException("String 3 doesn't match either");
-                }
+                throw new RuntimeException("Deduplication has not occurred for string 3");
             }
 
             if (afterInternedValue != getValue(dupString2)) {


### PR DESCRIPTION
There's a section in the test that waits up to 10 seconds for a string to be deduplicated and then does a final verification that the string was correctly deduplicated. However, the initial waiting gets passed the wrong comparison string, which has the effect that this test always waits for 10 seconds before proceeding.

The problem is here:
```
            if (!waitForDeduplication(dupString3, baseString)) {
                if (getValue(dupString3) != getValue(internedString)) {
```
where the first line should say:
```
            if (!waitForDeduplication(dupString3, internedString)) { 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309890](https://bugs.openjdk.org/browse/JDK-8309890): TestStringDeduplicationInterned.java waits for the wrong condition (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14437/head:pull/14437` \
`$ git checkout pull/14437`

Update a local copy of the PR: \
`$ git checkout pull/14437` \
`$ git pull https://git.openjdk.org/jdk.git pull/14437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14437`

View PR using the GUI difftool: \
`$ git pr show -t 14437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14437.diff">https://git.openjdk.org/jdk/pull/14437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14437#issuecomment-1588592385)