### PR TITLE
8309034: NoClassDefFoundError when initializing Long$LongCache

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2777,7 +2777,7 @@ Handle java_lang_Throwable::create_initialization_error(JavaThread* current, Han
   // If new_exception returns a different exception while creating the exception,
   // abandon the attempt to save the initialization error and return null.
   if (init_error->klass()->name() != exception_name) {
-    log_info(class, init)("Exception thrown while saving initialization exception %s",
+    log_info(class, init)("Exception %s thrown while saving initialization exception",
                         init_error->klass()->external_name());
     return Handle();
   }

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -110,6 +110,7 @@ class Universe: AllStatic {
 
   // preallocated error objects (no backtrace)
   static OopHandle    _out_of_memory_errors;
+  static OopHandle    _class_init_stack_overflow_error;
 
   // preallocated cause message for delayed StackOverflowError
   static OopHandle    _delayed_stack_overflow_error_message;
@@ -312,6 +313,11 @@ class Universe: AllStatic {
   // Throw default _out_of_memory_error_retry object as it will never propagate out of the VM
   static oop out_of_memory_error_retry();
   static oop delayed_stack_overflow_error_message();
+
+  // Saved StackOverflowError and OutOfMemoryError for use when
+  // class initialization can't create ExceptionInInitializerError.
+  static oop class_init_stack_overflow_error();
+  static oop class_init_out_of_memory_error();
 
   // If it's a certain type of OOME object
   static bool is_out_of_memory_error_metaspace(oop ex_obj);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -983,17 +983,26 @@ ResourceHashtable<const InstanceKlass*, OopHandle, 107, AnyObj::C_HEAP, mtClass>
 void InstanceKlass::add_initialization_error(JavaThread* current, Handle exception) {
   // Create the same exception with a message indicating the thread name,
   // and the StackTraceElements.
-  // If the initialization error is OOM, this might not work, but if GC kicks in
-  // this would be still be helpful.
-  JavaThread* THREAD = current;
   Handle init_error = java_lang_Throwable::create_initialization_error(current, exception);
-  ResourceMark rm(THREAD);
+  ResourceMark rm(current);
   if (init_error.is_null()) {
-    log_trace(class, init)("Initialization error is null for class %s", external_name());
-    return;
+    log_trace(class, init)("Unable to create the desired initialization error for class %s", external_name());
+
+    // We failed to create the new exception, most likely due to either out-of-memory or
+    // a stackoverflow error. If the original exception was either of those then we save
+    // the shared, pre-allocated, stackless, instance of that exception.
+    if (exception->klass() == vmClasses::StackOverflowError_klass()) {
+      log_trace(class, init)("Using shared StackOverflowError as initialization error for class %s", external_name());
+      init_error = Handle(current, Universe::class_init_stack_overflow_error());
+    } else if (exception->klass() == vmClasses::OutOfMemoryError_klass()) {
+      log_trace(class, init)("Using shared OutOfMemoryError as initialization error for class %s", external_name());
+      init_error = Handle(current, Universe::class_init_out_of_memory_error());
+    } else {
+      return;
+    }
   }
 
-  MutexLocker ml(THREAD, ClassInitError_lock);
+  MutexLocker ml(current, ClassInitError_lock);
   OopHandle elem = OopHandle(Universe::vm_global(), init_error());
   bool created;
   _initialization_error_table.put_if_absent(this, elem, &created);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -992,10 +992,10 @@ void InstanceKlass::add_initialization_error(JavaThread* current, Handle excepti
     // a stackoverflow error. If the original exception was either of those then we save
     // the shared, pre-allocated, stackless, instance of that exception.
     if (exception->klass() == vmClasses::StackOverflowError_klass()) {
-      log_trace(class, init)("Using shared StackOverflowError as initialization error for class %s", external_name());
+      log_debug(class, init)("Using shared StackOverflowError as initialization error for class %s", external_name());
       init_error = Handle(current, Universe::class_init_stack_overflow_error());
     } else if (exception->klass() == vmClasses::OutOfMemoryError_klass()) {
-      log_trace(class, init)("Using shared OutOfMemoryError as initialization error for class %s", external_name());
+      log_debug(class, init)("Using shared OutOfMemoryError as initialization error for class %s", external_name());
       init_error = Handle(current, Universe::class_init_out_of_memory_error());
     } else {
       return;

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
@@ -71,9 +71,9 @@ public class TestOutOfMemoryDuringInit {
 
     private static void verify_stack(Throwable e, String expected, String cause) throws Exception {
         ByteArrayOutputStream byteOS = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(byteOS);
-        e.printStackTrace(printStream);
-        printStream.close();
+        try (PrintStream printStream = new PrintStream(byteOS)) {
+            e.printStackTrace(printStream);
+        }
         String stackTrace = byteOS.toString("ASCII");
         System.out.println(stackTrace);
         if (!stackTrace.contains(expected) ||

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
@@ -29,7 +29,7 @@
  *          cause, even if we can't create the ExceptionInInitializerError
  *
  * @comment Enable logging to ease failure diagnosis
- * @run main/othervm -Xlog:class+init=debug,exceptions=debug -Xms64m -Xmx64m TestOutOfMemoryDuringInit
+ * @run main/othervm -Xms64m -Xmx64m TestOutOfMemoryDuringInit
  */
 
 import java.io.ByteArrayOutputStream;

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8309034
+ * @summary Test that when saving a class initialization failure caused by
+ *          an OutOfMemoryError, that we record the OOME as the underlying
+ *          cause, even if we can't create the ExceptionInInitializerError
+ *
+ * @comment Enable logging to ease failure diagnosis
+ * @run main/othervm -Xlog:class+init=debug,exceptions=debug -Xms64m -Xmx64m TestOutOfMemoryDuringInit
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedList;
+
+public class TestOutOfMemoryDuringInit {
+
+    static LinkedList<Object> theList = new LinkedList<>();
+
+    static class Nested {
+        static void forceInit() { }
+        static {
+            while (theList != null) {
+                theList.add(new Object());
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String expected = "java.lang.NoClassDefFoundError: Could not initialize class TestOutOfMemoryDuringInit$Nested";
+        // This cause will match either the shared OOME or the EIIE we get
+        // with some GC's.
+        String cause = "java.lang.OutOfMemoryError";
+
+        try {
+            Nested.forceInit();
+        } catch (OutOfMemoryError oome) {
+            theList = null; // free memory for verification process
+            System.out.println("Trying to access class Nested ...");
+            try {
+                Nested.forceInit();
+                throw new RuntimeException("NoClassDefFoundError was not thrown");
+            } catch (NoClassDefFoundError ncdfe) {
+                verify_stack(ncdfe, expected, cause);
+            }
+        }
+    }
+
+    private static void verify_stack(Throwable e, String expected, String cause) throws Exception {
+        ByteArrayOutputStream byteOS = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(byteOS);
+        e.printStackTrace(printStream);
+        printStream.close();
+        String stackTrace = byteOS.toString("ASCII");
+        System.out.println(stackTrace);
+        if (!stackTrace.contains(expected) ||
+            (cause != null && !stackTrace.contains(cause))) {
+            throw new RuntimeException(expected + " and/or " + cause + " missing from stacktrace");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8309034
+ * @summary Test that when saving the cause of a class initialization failure
+ *          and we encounter a StackOverflowError, that we record the SOE as
+ *          the underlying cause
+ * @requires os.simpleArch == "x64"
+ * @comment The reproducer only fails in the desired way on x64.
+ * @requires vm.flagless
+ * @comment This test could easily be perturbed so don't allow flag settings.
+ *
+ * @run main/othervm TestStackOverflowDuringInit
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class TestStackOverflowDuringInit {
+
+    // Test case is fuzzed/obfuscated
+
+    public static void main(String[] args) throws Exception {
+        String expected = "java.lang.NoClassDefFoundError: Could not initialize class java.lang.Long$LongCache";
+        String cause = "Caused by: java.lang.StackOverflowError";
+
+        TestStackOverflowDuringInit i = new TestStackOverflowDuringInit();
+        try {
+            i.j();
+        } catch (Throwable ex) {
+            //            ex.printStackTrace();
+            verify_stack(ex, expected, cause);
+        }
+    }
+
+    void j() { ((e) new a()).g = 0; }
+
+    private static void verify_stack(Throwable e, String expected, String cause) throws Exception {
+        ByteArrayOutputStream byteOS = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(byteOS);
+        e.printStackTrace(printStream);
+        printStream.close();
+        String stackTrace = byteOS.toString("ASCII");
+        System.out.println(stackTrace);
+        if (!stackTrace.contains(expected) ||
+            (cause != null && !stackTrace.contains(cause))) {
+            throw new RuntimeException(expected + " and/or " + cause + " missing from stacktrace");
+        }
+    }
+}
+
+class a {
+    Boolean b;
+    {
+        try {
+            Long.valueOf(509505376256L);
+            Boolean c =
+                true ? new d().b
+                : 5 != ((e)java.util.HashSet.newHashSet(301758).clone()).f;
+        } finally {
+            Long.valueOf(0);
+        }
+    }
+}
+class e extends a {
+    double g;
+    int f;
+}
+class d extends a {}

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -24,9 +24,9 @@
 /**
  * @test
  * @bug 8309034
- * @summary Test that when saving the cause of a class initialization failure
- *          and we encounter a StackOverflowError, that we record the SOE as
- *          the underlying cause
+ * @summary Test that when saving a class initialization failure caused by
+ *          a StackOverflowError, that we record the SOE as the underlying
+ *          cause, even if we can't create the ExceptionInInitializerError
  * @requires os.simpleArch == "x64"
  * @comment The reproducer only fails in the desired way on x64.
  * @requires vm.flagless

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -59,9 +59,9 @@ public class TestStackOverflowDuringInit {
 
     private static void verify_stack(Throwable e, String expected, String cause) throws Exception {
         ByteArrayOutputStream byteOS = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(byteOS);
-        e.printStackTrace(printStream);
-        printStream.close();
+        try (PrintStream printStream = new PrintStream(byteOS)) {
+            e.printStackTrace(printStream);
+        }
         String stackTrace = byteOS.toString("ASCII");
         System.out.println(stackTrace);
         if (!stackTrace.contains(expected) ||


### PR DESCRIPTION
When a class fails to initialize we try to preserve information about the original cause of the failure in a constructed `ExceptionInInitializerError` so that the EIIE can be attached to subsequent `NoClassDefFoundError`s thrown when an erroneous class is later accessed. If construction of the EIIE itself throws an exception we presently do nothing and the original problem is lost. The main reasons we would fail to create the EIIE are because we throw `OutOfMemoryError` or `StackOverflowError`. If the original class initialization failed due to stackoverflow then it is very likely the attempt to create the EIIE will as well. This leads to a situation, as per the obscure message in the bug synopsis, where you get totally unexpected failure modes with nothing to tell that the stackoverflow was the original cause. You would need to enable VM exception logging to try and determine that.

This enhancement improves the current situation by setting the cause of the class initialization failure to be a `StackOverflowError` or `OutOfMemoryError`, if the original failure was the same, and the attempt to create the EIIE fails. We cannot create these dynamically of course (else we'd have created the EIIE) so these are pre-allocated, stackless shared instances, created a VM startup. The preallocated `OutOfMemoryError` already exists so we just added a pre-allocated `StackOverflowError`. Now when we get the `NoClassDefFoundError` instead of the obscure and uninformative:
```
java.lang.NoClassDefFoundError: Could not initialize class java.lang.Long$LongCache
	at java.base/java.lang.Long.valueOf(Long.java:1202)
	at a.<init>(Test_545.java:10)
	at Test_545.j(Test_545.java:38)
	at Test_545.main(Test_545.java:25)
```
we now see an additional piece of information to shed light on the original issue:
```
java.lang.NoClassDefFoundError: Could not initialize class java.lang.Long$LongCache
	at java.base/java.lang.Long.valueOf(Long.java:1202)
	at a.<init>(Test_545.java:10)
	at Test_545.j(Test_545.java:38)
	at Test_545.main(Test_545.java:25)
Caused by: java.lang.StackOverflowError
```
Testing:

Tiers 1-3 sanity testing

The original reproducer was adapted into a regression test, but it was discovered that the failure mode was only observed on x64 systems (not unexpected as different architectures have different stack requirements and so will exhibit different stackoverflow behaviour). This was run 50 times on each x64 platform to check for intermittent failures. As we know this test could be fragile I also marked it as requiring `vm.flagless` just to be safe.

A regression test was also created for the out-of-memory condition. This test seems quite stable across all platforms, and again was tested 50 times on each.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309034](https://bugs.openjdk.org/browse/JDK-8309034): NoClassDefFoundError when initializing Long$LongCache (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [4ec4c085](https://git.openjdk.org/jdk/pull/14438/files/4ec4c08532cb64c1f1f2379e50070600b855be36)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14438/head:pull/14438` \
`$ git checkout pull/14438`

Update a local copy of the PR: \
`$ git checkout pull/14438` \
`$ git pull https://git.openjdk.org/jdk.git pull/14438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14438`

View PR using the GUI difftool: \
`$ git pr show -t 14438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14438.diff">https://git.openjdk.org/jdk/pull/14438.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14438#issuecomment-1589198421)