### PR TITLE
8309601: [JVMCI] AMD64#getLargestStorableKind returns incorrect mask kind

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,6 +248,8 @@ public class AMD64 extends Architecture {
 
     private final AMD64Kind largestKind;
 
+    private final AMD64Kind largestMaskKind;
+
     public AMD64(EnumSet<CPUFeature> features, EnumSet<Flag> flags) {
         super("AMD64", AMD64Kind.QWORD, ByteOrder.LITTLE_ENDIAN, true, allRegisters, LOAD_LOAD | LOAD_STORE | STORE_STORE, 1, 8);
         this.features = features;
@@ -256,10 +258,17 @@ public class AMD64 extends Architecture {
 
         if (features.contains(CPUFeature.AVX512F)) {
             largestKind = AMD64Kind.V512_QWORD;
+            if (features.contains(CPUFeature.AVX512BW)) {
+                largestMaskKind = AMD64Kind.MASK64;
+            } else {
+                largestMaskKind = AMD64Kind.MASK16;
+            }
         } else if (features.contains(CPUFeature.AVX)) {
             largestKind = AMD64Kind.V256_QWORD;
+            largestMaskKind = null;
         } else {
             largestKind = AMD64Kind.V128_QWORD;
+            largestMaskKind = null;
         }
     }
 
@@ -324,7 +333,7 @@ public class AMD64 extends Architecture {
         } else if (category.equals(XMM)) {
             return largestKind;
         } else if (category.equals(MASK)) {
-            return AMD64Kind.MASK64;
+            return largestMaskKind;
         } else {
             return null;
         }


### PR DESCRIPTION
`jdk.vm.ci.amd64.AMD64#getLargestStorableKind(RegisterCategory)` unconditionally returns `AMD64Kind.MASK64` for mask registers. This is only correct if the target supports AVX512BW. On other AVX512 versions this should be `MASK16`.

The Graal compiler uses this method to determine how to spill a given register. An incorrect size will lead to compilation errors due to trying to emit a move with a size that is not supported by the target. I have manually verified that this fixes those problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309601](https://bugs.openjdk.org/browse/JDK-8309601): [JVMCI] AMD64#getLargestStorableKind returns incorrect mask kind (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14441/head:pull/14441` \
`$ git checkout pull/14441`

Update a local copy of the PR: \
`$ git checkout pull/14441` \
`$ git pull https://git.openjdk.org/jdk.git pull/14441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14441`

View PR using the GUI difftool: \
`$ git pr show -t 14441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14441.diff">https://git.openjdk.org/jdk/pull/14441.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14441#issuecomment-1589287520)