### PR TITLE
8309907: Remove unused _print_gc_overhead_limit_would_be_exceeded

### DIFF
--- a/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
@@ -30,7 +30,6 @@
 
 GCOverheadChecker::GCOverheadChecker() :
   _gc_overhead_limit_exceeded(false),
-  _print_gc_overhead_limit_would_be_exceeded(false),
   _gc_overhead_limit_count(0) {
   assert(GCOverheadLimitThreshold > 0,
     "No opportunity to clear SoftReferences before GC overhead limit");

--- a/src/hotspot/share/gc/shared/gcOverheadChecker.hpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.hpp
@@ -42,9 +42,6 @@ class GCOverheadChecker: public CHeapObj<mtGC> {
   // This is a hint for the heap:  we've detected that GC times
   // are taking longer than GCTimeLimit allows.
   bool _gc_overhead_limit_exceeded;
-  // Use for diagnostics only.  If UseGCOverheadLimit is false,
-  // this variable is still set.
-  bool _print_gc_overhead_limit_would_be_exceeded;
   // Count of consecutive GC that have exceeded the
   // GC time limit criterion
   uint _gc_overhead_limit_count;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309907](https://bugs.openjdk.org/browse/JDK-8309907): Remove unused _print_gc_overhead_limit_would_be_exceeded (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14442/head:pull/14442` \
`$ git checkout pull/14442`

Update a local copy of the PR: \
`$ git checkout pull/14442` \
`$ git pull https://git.openjdk.org/jdk.git pull/14442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14442`

View PR using the GUI difftool: \
`$ git pr show -t 14442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14442.diff">https://git.openjdk.org/jdk/pull/14442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14442#issuecomment-1588880729)