### PR TITLE
8309880: Add support for linking libffi on Windows and Mac

### DIFF
--- a/make/autoconf/lib-ffi.m4
+++ b/make/autoconf/lib-ffi.m4
@@ -57,7 +57,11 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBFFI],
 
     if test "x${with_libffi}" != x; then
       LIBFFI_LIB_PATH="${with_libffi}/lib"
-      LIBFFI_LIBS="-L${with_libffi}/lib -lffi"
+      if test "x${OPENJDK_TARGET_OS}" != "xwindows"; then
+        LIBFFI_LIBS="-L${with_libffi}/lib -lffi"
+      else
+        LIBFFI_LIBS="${with_libffi}/lib/libffi.lib"
+      fi
       LIBFFI_CFLAGS="-I${with_libffi}/include"
       LIBFFI_FOUND=yes
     fi
@@ -67,7 +71,11 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBFFI],
     fi
     if test "x${with_libffi_lib}" != x; then
       LIBFFI_LIB_PATH="${with_libffi_lib}"
-      LIBFFI_LIBS="-L${with_libffi_lib} -lffi"
+      if test "x${OPENJDK_TARGET_OS}" != "xwindows"; then
+        LIBFFI_LIBS="-L${with_libffi_lib} -lffi"
+      else
+        LIBFFI_LIBS="${with_libffi_lib}/libffi.lib"
+      fi
       LIBFFI_FOUND=yes
     fi
     # Do not try pkg-config if we have a sysroot set.
@@ -132,37 +140,45 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBFFI],
 
     # Find the libffi.so.X to bundle
     if test "x${ENABLE_LIBFFI_BUNDLING}" = "xtrue"; then
+      if test "x${OPENJDK_TARGET_OS}" = "xmacosx"; then
+        LIBFFI_LIB_FILE_NAME=libffi.?.dylib
+      elif test "x${OPENJDK_TARGET_OS}" = "xwindows"; then
+        LIBFFI_LIB_FILE_NAME=libffi.dll
+      else
+        LIBFFI_LIB_FILE_NAME=libffi.so.?
+      fi
+    
       AC_MSG_CHECKING([for libffi lib file location])
       if test "x${LIBFFI_LIB_PATH}" != x; then
-        if test -e ${LIBFFI_LIB_PATH}/libffi.so.?; then
-          LIBFFI_LIB_FILE="${LIBFFI_LIB_PATH}/libffi.so.?"
+        if test -e ${LIBFFI_LIB_PATH}/${LIBFFI_LIB_FILE_NAME}; then
+          LIBFFI_LIB_FILE="${LIBFFI_LIB_PATH}/${LIBFFI_LIB_FILE_NAME}"
         else
-          AC_MSG_ERROR([Could not locate libffi.so.? for bundling in ${LIBFFI_LIB_PATH}])
+          AC_MSG_ERROR([Could not locate ${LIBFFI_LIB_FILE_NAME} for bundling in ${LIBFFI_LIB_PATH}])
         fi
       else
         # If we don't have an explicit path, look in a few obvious places
         if test "x${OPENJDK_TARGET_CPU}" = "xx86"; then
-          if test -e ${SYSROOT}/usr/lib/libffi.so.? ; then
-            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/libffi.so.?"
-          elif test -e ${SYSROOT}/usr/lib/i386-linux-gnu/libffi.so.? ; then
-            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/i386-linux-gnu/libffi.so.?"
+          if test -e ${SYSROOT}/usr/lib/${LIBFFI_LIB_FILE_NAME} ; then
+            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/${LIBFFI_LIB_FILE_NAME}"
+          elif test -e ${SYSROOT}/usr/lib/i386-linux-gnu/${LIBFFI_LIB_FILE_NAME} ; then
+            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/i386-linux-gnu/${LIBFFI_LIB_FILE_NAME}"
           else
-            AC_MSG_ERROR([Could not locate libffi.so.? for bundling])
+            AC_MSG_ERROR([Could not locate ${LIBFFI_LIB_FILE_NAME} for bundling])
           fi
         elif test "x${OPENJDK_TARGET_CPU}" = "xx86_64" || test "x${OPENJDK_TARGET_CPU}" = "xaarch64"; then
-          if test -e ${SYSROOT}/usr/lib64/libffi.so.? ; then
-            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib64/libffi.so.?"
-          elif test -e ${SYSROOT}/usr/lib/x86_64-linux-gnu/libffi.so.? ; then
-            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/x86_64-linux-gnu/libffi.so.?"
+          if test -e ${SYSROOT}/usr/lib64/${LIBFFI_LIB_FILE_NAME} ; then
+            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib64/${LIBFFI_LIB_FILE_NAME}"
+          elif test -e ${SYSROOT}/usr/lib/x86_64-linux-gnu/${LIBFFI_LIB_FILE_NAME} ; then
+            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/x86_64-linux-gnu/${LIBFFI_LIB_FILE_NAME}"
           else
-            AC_MSG_ERROR([Could not locate libffi.so.? for bundling])
+            AC_MSG_ERROR([Could not locate ${LIBFFI_LIB_FILE_NAME} for bundling])
           fi
         else
           # Fallback on the default /usr/lib dir
-          if test -e ${SYSROOT}/usr/lib/libffi.so.? ; then
-            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/libffi.so.?"
+          if test -e ${SYSROOT}/usr/lib/${LIBFFI_LIB_FILE_NAME} ; then
+            LIBFFI_LIB_FILE="${SYSROOT}/usr/lib/${LIBFFI_LIB_FILE_NAME}"
           else
-            AC_MSG_ERROR([Could not locate libffi.so.? for bundling])
+            AC_MSG_ERROR([Could not locate ${LIBFFI_LIB_FILE_NAME} for bundling])
           fi
         fi
       fi

--- a/make/devkit/createLibffiBundle.sh
+++ b/make/devkit/createLibffiBundle.sh
@@ -60,11 +60,11 @@
 # ```
 # (`<install dest>` can be whatever you like. That's what you point `--with-libffi` to).
 #
-# 4. run `make install`. This should create the `<intstall dest>` directory with the files:
+# 4. run `make install`. This should create the `<install dest>` directory with the files:
 #    `include/ffi.h`, `include/ffitarget.h`, `lib/libffi.dll`. It also creates a `lib/libffi.lib` file,
 #    but it is of the wrong file type, `DLL` rather than `LIBRARY`.
 #
-# 5. Manually create a working `.lib` file:
+# 5. Manually create a working `.lib` file (in the <install dest>/lib dir):
 #   5.a use `dumpbin /exports libffi.dll` to get a list of exported symbols
 #   5.b put them in a `libffi.def` file: `EXPORTS` on the first line, then a symbol on each line following
 #   5.c run `lib /def:libffi.def /machine:x64 /out:libffi.lib` to create the right `.lib` file (`lib` is a visual studio tool)

--- a/make/devkit/createLibffiBundle.sh
+++ b/make/devkit/createLibffiBundle.sh
@@ -38,6 +38,38 @@
 # Note that the libtool and texinfo packages are needed to build libffi
 # $ sudo apt install libtool texinfo
 
+# Note that while the build system supports linking against libffi on Windows (x64),
+# I couldn't get this script working with a Windows devkit, and instead had to manually create
+# a libffi bundle for Windows. The steps I took were as follows:
+#
+# 1. run 'x64 Native Tools Command Prompt for VS 2022'. After that, cl.exe and link.exe should be on path
+#
+# 2. in the same shell, run `ucrt64` (this is one of the shell environments that comes with MSYS2).
+#    This should carry over the environment set up by the VS dev prompt into the ucrt64 prompt.
+#
+# 3. then, in the libffi repo root folder:
+#   3.a run `autogen.sh`
+#   3.b run:
+# ```
+# bash configure \
+#   CC="/path/to/libffi/msvcc.sh -m64" \
+#   CXX="/path/to/libffi/msvcc.sh -m64" \
+#   CPPFLAGS="-DFFI_BUILDING_DLL" \
+#   --disable-docs \
+#   --prefix=<install dest>
+# ```
+# (`<install dest>` can be whatever you like. That's what you point `--with-libffi` to).
+#
+# 4. run `make install`. This should create the `<intstall dest>` directory with the files:
+#    `include/ffi.h`, `include/ffitarget.h`, `lib/libffi.dll`. It also creates a `lib/libffi.lib` file,
+#    but it is of the wrong file type, `DLL` rather than `LIBRARY`.
+#
+# 5. Manually create a working `.lib` file:
+#   5.a use `dumpbin /exports libffi.dll` to get a list of exported symbols
+#   5.b put them in a `libffi.def` file: `EXPORTS` on the first line, then a symbol on each line following
+#   5.c run `lib /def:libffi.def /machine:x64 /out:libffi.lib` to create the right `.lib` file (`lib` is a visual studio tool)
+#
+
 LIBFFI_VERSION=3.4.2
 
 BUNDLE_NAME=libffi-$LIBFFI_VERSION.tar.gz

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -228,7 +228,7 @@ ifeq ($(ENABLE_FALLBACK_LINKER), true)
       LDFLAGS := $(LDFLAGS_JDKLIB) \
                  $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := $(LIBFFI_LIBS), \
-	  LIBS_windows := $(LIBFFI_LIBS) ws2_32.lib, \
+      LIBS_windows := $(LIBFFI_LIBS) ws2_32.lib, \
   ))
 
   TARGETS += $(BUILD_LIBFALLBACKLINKER)

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -228,6 +228,7 @@ ifeq ($(ENABLE_FALLBACK_LINKER), true)
       LDFLAGS := $(LDFLAGS_JDKLIB) \
                  $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := $(LIBFFI_LIBS), \
+	  LIBS_windows := $(LIBFFI_LIBS) ws2_32.lib, \
   ))
 
   TARGETS += $(BUILD_LIBFALLBACKLINKER)

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -32,10 +32,6 @@
 
 #define SUPPORT_MONITOR_COUNT
 
-#ifdef __APPLE__
-#define FFI_GO_CLOSURES 0
-#endif
-
 #include <ffi.h>
 
 // Indicates whether the C calling conventions require that

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -28,6 +28,7 @@
 #include <ffi.h>
 
 #include <errno.h>
+#include <stdint.h>
 #ifdef _WIN64
 #include <Windows.h>
 #include <Winsock2.h>

--- a/test/jdk/java/foreign/TestUpcallStack.java
+++ b/test/jdk/java/foreign/TestUpcallStack.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires (!(os.name == "Mac OS X" & os.arch == "aarch64") | jdk.foreign.linker != "FALLBACK")
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *

--- a/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
+++ b/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
@@ -26,6 +26,7 @@
  * @enablePreview
  * @library ../
  * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires (!(os.name == "Mac OS X" & os.arch == "aarch64") | jdk.foreign.linker != "FALLBACK")
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -39,6 +40,7 @@
  * @enablePreview
  * @library ../
  * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires (!(os.name == "Mac OS X" & os.arch == "aarch64") | jdk.foreign.linker != "FALLBACK")
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED


### PR DESCRIPTION
Update the make/autoconf/lib-ffi.m4 script to support using libffi on Windows and Mac.

For Windows I had to tweak `fallbackLinker.c` to be able to build: there was an import of `stdint.h` missing, and since it was using `WSAGetLastError` it needed to link against `ws2_32.lib`.

This PR also contains a fix originally made by @shipilev as part  of: https://github.com/openjdk/jdk/pull/13827 (with a minor tweak), in order to be able to build the fallback linker on mac correctly. I also disabled 3 tests that were failing when using the (libffi-based) fallback linker on that platform.

---

I've updated the `createLibffiBundle.sh` script for Mac, since I got it to work with a devkit, but I didn't manage to do the same for Windows. The steps I took to make my Windows libffi bundle were as follows:
1. run 'x64 Native Tools Command Prompt for VS 2022'. cl.exe and link.exe should be on path
2. run `ucrt64` (this is one of the shell environments that comes with MSYS2). This should carry over the environment set up by the VS dev prompt.
3. then, in the libffi repo root folder:
  3.a run `autogen.sh`
  3.b run:
```
bash configure \
  CC="/path/to/libffi/msvcc.sh -m64" \
  CXX="/path/to/libffi/msvcc.sh -m64" \
  CPPFLAGS="-DFFI_BUILDING_DLL" \
  --disable-docs \
  --prefix=<install dest>
```
(`<install dest>` can be whatever you like. That's what you point `--with-libffi` to).

4. run `make install`. This should create the `<intstall dest>` directory with the files: `include/ffi.h`, `include/ffitarget.h`, `lib/libffi.dll`. It also creates a `lib/libffi.lib` file, but it is of the wrong file type, `DLL` rather than `LIBRARY`.
5. Manually create a working `.lib` file:
  5.a use `dumpbin /exports libffi.dll` to get a list of exported symbols
  5.b put them in a `libffi.def` file: `EXPORTS` on the first line, then a symbol on each line following
  5.c run `lib /def:libffi.def /machine:x64 /out:libffi.lib` to create the right `.lib` file (`lib` is a visual studio tool)

---

Testing:
- manual testing on Windows/x64 and Mac/AArch64, by running the `jdk_foreign` test suite with `-Djdk.internal.foreign.CABI=FALLBACK` (i.e. using the fallback linker).
- Linux/x64 Zero test run of the `jdk_foreign` suite
- Linux/AArch64 Zero build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309880](https://bugs.openjdk.org/browse/JDK-8309880): Add support for linking libffi on Windows and Mac (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`
 * Jorn Vernee `<jvernee@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14446/head:pull/14446` \
`$ git checkout pull/14446`

Update a local copy of the PR: \
`$ git checkout pull/14446` \
`$ git pull https://git.openjdk.org/jdk.git pull/14446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14446`

View PR using the GUI difftool: \
`$ git pr show -t 14446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14446.diff">https://git.openjdk.org/jdk/pull/14446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14446#issuecomment-1589364753)