### PR TITLE
JDK-8309934: Update GitHub Actions to use JDK 17 for building jtreg

### DIFF
--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME_11_X64"
+        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src


### PR DESCRIPTION
Please review this change to use the pre-installed JDK 17 for building jtreg when running on GitHub Actions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309934](https://bugs.openjdk.org/browse/JDK-8309934): Update GitHub Actions to use JDK 17 for building jtreg (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14448/head:pull/14448` \
`$ git checkout pull/14448`

Update a local copy of the PR: \
`$ git checkout pull/14448` \
`$ git pull https://git.openjdk.org/jdk.git pull/14448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14448`

View PR using the GUI difftool: \
`$ git pr show -t 14448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14448.diff">https://git.openjdk.org/jdk/pull/14448.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14448#issuecomment-1589352777)