### PR TITLE
8309937: Add @sealedGraph for some Panama FFM interfaces

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -37,6 +37,7 @@ import jdk.internal.javac.PreviewFeature;
  * @implSpec
  * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
+ * @sealedGraph
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)


### PR DESCRIPTION
This PR proposes adding `@sealedGraph` to `GroupLayout` so the latter will be rendered in the javadocs the same way the other layouts that has public sub-interfaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309937](https://bugs.openjdk.org/browse/JDK-8309937): Add @sealedGraph for some Panama FFM interfaces (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14449/head:pull/14449` \
`$ git checkout pull/14449`

Update a local copy of the PR: \
`$ git checkout pull/14449` \
`$ git pull https://git.openjdk.org/jdk.git pull/14449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14449`

View PR using the GUI difftool: \
`$ git pr show -t 14449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14449.diff">https://git.openjdk.org/jdk/pull/14449.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14449#issuecomment-1589417272)