### PR TITLE
8309955: Matcher uses @since {@inheritDoc}

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -1828,7 +1828,7 @@ public final class Matcher implements MatchResult {
      *
      * @return {@inheritDoc}
      *
-     * @since {@inheritDoc}
+     * @since 20
      */
     @Override
     public Map<String, Integer> namedGroups() {
@@ -1843,7 +1843,7 @@ public final class Matcher implements MatchResult {
      *
      * @return {@inheritDoc}
      *
-     * @since {@inheritDoc}
+     * @since 20
      */
     @Override
     public boolean hasMatch() {


### PR DESCRIPTION
Trivial fix to working but unsupported use of {@inheritDoc}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309955](https://bugs.openjdk.org/browse/JDK-8309955): Matcher uses @since {@inheritDoc} (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14452/head:pull/14452` \
`$ git checkout pull/14452`

Update a local copy of the PR: \
`$ git checkout pull/14452` \
`$ git pull https://git.openjdk.org/jdk.git pull/14452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14452`

View PR using the GUI difftool: \
`$ git pr show -t 14452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14452.diff">https://git.openjdk.org/jdk/pull/14452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14452#issuecomment-1589806798)