### PR TITLE
JDK-8309746

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -138,7 +138,10 @@ ifeq ($(HAS_SPEC),)
     # The spec files depend on the autoconf source code. This check makes sure
     # the configuration is up to date after changes to configure.
     $(SPECS): $(wildcard $(topdir)/make/autoconf/*) \
-            $(if $(CUSTOM_CONFIG_DIR), $(wildcard $(CUSTOM_CONFIG_DIR)/*))
+            $(if $(CUSTOM_CONFIG_DIR), $(wildcard $(CUSTOM_CONFIG_DIR)/*)) \
+            $(addprefix $(topdir)/make/conf/, version-numbers.conf branding.conf) \
+            $(if $(CUSTOM_CONF_DIR), $(wildcard $(addprefix $(CUSTOM_CONF_DIR)/, \
+                version-numbers.conf branding.conf)))
         ifeq ($(CONF_CHECK), fail)
 	  @echo Error: The configuration is not up to date for \
 	      "'$(lastword $(subst /, , $(dir $@)))'."


### PR DESCRIPTION
When we bump the JDK version, we need to reconfigure to get a working build. Users were reporting that this didn't happen automatically, or wasn't warned about, after pulling down that change. This patch addresses that by adding the files in the `make/conf` dir that are read by configure to the rule that checks the need for reconfigure.