### PR TITLE
8308585: AC_REQUIRE: `PLATFORM_EXTRACT_TARGET_AND_BUILD' was expanded before it was required

### DIFF
--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -664,7 +664,6 @@ AC_DEFUN_ONCE([PLATFORM_CHECK_DEPRECATION],
 [
   AC_ARG_ENABLE(deprecated-ports, [AS_HELP_STRING([--enable-deprecated-ports@<:@=yes/no@:>@],
        [Suppress the error when configuring for a deprecated port @<:@no@:>@])])
-  AC_REQUIRE([PLATFORM_EXTRACT_TARGET_AND_BUILD])
   if test "x$OPENJDK_TARGET_OS" = xwindows && test "x$OPENJDK_TARGET_CPU" = xx86; then
     if test "x$enable_deprecated_ports" = "xyes"; then
       AC_MSG_WARN([The Windows 32-bit x86 port is deprecated and may be removed in a future release.])

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -660,7 +660,7 @@ AC_DEFUN_ONCE([PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET],
   PLATFORM_CHECK_DEPRECATION
 ])
 
-AC_DEFUN_ONCE([PLATFORM_CHECK_DEPRECATION],
+AC_DEFUN([PLATFORM_CHECK_DEPRECATION],
 [
   AC_ARG_ENABLE(deprecated-ports, [AS_HELP_STRING([--enable-deprecated-ports@<:@=yes/no@:>@],
        [Suppress the error when configuring for a deprecated port @<:@no@:>@])])

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -463,7 +463,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_cpu: "x86",
             build_cpu: "x64",
             dependencies: ["devkit", "gtest"],
-            configure_args: concat(common.configure_args_32bit),
+            configure_args: concat(common.configure_args_32bit,
+                "--enable-deprecated-ports"),
         },
 
         "windows-aarch64": {


### PR DESCRIPTION
Autoconf is emitting this warning after [JDK-8307573](https://bugs.openjdk.org/browse/JDK-8307573):

stdin:85: warning: AC_REQUIRE: `PLATFORM_EXTRACT_TARGET_AND_BUILD' was expanded before it was required
stdin:85: http://www.gnu.org/software/autoconf/manual/autoconf.html#Expanded-Before-Required
/home/erik/git/jdk/open/make/autoconf/platform.m4:644: PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET is expanded from...
stdin:85: the top level

This is caused by using `AC_DEFUN_ONCE` and `AC_REQUIRE` in the wrong way. In the OpenJDK configure script, we use a more imperative model of explicitly calling `AC_DEFUN` macros in most situations. This is mostly done due to how easy it is to get the other model wrong, especially when the models are mixed. The simple solution here is to just change `PLATFORM_CHECK_DEPRECATION` to an `AC_DEFUN` macro and remove the `AC_REQUIRE` call.

When verifying the fix, I noticed that the check isn't currently working. At least I am still able to configure windows-x86 with no warning or error. With this fix, the error is printed as expected. This makes me wonder if the original change ever worked.

I'm also adding the deprecation override configure arg to jib-profiles.js to make it possible to still configure windows-x86 using Jib at Oracle. We aren't doing that regularly, but as long as the configuration is there, it should at least work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308585](https://bugs.openjdk.org/browse/JDK-8308585): AC_REQUIRE: `PLATFORM_EXTRACT_TARGET_AND_BUILD' was expanded before it was required (**Bug** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14459/head:pull/14459` \
`$ git checkout pull/14459`

Update a local copy of the PR: \
`$ git checkout pull/14459` \
`$ git pull https://git.openjdk.org/jdk.git pull/14459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14459`

View PR using the GUI difftool: \
`$ git pr show -t 14459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14459.diff">https://git.openjdk.org/jdk/pull/14459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14459#issuecomment-1590073283)