### PR TITLE
8309663: test fails "assert(check_alignment(result)) failed: address not aligned: 0x00000008baadbabe"

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2320,7 +2320,10 @@ bool StackRefCollector::do_frame(vframe* vf) {
       // Follow oops from compiled nmethod.
       if (jvf->cb() != nullptr && jvf->cb()->is_nmethod()) {
         _blk->set_context(_thread_tag, _tid, _depth, method);
-        jvf->cb()->as_nmethod()->oops_do(_blk);
+        // Need to apply load barriers for unmounted vthreads.
+        nmethod* nm = jvf->cb()->as_nmethod();
+        nm->run_nmethod_entry_barrier();
+        nm->oops_do(_blk);
         if (_blk->stopped()) {
           return false;
         }

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -45,4 +45,3 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
-serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#default 8309663 linux-x64


### PR DESCRIPTION
If virtual thread has frames in stackChunks, need to apply load barriers before processing nmethods (javaVFrame::locals() and javaVFrame::expressions() do it internally)

Testing: tier1-tier5;
400 runs of VThreadStackRefTest.java test on linux-x64 and linux-x64-debug with "-XX:+UseZGC -Xcomp -XX:-TieredCompilation"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309663](https://bugs.openjdk.org/browse/JDK-8309663): test fails "assert(check_alignment(result)) failed: address not aligned: 0x00000008baadbabe" (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14460/head:pull/14460` \
`$ git checkout pull/14460`

Update a local copy of the PR: \
`$ git checkout pull/14460` \
`$ git pull https://git.openjdk.org/jdk.git pull/14460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14460`

View PR using the GUI difftool: \
`$ git pr show -t 14460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14460.diff">https://git.openjdk.org/jdk/pull/14460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14460#issuecomment-1590277238)