### PR TITLE
8309978: [x64] Fix useless padding

### DIFF
--- a/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
@@ -100,7 +100,7 @@ int IntelJccErratum::compute_padding(uintptr_t current_offset, const MachNode* m
   if (index_in_block < block->number_of_nodes() - 1) {
     Node* next = block->get_node(index_in_block + 1);
     if (next->is_Mach() && (next->as_Mach()->flags() & Node::PD::Flag_intel_jcc_erratum)) {
-      jcc_size += mach->size(regalloc);
+      jcc_size += next->size(regalloc);
     }
   }
   if (jcc_size > largest_jcc_size()) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2971,9 +2971,8 @@ void Compile::Code_Gen() {
     output.Output();
     if (failing())  return;
     output.install();
+    print_method(PHASE_FINAL_CODE, 1); // Compile::_output is not null here
   }
-
-  print_method(PHASE_FINAL_CODE, 1);
 
   // He's dead, Jim.
   _cfg     = (PhaseCFG*)((intptr_t)0xdeadbeef);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
@@ -43,11 +43,8 @@ public class TestPadding {
 
     @Run(test = "test")
     public static void test_runner() {
-        tpf = new TestPadding();
-        for (int i = 0; i < 11000; i++) {
-            test(i);
-            tpf.b1++; // to take both branches in test()
-        }
+        test(42);
+        tpf.b1++; // to take both branches in test()
     }
 
     @Test
@@ -65,7 +62,7 @@ public class TestPadding {
     static TestPadding t3;
     static TestPadding t4;
 
-    static TestPadding tpf; // Static field offset > 128
+    static TestPadding tpf = new TestPadding(); // Static field offset > 128
 
     int i1;
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8309978
+ * @summary [x64] Fix useless padding
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @requires (os.simpleArch == "x64")
+ * @run driver compiler.c2.irTests.TestPadding
+ */
+
+public class TestPadding {
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+IntelJccErratumMitigation");
+    }
+
+    @Run(test = "test")
+    public static void test_runner() {
+        tpf = new TestPadding();
+        for (int i = 0; i < 11000; i++) {
+            test(i);
+            tpf.b1++; // to take both branches in test()
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.NOP, "1" })
+    static int test(int i) {
+        TestPadding tp = tpf;
+        if (tp.b1 > 42) { // Big 'cmpb' instruction at offset 0x30
+          tp.i1 = i;
+        }
+        return i;
+    }
+
+    static TestPadding t1;
+    static TestPadding t2;
+    static TestPadding t3;
+    static TestPadding t4;
+
+    static TestPadding tpf; // Static field offset > 128
+
+    int i1;
+
+    long l1;
+    long l2;
+    long l3;
+    long l4;
+    long l5;
+    long l6;
+    long l7;
+    long l8;
+    long l9;
+    long l10;
+    long l11;
+    long l12;
+    long l13;
+    long l14;
+    long l15;
+    long l16;
+
+    byte b1 = 1; // Field offset > 128
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -809,6 +809,11 @@ public class IRNode {
         beforeMatchingNameRegex(NEG_V, "NegV(F|D)");
     }
 
+    public static final String NOP = PREFIX + "NOP" + POSTFIX;
+    static {
+        machOnlyNameRegex(NOP, "Nop");
+    }
+
     public static final String NULL_ASSERT_TRAP = PREFIX + "NULL_ASSERT_TRAP" + POSTFIX;
     static {
         trapNodes(NULL_ASSERT_TRAP,"null_assert");


### PR DESCRIPTION
Fixed typo in `IntelJccErratum::compute_padding()`.

Due to the typo (`mach` instead of `next`) useless padding could be generated because size of `mach` instruction (which is `cmp` in this case and big)  counted twice. As result combined size most likely cross 32-bytes cache line boundary and padding is generated to avoid that.

```
030    B2: # out( B4 B3 ) <- in( B1 ) Freq: 0.999999 
       nop # 16 bytes pad for loops and calls 
040    cmpb [R12 + R10 << 3 + #144] (compressed oop addressing), #42 
049    jle,s B4 P=0.667944 C=6785.000000
```
Note: only some x86 CPUs are [affected](https://github.com/openjdk/jdk/blob/ba837b4bfa2dea85653d8a8fccd0817a569b4378/src/hotspot/cpu/x86/vm_version_x86.cpp#L1957).

For new IR test to work I moved `PHASE_FINAL_CODE` IR print inside `PhaseOutput` scope because padding nodes (`NOP` mach nodes) are present only in this phase IR.

Added new IR test. Tested tier1-3, xcomp, stress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309978](https://bugs.openjdk.org/browse/JDK-8309978): [x64] Fix useless padding (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [5c711eff](https://git.openjdk.org/jdk/pull/14461/files/5c711efff5667ad46f637511ee460aa26f3fad94)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [5c711eff](https://git.openjdk.org/jdk/pull/14461/files/5c711efff5667ad46f637511ee460aa26f3fad94)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14461/head:pull/14461` \
`$ git checkout pull/14461`

Update a local copy of the PR: \
`$ git checkout pull/14461` \
`$ git pull https://git.openjdk.org/jdk.git pull/14461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14461`

View PR using the GUI difftool: \
`$ git pr show -t 14461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14461.diff">https://git.openjdk.org/jdk/pull/14461.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14461#issuecomment-1590462969)