### PR TITLE
8304478: Initial nroff manpage generation for JDK 22

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVA" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVA" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -187,7 +187,7 @@ with new values added and old values removed.
 You\[aq]ll get an error message if you use a value of \f[I]N\f[R] that
 is no longer supported.
 The supported values of \f[I]N\f[R] are the current Java SE release
-(\f[V]21\f[R]) and a limited number of previous releases, detailed in
+(\f[V]22\f[R]) and a limited number of previous releases, detailed in
 the command-line help for \f[V]javac\f[R], under the \f[V]--source\f[R]
 and \f[V]--release\f[R] options.
 .RE
@@ -3813,7 +3813,7 @@ This option was deprecated in JDK 16 by \f[B]JEP 396\f[R]
 403\f[R] [https://openjdk.org/jeps/403].
 .SH REMOVED JAVA OPTIONS
 .PP
-These \f[V]java\f[R] options have been removed in JDK 21 and using them
+These \f[V]java\f[R] options have been removed in JDK 22 and using them
 results in an error of:
 .RS
 .PP

--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "KEYTOOL" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "KEYTOOL" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -447,7 +447,7 @@ single-element certificate chain.
 When the \f[V]-signer\f[R] option is specified, a new certificate is
 generated and signed by the designated signer and stored as a
 multiple-element certificate chain (containing the generated certificate
-itself, and the signer?s certificate chain).
+itself, and the signer\[aq]s certificate chain).
 The certificate chain and private key are stored in a new keystore entry
 that is identified by its alias.
 .PP
@@ -467,8 +467,8 @@ specified.
 The \f[V]-signer\f[R] value specifies the alias of a
 \f[V]PrivateKeyEntry\f[R] for the signer that already exists in the
 keystore.
-This option is used to sign the certificate with the signer?s private
-key.
+This option is used to sign the certificate with the signer\[aq]s
+private key.
 This is especially useful for key agreement algorithms (i.e.
 the \f[V]-keyalg\f[R] value is \f[V]XDH\f[R], \f[V]X25519\f[R],
 \f[V]X448\f[R], or \f[V]DH\f[R]) as these keys cannot be used for
@@ -476,7 +476,7 @@ digital signatures, and therefore a self-signed certificate cannot be
 created.
 .PP
 The \f[V]-signerkeypass\f[R] value specifies the password of the
-signer?s private key.
+signer\[aq]s private key.
 It can be specified if the private key of the signer entry is protected
 by a password different from the store password.
 .PP

--- a/src/java.rmi/share/man/rmiregistry.1
+++ b/src/java.rmi/share/man/rmiregistry.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "RMIREGISTRY" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "RMIREGISTRY" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JRUNSCRIPT" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JRUNSCRIPT" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -413,12 +413,14 @@ generated class file so that the method
 \f[V]java.lang.reflect.Executable.getParameters\f[R] from the Reflection
 API can retrieve them.
 .TP
-\f[V]-proc:\f[R][\f[V]none\f[R], \f[V]only\f[R]]
+\f[V]-proc:\f[R][\f[V]none\f[R], \f[V]only\f[R], \f[V]full\f[R]]
 Controls whether annotation processing and compilation are done.
 \f[V]-proc:none\f[R] means that compilation takes place without
 annotation processing.
 \f[V]-proc:only\f[R] means that only annotation processing is done,
 without any subsequent compilation.
+If this option is not used, or \f[V]-proc:full\f[R] is specified,
+annotation processing and compilation are done.
 .TP
 \f[V]-processor\f[R] \f[I]class1\f[R][\f[V],\f[R]\f[I]class2\f[R]\f[V],\f[R]\f[I]class3\f[R]...]
 Names of the annotation processors to run.
@@ -736,6 +738,10 @@ constructors in public and protected classes in exported packages.
 \f[V]options\f[R]: Warns about the issues relating to use of command
 line options.
 .IP \[bu] 2
+\f[V]output-file-clash\f[R]: Warns if any output file is overwritten
+during compilation.
+This can occur, for example, on case-insensitive filesystems.
+.IP \[bu] 2
 \f[V]overloads\f[R]: Warns about the issues related to method overloads.
 .IP \[bu] 2
 \f[V]overrides\f[R]: Warns about the issues related to method overrides.
@@ -775,6 +781,9 @@ instances of value-based classes.
 .IP \[bu] 2
 \f[V]text-blocks\f[R]: Warns about inconsistent white space characters
 in text block indentation.
+.IP \[bu] 2
+\f[V]this-escape\f[R]: Warns about constructors leaking \f[V]this\f[R]
+prior to subclass initialization.
 .IP \[bu] 2
 \f[V]try\f[R]: Warns about the issues relating to the use of try blocks
 (that is, try-with-resources).
@@ -2211,6 +2220,48 @@ To resolve this issue, you can call the \f[V]static\f[R] method
 .PP
 Alternately, you can remove the \f[V]static\f[R] keyword from the
 declaration of the method \f[V]m1\f[R].
+.RE
+.TP
+\f[V]this-escape\f[R]
+Warns about constructors leaking \f[V]this\f[R] prior to subclass
+initialization.
+For example, this class:
+.RS
+.IP
+.nf
+\f[CB]
+public class MyClass {
+  public MyClass() {
+    System.out.println(this.hashCode());
+  }
+}
+\f[R]
+.fi
+.PP
+generates the following warning:
+.IP
+.nf
+\f[CB]
+MyClass.java:3: warning: [this-escape] possible \[aq]this\[aq] escape
+                         before subclass is fully initialized
+    System.out.println(this.hashCode());
+                                    \[ha]
+\f[R]
+.fi
+.PP
+A \[aq]this\[aq] escape warning is generated when a constructor does
+something that might result in a subclass method being invoked before
+the constructor returns.
+In such cases the subclass method would be operating on an incompletely
+initialized instance.
+In the above example, a subclass of \f[V]MyClass\f[R] that overrides
+\f[V]hashCode()\f[R] to incorporate its own fields would likely produce
+an incorrect result when invoked as shown.
+.PP
+Warnings are only generated if a subclass could exist that is outside of
+the current module (or package, if no module) being compiled.
+So, for example, constructors in final and non-public classes do not
+generate warnings.
 .RE
 .TP
 \f[V]try\f[R]

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAC" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVAC" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -736,9 +736,6 @@ constructors in public and protected classes in exported packages.
 \f[V]options\f[R]: Warns about the issues relating to use of command
 line options.
 .IP \[bu] 2
-\f[V]output-file-clash\f[R]: Warns if any output file is overwritten during compilation.
-This can occur, for example, on case-insensitive filesystems.
-.IP \[bu] 2
 \f[V]overloads\f[R]: Warns about the issues related to method overloads.
 .IP \[bu] 2
 \f[V]overrides\f[R]: Warns about the issues related to method overrides.
@@ -778,9 +775,6 @@ instances of value-based classes.
 .IP \[bu] 2
 \f[V]text-blocks\f[R]: Warns about inconsistent white space characters
 in text block indentation.
-.IP \[bu] 2
-\f[V]this-escape\f[R]: Warns about constructors leaking
-\f[V]this\f[R] prior to subclass initialization.
 .IP \[bu] 2
 \f[V]try\f[R]: Warns about the issues relating to the use of try blocks
 (that is, try-with-resources).
@@ -2217,48 +2211,6 @@ To resolve this issue, you can call the \f[V]static\f[R] method
 .PP
 Alternately, you can remove the \f[V]static\f[R] keyword from the
 declaration of the method \f[V]m1\f[R].
-.RE
-.TP
-\f[V]this\-escape\f[R]
-Warns about constructors leaking \f[V]this\f[R] prior to subclass
-initialization.
-For example, this class:
-.RS
-.IP
-.nf
-\f[CB]
-public class MyClass {
-  public MyClass() {
-    System.out.println(this.hashCode());
-  }
-}
-\f[R]
-.fi
-.PP
-generates the following warning:
-.IP
-.nf
-\f[CB]
-MyClass.java:3: warning: [this-escape] possible 'this' escape
-                         before subclass is fully initialized
-    System.out.println(this.hashCode());
-                                    ^
-\f[R]
-.fi
-.PP
-A 'this' escape warning is generated when a constructor does something
-that might result in a subclass method being invoked before the
-constructor returns.
-In such cases the subclass method would be operating on an incompletely
-initialized instance.
-In the above example, a subclass of \f[V]MyClass\f[R] that overrides
-\f[V]hashCode()\f[R] to incorporate its own fields would likely produce
-an incorrect result when invoked as shown.
-.PP
-Warnings are only generated if a subclass could exist that is outside
-of the current module (or package, if no module) being compiled.
-So, for example, constructors in final and non-public classes do not
-generate warnings.
 .RE
 .TP
 \f[V]try\f[R]

--- a/src/jdk.compiler/share/man/serialver.1
+++ b/src/jdk.compiler/share/man/serialver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "SERIALVER" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "SERIALVER" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.hotspot.agent/share/man/jhsdb.1
+++ b/src/jdk.hotspot.agent/share/man/jhsdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JHSDB" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JHSDB" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.httpserver/share/man/jwebserver.1
+++ b/src/jdk.httpserver/share/man/jwebserver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JWEBSERVER" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JWEBSERVER" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAR" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JARSIGNER" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JARSIGNER" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -1082,63 +1082,6 @@ name(s) cannot be set in this file.
 .TP
 \f[V]-version\f[R]
 Prints the program version.
-.SH DEPRECATED OPTIONS
-.PP
-The following \f[V]jarsigner\f[R] options are deprecated as of JDK 9 and
-might be removed in a future JDK release.
-.TP
-\f[V]-altsigner\f[R] \f[I]class\f[R]
-This option specifies an alternative signing mechanism.
-The fully qualified class name identifies a class file that extends the
-\f[V]com.sun.jarsigner.ContentSigner\f[R] abstract class.
-The path to this class file is defined by the \f[V]-altsignerpath\f[R]
-option.
-If the \f[V]-altsigner\f[R] option is used, then the \f[V]jarsigner\f[R]
-command uses the signing mechanism provided by the specified class.
-Otherwise, the \f[V]jarsigner\f[R] command uses its default signing
-mechanism.
-.RS
-.PP
-For example, to use the signing mechanism provided by a class named
-\f[V]com.sun.sun.jarsigner.AuthSigner\f[R], use the \f[V]jarsigner\f[R]
-option \f[V]-altsigner com.sun.jarsigner.AuthSigner\f[R].
-.RE
-.TP
-\f[V]-altsignerpath\f[R] \f[I]classpathlist\f[R]
-Specifies the path to the class file and any JAR file it depends on.
-The class file name is specified with the \f[V]-altsigner\f[R] option.
-If the class file is in a JAR file, then this option specifies the path
-to that JAR file.
-.RS
-.PP
-An absolute path or a path relative to the current directory can be
-specified.
-If \f[I]classpathlist\f[R] contains multiple paths or JAR files, then
-they should be separated with a:
-.IP \[bu] 2
-Colon (\f[V]:\f[R]) on Linux and macOS
-.IP \[bu] 2
-Semicolon (\f[V];\f[R]) on Windows
-.PP
-This option isn\[aq]t necessary when the class is already in the search
-path.
-.PP
-The following example shows how to specify the path to a JAR file that
-contains the class file.
-The JAR file name is included.
-.RS
-.PP
-\f[V]-altsignerpath /home/user/lib/authsigner.jar\f[R]
-.RE
-.PP
-The following example shows how to specify the path to the JAR file that
-contains the class file.
-The JAR file name is omitted.
-.RS
-.PP
-\f[V]-altsignerpath /home/user/classes/com/sun/tools/jarsigner/\f[R]
-.RE
-.RE
 .SH ERRORS AND WARNINGS
 .PP
 During the signing or verifying process, the \f[V]jarsigner\f[R] command

--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVADOC" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVADOC" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JCMD" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jinfo.1
+++ b/src/jdk.jcmd/share/man/jinfo.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JINFO" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JINFO" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jmap.1
+++ b/src/jdk.jcmd/share/man/jmap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMAP" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JMAP" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jps.1
+++ b/src/jdk.jcmd/share/man/jps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPS" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JPS" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstack.1
+++ b/src/jdk.jcmd/share/man/jstack.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTACK" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSTACK" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTAT" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSTAT" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jconsole/share/man/jconsole.1
+++ b/src/jdk.jconsole/share/man/jconsole.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCONSOLE" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JCONSOLE" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/javap.1
+++ b/src/jdk.jdeps/share/man/javap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAP" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVAP" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPRSCAN" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JDEPRSCAN" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPS" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JDEPS" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -246,6 +246,7 @@ the pattern to the dependencies.
 .TP
 \f[V]-P\f[R] or \f[V]-profile\f[R]
 Shows the profile containing a package.
+This option is deprecated and may be removed in a future release.
 .TP
 \f[V]-R\f[R] or \f[V]--recursive\f[R]
 Recursively traverses all run-time dependences.

--- a/src/jdk.jdi/share/man/jdb.1
+++ b/src/jdk.jdi/share/man/jdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDB" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JDB" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jfr/share/man/jfr.1
+++ b/src/jdk.jfr/share/man/jfr.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JFR" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JFR" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JLINK" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JLINK" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMOD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JMOD" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPACKAGE" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JPACKAGE" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .PP
 For more than one script, use a space to separate the names.
 Scripts are run in the order in which they\[aq]re entered on the command
@@ -231,6 +236,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .PP
 For more than one script, provide a separate instance of this option for
 each script.
@@ -451,6 +461,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .RE
 .TP
 \f[V]/reload\f[R] [\f[I]options\f[R]]
@@ -765,6 +780,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .PP
 The following options are valid:
 .TP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSHELL" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSHELL" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTATD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSTATD" "1" "2024" "JDK 22-ea" "JDK Commands"
 .hy
 .SH NAME
 .PP


### PR DESCRIPTION
Updated the version to 22-ea and year to 2024.

The following unpublished changes will also be included in this update:
- [JDK-8290626](https://bugs.openjdk.org/browse/JDK-8290626): keytool manpage contains a special character
- [JDK-8303928](https://bugs.openjdk.org/browse/JDK-8303928): Update jarsigner man page after [JDK-8303410](https://bugs.openjdk.org/browse/JDK-8303410)
- [JDK-8301207](https://bugs.openjdk.org/browse/JDK-8301207): (jdeps) Deprecate jdeps -profile option

The following changes, to `javac.1`, were never applied to the closed sources and are "lost" by this update. These changes will need to be re-applied directly in JDK 21 and JDK 22:
- [JDK-8296656](https://bugs.openjdk.org/browse/JDK-8296656): java.lang.NoClassDefFoundError exception on running fully legitimate code
- [JDK-8015831](https://bugs.openjdk.org/browse/JDK-8015831): Add lint check for calling overridable methods from a constructor

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304478](https://bugs.openjdk.org/browse/JDK-8304478): Initial nroff manpage generation for JDK 22 (**Task** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [3efc518f](https://git.openjdk.org/jdk/pull/14462/files/3efc518fd962dd76c1ba5f898459cadff8ca2061)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [3efc518f](https://git.openjdk.org/jdk/pull/14462/files/3efc518fd962dd76c1ba5f898459cadff8ca2061)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [3efc518f](https://git.openjdk.org/jdk/pull/14462/files/3efc518fd962dd76c1ba5f898459cadff8ca2061)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [3efc518f](https://git.openjdk.org/jdk/pull/14462/files/3efc518fd962dd76c1ba5f898459cadff8ca2061)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14462/head:pull/14462` \
`$ git checkout pull/14462`

Update a local copy of the PR: \
`$ git checkout pull/14462` \
`$ git pull https://git.openjdk.org/jdk.git pull/14462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14462`

View PR using the GUI difftool: \
`$ git pr show -t 14462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14462.diff">https://git.openjdk.org/jdk/pull/14462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14462#issuecomment-1590488227)