### PR TITLE
8310019: MIPS builds are broken after JDK-8304913

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -109,7 +109,7 @@ public enum Architecture {
      */
     @ForceInline
     public static boolean isMIPSEL() {
-        return PlatformProps.TARGET_ARCH_IS_AARCH64;
+        return PlatformProps.TARGET_ARCH_IS_MIPSEL;
     }
 
     /**
@@ -117,7 +117,7 @@ public enum Architecture {
      */
     @ForceInline
     public static boolean isMIPS64EL() {
-        return PlatformProps.TARGET_ARCH_IS_AARCH64;
+        return PlatformProps.TARGET_ARCH_IS_MIPS64EL;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -41,6 +41,8 @@ public enum Architecture {
     RISCV64,
     S390,
     PPC64,
+    MIPSEL,
+    MIPS64EL
     ;
 
     private static Architecture CURRENT_ARCH = initArch(PlatformProps.CURRENT_ARCH_STRING);
@@ -99,6 +101,22 @@ public enum Architecture {
      */
     @ForceInline
     public static boolean isAARCH64() {
+        return PlatformProps.TARGET_ARCH_IS_AARCH64;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is MIPSEL}
+     */
+    @ForceInline
+    public static boolean isMIPSEL() {
+        return PlatformProps.TARGET_ARCH_IS_AARCH64;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is MIPS64EL}
+     */
+    @ForceInline
+    public static boolean isMIPS64EL() {
         return PlatformProps.TARGET_ARCH_IS_AARCH64;
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -57,4 +57,6 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
     static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";
+    static final boolean TARGET_ARCH_IS_MIPSEL  = "@@OPENJDK_TARGET_CPU@@" == "mipsel";
+    static final boolean TARGET_ARCH_IS_MIPS64EL= "@@OPENJDK_TARGET_CPU@@" == "mips64el";
 }

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -75,7 +75,7 @@ public class ArchTest {
             case "s390x", "s390" -> S390;
             case "ppc64", "ppc64le" -> PPC64;
             case "mipsel" -> MIPSEL;
-            case "mip64sel" -> MIPS64EL;
+            case "mips64el" -> MIPS64EL;
             default -> OTHER;
         };
         assertEquals(Architecture.current(), arch, "mismatch in Architecture.current vs " + osArch);

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -34,6 +34,8 @@ import static jdk.internal.util.Architecture.RISCV64;
 import static jdk.internal.util.Architecture.S390;
 import static jdk.internal.util.Architecture.X64;
 import static jdk.internal.util.Architecture.X86;
+import static jdk.internal.util.Architecture.MIPSEL;
+import static jdk.internal.util.Architecture.MIPS64EL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -72,6 +74,8 @@ public class ArchTest {
             case "riscv64" -> RISCV64;
             case "s390x", "s390" -> S390;
             case "ppc64", "ppc64le" -> PPC64;
+            case "mipsel" -> MIPSEL;
+            case "mip64sel" -> MIPS64EL;
             default -> OTHER;
         };
         assertEquals(Architecture.current(), arch, "mismatch in Architecture.current vs " + osArch);
@@ -89,6 +93,8 @@ public class ArchTest {
                 Arguments.of(ARM, Architecture.isARM()),
                 Arguments.of(RISCV64, Architecture.isRISCV64()),
                 Arguments.of(S390, Architecture.isS390()),
+                Arguments.of(MIPSEL, Architecture.isMIPSEL()),
+                Arguments.of(MIPS64EL, Architecture.isMIPS64EL()),
                 Arguments.of(PPC64, Architecture.isPPC64())
         );
     }


### PR DESCRIPTION
Add mipsel and mips64el to the Architecture enum.
(Later to be backported to JDK 21)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310019](https://bugs.openjdk.org/browse/JDK-8310019): MIPS builds are broken after JDK-8304913 (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [4c18377a](https://git.openjdk.org/jdk/pull/14471/files/4c18377a78b7d22b8fa41dc36c934794974b3877)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [ce8d31fa](https://git.openjdk.org/jdk/pull/14471/files/ce8d31fae1f4e607788622436b937ed1d0b78cca)
 * [Ao Qi](https://openjdk.org/census#aoqi) (@theaoqi - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14471/head:pull/14471` \
`$ git checkout pull/14471`

Update a local copy of the PR: \
`$ git checkout pull/14471` \
`$ git pull https://git.openjdk.org/jdk.git pull/14471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14471`

View PR using the GUI difftool: \
`$ git pr show -t 14471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14471.diff">https://git.openjdk.org/jdk/pull/14471.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14471#issuecomment-1591437076)