### PR TITLE
8310037: Parallel/Serial: Space Counters classes leak helper instances

### DIFF
--- a/src/hotspot/share/gc/parallel/spaceCounters.cpp
+++ b/src/hotspot/share/gc/parallel/spaceCounters.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/spaceCounters.cpp
+++ b/src/hotspot/share/gc/parallel/spaceCounters.cpp
@@ -34,7 +34,8 @@
 
 SpaceCounters::SpaceCounters(const char* name, int ordinal, size_t max_size,
                              MutableSpace* m, GenerationCounters* gc) :
-   _object_space(m) {
+   _object_space(m),
+   _perf_used_helper(nullptr) {
 
   if (UsePerfData) {
     EXCEPTION_MARK;
@@ -59,8 +60,9 @@ SpaceCounters::SpaceCounters(const char* name, int ordinal, size_t max_size,
                                    _object_space->capacity_in_bytes(), CHECK);
 
     cname = PerfDataManager::counter_name(_name_space, "used");
+    _perf_used_helper = new MutableSpaceUsedHelper(_object_space);
     _used = PerfDataManager::create_variable(SUN_GC, cname, PerfData::U_Bytes,
-                                    new MutableSpaceUsedHelper(_object_space),
+                                    _perf_used_helper,
                                     CHECK);
 
     cname = PerfDataManager::counter_name(_name_space, "initCapacity");
@@ -70,6 +72,7 @@ SpaceCounters::SpaceCounters(const char* name, int ordinal, size_t max_size,
 }
 
 SpaceCounters::~SpaceCounters() {
+  delete _perf_used_helper;
   FREE_C_HEAP_ARRAY(char, _name_space);
 }
 

--- a/src/hotspot/share/gc/parallel/spaceCounters.hpp
+++ b/src/hotspot/share/gc/parallel/spaceCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/spaceCounters.hpp
+++ b/src/hotspot/share/gc/parallel/spaceCounters.hpp
@@ -30,9 +30,10 @@
 #include "runtime/perfData.hpp"
 #include "utilities/macros.hpp"
 
+class MutableSpaceUsedHelper;
+
 // A SpaceCounter is a holder class for performance counters
 // that track a space;
-
 class SpaceCounters: public CHeapObj<mtGC> {
   friend class VMStructs;
 
@@ -47,6 +48,7 @@ class SpaceCounters: public CHeapObj<mtGC> {
   MutableSpace*     _object_space;
   char*             _name_space;
 
+  MutableSpaceUsedHelper* _perf_used_helper;
  public:
 
   SpaceCounters(const char* name, int ordinal, size_t max_size,

--- a/src/hotspot/share/gc/serial/cSpaceCounters.cpp
+++ b/src/hotspot/share/gc/serial/cSpaceCounters.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,8 @@
 
 CSpaceCounters::CSpaceCounters(const char* name, int ordinal, size_t max_size,
                                ContiguousSpace* s, GenerationCounters* gc) :
-   _space(s) {
+   _space(s),
+   _perf_used_helper(nullptr) {
 
   if (UsePerfData) {
     EXCEPTION_MARK;
@@ -54,8 +55,9 @@ CSpaceCounters::CSpaceCounters(const char* name, int ordinal, size_t max_size,
                                                  _space->capacity(), CHECK);
 
     cname = PerfDataManager::counter_name(_name_space, "used");
+    _perf_used_helper = new ContiguousSpaceUsedHelper(_space);
     _used = PerfDataManager::create_variable(SUN_GC, cname, PerfData::U_Bytes,
-                                    new ContiguousSpaceUsedHelper(_space),
+                                    _perf_used_helper,
                                     CHECK);
 
     cname = PerfDataManager::counter_name(_name_space, "initCapacity");
@@ -65,6 +67,7 @@ CSpaceCounters::CSpaceCounters(const char* name, int ordinal, size_t max_size,
 }
 
 CSpaceCounters::~CSpaceCounters() {
+  delete _perf_used_helper;
   FREE_C_HEAP_ARRAY(char, _name_space);
 }
 

--- a/src/hotspot/share/gc/serial/cSpaceCounters.hpp
+++ b/src/hotspot/share/gc/serial/cSpaceCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
 #include "gc/shared/space.hpp"
 #include "runtime/perfData.hpp"
 
+class ContiguousSpaceUsedHelper;
+
 // A CSpaceCounters is a holder class for performance counters
 // that track a space;
 
@@ -47,6 +49,7 @@ class CSpaceCounters: public CHeapObj<mtGC> {
   ContiguousSpace*     _space;
   char*                _name_space;
 
+  ContiguousSpaceUsedHelper* _perf_used_helper;
  public:
 
   CSpaceCounters(const char* name, int ordinal, size_t max_size,


### PR DESCRIPTION
Please review this small fix for memory leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310037](https://bugs.openjdk.org/browse/JDK-8310037): Parallel/Serial: Space Counters classes leak helper instances (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Yumin Qi](https://openjdk.org/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14472/head:pull/14472` \
`$ git checkout pull/14472`

Update a local copy of the PR: \
`$ git checkout pull/14472` \
`$ git pull https://git.openjdk.org/jdk.git pull/14472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14472`

View PR using the GUI difftool: \
`$ git pr show -t 14472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14472.diff">https://git.openjdk.org/jdk/pull/14472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14472#issuecomment-1591656147)