### PR TITLE
JDK-8309958: Incorrect @since tag format in Container.java

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -562,7 +562,7 @@ public class Container extends Component {
      * index without calling removeNotify.
      * Note: Should be called while holding treeLock
      * Returns whether removeNotify was invoked
-     * @since: 1.5
+     * @since 1.5
      */
     private boolean removeDelicately(Component comp, Container newParent, int newIndex) {
         checkTreeLock();
@@ -687,7 +687,7 @@ public class Container extends Component {
      * removeNotify on the component. Since removeNotify destroys native window this might (not)
      * be required. For example, if new container and old containers are the same we don't need to
      * destroy native window.
-     * @since: 1.5
+     * @since 1.5
      */
     private static boolean isRemoveNotifyNeeded(Component comp, Container oldContainer, Container newContainer) {
         if (oldContainer == null) { // Component didn't have parent - no removeNotify


### PR DESCRIPTION
Minor Javadoc change for since tag in Container.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309958](https://bugs.openjdk.org/browse/JDK-8309958): Incorrect @since tag format in Container.java (**Bug** - P5)


### Reviewers
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14474/head:pull/14474` \
`$ git checkout pull/14474`

Update a local copy of the PR: \
`$ git checkout pull/14474` \
`$ git pull https://git.openjdk.org/jdk.git pull/14474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14474`

View PR using the GUI difftool: \
`$ git pr show -t 14474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14474.diff">https://git.openjdk.org/jdk/pull/14474.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14474#issuecomment-1591790387)