### PR TITLE
8310053: VarHandle and slice handle derived from layout are lacking alignment check

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -440,6 +440,10 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * long size = select(elements).byteSize();
      * MemorySegment slice = segment.asSlice(offset, size);
      * }
+     * <p>
+     * The segment to be must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the {@linkplain
+     * #byteAlignment() alignment constraint} of the root layout (this layout). Note that this can be more strict
+     * (but not less) than the alignment constraint of the selected value layout.
      *
      * @apiNote The returned method handle can be used to obtain a memory segment slice, similarly to {@link MemorySegment#asSlice(long, long)},
      * but more flexibly, as some indices can be specified when invoking the method handle.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -380,7 +380,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * Additionally, the provided dynamic values must conform to bounds which are derived from the layout path, that is,
      * {@code 0 <= x_i < b_i}, where {@code 1 <= i <= n}, or {@link IndexOutOfBoundsException} is thrown.
      * <p>
-     * The accessed address must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the {@linkplain
+     * The base address must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the {@linkplain
      * #byteAlignment() alignment constraint} of the root layout (this layout). Note that this can be more strict
      * (but not less) than the alignment constraint of the selected value layout.
      * <p>

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -441,9 +441,9 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * MemorySegment slice = segment.asSlice(offset, size);
      * }
      * <p>
-     * The segment to be must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the {@linkplain
-     * #byteAlignment() alignment constraint} of the root layout (this layout). Note that this can be more strict
-     * (but not less) than the alignment constraint of the selected value layout.
+     * The segment to be sliced must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the
+     * {@linkplain #byteAlignment() alignment constraint} of the root layout (this layout). Note that this can be more
+     * strict (but not less) than the alignment constraint of the selected value layout.
      *
      * @apiNote The returned method handle can be used to obtain a memory segment slice, similarly to {@link MemorySegment#asSlice(long, long)},
      * but more flexibly, as some indices can be specified when invoking the method handle.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -380,6 +380,10 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * Additionally, the provided dynamic values must conform to bounds which are derived from the layout path, that is,
      * {@code 0 <= x_i < b_i}, where {@code 1 <= i <= n}, or {@link IndexOutOfBoundsException} is thrown.
      * <p>
+     * The accessed address must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the {@linkplain
+     * #byteAlignment() alignment constraint} of the root layout (this layout). Note that this can be more strict
+     * (but not less) than the alignment constraint of the selected value layout.
+     * <p>
      * Multiple paths can be chained, with <a href=#deref-path-elements>dereference path elements</a>.
      * A dereference path element constructs a fresh native memory segment whose base address is the address value
      * read obtained by accessing a memory segment at the offset determined by the layout path elements immediately preceding

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -58,6 +58,7 @@ public class LayoutPath {
 
     private static final MethodHandle MH_ADD_SCALED_OFFSET;
     private static final MethodHandle MH_SLICE;
+    private static final MethodHandle MH_CHECK_ALIGN;
     private static final MethodHandle MH_SEGMENT_RESIZE;
 
     static {
@@ -66,7 +67,9 @@ public class LayoutPath {
             MH_ADD_SCALED_OFFSET = lookup.findStatic(LayoutPath.class, "addScaledOffset",
                     MethodType.methodType(long.class, long.class, long.class, long.class, long.class));
             MH_SLICE = lookup.findVirtual(MemorySegment.class, "asSlice",
-                    MethodType.methodType(MemorySegment.class, long.class, long.class));
+                    MethodType.methodType(MemorySegment.class, long.class, MemoryLayout.class));
+            MH_CHECK_ALIGN = lookup.findStatic(LayoutPath.class, "checkAlign",
+                    MethodType.methodType(MemorySegment.class, MemorySegment.class, MemoryLayout.class));
             MH_SEGMENT_RESIZE = lookup.findStatic(LayoutPath.class, "resizeSegment",
                     MethodType.methodType(MemorySegment.class, MemorySegment.class, MemoryLayout.class));
         } catch (Throwable ex) {
@@ -194,16 +197,11 @@ public class LayoutPath {
         }
 
         VarHandle handle = Utils.makeSegmentViewVarHandle(valueLayout);
-        for (int i = strides.length - 1; i >= 0; i--) {
-            MethodHandle collector = MethodHandles.insertArguments(MH_ADD_SCALED_OFFSET, 2,
-                    strides[i],
-                    bounds[i]);
-            // (J, ...) -> J to (J, J, ...) -> J
-            // i.e. new coord is prefixed. Last coord will correspond to innermost layout
-            handle = MethodHandles.collectCoordinates(handle, 1, collector);
+        handle = MethodHandles.collectCoordinates(handle, 1, offsetHandle());
+        if (enclosing != null) {
+            MethodHandle checkHandle = MethodHandles.insertArguments(MH_CHECK_ALIGN, 1, rootLayout());
+            handle = MethodHandles.filterCoordinates(handle, 0, checkHandle);
         }
-        handle = MethodHandles.insertCoordinates(handle, 1,
-                offset);
 
         if (adapt) {
             for (int i = derefAdapters.length; i > 0; i--) {
@@ -231,14 +229,28 @@ public class LayoutPath {
         return mh;
     }
 
-    public MethodHandle sliceHandle() {
-        MethodHandle offsetHandle = offsetHandle(); // byte offset
+    private MemoryLayout rootLayout() {
+        return enclosing != null ? enclosing.rootLayout() : this.layout;
+    }
 
-        MethodHandle sliceHandle = MH_SLICE; // (MS, long, long) -> MS
-        sliceHandle = MethodHandles.insertArguments(sliceHandle, 2, layout.byteSize()); // (MS, long) -> MS
-        sliceHandle = MethodHandles.collectArguments(sliceHandle, 1, offsetHandle); // (MS, ...) -> MS
+    public MethodHandle sliceHandle() {
+        MethodHandle sliceHandle = MH_SLICE; // (MS, long, MemoryLayout) -> MS
+        sliceHandle = MethodHandles.insertArguments(sliceHandle, 2, layout); // (MS, long) -> MS
+        sliceHandle = MethodHandles.collectArguments(sliceHandle, 1, offsetHandle()); // (MS, ...) -> MS
+
+        if (enclosing != null) {
+            MethodHandle checkHandle = MethodHandles.insertArguments(MH_CHECK_ALIGN, 1, rootLayout());
+            sliceHandle = MethodHandles.filterArguments(sliceHandle, 0, checkHandle);
+        }
 
         return sliceHandle;
+    }
+
+    private static MemorySegment checkAlign(MemorySegment segment, MemoryLayout constraint) {
+        if (!((AbstractMemorySegmentImpl) segment).isAlignedForElement(0, constraint)) {
+            throw new IllegalArgumentException("Target offset incompatible with alignment constraints: " + constraint.byteAlignment());
+        }
+        return segment;
     }
 
     public MemoryLayout layout() {

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -204,7 +204,11 @@ public class LayoutPath {
         ValueLayout accessedLayout = enclosing != null ? valueLayout.withByteAlignment(1) : valueLayout;
         VarHandle handle = Utils.makeSegmentViewVarHandle(accessedLayout);
         handle = MethodHandles.collectCoordinates(handle, 1, offsetHandle());
-        if (enclosing != null) {
+
+        // we only have to check the alignment of the root layout for the first dereference we do,
+        // as each dereference checks the alignment of the target address when constructing its segment
+        // (see Utils::longToAddress)
+        if (derefAdapters.length == 0 && enclosing != null) {
             MethodHandle checkHandle = MethodHandles.insertArguments(MH_CHECK_ALIGN, 1, rootLayout());
             handle = MethodHandles.filterCoordinates(handle, 0, checkHandle);
         }

--- a/test/jdk/java/foreign/TestDereferencePath.java
+++ b/test/jdk/java/foreign/TestDereferencePath.java
@@ -143,4 +143,16 @@ public class TestDereferencePath {
     void badDerefAddressNoTarget() {
         A_MULTI_NO_TARGET.varHandle(PathElement.groupElement("bs"), PathElement.dereferenceElement());
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void badDerefMisAligned() {
+        MemoryLayout struct = MemoryLayout.structLayout(
+            ValueLayout.ADDRESS.withTargetLayout(ValueLayout.JAVA_INT).withName("x"));
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(struct.byteSize() + 1).asSlice(1);
+            VarHandle vhX = struct.varHandle(PathElement.groupElement("x"), PathElement.dereferenceElement());
+            vhX.set(segment, 42); // should throw
+        }
+    }
 }

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -31,10 +31,10 @@
 import java.lang.foreign.*;
 import java.lang.foreign.MemoryLayout.PathElement;
 
-import org.testng.SkipException;
 import org.testng.annotations.*;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntFunction;
@@ -42,6 +42,7 @@ import java.util.function.IntFunction;
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
 import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 import static org.testng.Assert.*;
 
 public class TestLayoutPaths {
@@ -132,6 +133,38 @@ public class TestLayoutPaths {
     public void testByteOffsetHandleBadRange() {
         SequenceLayout seq = MemoryLayout.sequenceLayout(5, MemoryLayout.structLayout(JAVA_INT));
         seq.byteOffsetHandle(sequenceElement(5, 1)); // invalid range (starting position is outside the sequence)
+    }
+
+    @Test
+    public void testBadAlignmentOfRoot() throws Throwable {
+        MemoryLayout struct = MemoryLayout.structLayout(
+            JAVA_INT,
+            JAVA_SHORT.withName("x"));
+        assertEquals(struct.byteAlignment(), 4);
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment seg = arena.allocate(struct.byteSize() + 2, struct.byteAlignment()).asSlice(2);
+            assertEquals(seg.address() % JAVA_SHORT.byteAlignment(), 0); // should be aligned
+            assertNotEquals(seg.address() % struct.byteAlignment(), 0); // should not be aligned
+
+            String expectedMessage = "Target offset incompatible with alignment constraints: " + struct.byteAlignment();
+
+            try {
+                VarHandle vhX = struct.varHandle(groupElement("x"));
+                vhX.set(seg, (short) 42); // should throw
+                fail("var handle didn't throw");
+            } catch (IllegalArgumentException e) {
+                assertEquals(e.getMessage(), expectedMessage);
+            }
+
+            try {
+                MethodHandle sliceX = struct.sliceHandle(groupElement("x"));
+                MemorySegment slice = (MemorySegment) sliceX.invokeExact(seg); // should throw
+                fail("slice handle didn't throw");
+            } catch (IllegalArgumentException e) {
+                assertEquals(e.getMessage(), expectedMessage);
+            }
+        }
     }
 
     @Test
@@ -338,4 +371,3 @@ public class TestLayoutPaths {
     }
 
 }
-

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -149,21 +149,17 @@ public class TestLayoutPaths {
 
             String expectedMessage = "Target offset incompatible with alignment constraints: " + struct.byteAlignment();
 
-            try {
-                VarHandle vhX = struct.varHandle(groupElement("x"));
-                vhX.set(seg, (short) 42); // should throw
-                fail("var handle didn't throw");
-            } catch (IllegalArgumentException e) {
-                assertEquals(e.getMessage(), expectedMessage);
-            }
+            VarHandle vhX = struct.varHandle(groupElement("x"));
+            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> {
+                vhX.set(seg, (short) 42);
+            });
+            assertEquals(iae.getMessage(), expectedMessage);
 
-            try {
-                MethodHandle sliceX = struct.sliceHandle(groupElement("x"));
-                MemorySegment slice = (MemorySegment) sliceX.invokeExact(seg); // should throw
-                fail("slice handle didn't throw");
-            } catch (IllegalArgumentException e) {
-                assertEquals(e.getMessage(), expectedMessage);
-            }
+            MethodHandle sliceX = struct.sliceHandle(groupElement("x"));
+            iae = expectThrows(IllegalArgumentException.class, () -> {
+                MemorySegment slice = (MemorySegment) sliceX.invokeExact(seg);
+            });
+            assertEquals(iae.getMessage(), expectedMessage);
         }
     }
 


### PR DESCRIPTION
Add missing alignment checks for the alignment constraint of the root layout of a VarHandle created through `MemoryLayout::varHandle` and a MethodHandle `MemoryLayout::sliceHandle`.

Testing: `jdk_foreign` test suite

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8310068](https://bugs.openjdk.org/browse/JDK-8310068) to be approved

### Issues
 * [JDK-8310053](https://bugs.openjdk.org/browse/JDK-8310053): VarHandle and slice handle derived from layout are lacking alignment check (**Bug** - P3)
 * [JDK-8310068](https://bugs.openjdk.org/browse/JDK-8310068): VarHandle and slice handle derived from layout are lacking alignment check (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14475/head:pull/14475` \
`$ git checkout pull/14475`

Update a local copy of the PR: \
`$ git checkout pull/14475` \
`$ git pull https://git.openjdk.org/jdk.git pull/14475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14475`

View PR using the GUI difftool: \
`$ git pr show -t 14475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14475.diff">https://git.openjdk.org/jdk/pull/14475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14475#issuecomment-1592049952)