### PR TITLE
8310076: Reduce inclusion of bytecodeStream.hpp

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -26,6 +26,7 @@
 #include "cds/metaspaceShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "interpreter/bytecodes.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/rewriter.hpp"
 #include "memory/metadataFactory.hpp"

--- a/src/hotspot/share/oops/generateOopMap.hpp
+++ b/src/hotspot/share/oops/generateOopMap.hpp
@@ -25,7 +25,6 @@
 #ifndef SHARE_OOPS_GENERATEOOPMAP_HPP
 #define SHARE_OOPS_GENERATEOOPMAP_HPP
 
-#include "interpreter/bytecodeStream.hpp"
 #include "memory/allocation.hpp"
 #include "oops/method.hpp"
 #include "oops/oopsHierarchy.hpp"
@@ -33,6 +32,7 @@
 #include "utilities/bitMap.hpp"
 
 // Forward definition
+class BytecodeStream;
 class GenerateOopMap;
 class BasicBlock;
 class CellTypeState;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -43,6 +43,7 @@
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "interpreter/rewriter.hpp"
 #include "jvm.h"

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -23,9 +23,11 @@
  */
 
 #include "precompiled.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/constantPool.inline.hpp"
+#include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "prims/methodComparator.hpp"

--- a/src/hotspot/share/prims/methodComparator.hpp
+++ b/src/hotspot/share/prims/methodComparator.hpp
@@ -25,9 +25,11 @@
 #ifndef SHARE_PRIMS_METHODCOMPARATOR_HPP
 #define SHARE_PRIMS_METHODCOMPARATOR_HPP
 
-#include "interpreter/bytecodeStream.hpp"
-#include "oops/constantPool.hpp"
-#include "oops/method.hpp"
+#include "interpreter/bytecodes.hpp"
+
+class BytecodeStream;
+class ConstantPool;
+class Method;
 
 // methodComparator provides an interface for determining if methods of
 // different versions of classes are equivalent or switchable

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -36,6 +36,7 @@
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "jvm.h"


### PR DESCRIPTION
The popular header file generateOopMap.hpp includes bytecodeStream.hpp, but it doesn't actually needs the full declaration of the BytecodeStream class.

This inclusion can be replaced with a simple forward declaration of the BytecodeStream class.

This reduces the number of HotSpot .o files that include bytecodeStream.hpp from 571 to 21.