### PR TITLE
JDK-8310107: os::trace_page_sizes_for_requested_size should name alignment as requested page size

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1307,10 +1307,10 @@ G1RegionToSpaceMapper* G1CollectedHeap::create_aux_memory_mapper(const char* des
 
   os::trace_page_sizes_for_requested_size(description,
                                           size,
-                                          page_size,
                                           preferred_page_size,
                                           rs.base(),
-                                          rs.size());
+                                          rs.size(),
+                                          page_size);
 
   return result;
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1675,23 +1675,23 @@ void os::trace_page_sizes(const char* str,
 
 void os::trace_page_sizes_for_requested_size(const char* str,
                                              const size_t requested_size,
-                                             const size_t page_size,
-                                             const size_t alignment,
+                                             const size_t requested_page_size,
                                              const char* base,
-                                             const size_t size) {
+                                             const size_t size,
+                                             const size_t page_size) {
 
   log_info(pagesize)("%s:"
                      " req_size=" SIZE_FORMAT "%s"
+                     " req_page_size=" SIZE_FORMAT "%s"
                      " base=" PTR_FORMAT
-                     " page_size=" SIZE_FORMAT "%s"
-                     " alignment=" SIZE_FORMAT "%s"
-                     " size=" SIZE_FORMAT "%s",
+                     " size=" SIZE_FORMAT "%s"
+                     " page_size=" SIZE_FORMAT "%s",
                      str,
                      trace_page_size_params(requested_size),
+                     trace_page_size_params(requested_page_size),
                      p2i(base),
-                     trace_page_size_params(page_size),
-                     trace_page_size_params(alignment),
-                     trace_page_size_params(size));
+                     trace_page_size_params(size),
+                     trace_page_size_params(page_size));
 }
 
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -414,10 +414,10 @@ class os: AllStatic {
                                const size_t size);
   static void trace_page_sizes_for_requested_size(const char* str,
                                                   const size_t requested_size,
-                                                  const size_t page_size,
-                                                  const size_t alignment,
+                                                  const size_t requested_page_size,
                                                   const char* base,
-                                                  const size_t size);
+                                                  const size_t size,
+                                                  const size_t page_size);
 
   static size_t vm_allocation_granularity() { return OSInfo::vm_allocation_granularity(); }
 


### PR DESCRIPTION
Somewhat trivial renaming patch.

`os::trace_page_sizes_for_requested_size()` uses "alignment" to name what is actually the requested page size (which may differ from the actual page size of a region, which is traced independently). I believe the naming stems from ReservedSpace and os::reserve_...() misusing "alignment" for "page size", but that would be a bigger RFE to clean up. One step at the time.

As a first step, I propose to make naming for os::trace_page_sizes_for_requested_size() clearer. 

Patch renames "alignment" to "requested pagesize" in both printout and code.

It also reshuffles the parameters somewhat to have requested properties at the beginning, followed by the actual properties of the region.

Printout before, for a failed 2M paged allocation (notice the difference between requested and actual page size, which is here named "alignment"):

```
OpenJDK 64-Bit Server VM warning: Failed to reserve and commit memory using large pages. req_addr: 0x0000000000000000 bytes: 2097152
[0.012s][info][pagesize] Block Offset Table: req_size=2M base=0x00007f3518200000 page_size=4K alignment=2M size=2M
```

Printout now:

```
OpenJDK 64-Bit Server VM warning: Failed to reserve and commit memory using large pages. req_addr: 0x0000000000000000 bytes: 2097152
[0.011s][info][pagesize] Block Offset Table: req_size=2M req_page_size=2M base=0x00007fda0e400000 size=2M page_size=4K
```
