### PR TITLE
8248149: G1: change _cleaning_claimed from int to bool

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
+++ b/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
@@ -32,15 +32,15 @@
 
 #if INCLUDE_JVMCI
 JVMCICleaningTask::JVMCICleaningTask() :
-  _cleaning_claimed(0) {
+  _cleaning_claimed(false) {
 }
 
 bool JVMCICleaningTask::claim_cleaning_task() {
-  if (_cleaning_claimed) {
+  if (Atomic::load(&_cleaning_claimed)) {
     return false;
   }
 
-  return Atomic::cmpxchg(&_cleaning_claimed, 0, 1) == 0;
+  return !Atomic::cmpxchg(&_cleaning_claimed, false, true);
 }
 
 void JVMCICleaningTask::work(bool unloading_occurred) {

--- a/src/hotspot/share/gc/g1/g1ParallelCleaning.hpp
+++ b/src/hotspot/share/gc/g1/g1ParallelCleaning.hpp
@@ -29,7 +29,7 @@
 
 #if INCLUDE_JVMCI
 class JVMCICleaningTask : public StackObj {
-  volatile int       _cleaning_claimed;
+  volatile bool _cleaning_claimed;
 
 public:
   JVMCICleaningTask();


### PR DESCRIPTION
Hi all,

  please review this change to fix some claim variable from `int` to `bool` as it should be.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248149](https://bugs.openjdk.org/browse/JDK-8248149): G1: change _cleaning_claimed from int to bool (**Enhancement** - P4)


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14487/head:pull/14487` \
`$ git checkout pull/14487`

Update a local copy of the PR: \
`$ git checkout pull/14487` \
`$ git pull https://git.openjdk.org/jdk.git pull/14487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14487`

View PR using the GUI difftool: \
`$ git pr show -t 14487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14487.diff">https://git.openjdk.org/jdk/pull/14487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14487#issuecomment-1592699139)