### PR TITLE
C2: assert(final_con == (jlong)final_int) failed: final value should be integer

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2282,11 +2282,13 @@ const Type* LoopLimitNode::Value(PhaseGVN* phase) const {
   if (limit_t  == Type::TOP) return Type::TOP;
   if (stride_t == Type::TOP) return Type::TOP;
 
-  int stride_con = stride_t->is_int()->get_con();
-  if (stride_con == 1)
-    return bottom_type();  // Identity
+  if(in(Init)->is_ConI() && in(Limit)->is_ConI() && in(Stride)->is_ConI()){
+    int stride_con = stride_t->is_int()->get_con();
+    if (stride_con == 1) {
+      return bottom_type();  // Identity
+    }
 
-  if (init_t->is_int()->is_con() && limit_t->is_int()->is_con()) {
+    assert(init_t->is_int()->is_con() && limit_t->is_int()->is_con(), "init_t and limit_t should have constant values");
     // Use jlongs to avoid integer overflow.
     jlong init_con   =  init_t->is_int()->get_con();
     jlong limit_con  = limit_t->is_int()->get_con();

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopLimitOverflowDuringCCP.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopLimitOverflowDuringCCP.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309266
+ * @summary Integer overflow in LoopLimit::Value during PhaseCCP::analyze, triggered by the Phi Node from "flag ? Integer.MAX_VALUE : 1000"
+ * @run main/othervm -Xbatch -XX:CompileOnly=compiler.loopopts.TestLoopLimitOverflowDuringCCP::* compiler.loopopts.TestLoopLimitOverflowDuringCCP
+ */
+
+package compiler.loopopts;
+
+public class TestLoopLimitOverflowDuringCCP {
+    static boolean flag;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            flag = !flag;
+            test();
+        }
+    }
+
+    public static void test() {
+        int limit = flag ? Integer.MAX_VALUE : 1000;
+        int i = 0;
+        while (i < limit) {
+            i += 3;
+            if (flag) {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Acknowledgments**: Thanks to @quadhier for the preliminary work on this issue: https://github.com/openjdk/jdk/pull/14353

**JDK-8309266**: TestLoopLimitOverflowDuringCCP.java causes an assertion error (overflow check) in LoopLimitNode::Value. To fix the issue I added a check in LoopLimitNode::Value that verifies that the input nodes are ConI type nodes. 

Previously, TestLoopLimitOverflowDuringCCP would cause the assertion error in LoopLimitNode::Value, during PhaseCCP::analyze. The problem originated from PhaseCCP initializing all types to TOP, resulting in the Phi node from `int limit = flag ? 1000 : Integer.MAX_VALUE` being temporarily considered as Integer.MAX_VALUE. This happens as the Node for the Integer.MAX_VALUE case was already analyzed by CCP while the Node for the 1000 case was still initialized to TOP. When resolving the value of the Phi node, Integer.MAX_VALUE and TOP get merged to Integer.MAX_VALUE, which is then processed by LoopLimitNode::Value as a constant, resulting in the integer overflow.

By checking that the input nodes are ConI nodes in LoopLimitNode::Value, we avoid Phi nodes being misinterpreted during PhaseCCP. If the Phi nodes turn out to be constant they should rather be first transformed to ConI nodes.