### PR TITLE
8310130: C2: assert(false) failed: scalar_input is neither phi nor a matchin reduction

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -4224,7 +4224,8 @@ void PhaseIdealLoop::move_unordered_reduction_out_of_loop(IdealLoopTree* loop) {
           if (use != phi && ctrl_or_self(use) == cl) {
             DEBUG_ONLY( current->dump(-1); )
             assert(false, "reduction has use inside loop");
-            break; // Chain traversal fails.
+            // Should not be allowed by SuperWord::mark_reductions
+            return; // bail out of optimization
           }
         }
       } else {

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -4245,8 +4245,9 @@ void PhaseIdealLoop::move_unordered_reduction_out_of_loop(IdealLoopTree* loop) {
         current = nullptr;
         break; // Success.
       } else {
-        DEBUG_ONLY( current->dump(1); )
-        assert(false, "scalar_input is neither phi nor a matchin reduction");
+        // scalar_input is neither phi nor a matching reduction
+        // Can for example be scalar reduction when we have
+        // partial vectorization.
         break; // Chain traversal fails.
       }
     }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -43,7 +43,7 @@ public class TestUnorderedReduction {
                                    "-XX:MaxVectorSize=16");
     }
 
-    @Run(test = {"test1", "test2"})
+    @Run(test = {"test1", "test2", "test3"})
     @Warmup(0)
     public void runTests() throws Exception {
         int[] data = new int[RANGE];
@@ -62,6 +62,14 @@ public class TestUnorderedReduction {
             int r2 = ref2(data, i);
             if (r1 != r2) {
                 throw new RuntimeException("Wrong result test2: " + r1 + " != " + r2);
+            }
+        }
+
+        for (int i = 0; i < ITER; i++) {
+            int r1 = test3(data, i);
+            int r2 = ref3(data, i);
+            if (r1 != r2) {
+                throw new RuntimeException("Wrong result test3: " + r1 + " != " + r2);
             }
         }
     }
@@ -140,6 +148,39 @@ public class TestUnorderedReduction {
         return sum;
     }
 
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
+                  IRNode.ADD_VI, "> 0",
+                  IRNode.ADD_REDUCTION_VI, "> 0",},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    static int test3(int[] data, int sum) {
+        for (int i = 0; i < RANGE; i+=8) {
+            // Partial vectorization of reduction chain -> cannot move out of loop
+            sum += 11 * data[i+0]; // vec 1
+            sum += 13 & data[i+1]; // ---------- breaks vec 1 -> scalar reductions
+            sum += 11 * data[i+2];
+            sum += 11 * data[i+3];
+            sum += 11 * data[i+4]; // vec 2 -> vectorizes -> vector reduction
+            sum += 11 * data[i+5];
+            sum += 11 * data[i+6];
+            sum += 11 * data[i+7];
+        }
+        return sum;
+    }
+
+    static int ref3(int[] data, int sum) {
+        for (int i = 0; i < RANGE; i+=8) {
+            sum += 11 * data[i+0];
+            sum += 13 & data[i+1];
+            sum += 11 * data[i+2];
+            sum += 11 * data[i+3];
+            sum += 11 * data[i+4];
+            sum += 11 * data[i+5];
+            sum += 11 * data[i+6];
+            sum += 11 * data[i+7];
+        }
+        return sum;
+    }
 
     static void init(int[] data) {
         for (int i = 0; i < RANGE; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -150,7 +150,8 @@ public class TestUnorderedReduction {
 
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
-                  IRNode.ADD_VI, "> 0",
+                  IRNode.MUL_VI, "> 0",
+                  IRNode.ADD_VI, "= 0", // reduction not moved out of loop
                   IRNode.ADD_REDUCTION_VI, "> 0",},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static int test3(int[] data, int sum) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -61,7 +61,7 @@ public class TestUnorderedReductionPartialVectorization {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
                   IRNode.OR_REDUCTION_V, "> 0",},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i++) {
             // Mixing int and long ops means we only end up allowing half of the int

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -71,7 +71,7 @@ public class TestUnorderedReductionPartialVectorization {
             // with vectorization. That means we have a mixed scalar/vector reduction
             // chain. This way it is possible that a vector-reduction has a scalar
             // reduction as input, which is neigher a phi nor a vector reduction.
-            // In such a case, we must bail out of the optimization in 
+            // In such a case, we must bail out of the optimization in
             // PhaseIdealLoop::move_unordered_reduction_out_of_loop
             int v = data[i]; // int read
             data[0] = 0;     // ruin the first pack

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -39,8 +39,7 @@ public class TestUnorderedReductionPartialVectorization {
     static final int ITER  = 10;
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-Xbatch", "-XX:-TieredCompilation",
-                                   "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestUnorderedReductionPartialVectorization::test*");
+        TestFramework.run();
     }
 
     @Run(test = {"test1"})

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug JDK-8310130
+ * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ *          Here a case with partial vectorization of the reduction.
+ * @library /test/lib /
+ * @run driver compiler.loopopts.superword.TestUnorderedReductionPartialVectorization
+ */
+
+package compiler.loopopts.superword;
+
+import compiler.lib.ir_framework.*;
+
+public class TestUnorderedReductionPartialVectorization {
+    static final int RANGE = 1024;
+    static final int ITER  = 10;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-Xbatch", "-XX:-TieredCompilation",
+                                   "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestUnorderedReductionPartialVectorization::test*");
+    }
+
+    @Run(test = {"test1"})
+    @Warmup(0)
+    public void runTests() throws Exception {
+        int[] data = new int[RANGE];
+
+        init(data);
+        for (int i = 0; i < ITER; i++) {
+            long r1 = test1(data, i);
+            long r2 = ref1(data, i);
+            if (r1 != r2) {
+                throw new RuntimeException("Wrong result test1: " + r1 + " != " + r2);
+            }
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
+                  IRNode.OR_REDUCTION_V, "> 0",},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    static long test1(int[] data, long sum) {
+        for (int i = 0; i < data.length; i++) {
+            // Mixing int and long ops means we only end up allowing half of the int
+            // loads in one pack, and we have two int packs. The first pack has one
+            // of the pairs missing because of the store, which creates a dependency.
+            // The first pack is rejected and left as scalar, the second pack succeeds
+            // with vectorization. That means we have a mixed scalar/vector reduction
+            // chain. This way it is possible that a vector-reduction has a scalar
+            // reduction as input, which is neigher a phi nor a vector reduction.
+            // In such a case, we must bail out of the optimization in 
+            // PhaseIdealLoop::move_unordered_reduction_out_of_loop
+            int v = data[i]; // int read
+            data[0] = 0;     // ruin the first pack
+            sum |= v;        // long reduction
+        }
+        return sum;
+    }
+
+    static long ref1(int[] data, long sum) {
+        for (int i = 0; i < data.length; i++) {
+            int v = data[i];
+            data[0] = 0;
+            sum |= v;
+        }
+        return sum;
+    }
+
+    static void init(int[] data) {
+        for (int i = 0; i < RANGE; i++) {
+            data[i] = i + 1;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -26,6 +26,7 @@
  * @bug JDK-8310130
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
  *          Here a case with partial vectorization of the reduction.
+ * @requires vm.bits == "64"
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReductionPartialVectorization
  */

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -61,7 +61,7 @@ public class TestUnorderedReductionPartialVectorization {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
                   IRNode.OR_REDUCTION_V, "> 0",},
-        applyIfCPUFeatureOr = {"sse4.1", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i++) {
             // Mixing int and long ops means we only end up allowing half of the int


### PR DESCRIPTION
Removed a spurious assert before optimization bailout.

I assumed that the "scalar input" of a Reduction node must always be either a Phi or another Reduction node. But that is incorrect, partial vectorization can lead to a reduction node chain where we have vector reductions and scalar reductions at the same time. In those cases, we cannot move the UnorderedReductions out of the loop, so a optimization bailout is appropriate.

I assessed the other asserts in `PhaseIdealLoop::move_unordered_reduction_out_of_loop`, and I think they are all justified. However, one assert would have lead to a `continue` in production, which would not break out of the nested loop correctly. I changed it to a `return`, so that would be a bailout from the optimization. This assert should not be triggered because in `SuperWord::mark_reductions` we forbid that a reduction node has any uses inside the loop except for the successor node in the reduction chain.

I have one regression test delivered by the fuzzer, and one that I constructed myself after understanding the issue.
Testing up to tier6 and stress testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310130](https://bugs.openjdk.org/browse/JDK-8310130): C2: assert(false) failed: scalar_input is neither phi nor a matchin reduction (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [53e8913e](https://git.openjdk.org/jdk/pull/14494/files/53e8913ec04a7a466ef8e0fc68c8d78bdecf80f9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14494/head:pull/14494` \
`$ git checkout pull/14494`

Update a local copy of the PR: \
`$ git checkout pull/14494` \
`$ git pull https://git.openjdk.org/jdk.git pull/14494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14494`

View PR using the GUI difftool: \
`$ git pr show -t 14494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14494.diff">https://git.openjdk.org/jdk/pull/14494.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14494#issuecomment-1596778249)