### PR TITLE
8310133: Effectivelly final condition not enforced in guards for binding variables from the same case

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -3233,7 +3233,7 @@ public class Flow {
         void checkEffectivelyFinal(DiagnosticPosition pos, VarSymbol sym) {
             if (currentTree != null &&
                     sym.owner.kind == MTH &&
-                    sym.pos < currentTree.getStartPosition()) {
+                    sym.pos < getCurrentTreeStartPosition()) {
                 switch (currentTree.getTag()) {
                     case CLASSDEF:
                     case CASE:
@@ -3243,6 +3243,11 @@ public class Flow {
                         }
                 }
             }
+        }
+
+        int getCurrentTreeStartPosition() {
+            return currentTree instanceof JCCase cse ? cse.guard.getStartPosition()
+                                                     : currentTree.getStartPosition();
         }
 
         @SuppressWarnings("fallthrough")

--- a/test/langtools/tools/javac/patterns/GuardsErrors.java
+++ b/test/langtools/tools/javac/patterns/GuardsErrors.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8262891
+ * @bug 8262891 8310133
  * @summary Check errors reported for guarded patterns.
  * @compile/fail/ref=GuardsErrors.out -XDrawDiagnostics GuardsErrors.java
  */
@@ -54,6 +54,9 @@ public class GuardsErrors {
                     return i == 2;
                 }
             }.test() -> {}
+            case Integer v when v != null -> {
+                v = null;
+            }
             case Number v1 when v1 instanceof Integer v2 && (v2 = 0) == 0 -> {}
             default -> {}
         }

--- a/test/langtools/tools/javac/patterns/GuardsErrors.out
+++ b/test/langtools/tools/javac/patterns/GuardsErrors.out
@@ -2,5 +2,6 @@ GuardsErrors.java:36:38: compiler.err.cant.ref.non.effectively.final.var: check,
 GuardsErrors.java:47:34: compiler.err.cannot.assign.not.declared.guard: i1
 GuardsErrors.java:48:33: compiler.err.cant.ref.non.effectively.final.var: i2, (compiler.misc.guard)
 GuardsErrors.java:49:35: compiler.err.cant.ref.non.effectively.final.var: i2, (compiler.misc.guard)
-GuardsErrors.java:64:34: compiler.err.cannot.assign.not.declared.guard: f
-5 errors
+GuardsErrors.java:57:33: compiler.err.cant.ref.non.effectively.final.var: v, (compiler.misc.guard)
+GuardsErrors.java:67:34: compiler.err.cannot.assign.not.declared.guard: f
+6 errors


### PR DESCRIPTION
Consider code containing snippet like:
```
...
case String s when s.isEmpty() -> {
s = null;
}
...
````

The `s` binding variable is obviously not effectively final, but the specification currently requires variables used inside the guard to be effectively final or final.

The cause here is in a position check - for error reporting we need to sent a shared variable `currentTree` to the case, but the effectively final check will only check variables declared before the start of `currentTree` (to avoid reporting issues for variables inside a lambda, for example). The proposed fix is to keep the case inside `currentTree`, but ensure the guard's starting position is used, to allow a proper effectively final check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310133](https://bugs.openjdk.org/browse/JDK-8310133): Effectivelly final condition not enforced in guards for binding variables from the same case (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14498/head:pull/14498` \
`$ git checkout pull/14498`

Update a local copy of the PR: \
`$ git checkout pull/14498` \
`$ git pull https://git.openjdk.org/jdk.git pull/14498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14498`

View PR using the GUI difftool: \
`$ git pr show -t 14498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14498.diff">https://git.openjdk.org/jdk/pull/14498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14498#issuecomment-1593385391)