### PR TITLE
8310170: Use sp's argument to improve performance of outputStream::indent and remove SP_USE_TABS

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -186,18 +186,9 @@ void outputStream::put(char ch) {
   write(buf, 1);
 }
 
-#define SP_USE_TABS false
-
 void outputStream::sp(int count) {
   if (count < 0)  return;
-  if (SP_USE_TABS && count >= 8) {
-    int target = position() + count;
-    while (count >= 8) {
-      this->write("\t", 1);
-      count -= 8;
-    }
-    count = target - position();
-  }
+
   while (count > 0) {
     int nw = (count > 8) ? 8 : count;
     this->write("        ", nw);

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -257,7 +257,7 @@ void outputStream::date_stamp(bool guard,
 }
 
 outputStream& outputStream::indent() {
-  while (_position < _indentation) sp();
+  sp(_indentation - _position);
   return *this;
 }
 


### PR DESCRIPTION
Hi,

Please consider this small enhancement. `sp` takes a count argument, this was never used by `indent`, let's just use it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310170](https://bugs.openjdk.org/browse/JDK-8310170): Use sp's argument to improve performance of outputStream::indent and remove SP_USE_TABS (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [d9ee4c2f](https://git.openjdk.org/jdk/pull/14502/files/d9ee4c2f8093848b1b62b4890fa90fdd2530d4c3)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14502/head:pull/14502` \
`$ git checkout pull/14502`

Update a local copy of the PR: \
`$ git checkout pull/14502` \
`$ git pull https://git.openjdk.org/jdk.git pull/14502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14502`

View PR using the GUI difftool: \
`$ git pr show -t 14502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14502.diff">https://git.openjdk.org/jdk/pull/14502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14502#issuecomment-1594333513)