### PR TITLE
JDK-8309747: Update --release 21 symbol information for JDK 21 build 27

### DIFF
--- a/src/jdk.compiler/share/data/symbols/java.base-L.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.base-L.sym.txt
@@ -668,6 +668,8 @@ class name java/lang/invoke/VarHandle
 header extends java/lang/Object implements java/lang/constant/Constable nestMembers java/lang/invoke/VarHandle$VarHandleDesc,java/lang/invoke/VarHandle$AccessMode sealed true flags 421
 innerclass innerClass java/lang/invoke/VarHandle$AccessMode outerClass java/lang/invoke/VarHandle innerClassName AccessMode flags 4019
 innerclass innerClass java/lang/invoke/VarHandle$VarHandleDesc outerClass java/lang/invoke/VarHandle innerClassName VarHandleDesc flags 19
+-method name isAccessModeSupported descriptor (Ljava/lang/invoke/VarHandle$AccessMode;)Z
+method name isAccessModeSupported descriptor (Ljava/lang/invoke/VarHandle$AccessMode;)Z flags 1
 
 class name java/lang/module/Configuration
 header extends java/lang/Object flags 31


### PR DESCRIPTION
Usual symbol file update in JDK 22 for the newest JDK 21 build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309747](https://bugs.openjdk.org/browse/JDK-8309747): Update --release 21 symbol information for JDK 21 build 27 (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14503/head:pull/14503` \
`$ git checkout pull/14503`

Update a local copy of the PR: \
`$ git checkout pull/14503` \
`$ git pull https://git.openjdk.org/jdk.git pull/14503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14503`

View PR using the GUI difftool: \
`$ git pr show -t 14503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14503.diff">https://git.openjdk.org/jdk/pull/14503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14503#issuecomment-1593813152)