### PR TITLE
8310027: Fix -Wconversion warnings in nmethod and compiledMethod related code

### DIFF
--- a/src/hotspot/cpu/x86/relocInfo_x86.cpp
+++ b/src/hotspot/cpu/x86/relocInfo_x86.cpp
@@ -73,7 +73,7 @@ void Relocation::pd_set_data_value(address x, intptr_t o, bool verify_only) {
     if (verify_only) {
       guarantee(*(int32_t*) disp == (x - next_ip), "instructions must match");
     } else {
-      *(int32_t*) disp = x - next_ip;
+      *(int32_t*) disp = checked_cast<int32_t>(x - next_ip);
     }
   }
 #else
@@ -130,7 +130,7 @@ void Relocation::pd_set_call_destination(address x) {
     // %%%% kludge this, for now, until we get a jump_destination method
     address old_dest = nativeGeneralJump_at(addr())->jump_destination();
     address disp = Assembler::locate_operand(addr(), Assembler::call32_operand);
-    *(jint*)disp += (x - old_dest);
+    *(jint*)disp += checked_cast<jint>(x - old_dest);
   } else if (ni->is_mov_literal64()) {
     ((NativeMovConstReg*)ni)->set_data((intptr_t)x);
   } else {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -104,7 +104,7 @@ class CodeSection {
   bool        _locs_own;        // did I allocate the locs myself?
   bool        _scratch_emit;    // Buffer is used for scratch emit, don't relocate.
   int         _skipped_instructions_size;
-  char        _index;           // my section number (SECT_INST, etc.)
+  int8_t      _index;           // my section number (SECT_INST, etc.)
   CodeBuffer* _outer;           // enclosing CodeBuffer
 
   // (Note:  _locs_point used to be called _last_reloc_offset.)
@@ -121,11 +121,11 @@ class CodeSection {
     _locs_own      = false;
     _scratch_emit  = false;
     _skipped_instructions_size = 0;
-    debug_only(_index = (char)-1);
+    debug_only(_index = -1);
     debug_only(_outer = (CodeBuffer*)badAddress);
   }
 
-  void initialize_outer(CodeBuffer* outer, int index) {
+  void initialize_outer(CodeBuffer* outer, int8_t index) {
     _outer = outer;
     _index = index;
   }
@@ -173,7 +173,7 @@ class CodeSection {
   csize_t     locs_point_off() const{ return (csize_t)(_locs_point - _start); }
   csize_t     locs_capacity() const { return (csize_t)(_locs_limit - _locs_start); }
 
-  int         index() const         { return _index; }
+  int8_t      index() const         { return _index; }
   bool        is_allocated() const  { return _start != nullptr; }
   bool        is_empty() const      { return _start == _end; }
   bool        has_locs() const      { return _locs_end != nullptr; }
@@ -396,7 +396,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
  public:
   typedef int csize_t;  // code size type; would be size_t except for history
-  enum {
+  enum : int8_t {
     // Here is the list of all possible sections.  The order reflects
     // the final layout.
     SECT_FIRST = 0,

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -679,7 +679,7 @@ bool CompiledMethod::cleanup_inline_caches_impl(bool unloading_occurred, bool cl
 address CompiledMethod::continuation_for_implicit_exception(address pc, bool for_div0_check) {
   // Exception happened outside inline-cache check code => we are inside
   // an active nmethod => use cpc to determine a return address
-  int exception_offset = pc - code_begin();
+  int exception_offset = int(pc - code_begin());
   int cont_offset = ImplicitExceptionTable(this).continuation_offset( exception_offset );
 #ifdef ASSERT
   if (cont_offset == 0) {

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -206,11 +206,11 @@ public:
   bool  has_wide_vectors() const                  { return _has_wide_vectors; }
   void  set_has_wide_vectors(bool z)              { _has_wide_vectors = z; }
 
-  enum { not_installed = -1, // in construction, only the owner doing the construction is
-                             // allowed to advance state
-         in_use        = 0,  // executable nmethod
-         not_used      = 1,  // not entrant, but revivable
-         not_entrant   = 2,  // marked for deoptimization but activations may still exist
+  enum : signed char { not_installed = -1, // in construction, only the owner doing the construction is
+                                           // allowed to advance state
+                       in_use        = 0,  // executable nmethod
+                       not_used      = 1,  // not entrant, but revivable
+                       not_entrant   = 2,  // marked for deoptimization but activations may still exist
   };
 
   virtual bool  is_in_use() const = 0;
@@ -266,11 +266,11 @@ public:
 
   address scopes_data_begin() const { return _scopes_data_begin; }
   virtual address scopes_data_end() const = 0;
-  int scopes_data_size() const { return scopes_data_end() - scopes_data_begin(); }
+  int scopes_data_size() const { return int(scopes_data_end() - scopes_data_begin()); }
 
   virtual PcDesc* scopes_pcs_begin() const = 0;
   virtual PcDesc* scopes_pcs_end() const = 0;
-  int scopes_pcs_size() const { return (intptr_t) scopes_pcs_end() - (intptr_t) scopes_pcs_begin(); }
+  int scopes_pcs_size() const { return int((intptr_t) scopes_pcs_end() - (intptr_t) scopes_pcs_begin()); }
 
   address insts_begin() const { return code_begin(); }
   address insts_end() const { return stub_begin(); }
@@ -279,31 +279,31 @@ public:
   bool insts_contains(address addr) const { return insts_begin() <= addr && addr < insts_end(); }
   bool insts_contains_inclusive(address addr) const { return insts_begin() <= addr && addr <= insts_end(); }
 
-  int insts_size() const { return insts_end() - insts_begin(); }
+  int insts_size() const { return int(insts_end() - insts_begin()); }
 
   virtual address consts_begin() const = 0;
   virtual address consts_end() const = 0;
   bool consts_contains(address addr) const { return consts_begin() <= addr && addr < consts_end(); }
-  int consts_size() const { return consts_end() - consts_begin(); }
+  int consts_size() const { return int(consts_end() - consts_begin()); }
 
   virtual int skipped_instructions_size() const = 0;
 
   virtual address stub_begin() const = 0;
   virtual address stub_end() const = 0;
   bool stub_contains(address addr) const { return stub_begin() <= addr && addr < stub_end(); }
-  int stub_size() const { return stub_end() - stub_begin(); }
+  int stub_size() const { return int(stub_end() - stub_begin()); }
 
   virtual address handler_table_begin() const = 0;
   virtual address handler_table_end() const = 0;
   bool handler_table_contains(address addr) const { return handler_table_begin() <= addr && addr < handler_table_end(); }
-  int handler_table_size() const { return handler_table_end() - handler_table_begin(); }
+  int handler_table_size() const { return int(handler_table_end() - handler_table_begin()); }
 
   virtual address exception_begin() const = 0;
 
   virtual address nul_chk_table_begin() const = 0;
   virtual address nul_chk_table_end() const = 0;
   bool nul_chk_table_contains(address addr) const { return nul_chk_table_begin() <= addr && addr < nul_chk_table_end(); }
-  int nul_chk_table_size() const { return nul_chk_table_end() - nul_chk_table_begin(); }
+  int nul_chk_table_size() const { return int(nul_chk_table_end() - nul_chk_table_begin()); }
 
   virtual oop* oop_addr_at(int index) const = 0;
   virtual Metadata** metadata_addr_at(int index) const = 0;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -221,7 +221,7 @@ class nmethod : public CompiledMethod {
 #endif
   int _nmethod_end_offset;
 
-  int code_offset() const { return (address) code_begin() - header_begin(); }
+  int code_offset() const { return int(code_begin() - header_begin()); }
 
   // location in frame (offset for sp) that deopt can store the original
   // pc during a deopt.
@@ -307,7 +307,7 @@ class nmethod : public CompiledMethod {
 
   const char* reloc_string_for(u_char* begin, u_char* end);
 
-  bool try_transition(int new_state);
+  bool try_transition(signed char new_state);
 
   // Returns true if this thread changed the state of the nmethod or
   // false if another thread performed the transition.
@@ -321,7 +321,7 @@ class nmethod : public CompiledMethod {
   void init_defaults();
 
   // Offsets
-  int content_offset() const                  { return content_begin() - header_begin(); }
+  int content_offset() const                  { return int(content_begin() - header_begin()); }
   int data_offset() const                     { return _data_offset; }
 
   address header_end() const                  { return (address)    header_begin() + header_size(); }
@@ -407,12 +407,12 @@ class nmethod : public CompiledMethod {
 #endif
 
   // Sizes
-  int oops_size         () const                  { return (address)  oops_end         () - (address)  oops_begin         (); }
-  int metadata_size     () const                  { return (address)  metadata_end     () - (address)  metadata_begin     (); }
-  int dependencies_size () const                  { return            dependencies_end () -            dependencies_begin (); }
+  int oops_size         () const                  { return int((address)  oops_end         () - (address)  oops_begin         ()); }
+  int metadata_size     () const                  { return int((address)  metadata_end     () - (address)  metadata_begin     ()); }
+  int dependencies_size () const                  { return int(           dependencies_end () -            dependencies_begin ()); }
 #if INCLUDE_JVMCI
-  int speculations_size () const                  { return            speculations_end () -            speculations_begin (); }
-  int jvmci_data_size   () const                  { return            jvmci_data_end   () -            jvmci_data_begin   (); }
+  int speculations_size () const                  { return int(           speculations_end () -            speculations_begin ()); }
+  int jvmci_data_size   () const                  { return int(           jvmci_data_end   () -            jvmci_data_begin   ()); }
 #endif
 
   int     oops_count() const { assert(oops_size() % oopSize == 0, "");  return (oops_size() / oopSize) + 1; }

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -76,7 +76,7 @@ relocInfo* relocInfo::finish_prefix(short* prefix_limit) {
   assert(sizeof(relocInfo) == sizeof(short), "change this code");
   short* p = (short*)(this+1);
   assert(prefix_limit >= p, "must be a valid span of data");
-  int plen = prefix_limit - p;
+  int plen = checked_cast<int>(prefix_limit - p);
   if (plen == 0) {
     debug_only(_value = 0xFFFF);
     return this;                         // no data: remove self completely


### PR DESCRIPTION
This change adds casts to nmethod and compiled method offset and size functions that return int, and checked_casts where it's not obvious or already checked that the cast is correct.
Tested with tier1 on Oracle platforms, and tier1-4 linux and windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310027](https://bugs.openjdk.org/browse/JDK-8310027): Fix -Wconversion warnings in nmethod and compiledMethod related code (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14505/head:pull/14505` \
`$ git checkout pull/14505`

Update a local copy of the PR: \
`$ git checkout pull/14505` \
`$ git pull https://git.openjdk.org/jdk.git pull/14505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14505`

View PR using the GUI difftool: \
`$ git pr show -t 14505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14505.diff">https://git.openjdk.org/jdk/pull/14505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14505#issuecomment-1594615653)