### PR TITLE
8310183: Update GitHub Actions to use boot JDK for building jtreg

### DIFF
--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk bootjdk/jdk
+        bash make/build.sh
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$(realpath bootjdk/jdk)
+        bash make/build.sh --jdk "$(realpath bootjdk/jdk)"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -54,17 +54,10 @@ runs:
         path: jtreg/src
       if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
 
-    - name: 'Install JDK'
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'oracle'
-        java-version: '17'
-      if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
-
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME"
+        bash make/build.sh --jdk "$(realpath bootjdk/jdk)
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -54,10 +54,17 @@ runs:
         path: jtreg/src
       if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
 
+    - name: 'Install JDK'
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'oracle'
+        java-version: '17'
+      if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
+
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh
+        bash make/build.sh --jdk "$JAVA_HOME"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -56,10 +56,8 @@ runs:
 
     - name: 'Build JTReg'
       run: |
-        # Prevent "Bad address" errors
-        export MSYS2_ARG_CONV_EXCL='*'
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME_11_X64"
+        bash make/build.sh --jdk bootjdk/jdk
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -56,8 +56,10 @@ runs:
 
     - name: 'Build JTReg'
       run: |
+        # Prevent "Bad address" errors
+        export MSYS2_ARG_CONV_EXCL='*'
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
+        bash make/build.sh --jdk "$JAVA_HOME_11_X64"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src


### PR DESCRIPTION
Please review this change to use the boot JDK for building jtreg when running on GitHub Actions.

This is a best-effort follow-up change to
- #14448
which didn't have the desired results - the `Bad address` error does still appear with using the pre-installed JDKs 11 and 17.

Tests using the boot JDK for building jtreg seem to be successful and more stable.