### PR TITLE
8310187: Improve Generational ZGC jtreg testing

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1296,6 +1296,11 @@ WB_ENTRY(jboolean, WB_IsConstantVMFlag(JNIEnv* env, jobject o, jstring name))
   return (flag != nullptr) && flag->is_constant_in_binary();
 WB_END
 
+WB_ENTRY(jboolean, WB_IsDefaultVMFlag(JNIEnv* env, jobject o, jstring name))
+  const JVMFlag* flag = getVMFlag(thread, env, name);
+  return (flag != nullptr) && flag->is_default();
+WB_END
+
 WB_ENTRY(jboolean, WB_IsLockedVMFlag(JNIEnv* env, jobject o, jstring name))
   const JVMFlag* flag = getVMFlag(thread, env, name);
   return (flag != nullptr) && !(flag->is_unlocked() || flag->is_unlocker());
@@ -2693,6 +2698,7 @@ static JNINativeMethod methods[] = {
                                                         (void*)&WB_ShouldPrintAssembly},
 
   {CC"isConstantVMFlag",   CC"(Ljava/lang/String;)Z", (void*)&WB_IsConstantVMFlag},
+  {CC"isDefaultVMFlag",    CC"(Ljava/lang/String;)Z", (void*)&WB_IsDefaultVMFlag},
   {CC"isLockedVMFlag",     CC"(Ljava/lang/String;)Z", (void*)&WB_IsLockedVMFlag},
   {CC"setBooleanVMFlag",   CC"(Ljava/lang/String;Z)V",(void*)&WB_SetBooleanVMFlag},
   {CC"setIntVMFlag",       CC"(Ljava/lang/String;J)V",(void*)&WB_SetIntVMFlag},

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -59,6 +59,8 @@ requires.properties= \
     vm.gc.Shenandoah \
     vm.gc.Epsilon \
     vm.gc.Z \
+    vm.gc.ZGenerational \
+    vm.gc.ZSinglegen \
     vm.jvmci \
     vm.emulatedClient \
     vm.cpu.features \

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *          necessary barriers. The tests use volatile memory accesses and
  *          blackholes to prevent C2 from simply optimizing them away.
  * @library /test/lib /
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @run driver compiler.gcbarriers.TestZGCBarrierElision test-correctness
  */
 
@@ -43,7 +43,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * @summary Test that the ZGC barrier elision optimization elides unnecessary
  *          barriers following simple allocation and domination rules.
  * @library /test/lib /
- * @requires vm.gc.Z & vm.opt.final.ZGenerational & (vm.simpleArch == "x64" | vm.simpleArch == "aarch64")
+ * @requires vm.gc.ZGenerational & (vm.simpleArch == "x64" | vm.simpleArch == "aarch64")
  * @run driver compiler.gcbarriers.TestZGCBarrierElision test-effectiveness
  */
 
@@ -99,7 +99,7 @@ public class TestZGCBarrierElision {
         }
         String commonName = Common.class.getName();
         TestFramework test = new TestFramework(testClass);
-        test.addFlags("-XX:+UseZGC", "-XX:+UnlockExperimentalVMOptions",
+        test.addFlags("-XX:+UseZGC", "-XX:+ZGenerational", "-XX:+UnlockExperimentalVMOptions",
                       "-XX:CompileCommand=blackhole," + commonName + "::blackhole",
                       "-XX:CompileCommand=dontinline," + commonName + "::nonInlinedMethod",
                       "-XX:LoopMaxUnroll=0");

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -22,14 +22,14 @@
  */
 
 /*
- * @test id=ZDebug
+ * @test id=ZSinglegenDebug
  * @key randomness
  * @bug 8059022 8271855
  * @modules java.base/jdk.internal.misc:+open
  * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
- * @requires vm.gc.Z & vm.debug
+ * @requires vm.gc.ZSinglegen & vm.debug
  * @library /test/lib
- * @run main/othervm -XX:+UseZGC
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+ZVerifyOops -XX:ZCollectionInterval=1
  *                   -XX:-CreateCoredumpOnCrash
@@ -38,14 +38,46 @@
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @key randomness
  * @bug 8059022 8271855
  * @modules java.base/jdk.internal.misc:+open
  * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
- * @requires vm.gc.Z & !vm.debug
+ * @requires vm.gc.ZSinglegen & !vm.debug
  * @library /test/lib
- * @run main/othervm -XX:+UseZGC
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:ZCollectionInterval=1
+ *                   -XX:-CreateCoredumpOnCrash
+ *                   -XX:CompileCommand=dontinline,*::mergeImpl*
+ *                   compiler.gcbarriers.UnsafeIntrinsicsTest
+ */
+
+/*
+ * @test id=ZGenerationalDebug
+ * @key randomness
+ * @bug 8059022 8271855
+ * @modules java.base/jdk.internal.misc:+open
+ * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
+ * @requires vm.gc.ZGenerational & vm.debug
+ * @library /test/lib
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+ZVerifyOops -XX:ZCollectionInterval=1
+ *                   -XX:-CreateCoredumpOnCrash
+ *                   -XX:CompileCommand=dontinline,*::mergeImpl*
+ *                   compiler.gcbarriers.UnsafeIntrinsicsTest
+ */
+
+/*
+ * @test id=ZGenerational
+ * @key randomness
+ * @bug 8059022 8271855
+ * @modules java.base/jdk.internal.misc:+open
+ * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
+ * @requires vm.gc.ZGenerational & !vm.debug
+ * @library /test/lib
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:ZCollectionInterval=1
  *                   -XX:-CreateCoredumpOnCrash

--- a/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
@@ -22,14 +22,25 @@
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @key stress randomness
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @bug 8237859
  * @summary A LoadP node has a wrong control input (too early) which results in an out-of-bounds read of an object array with ZGC.
  *
- * @run main/othervm -XX:+UseZGC compiler.loopopts.TestRangeCheckPredicatesControl
- * @run main/othervm -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
+ */
+
+/*
+ * @test id=ZGenerational
+ * @key stress randomness
+ * @requires vm.gc.ZGenerational
+ * @bug 8237859
+ * @summary A LoadP node has a wrong control input (too early) which results in an out-of-bounds read of an object array with ZGC.
+ *
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
  */
 
 package compiler.loopopts;

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestNoWarningLoopStripMiningIterSet.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestNoWarningLoopStripMiningIterSet.java
@@ -44,14 +44,25 @@
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @bug 8241486
  * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
  * @requires vm.flagless
  * @requires vm.flavor == "server" & !vm.graal.enabled
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
- * @run driver TestNoWarningLoopStripMiningIterSet Z
+ * @run driver TestNoWarningLoopStripMiningIterSet Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8241486
+ * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
+ * @requires vm.flagless
+ * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @run driver TestNoWarningLoopStripMiningIterSet Z -XX:+ZGenerational
  */
 
 /*
@@ -95,9 +106,18 @@ public class TestNoWarningLoopStripMiningIterSet {
 
     public static void main(String[] args) throws Exception {
         String gc = "-XX:+Use" + args[0] + "GC";
-        testWith(output -> output.shouldNotContain(CLSOffLSMGreaterZero), "should have CLS and LSM enabled", true, 100, "-XX:LoopStripMiningIter=100", gc);
-        testWith(output -> output.shouldContain(CLSOffLSMGreaterZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=100", gc);
-        testWith(output -> output.shouldContain(CLSOnLSMEqualZero), "should have CLS and LSM enabled", true, 1, "-XX:LoopStripMiningIter=0", gc);
-        testWith(output -> output.shouldNotContain(CLSOnLSMEqualZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=0", gc);
+        if (args.length > 1) {
+            String extraVMArg = args[1];
+            testWith(output -> output.shouldNotContain(CLSOffLSMGreaterZero), "should have CLS and LSM enabled", true, 100, "-XX:LoopStripMiningIter=100", gc, extraVMArg);
+            testWith(output -> output.shouldContain(CLSOffLSMGreaterZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=100", gc, extraVMArg);
+            testWith(output -> output.shouldContain(CLSOnLSMEqualZero), "should have CLS and LSM enabled", true, 1, "-XX:LoopStripMiningIter=0", gc, extraVMArg);
+            testWith(output -> output.shouldNotContain(CLSOnLSMEqualZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=0", gc, extraVMArg);
+        } else {
+            testWith(output -> output.shouldNotContain(CLSOffLSMGreaterZero), "should have CLS and LSM enabled", true, 100, "-XX:LoopStripMiningIter=100", gc);
+            testWith(output -> output.shouldContain(CLSOffLSMGreaterZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=100", gc);
+            testWith(output -> output.shouldContain(CLSOnLSMEqualZero), "should have CLS and LSM enabled", true, 1, "-XX:LoopStripMiningIter=0", gc);
+            testWith(output -> output.shouldNotContain(CLSOnLSMEqualZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=0", gc);
+
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -34,15 +34,28 @@
  */
 
 /*
- * @test
+ * @test id=ZSinglegen
  * @bug 8273456
  * @summary Test that ttyLock is ranked above StackWatermark_lock
- * @requires !vm.graal.enabled & vm.gc.Z
+ * @requires !vm.graal.enabled & vm.gc.ZSinglegen
  * @run main/othervm -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
  *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+UseZGC -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
+ *      -XX:+UseZGC -XX:-ZGenerational -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
+ *      compiler.uncommontrap.TestDeoptOOM
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8273456
+ * @summary Test that ttyLock is ranked above StackWatermark_lock
+ * @requires !vm.graal.enabled & vm.gc.ZGenerational
+ * @run main/othervm -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+UseZGC -XX:+ZGenerational -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
  *      compiler.uncommontrap.TestDeoptOOM
  */
 

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
@@ -53,7 +53,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:CompileCommand=compileonly,jdk/incubator/vector/ByteVector.fromMemorySegment
- *      -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:+UseZGC -XX:-ZGenerational -Xbatch -Xmx256m VectorRebracket128Test
+ *      -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:+UseZGC -XX:+ZGenerational -Xbatch -Xmx256m VectorRebracket128Test
  */
 
 @Test

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
@@ -35,14 +35,25 @@ import jdk.incubator.vector.*;
 import jdk.internal.vm.annotation.ForceInline;
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @bug 8260473
  * @enablePreview
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:CompileCommand=compileonly,jdk/incubator/vector/ByteVector.fromMemorySegment
- *      -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:+UseZGC -Xbatch -Xmx256m VectorRebracket128Test
+ *      -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:+UseZGC -XX:-ZGenerational -Xbatch -Xmx256m VectorRebracket128Test
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8260473
+ * @enablePreview
+ * @requires vm.gc.ZGenerational
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm -XX:CompileCommand=compileonly,jdk/incubator/vector/ByteVector.fromMemorySegment
+ *      -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:+UseZGC -XX:-ZGenerational -Xbatch -Xmx256m VectorRebracket128Test
  */
 
 @Test

--- a/test/hotspot/jtreg/gc/TestReferenceClearDuringReferenceProcessing.java
+++ b/test/hotspot/jtreg/gc/TestReferenceClearDuringReferenceProcessing.java
@@ -36,16 +36,27 @@ package gc;
  *      gc.TestReferenceClearDuringReferenceProcessing
  */
 
-/* @test id=Z
+/* @test id=ZSinglegen
  * @bug 8256517
- * @requires vm.gc.Z
- * @requires vm.gc != "null"
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm
  *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseZGC -XX:-ZGenerational
+ *      gc.TestReferenceClearDuringReferenceProcessing
+ */
+
+/* @test id=ZGenerational
+ * @bug 8256517
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm
+ *      -Xbootclasspath/a:.
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseZGC -XX:+ZGenerational
  *      gc.TestReferenceClearDuringReferenceProcessing
  */
 

--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -58,8 +58,8 @@ package gc;
  */
 
 /*
- * @test id=ZSingleGenMode
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @test id=ZSinglegen
+ * @requires vm.gc.ZSinglegen
  * @comment ZGC will not start when LargePages cannot be allocated, therefore
  *          we do not run such configuration.
  * @summary Runs System.gc() with different flags.
@@ -67,8 +67,8 @@ package gc;
  */
 
 /*
- * @test id=Z
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @test id=ZGenerational
+ * @requires vm.gc.ZGenerational
  * @comment ZGC will not start when LargePages cannot be allocated, therefore
  *          we do not run such configuration.
  * @summary Runs System.gc() with different flags.

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithZ.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithZ.java
@@ -27,29 +27,29 @@ package gc.stress.gcbasher;
 import java.io.IOException;
 
 /*
- * @test TestGCBasherWithZ
+ * @test TestGCBasherWithZGenerational
  * @key stress
  * @library /
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress ZGC
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx384m -server -XX:+UseZGC -XX:+ZGenerational  gc.stress.gcbasher.TestGCBasherWithZ 120000
  */
 /*
- * @test TestGCBasherWithZSingleGenMode
+ * @test TestGCBasherWithZSinglegen
  * @key stress
  * @library /
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress ZGC
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx384m -server -XX:+UseZGC -XX:-ZGenerational gc.stress.gcbasher.TestGCBasherWithZ 120000
  */
 
 /*
- * @test TestGCBasherDeoptWithZ
+ * @test TestGCBasherDeoptWithZGenerational
  * @key stress
  * @library /
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
  * @summary Stress ZGC with nmethod barrier forced deoptimization enabled.
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx384m -server -XX:+UseZGC -XX:+ZGenerational
@@ -58,10 +58,10 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithZSingleGenMode
+ * @test TestGCBasherDeoptWithZSinglegen
  * @key stress
  * @library /
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
  * @summary Stress ZGC with nmethod barrier forced deoptimization enabled.
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx384m -server -XX:+UseZGC -XX:-ZGenerational

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithZ.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithZ.java
@@ -25,20 +25,20 @@
 package gc.stress.gcold;
 
 /*
- * @test TestGCOldWithZ
+ * @test TestGCOldWithZGenerational
  * @key randomness
  * @library / /test/lib
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Stress the Z
  * @run main/othervm -Xmx384M -XX:+UseZGC -XX:+ZGenerational gc.stress.gcold.TestGCOldWithZ 50 1 20 10 10000
  * @run main/othervm -Xmx256m -XX:+UseZGC -XX:+ZGenerational gc.stress.gcold.TestGCOldWithZ 50 5 20 1 5000
  */
 
 /*
- * @test TestGCOldWithZSingleGenMode
+ * @test TestGCOldWithZSinglegen
  * @key randomness
  * @library / /test/lib
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Stress the Z
  * @run main/othervm -Xmx384M -XX:+UseZGC -XX:-ZGenerational gc.stress.gcold.TestGCOldWithZ 50 1 20 10 10000
  * @run main/othervm -Xmx256m -XX:+UseZGC -XX:-ZGenerational gc.stress.gcold.TestGCOldWithZ 50 5 20 1 5000

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationAgeThreshold.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationAgeThreshold.java
@@ -76,16 +76,29 @@ package gc.stringdedup;
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @summary Test string deduplication age threshold
  * @bug 8029075
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationAgeThreshold Z
+ * @run driver gc.stringdedup.TestStringDeduplicationAgeThreshold Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @summary Test string deduplication age threshold
+ * @bug 8029075
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationAgeThreshold Z -XX:+ZGenerational
  */
 
 public class TestStringDeduplicationAgeThreshold {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationFullGC.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationFullGC.java
@@ -76,16 +76,29 @@ package gc.stringdedup;
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @summary Test string deduplication during full GC
  * @bug 8029075
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationFullGC Z
+ * @run driver gc.stringdedup.TestStringDeduplicationFullGC Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @summary Test string deduplication during full GC
+ * @bug 8029075
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationFullGC Z -XX:+ZGenerational
  */
 
 public class TestStringDeduplicationFullGC {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationInterned.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationInterned.java
@@ -76,16 +76,29 @@ package gc.stringdedup;
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @summary Test string deduplication of interned strings
  * @bug 8029075
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationInterned Z
+ * @run driver gc.stringdedup.TestStringDeduplicationInterned Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @summary Test string deduplication of interned strings
+ * @bug 8029075
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationInterned Z -XX:+ZGenerational
  */
 
 public class TestStringDeduplicationInterned {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationPrintOptions.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationPrintOptions.java
@@ -76,16 +76,29 @@ package gc.stringdedup;
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @summary Test string deduplication print options
  * @bug 8029075
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationPrintOptions Z
+ * @run driver gc.stringdedup.TestStringDeduplicationPrintOptions Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @summary Test string deduplication print options
+ * @bug 8029075
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationPrintOptions Z -XX:+ZGenerational
  */
 
 public class TestStringDeduplicationPrintOptions {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTableResize.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTableResize.java
@@ -76,16 +76,29 @@ package gc.stringdedup;
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @summary Test string deduplication table resize
  * @bug 8029075
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationTableResize Z
+ * @run driver gc.stringdedup.TestStringDeduplicationTableResize Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @summary Test string deduplication table resize
+ * @bug 8029075
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationTableResize Z -XX:+ZGenerational
  */
 
 public class TestStringDeduplicationTableResize {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -55,6 +55,7 @@ class TestStringDeduplicationTools {
     private static byte[] dummy;
 
     private static String selectedGC = null;
+    private static String selectedGCMode = null;
 
     static {
         try {
@@ -71,6 +72,9 @@ class TestStringDeduplicationTools {
 
     public static void selectGC(String[] args) {
         selectedGC = args[0];
+        if (args.length > 1) {
+            selectedGCMode = args[1];
+        }
     }
 
     private static Object getValue(String string) {
@@ -289,6 +293,9 @@ class TestStringDeduplicationTools {
 
         ArrayList<String> args = new ArrayList<String>();
         args.add("-XX:+Use" + selectedGC + "GC");
+        if (selectedGCMode != null) {
+            args.add(selectedGCMode);
+        }
         args.addAll(Arrays.asList(defaultArgs));
         args.addAll(Arrays.asList(extraArgs));
 

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationYoungGC.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationYoungGC.java
@@ -76,16 +76,29 @@ package gc.stringdedup;
  */
 
 /*
- * @test id=Z
+ * @test id=ZSinglegen
  * @summary Test string deduplication during young GC
  * @bug 8029075
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationYoungGC Z
+ * @run driver gc.stringdedup.TestStringDeduplicationYoungGC Z -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @summary Test string deduplication during young GC
+ * @bug 8029075
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationYoungGC Z -XX:+ZGenerational
  */
 
 public class TestStringDeduplicationYoungGC {

--- a/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestAllocateHeapAt
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational & os.family == "linux"
+ * @requires vm.gc.ZSinglegen & os.family == "linux"
  * @summary Test ZGC with -XX:AllocateHeapAt
  * @library /test/lib
  * @run main/othervm gc.x.TestAllocateHeapAt . true

--- a/test/hotspot/jtreg/gc/x/TestAlwaysPreTouch.java
+++ b/test/hotspot/jtreg/gc/x/TestAlwaysPreTouch.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestAlwaysPreTouch
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC parallel pre-touch
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xlog:gc* -XX:-AlwaysPreTouch -Xms128M -Xmx128M gc.x.TestAlwaysPreTouch
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xlog:gc* -XX:+AlwaysPreTouch -XX:ParallelGCThreads=1 -Xms2M -Xmx128M gc.x.TestAlwaysPreTouch

--- a/test/hotspot/jtreg/gc/x/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/x/TestGarbageCollectorMXBean.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /**
  * @test TestGarbageCollectorMXBean
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms256M -Xmx512M -Xlog:gc gc.x.TestGarbageCollectorMXBean 256 512

--- a/test/hotspot/jtreg/gc/x/TestHighUsage.java
+++ b/test/hotspot/jtreg/gc/x/TestHighUsage.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestHighUsage
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC "High Usage" rule
  * @library /test/lib
  * @run main/othervm gc.x.TestHighUsage

--- a/test/hotspot/jtreg/gc/x/TestMemoryMXBean.java
+++ b/test/hotspot/jtreg/gc/x/TestMemoryMXBean.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /**
  * @test TestMemoryMXBean
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC heap memory MXBean
  * @modules java.management
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms128M -Xmx256M -Xlog:gc* gc.x.TestMemoryMXBean 128 256

--- a/test/hotspot/jtreg/gc/x/TestMemoryManagerMXBean.java
+++ b/test/hotspot/jtreg/gc/x/TestMemoryManagerMXBean.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /**
  * @test TestMemoryManagerMXBean
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC memory manager MXBean
  * @modules java.management
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx128M gc.x.TestMemoryManagerMXBean

--- a/test/hotspot/jtreg/gc/x/TestNoUncommit.java
+++ b/test/hotspot/jtreg/gc/x/TestNoUncommit.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestNoUncommit
- * @requires vm.gc.Z  & !vm.opt.final.ZGenerational & !vm.graal.enabled
+ * @requires vm.gc.ZSinglegen & !vm.graal.enabled
  * @summary Test ZGC uncommit unused memory disabled
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms512M -Xmx512M -XX:ZUncommitDelay=1 gc.x.TestNoUncommit
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms128M -Xmx512M -XX:ZUncommitDelay=1 -XX:-ZUncommit gc.x.TestNoUncommit

--- a/test/hotspot/jtreg/gc/x/TestPageCacheFlush.java
+++ b/test/hotspot/jtreg/gc/x/TestPageCacheFlush.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestPageCacheFlush
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC page cache flushing
  * @library /test/lib
  * @run driver gc.x.TestPageCacheFlush

--- a/test/hotspot/jtreg/gc/x/TestRelocateInPlace.java
+++ b/test/hotspot/jtreg/gc/x/TestRelocateInPlace.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestRelocateInPlace
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC in-place relocateion
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xlog:gc*,gc+stats=off -Xmx256M -XX:+UnlockDiagnosticVMOptions -XX:+ZStressRelocateInPlace gc.x.TestRelocateInPlace
  */

--- a/test/hotspot/jtreg/gc/x/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/x/TestSmallHeap.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestSmallHeap
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC with small heaps
  * @library / /test/lib
  * @run driver gc.x.TestSmallHeap 8M 16M 32M 64M 128M 256M 512M 1024M

--- a/test/hotspot/jtreg/gc/x/TestUncommit.java
+++ b/test/hotspot/jtreg/gc/x/TestUncommit.java
@@ -25,7 +25,7 @@ package gc.x;
 
 /*
  * @test TestUncommit
- * @requires vm.gc.Z & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @summary Test ZGC uncommit unused memory
  * @library /test/lib
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms128M -Xmx512M -XX:ZUncommitDelay=10 gc.x.TestUncommit

--- a/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestAllocateHeapAt
- * @requires vm.gc.Z & vm.opt.final.ZGenerational & os.family == "linux"
+ * @requires vm.gc.ZGenerational & os.family == "linux"
  * @summary Test ZGC with -XX:AllocateHeapAt
  * @library /test/lib
  * @run main/othervm gc.z.TestAllocateHeapAt . true

--- a/test/hotspot/jtreg/gc/z/TestAlwaysPreTouch.java
+++ b/test/hotspot/jtreg/gc/z/TestAlwaysPreTouch.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestAlwaysPreTouch
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC parallel pre-touch
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xlog:gc* -XX:-AlwaysPreTouch -Xms128M -Xmx128M gc.z.TestAlwaysPreTouch
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xlog:gc* -XX:+AlwaysPreTouch -XX:ParallelGCThreads=1 -Xms2M -Xmx128M gc.z.TestAlwaysPreTouch

--- a/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /**
  * @test TestGarbageCollectorMXBean
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms256M -Xmx512M -Xlog:gc gc.z.TestGarbageCollectorMXBean 256 512

--- a/test/hotspot/jtreg/gc/z/TestHighUsage.java
+++ b/test/hotspot/jtreg/gc/z/TestHighUsage.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestHighUsage
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC "High Usage" rule
  * @library /test/lib
  * @run main/othervm gc.z.TestHighUsage

--- a/test/hotspot/jtreg/gc/z/TestMemoryMXBean.java
+++ b/test/hotspot/jtreg/gc/z/TestMemoryMXBean.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /**
  * @test TestMemoryMXBean
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC heap memory MXBean
  * @modules java.management
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms128M -Xmx256M -Xlog:gc* gc.z.TestMemoryMXBean 128 256

--- a/test/hotspot/jtreg/gc/z/TestMemoryManagerMXBean.java
+++ b/test/hotspot/jtreg/gc/z/TestMemoryManagerMXBean.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /**
  * @test TestMemoryManagerMXBean
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC memory manager MXBean
  * @modules java.management
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx128M gc.z.TestMemoryManagerMXBean

--- a/test/hotspot/jtreg/gc/z/TestNoUncommit.java
+++ b/test/hotspot/jtreg/gc/z/TestNoUncommit.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestNoUncommit
- * @requires vm.gc.Z & vm.opt.final.ZGenerational & !vm.graal.enabled
+ * @requires vm.gc.ZGenerational & !vm.graal.enabled
  * @summary Test ZGC uncommit unused memory disabled
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms512M -Xmx512M -XX:ZUncommitDelay=1 gc.z.TestNoUncommit
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms128M -Xmx512M -XX:ZUncommitDelay=1 -XX:-ZUncommit gc.z.TestNoUncommit

--- a/test/hotspot/jtreg/gc/z/TestPageCacheFlush.java
+++ b/test/hotspot/jtreg/gc/z/TestPageCacheFlush.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestPageCacheFlush
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC page cache flushing
  * @library /test/lib
  * @run driver gc.z.TestPageCacheFlush

--- a/test/hotspot/jtreg/gc/z/TestRelocateInPlace.java
+++ b/test/hotspot/jtreg/gc/z/TestRelocateInPlace.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestRelocateInPlace
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC in-place relocateion
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xlog:gc*,gc+stats=off -Xmx256M -XX:+UnlockDiagnosticVMOptions -XX:+ZStressRelocateInPlace gc.z.TestRelocateInPlace
  */

--- a/test/hotspot/jtreg/gc/z/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/z/TestSmallHeap.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestSmallHeap
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC with small heaps
  * @library / /test/lib
  * @run driver gc.z.TestSmallHeap 8M 16M 32M 64M 128M 256M 512M 1024M

--- a/test/hotspot/jtreg/gc/z/TestUncommit.java
+++ b/test/hotspot/jtreg/gc/z/TestUncommit.java
@@ -25,7 +25,7 @@ package gc.z;
 
 /*
  * @test TestUncommit
- * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @summary Test ZGC uncommit unused memory
  * @library /test/lib
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xlog:gc*,gc+heap=debug,gc+stats=off -Xms128M -Xmx512M -XX:ZUncommitDelay=10 gc.z.TestUncommit

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
@@ -22,15 +22,29 @@
  */
 
 /*
- * @test 8232069 for ZGC
+ * @test id=ZSinglegen
+ * @bug 8232069
  * @requires vm.cds
  * @requires vm.bits == 64
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @requires vm.gc.Serial
  * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/Hello.java
- * @run driver TestZGCWithCDS
+ * @run driver TestZGCWithCDS -XX:-ZGenerational
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8232069
+ * @requires vm.cds
+ * @requires vm.bits == 64
+ * @requires vm.gc.ZGenerational
+ * @requires vm.gc.Serial
+ * @requires vm.gc == null
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @compile test-classes/Hello.java
+ * @run driver TestZGCWithCDS -XX:+ZGenerational
  */
 
 import jdk.test.lib.Platform;
@@ -41,12 +55,14 @@ public class TestZGCWithCDS {
     public final static String UNABLE_TO_USE_ARCHIVE = "Unable to use shared archive.";
     public final static String ERR_MSG = "The saved state of UseCompressedOops and UseCompressedClassPointers is different from runtime, CDS will be disabled.";
     public static void main(String... args) throws Exception {
+         String zGenerational = args[0];
          String helloJar = JarBuilder.build("hello", "Hello");
          System.out.println("0. Dump with ZGC");
          OutputAnalyzer out = TestCommon
                                   .dump(helloJar,
                                         new String[] {"Hello"},
                                         "-XX:+UseZGC",
+                                        zGenerational,
                                         "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
          out.shouldHaveExitValue(0);
@@ -55,6 +71,7 @@ public class TestZGCWithCDS {
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",
+                         zGenerational,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);
@@ -134,6 +151,7 @@ public class TestZGCWithCDS {
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",
+                         zGenerational,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -53,9 +53,9 @@
  */
 
 /**
- * @test id=custom-cl-zgc
+ * @test id=custom-cl-zgc-singlegen
  * @requires vm.cds.custom.loaders
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @summary Test dumptime_table entries are removed with zgc eager class unloading
  * @bug 8274935
  * @library /test/lib
@@ -67,6 +67,23 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc
+ */
+
+/**
+ * @test id=custom-cl-zgc-generational
+ * @requires vm.cds.custom.loaders
+ * @requires vm.gc.ZGenerational
+ * @summary Test dumptime_table entries are removed with zgc eager class unloading
+ * @bug 8274935
+ * @library /test/lib
+ *          /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive
+ * @modules java.base/jdk.internal.misc
+ *          jdk.httpserver
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc-generational
  */
 
 import com.sun.net.httpserver.HttpExchange;
@@ -101,10 +118,12 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
      */
     static boolean useCustomLoader;
     static boolean useZGC;
+    static boolean useZGenerational;
 
     public static void main(String[] args) throws Exception {
         useCustomLoader = (args.length != 0);
-        useZGC = (args.length != 0 && args[0].equals("custom-zgc"));
+        useZGenerational = (args.length != 0 && args[0].equals("custom-zgc-generational"));
+        useZGC = useZGenerational || (args.length != 0 && args[0].equals("custom-zgc"));
         runTest(DynamicLoaderConstraintsTest::doTest);
     }
 
@@ -130,7 +149,8 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
   static void doTest(boolean errorInDump) throws Exception  {
         for (int i = 1; i <= 3; i++) {
             System.out.println("========================================");
-            System.out.println("errorInDump: " + errorInDump + ", useCustomLoader: " + useCustomLoader + ", useZGC: " + useZGC + ", case: " + i);
+            System.out.println("errorInDump: " + errorInDump + ", useCustomLoader: " + useCustomLoader +
+                               ", useZGC: " + useZGC + ", ZGenerational: " + useZGenerational + ", case: " + i);
             System.out.println("========================================");
             String topArchiveName = getNewArchiveName();
             String testCase = Integer.toString(i);
@@ -144,9 +164,10 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
 
             if (useCustomLoader) {
                 if (useZGC) {
+                    String zGenerational = "-XX:" + (useZGenerational ? "+" : "-") + "ZGenerational";
                     // Add options to force eager class unloading.
                     cmdLine = TestCommon.concat(cmdLine, "-cp", loaderJar,
-                                                "-XX:+UseZGC", "-XX:ZCollectionInterval=0.01",
+                                                "-XX:+UseZGC", zGenerational, "-XX:ZCollectionInterval=0.01",
                                                 loaderMainClass, appJar);
                     setBaseArchiveOptions("-XX:+UseZGC", "-Xlog:cds");
                 } else {

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpCompressedTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpCompressedTest.java
@@ -71,15 +71,27 @@ import jdk.test.lib.process.OutputAnalyzer;
  */
 
 /*
- * @test id=Z
- * @requires vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.gc.ZSinglegen
  * @summary Test of diagnostic command GC.heap_dump with gzipped output (Z GC)
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+UseZGC HeapDumpCompressedTest
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational HeapDumpCompressedTest
+ */
+
+/*
+ * @test id=ZGenerational
+ * @requires vm.gc.ZGenerational
+ * @summary Test of diagnostic command GC.heap_dump with gzipped output (Z GC)
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational HeapDumpCompressedTest
  */
 
 /*

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -59,6 +59,8 @@ requires.properties= \
     vm.gc.Shenandoah \
     vm.gc.Epsilon \
     vm.gc.Z \
+    vm.gc.ZGenerational \
+    vm.gc.ZSinglegen \
     vm.graal.enabled \
     vm.compiler1.enabled \
     vm.compiler2.enabled \

--- a/test/jdk/java/awt/Graphics2D/LargeWindowPaintTest.java
+++ b/test/jdk/java/awt/Graphics2D/LargeWindowPaintTest.java
@@ -22,16 +22,36 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8240654
  * @summary Test painting a large window works
  * @key headful
  * @requires (os.family == "windows")
  * @requires vm.gc.Z
- * @run main/othervm -Dsun.java2d.uiScale=1 LargeWindowPaintTest
- * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false LargeWindowPaintTest
- * @run main/othervm -XX:+UseZGC -Dsun.java2d.uiScale=1 LargeWindowPaintTest
- * @run main/othervm -XX:+UseZGC -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false LargeWindowPaintTest
+ * @run main/othervm -XX:-UseZGC -Dsun.java2d.uiScale=1 LargeWindowPaintTest
+ * @run main/othervm -XX:-UseZGC -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false LargeWindowPaintTest
+ */
+
+/*
+ * @test id=ZSinglegen
+ * @bug 8240654
+ * @summary Test painting a large window works
+ * @key headful
+ * @requires (os.family == "windows")
+ * @requires vm.gc.ZSinglegen
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Dsun.java2d.uiScale=1 LargeWindowPaintTest
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false LargeWindowPaintTest
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8240654
+ * @summary Test painting a large window works
+ * @key headful
+ * @requires (os.family == "windows")
+ * @requires vm.gc.ZGenerational
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Dsun.java2d.uiScale=1 LargeWindowPaintTest
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false LargeWindowPaintTest
  */
 
 import java.awt.Color;

--- a/test/jdk/java/awt/print/PrinterJob/AlphaPrintTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/AlphaPrintTest.java
@@ -22,13 +22,23 @@
  */
 
 /*
- * @test
+ * @test id=ZSinglegen
  * @bug 8240654
  * @summary Test printing alpha colors - banded printing works with ZGC.
  * @key headful printer
  * @requires (os.family == "windows")
- * @requires vm.gc.Z
- * @run main/manual/othervm -XX:+UseZGC -Dsun.java2d.d3d=false AlphaPrintTest
+ * @requires vm.gc.ZSinglegen
+ * @run main/manual/othervm -XX:+UseZGC -XX:-ZGenerational -Dsun.java2d.d3d=false AlphaPrintTest
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8240654
+ * @summary Test printing alpha colors - banded printing works with ZGC.
+ * @key headful printer
+ * @requires (os.family == "windows")
+ * @requires vm.gc.ZGenerational
+ * @run main/manual/othervm -XX:+UseZGC -XX:+ZGenerational -Dsun.java2d.d3d=false AlphaPrintTest
  */
 
 import java.awt.Color;

--- a/test/jdk/java/foreign/stackwalk/TestAsyncStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestAsyncStackWalk.java
@@ -25,6 +25,7 @@
  * @test id=default_gc
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires vm.gc != "Z"
  * @library /test/lib
  * @library ../
  * @build jdk.test.whitebox.WhiteBox
@@ -40,10 +41,10 @@
  */
 
 /*
- * @test id=zgc
+ * @test id=ZSinglegen
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library ../
  * @build jdk.test.whitebox.WhiteBox
@@ -55,9 +56,30 @@
  *   -XX:+WhiteBoxAPI
  *   --enable-native-access=ALL-UNNAMED
  *   -Xbatch
- *   -XX:+UseZGC
+ *   -XX:+UseZGC -XX:-ZGenerational
  *   TestAsyncStackWalk
  */
+
+/*
+ * @test id=ZGenerational
+ * @enablePreview
+ * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library ../
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseZGC -XX:+ZGenerational
+ *   TestAsyncStackWalk
+ */
+
 /*
  * @test id=shenandoah
  * @enablePreview

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -25,6 +25,7 @@
  * @test id=default_gc
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires vm.gc != "Z"
  * @library /test/lib
  * @library ../
  * @build jdk.test.whitebox.WhiteBox
@@ -40,10 +41,10 @@
  */
 
 /*
- * @test id=zgc
+ * @test id=ZSinglegen
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library ../
  * @build jdk.test.whitebox.WhiteBox
@@ -55,9 +56,30 @@
  *   -XX:+WhiteBoxAPI
  *   --enable-native-access=ALL-UNNAMED
  *   -Xbatch
- *   -XX:+UseZGC
+ *   -XX:+UseZGC -XX:-ZGenerational
  *   TestStackWalk
  */
+
+/*
+ * @test id=ZGenerational
+ * @enablePreview
+ * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires vm.gc.ZGenerational
+ * @library /test/lib
+ * @library ../
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseZGC -XX:+ZGenerational
+ *   TestStackWalk
+ */
+
 /*
  * @test id=shenandoah
  * @enablePreview

--- a/test/jdk/java/lang/ProcessBuilder/CloseRace.java
+++ b/test/jdk/java/lang/ProcessBuilder/CloseRace.java
@@ -35,7 +35,7 @@
  * @test
  * @comment Turn up heap size to lower amount of GCs
  * @requires vm.gc.Z & vm.opt.final.ZGenerational
- * @run main/othervm -Xmx32M -Dtest.duration=2 CloseRace
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M -Dtest.duration=2 CloseRace
  */
 
 import java.io.*;

--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @summary Stress test virtual threads with a variation of the Skynet 1M benchmark
  * @requires vm.continuations
  * @requires !vm.debug | vm.gc != "Z"

--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -25,14 +25,25 @@
  * @test
  * @summary Stress test virtual threads with a variation of the Skynet 1M benchmark
  * @requires vm.continuations
+ * @requires !vm.debug | vm.gc != "Z"
  * @run main/othervm/timeout=300 -Xmx1g Skynet
  */
 
 /*
- * @test
+ * @test id=ZSinglegen
  * @requires vm.debug == true & vm.continuations
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+UseZGC -XX:-ZGenerational
+ *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1g Skynet
+ */
+
+/*
+ * @test id=ZGenerational
+ * @requires vm.debug == true & vm.continuations
+ * @requires vm.gc.ZGenerational
+ * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+UseZGC -XX:+ZGenerational
  *     -XX:+ZVerifyOops -XX:ZCollectionInterval=0.01 -Xmx1g Skynet
  */
 

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -34,27 +34,27 @@
  */
 
 /*
- * @test
+ * @test id=ZSinglegen
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc == "Z" & !vm.opt.final.ZGenerational
+ * @requires vm.gc.ZSinglegen
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 2 1
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational MemoryTest 2 1
  */
 
 /*
- * @test
+ * @test id=ZGenerational
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc == "Z" & vm.opt.final.ZGenerational
+ * @requires vm.gc.ZGenerational
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 4 2
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational MemoryTest 4 2
  */
 
 /*

--- a/test/jdk/jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java
+++ b/test/jdk/jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java
@@ -46,11 +46,19 @@
  */
 
 /*
- * @test id=with_ZGC
- * @requires vm.gc.Z
+ * @test id=with_ZGC_Singlegen
+ * @requires vm.gc.ZSinglegen
  * @bug 8198540
  * @summary Test TypeConverterFactory is not leaking method handles (Z GC)
- * @run main/othervm -XX:+UseZGC TypeConverterFactoryMemoryLeakTest
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational TypeConverterFactoryMemoryLeakTest
+ */
+
+/*
+ * @test id=with_ZGC_Generational
+ * @requires vm.gc.ZGenerational
+ * @bug 8198540
+ * @summary Test TypeConverterFactory is not leaking method handles (Z GC)
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational TypeConverterFactoryMemoryLeakTest
  */
 
 /*

--- a/test/jdk/jdk/dynalink/TypeConverterFactoryRetentionTests.java
+++ b/test/jdk/jdk/dynalink/TypeConverterFactoryRetentionTests.java
@@ -46,11 +46,19 @@
  */
 
 /*
- * @test id=with_ZGC
- * @requires vm.gc.Z
+ * @test id=with_ZGC_Singlegen
+ * @requires vm.gc.ZSinglegen
  * @bug 8198540
  * @summary Test TypeConverterFactory is not leaking class loaders (Z GC)
- * @run main/othervm -XX:+UseZGC TypeConverterFactoryRetentionTests
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational TypeConverterFactoryRetentionTests
+ */
+
+/*
+ * @test id=with_ZGC_Generational
+ * @requires vm.gc.ZGenerational
+ * @bug 8198540
+ * @summary Test TypeConverterFactory is not leaking class loaders (Z GC)
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational TypeConverterFactoryRetentionTests
  */
 
 /*

--- a/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
@@ -41,14 +41,26 @@ import java.util.List;
  */
 
 /*
- * @test
+ * @test id=ZSinglegen
  * @bug 8281544
  * @summary Test that ZGC and vectorapi with KNL work together.
- * @requires vm.gc.Z
+ * @requires vm.gc.ZSinglegen
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *                      -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions
+ *                      -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:-ZGenerational -XX:+IgnoreUnrecognizedVMOptions
+ *                      VectorMaxConversionTests
+ */
+
+/*
+ * @test id=ZGenerational
+ * @bug 8281544
+ * @summary Test that ZGC and vectorapi with KNL work together.
+ * @requires vm.gc.ZGenerational
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ *                      -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:+ZGenerational -XX:+IgnoreUnrecognizedVMOptions
  *                      VectorMaxConversionTests
  */
 

--- a/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMajor.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMajor.java
@@ -35,10 +35,10 @@ import jdk.test.lib.jfr.Events;
 
 /**
  * @test
- * @requires vm.hasJFR & vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
  * @key jfr
  * @library /test/lib /test/jdk
- * @run main/othervm -Xmx50m -XX:+UseZGC -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestGarbageCollectionEventWithZMajor
+ * @run main/othervm -Xmx50m -XX:+UseZGC -XX:+ZGenerational -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestGarbageCollectionEventWithZMajor
  */
 public class TestGarbageCollectionEventWithZMajor {
 

--- a/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java
@@ -40,12 +40,12 @@ import jdk.test.whitebox.WhiteBox;
 /**
  * @test
  * @key jfr
- * @requires vm.hasJFR & vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
  * @key jfr
  * @library /test/lib /test/jdk
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestGarbageCollectionEventWithZMinor
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UseZGC  -XX:+ZGenerational -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestGarbageCollectionEventWithZMinor
  */
 public class TestGarbageCollectionEventWithZMinor {
 

--- a/test/jdk/jdk/jfr/event/gc/collection/TestZOldGarbageCollectionEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestZOldGarbageCollectionEvent.java
@@ -35,10 +35,10 @@ import jdk.test.lib.jfr.Events;
 
 /**
  * @test
- * @requires vm.hasJFR & vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
  * @key jfr
  * @library /test/lib /test/jdk
- * @run main/othervm -Xmx50m -XX:+UseZGC -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestZOldGarbageCollectionEvent
+ * @run main/othervm -Xmx50m -XX:+UseZGC -XX:+ZGenerational -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestZOldGarbageCollectionEvent
  */
 public class TestZOldGarbageCollectionEvent {
 

--- a/test/jdk/jdk/jfr/event/gc/collection/TestZYoungGarbageCollectionEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestZYoungGarbageCollectionEvent.java
@@ -35,10 +35,10 @@ import jdk.test.lib.jfr.Events;
 
 /**
  * @test
- * @requires vm.hasJFR & vm.gc.Z & vm.opt.final.ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
  * @key jfr
  * @library /test/lib /test/jdk
- * @run main/othervm -Xmx50m -XX:+UseZGC -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestZYoungGarbageCollectionEvent
+ * @run main/othervm -Xmx50m -XX:+UseZGC -XX:+ZGenerational -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Xlog:gc* jdk.jfr.event.gc.collection.TestZYoungGarbageCollectionEvent
  */
 public class TestZYoungGarbageCollectionEvent {
 

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
@@ -31,19 +31,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestGCPhaseConcurrent
+ * @test id=ZGenerational
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @requires vm.hasJFR & vm.gc.Z & vm.opt.final.ZGenerational
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent Z
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent Z
  */
 
 /**
- * @test TestGCPhaseConcurrent
+ * @test id=ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @requires vm.hasJFR & vm.gc.Z & !vm.opt.final.ZGenerational
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent X
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent X
  */
 
 /**

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
@@ -32,11 +32,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestZAllocationStallEvent
- * @requires vm.hasJFR & vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
+ */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @library /test/lib /test/jdk /test/hotspot/jtreg
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
  */
 
 public class TestZAllocationStallEvent {

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java
@@ -32,11 +32,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestZPageAllocationEvent
- * @requires vm.hasJFR & vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZPageAllocationEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZPageAllocationEvent
+ */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @library /test/lib /test/jdk /test/hotspot/jtreg
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZPageAllocationEvent
  */
 
 public class TestZPageAllocationEvent {

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetEvent.java
@@ -32,11 +32,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestZRelocationSetEvent
- * @requires vm.hasJFR & vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetEvent
+ */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @library /test/lib /test/jdk /test/hotspot/jtreg
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetEvent
  */
 
 public class TestZRelocationSetEvent {

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZRelocationSetGroupEvent.java
@@ -32,11 +32,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestZRelocationSetGroupEvent
- * @requires vm.hasJFR & vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetGroupEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetGroupEvent
+ */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @library /test/lib /test/jdk /test/hotspot/jtreg
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZRelocationSetGroupEvent
  */
 
 public class TestZRelocationSetGroupEvent {

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZUncommitEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZUncommitEvent.java
@@ -34,11 +34,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestZUncommitEvent
- * @requires vm.hasJFR & vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xms32M -Xmx128M -Xlog:gc,gc+heap -XX:+ZUncommit -XX:ZUncommitDelay=1 jdk.jfr.event.gc.detailed.TestZUncommitEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms32M -Xmx128M -Xlog:gc,gc+heap -XX:+ZUncommit -XX:ZUncommitDelay=1 jdk.jfr.event.gc.detailed.TestZUncommitEvent
+ */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @library /test/lib /test/jdk /test/hotspot/jtreg
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms32M -Xmx128M -Xlog:gc,gc+heap -XX:+ZUncommit -XX:ZUncommitDelay=1 jdk.jfr.event.gc.detailed.TestZUncommitEvent
  */
 
 public class TestZUncommitEvent {

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZUnmapEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZUnmapEvent.java
@@ -32,11 +32,19 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test TestZUnmapEvent
- * @requires vm.hasJFR & vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestZUnmapEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZUnmapEvent
+ */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @library /test/lib /test/jdk /test/hotspot/jtreg
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZUnmapEvent
  */
 
 public class TestZUnmapEvent {

--- a/test/jdk/jdk/jfr/event/oldobject/TestZ.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestZ.java
@@ -33,14 +33,25 @@ import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
 /**
- * @test
+ * @test id=ZSinglegen
+ * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
- * @requires vm.hasJFR & vm.gc.Z
  * @summary Test leak profiler with ZGC
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm  -XX:TLABSize=2k -XX:+UseZGC jdk.jfr.event.oldobject.TestZ
+ * @run main/othervm  -XX:TLABSize=2k -XX:+UseZGC -XX:-ZGenerational jdk.jfr.event.oldobject.TestZ
  */
+
+/**
+ * @test id=ZGenerational
+ * @requires vm.hasJFR & vm.gc.ZGenerational
+ * @key jfr
+ * @summary Test leak profiler with ZGC
+ * @library /test/lib /test/jdk
+ * @modules jdk.jfr/jdk.jfr.internal.test
+ * @run main/othervm  -XX:TLABSize=2k -XX:+UseZGC -XX:+ZGenerational jdk.jfr.event.oldobject.TestZ
+ */
+
 public class TestZ {
 
     static private class FindMe {

--- a/test/jdk/sun/tools/jmap/BasicJMapTest.java
+++ b/test/jdk/sun/tools/jmap/BasicJMapTest.java
@@ -89,8 +89,8 @@ import jdk.test.lib.process.ProcessTools;
  */
 
 /*
- * @test id=Z
- * @requires vm.gc.Z
+ * @test id=ZSinglegen
+ * @requires vm.gc.ZSinglegen
  * @summary Unit test for jmap utility (Z GC)
  * @key intermittent
  * @library /test/lib
@@ -98,7 +98,20 @@ import jdk.test.lib.process.ProcessTools;
  * @build jdk.test.lib.hprof.model.*
  * @build jdk.test.lib.hprof.parser.*
  * @build jdk.test.lib.hprof.util.*
- * @run main/othervm/timeout=240 -XX:+UseZGC BasicJMapTest
+ * @run main/othervm/timeout=240 -XX:+UseZGC -XX:-ZGenerational BasicJMapTest
+ */
+
+/*
+ * @test id=ZGenerational
+ * @requires vm.gc.ZGenerational
+ * @summary Unit test for jmap utility (Z GC)
+ * @key intermittent
+ * @library /test/lib
+ * @build jdk.test.lib.hprof.*
+ * @build jdk.test.lib.hprof.model.*
+ * @build jdk.test.lib.hprof.parser.*
+ * @build jdk.test.lib.hprof.util.*
+ * @run main/othervm/timeout=240 -XX:+UseZGC -XX:+ZGenerational BasicJMapTest
  */
 
 public class BasicJMapTest {

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -621,6 +621,7 @@ public class WhiteBox {
 
   // VM flags
   public native boolean isConstantVMFlag(String name);
+  public native boolean isDefaultVMFlag(String name);
   public native boolean isLockedVMFlag(String name);
   public native void    setBooleanVMFlag(String name, boolean value);
   public native void    setIntVMFlag(String name, long value);


### PR DESCRIPTION
The current implementation for testing generational ZGC with jtreg is implemented with a filter on the mode flag `ZGenerational`. Because of this only environments which set this flag explicitly will run most of the tests. 
So they get missed in Github Actions and for developers running jtreg locally without supplying the `ZGenerational` flag.

The proposed change here is to introduce two new jtreg requirement properties, `vm.gc.ZGenerational` and `vm.gc.ZSingelgen`. These flags will effectively behave the same as the existing `vm.gc.<GC>` flags but also take the specific ZGC mode in account.

If no gc flags are supplied to jtreg and the `vm.gc.Z` is true (the build includes ZGC) both `vm.gc.ZGenerational` and `vm.gc.ZSinglegen` will be true.

If `-XX:+UseZGC` is supplied then both `vm.gc.ZGenerational` and `vm.gc.ZSinglegen` will also be true.

If `-XX:{+,-}ZGenerational` is supplied then either  `vm.gc.ZGenerational` or `vm.gc.ZSinglegen` be true depending on the flags value.

And if `vm.gc.Z` is false both `vm.gc.ZGenerational` and `vm.gc.ZSinglegen` will be false.

This change also splits the relevant tests into two distinct runs for the two modes. And the respective test ids are set to `ZGenerational` or `ZSinglegen` to make it easier to distinguish the runs.

This also solves the issue that some compiler tests will never run with generational ZGC unless the `TEST_VM_FLAGLESS` is set. This is because the current filter `vm.opt.final.ZGenerational` requires the flag to be explicit, but these compiler tests uses `vm.flagless`. 

The introduction of  `vm.gc.ZGenerational` and `vm.gc.ZSinglegen` harmonizes the way you specify generational / single gen ZGC test with the way it is done for other gcs with `vm.gc.<GC>`

To support this feature the Whitebox API is extended with `isDefaultVMFlag` to enable checking if `ZGenerational` is default or not.

`vm.opt.final.ZGenerational` is still kept because we still have some reasons to filter based on the supplied flags. 
- `test/hotspot/jtreg/gc/cslocker/TestCSLocker.java` is disabled when running with ZGenerational
- `test/jdk/java/lang/ProcessBuilder/CloseRace.java` is ran with a different max heap size for ZGenerational, but it is not the intent to dispatch the test to both G1 and generational ZGC if Generational ZGC is not specified.  

`test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java` was also changed to not filter but instead dispatch. However unsure if this change should be included. The change is isolated in 5c0c0bdab9012a5f35dd4ab3a2847374578c8b9f . It seems more appropriate to actually test the MXBeans by default with no explicit gc, but I am open reverting this part.

The plan is to also backport this to 21 to improve the testing until release. The changes here should fall under `P1–P5 doc/test changes`

Running tests in Oracle CI. (tier1-tier5)
Verified that both `ZGenerational` and `ZSinglegen` tests get run in GHA.
Running tests in builds with `--disable-jvm-feature-zgc` to verify no regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310187](https://bugs.openjdk.org/browse/JDK-8310187): Improve Generational ZGC jtreg testing (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [e571b87f](https://git.openjdk.org/jdk/pull/14509/files/e571b87f44c496e55d998d708940d4b4c1d9e63b)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [e571b87f](https://git.openjdk.org/jdk/pull/14509/files/e571b87f44c496e55d998d708940d4b4c1d9e63b)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14509/head:pull/14509` \
`$ git checkout pull/14509`

Update a local copy of the PR: \
`$ git checkout pull/14509` \
`$ git pull https://git.openjdk.org/jdk.git pull/14509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14509`

View PR using the GUI difftool: \
`$ git pr show -t 14509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14509.diff">https://git.openjdk.org/jdk/pull/14509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14509#issuecomment-1594386417)