### PR TITLE
8310192: RISC-V: Merge vector min & max instructs with similar match rules

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1679,10 +1679,10 @@ void C2_MacroAssembler::string_indexof_char_v(Register str1, Register cnt1,
 
 // Set dst to NaN if any NaN input.
 void C2_MacroAssembler::minmax_fp_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
-                                    bool is_double, bool is_min, int vector_length) {
+                                    BasicType bt, bool is_min, int vector_length) {
   assert_different_registers(dst, src1, src2);
 
-  vsetvli_helper(is_double ? T_DOUBLE : T_FLOAT, vector_length);
+  vsetvli_helper(bt, vector_length);
 
   is_min ? vfmin_vv(dst, src1, src2)
          : vfmax_vv(dst, src1, src2);
@@ -1698,9 +1698,9 @@ void C2_MacroAssembler::minmax_fp_v(VectorRegister dst, VectorRegister src1, Vec
 // are handled with a mask-undisturbed policy.
 void C2_MacroAssembler::minmax_fp_masked_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
                                            VectorRegister vmask, VectorRegister tmp1, VectorRegister tmp2,
-                                           bool is_double, bool is_min, int vector_length) {
+                                           BasicType bt, bool is_min, int vector_length) {
   assert_different_registers(src1, src2, tmp1, tmp2);
-  vsetvli_helper(is_double ? T_DOUBLE : T_FLOAT, vector_length);
+  vsetvli_helper(bt, vector_length);
 
   // Check vector elements of src1 and src2 for NaN.
   vmfeq_vv(tmp1, src1, src1);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -187,11 +187,11 @@
 
  void minmax_fp_v(VectorRegister dst,
                   VectorRegister src1, VectorRegister src2,
-                  bool is_double, bool is_min, int vector_length);
+                  BasicType bt, bool is_min, int vector_length);
 
  void minmax_fp_masked_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
                          VectorRegister vmask, VectorRegister tmp1, VectorRegister tmp2,
-                         bool is_double, bool is_min, int vector_length);
+                         BasicType bt, bool is_min, int vector_length);
 
  void reduce_minmax_fp_v(FloatRegister dst,
                          FloatRegister src1, VectorRegister src2,

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -626,120 +626,70 @@ instruct vmin_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector float-point max/min
 
-instruct vmaxF(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
+instruct vmax_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
+            Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vmaxF $dst, $src1, $src2" %}
+  format %{ "vmax_fp $dst, $src1, $src2" %}
   ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   false /* is_double */, false /* is_min */, Matcher::vector_length(this));
+                   bt, false /* is_min */, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaxD(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP v0);
-  ins_cost(VEC_COST);
-  format %{ "vmaxD $dst, $src1, $src2" %}
-  ins_encode %{
-    __ minmax_fp_v(as_VectorRegister($dst$$reg),
-                   as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   true /* is_double */, false /* is_min */, Matcher::vector_length(this));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vminF(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
+instruct vmin_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
+            Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vminF $dst, $src1, $src2" %}
+  format %{ "vmin_fp $dst, $src1, $src2" %}
   ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   false /* is_double */, true /* is_min */, Matcher::vector_length(this));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vminD(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP v0);
-  ins_cost(VEC_COST);
-  format %{ "vminD $dst, $src1, $src2" %}
-  ins_encode %{
-    __ minmax_fp_v(as_VectorRegister($dst$$reg),
-                   as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   true /* is_double */, true /* is_min */, Matcher::vector_length(this));
+                   bt, true /* is_min */, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}
 
 // vector float-point max/min - predicated
 
-instruct vmaxF_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vReg tmp2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
+instruct vmax_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vReg tmp2, vRegMask_V0 v0) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
+            Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst_src1 (MaxV (Binary dst_src1 src2) vmask));
   effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vmaxF_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
+  format %{ "vmax_fp_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
   ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_masked_v(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                           as_VectorRegister($src2$$reg), as_VectorRegister($vmask$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, false /* is_min */, Matcher::vector_length(this));
+                          bt, false /* is_min */, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vmaxD_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vReg tmp2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst_src1 (MaxV (Binary dst_src1 src2) vmask));
-  effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
-  ins_cost(VEC_COST);
-  format %{ "vmaxD_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
-  ins_encode %{
-    __ minmax_fp_masked_v(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
-                          as_VectorRegister($src2$$reg), as_VectorRegister($vmask$$reg),
-                          as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, false /* is_min */, Matcher::vector_length(this));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vminF_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vReg tmp2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
+instruct vmin_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vReg tmp2, vRegMask_V0 v0) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
+            Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst_src1 (MinV (Binary dst_src1 src2) vmask));
   effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
   ins_cost(VEC_COST);
-  format %{ "vminF_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
+  format %{ "vmin_fp_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
   ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_masked_v(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                           as_VectorRegister($src2$$reg), as_VectorRegister($vmask$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, true /* is_min */, Matcher::vector_length(this));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vminD_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vReg tmp2, vRegMask_V0 v0) %{
-  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst_src1 (MinV (Binary dst_src1 src2) vmask));
-  effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
-  ins_cost(VEC_COST);
-  format %{ "vminD_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
-  ins_encode %{
-    __ minmax_fp_masked_v(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
-                          as_VectorRegister($src2$$reg), as_VectorRegister($vmask$$reg),
-                          as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, true /* is_min */, Matcher::vector_length(this));
+                          bt, true /* is_min */, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -851,47 +851,6 @@ class StubGenerator: public StubCodeGenerator {
 
   Label copy_f, copy_b;
 
-  // All-singing all-dancing memory copy.
-  //
-  // Copy count units of memory from s to d.  The size of a unit is
-  // step, which can be positive or negative depending on the direction
-  // of copy.  If is_aligned is false, we align the source address.
-  //
-  /*
-   * if (is_aligned) {
-   *   if (count >= 32)
-   *     goto copy32_loop;
-   *   if (count >= 8)
-   *     goto copy8_loop;
-   *   goto copy_small;
-   * }
-   * bool is_backwards = step < 0;
-   * int granularity = uabs(step);
-   * count = count  *  granularity;   * count bytes
-   *
-   * if (is_backwards) {
-   *   s += count;
-   *   d += count;
-   * }
-   *
-   * count limit maybe greater than 16, for better performance
-   * if (count < 16) {
-   *   goto copy_small;
-   * }
-   *
-   * if ((dst % 8) == (src % 8)) {
-   *   aligned;
-   *   goto copy_big;
-   * }
-   *
-   * copy_big:
-   * if the amount to copy is more than (or equal to) 32 bytes goto copy32_loop
-   *  else goto copy8_loop
-   * copy_small:
-   *   load element one by one;
-   * done;
-   */
-
   typedef void (MacroAssembler::*copy_insn)(Register Rd, const Address &adr, Register temp);
 
   void copy_memory_v(Register s, Register d, Register count, int step) {
@@ -944,6 +903,12 @@ class StubGenerator: public StubCodeGenerator {
     }
   }
 
+  // All-singing all-dancing memory copy.
+  //
+  // Copy count units of memory from s to d.  The size of a unit is
+  // step, which can be positive or negative depending on the direction
+  // of copy.
+  //
   void copy_memory(DecoratorSet decorators, BasicType type, bool is_aligned,
                    Register s, Register d, Register count, int step) {
     BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -1037,7 +1002,7 @@ class StubGenerator: public StubCodeGenerator {
     __ beqz(cnt, done); // if that's all - done
 
     __ addi(t0, cnt, -8); // if not - copy the reminder
-    __ bltz(t0, copy_small); // cnt < 8, go to copy_small, else fall throught to copy8_loop
+    __ bltz(t0, copy_small); // cnt < 8, go to copy_small, else fall through to copy8_loop
 
     __ bind(copy8_loop);
     if (is_backwards) {


### PR DESCRIPTION
Hi, We merged vector min and max instructions with similar matching rules in this PR, and modified some comments of the copy_memory function in stubGenerator_riscv.cpp.

Please take a look and have some reviews. Thanks a lot.

## Testing:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)