### PR TITLE
8310015: ZGC: Unbounded asynchronous unmapping can lead to running out of address space

### DIFF
--- a/src/hotspot/share/gc/x/xUnmapper.hpp
+++ b/src/hotspot/share/gc/x/xUnmapper.hpp
@@ -36,9 +36,14 @@ private:
   XPageAllocator* const _page_allocator;
   XConditionLock        _lock;
   XList<XPage>          _queue;
+  size_t                _enqueued_bytes;
+  bool                  _warned_sync_unmapping;
   bool                  _stop;
 
   XPage* dequeue();
+  bool try_enqueue(XPage* page);
+  size_t queue_capacity() const;
+  bool is_saturated() const;
   void do_unmap_and_destroy_page(XPage* page) const;
 
 protected:

--- a/src/hotspot/share/gc/z/shared/z_shared_globals.hpp
+++ b/src/hotspot/share/gc/z/shared/z_shared_globals.hpp
@@ -61,6 +61,13 @@
           "Uncommit memory if it has been unused for the specified "        \
           "amount of time (in seconds)")                                    \
                                                                             \
+  product(double, ZAsyncUnmappingLimit, 100.0, DIAGNOSTIC,                  \
+          "Specify the max amount (percentage of max heap size) of async "  \
+          "unmapping that can be in-flight before unmapping requests are "  \
+          "temporarily forced to be synchronous instead. "                  \
+          "The default means after an amount of pages proportional to the " \
+          "max capacity is enqueued, we resort to synchronous unmapping.")  \
+                                                                            \
   product(uint, ZStatisticsInterval, 10, DIAGNOSTIC,                        \
           "Time between statistics print outs (in seconds)")                \
           range(1, (uint)-1)                                                \

--- a/src/hotspot/share/gc/z/zUnmapper.cpp
+++ b/src/hotspot/share/gc/z/zUnmapper.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zList.inline.hpp"
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
@@ -35,6 +36,8 @@ ZUnmapper::ZUnmapper(ZPageAllocator* page_allocator)
   : _page_allocator(page_allocator),
     _lock(),
     _queue(),
+    _enqueued_bytes(0),
+    _warned_sync_unmapping(false),
     _stop(false) {
   set_name("ZUnmapper");
   create_and_start();
@@ -50,11 +53,43 @@ ZPage* ZUnmapper::dequeue() {
 
     ZPage* const page = _queue.remove_first();
     if (page != nullptr) {
+      _enqueued_bytes -= page->size();
       return page;
     }
 
     _lock.wait();
   }
+}
+
+bool ZUnmapper::try_enqueue(ZPage* page) {
+  // Enqueue for asynchronous unmap and destroy
+  ZLocker<ZConditionLock> locker(&_lock);
+  if (is_saturated()) {
+    // The unmapper thread is lagging behind and is unable to unmap memory fast enough
+    if (!_warned_sync_unmapping) {
+      _warned_sync_unmapping = true;
+      log_warning_p(gc)("WARNING: Encountered synchronous unmapping because asynchronous unmapping could not keep up");
+    }
+    log_debug(gc, unmap)("Synchronous unmapping " SIZE_FORMAT "M page", page->size() / M);
+    return false;
+  }
+
+  log_trace(gc, unmap)("Asynchronous unmapping " SIZE_FORMAT "M page (" SIZE_FORMAT "M / " SIZE_FORMAT "M enqueued)",
+                       page->size() / M, _enqueued_bytes / M, queue_capacity() / M);
+
+  _queue.insert_last(page);
+  _enqueued_bytes += page->size();
+  _lock.notify_all();
+
+  return true;
+}
+
+size_t ZUnmapper::queue_capacity() const {
+  return align_up<size_t>(_page_allocator->max_capacity() * ZAsyncUnmappingLimit / 100.0, ZGranuleSize);
+}
+
+bool ZUnmapper::is_saturated() const {
+  return _enqueued_bytes >= queue_capacity();
 }
 
 void ZUnmapper::do_unmap_and_destroy_page(ZPage* page) const {
@@ -70,10 +105,10 @@ void ZUnmapper::do_unmap_and_destroy_page(ZPage* page) const {
 }
 
 void ZUnmapper::unmap_and_destroy_page(ZPage* page) {
-  // Enqueue for asynchronous unmap and destroy
-  ZLocker<ZConditionLock> locker(&_lock);
-  _queue.insert_last(page);
-  _lock.notify_all();
+  if (!try_enqueue(page)) {
+    // Synchronously unmap and destroy
+    do_unmap_and_destroy_page(page);
+  }
 }
 
 void ZUnmapper::run_thread() {

--- a/src/hotspot/share/gc/z/zUnmapper.hpp
+++ b/src/hotspot/share/gc/z/zUnmapper.hpp
@@ -36,9 +36,14 @@ private:
   ZPageAllocator* const _page_allocator;
   ZConditionLock        _lock;
   ZList<ZPage>          _queue;
+  size_t                _enqueued_bytes;
+  bool                  _warned_sync_unmapping;
   bool                  _stop;
 
   ZPage* dequeue();
+  bool try_enqueue(ZPage* page);
+  size_t queue_capacity() const;
+  bool is_saturated() const;
   void do_unmap_and_destroy_page(ZPage* page) const;
 
 protected:

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -197,6 +197,7 @@ class outputStream;
   LOG_TAG(tlab) \
   LOG_TAG(tracking) \
   LOG_TAG(unload) /* Trace unloading of classes */ \
+  LOG_TAG(unmap) \
   LOG_TAG(unshareable) \
   NOT_PRODUCT(LOG_TAG(upcall)) \
   LOG_TAG(update) \


### PR DESCRIPTION
ZGC (both generational and non-generational) use asynchronous unmapping. Today the amount of unmapping requests we can queue up is unbounded. This can lead to a classic consumer producer problem, where the consumer is slower than the producer, and we eventually run out of address space and have to shut down. 
This PR introduces an upper bound for the asynchronous unmapping, to prevent the VM from shutting down. Going forwards, there are some ideas to both increase the speed of unmapping and reduce the need for unmapping, but this PR is focused only on introducing a configurable bound for async unmapping.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310015](https://bugs.openjdk.org/browse/JDK-8310015): ZGC: Unbounded asynchronous unmapping can lead to running out of address space (**Bug** - P2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14513/head:pull/14513` \
`$ git checkout pull/14513`

Update a local copy of the PR: \
`$ git checkout pull/14513` \
`$ git pull https://git.openjdk.org/jdk.git pull/14513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14513`

View PR using the GUI difftool: \
`$ git pr show -t 14513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14513.diff">https://git.openjdk.org/jdk/pull/14513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14513#issuecomment-1594468880)