### PR TITLE
8310143: RandomCommandsTest fails due to unexpected VM exit code after JDK-8282797

### DIFF
--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$(realpath bootjdk/jdk)"
+        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,7 +30,8 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
-      uses: msys2/setup-msys2@v2
+      # use a specific release of msys2/setup-msys2 to prevent jtreg build failures on newer release
+      uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1207,7 +1207,8 @@ void LIRGenerator::do_Reference_get(Intrinsic* x) {
 
   LIR_Opr result = rlock_result(x, T_OBJECT);
   access_load_at(IN_HEAP | ON_WEAK_OOP_REF, T_OBJECT,
-                 reference, LIR_OprFact::intConst(referent_offset), result);
+                 reference, LIR_OprFact::intConst(referent_offset), result,
+                 nullptr, info);
 }
 
 // Example: clazz.isInstance(object)

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1307,10 +1307,10 @@ G1RegionToSpaceMapper* G1CollectedHeap::create_aux_memory_mapper(const char* des
 
   os::trace_page_sizes_for_requested_size(description,
                                           size,
-                                          page_size,
                                           preferred_page_size,
                                           rs.base(),
-                                          rs.size());
+                                          rs.size(),
+                                          page_size);
 
   return result;
 }
@@ -1400,9 +1400,9 @@ jint G1CollectedHeap::initialize() {
   os::trace_page_sizes("Heap",
                        MinHeapSize,
                        reserved_byte_size,
-                       page_size,
                        heap_rs.base(),
-                       heap_rs.size());
+                       heap_rs.size(),
+                       page_size);
   heap_storage->set_mapping_changed_listener(&_listener);
 
   // Create storage for the BOT, card table and the bitmap.

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
@@ -51,8 +51,8 @@ ParMarkBitMap::initialize(MemRegion covered_region)
     MAX2(page_sz, granularity);
   ReservedSpace rs(_reserved_byte_size, rs_align, page_sz);
   const size_t used_page_sz = rs.page_size();
-  os::trace_page_sizes("Mark Bitmap", raw_bytes, raw_bytes, used_page_sz,
-                       rs.base(), rs.size());
+  os::trace_page_sizes("Mark Bitmap", raw_bytes, raw_bytes,
+                       rs.base(), rs.size(), used_page_sz);
 
   MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -785,9 +785,9 @@ void ParallelScavengeHeap::trace_actual_reserved_page_size(const size_t reserved
     os::trace_page_sizes("Heap",
                          MinHeapSize,
                          reserved_heap_size,
-                         page_size,
                          rs.base(),
-                         rs.size());
+                         rs.size(),
+                         page_size);
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -448,8 +448,8 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
   const size_t rs_align = page_sz == os::vm_page_size() ? 0 :
     MAX2(page_sz, granularity);
   ReservedSpace rs(_reserved_byte_size, rs_align, page_sz);
-  os::trace_page_sizes("Parallel Compact Data", raw_bytes, raw_bytes, page_sz, rs.base(),
-                       rs.size());
+  os::trace_page_sizes("Parallel Compact Data", raw_bytes, raw_bytes, rs.base(),
+                       rs.size(), page_sz);
 
   MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -97,7 +97,7 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
   MemTracker::record_virtual_memory_type((address)heap_rs.base(), mtGC);
 
   os::trace_page_sizes("Card Table", num_bytes, num_bytes,
-                       _page_size, heap_rs.base(), heap_rs.size());
+                       heap_rs.base(), heap_rs.size(), _page_size);
   if (!heap_rs.is_reserved()) {
     vm_exit_during_initialization("Could not reserve enough space for the "
                                   "card marking array");

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -159,9 +159,9 @@ ReservedHeapSpace GenCollectedHeap::allocate(size_t alignment) {
   os::trace_page_sizes("Heap",
                        MinHeapSize,
                        total_reserved,
-                       used_page_size,
                        heap_rs.base(),
-                       heap_rs.size());
+                       heap_rs.size(),
+                       used_page_size);
 
   return heap_rs;
 }

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -26,6 +26,7 @@
 #include "cds/metaspaceShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "interpreter/bytecodes.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/rewriter.hpp"
 #include "memory/metadataFactory.hpp"

--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -114,9 +114,9 @@ bool JfrVirtualMemorySegment::initialize(size_t reservation_size_request_bytes) 
   assert(is_aligned(_rs.size(), os::vm_allocation_granularity()), "invariant");
   os::trace_page_sizes("Jfr", reservation_size_request_bytes,
                               reservation_size_request_bytes,
-                              os::vm_page_size(),
                               _rs.base(),
-                              _rs.size());
+                              _rs.size(),
+                              os::vm_page_size());
   MemTracker::record_virtual_memory_type((address)_rs.base(), mtTracing);
   assert(is_aligned(_rs.base(), os::vm_page_size()), "invariant");
   assert(is_aligned(_rs.size(), os::vm_page_size()), "invariant");

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -212,8 +212,7 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
   const size_t c_size = align_up(committed_size, page_size);
   assert(c_size <= rs.size(), "alignment made committed size to large");
 
-  os::trace_page_sizes(_name, c_size, rs.size(), page_size,
-                       rs.base(), rs.size());
+  os::trace_page_sizes(_name, c_size, rs.size(), rs.base(), rs.size(), page_size);
   if (!_memory.initialize(rs, c_size)) {
     return false;
   }

--- a/src/hotspot/share/oops/generateOopMap.hpp
+++ b/src/hotspot/share/oops/generateOopMap.hpp
@@ -25,7 +25,6 @@
 #ifndef SHARE_OOPS_GENERATEOOPMAP_HPP
 #define SHARE_OOPS_GENERATEOOPMAP_HPP
 
-#include "interpreter/bytecodeStream.hpp"
 #include "memory/allocation.hpp"
 #include "oops/method.hpp"
 #include "oops/oopsHierarchy.hpp"
@@ -33,6 +32,7 @@
 #include "utilities/bitMap.hpp"
 
 // Forward definition
+class BytecodeStream;
 class GenerateOopMap;
 class BasicBlock;
 class CellTypeState;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -43,6 +43,7 @@
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "interpreter/rewriter.hpp"
 #include "jvm.h"

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1385,9 +1385,8 @@ JVM_ENTRY(jobject, JVM_FindScopedValueBindings(JNIEnv *env, jclass cls))
 
     InstanceKlass* holder = method->method_holder();
     if (name == vmSymbols::runWith_method_name()) {
-      if ((holder == resolver.Carrier_klass
-           || holder == vmClasses::VirtualThread_klass()
-           || holder == vmClasses::Thread_klass())) {
+      if (holder == vmClasses::Thread_klass()
+          || holder == resolver.Carrier_klass) {
         loc = 1;
       }
     }

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -23,9 +23,11 @@
  */
 
 #include "precompiled.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/constantPool.inline.hpp"
+#include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "prims/methodComparator.hpp"

--- a/src/hotspot/share/prims/methodComparator.hpp
+++ b/src/hotspot/share/prims/methodComparator.hpp
@@ -25,9 +25,11 @@
 #ifndef SHARE_PRIMS_METHODCOMPARATOR_HPP
 #define SHARE_PRIMS_METHODCOMPARATOR_HPP
 
-#include "interpreter/bytecodeStream.hpp"
-#include "oops/constantPool.hpp"
-#include "oops/method.hpp"
+#include "interpreter/bytecodes.hpp"
+
+class BytecodeStream;
+class ConstantPool;
+class Method;
 
 // methodComparator provides an interface for determining if methods of
 // different versions of classes are equivalent or switchable

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -36,6 +36,7 @@
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/oopMapCache.hpp"
 #include "jvm.h"

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1655,43 +1655,43 @@ const char* os::errno_name(int e) {
 void os::trace_page_sizes(const char* str,
                           const size_t region_min_size,
                           const size_t region_max_size,
-                          const size_t page_size,
                           const char* base,
-                          const size_t size) {
+                          const size_t size,
+                          const size_t page_size) {
 
   log_info(pagesize)("%s: "
                      " min=" SIZE_FORMAT "%s"
                      " max=" SIZE_FORMAT "%s"
                      " base=" PTR_FORMAT
-                     " page_size=" SIZE_FORMAT "%s"
-                     " size=" SIZE_FORMAT "%s",
+                     " size=" SIZE_FORMAT "%s"
+                     " page_size=" SIZE_FORMAT "%s",
                      str,
                      trace_page_size_params(region_min_size),
                      trace_page_size_params(region_max_size),
                      p2i(base),
-                     trace_page_size_params(page_size),
-                     trace_page_size_params(size));
+                     trace_page_size_params(size),
+                     trace_page_size_params(page_size));
 }
 
 void os::trace_page_sizes_for_requested_size(const char* str,
                                              const size_t requested_size,
-                                             const size_t page_size,
-                                             const size_t alignment,
+                                             const size_t requested_page_size,
                                              const char* base,
-                                             const size_t size) {
+                                             const size_t size,
+                                             const size_t page_size) {
 
   log_info(pagesize)("%s:"
                      " req_size=" SIZE_FORMAT "%s"
+                     " req_page_size=" SIZE_FORMAT "%s"
                      " base=" PTR_FORMAT
-                     " page_size=" SIZE_FORMAT "%s"
-                     " alignment=" SIZE_FORMAT "%s"
-                     " size=" SIZE_FORMAT "%s",
+                     " size=" SIZE_FORMAT "%s"
+                     " page_size=" SIZE_FORMAT "%s",
                      str,
                      trace_page_size_params(requested_size),
+                     trace_page_size_params(requested_page_size),
                      p2i(base),
-                     trace_page_size_params(page_size),
-                     trace_page_size_params(alignment),
-                     trace_page_size_params(size));
+                     trace_page_size_params(size),
+                     trace_page_size_params(page_size));
 }
 
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -405,19 +405,18 @@ class os: AllStatic {
   // passed to page_size_for_region() and page_size should be the result of that
   // call.  The (optional) base and size parameters should come from the
   // ReservedSpace base() and size() methods.
-  static void trace_page_sizes(const char* str, const size_t* page_sizes, int count);
   static void trace_page_sizes(const char* str,
                                const size_t region_min_size,
                                const size_t region_max_size,
-                               const size_t page_size,
                                const char* base,
-                               const size_t size);
+                               const size_t size,
+                               const size_t page_size);
   static void trace_page_sizes_for_requested_size(const char* str,
                                                   const size_t requested_size,
-                                                  const size_t page_size,
-                                                  const size_t alignment,
+                                                  const size_t requested_page_size,
                                                   const char* base,
-                                                  const size_t size);
+                                                  const size_t size,
+                                                  const size_t page_size);
 
   static size_t vm_allocation_granularity() { return OSInfo::vm_allocation_granularity(); }
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -525,79 +525,10 @@
   nonstatic_field(InterpreterCodelet,          _bytecode,                                     Bytecodes::Code)                       \
                                                                                                                                      \
   /***********************************/                                                                                              \
-  /* StubRoutines (NOTE: incomplete) */                                                                                              \
+  /* StubRoutine for stack walking.  */                                                                                              \
   /***********************************/                                                                                              \
                                                                                                                                      \
-     static_field(StubRoutines,                _verify_oop_count,                             jint)                                  \
      static_field(StubRoutines,                _call_stub_return_address,                     address)                               \
-     static_field(StubRoutines,                _aescrypt_encryptBlock,                        address)                               \
-     static_field(StubRoutines,                _aescrypt_decryptBlock,                        address)                               \
-     static_field(StubRoutines,                _cipherBlockChaining_encryptAESCrypt,          address)                               \
-     static_field(StubRoutines,                _cipherBlockChaining_decryptAESCrypt,          address)                               \
-     static_field(StubRoutines,                _electronicCodeBook_encryptAESCrypt,           address)                               \
-     static_field(StubRoutines,                _electronicCodeBook_decryptAESCrypt,           address)                               \
-     static_field(StubRoutines,                _counterMode_AESCrypt,                         address)                               \
-     static_field(StubRoutines,                _galoisCounterMode_AESCrypt,                   address)                               \
-     static_field(StubRoutines,                _ghash_processBlocks,                          address)                               \
-     static_field(StubRoutines,                _chacha20Block,                                address)                               \
-     static_field(StubRoutines,                _base64_encodeBlock,                           address)                               \
-     static_field(StubRoutines,                _base64_decodeBlock,                           address)                               \
-     static_field(StubRoutines,                _poly1305_processBlocks,                       address)                               \
-     static_field(StubRoutines,                _updateBytesCRC32,                             address)                               \
-     static_field(StubRoutines,                _crc_table_adr,                                address)                               \
-     static_field(StubRoutines,                _crc32c_table_addr,                            address)                               \
-     static_field(StubRoutines,                _updateBytesCRC32C,                            address)                               \
-     static_field(StubRoutines,                _updateBytesAdler32,                           address)                               \
-     static_field(StubRoutines,                _multiplyToLen,                                address)                               \
-     static_field(StubRoutines,                _squareToLen,                                  address)                               \
-     static_field(StubRoutines,                _bigIntegerRightShiftWorker,                   address)                               \
-     static_field(StubRoutines,                _bigIntegerLeftShiftWorker,                    address)                               \
-     static_field(StubRoutines,                _mulAdd,                                       address)                               \
-     static_field(StubRoutines,                _dexp,                                         address)                               \
-     static_field(StubRoutines,                _dlog,                                         address)                               \
-     static_field(StubRoutines,                _dlog10,                                       address)                               \
-     static_field(StubRoutines,                _dpow,                                         address)                               \
-     static_field(StubRoutines,                _fmod,                                         address)                               \
-     static_field(StubRoutines,                _dsin,                                         address)                               \
-     static_field(StubRoutines,                _dcos,                                         address)                               \
-     static_field(StubRoutines,                _dtan,                                         address)                               \
-     static_field(StubRoutines,                _vectorizedMismatch,                           address)                               \
-     static_field(StubRoutines,                _jbyte_arraycopy,                              address)                               \
-     static_field(StubRoutines,                _jshort_arraycopy,                             address)                               \
-     static_field(StubRoutines,                _jint_arraycopy,                               address)                               \
-     static_field(StubRoutines,                _jlong_arraycopy,                              address)                               \
-     static_field(StubRoutines,                _oop_arraycopy,                                address)                               \
-     static_field(StubRoutines,                _oop_arraycopy_uninit,                         address)                               \
-     static_field(StubRoutines,                _jbyte_disjoint_arraycopy,                     address)                               \
-     static_field(StubRoutines,                _jshort_disjoint_arraycopy,                    address)                               \
-     static_field(StubRoutines,                _jint_disjoint_arraycopy,                      address)                               \
-     static_field(StubRoutines,                _jlong_disjoint_arraycopy,                     address)                               \
-     static_field(StubRoutines,                _oop_disjoint_arraycopy,                       address)                               \
-     static_field(StubRoutines,                _oop_disjoint_arraycopy_uninit,                address)                               \
-     static_field(StubRoutines,                _arrayof_jbyte_arraycopy,                      address)                               \
-     static_field(StubRoutines,                _arrayof_jshort_arraycopy,                     address)                               \
-     static_field(StubRoutines,                _arrayof_jint_arraycopy,                       address)                               \
-     static_field(StubRoutines,                _arrayof_jlong_arraycopy,                      address)                               \
-     static_field(StubRoutines,                _arrayof_oop_arraycopy,                        address)                               \
-     static_field(StubRoutines,                _arrayof_oop_arraycopy_uninit,                 address)                               \
-     static_field(StubRoutines,                _arrayof_jbyte_disjoint_arraycopy,             address)                               \
-     static_field(StubRoutines,                _arrayof_jshort_disjoint_arraycopy,            address)                               \
-     static_field(StubRoutines,                _arrayof_jint_disjoint_arraycopy,              address)                               \
-     static_field(StubRoutines,                _arrayof_jlong_disjoint_arraycopy,             address)                               \
-     static_field(StubRoutines,                _arrayof_oop_disjoint_arraycopy,               address)                               \
-     static_field(StubRoutines,                _arrayof_oop_disjoint_arraycopy_uninit,        address)                               \
-     static_field(StubRoutines,                _checkcast_arraycopy,                          address)                               \
-     static_field(StubRoutines,                _checkcast_arraycopy_uninit,                   address)                               \
-     static_field(StubRoutines,                _unsafe_arraycopy,                             address)                               \
-     static_field(StubRoutines,                _generic_arraycopy,                            address)                               \
-                                                                                                                                     \
-  /*****************/                                                                                                                \
-  /* SharedRuntime */                                                                                                                \
-  /*****************/                                                                                                                \
-                                                                                                                                     \
-     static_field(SharedRuntime,               _wrong_method_blob,                            RuntimeStub*)                          \
-     static_field(SharedRuntime,               _ic_miss_blob,                                 RuntimeStub*)                          \
-     static_field(SharedRuntime,               _deopt_blob,                                   DeoptimizationBlob*)                   \
                                                                                                                                      \
   /***************************************/                                                                                          \
   /* PcDesc and other compiled code info */                                                                                          \

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1578,7 +1578,7 @@ public class Thread implements Runnable {
      */
     @Hidden
     @ForceInline
-    private void runWith(Object bindings, Runnable op) {
+    final void runWith(Object bindings, Runnable op) {
         ensureMaterializedForStackWalk(bindings);
         op.run();
         Reference.reachabilityFence(bindings);

--- a/src/java.base/share/classes/java/lang/ThreadBuilders.java
+++ b/src/java.base/share/classes/java/lang/ThreadBuilders.java
@@ -433,7 +433,8 @@ class ThreadBuilders {
             // run is specified to do nothing when Thread is a virtual thread
             if (Thread.currentThread() == this && !runInvoked) {
                 runInvoked = true;
-                task.run();
+                Object bindings = Thread.scopedValueBindings();
+                runWith(bindings, task);
             }
         }
 

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,6 @@
  */
 package java.lang;
 
-import java.lang.ref.Reference;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Locale;
@@ -54,7 +53,6 @@ import jdk.internal.vm.StackableScope;
 import jdk.internal.vm.ThreadContainer;
 import jdk.internal.vm.ThreadContainers;
 import jdk.internal.vm.annotation.ChangesCurrentThread;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Hidden;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.JvmtiMountTransition;
@@ -306,7 +304,7 @@ final class VirtualThread extends BaseVirtualThread {
             event.commit();
         }
 
-        Object bindings = scopedValueBindings();
+        Object bindings = Thread.scopedValueBindings();
         try {
             runWith(bindings, task);
         } catch (Throwable exc) {
@@ -332,14 +330,6 @@ final class VirtualThread extends BaseVirtualThread {
                 setState(TERMINATED);
             }
         }
-    }
-
-    @Hidden
-    @ForceInline
-    private void runWith(Object bindings, Runnable op) {
-        ensureMaterializedForStackWalk(bindings);
-        op.run();
-        Reference.reachabilityFence(bindings);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -37,6 +37,7 @@ import jdk.internal.javac.PreviewFeature;
  * @implSpec
  * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
+ * @sealedGraph
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)

--- a/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,9 @@ public abstract class AbstractProcessor implements Processor {
     protected AbstractProcessor() {}
 
     /**
+     * Returns the options recognized by this processor.
+     *
+     * @implSpec
      * If the processor class is annotated with {@link
      * SupportedOptions}, return an unmodifiable set with the same set
      * of strings as the annotation.  If the class is not so
@@ -85,6 +88,9 @@ public abstract class AbstractProcessor implements Processor {
     }
 
     /**
+     * Returns the names of the annotation interfaces supported by this processor.
+     *
+     * @implSpec
      * If the processor class is annotated with {@link
      * SupportedAnnotationTypes}, return an unmodifiable set with the
      * same set of strings as the annotation.  If the class is not so
@@ -96,8 +102,7 @@ public abstract class AbstractProcessor implements Processor {
      * then any leading {@linkplain Processor#getSupportedAnnotationTypes
      * module prefixes} are stripped from the names.
      *
-     * @return the names of the annotation interfaces supported by
-     * this processor, or an empty set if none
+     * @return {@inheritDoc Processor}
      */
     @Override
     public Set<String> getSupportedAnnotationTypes() {
@@ -120,12 +125,15 @@ public abstract class AbstractProcessor implements Processor {
         }
 
     /**
+     * {@inheritDoc Processor}
+     *
+     * @implSpec
      * If the processor class is annotated with {@link
      * SupportedSourceVersion}, return the source version in the
      * annotation.  If the class is not so annotated, {@link
      * SourceVersion#RELEASE_6} is returned.
      *
-     * @return the latest source version supported by this processor
+     * @return {@inheritDoc Processor}
      */
     @Override
     public SourceVersion getSupportedSourceVersion() {
@@ -145,6 +153,9 @@ public abstract class AbstractProcessor implements Processor {
 
 
     /**
+     * {@inheritDoc Processor}
+     *
+     * @implSpec
      * Initializes the processor with the processing environment by
      * setting the {@code processingEnv} field to the value of the
      * {@code processingEnv} argument.  An {@code
@@ -165,7 +176,9 @@ public abstract class AbstractProcessor implements Processor {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc Processor}
+     * @param annotations {@inheritDoc Processor}
+     * @param roundEnv {@inheritDoc Processor}
      */
     @Override
     public abstract boolean process(Set<? extends TypeElement> annotations,
@@ -174,10 +187,10 @@ public abstract class AbstractProcessor implements Processor {
     /**
      * {@return an empty iterable of completions}
      *
-     * @param element {@inheritDoc}
-     * @param annotation {@inheritDoc}
-     * @param member {@inheritDoc}
-     * @param userText {@inheritDoc}
+     * @param element {@inheritDoc Processor}
+     * @param annotation {@inheritDoc Processor}
+     * @param member {@inheritDoc Processor}
+     * @param userText {@inheritDoc Processor}
      */
     @Override
     public Iterable<? extends Completion> getCompletions(Element element,

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -32,6 +32,7 @@ import java.lang.annotation.IncompleteAnnotationException;
 import java.util.List;
 import java.util.Set;
 
+import javax.lang.model.AnnotatedConstruct;
 import javax.lang.model.type.*;
 import javax.lang.model.util.*;
 
@@ -56,7 +57,7 @@ import javax.lang.model.util.*;
  * @see TypeMirror
  * @since 1.6
  */
-public interface Element extends javax.lang.model.AnnotatedConstruct {
+public interface Element extends AnnotatedConstruct {
     /**
      * {@return the type defined by this element}
      *
@@ -261,7 +262,7 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
     int hashCode();
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotatedConstruct}
      *
      * <p>To get inherited annotations as well, use {@link
      * Elements#getAllAnnotationMirrors(Element)
@@ -276,7 +277,7 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
     List<? extends AnnotationMirror> getAnnotationMirrors();
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotatedConstruct}
      *
      * <p>Note that any annotation returned by this method is a
      * declaration annotation.
@@ -287,7 +288,7 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
     <A extends Annotation> A getAnnotation(Class<A> annotationType);
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotatedConstruct}
      *
      * <p>Note that any annotations returned by this method are
      * declaration annotations.

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package javax.lang.model.type;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+
+import javax.lang.model.AnnotatedConstruct;
 import javax.lang.model.element.*;
 import javax.lang.model.util.Types;
 
@@ -62,7 +64,7 @@ import javax.lang.model.util.Types;
  * @jls 10.1 Array Types
  * @since 1.6
  */
-public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
+public interface TypeMirror extends AnnotatedConstruct {
 
     /**
      * {@return the {@code kind} of this type}
@@ -141,7 +143,7 @@ public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
     String toString();
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotatedConstruct}
      *
      * <p>Note that any annotations returned by this method are type
      * annotations.
@@ -152,7 +154,7 @@ public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
     List<? extends AnnotationMirror> getAnnotationMirrors();
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotatedConstruct}
      *
      * <p>Note that any annotation returned by this method is a type
      * annotation.
@@ -163,7 +165,7 @@ public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
     <A extends Annotation> A getAnnotation(Class<A> annotationType);
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotatedConstruct}
      *
      * <p>Note that any annotations returned by this method are type
      * annotations.

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,9 +82,9 @@ public abstract class AbstractAnnotationValueVisitor6<R, P>
      * Visits any annotation value as if by passing itself to that
      * value's {@link AnnotationValue#accept accept}.  The invocation
      * {@code v.visit(av, p)} is equivalent to {@code av.accept(v, p)}.
-     * @param av {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param av {@inheritDoc AnnotationValueVisitor}
+     * @param p  {@inheritDoc AnnotationValueVisitor}
+     * @return   {@inheritDoc AnnotationValueVisitor}
      */
     public final R visit(AnnotationValue av, P p) {
         return av.accept(this, p);
@@ -96,24 +96,25 @@ public abstract class AbstractAnnotationValueVisitor6<R, P>
      * {@code null} for the additional parameter.  The invocation
      * {@code v.visit(av)} is equivalent to {@code av.accept(v,
      * null)}.
-     * @param av {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param av {@inheritDoc AnnotationValueVisitor}
+     * @return   {@inheritDoc AnnotationValueVisitor}
      */
     public final R visit(AnnotationValue av) {
         return av.accept(this, null);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec The default implementation of this method in {@code
      * AbstractAnnotationValueVisitor6} will always throw {@code
      * new UnknownAnnotationValueException(av, p)}.  This behavior is not
      * required of a subclass.
      *
-     * @param av {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param av {@inheritDoc AnnotationValueVisitor}
+     * @param p  {@inheritDoc AnnotationValueVisitor}
+     * @return   {@inheritDoc AnnotationValueVisitor}
+     * @throws UnknownAnnotationValueException {@inheritDoc AnnotationValueVisitor}
      */
     @Override
     public R visitUnknown(AnnotationValue av, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javax.lang.model.util;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.RecordComponentElement;
 import static javax.lang.model.SourceVersion.*;
 
@@ -59,14 +60,14 @@ public abstract class AbstractElementVisitor14<R, P> extends AbstractElementVisi
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec Visits a {@code RecordComponentElement} in a manner defined by a
      * subclass.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return   {@inheritDoc ElementVisitor}
      */
     @Override
     public abstract R visitRecordComponent(RecordComponentElement e, P p);

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,18 +107,17 @@ public abstract class AbstractElementVisitor6<R, P> implements ElementVisitor<R,
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec The default implementation of this method in
      * {@code AbstractElementVisitor6} will always throw
      * {@code new UnknownElementException(e, p)}.
      * This behavior is not required of a subclass.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
-     * @throws UnknownElementException
-     *          a visitor implementation may optionally throw this exception
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
+     * @throws UnknownElementException {@inheritDoc ElementVisitor}
      */
     @Override
     public R visitUnknown(Element e, P p) {
@@ -126,14 +125,14 @@ public abstract class AbstractElementVisitor6<R, P> implements ElementVisitor<R,
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec Visits a {@code ModuleElement} by calling {@code
      * visitUnknown}.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return   {@inheritDoc ElementVisitor}
      *
      * @since 9
      */
@@ -144,14 +143,14 @@ public abstract class AbstractElementVisitor6<R, P> implements ElementVisitor<R,
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec Visits a {@code RecordComponentElement} by calling {@code
      * visitUnknown}.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return   {@inheritDoc ElementVisitor}
      *
      * @since 14
      */

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javax.lang.model.util;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ModuleElement;
 import static javax.lang.model.SourceVersion.*;
 
@@ -59,14 +60,14 @@ public abstract class AbstractElementVisitor9<R, P> extends AbstractElementVisit
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec Visits a {@code ModuleElement} in a manner defined by a
      * subclass.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return   {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return   {@inheritDoc ElementVisitor}
      */
     @Override
     public abstract R visitModule(ModuleElement e, P p);

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,29 +105,30 @@ public abstract class AbstractTypeVisitor6<R, P> implements TypeVisitor<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec Visits a {@code UnionType} element by calling {@code
      * visitUnknown}.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return the result of {@code visitUnknown}
      *
      * @since 1.7
      */
+    @Override
     public R visitUnion(UnionType t, P p) {
         return visitUnknown(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec Visits an {@code IntersectionType} element by calling {@code
      * visitUnknown}.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return the result of {@code visitUnknown}
      *
      * @since 1.8
@@ -138,18 +139,17 @@ public abstract class AbstractTypeVisitor6<R, P> implements TypeVisitor<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec The default implementation of this method in {@code
      * AbstractTypeVisitor6} will always throw {@code
      * new UnknownTypeException(t, p)}.  This behavior is not required of a
      * subclass.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return a visitor-specified result
-     * @throws UnknownTypeException
-     *  a visitor implementation may optionally throw this exception
+     * @throws UnknownTypeException {@inheritDoc TypeVisitor}
      */
     @Override
     public R visitUnknown(TypeMirror t, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,8 +65,8 @@ public abstract class AbstractTypeVisitor7<R, P> extends AbstractTypeVisitor6<R,
     /**
      * Visits a {@code UnionType} in a manner defined by a subclass.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return the result of the visit as defined by a subclass
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,12 @@ public abstract class AbstractTypeVisitor8<R, P> extends AbstractTypeVisitor7<R,
     }
 
     /**
-     * Visits an {@code IntersectionType} in a manner defined by a subclass.
+     * {@inheritDoc TypeVisitor}
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @implSpec Visits an {@code IntersectionType} in a manner defined by a subclass.
+     *
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return the result of the visit as defined by a subclass
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,12 +82,12 @@ public class ElementKindVisitor14<R, P> extends ElementKindVisitor9<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
      * @return  the result of {@code defaultAction}
      */
     @Override
@@ -96,12 +96,12 @@ public class ElementKindVisitor14<R, P> extends ElementKindVisitor9<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementKindVisitor6}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *.
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
+     * @param e {@inheritDoc ElementKindVisitor6}
+     * @param p {@inheritDoc ElementKindVisitor6}
      * @return  the result of {@code defaultAction}
      */
     @Override
@@ -110,12 +110,12 @@ public class ElementKindVisitor14<R, P> extends ElementKindVisitor9<R, P> {
     }
 
     /**
-     * Visits a {@code BINDING_VARIABLE} variable element.
+     * {@inheritDoc ElementKindVisitor6}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param e {@inheritDoc ElementKindVisitor6}
+     * @param p {@inheritDoc ElementKindVisitor6}
      * @return  the result of {@code defaultAction}
      *
      * @since 14

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,11 @@
 package javax.lang.model.util;
 
 import javax.lang.model.element.*;
-import static javax.lang.model.element.ElementKind.*;
 import javax.annotation.processing.SupportedSourceVersion;
-import static javax.lang.model.SourceVersion.*;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
+import static javax.lang.model.element.ElementKind.*;
+import static javax.lang.model.SourceVersion.*;
 
 
 /**
@@ -107,15 +108,15 @@ public class ElementKindVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * The element argument has kind {@code PACKAGE}.
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
     @Override
     public R visitPackage(PackageElement e, P p) {
@@ -124,15 +125,15 @@ public class ElementKindVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation dispatches to the visit method for the
      * specific {@linkplain ElementKind kind} of type, {@code
      * ANNOTATION_TYPE}, {@code CLASS}, {@code ENUM}, or {@code
      * INTERFACE}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
      * @return  the result of the kind-specific visit method
      */
     @Override
@@ -227,15 +228,15 @@ public class ElementKindVisitor6<R, P>
     }
 
     /**
-     * Visits a variable element
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation dispatches to the visit method for
      * the specific {@linkplain ElementKind kind} of variable, {@code
      * ENUM_CONSTANT}, {@code EXCEPTION_PARAMETER}, {@code FIELD},
      * {@code LOCAL_VARIABLE}, {@code PARAMETER}, or {@code RESOURCE_VARIABLE}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
      * @return  the result of the kind-specific visit method
      */
     @Override
@@ -364,15 +365,15 @@ public class ElementKindVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation dispatches to the visit method
      * for the specific {@linkplain ElementKind kind} of executable,
      * {@code CONSTRUCTOR}, {@code INSTANCE_INIT}, {@code METHOD}, or
      * {@code STATIC_INIT}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
      * @return  the result of the kind-specific visit method
      */
     @Override
@@ -449,15 +450,15 @@ public class ElementKindVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * The element argument has kind {@code TYPE_PARAMETER}.
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
     @Override
     public R visitTypeParameter(TypeParameterElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,12 +88,12 @@ public class ElementKindVisitor7<R, P> extends ElementKindVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementKindVisitor6}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param e {@inheritDoc ElementKindVisitor6}
+     * @param p {@inheritDoc ElementKindVisitor6}
      * @return  the result of {@code defaultAction}
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,9 @@ package javax.lang.model.util;
 
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
-import static javax.lang.model.SourceVersion.*;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
+import static javax.lang.model.SourceVersion.*;
 
 /**
  * A visitor of program elements based on their {@linkplain
@@ -82,12 +83,12 @@ public class ElementKindVisitor9<R, P> extends ElementKindVisitor8<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
      * @return  the result of {@code defaultAction}
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 /**
@@ -98,15 +99,15 @@ public class ElementScanner14<R, P> extends ElementScanner9<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the type parameters, if
      * any, and then the enclosed elements.
      *
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return the result of scanning
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return   {@inheritDoc ElementScanner6}
      */
     @Override
     public R visitType(TypeElement e, P p) {
@@ -114,15 +115,16 @@ public class ElementScanner14<R, P> extends ElementScanner9<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation first scans the type parameters, if any, and then
      * the parameters.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return the result of scanning
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return   {@inheritDoc ElementScanner6}
      */
+    @Override
     public R visitExecutable(ExecutableElement e, P p) {
         return scan(createScanningList(e, e.getParameters()), p);
     }
@@ -140,13 +142,13 @@ public class ElementScanner14<R, P> extends ElementScanner9<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements.
      *
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
-     * @return  the result of the scan
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementScanner6}
      */
     @Override
     public R visitRecordComponent(RecordComponentElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@ package javax.lang.model.util;
 
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
-
 
 /**
  * A scanning visitor of program elements with default behavior
@@ -162,20 +162,21 @@ public class ElementScanner6<R, P> extends AbstractElementVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
      * @return the result of scanning
      */
+    @Override
     public R visitPackage(PackageElement e, P p) {
         return scan(e.getEnclosedElements(), p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements.
      * Note that type parameters are <em>not</em> scanned by this
@@ -183,25 +184,27 @@ public class ElementScanner6<R, P> extends AbstractElementVisitor6<R, P> {
      * {@linkplain TypeElement#getEnclosedElements enclosed elements
      * of a type}.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
      * @return the result of scanning
      */
+    @Override
     public R visitType(TypeElement e, P p) {
         return scan(e.getEnclosedElements(), p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements, unless the
      * element is a {@code RESOURCE_VARIABLE} in which case {@code
      * visitUnknown} is called.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
      * @return the result of scanning
      */
+    @Override
     public R visitVariable(VariableElement e, P p) {
         if (e.getKind() != ElementKind.RESOURCE_VARIABLE)
             return scan(e.getEnclosedElements(), p);
@@ -210,30 +213,46 @@ public class ElementScanner6<R, P> extends AbstractElementVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the parameters.
      * Note that type parameters are <em>not</em> scanned by this
      * implementation.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
      * @return the result of scanning
      */
+    @Override
     public R visitExecutable(ExecutableElement e, P p) {
         return scan(e.getParameters(), p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
      * @return the result of scanning
      */
+    @Override
     public R visitTypeParameter(TypeParameterElement e, P p) {
         return scan(e.getEnclosedElements(), p);
+    }
+
+    /**
+     * {@inheritDoc ElementVisitor}
+     *
+     * @implSpec This implementation calls {@code visitUnknown(e, p)}.
+     *
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return the result of scanning
+     */
+    @Override
+    public R visitRecordComponent(RecordComponentElement e, P p) {
+        return visitUnknown(e, p);
     }
 }

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 
@@ -104,13 +105,13 @@ public class ElementScanner7<R, P> extends ElementScanner6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements.
      *
-     * @param e  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return the result of scanning
+     * @param e  {@inheritDoc ElementVisitor}
+     * @param p  {@inheritDoc ElementVisitor}
+     * @return {@inheritDoc ElementScanner6}
      */
     @Override
     public R visitVariable(VariableElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 
@@ -97,13 +98,13 @@ public class ElementScanner9<R, P> extends ElementScanner8<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation scans the enclosed elements.
      *
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
-     * @return  the result of the scan
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementScanner6}
      */
     @Override
     public R visitModule(ModuleElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,12 +125,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param b {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param b {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitBoolean(boolean b, P p) {
@@ -138,12 +138,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param b {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param b {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitByte(byte b, P p) {
@@ -151,12 +151,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param c {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param c {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitChar(char c, P p) {
@@ -164,13 +164,13 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
      *
-     * @param d {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param d {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitDouble(double d, P p) {
@@ -178,13 +178,13 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
      *
-     * @param f {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param f {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitFloat(float f, P p) {
@@ -192,12 +192,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param i {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param i {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitInt(int i, P p) {
@@ -205,12 +205,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param i {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param i {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitLong(long i, P p) {
@@ -218,12 +218,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param s {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param s {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitShort(short s, P p) {
@@ -231,12 +231,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param s {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param s {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitString(String s, P p) {
@@ -244,12 +244,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitType(TypeMirror t, P p) {
@@ -257,12 +257,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param c {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param c {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitEnumConstant(VariableElement c, P p) {
@@ -270,12 +270,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param a {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param a {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitAnnotation(AnnotationMirror a, P p) {
@@ -283,12 +283,12 @@ public class SimpleAnnotationValueVisitor6<R, P>
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc AnnotationValueVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param vals {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param vals {@inheritDoc AnnotationValueVisitor}
+     * @param p {@inheritDoc AnnotationValueVisitor}
      * @return  the result of {@code defaultAction}
      */
     public R visitArray(List<? extends AnnotationValue> vals, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javax.lang.model.util;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.RecordComponentElement;
 import static javax.lang.model.SourceVersion.*;
 
@@ -78,14 +79,14 @@ public class SimpleElementVisitor14<R, P> extends SimpleElementVisitor9<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec Visits a {@code RecordComponentElement} by calling {@code
      * defaultAction}.
      *
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
     @Override
     public R visitRecordComponent(RecordComponentElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 
@@ -110,6 +111,7 @@ public class SimpleElementVisitor6<R, P> extends AbstractElementVisitor6<R, P> {
     protected SimpleElementVisitor6(R defaultValue){
         DEFAULT_VALUE = defaultValue;
     }
+
     /**
      * The default action for visit methods.
      *
@@ -125,42 +127,45 @@ public class SimpleElementVisitor6<R, P> extends AbstractElementVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
+    @Override
     public R visitPackage(PackageElement e, P p) {
         return defaultAction(e, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
+    @Override
     public R visitType(TypeElement e, P p) {
         return defaultAction(e, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}, unless the
      * element is a {@code RESOURCE_VARIABLE} in which case {@code
      * visitUnknown} is called.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
+    @Override
     public R visitVariable(VariableElement e, P p) {
         if (e.getKind() != ElementKind.RESOURCE_VARIABLE)
             return defaultAction(e, p);
@@ -169,27 +174,29 @@ public class SimpleElementVisitor6<R, P> extends AbstractElementVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
+    @Override
     public R visitExecutable(ExecutableElement e, P p) {
         return defaultAction(e, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
+    @Override
     public R visitTypeParameter(TypeParameterElement e, P p) {
         return defaultAction(e, p);
     }

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 /**
@@ -86,13 +87,13 @@ public class SimpleElementVisitor7<R, P> extends SimpleElementVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param e {@inheritDoc}
-     * @param p {@inheritDoc}
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
     @Override
     public R visitVariable(VariableElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javax.lang.model.util;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ModuleElement;
 import static javax.lang.model.SourceVersion.*;
 
@@ -78,14 +79,14 @@ public class SimpleElementVisitor9<R, P> extends SimpleElementVisitor8<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc ElementVisitor}
      *
      * @implSpec Visits a {@code ModuleElement} by calling {@code
      * defaultAction}.
      *
-     * @param e the element to visit
-     * @param p a visitor-specified parameter
-     * @return  {@inheritDoc}
+     * @param e {@inheritDoc ElementVisitor}
+     * @param p {@inheritDoc ElementVisitor}
+     * @return  {@inheritDoc ElementVisitor}
      */
     @Override
     public R visitModule(ModuleElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import javax.lang.model.type.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
+import javax.lang.model.type.TypeVisitor;
 
 
 /**
@@ -126,118 +127,127 @@ public class SimpleTypeVisitor6<R, P> extends AbstractTypeVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitPrimitive(PrimitiveType t, P p) {
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc} This implementation calls {@code defaultAction}.
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitNull(NullType t, P p){
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitArray(ArrayType t, P p){
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitDeclared(DeclaredType t, P p){
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitError(ErrorType t, P p){
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitTypeVariable(TypeVariable t, P p){
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitWildcard(WildcardType t, P p){
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitExecutable(ExecutableType t, P p) {
         return defaultAction(t, p);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
+    @Override
     public R visitNoType(NoType t, P p){
         return defaultAction(t, p);
     }

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import javax.lang.model.type.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
+import javax.lang.model.type.TypeVisitor;
 
 /**
  * A simple visitor of types with default behavior appropriate for the
@@ -86,12 +87,12 @@ public class SimpleTypeVisitor7<R, P> extends SimpleTypeVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return the result of {@code defaultAction}
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.type.IntersectionType;
 import static javax.lang.model.SourceVersion.*;
+import javax.lang.model.type.TypeVisitor;
 
 /**
  * A simple visitor of types with default behavior appropriate for the
@@ -80,12 +81,12 @@ public class SimpleTypeVisitor8<R, P> extends SimpleTypeVisitor7<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of {@code defaultAction}
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,14 +105,14 @@ public class TypeKindVisitor6<R, P> extends SimpleTypeVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation dispatches to the visit method for
      * the specific {@linkplain TypeKind kind} of primitive type:
      * {@code BOOLEAN}, {@code BYTE}, etc.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of the kind-specific visit method
      */
     @Override
@@ -253,14 +253,14 @@ public class TypeKindVisitor6<R, P> extends SimpleTypeVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation dispatches to the visit method for
      * the specific {@linkplain TypeKind kind} of pseudo-type:
      * {@code VOID}, {@code PACKAGE}, {@code MODULE}, or {@code NONE}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeVisitor}
+     * @param p {@inheritDoc TypeVisitor}
      * @return  the result of the kind-specific visit method
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,13 +88,13 @@ public class TypeKindVisitor7<R, P> extends TypeKindVisitor6<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
-     * @return the result of {@code defaultAction}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
+     * @return   the result of {@code defaultAction}
      */
     @Override
     public R visitUnion(UnionType t, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,12 +82,12 @@ public class TypeKindVisitor8<R, P> extends TypeKindVisitor7<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeVisitor}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t  {@inheritDoc}
-     * @param p  {@inheritDoc}
+     * @param t  {@inheritDoc TypeVisitor}
+     * @param p  {@inheritDoc TypeVisitor}
      * @return the result of {@code defaultAction}
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,12 +83,12 @@ public class TypeKindVisitor9<R, P> extends TypeKindVisitor8<R, P> {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritDoc TypeKindVisitor6}
      *
      * @implSpec This implementation calls {@code defaultAction}.
      *
-     * @param t {@inheritDoc}
-     * @param p {@inheritDoc}
+     * @param t {@inheritDoc TypeKindVisitor6}
+     * @param p {@inheritDoc TypeKindVisitor6}
      * @return  the result of {@code defaultAction}
      *
      * @since 10

--- a/src/java.desktop/windows/classes/sun/awt/windows/WScrollPanePeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WScrollPanePeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,13 @@
  */
 package sun.awt.windows;
 
-import java.awt.*;
+import java.awt.Adjustable;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.ScrollPane;
+import java.awt.ScrollPaneAdjustable;
 import java.awt.event.AdjustmentEvent;
 import java.awt.peer.ScrollPanePeer;
 
@@ -105,7 +111,6 @@ final class WScrollPanePeer extends WPanelPeer implements ScrollPanePeer {
         ScrollPane sp = (ScrollPane)target;
         Dimension vs = sp.getSize();
         setSpans(vs.width, vs.height, width, height);
-        setInsets();
     }
 
     synchronized native void setSpans(int viewWidth, int viewHeight,

--- a/src/java.desktop/windows/native/libawt/windows/awt_ScrollPane.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_ScrollPane.cpp
@@ -525,6 +525,7 @@ void AwtScrollPane::_SetSpans(void *param)
             parentWidth, parentHeight, childWidth, childHeight);
         s->RecalcSizes(parentWidth, parentHeight, childWidth, childHeight);
         s->VerifyState();
+        s->SetInsets(env);
     }
 ret:
    env->DeleteGlobalRef(self);
@@ -718,7 +719,7 @@ Java_sun_awt_windows_WScrollPanePeer_setInsets(JNIEnv *env, jobject self)
 {
     TRY
 
-    AwtToolkit::GetInstance().SyncCall(AwtScrollPane::_SetInsets,
+    AwtToolkit::GetInstance().InvokeFunction(AwtScrollPane::_SetInsets,
         env->NewGlobalRef(self));
     // global ref is deleted in _SetInsets()
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -971,6 +971,13 @@ public class JavaCompiler {
         } catch (Abort ex) {
             if (devVerbose)
                 ex.printStackTrace(System.err);
+
+            // In case an Abort was thrown before processAnnotations could be called,
+            // we could have deferred diagnostics that haven't been reported.
+            if (deferredDiagnosticHandler != null) {
+                deferredDiagnosticHandler.reportDeferredDiagnostics();
+                log.popDiagnosticHandler(deferredDiagnosticHandler);
+            }
         } finally {
             if (verbose) {
                 elapsed_msec = elapsed(start_msec);

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,13 +87,13 @@ public abstract class CPublicKey extends CKey implements PublicKey {
             if (encoding == null) {
                 try {
                     encoding = KeyFactory.getInstance("EC").generatePublic(
-                                new ECPublicKeySpec(getW(), getParams()))
-                            .getEncoded();
+                            new ECPublicKeySpec(getW(), getParams()))
+                        .getEncoded();
                 } catch (Exception e) {
                     // ignore
                 }
             }
-            return encoding;
+            return (encoding == null) ? null : encoding.clone();
         }
 
         @Override
@@ -179,7 +179,7 @@ public abstract class CPublicKey extends CKey implements PublicKey {
                     // ignore
                 }
             }
-            return encoding;
+            return (encoding == null) ? null : encoding.clone();
         }
 
         private native byte[] getExponent(byte[] keyBlob) throws KeyException;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,6 +248,8 @@ public class AMD64 extends Architecture {
 
     private final AMD64Kind largestKind;
 
+    private final AMD64Kind largestMaskKind;
+
     public AMD64(EnumSet<CPUFeature> features, EnumSet<Flag> flags) {
         super("AMD64", AMD64Kind.QWORD, ByteOrder.LITTLE_ENDIAN, true, allRegisters, LOAD_LOAD | LOAD_STORE | STORE_STORE, 1, 8);
         this.features = features;
@@ -256,10 +258,17 @@ public class AMD64 extends Architecture {
 
         if (features.contains(CPUFeature.AVX512F)) {
             largestKind = AMD64Kind.V512_QWORD;
+            if (features.contains(CPUFeature.AVX512BW)) {
+                largestMaskKind = AMD64Kind.MASK64;
+            } else {
+                largestMaskKind = AMD64Kind.MASK16;
+            }
         } else if (features.contains(CPUFeature.AVX)) {
             largestKind = AMD64Kind.V256_QWORD;
+            largestMaskKind = null;
         } else {
             largestKind = AMD64Kind.V128_QWORD;
+            largestMaskKind = null;
         }
     }
 
@@ -324,7 +333,7 @@ public class AMD64 extends Architecture {
         } else if (category.equals(XMM)) {
             return largestKind;
         } else if (category.equals(MASK)) {
-            return AMD64Kind.MASK64;
+            return largestMaskKind;
         } else {
             return null;
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -300,7 +300,14 @@ public class IndexBuilder {
     }
 
     private static Character keyCharacter(String s) {
-        return s.isEmpty() ? '*' : Character.toUpperCase(s.charAt(0));
+        // Use first valid java identifier start character as key,
+        // or '*' for strings that do not contain one.
+        for (int i = 0; i < s.length(); i++) {
+            if (Character.isJavaIdentifierStart(s.charAt(i))) {
+                return Character.toUpperCase(s.charAt(i));
+            }
+        }
+        return '*';
     }
 
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/MultiCommand.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/MultiCommand.java
@@ -51,12 +51,12 @@ public class MultiCommand extends AbstractTestBase {
      * @return test instance to run
      */
     public static AbstractTestBase generateRandomTest(boolean validOnly) {
-        boolean isValid = true;
         CommandGenerator cmdGen = new CommandGenerator();
         List<Command> commands = cmdGen.generateCommands();
         List<CompileCommand> testCases = new ArrayList<>();
 
         for (Command cmd : commands) {
+            boolean isValid = true;
             String argument = null;
 
             if (validOnly && cmd == Command.NONEXISTENT) {
@@ -80,7 +80,7 @@ public class MultiCommand extends AbstractTestBase {
                 md = AbstractTestBase.getValidMethodDescriptor(exec);
             } else {
                 md = AbstractTestBase.METHOD_GEN.generateRandomDescriptor(exec);
-                isValid = false;
+                isValid &= md.isValid();
             }
             CompileCommand cc;
             if (cmd == Command.INTRINSIC) {

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 
 public class Executor {
-    private final boolean isValid;
     private final List<String> vmOptions;
     private final Map<Executable, State> states;
     private final List<String> jcmdCommands;
@@ -57,16 +56,13 @@ public class Executor {
     /**
      * Constructor
      *
-     * @param isValid      shows that the input given to the VM is valid and
-     *                     VM shouldn't fail
      * @param vmOptions    a list of VM input options
      * @param states       a state map, or null for the non-checking execution
      * @param jcmdCommands a list of diagnostic commands to be preformed
      *                     on test VM
      */
-    public Executor(boolean isValid, List<String> vmOptions,
-            Map<Executable, State> states, List<String> jcmdCommands) {
-        this.isValid = isValid;
+    public Executor(List<String> vmOptions, Map<Executable, State> states,
+                    List<String> jcmdCommands) {
         if (vmOptions == null) {
             this.vmOptions = new ArrayList<>();
         } else {
@@ -77,7 +73,7 @@ public class Executor {
     }
 
     /**
-     * Executes separate VM a gets an OutputAnalyzer instance with the results
+     * Executes separate VM and gets an OutputAnalyzer instance with the results
      * of execution
      */
     public List<OutputAnalyzer> execute() {

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
@@ -104,7 +104,7 @@ public final class Scenario {
             jcmdExecCommands.add(JcmdType.PRINT.command);
         }
         jcmdProcessor = new PrintDirectivesProcessor(directives);
-        executor = new Executor(isValid, vmopts, states, jcmdExecCommands);
+        executor = new Executor(vmopts, states, jcmdExecCommands);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGetWithNull.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGetWithNull.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8310126
+* @summary Test that the Reference::get intrinsic works with a null argument.
+* @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,*TestReferenceGetWithNull::test -Xbatch
+*                   compiler.intrinsics.TestReferenceGetWithNull
+*/
+
+package compiler.intrinsics;
+
+import java.lang.ref.WeakReference;
+
+public class TestReferenceGetWithNull {
+
+    // Declare final such that static binding at the call site is possible
+    static final class MyReference<T> extends WeakReference<T> {
+        public MyReference(T referent) {
+            super(referent);
+        }
+    }
+
+    static void test(MyReference r) {
+        try {
+            r.get();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    public static void main(String[] args) {
+        // Make sure MyReference is loaded
+        MyReference<String[]> obj = new MyReference<>(args);
+        // Trigger compilation
+        for (int i = 0; i < 50_000; ++i) {
+            test(null);
+        }
+    }
+}

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -101,11 +101,11 @@ public class TestLargePageUseForAuxMemory {
     }
 
     static void checkSmallTables(OutputAnalyzer output, long expectedPageSize) throws Exception {
-        checkSize(output, expectedPageSize, "Block Offset Table: .*page_size=([^ ]+)");
+        checkSize(output, expectedPageSize, "Block Offset Table: .* page_size=(\\d+[BKMG])");
     }
 
     static void checkBitmap(OutputAnalyzer output, long expectedPageSize) throws Exception {
-        checkSize(output, expectedPageSize, "Mark Bitmap: .*page_size=([^ ]+)");
+        checkSize(output, expectedPageSize, "Mark Bitmap: .* page_size=(\\d+[BKMG])");
     }
 
     static List<String> getOpts(long heapsize, boolean largePageEnabled) {
@@ -126,6 +126,7 @@ public class TestLargePageUseForAuxMemory {
         pb = ProcessTools.createJavaProcessBuilder(getOpts(heapsize, true));
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
         // Only expect large page size if large pages are enabled.
         if (largePagesEnabled(output)) {
             checkSmallTables(output, (cardsShouldUseLargePages ? largePageSize : smallPageSize));

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForHeap.java
@@ -81,7 +81,7 @@ public class TestLargePageUseForHeap {
     }
 
     static void checkHeap(OutputAnalyzer output, long expectedPageSize) throws Exception {
-        checkSize(output, expectedPageSize, "Heap: .*page_size=([^ ]+)");
+        checkSize(output, expectedPageSize, "Heap: .* page_size=(\\d+[BKMG])");
     }
 
     static void testVM(long regionSize) throws Exception {

--- a/test/hotspot/jtreg/gc/g1/numa/TestG1NUMATouchRegions.java
+++ b/test/hotspot/jtreg/gc/g1/numa/TestG1NUMATouchRegions.java
@@ -95,7 +95,7 @@ public class TestG1NUMATouchRegions {
     }
 
     static long heapPageSize(OutputAnalyzer output) {
-        String HeapPageSizePattern = "Heap:  .*page_size=([^ ]+)";
+        String HeapPageSizePattern = "Heap:  .* page_size=(\\d+[BKMG])";
         String str = output.firstMatch(HeapPageSizePattern, 1);
 
         if (str == null) {

--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -258,7 +258,7 @@ public class TestTracePageSizes {
         parseSmaps();
 
         // Setup patters for the JVM page size logging.
-        String traceLinePatternString = ".*base=(0x[0-9A-Fa-f]*).*page_size=([^ ]+).*";
+        String traceLinePatternString = ".*base=(0x[0-9A-Fa-f]*).* page_size=(\\d+[BKMG]).*";
         Pattern traceLinePattern = Pattern.compile(traceLinePatternString);
 
         // The test needs to be run with page size logging printed to ps-$pid.log.

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
@@ -44,7 +44,7 @@ static frame_info expected_virtual_frames[] = {
     {"Lgetstacktr03;", "dummy", "()V"},
     {"Lgetstacktr03;", "chain", "()V"},
     {"Lgetstacktr03$Task;", "run", "()V"},
-    {"Ljava/lang/VirtualThread;", "runWith", "(Ljava/lang/Object;Ljava/lang/Runnable;)V"},
+    {"Ljava/lang/Thread;", "runWith", "(Ljava/lang/Object;Ljava/lang/Runnable;)V"},
     {"Ljava/lang/VirtualThread;", "run", "(Ljava/lang/Runnable;)V"},
     {"Ljava/lang/VirtualThread$VThreadContinuation$1;", "run", "()V"},
     {"Ljdk/internal/vm/Continuation;", "enter0", "()V"},

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -42,8 +42,6 @@ javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-
 
 javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
 
-java/lang/ScopedValue/StressStackOverflow.java 8309646 generic-all
-
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
 ##########

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -487,8 +487,6 @@ java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 
-java/lang/ScopedValue/StressStackOverflow.java                  8303498 linux-s390x
-
 ############################################################################
 
 # jdk_instrument

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneExtraScrollBar.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneExtraScrollBar.java
@@ -23,7 +23,7 @@
 
 /*
   @test
-  @bug 4152524
+  @bug 4152524 8310054
   @requires os.family=="windows"
   @summary Test that scroll pane doesn't have scroll bars visible when it is
   shown for the first time with SCROLLBARS_AS_NEEDED style
@@ -57,7 +57,7 @@ public class ScrollPaneExtraScrollBar {
             sp = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
             sp.add(new Button("TEST"));
             f.add("Center", sp);
-            f.pack();
+            // Frame must not be packed, otherwise the bug isn't reproduced
             f.setLocationRelativeTo(null);
             f.setVisible(true);
         });

--- a/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
+++ b/test/jdk/java/lang/ScopedValue/StressStackOverflow.java
@@ -21,8 +21,8 @@
  * questions.
  */
 
-/**
- * @test
+/*
+ * @test id=default
  * @summary StressStackOverflow the recovery path for ScopedValue
  * @enablePreview
  * @run main/othervm/timeout=300 -XX:-TieredCompilation StressStackOverflow
@@ -30,8 +30,14 @@
  * @run main/othervm/timeout=300 StressStackOverflow
  */
 
+/*
+ * @test id=no-vmcontinuations
+ * @requires vm.continuations
+ * @enablePreview
+ * @run main/othervm/timeout=300 -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations StressStackOverflow
+ */
+
 import java.util.concurrent.Callable;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.StructureViolationException;
 import java.util.concurrent.StructuredTaskScope;
@@ -42,7 +48,6 @@ public class StressStackOverflow {
 
     public static final ScopedValue<Integer> inheritedValue = ScopedValue.newInstance();
 
-    final ThreadLocalRandom tlr = ThreadLocalRandom.current();
     static final TestFailureException testFailureException = new TestFailureException("Unexpected value for ScopedValue");
     int ITERS = 1_000_000;
 
@@ -50,13 +55,15 @@ public class StressStackOverflow {
         TestFailureException(String s) { super(s); }
     }
 
+    static final long MINUTES = 60 * 1_000_000_000L; // 60 * 10**9 ns
+
     // Test the ScopedValue recovery mechanism for stack overflows. We implement both Callable
     // and Runnable interfaces. Which one gets tested depends on the constructor argument.
-    class DeepRecursion implements Callable, Supplier, Runnable {
+    class DeepRecursion implements Callable<Object>, Supplier<Object>, Runnable {
 
-        static enum Behaviour {
+        enum Behaviour {
             CALL, GET, RUN;
-            private static Behaviour[] values = values();
+            private static final Behaviour[] values = values();
             public static Behaviour choose(ThreadLocalRandom tlr) {
                 return values[tlr.nextInt(3)];
             }
@@ -70,38 +77,40 @@ public class StressStackOverflow {
 
         public void run() {
             final var last = el.get();
-            ITERS--;
-            var nextRandomFloat = tlr.nextFloat();
-            try {
-                switch (behaviour) {
-                    case CALL ->
-                        ScopedValue.where(el, el.get() + 1).call(() -> fibonacci_pad(20, this));
-                    case GET ->
-                        ScopedValue.where(el, el.get() + 1).get(() -> fibonacci_pad(20, this));
-                    case RUN ->
-                        ScopedValue.where(el, el.get() + 1).run(() -> fibonacci_pad(20, this));
+            while (ITERS-- > 0) {
+                if (System.nanoTime() - startTime > 3 * MINUTES) { // 3 minutes is long enough
+                    return;
                 }
-                if (!last.equals(el.get())) {
-                    throw testFailureException;
-                }
-            } catch (StackOverflowError e) {
-                if (nextRandomFloat <= 0.1) {
-                    ScopedValue.where(el, el.get() + 1).run(this);
-                }
-            } catch (TestFailureException e) {
-                throw e;
-            } catch (Throwable throwable) {
-                // StackOverflowErrors cause many different failures. These include
-                // StructureViolationExceptions and InvocationTargetExceptions. This test
-                // checks that, no matter what the failure mode, scoped values are handled
-                // correctly.
-            } finally {
-                if (!last.equals(el.get())) {
-                    throw testFailureException;
-                }
-            }
 
-            Thread.yield();
+                var nextRandomFloat = ThreadLocalRandom.current().nextFloat();
+                try {
+                    switch (behaviour) {
+                        case CALL -> ScopedValue.where(el, el.get() + 1).call(() -> fibonacci_pad(20, this));
+                        case GET -> ScopedValue.where(el, el.get() + 1).get(() -> fibonacci_pad(20, this));
+                        case RUN -> ScopedValue.where(el, el.get() + 1).run(() -> fibonacci_pad(20, this));
+                    }
+                    if (!last.equals(el.get())) {
+                        throw testFailureException;
+                    }
+                } catch (StackOverflowError e) {
+                    if (nextRandomFloat <= 0.1) {
+                        ScopedValue.where(el, el.get() + 1).run(this);
+                    }
+                } catch (TestFailureException e) {
+                    throw e;
+                } catch (Throwable throwable) {
+                    // StackOverflowErrors cause many different failures. These include
+                    // StructureViolationExceptions and InvocationTargetExceptions. This test
+                    // checks that, no matter what the failure mode, scoped values are handled
+                    // correctly.
+                } finally {
+                    if (!last.equals(el.get())) {
+                        throw testFailureException;
+                    }
+                }
+
+                Thread.yield();
+            }
         }
 
         public Object get() {
@@ -114,13 +123,10 @@ public class StressStackOverflow {
         }
     }
 
-    static final Runnable nop = new Runnable() {
-        public void run() { }
-    };
+    static final Runnable nop = () -> {};
 
     // Consume some stack.
     //
-
     // The double recursion used here prevents an optimizing JIT from
     // inlining all the recursive calls, which would make it
     // ineffective.
@@ -137,7 +143,7 @@ public class StressStackOverflow {
     long fibonacci_pad(int n, Runnable op) {
         final var last = el.get();
         try {
-            return fibonacci_pad1(tlr.nextInt(n), op);
+            return fibonacci_pad1(ThreadLocalRandom.current().nextInt(n), op);
         } catch (StackOverflowError err) {
             if (!inheritedValue.get().equals(I_42)) {
                 throw testFailureException;
@@ -152,14 +158,16 @@ public class StressStackOverflow {
     // Run op in a new thread. Platform or virtual threads are chosen at random.
     void runInNewThread(Runnable op) {
         var threadFactory
-                = (tlr.nextBoolean() ? Thread.ofPlatform() : Thread.ofVirtual()).factory();
-        try (var scope = new StructuredTaskScope<Object>("", threadFactory)) {
+                = (ThreadLocalRandom.current().nextBoolean() ? Thread.ofPlatform() : Thread.ofVirtual()).factory();
+        try (var scope = new StructuredTaskScope<>("", threadFactory)) {
             var handle = scope.fork(() -> {
                 op.run();
                 return null;
             });
             scope.join();
             handle.get();
+        } catch (TestFailureException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -168,12 +176,12 @@ public class StressStackOverflow {
     public void run() {
         try {
             ScopedValue.where(inheritedValue, 42).where(el, 0).run(() -> {
-                try (var scope = new StructuredTaskScope<Object>()) {
+                try (var scope = new StructuredTaskScope<>()) {
                     try {
-                        if (tlr.nextBoolean()) {
+                        if (ThreadLocalRandom.current().nextBoolean()) {
                             // Repeatedly test Scoped Values set by ScopedValue::call(), get(), and run()
                             final var deepRecursion
-                                = new DeepRecursion(DeepRecursion.Behaviour.choose(tlr));
+                                = new DeepRecursion(DeepRecursion.Behaviour.choose(ThreadLocalRandom.current()));
                             deepRecursion.run();
                         } else {
                             // Recursively run ourself until we get a stack overflow
@@ -204,21 +212,39 @@ public class StressStackOverflow {
                     } catch (StructureViolationException structureViolationException) {
                         // Can happen if a stack overflow prevented a StackableScope from
                         // being removed. We can continue.
+                    } catch (TestFailureException e) {
+                        throw e;
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
                 }
             });
-        } catch (StructureViolationException structureViolationException) {
+        } catch (TestFailureException e) {
+            throw e;
+        } catch (Exception e) {
             // Can happen if a stack overflow prevented a StackableScope from
             // being removed. We can continue.
         }
     }
 
+    static long startTime = System.nanoTime();
+
     public static void main(String[] args) {
         var torture = new StressStackOverflow();
-        while (torture.ITERS > 0) {
-            torture.run();
+        while (torture.ITERS > 0
+                && System.nanoTime() - startTime <= 3 * MINUTES) { // 3 minutes is long enough
+            try {
+                torture.run();
+                if (inheritedValue.isBound()) {
+                    throw new TestFailureException("Should not be bound here");
+                }
+            } catch (TestFailureException e) {
+                throw e;
+            } catch (Exception e) {
+                // ScopedValueContainer and StructuredTaskScope can
+                // throw many exceptions on stack overflow. Ignore
+                // them all.
+            }
         }
         System.out.println("OK");
     }

--- a/test/jdk/sun/security/mscapi/EncodingMutability.java
+++ b/test/jdk/sun/security/mscapi/EncodingMutability.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+
+/*
+ * @test
+ * @bug 8308808
+ * @requires os.family == "windows"
+ * @modules jdk.crypto.mscapi
+ * @run main EncodingMutability
+ */
+public class EncodingMutability {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", "SunMSCAPI");
+        PublicKey publicKey = keyGen.generateKeyPair().getPublic();
+        byte initialByte = publicKey.getEncoded()[0];
+        publicKey.getEncoded()[0] = 0;
+        byte mutatedByte = publicKey.getEncoded()[0];
+
+        if (initialByte != mutatedByte) {
+            System.out.println("Was able to mutate first byte of pubkey from " + initialByte + " to " + mutatedByte);
+            throw new RuntimeException("Pubkey was mutated via getEncoded");
+        }
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8289332 8286470
+ * @bug 8289332 8286470 8309471
  * @summary Auto-generate ids for user-defined headings
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -59,9 +59,9 @@ public class TestAutoHeaderId extends JavadocTester {
                         /**
                          * First sentence.
                          *
-                         * <h2>First Header</h2>
+                         * <h2>1.0 First Header</h2>
                          *
-                         * <h3 id="fixed-id-1">Header with ID</h3>
+                         * <h3 id="fixed-id-1">1.1 Header with ID</h3>
                          *
                          * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
                          *
@@ -73,13 +73,13 @@ public class TestAutoHeaderId extends JavadocTester {
                          *
                          * <h4>Duplicate Text</h4>
                          *
-                         * <h2>Extra (#*!. chars</h2>
+                         * <h2>2.0 Extra (#*!. chars</h2>
                          *
                          * <h3 style="color: red;" class="some-class">Other attributes</h3>
                          *
                          * <h4></h4>
                          *
-                         * <h2>  Multi-line
+                         * <h2> 3.0 Multi-line
                          *       heading   with extra
                          *                 whitespace</h2>
                          *
@@ -94,13 +94,18 @@ public class TestAutoHeaderId extends JavadocTester {
         javadoc("-d", base.resolve("api").toString(),
                 "-sourcepath", src.toString(),
                 "--no-platform-links", "p");
+        checkIds();
+        checkSearchIndex();
+        checkHtmlIndex();
+    }
 
+    private void checkIds() {
         checkOutput("p/C.html", true,
                 """
-                    <h2 id="first-header-heading">First Header</h2>
+                    <h2 id="1-0-first-header-heading">1.0 First Header</h2>
                     """,
                 """
-                    <h3 id="fixed-id-1">Header with ID</h3>
+                    <h3 id="fixed-id-1">1.1 Header with ID</h3>
                     """,
                 """
                     <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
@@ -118,7 +123,7 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4 id="duplicate-text-heading1">Duplicate Text</h4>
                     """,
                 """
-                    <h2 id="extra-chars-heading">Extra (#*!. chars</h2>
+                    <h2 id="2-0-extra-chars-heading">2.0 Extra (#*!. chars</h2>
                     """,
                 """
                     <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
@@ -127,9 +132,12 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4 id="-heading"></h4>
                     """,
                 """
-                    <h2 id="multi-line-heading-with-extra-whitespace-heading">  Multi-line
+                    <h2 id="3-0-multi-line-heading-with-extra-whitespace-heading"> 3.0 Multi-line
                            heading   with extra
                                      whitespace</h2>""");
+    }
+
+    private void checkSearchIndex() {
         checkOutput("tag-search-index.js", true,
                 """
                     {"l":"Duplicate Text","h":"class p.C","d":"Section","u":"p/C.html#duplicate-text-heading"}""",
@@ -142,15 +150,87 @@ public class TestAutoHeaderId extends JavadocTester {
                 """
                     {"l":"Embedded Link Tag","h":"class p.C","d":"Section","u":"p/C.html#embedded-link-tag-heading"}""",
                 """
-                    {"l":"Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#extra-chars-heading"}""",
+                    {"l":"2.0 Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#2-0-extra-chars-heading"}""",
                 """
-                    {"l":"First Header","h":"class p.C","d":"Section","u":"p/C.html#first-header-heading"}""",
+                    {"l":"1.0 First Header","h":"class p.C","d":"Section","u":"p/C.html#1-0-first-header-heading"}""",
                 """
-                    {"l":"Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
+                    {"l":"1.1 Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
                 """
-                    {"l":"Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
-                    #multi-line-heading-with-extra-whitespace-heading"}""",
+                    {"l":"3.0 Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
+                    #3-0-multi-line-heading-with-extra-whitespace-heading"}""",
                 """
                     {"l":"Other attributes","h":"class p.C","d":"Section","u":"p/C.html#other-attributes-heading"}""");
+    }
+
+    private void checkHtmlIndex() {
+        // Make sure section links are not included in static index pages
+        checkOutput("index-all.html", true,
+                """
+                    <a href="#I:C">C</a>&nbsp;<a href="#I:D">D</a>&nbsp;<a href="#I:E">E</a>&nbsp;<a href="#I\
+                    :F">F</a>&nbsp;<a href="#I:H">H</a>&nbsp;<a href="#I:M">M</a>&nbsp;<a href="#I:O">O</a>&n\
+                    bsp;<a href="#I:P">P</a>&nbsp;<br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;a\
+                    nd&nbsp;Interfaces</a><span class="vertical-separator">|</span><a href="allpackages-index\
+                    .html">All&nbsp;Packages</a>
+                    <h2 class="title" id="I:C">C</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html" class="type-name-link" title="class in p">C</a> - Class in <a href\
+                    ="p/package-summary.html">p</a></dt>
+                    <dd>
+                    <div class="block">First sentence.</div>
+                    </dd>
+                    </dl>
+                    <h2 class="title" id="I:D">D</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#duplicate-text-heading" class="search-tag-link">Duplicate Text</a> \
+                    - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#duplicate-text-heading1" class="search-tag-link">Duplicate Text</a>\
+                     - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:E">E</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#2-0-extra-chars-heading" class="search-tag-link">2.0 Extra (#*!. ch\
+                    ars</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#fixed-id-2" class="search-tag-link">Embedded A-Tag with ID</a> - Se\
+                    arch tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#embedded-code-tag-heading" class="search-tag-link">Embedded Code Ta\
+                    g</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#embedded-link-tag-heading" class="search-tag-link">Embedded Link Ta\
+                    g</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:F">F</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#1-0-first-header-heading" class="search-tag-link">1.0 First Header<\
+                    /a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:H">H</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#fixed-id-1" class="search-tag-link">1.1 Header with ID</a> - Search\
+                     tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:M">M</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#3-0-multi-line-heading-with-extra-whitespace-heading" class="search\
+                    -tag-link">3.0 Multi-line heading with extra whitespace</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:O">O</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#other-attributes-heading" class="search-tag-link">Other attributes<\
+                    /a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:P">P</h2>
+                    <dl class="index">
+                    <dt><a href="p/package-summary.html">p</a> - package p</dt>
+                    <dd>&nbsp;</dd>
+                    </dl>""");
     }
 }

--- a/test/langtools/tools/javac/fatalErrors/NoJavaLangWithAnnotationProcessorTest.java
+++ b/test/langtools/tools/javac/fatalErrors/NoJavaLangWithAnnotationProcessorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309499
+ * @summary Verify that java.lang unavailable error is not swallowed when
+ *  annotation processor is used.
+ * @library /tools/lib /tools/javac/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @build NoJavaLangWithAnnotationProcessorTest JavacTestingAbstractProcessor
+ * @run main NoJavaLangWithAnnotationProcessorTest
+ */
+
+import java.nio.file.*;
+import java.util.Set;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class NoJavaLangWithAnnotationProcessorTest extends JavacTestingAbstractProcessor {
+
+    private static final String noJavaLangSrc =
+        "public class NoJavaLang {\n" +
+        "    private String s;\n" +
+        "}";
+
+    private static final String compilerErrorMessage =
+        "compiler.err.no.java.lang";
+
+    // No-Op annotation processor
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    public static void main(String[] args) throws Exception {
+        new NoJavaLangWithAnnotationProcessorTest().run();
+    }
+
+    final ToolBox tb = new ToolBox();
+
+    void run() throws Exception {
+        testCompilesNormallyWithNonEmptyBootClassPath();
+        testBootClassPath();
+        testModulePath();
+    }
+
+    // Normal case with java.lang available
+    void testCompilesNormallyWithNonEmptyBootClassPath() {
+        new JavacTask(tb)
+                .sources(noJavaLangSrc)
+                .options("-processor", "NoJavaLangWithAnnotationProcessorTest")
+                .run();
+    }
+
+
+    // test with bootclasspath, for as long as its around
+    void testBootClassPath() {
+        String[] bcpOpts = {"-XDrawDiagnostics", "-Xlint:-options", "-source", "8", "-target", "8",
+            "-bootclasspath", ".", "-classpath", ".",
+            "-processor", "NoJavaLangWithAnnotationProcessorTest", "-processorpath", System.getProperty("test.class.path") };
+        test(bcpOpts, compilerErrorMessage);
+    }
+
+    // test with module path
+    void testModulePath() throws Exception {
+        // need to ensure there is an empty java.base to avoid different error message
+        Files.createDirectories(Paths.get("modules/java.base"));
+        new JavacTask(tb)
+                .sources("module java.base { }",
+                         "package java.lang; public class Object {}")
+                .outdir("modules/java.base")
+                .run();
+
+        Files.delete(Paths.get("modules", "java.base", "java", "lang", "Object.class"));
+
+        String[] mpOpts = {"-XDrawDiagnostics", "--system", "none", "--module-path", "modules",
+            "-processor", "NoJavaLangWithAnnotationProcessorTest", "-processorpath", System.getProperty("test.class.path") };
+        test(mpOpts, compilerErrorMessage);
+    }
+
+    private void test(String[] options, String expect) {
+        System.err.println("Testing " + java.util.Arrays.toString(options));
+
+        String out = new JavacTask(tb)
+                .options(options)
+                .sources(noJavaLangSrc)
+                .run(Task.Expect.FAIL, 1)
+                .writeAll()
+                .getOutput(Task.OutputKind.DIRECT);
+
+        if (!out.contains(expect)) {
+            throw new AssertionError("javac generated error output is not correct");
+        }
+    }
+
+}

--- a/test/langtools/tools/javac/parser/ExtraImportSemicolon.java
+++ b/test/langtools/tools/javac/parser/ExtraImportSemicolon.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 5059679
+ * @bug 8027682
  * @summary Verify proper error reporting of extra semicolon before import statement
  * @compile/fail/ref=ExtraImportSemicolon.out1 -XDrawDiagnostics ExtraImportSemicolon.java
  * @compile/ref=ExtraImportSemicolon.out2 --release 20 -XDrawDiagnostics ExtraImportSemicolon.java


### PR DESCRIPTION
The fix for [JDK-8282797](https://bugs.openjdk.org/browse/JDK-8282797) missed that randomly generated Compile Commands can be invalid. I verified with the corresponding seeds that all occurrences of this intermittent failure are now fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310143](https://bugs.openjdk.org/browse/JDK-8310143): RandomCommandsTest fails due to unexpected VM exit code after JDK-8282797 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [61f44405](https://git.openjdk.org/jdk/pull/14514/files/61f4440523434526967bdf1642ee946f289d0479)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14514/head:pull/14514` \
`$ git checkout pull/14514`

Update a local copy of the PR: \
`$ git checkout pull/14514` \
`$ git pull https://git.openjdk.org/jdk.git pull/14514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14514`

View PR using the GUI difftool: \
`$ git pr show -t 14514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14514.diff">https://git.openjdk.org/jdk/pull/14514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14514#issuecomment-1594473151)