### PR TITLE
JDK-8310191: com/sun/tools/attach/warnings/DynamicLoadWarningTest.java second failure on AIX

### DIFF
--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -119,24 +119,22 @@ class DynamicLoadWarningTest {
         test().whenRunning(loadJvmtiAgent1)
                 .stderrShouldContain(JVMTI_AGENT_WARNING);
 
-        // dynamically load loadJvmtiAgent1 twice, should be one warning on platforms
-        // that can detect if an agent library was previously loaded
-        if (!Platform.isAix()) {
-            test().whenRunning(loadJvmtiAgent1)
-                    .whenRunning(loadJvmtiAgent1)
-                    .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
-        }
-
         // opt-in via command line option to allow dynamic loading of agents
         test().withOpts("-XX:+EnableDynamicAgentLoading")
                 .whenRunning(loadJvmtiAgent1)
                 .stderrShouldNotContain(JVMTI_AGENT_WARNING);
 
-        // start loadJvmtiAgent1 via the command line, then dynamically load loadJvmtiAgent1
+        // test behavior on platforms that can detect if an agent library was previously loaded
         if (!Platform.isAix()) {
+            // start loadJvmtiAgent1 via the command line, then dynamically load loadJvmtiAgent1
             test().withOpts("-agentpath:" + jvmtiAgentPath1)
                     .whenRunning(loadJvmtiAgent1)
                     .stderrShouldNotContain(JVMTI_AGENT_WARNING);
+
+            // dynamically load loadJvmtiAgent1 twice, should be one warning
+            test().whenRunning(loadJvmtiAgent1)
+                    .whenRunning(loadJvmtiAgent1)
+                    .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
         }
     }
 

--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -133,9 +133,11 @@ class DynamicLoadWarningTest {
                 .stderrShouldNotContain(JVMTI_AGENT_WARNING);
 
         // start loadJvmtiAgent1 via the command line, then dynamically load loadJvmtiAgent1
-        test().withOpts("-agentpath:" + jvmtiAgentPath1)
-                .whenRunning(loadJvmtiAgent1)
-                .stderrShouldNotContain(JVMTI_AGENT_WARNING);
+        if (!Platform.isAix()) {
+            test().withOpts("-agentpath:" + jvmtiAgentPath1)
+                    .whenRunning(loadJvmtiAgent1)
+                    .stderrShouldNotContain(JVMTI_AGENT_WARNING);
+        }
     }
 
     /**


### PR DESCRIPTION
After push of [JDK-8307478](https://bugs.openjdk.org/browse/JDK-8307478) , the following test started to fail on AIX :
com/sun/tools/attach/warnings/DynamicLoadWarningTest.java ; failure output :

java.lang.RuntimeException: 'WARNING: A JVM TI agent has been loaded dynamically' found in stderr
at jdk.test.lib.process.OutputAnalyzer.stderrShouldNotContain(OutputAnalyzer.java:320)
at DynamicLoadWarningTest$AppRunner.stderrShouldNotContain(DynamicLoadWarningTest.java:308)
at DynamicLoadWarningTest.testLoadOneJvmtiAgent(DynamicLoadWarningTest.java:138)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)

Should be handled in a similar way to [JDK-8309549](https://bugs.openjdk.org/browse/JDK-8309549) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310191](https://bugs.openjdk.org/browse/JDK-8310191): com/sun/tools/attach/warnings/DynamicLoadWarningTest.java second failure on AIX (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14515/head:pull/14515` \
`$ git checkout pull/14515`

Update a local copy of the PR: \
`$ git checkout pull/14515` \
`$ git pull https://git.openjdk.org/jdk.git pull/14515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14515`

View PR using the GUI difftool: \
`$ git pr show -t 14515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14515.diff">https://git.openjdk.org/jdk/pull/14515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14515#issuecomment-1594490597)