### PR TITLE
8310259: Pin msys2/setup-msys2 github action to a specific commit

### DIFF
--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$(realpath bootjdk/jdk)"
+        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,6 +30,7 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
+      # use a specific release of msys2/setup-msys2 to prevent jtreg build failures on newer release
       uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff
       with:
         install: 'autoconf tar unzip zip make'


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the recent github actions failures?

As noted in https://bugs.openjdk.org/browse/JDK-8310259 the commit in this PR pins the `msys2/setup-msys2` to a previous release (that works) and also reverts the change that was done in https://github.com/openjdk/jdk/pull/14507, for reasons discussed in that PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310259](https://bugs.openjdk.org/browse/JDK-8310259): Pin msys2/setup-msys2 github action to a specific commit (**Task** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14516/head:pull/14516` \
`$ git checkout pull/14516`

Update a local copy of the PR: \
`$ git checkout pull/14516` \
`$ git pull https://git.openjdk.org/jdk.git pull/14516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14516`

View PR using the GUI difftool: \
`$ git pr show -t 14516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14516.diff">https://git.openjdk.org/jdk/pull/14516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14516#issuecomment-1595581703)