### PR TITLE
8310194: Generational ZGC: Lock-order asserts in JVMTI IterateThroughHeap

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -299,10 +299,6 @@ void ZHeap::object_iterate(ObjectClosure* object_cl, bool visit_weaks) {
 
 void ZHeap::object_and_field_iterate_for_verify(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  // We use AtMark to make sure that verification catches broken objects as
-  // soon as they are encountered. The AtMark location has stricter
-  // requirements on the passed in closures. The reason for this is because the
-  // closures will be called during root iteraiton, which takes various locks.
   ZHeapIterator iter(1 /* nworkers */, visit_weaks, true /* for_verify */);
   iter.object_and_field_iterate(object_cl, field_cl, 0 /* worker_id */);
 }

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -293,19 +293,23 @@ bool ZHeap::is_allocating(zaddress addr) const {
 
 void ZHeap::object_iterate(ObjectClosure* object_cl, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  ZHeapIterator iter(1 /* nworkers */, visit_weaks);
+  ZHeapIterator iter(1 /* nworkers */, visit_weaks, false /* for_verify */);
   iter.object_iterate(object_cl, 0 /* worker_id */);
 }
 
-void ZHeap::object_and_field_iterate(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks) {
+void ZHeap::object_and_field_iterate_for_verify(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  ZHeapIterator iter(1 /* nworkers */, visit_weaks);
+  // We use AtMark to make sure that verification catches broken objects as
+  // soon as they are encountered. The AtMark location has stricter
+  // requirements on the passed in closures. The reason for this is because the
+  // closures will be called during root iteraiton, which takes various locks.
+  ZHeapIterator iter(1 /* nworkers */, visit_weaks, true /* for_verify */);
   iter.object_and_field_iterate(object_cl, field_cl, 0 /* worker_id */);
 }
 
 ParallelObjectIteratorImpl* ZHeap::parallel_object_iterator(uint nworkers, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  return new ZHeapIterator(nworkers, visit_weaks);
+  return new ZHeapIterator(nworkers, visit_weaks, false /* for_verify */);
 }
 
 void ZHeap::serviceability_initialize() {

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -118,7 +118,7 @@ public:
 
   // Iteration
   void object_iterate(ObjectClosure* object_cl, bool visit_weaks);
-  void object_and_field_iterate(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks);
+  void object_and_field_iterate_for_verify(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks);
   ParallelObjectIteratorImpl* parallel_object_iterator(uint nworkers, bool visit_weaks);
 
   void threads_do(ThreadClosure* tc) const;

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -426,7 +426,7 @@ void ZVerify::objects(bool verify_weaks) {
   threads_start_processing();
 
   ZVerifyObjectClosure object_cl(verify_weaks);
-  ZHeap::heap()->object_and_field_iterate(&object_cl, &object_cl, verify_weaks);
+  ZHeap::heap()->object_and_field_iterate_for_verify(&object_cl, &object_cl, verify_weaks);
 }
 
 void ZVerify::before_zoperation() {


### PR DESCRIPTION
Generational ZGC changed the location where the heap object iterator called the visit function. It used to be called when the objects were popped and then followed, but it was changed so that the function where called immediately when the objects are marked. This gave the benefit that the verification code code show exactly what root had a broken object. Unfortunately, this change started to apply non-GC closure during the root iteration. This could lead to lock order issues, just like the one described in the JBS entry.

This fix moves the visit calls for non-GC closures back to the follow calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310194](https://bugs.openjdk.org/browse/JDK-8310194): Generational ZGC: Lock-order asserts in JVMTI IterateThroughHeap (**Bug** - P2)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14518/head:pull/14518` \
`$ git checkout pull/14518`

Update a local copy of the PR: \
`$ git checkout pull/14518` \
`$ git pull https://git.openjdk.org/jdk.git pull/14518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14518`

View PR using the GUI difftool: \
`$ git pr show -t 14518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14518.diff">https://git.openjdk.org/jdk/pull/14518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14518#issuecomment-1594582780)