### PR TITLE
8310160: Make GC APIs for handling archive heap objects agnostic of GC policy

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -333,7 +333,7 @@ size_t ArchiveHeapWriter::copy_one_source_obj_to_buffer(oop src_obj) {
 void ArchiveHeapWriter::set_requested_address(ArchiveHeapInfo* info) {
   assert(!info->is_used(), "only set once");
   assert(UseG1GC, "must be");
-  address heap_end = (address)G1CollectedHeap::heap()->reserved().end();
+  address heap_end = (address)G1CollectedHeap::heap()->reserved_region().end();
   log_info(cds, heap)("Heap end = %p", heap_end);
 
   size_t heap_region_byte_size = _buffer_used;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -211,8 +211,8 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
       _heap_end = CompressedOops::end();
     } else {
       assert(UseG1GC, "used by G1 only");
-      address start = (address)Universe::heap()->reserved().start();
-      address end = (address)Universe::heap()->reserved().end();
+      address start = (address)Universe::heap()->reserved_region().start();
+      address end = (address)Universe::heap()->reserved_region().end();
       _heap_begin = HeapShared::to_requested_address(start);
       _heap_end = HeapShared::to_requested_address(end);
     }
@@ -1568,7 +1568,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
       assert((mapping_offset >> CompressedOops::shift()) << CompressedOops::shift() == mapping_offset, "must be");
     } else {
       assert(UseG1GC, "used by G1 only");
-      mapping_offset = requested_base - (char*)Universe::heap()->reserved().start();
+      mapping_offset = requested_base - (char*)Universe::heap()->reserved_region().start();
     }
 #endif // INCLUDE_CDS_JAVA_HEAP
   } else {
@@ -2031,8 +2031,8 @@ bool FileMapInfo::can_use_heap_region() {
   log_info(cds)("    narrow_oop_mode = %d, narrow_oop_base = " PTR_FORMAT ", narrow_oop_shift = %d",
                 CompressedOops::mode(), p2i(CompressedOops::base()), CompressedOops::shift());
   log_info(cds)("    heap range = [" PTR_FORMAT " - "  PTR_FORMAT "]",
-                UseCompressedOops ? p2i(CompressedOops::begin()) : p2i((address)Universe::heap()->reserved().start()),
-                UseCompressedOops ? p2i(CompressedOops::end()) : p2i((address)Universe::heap()->reserved().end()));
+                UseCompressedOops ? p2i(CompressedOops::begin()) : p2i((address)Universe::heap()->reserved_region().start()),
+                UseCompressedOops ? p2i(CompressedOops::end()) : p2i((address)Universe::heap()->reserved_region().end()));
 
   if (narrow_klass_base() != CompressedKlassPointers::base() ||
       narrow_klass_shift() != CompressedKlassPointers::shift()) {
@@ -2091,7 +2091,7 @@ bool FileMapInfo::map_heap_region() {
 
     // Make sure we map at the very top of the heap - see comments in
     // init_heap_region_relocation().
-    MemRegion heap_range = Universe::heap()->reserved();
+    MemRegion heap_range = Universe::heap()->reserved_region();
     assert(heap_range.contains(_mapped_heap_memregion), "must be");
 
     if (UseG1GC) {

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2124,7 +2124,7 @@ bool FileMapInfo::map_heap_region_impl() {
   log_info(cds)("Preferred address to map heap data (to avoid relocation) is " INTPTR_FORMAT, p2i(requested_start));
 
   // allocate from java heap
-  HeapWord* start = Universe::heap()->alloc_archive_space(word_size, (HeapWord*)requested_start);
+  HeapWord* start = Universe::heap()->allocate_archive_space(word_size, (HeapWord*)requested_start);
   if (start == nullptr) {
     log_info(cds)("UseSharedSpaces: Unable to allocate java heap region for archive heap.");
     return false;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1567,7 +1567,6 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
       mapping_offset = (size_t)((address)requested_base - CompressedOops::base());
       assert((mapping_offset >> CompressedOops::shift()) << CompressedOops::shift() == mapping_offset, "must be");
     } else {
-      assert(UseG1GC, "used by G1 only");
       mapping_offset = requested_base - (char*)Universe::heap()->reserved_region().start();
     }
 #endif // INCLUDE_CDS_JAVA_HEAP
@@ -2094,12 +2093,10 @@ bool FileMapInfo::map_heap_region() {
     MemRegion heap_range = Universe::heap()->reserved_region();
     assert(heap_range.contains(_mapped_heap_memregion), "must be");
 
-    if (UseG1GC) {
-      address heap_end = (address)heap_range.end();
-      address mapped_heap_region_end = (address)_mapped_heap_memregion.end();
-      assert(heap_end - mapped_heap_region_end < (intx)(HeapRegion::GrainBytes),
-             "must be at the top of the heap to avoid fragmentation");
-    }
+    address heap_end = (address)heap_range.end();
+    address mapped_heap_region_end = (address)_mapped_heap_memregion.end();
+    assert(heap_end - mapped_heap_region_end < (intx)(HeapRegion::GrainBytes),
+           "must be at the top of the heap to avoid fragmentation");
 #endif
 
     ArchiveHeapLoader::set_mapped();

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -548,7 +548,7 @@ public:
   bool  validate_boot_class_paths() NOT_CDS_RETURN_(false);
   bool  validate_app_class_paths(int shared_app_paths_len) NOT_CDS_RETURN_(false);
   bool  map_heap_region_impl() NOT_CDS_JAVA_HEAP_RETURN_(false);
-  void  dealloc_heap_region() NOT_CDS_JAVA_HEAP_RETURN;
+  void  handle_failed_mapping() NOT_CDS_JAVA_HEAP_RETURN;
   bool  can_use_heap_region();
   bool  load_heap_region() NOT_CDS_JAVA_HEAP_RETURN_(false);
   bool  map_heap_region() NOT_CDS_JAVA_HEAP_RETURN_(false);

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -532,9 +532,9 @@ void HeapShared::archive_objects(ArchiveHeapInfo *heap_info) {
 
     log_info(cds)("Heap range = [" PTR_FORMAT " - "  PTR_FORMAT "]",
                    UseCompressedOops ? p2i(CompressedOops::begin()) :
-                                       p2i((address)G1CollectedHeap::heap()->reserved().start()),
+                                       p2i((address)G1CollectedHeap::heap()->reserved_region().start()),
                    UseCompressedOops ? p2i(CompressedOops::end()) :
-                                       p2i((address)G1CollectedHeap::heap()->reserved().end()));
+                                       p2i((address)G1CollectedHeap::heap()->reserved_region().end()));
     copy_objects();
 
     CDSHeapVerifier::verify();
@@ -1700,8 +1700,8 @@ address HeapShared::to_requested_address(address dumptime_addr) {
 
   // With UseCompressedOops==false, actual_base is selected by the OS so
   // it's different across -Xshare:dump runs.
-  address actual_base = (address)G1CollectedHeap::heap()->reserved().start();
-  address actual_end  = (address)G1CollectedHeap::heap()->reserved().end();
+  address actual_base = (address)G1CollectedHeap::heap()->reserved_region().start();
+  address actual_end  = (address)G1CollectedHeap::heap()->reserved_region().end();
   assert(actual_base <= dumptime_addr && dumptime_addr <= actual_end, "must be an address in the heap");
 
   // We always write the objects as if the heap started at this address. This

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -528,7 +528,7 @@ void G1CollectedHeap::iterate_regions_in_range(MemRegion range, const Func& func
   }
 }
 
-HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* preferred_addr) {
+HeapWord* G1CollectedHeap::alloc_archive_space(size_t word_size, HeapWord* preferred_addr) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   MutexLocker x(Heap_lock);
 
@@ -575,7 +575,7 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
   return start_addr;
 }
 
-void G1CollectedHeap::populate_archive_regions_bot_part(MemRegion range) {
+void G1CollectedHeap::fixup_archive_space(MemRegion range) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
 
   iterate_regions_in_range(range,
@@ -584,7 +584,7 @@ void G1CollectedHeap::populate_archive_regions_bot_part(MemRegion range) {
                            });
 }
 
-void G1CollectedHeap::dealloc_archive_regions(MemRegion range) {
+void G1CollectedHeap::handle_archive_space_failure(MemRegion range) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   MemRegion reserved = _hrm.reserved();
   size_t size_used = 0;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -528,7 +528,7 @@ void G1CollectedHeap::iterate_regions_in_range(MemRegion range, const Func& func
   }
 }
 
-HeapWord* G1CollectedHeap::alloc_archive_space(size_t word_size, HeapWord* preferred_addr) {
+HeapWord* G1CollectedHeap::allocate_archive_space(size_t word_size, HeapWord* preferred_addr) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   MutexLocker x(Heap_lock);
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -532,7 +532,7 @@ HeapWord* G1CollectedHeap::allocate_archive_space(size_t word_size, HeapWord* pr
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   MutexLocker x(Heap_lock);
 
-  MemRegion reserved = _hrm.reserved();
+  MemRegion reserved = reserved_region();
 
   if (reserved.word_size() <= word_size) {
     log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = " SIZE_FORMAT
@@ -586,7 +586,7 @@ void G1CollectedHeap::fixup_archive_space(MemRegion range) {
 
 void G1CollectedHeap::handle_archive_space_failure(MemRegion range) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
-  MemRegion reserved = _hrm.reserved();
+  MemRegion reserved = reserved_region();
   size_t size_used = 0;
   uint shrink_count = 0;
 
@@ -1445,12 +1445,12 @@ jint G1CollectedHeap::initialize() {
 
   FreeRegionList::set_unrealistically_long_length(max_regions() + 1);
 
-  _bot = new G1BlockOffsetTable(reserved(), bot_storage);
+  _bot = new G1BlockOffsetTable(reserved_region(), bot_storage);
 
   {
     size_t granularity = HeapRegion::GrainBytes;
 
-    _region_attr.initialize(reserved(), granularity);
+    _region_attr.initialize(reserved_region(), granularity);
   }
 
   _workers = new WorkerThreads("GC Thread", ParallelGCThreads);
@@ -2202,8 +2202,8 @@ void G1CollectedHeap::print_on(outputStream* st) const {
   st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
             capacity()/K, heap_used/K);
   st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
-            p2i(_hrm.reserved().start()),
-            p2i(_hrm.reserved().end()));
+            p2i(reserved_region().start()),
+            p2i(reserved_region().end()));
   st->cr();
   st->print("  region size " SIZE_FORMAT "K, ", HeapRegion::GrainBytes / K);
   uint young_regions = young_regions_count();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1048,7 +1048,7 @@ public:
   inline G1HeapRegionAttr region_attr(uint idx) const;
 
   bool is_in_reserved(const void* addr) const {
-    return reserved().contains(addr);
+    return reserved_region().contains(addr);
   }
 
   G1CardTable* card_table() const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -711,7 +711,7 @@ public:
   // not be same as the preferred address.
   // This API is only used for allocating heap space for the archived heap objects
   // in the CDS archive.
-  HeapWord* alloc_archive_space(size_t word_size, HeapWord* preferred_addr) override;
+  HeapWord* allocate_archive_space(size_t word_size, HeapWord* preferred_addr) override;
 
   // Populate the G1BlockOffsetTableParts for the archived regions in the given range.
   // That ensures fast G1BlockOffsetTablePart::block_start operations for any given
@@ -720,7 +720,7 @@ public:
   void fixup_archive_space(MemRegion range) override;
 
   // For the specified range, uncommit the containing G1 regions
-  // which had been allocated by alloc_archive_space. This should be called
+  // which had been allocated by allocate_archive_space. This should be called
   // at JVM init time if the archive heap's contents cannot be used (e.g., if
   // CRC check fails).
   void handle_archive_space_failure(MemRegion range) override;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -121,12 +121,12 @@ inline void G1CollectedHeap::humongous_obj_regions_iterate(HeapRegion* start, co
 inline uint G1CollectedHeap::addr_to_region(const void* addr) const {
   assert(is_in_reserved(addr),
          "Cannot calculate region index for address " PTR_FORMAT " that is outside of the heap [" PTR_FORMAT ", " PTR_FORMAT ")",
-         p2i(addr), p2i(reserved().start()), p2i(reserved().end()));
-  return (uint)(pointer_delta(addr, reserved().start(), sizeof(uint8_t)) >> HeapRegion::LogOfHRGrainBytes);
+         p2i(addr), p2i(reserved_region().start()), p2i(reserved_region().end()));
+  return (uint)(pointer_delta(addr, reserved_region().start(), sizeof(uint8_t)) >> HeapRegion::LogOfHRGrainBytes);
 }
 
 inline HeapWord* G1CollectedHeap::bottom_addr_for_region(uint index) const {
-  return _hrm.reserved().start() + index * HeapRegion::GrainWords;
+  return reserved_region().start() + index * HeapRegion::GrainWords;
 }
 
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -368,7 +368,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
 
   _mark_bitmap(),
 
-  _heap(_g1h->reserved()),
+  _heap(_g1h->reserved_region()),
 
   _root_regions(_g1h->max_regions()),
 
@@ -416,7 +416,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
 {
   assert(CGC_lock != nullptr, "CGC_lock must be initialized");
 
-  _mark_bitmap.initialize(g1h->reserved(), bitmap_storage);
+  _mark_bitmap.initialize(g1h->reserved_region(), bitmap_storage);
 
   // Create & start ConcurrentMark thread.
   _cm_thread = new G1ConcurrentMarkThread(this);
@@ -2930,7 +2930,7 @@ G1PrintRegionLivenessInfoClosure::G1PrintRegionLivenessInfoClosure(const char* p
   }
 
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
-  MemRegion reserved = g1h->reserved();
+  MemRegion reserved = g1h->reserved_region();
   double now = os::elapsedTime();
 
   // Print the header of the output.

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -149,7 +149,7 @@ G1FullCollector::G1FullCollector(G1CollectedHeap* heap,
     _oop_queue_set.register_queue(i, marker(i)->oop_stack());
     _array_queue_set.register_queue(i, marker(i)->objarray_stack());
   }
-  _region_attr_table.initialize(heap->reserved(), HeapRegion::GrainBytes);
+  _region_attr_table.initialize(heap->reserved_region(), HeapRegion::GrainBytes);
 }
 
 G1FullCollector::~G1FullCollector() {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -186,7 +186,6 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool requires_barriers(stackChunkOop obj) const override;
 
-  MemRegion reserved_region() const { return _reserved; }
   HeapWord* base() const { return _reserved.start(); }
 
   // Memory allocation.   "gc_time_limit_was_exceeded" will

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -207,7 +207,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   }
 
  public:
-  MemRegion reserved() const {
+  MemRegion reserved_region() const {
     return _reserved;
   }
 

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -207,6 +207,9 @@ class CollectedHeap : public CHeapObj<mtGC> {
   }
 
  public:
+  MemRegion reserved() const {
+    return _reserved;
+  }
 
   static inline size_t filler_array_max_size() {
     return _filler_array_max_size;
@@ -517,6 +520,20 @@ class CollectedHeap : public CHeapObj<mtGC> {
   virtual bool can_load_archived_objects() const { return false; }
   virtual HeapWord* allocate_loaded_archive_space(size_t size) { return nullptr; }
   virtual void complete_loaded_archive_space(MemRegion archive_space) { }
+
+  // Commit the heap memory for CDS heap archive area according to the requested size.
+  // Preferred address is treated as a hint for the location of the archive area in the heap.
+  // The returned memory range may or may start at the preferred address.
+  // Return MemRegion corresponding to the commited heap memory.
+  virtual HeapWord* alloc_archive_space(size_t word_size, HeapWord* preferred_addr) { return nullptr; }
+
+  // This must be called after alloc_archive_space, and after class loading has occurred.
+  // GC policy can take necessary actions to make the archive space usable,
+  // such as inserting filler objects to make it parseable, or updating block offset table.
+  virtual void fixup_archive_space(MemRegion range) { return; }
+
+  // Handle any failure in loading the CDS archive area.
+  virtual void handle_archive_space_failure(MemRegion range) { return; }
 
   virtual bool is_oop(oop object) const;
   // Non product verification and debugging.

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -525,9 +525,9 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // Preferred address is treated as a hint for the location of the archive area in the heap.
   // The returned memory range may or may start at the preferred address.
   // Return MemRegion corresponding to the commited heap memory.
-  virtual HeapWord* alloc_archive_space(size_t word_size, HeapWord* preferred_addr) { return nullptr; }
+  virtual HeapWord* allocate_archive_space(size_t word_size, HeapWord* preferred_addr) { return nullptr; }
 
-  // This must be called after alloc_archive_space, and after class loading has occurred.
+  // This must be called after allocate_archive_space, and after class loading has occurred.
   // GC policy can take necessary actions to make the archive space usable,
   // such as inserting filler objects to make it parseable, or updating block offset table.
   virtual void fixup_archive_space(MemRegion range) { return; }

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -145,7 +145,6 @@ public:
   bool is_young_gen(const Generation* gen) const { return gen == _young_gen; }
   bool is_old_gen(const Generation* gen) const { return gen == _old_gen; }
 
-  MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   GenerationSpec* young_gen_spec() const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -467,7 +467,6 @@ public:
 
   bool requires_barriers(stackChunkOop obj) const override;
 
-  MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   void collect(GCCause::Cause cause) override;


### PR DESCRIPTION
This PR adds GC APIs to be implemented by all collectors for proper handling of archive heap space. Currently only G1 is updated to use these APIs which just involves renaming the existing G1 APIs.
In addition to that filemap.cpp is updated to replace calls to `G1CollectedHeap::heap()` with `Universe::heap()` to avoid G1 specific code as much as possible.

At many places in filemap.cpp heap range is requested from GC. All collectors except ZGC have contiguous heap and set `CollectedHeap::_reserved` to the heap range, so it can be easily exposed to the CDS code. This is done in this patch through `CollectedHeap::reserved` API. But for ZGC the heap can be discontiguous which makes it tricky to expose the heap range.
Another point to note is that most of the usage for heap range is for logging purpose, but there is one place where it is used for setting the `mapping_offset` in `FileMapInfo::write_region()` based on the heap start. So purely based on the functional requirement, we only need the heap start address, not the range.

To keep things simple and considering ZGC does not currently support archive heap, i refrained from tackling the issue of discontiguous heap range in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310160](https://bugs.openjdk.org/browse/JDK-8310160): Make GC APIs for handling archive heap objects agnostic of GC policy (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14520/head:pull/14520` \
`$ git checkout pull/14520`

Update a local copy of the PR: \
`$ git checkout pull/14520` \
`$ git pull https://git.openjdk.org/jdk.git pull/14520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14520`

View PR using the GUI difftool: \
`$ git pr show -t 14520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14520.diff">https://git.openjdk.org/jdk/pull/14520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14520#issuecomment-1594794285)