### PR TITLE
8310211: serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java failing

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
@@ -44,7 +44,7 @@ static frame_info expected_virtual_frames[] = {
     {"Lgetstacktr03;", "dummy", "()V"},
     {"Lgetstacktr03;", "chain", "()V"},
     {"Lgetstacktr03$Task;", "run", "()V"},
-    {"Ljava/lang/VirtualThread;", "runWith", "(Ljava/lang/Object;Ljava/lang/Runnable;)V"},
+    {"Ljava/lang/Thread;", "runWith", "(Ljava/lang/Object;Ljava/lang/Runnable;)V"},
     {"Ljava/lang/VirtualThread;", "run", "(Ljava/lang/Runnable;)V"},
     {"Ljava/lang/VirtualThread$VThreadContinuation$1;", "run", "()V"},
     {"Ljdk/internal/vm/Continuation;", "enter0", "()V"},


### PR DESCRIPTION
A trivia fix for serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java failing.