### PR TITLE
8309740: Expand timeout windows for tests in JDK-8179502

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -37,16 +37,16 @@
  * @library ../../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
  * @run main/othervm OCSPTimeout 1000 true
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=2
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=5
  *      OCSPTimeout 1000 true
  * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1
- *      OCSPTimeout 2000 false
+ *      OCSPTimeout 5000 false
  * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1s
- *      OCSPTimeout 2000 false
+ *      OCSPTimeout 5000 false
  * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1500ms
- *      OCSPTimeout 2000 false
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=2750ms
- *      OCSPTimeout 2000 true
+ *      OCSPTimeout 5000 false
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=4500ms
+ *      OCSPTimeout 1000 true
  */
 
 import java.io.*;

--- a/test/jdk/sun/security/x509/URICertStore/AIACertTimeout.java
+++ b/test/jdk/sun/security/x509/URICertStore/AIACertTimeout.java
@@ -30,15 +30,15 @@
  * @library /test/lib ../../../../java/security/testlibrary
  * @build CertificateBuilder
  * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
- *      -Dcom.sun.security.cert.readtimeout=1 AIACertTimeout 2000 false
+ *      -Dcom.sun.security.cert.readtimeout=1 AIACertTimeout 5000 false
  * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
- *      -Dcom.sun.security.cert.readtimeout=1s AIACertTimeout 2000 false
+ *      -Dcom.sun.security.cert.readtimeout=1s AIACertTimeout 5000 false
  * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
- *      -Dcom.sun.security.cert.readtimeout=3 AIACertTimeout 2000 true
+ *      -Dcom.sun.security.cert.readtimeout=4 AIACertTimeout 1000 true
  * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
- *      -Dcom.sun.security.cert.readtimeout=1500ms AIACertTimeout 2000 false
+ *      -Dcom.sun.security.cert.readtimeout=1500ms AIACertTimeout 5000 false
  * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
- *      -Dcom.sun.security.cert.readtimeout=2750ms AIACertTimeout 2000 true
+ *      -Dcom.sun.security.cert.readtimeout=4500ms AIACertTimeout 1000 true
  * @run main/othervm -Djava.security.debug=certpath
  *      -Dcom.sun.security.enableAIAcaIssuers=false
  *      -Dcom.sun.security.cert.readtimeout=20000ms AIACertTimeout 10000 false

--- a/test/jdk/sun/security/x509/URICertStore/CRLReadTimeout.java
+++ b/test/jdk/sun/security/x509/URICertStore/CRLReadTimeout.java
@@ -28,11 +28,16 @@
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util
  * @library /test/lib
- * @run main/othervm -Dcom.sun.security.crl.readtimeout=1 CRLReadTimeout 2000 false
- * @run main/othervm -Dcom.sun.security.crl.readtimeout=1s CRLReadTimeout 2000 false
- * @run main/othervm -Dcom.sun.security.crl.readtimeout=4 CRLReadTimeout 2000 true
- * @run main/othervm -Dcom.sun.security.crl.readtimeout=1500ms CRLReadTimeout 2000 false
- * @run main/othervm -Dcom.sun.security.crl.readtimeout=2750ms CRLReadTimeout 2000 true
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=1
+ *      CRLReadTimeout 5000 false
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=1s
+ *      CRLReadTimeout 5000 false
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=4
+ *      CRLReadTimeout 1000 true
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=1500ms
+ *      CRLReadTimeout 5000 false
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=4500ms
+ *      CRLReadTimeout 1000 true
  */
 
 import java.io.*;


### PR DESCRIPTION
This PR is for tests that were modified/added in JDK-8179502.  The timeout windows for those tests were a little too short on some test systems, especially when the system is under heavy load.  After a few iterations trying out various longer time windows I have a set that should not run into issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309740](https://bugs.openjdk.org/browse/JDK-8309740): Expand timeout windows for tests in JDK-8179502 (**Bug** - P3)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14526/head:pull/14526` \
`$ git checkout pull/14526`

Update a local copy of the PR: \
`$ git checkout pull/14526` \
`$ git pull https://git.openjdk.org/jdk.git pull/14526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14526`

View PR using the GUI difftool: \
`$ git pr show -t 14526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14526.diff">https://git.openjdk.org/jdk/pull/14526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14526#issuecomment-1595115952)