### PR TITLE
8310264: In PhaseChaitin::Split defs and phis are leaked

### DIFF
--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -571,8 +571,8 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   }
 
   // Keep track of DEFS & Phis for later passes
-  Node_List defs{split_arena, 8};
-  Node_List phis{split_arena, 16};
+  Node_List defs(split_arena, 8);
+  Node_List phis(split_arena, 16);
 
   //----------PASS 1----------
   //----------Propagation & Node Insertion Code----------

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -571,8 +571,8 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   }
 
   // Keep track of DEFS & Phis for later passes
-  Node_List defs{split_arena, 128}; // Typically less than 128
-  Node_List phis{split_arena, 256}; // Typically less than 256
+  Node_List defs{split_arena, 8};
+  Node_List phis{split_arena, 16};
 
   //----------PASS 1----------
   //----------Propagation & Node Insertion Code----------

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -518,11 +518,6 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   //----------Setup Code----------
   // Create a convenient mapping from lrg numbers to reaches/leaves indices
   uint *lrg2reach = NEW_SPLIT_ARRAY(uint, maxlrg);
-  // Keep track of DEFS & Phis for later passes
-  Arena defs_arena{mtCompiler, Chunk::medium_size};
-  Arena phis_arena{mtCompiler, Chunk::medium_size}
-  Node_List defs{&defs_arena};
-  Node_List phis{&phis_arena};
   // Gather info on which LRG's are spilling, and build maps
   for (bidx = 1; bidx < maxlrg; bidx++) {
     if (lrgs(bidx).alive() && lrgs(bidx).reg() >= LRG::SPILL_REG) {
@@ -574,6 +569,10 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   for (slidx = 0; slidx < spill_cnt; slidx++) {
     UP_entry[slidx] = new(split_arena) VectorSet(split_arena);
   }
+
+  // Keep track of DEFS & Phis for later passes
+  Node_List defs{split_arena, 128}; // Typically less than 128
+  Node_List phis{split_arena, 256}; // Typically less than 256
 
   //----------PASS 1----------
   //----------Propagation & Node Insertion Code----------

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -570,7 +570,7 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
 
   // Initialize to array of empty vectorsets
   for( slidx = 0; slidx < spill_cnt; slidx++ )
-    UP_entry[slidx] = new VectorSet(split_arena);
+    UP_entry[slidx] = new(split_arena) VectorSet(split_arena);
 
   //----------PASS 1----------
   //----------Propagation & Node Insertion Code----------

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -499,6 +499,7 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
 
   // Free thread local resources used by this method on exit.
   ResourceMark rm(split_arena);
+  ResourceMark rm2;
 
   uint                 bidx, pidx, slidx, insidx, inpidx, twoidx;
   uint                 non_phi = 1, spill_cnt = 0;

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -504,7 +504,6 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   uint                 bidx, pidx, slidx, insidx, inpidx, twoidx;
   uint                 non_phi = 1, spill_cnt = 0;
   Node                *n1, *n2, *n3;
-  Node_List           *defs,*phis;
   bool                *UPblock;
   bool                 u1, u2, u3;
   Block               *b, *pred;
@@ -521,8 +520,8 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   // Create a convenient mapping from lrg numbers to reaches/leaves indices
   uint *lrg2reach = NEW_SPLIT_ARRAY(uint, maxlrg);
   // Keep track of DEFS & Phis for later passes
-  defs = new Node_List();
-  phis = new Node_List();
+  Node_List defs{};
+  Node_List phis{};
   // Gather info on which LRG's are spilling, and build maps
   for (bidx = 1; bidx < maxlrg; bidx++) {
     if (lrgs(bidx).alive() && lrgs(bidx).reg() >= LRG::SPILL_REG) {
@@ -703,7 +702,7 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
         }  // end if not found correct phi
         // Here you have either found or created the Phi, so record it
         assert(phi != nullptr,"Must have a Phi Node here");
-        phis->push(phi);
+        phis.push(phi);
         // PhiNodes should either force the LRG UP or DOWN depending
         // on its inputs and the register pressure in the Phi's block.
         UPblock[slidx] = true;  // Assume new DEF is UP
@@ -1190,7 +1189,7 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
       if( deflrg.reg() >= LRG::SPILL_REG ) {    // Spilled?
         uint slidx = lrg2reach[defidx];
         // Add to defs list for later assignment of new live range number
-        defs->push(n);
+        defs.push(n);
         // Set a flag on the Node indicating it has already spilled.
         // Only do it for capacity spills not conflict spills.
         if( !deflrg._direct_conflict )
@@ -1309,9 +1308,9 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
 
   //----------PASS 2----------
   // Reset all DEF live range numbers here
-  for( insidx = 0; insidx < defs->size(); insidx++ ) {
+  for( insidx = 0; insidx < defs.size(); insidx++ ) {
     // Grab the def
-    n1 = defs->at(insidx);
+    n1 = defs.at(insidx);
     // Set new lidx for DEF
     new_lrg(n1, maxlrg++);
   }
@@ -1321,8 +1320,8 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
   // info for each spilled LRG and update edges.
   // Walk the phis list to patch inputs, split phis, and name phis
   uint lrgs_before_phi_split = maxlrg;
-  for( insidx = 0; insidx < phis->size(); insidx++ ) {
-    Node *phi = phis->at(insidx);
+  for( insidx = 0; insidx < phis.size(); insidx++ ) {
+    Node *phi = phis.at(insidx);
     assert(phi->is_Phi(),"This list must only contain Phi Nodes");
     Block *b = _cfg.get_block_for_node(phi);
     // Grab the live range number
@@ -1390,8 +1389,8 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
 
   //----------PASS 3----------
   // Pass over all Phi's to union the live ranges
-  for( insidx = 0; insidx < phis->size(); insidx++ ) {
-    Node *phi = phis->at(insidx);
+  for( insidx = 0; insidx < phis.size(); insidx++ ) {
+    Node *phi = phis.at(insidx);
     assert(phi->is_Phi(),"This list must only contain Phi Nodes");
     // Walk all inputs to Phi and Union input live range with Phi live range
     for( uint i = 1; i < phi->req(); i++ ) {
@@ -1409,9 +1408,9 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
     }  // End for all inputs to the Phi Node
   }  // End for all Phi Nodes
   // Now union all two address instructions
-  for (insidx = 0; insidx < defs->size(); insidx++) {
+  for (insidx = 0; insidx < defs.size(); insidx++) {
     // Grab the def
-    n1 = defs->at(insidx);
+    n1 = defs.at(insidx);
     // Set new lidx for DEF & handle 2-addr instructions
     if (n1->is_Mach() && ((twoidx = n1->as_Mach()->two_adr()) != 0)) {
       assert(_lrg_map.find(n1->in(twoidx)) < maxlrg,"Assigning bad live range index");


### PR DESCRIPTION
Hi,

`defs` and `phis` are leaked as they are resource allocated but not protected by a `ResourceMark`. The intention might have been for these to also live in the `split_arena`.. This change is the most conservative one, however, and does fix the memory leak.

Please consider, thanks.

Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310264](https://bugs.openjdk.org/browse/JDK-8310264): In PhaseChaitin::Split defs and phis are leaked (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14530/head:pull/14530` \
`$ git checkout pull/14530`

Update a local copy of the PR: \
`$ git checkout pull/14530` \
`$ git pull https://git.openjdk.org/jdk.git pull/14530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14530`

View PR using the GUI difftool: \
`$ git pr show -t 14530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14530.diff">https://git.openjdk.org/jdk/pull/14530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14530#issuecomment-1595797285)