### PR TITLE
JDK-8310265: (process) jspawnhelper should not use argv[0]

### DIFF
--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[]) {
 #ifdef DEBUG
     jtregSimulateCrash(0, 4);
 #endif
-    r = sscanf (argv[argc-1], "%d:%d:%d", &fdinr, &fdinw, &fdout);
+    r = sscanf (argv[1], "%d:%d:%d", &fdinr, &fdinw, &fdout);
     if (r == 3 && fcntl(fdinr, F_GETFD) != -1 && fcntl(fdinw, F_GETFD) != -1) {
         fstat(fdinr, &buf);
         if (!S_ISFIFO(buf.st_mode))

--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -136,7 +136,7 @@ void initChildStuff (int fdin, int fdout, ChildStuff *c) {
 int main(int argc, char *argv[]) {
     ChildStuff c;
     struct stat buf;
-    /* argv[0] contains the fd number to read all the child info */
+    /* argv[1] contains the fd number to read all the child info */
     int r, fdinr, fdinw, fdout;
     sigset_t unblock_signals;
 

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -497,7 +497,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     snprintf(buf1, sizeof(buf1), "%d:%d:%d", c->childenv[0], c->childenv[1], c->fail[1]);
     /* NULL-terminated argv array.
      * argv[0] contains path to jspawnhelper, to follow conventions.
-     * argv[1] contains the fd string as argument to the helper cmd
+     * argv[1] contains the fd string as argument to jspawnhelper
      */
     hlpargs[0] = (char*)helperpath;
     hlpargs[1] = buf1;

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -488,16 +488,20 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     pid_t resultPid;
     int i, offset, rval, bufsize, magic;
     char *buf, buf1[(3 * 11) + 3]; // "%d:%d:%d\0"
-    char *hlpargs[2];
+    char *hlpargs[3];
     SpawnInfo sp;
 
     /* need to tell helper which fd is for receiving the childstuff
      * and which fd to send response back on
      */
     snprintf(buf1, sizeof(buf1), "%d:%d:%d", c->childenv[0], c->childenv[1], c->fail[1]);
-    /* put the fd string as argument to the helper cmd */
-    hlpargs[0] = buf1;
-    hlpargs[1] = 0;
+    /* NULL-terminated argv array.
+     * argv[0] contains path to jspawnhelper, to follow conventions.
+     * argv[1] contains the fd string as argument to the helper cmd
+     */
+    hlpargs[0] = (char*)helperpath;
+    hlpargs[1] = buf1;
+    hlpargs[2] = NULL;
 
     /* Following items are sent down the pipe to the helper
      * after it is spawned.


### PR DESCRIPTION
Reported by [jarabekit@gmail.com](mailto:jarabekit@gmail.com) [1] 

jspawnhelper uses argv[0] to receive the fd string from the parent. That breaks with conventions and trips over certain tools like binfmt_misc. 

For details, see linked ML discussion. 

[1] https://mail.openjdk.org/pipermail/core-libs-dev/2023-June/107738.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310265](https://bugs.openjdk.org/browse/JDK-8310265): (process) jspawnhelper should not use argv[0] (**Enhancement** - P4)


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14531/head:pull/14531` \
`$ git checkout pull/14531`

Update a local copy of the PR: \
`$ git checkout pull/14531` \
`$ git pull https://git.openjdk.org/jdk.git pull/14531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14531`

View PR using the GUI difftool: \
`$ git pr show -t 14531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14531.diff">https://git.openjdk.org/jdk/pull/14531.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14531#issuecomment-1595858177)