### PR TITLE
8310268: RISC-V: misaligned memory access in String.Compare intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -947,108 +947,19 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
     bne(tmp1, tmp2, DIFFERENCE);
     bltz(cnt2, NEXT_WORD);
     bind(TAIL);
-
-    if (AvoidUnalignedAccesses) {
-      if (str1_isL == str2_isL) { // LL or UU
-        Label TAIL02, TAIL01, TAIL08;
-        beqz(cnt2, TAIL08); // if cnt2 is zero then we need to copy one more aligned long
-        // add to str1/str2 what we have already read
-        add(str1, str1, cnt2);
-        add(str2, str2, cnt2);
-        sub(cnt2, zr, cnt2);
-        addi(cnt2, cnt2, 8); // now str1/2 is aligned, cnt2 has amounts of bytes left to read
-        // read 4 if needed, then read 2 if needed, then read 1 if needed and if isLL,
-        // str1 is 8 bytes aligned now,
-        test_bit(tmp1, cnt2, 2);
-        beqz(tmp1, TAIL02);
-        {
-          lwu(tmp1, Address(str1));
-          add(str1, str1, 4);
-          lwu(tmp2, Address(str2));
-          add(str2, str2, 4);
-          bne(tmp1, tmp2, DIFFERENCE);
-        }
-        bind(TAIL02);
-        // load two bytes if (address & 2) is not 0
-        test_bit(tmp1, cnt2, 1);
-        beqz(tmp1, isLL ? TAIL01 : DONE);
-        {
-          lhu(tmp1, Address(str1));
-          add(str1, str1, 2);
-          lhu(tmp2, Address(str2));
-          add(str2, str2, 2);
-          bne(tmp1, tmp2, DIFFERENCE);
-        }
-        if (isLL) {
-          bind(TAIL01);
-          // only if isLL, load one byte if address is odd
-          test_bit(tmp1, cnt2, 0);
-          beqz(tmp1, DONE);
-          {
-            lbu(tmp1, Address(str1));
-            lbu(tmp2, Address(str2));
-            bne(tmp1, tmp2, DIFFERENCE);
-          }
-        }
-        j(DONE);
-        bind(TAIL08);
-        ld(tmp1, Address(str1));
-        ld(tmp2, Address(str2));
-        bne(tmp1, tmp2, DIFFERENCE);
-        j(DONE);
-      } else {
-        //  LU and UL
-        Label TAIL08;
-
-        beqz(cnt2, TAIL08); // if cnt2 is zero then we need to copy one more aligned long/word
-
-        add(str1, str1, cnt1);
-        add(str2, str2, cnt2);
-
-        sub(cnt1, zr, cnt1);
-        sub(cnt2, zr, cnt2);
-
-        addi(cnt1, cnt1, isLU ? 4 : 8);
-        addi(cnt2, cnt2, isLU ? 8 : 4);
-        // SHORT_STRING operates on characters, not bytes, set cnt2 to min(cnt1, cnt2)
-        // but we already know cnt1=2*cnt2 for isLU or cnt2=2*cnt1 for isUL
-        if(isLU) {
-          mv(cnt2, cnt1);
-        }
-        j(SHORT_STRING);
-
-        bind(TAIL08);
-        if(isLU) {
-          lwu(tmp1, Address(str1));
-          ld(tmp2, Address(str2));
-          inflate_lo32(tmp3, tmp1);
-          mv(tmp1, tmp3);
-          bne(tmp1, tmp2, DIFFERENCE);
-          j(DONE);
-        } else {
-          ld(tmp1, Address(str1));
-          lwu(tmp2, Address(str2));
-          inflate_lo32(tmp3, tmp2);
-          mv(tmp2, tmp3);
-          bne(tmp1, tmp2, DIFFERENCE);
-          j(DONE);
-        }
-      }
-    } else {
-      if (str1_isL == str2_isL) { // LL or UU
-        ld(tmp1, Address(str1));
-        ld(tmp2, Address(str2));
-      } else if (isLU) { // LU case
-        lwu(tmp1, Address(str1));
-        ld(tmp2, Address(str2));
-        inflate_lo32(tmp3, tmp1);
-        mv(tmp1, tmp3);
-      } else { // UL case
-        lwu(tmp2, Address(str2));
-        ld(tmp1, Address(str1));
-        inflate_lo32(tmp3, tmp2);
-        mv(tmp2, tmp3);
-      }
+    if (str1_isL == str2_isL) { // LL or UU
+      load_long_misaligned(tmp1, Address(str1), tmp3, isLL ? 1 : 2);
+      load_long_misaligned(tmp2, Address(str2), tmp3, isLL ? 1 : 2);
+    } else if (isLU) { // LU case
+      load_int_misaligned(tmp1, Address(str1), tmp3, false);
+      load_long_misaligned(tmp2, Address(str2), tmp3, 2);
+      inflate_lo32(tmp3, tmp1);
+      mv(tmp1, tmp3);
+    } else { // UL case
+      load_int_misaligned(tmp2, Address(str2), tmp3, false);
+      load_long_misaligned(tmp1, Address(str1), tmp3, 2);
+      inflate_lo32(tmp3, tmp2);
+      mv(tmp2, tmp3);
     }
     bind(TAIL_CHECK);
     beq(tmp1, tmp2, DONE);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -898,7 +898,6 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
       mv(tmp1, tmp3);
       sub(cnt2, zr, cnt2);
       addi(cnt1, cnt1, 4);
-
     } else { // UL case
       ld(tmp1, Address(str1));
       lwu(tmp2, Address(str2));
@@ -949,7 +948,7 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
     bltz(cnt2, NEXT_WORD);
     bind(TAIL);
 
-    if (AvoidUnalignedAccesses){
+    if (AvoidUnalignedAccesses) {
       if (str1_isL == str2_isL) { // LL or UU
         Label TAIL02, TAIL01, TAIL08;
         beqz(cnt2, TAIL08); // if cnt2 is zero then we need to copy one more aligned long

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3968,18 +3968,17 @@ void MacroAssembler::ctzc_bit(Register Rd, Register Rs, bool isLL, Register tmp1
 void MacroAssembler::inflate_lo32(Register Rd, Register Rs, Register tmp1, Register tmp2) {
   assert_different_registers(Rd, Rs, tmp1, tmp2);
 
-  mv(tmp1, 0xFF);
-  mv(Rd, zr);
-  for (int i = 0; i <= 3; i++) {
+  mv(tmp1, 0xFF000000); // first byte mask at lower word
+  andr(Rd, Rs, tmp1);
+  for (int i = 0; i < 2; i++) {
+    slli(Rd, Rd, wordSize);
+    srli(tmp1, tmp1, wordSize);
     andr(tmp2, Rs, tmp1);
-    if (i) {
-      slli(tmp2, tmp2, i * 8);
-    }
     orr(Rd, Rd, tmp2);
-    if (i != 3) {
-      slli(tmp1, tmp1, 8);
-    }
   }
+  slli(Rd, Rd, wordSize);
+  andi(tmp2, Rs, 0xFF); // last byte mask at lower word
+  orr(Rd, Rd, tmp2);
 }
 
 // This instruction reads adjacent 4 bytes from the upper half of source register,
@@ -3988,17 +3987,8 @@ void MacroAssembler::inflate_lo32(Register Rd, Register Rs, Register tmp1, Regis
 // Rd: 00A700A600A500A4
 void MacroAssembler::inflate_hi32(Register Rd, Register Rs, Register tmp1, Register tmp2) {
   assert_different_registers(Rd, Rs, tmp1, tmp2);
-
-  mv(tmp1, 0xFF00000000);
-  mv(Rd, zr);
-  for (int i = 0; i <= 3; i++) {
-    andr(tmp2, Rs, tmp1);
-    orr(Rd, Rd, tmp2);
-    srli(Rd, Rd, 8);
-    if (i != 3) {
-      slli(tmp1, tmp1, 8);
-    }
-  }
+  srli(Rs, Rs, 32);   // only upper 32 bits are needed
+  inflate_lo32(Rd, Rs, tmp1, tmp2);
 }
 
 // The size of the blocks erased by the zero_blocks stub.  We must

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2532,7 +2532,6 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(str1, str1, 8);
       __ ld(tmp2, Address(str2));
       __ addi(str2, str2, 8);
-      __ beqz(cnt2, LAST_CHECK_AND_LENGTH_DIFF);
       __ sub(cnt2, cnt2, isLL ? 8 : 4);
     __ bind(CHECK_LAST);
       if (!isLL) {

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2311,18 +2311,18 @@ class StubGenerator: public StubCodeGenerator {
 
   // code for comparing 8 characters of strings with Latin1 and Utf16 encoding
   void compare_string_8_x_LU(Register tmpL, Register tmpU, Register strL, Register strU, Label& DIFF) {
-    const Register tmp = x30;
-    __ ld(t0, Address(strL));
+    const Register tmp = x30, tmpLval = x7;
+    __ ld(tmpLval, Address(strL));
     __ addi(strL, strL, wordSize);
     __ ld(tmpU, Address(strU));
     __ addi(strU, strU, wordSize);
-    __ inflate_lo32(tmpL, t0, tmp);
+    __ inflate_lo32(tmpL, tmpLval);
     __ xorr(tmp, tmpU, tmpL);
     __ bnez(tmp, DIFF);
 
     __ ld(tmpU, Address(strU));
     __ addi(strU, strU, wordSize);
-    __ inflate_hi32(tmpL, t0, tmp);
+    __ inflate_hi32(tmpL, tmpLval);
     __ xorr(tmp, tmpU, tmpL);
     __ bnez(tmp, DIFF);
   }

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2393,7 +2393,7 @@ class StubGenerator: public StubCodeGenerator {
       __ beqz(cnt2, DONE);  // no character left
       __ bind(LOAD_LAST);   // cnt2 = 1..7 characters left
 
-      __ addi(cnt2, cnt2, -wordSize); //cnt2 is now an offset in strL which points to last 8 bytes
+      __ addi(cnt2, cnt2, -wordSize); // cnt2 is now an offset in strL which points to last 8 bytes
       __ slli(t0, cnt2, 1);     // t0 is now an offset in strU which points to last 16 bytes
       __ add(strL, strL, cnt2); // Address of last 8 bytes in Latin1 string
       __ add(strU, strU, t0);   // Address of last 16 bytes in UTF-16 string

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2310,24 +2310,23 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   // code for comparing 8 characters of strings with Latin1 and Utf16 encoding
-  void compare_string_8_x_LU(Register tmpL, Register tmpU, Label &DIFF1,
-                              Label &DIFF2) {
-    const Register strU = x12, curU = x7, strL = x29, tmp = x30;
+  void compare_string_8_x_LU(Register tmpL, Register tmpU, Register strL, Register strU, Label& DIFF) {
+    const Register tmp = x30;
     __ ld(tmpL, Address(strL));
-    __ addi(strL, strL, 8);
+    __ addi(strL, strL, wordSize);
     __ ld(tmpU, Address(strU));
-    __ addi(strU, strU, 8);
+    __ addi(strU, strU, wordSize);
     __ inflate_lo32(tmp, tmpL);
     __ mv(t0, tmp);
-    __ xorr(tmp, curU, t0);
-    __ bnez(tmp, DIFF2);
+    __ xorr(tmp, tmpU, t0);
+    __ bnez(tmp, DIFF);
 
-    __ ld(curU, Address(strU));
-    __ addi(strU, strU, 8);
+    __ ld(tmpU, Address(strU));
+    __ addi(strU, strU, wordSize);
     __ inflate_hi32(tmp, tmpL);
     __ mv(t0, tmp);
     __ xorr(tmp, tmpU, t0);
-    __ bnez(tmp, DIFF1);
+    __ bnez(tmp, DIFF);
   }
 
   // x10  = result
@@ -2342,8 +2341,7 @@ class StubGenerator: public StubCodeGenerator {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", isLU ? "compare_long_string_different_encoding LU" : "compare_long_string_different_encoding UL");
     address entry = __ pc();
-    Label SMALL_LOOP, TAIL, TAIL_LOAD_16, LOAD_LAST, DIFF1, DIFF2,
-          DONE, CALCULATE_DIFFERENCE;
+    Label SMALL_LOOP, TAIL, LOAD_LAST, DIFF, DONE, CALCULATE_DIFFERENCE;
     const Register result = x10, str1 = x11, cnt1 = x12, str2 = x13, cnt2 = x14,
                    tmp1 = x28, tmp2 = x29, tmp3 = x30, tmp4 = x7, tmp5 = x31;
     RegSet spilled_regs = RegSet::of(tmp4, tmp5);
@@ -2354,16 +2352,9 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(isLU ? tmp1 : tmp2, tmp3);
     __ addi(str1, str1, isLU ? wordSize / 2 : wordSize);
     __ addi(str2, str2, isLU ? wordSize : wordSize / 2);
-    __ sub(cnt2, cnt2, 8); // Already loaded 4 symbols. Last 4 is special case.
+    __ sub(cnt2, cnt2, wordSize / 2); // Already loaded 4 symbols
     __ push_reg(spilled_regs, sp);
 
-    if (isLU) {
-      __ add(str1, str1, cnt2);
-      __ shadd(str2, cnt2, str2, t0, 1);
-    } else {
-      __ shadd(str1, cnt2, str1, t0, 1);
-      __ add(str2, str2, cnt2);
-    }
     __ xorr(tmp3, tmp1, tmp2);
     __ mv(tmp5, tmp2);
     __ bnez(tmp3, CALCULATE_DIFFERENCE);
@@ -2373,46 +2364,93 @@ class StubGenerator: public StubCodeGenerator {
              tmpU = isLU ? tmp5 : tmp1, // where to keep U for comparison
              tmpL = isLU ? tmp1 : tmp5; // where to keep L for comparison
 
-    __ sub(tmp2, strL, cnt2); // strL pointer to load from
-    __ slli(t0, cnt2, 1);
-    __ sub(cnt1, strU, t0); // strU pointer to load from
+    // make sure main loop is 8 byte-aligned, we should load another 4 bytes from strL
+    __ beqz(cnt2, DONE);  // no characters left
+    __ lwu(tmpL, Address(strL));
+    __ addi(strL, strL, wordSize / 2);
+    __ ld(tmpU, Address(strU));
+    __ addi(strU, strU, wordSize);
+    __ inflate_lo32(tmp3, tmpL);
+    __ mv(tmpL, tmp3);
+    __ xorr(tmp3, tmpU, tmpL);
+    __ bnez(tmp3, CALCULATE_DIFFERENCE);
+    __ addi(cnt2, cnt2, -wordSize / 2);
 
-    __ ld(tmp4, Address(cnt1));
-    __ addi(cnt1, cnt1, 8);
-    __ beqz(cnt2, LOAD_LAST); // no characters left except last load
-    __ sub(cnt2, cnt2, 16);
+    __ beqz(cnt2, DONE);  // no character left
+    // we are now 8-bytes aligned on strL
+    __ sub(cnt2, cnt2, wordSize * 2);
     __ bltz(cnt2, TAIL);
     __ bind(SMALL_LOOP); // smaller loop
-      __ sub(cnt2, cnt2, 16);
-      compare_string_8_x_LU(tmpL, tmpU, DIFF1, DIFF2);
-      compare_string_8_x_LU(tmpL, tmpU, DIFF1, DIFF2);
+      __ sub(cnt2, cnt2, wordSize * 2);
+      compare_string_8_x_LU(tmpL, tmpU, strL, strU, DIFF);
+      compare_string_8_x_LU(tmpL, tmpU, strL, strU, DIFF);
       __ bgez(cnt2, SMALL_LOOP);
-      __ addi(t0, cnt2, 16);
-      __ beqz(t0, LOAD_LAST);
-    __ bind(TAIL); // 1..15 characters left until last load (last 4 characters)
-      // Address of 8 bytes before last 4 characters in UTF-16 string
-      __ shadd(cnt1, cnt2, cnt1, t0, 1);
-      // Address of 16 bytes before last 4 characters in Latin1 string
-      __ add(tmp2, tmp2, cnt2);
-      __ ld(tmp4, Address(cnt1, -8));
-      // last 16 characters before last load
-      compare_string_8_x_LU(tmpL, tmpU, DIFF1, DIFF2);
-      compare_string_8_x_LU(tmpL, tmpU, DIFF1, DIFF2);
-      __ j(LOAD_LAST);
-    __ bind(DIFF2);
-      __ mv(tmpU, tmp4);
-    __ bind(DIFF1);
+      __ addi(t0, cnt2, wordSize * 2);
+      __ beqz(t0, DONE);
+    __ bind(TAIL);  // 1..15 characters left
+    if (AvoidUnalignedAccesses) {
+      // Aligned access. Load bytes in portions - 4, 2, 1.
+      Label LOAD_LAST, WORD_CMP, TAIL01, TAIL02;
+
+      __ addi(t0, cnt2, wordSize);
+      __ addi(cnt2, cnt2, wordSize*2); // amount of characters left to process
+      __ bltz(t0, LOAD_LAST);
+      // remaining characters are greater than or equals to 8, we can do one compare_string_8_x_LU
+      compare_string_8_x_LU(tmpL, tmpU, strL, strU, DIFF);
+      __ addi(cnt2, cnt2, -wordSize);
+      __ beqz(cnt2, DONE);  // no character left
+      __ bind(LOAD_LAST);   // cnt2 = 1..7 characters left
+      // load four bytes if (cnt2 & 4) is not 0
+      __ test_bit(t0, cnt2, 2);
+      __ beqz(t0, TAIL02);
+      {
+        __ lwu(tmpL, Address(strL));
+        __ addi(strL, strL, wordSize / 2);
+        __ ld(tmpU, Address(strU));
+        __ addi(strU, strU, wordSize);
+        __ inflate_lo32(tmp3, tmpL);
+        __ mv(tmpL, tmp3);
+        __ xorr(tmp3, tmpU, tmpL);
+        __ bnez(tmp3, CALCULATE_DIFFERENCE);
+        __ addi(cnt2, cnt2, -wordSize / 2);
+      }
+      __ bind(TAIL02);
+      // load two bytes if (cnt2 & 2) is not 0
+      __ test_bit(t0, cnt2, 1);
+      __ beqz(t0, TAIL01);
+      {
+        __ lhu(tmpL, Address(strL));
+        __ addi(strL, strL, wordSize / 4);
+        __ lwu(tmpU, Address(strU));
+        __ addi(strU, strU, wordSize / 2);
+        __ inflate_lo32(tmp3, tmpL);
+        __ mv(tmpL, tmp3);
+        __ xorr(tmp3, tmpU, tmpL);
+        __ bnez(tmp3, CALCULATE_DIFFERENCE);
+        __ addi(cnt2, cnt2, -wordSize / 4);
+      }
+      __ bind(TAIL01);
+      // load one byte if anything left in cnt2
+      __ beqz(cnt2, DONE);
+      {
+        __ lbu(tmpL, Address(strL)); // when only one byte left - no need to inflate
+        __ lhu(tmpU, Address(strU));
+        __ xorr(tmp3, tmpU, tmpL);
+        __ bnez(tmp3, CALCULATE_DIFFERENCE);
+      }
+      __ j(DONE); // no character left
+    } else {
+      // Unaligned accesses. Load from non-byte aligned address.
+      __ slli(t0, cnt2, 1);     // now in bytes
+      __ add(strU, strU, t0);   // Address of last 8 bytes in UTF-16 string
+      __ add(strL, strL, cnt2); // Address of last 16 bytes in Latin1 string
+      // last 16 characters
+      compare_string_8_x_LU(tmpL, tmpU, strL, strU, DIFF);
+      compare_string_8_x_LU(tmpL, tmpU, strL, strU, DIFF);
+      __ j(DONE);
+    }
+    __ bind(DIFF);
       __ mv(tmpL, t0);
-      __ j(CALCULATE_DIFFERENCE);
-    __ bind(LOAD_LAST);
-      // Last 4 UTF-16 characters are already pre-loaded into tmp4 by compare_string_8_x_LU.
-      // No need to load it again
-      __ mv(tmpU, tmp4);
-      __ ld(tmpL, Address(strL));
-      __ inflate_lo32(tmp3, tmpL);
-      __ mv(tmpL, tmp3);
-      __ xorr(tmp3, tmpU, tmpL);
-      __ beqz(tmp3, DONE);
 
       // Find the first different characters in the longwords and
       // compute their difference.
@@ -2529,6 +2567,7 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(str1, str1, 8);
       __ ld(tmp2, Address(str2));
       __ addi(str2, str2, 8);
+      __ beqz(cnt2, LAST_CHECK_AND_LENGTH_DIFF);
       __ sub(cnt2, cnt2, isLL ? 8 : 4);
     __ bind(CHECK_LAST);
       if (!isLL) {
@@ -2537,9 +2576,9 @@ class StubGenerator: public StubCodeGenerator {
       __ xorr(tmp4, tmp1, tmp2);
       __ bnez(tmp4, DIFF);
       __ add(str1, str1, cnt2);
-      __ ld(tmp5, Address(str1));
+      __ load_long_misaligned(tmp5, Address(str1), tmp3, isLL ? 1 : 2);
       __ add(str2, str2, cnt2);
-      __ ld(cnt1, Address(str2));
+      __ load_long_misaligned(cnt1, Address(str2), tmp3, isLL ? 1 : 2);
       __ xorr(tmp4, tmp5, cnt1);
       __ beqz(tmp4, LENGTH_DIFF);
       // Find the first different characters in the longwords and

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringCompareToDifferentLength.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringCompareToDifferentLength.java
@@ -24,20 +24,20 @@
 
 /*
  * @test
- * @requires os.arch=="aarch64"
+ * @requires os.arch=="aarch64" | os.arch=="riscv64"
  * @summary String::compareTo implementation uses different algorithms for
  *          different string length. This test creates string with specified
  *          size and longer string, which is same at beginning.
  *          Expecting length delta to be returned. Test class takes 2
  *          parameters: <string length>, <maximum string length delta>
- *          Input parameters for this test are set according to Aarch64
+ *          Input parameters for this test are set according to Aarch64/RISC-V
  *          String::compareTo intrinsic implementation specifics. Aarch64
  *          implementation has 1, 4, 8 -bytes loops for length < 72 and
- *          16, 32, 64 -characters loops for length >= 72. Code is also affected
+ *          16, 32, 64 -characters loops for length >= 72. Aarch64 Code is also affected
  *          by SoftwarePrefetchHintDistance vm flag value.
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=192 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90 192 193 208 209
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=16 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=-1 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:SoftwarePrefetchHintDistance=192 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90 192 193 208 209
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:SoftwarePrefetchHintDistance=16 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:SoftwarePrefetchHintDistance=-1 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90
  */
 
 package compiler.intrinsics.string;


### PR DESCRIPTION
Please review this fix. it eliminates misaligned loads in String.compare on risc-v

for small compares ( <= 72 bytes), the instrinsic in c2_MacroAssembler.cpp is used,
it reads ( in case of UU/LL) 8 bytes per loop, and at then end, it reads tail - misaligned load of last 8 bytes from the string.

so if string length is not 8x bytes long then last load is misaligned, also it performs read/compare of some data which already was processed.

I have changed that to compare only last length%8 bytes using SHORT_STRING part of intrinsic for UL/LU. But for UU/LL I have made an optimised version.

Thanks to optimisations for conditional branching at line [947](https://github.com/openjdk/jdk/pull/14534/files#diff-35eb1d2f1e2f0514dd46bd7fbad49ff2c87703d5a3041a6433956df00a3fe6e6R947) I’ve got no perf drop on thead ( with +AvoidUnalignedAccesses) which supports misaligned access.

Improvements to inflate_XX() methods gives 3-5% improvements for UL/LU cases on thead, almost no perf change on hifive.

for large strings, the instrinsics from stubGenerator.cpp is used
for UU/LL - generate_compare_long_string_same_encoding, I have just replaced misaligned ld with load_long_misaligned. Since this tail reading is not on hot path, this give some small penalty for thead when -XX:+AvoidUnalignedAccesses.

large LU/UL comparision is done in compare_long_string_different_encoding in sutbGenerator.cpp:
These changes are partially based on feilongjiang's patch, but I have changed tail reading to prevent reading past the end of string. I have observed no perf difference between feilongjiang's and my version.

This also enables regression test for string.Compare which previously was aarch64-only

Testing: tier1 and tier2 clean on hifive.

JMH testing, hifive:
before:
```
Benchmark                                   (delta)  (size)  Mode  Cnt     Score    Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9     6.474 ±  1.475  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9   125.823 ±  1.947  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9    10.512 ±  0.236  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9    13.032 ±  0.821  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9    18.983 ±  0.318  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9    29.925 ±  0.458  ms/op
StringCompareToDifferentLength.compareToLL        2     520  avgt    9    30.607 ±  0.963  ms/op
StringCompareToDifferentLength.compareToLL        2     523  avgt    9   150.772 ±  1.048  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9    13.979 ±  0.868  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9    18.344 ±  0.640  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   567.667 ±  5.222  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9  1060.860 ±  3.348  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9  2054.307 ±  6.988  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  4025.110 ± 16.923  ms/op
StringCompareToDifferentLength.compareToLU        2     520  avgt    9  4030.565 ± 18.757  ms/op
StringCompareToDifferentLength.compareToLU        2     523  avgt    9  4447.476 ± 21.069  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9    16.458 ±  0.640  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9    20.713 ±  0.705  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   566.969 ±  3.499  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9  1061.740 ±  3.034  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9  2050.731 ±  6.786  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  4028.398 ± 16.138  ms/op
StringCompareToDifferentLength.compareToUL        2     520  avgt    9  4034.976 ± 19.330  ms/op
StringCompareToDifferentLength.compareToUL        2     523  avgt    9  4445.266 ± 13.599  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9     7.673 ±  0.933  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9     9.495 ±  1.561  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9    14.430 ±  0.370  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9    19.752 ±  0.927  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9    30.463 ±  0.770  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9    52.556 ±  0.588  ms/op
StringCompareToDifferentLength.compareToUU        2     520  avgt    9    53.675 ±  0.544  ms/op
StringCompareToDifferentLength.compareToUU        2     523  avgt    9   173.248 ±  0.830  ms/op
```
after:
```
Benchmark                                   (delta)  (size)  Mode  Cnt    Score    Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9    6.403 ±  1.252  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9    8.473 ±  1.084  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9   11.301 ±  1.067  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9   15.615 ±  0.825  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9   21.007 ±  0.683  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9   32.836 ±  0.639  ms/op
StringCompareToDifferentLength.compareToLL        2     520  avgt    9   30.565 ±  1.188  ms/op
StringCompareToDifferentLength.compareToLL        2     523  avgt    9   33.284 ±  0.862  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9   14.089 ±  0.563  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9   17.754 ±  0.622  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   32.248 ±  0.679  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9   52.433 ±  4.008  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9   91.470 ±  0.927  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  174.563 ±  1.376  ms/op
StringCompareToDifferentLength.compareToLU        2     520  avgt    9  178.459 ±  1.381  ms/op
StringCompareToDifferentLength.compareToLU        2     523  avgt    9  202.416 ± 13.131  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9   15.420 ±  0.192  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9   19.283 ±  0.226  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   34.827 ±  1.365  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9   52.482 ±  1.852  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9   94.261 ±  1.677  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  179.576 ±  3.538  ms/op
StringCompareToDifferentLength.compareToUL        2     520  avgt    9  179.983 ±  1.184  ms/op
StringCompareToDifferentLength.compareToUL        2     523  avgt    9  180.987 ±  2.206  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9   10.841 ±  0.905  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9   11.709 ±  0.517  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9   15.979 ±  0.691  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9   20.225 ±  0.623  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9   31.435 ±  1.017  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9   53.657 ±  1.057  ms/op
StringCompareToDifferentLength.compareToUU        2     520  avgt    9   53.921 ±  1.079  ms/op
StringCompareToDifferentLength.compareToUU        2     523  avgt    9   54.215 ±  0.655  ms/op
```

thead:

before:
```
Benchmark                                   (delta)  (size)  Mode  Cnt    Score   Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9    2.592 ? 0.008  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9    3.727 ? 0.115  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9    7.277 ? 0.076  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9    8.733 ? 0.178  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9   13.334 ? 0.448  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9   19.843 ? 0.234  ms/op
StringCompareToDifferentLength.compareToLL        2     520  avgt    9   19.971 ? 0.093  ms/op
StringCompareToDifferentLength.compareToLL        2     523  avgt    9   21.052 ? 0.318  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9    7.847 ? 0.188  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9   10.890 ? 0.077  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   24.353 ? 0.277  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9   40.850 ? 0.591  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9   72.205 ? 0.352  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  134.445 ? 0.523  ms/op
StringCompareToDifferentLength.compareToLU        2     520  avgt    9  134.866 ? 1.081  ms/op
StringCompareToDifferentLength.compareToLU        2     523  avgt    9  138.925 ? 1.241  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9    9.532 ? 0.080  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9   12.873 ? 0.304  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   26.725 ? 0.582  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9   42.855 ? 0.451  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9   74.674 ? 0.817  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  136.531 ? 0.530  ms/op
StringCompareToDifferentLength.compareToUL        2     520  avgt    9  136.446 ? 0.946  ms/op
StringCompareToDifferentLength.compareToUL        2     523  avgt    9  141.521 ? 1.371  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9    4.106 ? 0.012  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9    5.458 ? 0.237  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9    9.530 ? 0.155  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9   13.908 ? 0.390  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9   20.331 ? 0.221  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9   33.734 ? 0.213  ms/op
StringCompareToDifferentLength.compareToUU        2     520  avgt    9   33.884 ? 0.201  ms/op
StringCompareToDifferentLength.compareToUU        2     523  avgt    9   35.376 ? 0.210  ms/op
```

after:
```
Benchmark                                   (delta)  (size)  Mode  Cnt    Score   Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9    2.701 ? 0.128  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9    3.552 ? 0.024  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9    7.533 ? 0.049  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9   10.330 ? 0.090  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9   15.484 ? 0.474  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9   21.892 ? 0.366  ms/op
StringCompareToDifferentLength.compareToLL        2     520  avgt    9   20.239 ? 0.102  ms/op
StringCompareToDifferentLength.compareToLL        2     523  avgt    9   22.113 ? 0.302  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9    7.150 ? 0.065  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9   10.103 ? 0.227  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   22.354 ? 0.218  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9   36.192 ? 0.374  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9   65.506 ? 0.301  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  124.193 ? 0.337  ms/op
StringCompareToDifferentLength.compareToLU        2     520  avgt    9  126.693 ? 0.560  ms/op
StringCompareToDifferentLength.compareToLU        2     523  avgt    9  127.654 ? 0.598  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9    9.611 ? 0.558  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9   12.892 ? 0.672  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   23.973 ? 0.570  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9   38.567 ? 1.064  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9   67.992 ? 0.986  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  126.910 ? 0.738  ms/op
StringCompareToDifferentLength.compareToUL        2     520  avgt    9  128.019 ? 0.508  ms/op
StringCompareToDifferentLength.compareToUL        2     523  avgt    9  127.973 ? 0.326  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9    3.903 ? 0.020  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9    4.911 ? 0.044  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9   10.019 ? 0.210  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9   14.479 ? 0.217  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9   20.668 ? 0.208  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9   34.244 ? 0.240  ms/op
StringCompareToDifferentLength.compareToUU        2     520  avgt    9   34.582 ? 0.220  ms/op
StringCompareToDifferentLength.compareToUU        2     523  avgt    9   34.804 ? 0.199  ms/op
```

after, with -XX:-AvoidUnalignedAccesses:
```
Benchmark                                   (delta)  (size)  Mode  Cnt    Score   Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9    2.641 ? 0.221  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9    3.486 ? 0.047  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9    7.528 ? 0.037  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9    9.002 ? 0.037  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9   13.772 ? 0.185  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9   20.139 ? 0.138  ms/op
StringCompareToDifferentLength.compareToLL        2     520  avgt    9   20.238 ? 0.322  ms/op
StringCompareToDifferentLength.compareToLL        2     523  avgt    9   20.928 ? 0.171  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9    7.100 ? 0.113  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9    9.976 ? 0.213  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   21.896 ? 0.205  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9   37.569 ? 0.113  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9   66.993 ? 0.730  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  126.249 ? 2.044  ms/op
StringCompareToDifferentLength.compareToLU        2     520  avgt    9  126.366 ? 0.585  ms/op
StringCompareToDifferentLength.compareToLU        2     523  avgt    9  129.772 ? 0.538  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9   10.031 ? 0.305  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9   12.185 ? 0.629  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   24.069 ? 0.539  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9   40.073 ? 0.573  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9   69.349 ? 0.609  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  128.168 ? 0.843  ms/op
StringCompareToDifferentLength.compareToUL        2     520  avgt    9  128.314 ? 0.584  ms/op
StringCompareToDifferentLength.compareToUL        2     523  avgt    9  132.530 ? 0.373  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9    3.658 ? 0.160  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9    4.496 ? 0.026  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9    9.397 ? 0.116  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9   13.752 ? 0.409  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9   20.053 ? 0.317  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9   33.385 ? 0.242  ms/op
StringCompareToDifferentLength.compareToUU        2     520  avgt    9   33.808 ? 0.301  ms/op
StringCompareToDifferentLength.compareToUU        2     523  avgt    9   35.481 ? 0.480  ms/op

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310268](https://bugs.openjdk.org/browse/JDK-8310268): RISC-V: misaligned memory access in String.Compare intrinsic (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [f6e066e5](https://git.openjdk.org/jdk/pull/14534/files/f6e066e58650f9a324fed3d76c236e2c8a75c004)


### Contributors
 * Feilong Jiang `<fjiang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14534/head:pull/14534` \
`$ git checkout pull/14534`

Update a local copy of the PR: \
`$ git checkout pull/14534` \
`$ git pull https://git.openjdk.org/jdk.git pull/14534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14534`

View PR using the GUI difftool: \
`$ git pr show -t 14534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14534.diff">https://git.openjdk.org/jdk/pull/14534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14534#issuecomment-1596559700)