### PR TITLE
8310276: RISC-V: Make use of shadd macro-assembler function when possible

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4329,6 +4329,7 @@ void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp
   }
 
   if (shamt != 0) {
+    assert_different_registers(Rs2, tmp);
     slli(tmp, Rs1, shamt);
     add(Rd, Rs2, tmp);
   } else {

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3337,8 +3337,7 @@ class StubGenerator: public StubCodeGenerator {
       assert(tmp1->encoding() < x28->encoding(), "register corruption");
       assert(tmp2->encoding() < x28->encoding(), "register corruption");
 
-      slli(tmp1, len, LogBytesPerWord);
-      add(s, s, tmp1);
+      shadd(s, len, s, tmp1, LogBytesPerWord);
       mv(tmp1, len);
       unroll_2(tmp1,  &MontgomeryMultiplyGenerator::reverse1, d, s, tmp2);
       slli(tmp1, len, LogBytesPerWord);

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1787,8 +1787,7 @@ void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) {
   //   _counters[_index] ++;
   Register counter_addr = t1;
   __ mv(x7, (address) &BytecodePairHistogram::_counters);
-  __ slli(index, index, LogBytesPerInt);
-  __ add(counter_addr, x7, index);
+  __ shadd(counter_addr, index, x7, counter_addr, LogBytesPerInt);
   __ atomic_addw(noreg, 1, counter_addr);
  }
 


### PR DESCRIPTION
Hi all,

We can use `shadd` to replace the following command combinations when
appropriate:
```
slli(rd1, rs1, imm)
add(rd2, rs2, rs3)
```

Conditions to be met:
1. Rd1 and rs3/rs2 are the same register;
2. The data given to rd1 by the `slli` instruction is not used later;
3.  Make sure rs2, rs3 are not the same register, so that the above instruction
combination will actually be executed if zba is not enabled, whereas if rs2,
rs3 are the same register then `slli` will destroy the value of rs3/rs2;
4.  The value of `imm` is in the range of [1, 3], so that if zba is enabled,
it will use sh1add, sh2add, sh3add instructions instead of the above two
instructions.

### Testing:

- tier1-3 on QEMU-System w/ and w/o UseZba (release build)
- tier1-3 tests on unmatched board w/o UseZba (release build)
- `hotspot_tier1`, `jdk_tier1` on QEMU-User w/ and w/o UseZba (fastdebug build)
- `hotspot_tier1`, `jdk_tier1` on unmatched w/o UseZba (fastdebug build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310276](https://bugs.openjdk.org/browse/JDK-8310276): RISC-V: Make use of shadd macro-assembler function when possible (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14535/head:pull/14535` \
`$ git checkout pull/14535`

Update a local copy of the PR: \
`$ git checkout pull/14535` \
`$ git pull https://git.openjdk.org/jdk.git pull/14535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14535`

View PR using the GUI difftool: \
`$ git pr show -t 14535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14535.diff">https://git.openjdk.org/jdk/pull/14535.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14535#issuecomment-1596624847)