### PR TITLE
8310299: C2: 8275201 broke constant folding of array store check in some cases

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2378,7 +2378,7 @@ const Type* LoadNode::klass_value_common(PhaseGVN* phase) const {
 
       // The array's TypeKlassPtr was declared 'precise' or 'not precise'
       // according to the element type's subclassing.
-      return tkls->is_aryklassptr()->elem();
+      return tkls->is_aryklassptr()->elem()->isa_klassptr()->cast_to_exactness(tkls->klass_is_exact());
     }
     if (tkls->isa_instklassptr() != nullptr && tkls->klass_is_exact() &&
         tkls->offset() == in_bytes(Klass::super_offset())) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestArrayElementTypeLoad.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestArrayElementTypeLoad.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestArrayElementTypeLoad
+ */
+
+public class TestArrayElementTypeLoad {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    static final A[] array = new A[1];
+
+    @Test
+    @IR(phase = { CompilePhase.ITER_GVN1 }, failOn = { IRNode.SUBTYPE_CHECK })
+    public static void test1(A a) {
+        array[0] = a;
+    }
+
+    @Run(test = "test1")
+    private void test1Runner() {
+        test1(new A());
+        test1(new B());
+    }
+
+    static class A {
+    }
+
+    static class B extends A {
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1193,6 +1193,11 @@ public class IRNode {
         beforeMatchingNameRegex(SUB_V, "SubV(B|S|I|L|F|D)");
     }
 
+    public static final String SUBTYPE_CHECK = PREFIX + "SUBTYPE_CHECK" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(SUBTYPE_CHECK, "SubTypeCheck");
+    }
+
     public static final String TRAP = PREFIX + "TRAP" + POSTFIX;
     static {
         trapNodes(TRAP,"reason");


### PR DESCRIPTION
Before 8275201, loading the element klass of an array returned:

```
TypeKlassPtr::make(tkls->ptr(), elem, 0/*offset*/);
```

that is exact if the array type is exact. I changed it to:

```
tkls->is_aryklassptr()->elem();
```

When the array type is exact (newly allocated array for instance) but
the element class has subclasses, this doesn't return an exact class
(so the logic is different from the one that was there before). That
affects array store checks that no longer constant fold.

