### PR TITLE
8310143: RandomCommandsTest fails due to unexpected VM exit code after JDK-8282797

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/StressAddJcmdBase.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/StressAddJcmdBase.java
@@ -116,7 +116,7 @@ public abstract class StressAddJcmdBase {
     private class TimeLimitedExecutor extends Executor {
         public TimeLimitedExecutor() {
             /* There are no need to check the state */
-            super(true, VM_OPTIONS, null, null);
+            super(VM_OPTIONS, null, null);
         }
 
         @Override

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/MultiCommand.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/MultiCommand.java
@@ -56,6 +56,7 @@ public class MultiCommand extends AbstractTestBase {
         List<CompileCommand> testCases = new ArrayList<>();
 
         for (Command cmd : commands) {
+            boolean isValid = true;
             String argument = null;
 
             if (validOnly && cmd == Command.NONEXISTENT) {
@@ -67,6 +68,7 @@ public class MultiCommand extends AbstractTestBase {
                     argument = Utils.getRandomElement(VALID_INTRINSIC_SAMPLES);
                 } else {
                     argument = Utils.getRandomElement(INVALID_INTRINSIC_SAMPLES);
+                    isValid = false;
                 }
             }
 
@@ -78,12 +80,13 @@ public class MultiCommand extends AbstractTestBase {
                 md = AbstractTestBase.getValidMethodDescriptor(exec);
             } else {
                 md = AbstractTestBase.METHOD_GEN.generateRandomDescriptor(exec);
+                isValid &= md.isValid();
             }
             CompileCommand cc;
             if (cmd == Command.INTRINSIC) {
-                cc = cmdGen.generateCompileCommand(cmd, true, md, null, argument);
+                cc = cmdGen.generateCompileCommand(cmd, isValid, md, null, argument);
             } else {
-                cc = cmdGen.generateCompileCommand(cmd, true, md, null);
+                cc = cmdGen.generateCompileCommand(cmd, isValid, md, null);
             }
             testCases.add(cc);
         }

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 
 public class Executor {
-    private final boolean isValid;
     private final List<String> vmOptions;
     private final Map<Executable, State> states;
     private final List<String> jcmdCommands;
@@ -57,16 +56,13 @@ public class Executor {
     /**
      * Constructor
      *
-     * @param isValid      shows that the input given to the VM is valid and
-     *                     VM shouldn't fail
      * @param vmOptions    a list of VM input options
      * @param states       a state map, or null for the non-checking execution
      * @param jcmdCommands a list of diagnostic commands to be preformed
      *                     on test VM
      */
-    public Executor(boolean isValid, List<String> vmOptions,
-            Map<Executable, State> states, List<String> jcmdCommands) {
-        this.isValid = isValid;
+    public Executor(List<String> vmOptions, Map<Executable, State> states,
+                    List<String> jcmdCommands) {
         if (vmOptions == null) {
             this.vmOptions = new ArrayList<>();
         } else {
@@ -77,7 +73,7 @@ public class Executor {
     }
 
     /**
-     * Executes separate VM a gets an OutputAnalyzer instance with the results
+     * Executes separate VM and gets an OutputAnalyzer instance with the results
      * of execution
      */
     public List<OutputAnalyzer> execute() {

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Scenario.java
@@ -104,7 +104,7 @@ public final class Scenario {
             jcmdExecCommands.add(JcmdType.PRINT.command);
         }
         jcmdProcessor = new PrintDirectivesProcessor(directives);
-        executor = new Executor(isValid, vmopts, states, jcmdExecCommands);
+        executor = new Executor(vmopts, states, jcmdExecCommands);
     }
 
     /**


### PR DESCRIPTION
The fix for [JDK-8282797](https://bugs.openjdk.org/browse/JDK-8282797) missed that randomly generated Compile Commands can be invalid. I verified with the corresponding seeds that all occurrences of this intermittent failure are now fixed. I also removed `Executor::isValid` because it's unused.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310143](https://bugs.openjdk.org/browse/JDK-8310143): RandomCommandsTest fails due to unexpected VM exit code after JDK-8282797 (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14538/head:pull/14538` \
`$ git checkout pull/14538`

Update a local copy of the PR: \
`$ git checkout pull/14538` \
`$ git pull https://git.openjdk.org/jdk.git pull/14538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14538`

View PR using the GUI difftool: \
`$ git pr show -t 14538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14538.diff">https://git.openjdk.org/jdk/pull/14538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14538#issuecomment-1597027791)