### PR TITLE
8310311: Serial: move Generation::contribute_scratch to DefNewGeneration

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -981,27 +981,18 @@ bool DefNewGeneration::no_allocs_since_save_marks() {
   return to()->saved_mark_at_top();
 }
 
-void DefNewGeneration::contribute_scratch(ScratchBlock*& list, Generation* requestor,
-                                         size_t max_alloc_words) {
-  if (requestor == this || _promotion_failed) {
+void DefNewGeneration::contribute_scratch(void*& scratch, size_t& num_words) {
+  if (_promotion_failed) {
     return;
   }
-  assert(GenCollectedHeap::heap()->is_old_gen(requestor), "We should not call our own generation");
 
-  /* $$$ Assert this?  "trace" is a "MarkSweep" function so that's not appropriate.
-  if (to_space->top() > to_space->bottom()) {
-    trace("to_space not empty when contribute_scratch called");
-  }
-  */
+  constexpr static size_t MinFreeScratchWords = 100;
 
   ContiguousSpace* to_space = to();
-  assert(to_space->end() >= to_space->top(), "pointers out of order");
-  size_t free_words = pointer_delta(to_space->end(), to_space->top());
+  const size_t free_words = pointer_delta(to_space->end(), to_space->top());
   if (free_words >= MinFreeScratchWords) {
-    ScratchBlock* sb = (ScratchBlock*)to_space->top();
-    sb->num_words = free_words;
-    sb->next = list;
-    list = sb;
+    scratch = to_space->top();
+    num_words = free_words;
   }
 }
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -986,7 +986,7 @@ void DefNewGeneration::contribute_scratch(void*& scratch, size_t& num_words) {
     return;
   }
 
-  constexpr static size_t MinFreeScratchWords = 100;
+  constexpr size_t MinFreeScratchWords = 100;
 
   ContiguousSpace* to_space = to();
   const size_t free_words = pointer_delta(to_space->end(), to_space->top());

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -986,7 +986,7 @@ void DefNewGeneration::contribute_scratch(void*& scratch, size_t& num_words) {
     return;
   }
 
-  constexpr size_t MinFreeScratchWords = 100;
+  const size_t MinFreeScratchWords = 100;
 
   ContiguousSpace* to_space = to();
   const size_t free_words = pointer_delta(to_space->end(), to_space->top());

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -143,12 +143,6 @@ class DefNewGeneration: public Generation {
 
   StringDedup::Requests _string_dedup_requests;
 
-  enum SomeProtectedConstants {
-    // Generations are GenGrain-aligned and have size that are multiples of
-    // GenGrain.
-    MinFreeScratchWords = 100
-  };
-
   // Return the size of a survivor space if this generation were of size
   // gen_size.
   size_t compute_survivor_size(size_t gen_size, size_t alignment) const {
@@ -248,13 +242,12 @@ class DefNewGeneration: public Generation {
   template <typename OopClosureType>
   void oop_since_save_marks_iterate(OopClosureType* cl);
 
-  // For non-youngest collection, the DefNewGeneration can contribute
-  // "to-space".
-  virtual void contribute_scratch(ScratchBlock*& list, Generation* requestor,
-                          size_t max_alloc_words);
+  // For Old collection (part of running Full GC), the DefNewGeneration can
+  // contribute the free part of "to-space" as the scratch space.
+  void contribute_scratch(void*& scratch, size_t& num_words);
 
   // Reset for contribution of "to-space".
-  virtual void reset_scratch();
+  void reset_scratch();
 
   // GC support
   virtual void compute_new_size();

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -228,17 +228,6 @@ public:
                               size_t requested_size,
                               size_t* actual_size) override;
 
-  // The "requestor" generation is performing some garbage collection
-  // action for which it would be useful to have scratch space.  The
-  // requestor promises to allocate no more than "max_alloc_words" in any
-  // older generation (via promotion say.)   Any blocks of space that can
-  // be provided are returned as a list of ScratchBlocks, sorted by
-  // decreasing size.
-  ScratchBlock* gather_scratch(Generation* requestor, size_t max_alloc_words);
-  // Allow each generation to reset any scratch space that it has
-  // contributed as it needs.
-  void release_scratch();
-
   // Ensure parsability
   void ensure_parsability(bool retire_tlabs) override;
 

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -326,22 +326,6 @@ class Generation: public CHeapObj<mtGC> {
   // generation since the last call to "save_marks".
   virtual bool no_allocs_since_save_marks() = 0;
 
-  // The "requestor" generation is performing some garbage collection
-  // action for which it would be useful to have scratch space.  If
-  // the target is not the requestor, no gc actions will be required
-  // of the target.  The requestor promises to allocate no more than
-  // "max_alloc_words" in the target generation (via promotion say,
-  // if the requestor is a young generation and the target is older).
-  // If the target generation can provide any scratch space, it adds
-  // it to "list", leaving "list" pointing to the head of the
-  // augmented list.  The default is to offer no space.
-  virtual void contribute_scratch(ScratchBlock*& list, Generation* requestor,
-                                  size_t max_alloc_words) {}
-
-  // Give each generation an opportunity to do clean up for any
-  // contributed scratch.
-  virtual void reset_scratch() {}
-
   // When an older generation has been collected, and perhaps resized,
   // this method will be invoked on all younger generations (from older to
   // younger), allowing them to resize themselves as appropriate.


### PR DESCRIPTION
Simple cleanup to move a method from base-class to  sub-class.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310311](https://bugs.openjdk.org/browse/JDK-8310311): Serial: move Generation::contribute_scratch to DefNewGeneration (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [04d3a6b0](https://git.openjdk.org/jdk/pull/14540/files/04d3a6b0eaffcef2f12eba9710393679e40cdbc9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14540/head:pull/14540` \
`$ git checkout pull/14540`

Update a local copy of the PR: \
`$ git checkout pull/14540` \
`$ git pull https://git.openjdk.org/jdk.git pull/14540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14540`

View PR using the GUI difftool: \
`$ git pr show -t 14540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14540.diff">https://git.openjdk.org/jdk/pull/14540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14540#issuecomment-1597081677)