### PR TITLE
8310314: Misplaced "unnamed classes are a preview feature and are disabled by default" error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3995,6 +3995,7 @@ public class JavacParser implements Parser {
                 }
 
                 if (isTopLevelMethodOrField) {
+                    checkSourceLevel(token.pos, Feature.UNNAMED_CLASSES);
                     defs.appendList(topLevelMethodOrFieldDeclaration(mods));
                     isUnnamedClass = true;
                 } else {
@@ -4025,8 +4026,6 @@ public class JavacParser implements Parser {
 
     // Restructure top level to be an unnamed class.
     private List<JCTree> constructUnnamedClass(List<JCTree> origDefs) {
-        checkSourceLevel(Feature.UNNAMED_CLASSES);
-
         ListBuffer<JCTree> topDefs = new ListBuffer<>();
         ListBuffer<JCTree> defs = new ListBuffer<>();
 

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
@@ -1,5 +1,7 @@
 /**
  * @test /nodynamiccopyright/
+ * @bug 8310314
+ * @summary Ensure proper error position for the "unnamed classes not supported" error
  * @compile/fail/ref=SourceLevelErrorPosition.out -XDrawDiagnostics SourceLevelErrorPosition.java
  */
 class Nested {}

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
@@ -1,0 +1,8 @@
+/**
+ * @test /nodynamiccopyright/
+ * @compile/fail/ref=SourceLevelErrorPosition.out -XDrawDiagnostics SourceLevelErrorPosition.java
+ */
+class Nested {}
+void main() {
+    System.err.println("");
+}

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
@@ -6,3 +6,6 @@ class Nested {}
 void main() {
     System.err.println("");
 }
+void test() {
+    System.err.println("");
+}

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.out
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.out
@@ -1,2 +1,2 @@
-SourceLevelErrorPosition.java:6:1: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.unnamed.classes)
+SourceLevelErrorPosition.java:8:1: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.unnamed.classes)
 1 error

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.out
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.out
@@ -1,0 +1,2 @@
+SourceLevelErrorPosition.java:6:1: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.unnamed.classes)
+1 error


### PR DESCRIPTION
Consider code like:
```
$ cat Test.java
void main() {
    System.err.println("Hello!");
}
```

Currently, the "unnamed classes are a preview feature and are disabled by default" error is put at the end of the file:
```
$ java Test.java
Test.java:4: error: unnamed classes are a preview feature and are disabled by default.

  (use --enable-preview to enable unnamed classes)
1 error
error: compilation failed
```

This does not seem to be user friendly. It seems to me that putting the error on the first method/variable in the file would be better:
```
$ java Test.java
Test.java:1: error: unnamed classes are a preview feature and are disabled by default.
void main() {
^
  (use --enable-preview to enable unnamed classes)
1 error
error: compilation failed
```

The proposed patch is to simply move the source level check to the place where the top-level method or field is parsed. Calling the method multiple times for a single file should not be a problem - `Log` itself will prevent printing the error multiple times for the same file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310314](https://bugs.openjdk.org/browse/JDK-8310314): Misplaced "unnamed classes are a preview feature and are disabled by default" error (**Bug** - P3)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14544/head:pull/14544` \
`$ git checkout pull/14544`

Update a local copy of the PR: \
`$ git checkout pull/14544` \
`$ git pull https://git.openjdk.org/jdk.git pull/14544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14544`

View PR using the GUI difftool: \
`$ git pr show -t 14544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14544.diff">https://git.openjdk.org/jdk/pull/14544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14544#issuecomment-1597427738)