### PR TITLE
8310326: Incorrect position of the synthetic unnamed class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4040,7 +4040,7 @@ public class JavacParser implements Parser {
             }
         }
 
-        int primaryPos = defs.first().pos;
+        int primaryPos = getStartPos(defs.first());
         String simplename = PathFileObject.getSimpleName(log.currentSourceFile());
 
         if (simplename.endsWith(".java")) {
@@ -4051,7 +4051,7 @@ public class JavacParser implements Parser {
         }
 
         Name name = names.fromString(simplename);
-        JCModifiers unnamedMods = F.at(primaryPos)
+        JCModifiers unnamedMods = F.at(Position.NOPOS)
                 .Modifiers(Flags.FINAL|Flags.SYNTHETIC|Flags.UNNAMED_CLASS, List.nil());
         JCClassDecl unnamed = F.at(primaryPos).ClassDef(
                 unnamedMods, name, List.nil(), null, List.nil(), List.nil(),


### PR DESCRIPTION
Considering code like:
```
void main() {
}
```

The method is wrapped in a synthetic class. But, for, this class:
 - `SourcePositions.getStartPosition` returns `5`, while `0` would be better (the reason is the the "name"/"preferred" position from the first member is used, not the starting position for the first member)
 - has (synthetic) empty modifiers with starting position `5`, while normally empty modifiers have starting pos `-1`, e.g.:
https://github.com/openjdk/jdk/blob/33c6ec9d4eb36649a94125aa005dc6b961dcd2c1/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java#L3525

This patch proposes to:
 - use the starting position of the first member as the position of the class
 - use `-1` as the position for the empty synthetic modifiers of the class

End positions for neither of these is not set, and continues not to be set, and hence `getEndPosition` returns `-1`. That is (AFAIK) the common behavior for synthetic trees.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310326](https://bugs.openjdk.org/browse/JDK-8310326): Incorrect position of the synthetic unnamed class (**Bug** - P4)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14548/head:pull/14548` \
`$ git checkout pull/14548`

Update a local copy of the PR: \
`$ git checkout pull/14548` \
`$ git pull https://git.openjdk.org/jdk.git pull/14548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14548`

View PR using the GUI difftool: \
`$ git pr show -t 14548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14548.diff">https://git.openjdk.org/jdk/pull/14548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14548#issuecomment-1597634674)