### PR TITLE
8298443: Remove expired flags in JDK 22

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -512,7 +512,6 @@ static SpecialFlag const special_jvm_flags[] = {
 
   // -------------- Obsolete Flags - sorted by expired_in --------------
 
-  { "EnableWaitForParallelLoad",    JDK_Version::jdk(20), JDK_Version::jdk(21), JDK_Version::jdk(22) },
   { "G1ConcRefinementGreenZone",    JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
   { "G1ConcRefinementYellowZone",   JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
   { "G1ConcRefinementRedZone",      JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
@@ -520,7 +519,6 @@ static SpecialFlag const special_jvm_flags[] = {
   { "G1UseAdaptiveConcRefinement",  JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
   { "G1ConcRefinementServiceIntervalMillis", JDK_Version::undefined(), JDK_Version::jdk(20), JDK_Version::undefined() },
 
-  { "G1UsePreventiveGC",            JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::jdk(22) },
   { "G1ConcRSLogCacheSize",         JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
   { "G1ConcRSHotCardLimit",         JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
   { "RefDiscoveryPolicy",           JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -3813,24 +3813,13 @@ This option was deprecated in JDK 16 by \f[B]JEP 396\f[R]
 403\f[R] [https://openjdk.org/jeps/403].
 .SH REMOVED JAVA OPTIONS
 .PP
-These \f[V]java\f[R] options have been removed in JDK 22 and using them
-results in an error of:
-.RS
-.PP
-\f[V]Unrecognized VM option\f[R] \f[I]option-name\f[R]
-.RE
-.TP
-\f[V]-XX:+ExtendedDTraceProbes\f[R]
-\f[B]Linux and macOS:\f[R] Enables additional \f[V]dtrace\f[R] tool
-probes that affect performance.
-By default, this option is disabled and \f[V]dtrace\f[R] performs only
-standard probes.
-Use the combination of these flags instead:
-\f[V]-XX:+DTraceMethodProbes\f[R], \f[V]-XX:+DTraceAllocProbes\f[R],
-\f[V]-XX:+DTraceMonitorProbes\f[R].
+No documented java options have been removed in JDK 22.
 .PP
 For the lists and descriptions of options removed in previous releases
 see the \f[I]Removed Java Options\f[R] section in:
+.IP \[bu] 2
+\f[B]The \f[VB]java\f[B] Command, Release 21\f[R]
+[https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html]
 .IP \[bu] 2
 \f[B]The \f[VB]java\f[B] Command, Release 20\f[R]
 [https://docs.oracle.com/en/java/javase/20/docs/specs/man/java.html]


### PR DESCRIPTION
Simple change to remove the two expired flags in JDK 22 and update the relevant section of the java manpage.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298443](https://bugs.openjdk.org/browse/JDK-8298443): Remove expired flags in JDK 22 (**Enhancement** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14549/head:pull/14549` \
`$ git checkout pull/14549`

Update a local copy of the PR: \
`$ git checkout pull/14549` \
`$ git pull https://git.openjdk.org/jdk.git pull/14549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14549`

View PR using the GUI difftool: \
`$ git pr show -t 14549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14549.diff">https://git.openjdk.org/jdk/pull/14549.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14549#issuecomment-1597940590)