### PR TITLE
8309109: AArch64: [TESTBUG] compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java fails on Neoverse N2 and V1

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
@@ -29,6 +29,9 @@
  * @library /test/lib /
  * @requires vm.flagless
  * @requires os.arch == "aarch64" & os.family == "mac"
+ * @comment sha3 is only implemented on AArch64 for now.
+ *          UseSHA3Intrinsics is only auto-enabled on Apple silicon, because it
+ *          may introduce performance regression on others. See JDK-8297092.
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
@@ -28,6 +28,7 @@
  * @summary Verify UseSHA3Intrinsics option processing on supported CPU.
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires os.arch == "aarch64" & os.family == "mac"
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
`UseSHA3Intrinsics` was introduced in JDK-8252204, but it was not auto-enabled due to the lack of real hardware. In JDK-8297092, the intrinsic was evaluated on existing hardware with the support of SHA3 feature (including Neoverse N2/V1 and Apple silicon), and it was auto-enabled by default on Apple silicon only. See the code [1].

As a result, test case `TestUseSHA3IntrinsicsOptionOnSupportedCPU.java` fails on Neoverse N2 and V1 with the following error message:

```
JavaTest Message: Test threw exception: java.lang.AssertionError: Option 'UseSHA3Intrinsics' is expected to have 'true' value
Option 'UseSHA3Intrinsics' should be enabled by default
```

The group of test cases `TestUseXXXIntrinsicsOptionOnSupportedCPU.java` are designed to verify that, option `UseXXXIntrinsics` should be enabled by default if the underlying hardware supports the corresponding CPU feature.

Apparently this check condition doesn't work for `UseSHA3Intrinsics`. The other expcetion case is `UseSHA512Intrinsics`. See JDK-8257796.

Fix: One `@requires` condition is added in this patch to limit that this test case is only run on macOS on Apple silicon. Note that SHA3 feature is currently supported by AArch64 only.

Test: this test case passed on Linux/Neoverse N2, Linux/Neoverse V1 and macOS on Apple silicon.

[1] https://github.com/openjdk/jdk/pull/11382/files#diff-a87e260510f34ca7d9b0feb089ad982be8268c5c8aa5a71221f6738b051ea488R338-R345

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309109](https://bugs.openjdk.org/browse/JDK-8309109): AArch64: [TESTBUG] compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java fails on Neoverse N2 and V1 (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14551/head:pull/14551` \
`$ git checkout pull/14551`

Update a local copy of the PR: \
`$ git checkout pull/14551` \
`$ git pull https://git.openjdk.org/jdk.git pull/14551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14551`

View PR using the GUI difftool: \
`$ git pr show -t 14551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14551.diff">https://git.openjdk.org/jdk/pull/14551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14551#issuecomment-1598199989)