### PR TITLE
8193513: add support for printing a stack trace on class loading

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -45,6 +45,7 @@ class outputStream;
   LOG_TAG(bot) \
   LOG_TAG(breakpoint) \
   LOG_TAG(bytecode) \
+  LOG_TAG(cause) \
   LOG_TAG(cds) \
   LOG_TAG(census) \
   LOG_TAG(class) \
@@ -124,6 +125,7 @@ class outputStream;
   LOG_TAG(module) \
   LOG_TAG(monitorinflation) \
   LOG_TAG(monitormismatch) \
+  LOG_TAG(native) \
   LOG_TAG(nestmates) \
   LOG_TAG(nmethod) \
   LOG_TAG(nmt) \

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3745,89 +3745,98 @@ void InstanceKlass::print_class_load_logging(ClassLoaderData* loader_data,
     ClassListWriter::write(this, cfs);
   }
 
-  if (log_is_enabled(Info, class, load)) {
-    ResourceMark rm;
-    LogMessage(class, load) msg;
-    stringStream info_stream;
+  print_class_load_helper(loader_data, module_entry, cfs);
+  print_class_load_cause_logging();
+}
 
-    // Name and class hierarchy info
-    info_stream.print("%s", external_name());
+void InstanceKlass::print_class_load_helper(ClassLoaderData* loader_data,
+                                             const ModuleEntry* module_entry,
+                                             const ClassFileStream* cfs) const {
 
-    // Source
-    if (cfs != nullptr) {
-      if (cfs->source() != nullptr) {
-        const char* module_name = (module_entry->name() == nullptr) ? UNNAMED_MODULE : module_entry->name()->as_C_string();
-        if (module_name != nullptr) {
-          // When the boot loader created the stream, it didn't know the module name
-          // yet. Let's format it now.
-          if (cfs->from_boot_loader_modules_image()) {
-            info_stream.print(" source: jrt:/%s", module_name);
-          } else {
-            info_stream.print(" source: %s", cfs->source());
-          }
+  if (!log_is_enabled(Info, class, load)) {
+    return;
+  }
+
+  ResourceMark rm;
+  LogMessage(class, load) msg;
+  stringStream info_stream;
+
+  // Name and class hierarchy info
+  info_stream.print("%s", external_name());
+
+  // Source
+  if (cfs != nullptr) {
+    if (cfs->source() != nullptr) {
+      const char* module_name = (module_entry->name() == nullptr) ? UNNAMED_MODULE : module_entry->name()->as_C_string();
+      if (module_name != nullptr) {
+        // When the boot loader created the stream, it didn't know the module name
+        // yet. Let's format it now.
+        if (cfs->from_boot_loader_modules_image()) {
+          info_stream.print(" source: jrt:/%s", module_name);
         } else {
           info_stream.print(" source: %s", cfs->source());
         }
-      } else if (loader_data == ClassLoaderData::the_null_class_loader_data()) {
-        Thread* current = Thread::current();
-        Klass* caller = current->is_Java_thread() ?
-          JavaThread::cast(current)->security_get_caller_class(1):
-          nullptr;
-        // caller can be null, for example, during a JVMTI VM_Init hook
-        if (caller != nullptr) {
-          info_stream.print(" source: instance of %s", caller->external_name());
-        } else {
-          // source is unknown
-        }
       } else {
-        oop class_loader = loader_data->class_loader();
-        info_stream.print(" source: %s", class_loader->klass()->external_name());
+        info_stream.print(" source: %s", cfs->source());
+      }
+    } else if (loader_data == ClassLoaderData::the_null_class_loader_data()) {
+      Thread* current = Thread::current();
+      Klass* caller = current->is_Java_thread() ?
+        JavaThread::cast(current)->security_get_caller_class(1):
+        nullptr;
+      // caller can be null, for example, during a JVMTI VM_Init hook
+      if (caller != nullptr) {
+        info_stream.print(" source: instance of %s", caller->external_name());
+      } else {
+        // source is unknown
       }
     } else {
-      assert(this->is_shared(), "must be");
-      if (MetaspaceShared::is_shared_dynamic((void*)this)) {
-        info_stream.print(" source: shared objects file (top)");
-      } else {
-        info_stream.print(" source: shared objects file");
-      }
+      oop class_loader = loader_data->class_loader();
+      info_stream.print(" source: %s", class_loader->klass()->external_name());
     }
-
-    msg.info("%s", info_stream.as_string());
-
-    if (log_is_enabled(Debug, class, load)) {
-      stringStream debug_stream;
-
-      // Class hierarchy info
-      debug_stream.print(" klass: " PTR_FORMAT " super: " PTR_FORMAT,
-                        p2i(this),  p2i(superklass()));
-
-      // Interfaces
-      if (local_interfaces() != nullptr && local_interfaces()->length() > 0) {
-        debug_stream.print(" interfaces:");
-        int length = local_interfaces()->length();
-        for (int i = 0; i < length; i++) {
-          debug_stream.print(" " PTR_FORMAT,
-                            p2i(InstanceKlass::cast(local_interfaces()->at(i))));
-        }
-      }
-
-      // Class loader
-      debug_stream.print(" loader: [");
-      loader_data->print_value_on(&debug_stream);
-      debug_stream.print("]");
-
-      // Classfile checksum
-      if (cfs) {
-        debug_stream.print(" bytes: %d checksum: %08x",
-                          cfs->length(),
-                          ClassLoader::crc32(0, (const char*)cfs->buffer(),
-                          cfs->length()));
-      }
-
-      msg.debug("%s", debug_stream.as_string());
+  } else {
+    assert(this->is_shared(), "must be");
+    if (MetaspaceShared::is_shared_dynamic((void*)this)) {
+      info_stream.print(" source: shared objects file (top)");
+    } else {
+      info_stream.print(" source: shared objects file");
     }
   }
-  print_class_load_cause_logging();
+
+  msg.info("%s", info_stream.as_string());
+
+  if (log_is_enabled(Debug, class, load)) {
+    stringStream debug_stream;
+
+    // Class hierarchy info
+    debug_stream.print(" klass: " PTR_FORMAT " super: " PTR_FORMAT,
+                      p2i(this),  p2i(superklass()));
+
+    // Interfaces
+    if (local_interfaces() != nullptr && local_interfaces()->length() > 0) {
+      debug_stream.print(" interfaces:");
+      int length = local_interfaces()->length();
+      for (int i = 0; i < length; i++) {
+        debug_stream.print(" " PTR_FORMAT,
+                          p2i(InstanceKlass::cast(local_interfaces()->at(i))));
+      }
+    }
+
+    // Class loader
+    debug_stream.print(" loader: [");
+    loader_data->print_value_on(&debug_stream);
+    debug_stream.print("]");
+
+    // Classfile checksum
+    if (cfs) {
+      debug_stream.print(" bytes: %d checksum: %08x",
+                        cfs->length(),
+                        ClassLoader::crc32(0, (const char*)cfs->buffer(),
+                        cfs->length()));
+    }
+
+    msg.debug("%s", debug_stream.as_string());
+  }
 }
 
 void InstanceKlass::print_class_load_cause_logging() const {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3745,92 +3745,89 @@ void InstanceKlass::print_class_load_logging(ClassLoaderData* loader_data,
     ClassListWriter::write(this, cfs);
   }
 
-  print_class_load_cause_logging();
+  if (log_is_enabled(Info, class, load)) {
+    ResourceMark rm;
+    LogMessage(class, load) msg;
+    stringStream info_stream;
 
-  if (!log_is_enabled(Info, class, load)) {
-    return;
-  }
+    // Name and class hierarchy info
+    info_stream.print("%s", external_name());
 
-  ResourceMark rm;
-  LogMessage(class, load) msg;
-  stringStream info_stream;
-
-  // Name and class hierarchy info
-  info_stream.print("%s", external_name());
-
-  // Source
-  if (cfs != nullptr) {
-    if (cfs->source() != nullptr) {
-      const char* module_name = (module_entry->name() == nullptr) ? UNNAMED_MODULE : module_entry->name()->as_C_string();
-      if (module_name != nullptr) {
-        // When the boot loader created the stream, it didn't know the module name
-        // yet. Let's format it now.
-        if (cfs->from_boot_loader_modules_image()) {
-          info_stream.print(" source: jrt:/%s", module_name);
+    // Source
+    if (cfs != nullptr) {
+      if (cfs->source() != nullptr) {
+        const char* module_name = (module_entry->name() == nullptr) ? UNNAMED_MODULE : module_entry->name()->as_C_string();
+        if (module_name != nullptr) {
+          // When the boot loader created the stream, it didn't know the module name
+          // yet. Let's format it now.
+          if (cfs->from_boot_loader_modules_image()) {
+            info_stream.print(" source: jrt:/%s", module_name);
+          } else {
+            info_stream.print(" source: %s", cfs->source());
+          }
         } else {
           info_stream.print(" source: %s", cfs->source());
         }
+      } else if (loader_data == ClassLoaderData::the_null_class_loader_data()) {
+        Thread* current = Thread::current();
+        Klass* caller = current->is_Java_thread() ?
+          JavaThread::cast(current)->security_get_caller_class(1):
+          nullptr;
+        // caller can be null, for example, during a JVMTI VM_Init hook
+        if (caller != nullptr) {
+          info_stream.print(" source: instance of %s", caller->external_name());
+        } else {
+          // source is unknown
+        }
       } else {
-        info_stream.print(" source: %s", cfs->source());
-      }
-    } else if (loader_data == ClassLoaderData::the_null_class_loader_data()) {
-      Thread* current = Thread::current();
-      Klass* caller = current->is_Java_thread() ?
-        JavaThread::cast(current)->security_get_caller_class(1):
-        nullptr;
-      // caller can be null, for example, during a JVMTI VM_Init hook
-      if (caller != nullptr) {
-        info_stream.print(" source: instance of %s", caller->external_name());
-      } else {
-        // source is unknown
+        oop class_loader = loader_data->class_loader();
+        info_stream.print(" source: %s", class_loader->klass()->external_name());
       }
     } else {
-      oop class_loader = loader_data->class_loader();
-      info_stream.print(" source: %s", class_loader->klass()->external_name());
-    }
-  } else {
-    assert(this->is_shared(), "must be");
-    if (MetaspaceShared::is_shared_dynamic((void*)this)) {
-      info_stream.print(" source: shared objects file (top)");
-    } else {
-      info_stream.print(" source: shared objects file");
-    }
-  }
-
-  msg.info("%s", info_stream.as_string());
-
-  if (log_is_enabled(Debug, class, load)) {
-    stringStream debug_stream;
-
-    // Class hierarchy info
-    debug_stream.print(" klass: " PTR_FORMAT " super: " PTR_FORMAT,
-                       p2i(this),  p2i(superklass()));
-
-    // Interfaces
-    if (local_interfaces() != nullptr && local_interfaces()->length() > 0) {
-      debug_stream.print(" interfaces:");
-      int length = local_interfaces()->length();
-      for (int i = 0; i < length; i++) {
-        debug_stream.print(" " PTR_FORMAT,
-                           p2i(InstanceKlass::cast(local_interfaces()->at(i))));
+      assert(this->is_shared(), "must be");
+      if (MetaspaceShared::is_shared_dynamic((void*)this)) {
+        info_stream.print(" source: shared objects file (top)");
+      } else {
+        info_stream.print(" source: shared objects file");
       }
     }
 
-    // Class loader
-    debug_stream.print(" loader: [");
-    loader_data->print_value_on(&debug_stream);
-    debug_stream.print("]");
+    msg.info("%s", info_stream.as_string());
 
-    // Classfile checksum
-    if (cfs) {
-      debug_stream.print(" bytes: %d checksum: %08x",
-                         cfs->length(),
-                         ClassLoader::crc32(0, (const char*)cfs->buffer(),
-                         cfs->length()));
+    if (log_is_enabled(Debug, class, load)) {
+      stringStream debug_stream;
+
+      // Class hierarchy info
+      debug_stream.print(" klass: " PTR_FORMAT " super: " PTR_FORMAT,
+                        p2i(this),  p2i(superklass()));
+
+      // Interfaces
+      if (local_interfaces() != nullptr && local_interfaces()->length() > 0) {
+        debug_stream.print(" interfaces:");
+        int length = local_interfaces()->length();
+        for (int i = 0; i < length; i++) {
+          debug_stream.print(" " PTR_FORMAT,
+                            p2i(InstanceKlass::cast(local_interfaces()->at(i))));
+        }
+      }
+
+      // Class loader
+      debug_stream.print(" loader: [");
+      loader_data->print_value_on(&debug_stream);
+      debug_stream.print("]");
+
+      // Classfile checksum
+      if (cfs) {
+        debug_stream.print(" bytes: %d checksum: %08x",
+                          cfs->length(),
+                          ClassLoader::crc32(0, (const char*)cfs->buffer(),
+                          cfs->length()));
+      }
+
+      msg.debug("%s", debug_stream.as_string());
     }
-
-    msg.debug("%s", debug_stream.as_string());
   }
+  print_class_load_cause_logging();
 }
 
 void InstanceKlass::print_class_load_cause_logging() const {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3836,11 +3836,12 @@ void InstanceKlass::print_class_load_cause_logging() const {
   bool log_cause_native = log_is_enabled(Info, class, load, cause, native);
   if (log_cause_native || log_is_enabled(Info, class, load, cause)) {
     JavaThread* current = JavaThread::current();
-    ResourceMark rm;
+    ResourceMark rm(current);
     const char* name = external_name();
 
-    if (LogClassLoadingCauseFor != nullptr &&
-        strstr(name, LogClassLoadingCauseFor) == nullptr) {
+    if (LogClassLoadingCauseFor == nullptr ||
+        (strcmp("*", LogClassLoadingCauseFor) != 0 &&
+         strstr(name, LogClassLoadingCauseFor) == nullptr)) {
         return;
     }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3739,6 +3739,15 @@ const char* InstanceKlass::internal_name() const {
 void InstanceKlass::print_class_load_logging(ClassLoaderData* loader_data,
                                              const ModuleEntry* module_entry,
                                              const ClassFileStream* cfs) const {
+  if (TraceClassLoadingCause != nullptr &&
+      (strcmp(TraceClassLoadingCause, "*") == 0 || strstr(external_name(), TraceClassLoadingCause) != nullptr))
+  {
+    stringStream st;
+    st.print_cr("Loading %s", external_name());
+    JavaThread::current()->print_stack_on(&st);
+    tty->print_raw(st.as_string());
+  }
+
   if (ClassListWriter::is_enabled()) {
     ClassListWriter::write(this, cfs);
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3744,7 +3744,10 @@ void InstanceKlass::print_class_load_logging(ClassLoaderData* loader_data,
   {
     stringStream st;
     st.print_cr("Loading %s", external_name());
-    JavaThread::current()->print_stack_on(&st);
+    Thread* current = Thread::current_or_null();
+    if (current != nullptr && current->is_Java_thread()) {
+      JavaThread::cast(current)->print_stack_on(&st);
+    }
     tty->print_raw(st.as_string());
   }
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1172,6 +1172,9 @@ public:
                                 const ClassFileStream* cfs) const;
  private:
   void print_class_load_cause_logging() const;
+  void print_class_load_helper(ClassLoaderData* loader_data,
+                               const ModuleEntry* module_entry,
+                               const ClassFileStream* cfs) const;
 };
 
 // for adding methods

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1170,6 +1170,8 @@ public:
   void print_class_load_logging(ClassLoaderData* loader_data,
                                 const ModuleEntry* module_entry,
                                 const ClassFileStream* cfs) const;
+ private:
+  void print_class_load_cause_logging() const;
 };
 
 // for adding methods

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3963,6 +3963,12 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
     warning("dependency logging results may be inflated by VerifyDependencies");
   }
 
+  bool log_class_load_cause = log_is_enabled(Info, class, load, cause, native) ||
+                              log_is_enabled(Info, class, load, cause);
+  if (log_class_load_cause && LogClassLoadingCauseFor == nullptr) {
+    warning("class load cause logging will not produce output without LogClassLoadingCauseFor");
+  }
+
   apply_debugger_ergo();
 
   if (log_is_enabled(Info, arguments)) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -933,8 +933,9 @@ const int ObjectAlignmentInBytes = 8;
              "Trace creation and removal of compiler threads")              \
                                                                             \
   product(ccstr, LogClassLoadingCauseFor, nullptr,                          \
-          "Restrict -Xlog:class+load+cause* to a class whose fully"         \
-          "qualified name contains this string.")                           \
+          "Apply -Xlog:class+load+cause* to classes whose fully "           \
+          "qualified name contains this string (\"*\" matches "             \
+          "any class).")                                                    \
                                                                             \
   develop(bool, InjectCompilerCreationFailure, false,                       \
           "Inject thread creation failures for "                            \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -932,10 +932,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, TraceCompilerThreads, false, DIAGNOSTIC,                    \
              "Trace creation and removal of compiler threads")              \
                                                                             \
-  product(ccstr, TraceClassLoadingCause, nullptr, DIAGNOSTIC,               \
-          "Print a stack trace when loading a class whose fully"            \
-          "qualified name contains this string (\"*\" matches "             \
-          "any class).")                                                    \
+  product(ccstr, LogClassLoadingCauseFor, nullptr,                          \
+          "Restrict -Xlog:class+load+cause* to a class whose fully"         \
+          "qualified name contains this string.")                           \
                                                                             \
   develop(bool, InjectCompilerCreationFailure, false,                       \
           "Inject thread creation failures for "                            \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -932,6 +932,11 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, TraceCompilerThreads, false, DIAGNOSTIC,                    \
              "Trace creation and removal of compiler threads")              \
                                                                             \
+  product(ccstr, TraceClassLoadingCause, nullptr, DIAGNOSTIC,               \
+          "Print a stack trace when loading a class whose fully"            \
+          "qualified name contains this string (\"*\" matches "             \
+          "any class).")                                                    \
+                                                                            \
   develop(bool, InjectCompilerCreationFailure, false,                       \
           "Inject thread creation failures for "                            \
           "UseDynamicNumberOfCompilerThreads")                              \

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -118,5 +118,22 @@ public class ClassLoadUnloadTest {
         pb = exec("-Xlog:class+loader+data=trace");
         checkFor("[class,loader,data]", "create loader data");
 
+        //  -Xlog:class+load+cause
+        pb = exec("-Xlog:class+load+cause");
+        checkAbsent("[class,load,cause]");
+        checkFor("class load cause logging will not produce output without LogClassLoadingCauseFor");
+
+        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringCoding
+        pb = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=java.lang.StringCoding");
+        checkFor("[class,load,cause]", "Java stack when loading java.lang.StringCoding:");
+
+        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringCoding
+        pb = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=java.lang.StringCoding");
+        checkFor("[class,load,cause,native]", "Native stack when loading java.lang.StringCoding:");
+
+        //  -Xlog:class+load+cause* -XX:LogClassLoadingCauseFor=java.lang.StringCoding
+        pb = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=java.lang.StringCoding");
+        checkFor("[class,load,cause] Java stack when loading java.lang.StringCoding:");
+        checkFor("[class,load,cause,native] Native stack when loading java.lang.StringCoding:");
     }
 }


### PR DESCRIPTION
In the development of libgraal, it has been very useful to see why a given class is loaded (e.g., trying to reduce startup time by avoiding unnecessary eager class loading). One way to do this is to see the stack trace when the VM loads a class. The only possibility currently is to add a static initializer to the class of interest. However, not only is this not always possible but it doesn't correlate with class loading but with class initialization.

This PR adds support for `-Xlog:class+load+cause` and `-Xlog:class+load+cause+native` that produce output according to a new `LogClassLoadingCauseFor` VM flag:

```
  product(ccstr, LogClassLoadingCauseFor, nullptr,                          \
          "Apply -Xlog:class+load+cause* to classes whose fully "           \
          "qualified name contains this string (\"*\" matches "             \
          "any class).")                                                    \
```

Example usage:
```
java "-Xlog:class+load+cause*" -XX:LogClassLoadingCauseFor=java.util.concurrent.ConcurrentHashMap\$V --version
[0.075s][info][class,load,cause] Java stack when loading java.util.concurrent.ConcurrentHashMap$ValuesView:
[0.075s][info][class,load,cause] 	at java.util.concurrent.ConcurrentHashMap.values(java.base/ConcurrentHashMap.java:1263)
[0.075s][info][class,load,cause] 	at jdk.internal.loader.NativeLibraries.find(java.base/NativeLibraries.java:102)
[0.075s][info][class,load,cause] 	at java.lang.ClassLoader.findNative(java.base/ClassLoader.java:2457)
[0.075s][info][class,load,cause] 	at sun.nio.fs.UnixNativeDispatcher.init(java.base/Native Method)
[0.075s][info][class,load,cause] 	at sun.nio.fs.UnixNativeDispatcher.<clinit>(java.base/UnixNativeDispatcher.java:817)
[0.075s][info][class,load,cause] 	at sun.nio.fs.UnixFileSystem.<init>(java.base/UnixFileSystem.java:96)
[0.075s][info][class,load,cause] 	at sun.nio.fs.BsdFileSystem.<init>(java.base/BsdFileSystem.java:50)
[0.075s][info][class,load,cause] 	at sun.nio.fs.MacOSXFileSystem.<init>(java.base/MacOSXFileSystem.java:52)
[0.075s][info][class,load,cause] 	at sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(java.base/MacOSXFileSystemProvider.java:44)
[0.075s][info][class,load,cause] 	at sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(java.base/MacOSXFileSystemProvider.java:37)
[0.075s][info][class,load,cause] 	at sun.nio.fs.UnixFileSystemProvider.<init>(java.base/UnixFileSystemProvider.java:78)
[0.075s][info][class,load,cause] 	at sun.nio.fs.BsdFileSystemProvider.<init>(java.base/BsdFileSystemProvider.java:38)
[0.075s][info][class,load,cause] 	at sun.nio.fs.MacOSXFileSystemProvider.<init>(java.base/MacOSXFileSystemProvider.java:39)
[0.075s][info][class,load,cause] 	at sun.nio.fs.DefaultFileSystemProvider.<clinit>(java.base/DefaultFileSystemProvider.java:35)
[0.075s][info][class,load,cause] 	at java.nio.file.FileSystems.getDefault(java.base/FileSystems.java:186)
[0.075s][info][class,load,cause] 	at java.nio.file.Path.of(java.base/Path.java:148)
[0.075s][info][class,load,cause] 	at jdk.internal.module.SystemModuleFinders.ofSystem(java.base/SystemModuleFinders.java:188)
[0.075s][info][class,load,cause] 	at jdk.internal.module.ModuleBootstrap.boot2(java.base/ModuleBootstrap.java:244)
[0.075s][info][class,load,cause] 	at jdk.internal.module.ModuleBootstrap.boot(java.base/ModuleBootstrap.java:174)
[0.075s][info][class,load,cause] 	at java.lang.System.initPhase2(java.base/System.java:2227)
[0.081s][info][class,load,cause,native] Native stack when loading java.util.concurrent.ConcurrentHashMap$ValuesView:
[0.081s][info][class,load,cause,native] 	Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9b64e4]  InstanceKlass::print_class_load_logging(ClassLoaderData*, ModuleEntry const*, ClassFileStream const*) const+0x6c
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x596084]  ClassFileParser::fill_instance_klass(InstanceKlass*, bool, ClassInstanceInfo const&, JavaThread*)+0x1a98
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x594288]  ClassFileParser::create_instance_klass(bool, ClassInstanceInfo const&, JavaThread*)+0x88
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xd9ff38]  KlassFactory::create_from_stream(ClassFileStream*, Symbol*, ClassLoaderData*, ClassLoadInfo const&, JavaThread*)+0x1f4
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x5a5eb8]  ClassLoader::load_class(Symbol*, bool, JavaThread*)+0x3f4
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x1269ca8]  SystemDictionary::load_instance_class_impl(Symbol*, Handle, JavaThread*)+0x838
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x12671e0]  SystemDictionary::load_instance_class(Symbol*, Handle, JavaThread*)+0x28
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x126631c]  SystemDictionary::resolve_instance_class_or_null(Symbol*, Handle, Handle, JavaThread*)+0xb34
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x1264848]  SystemDictionary::resolve_or_fail(Symbol*, Handle, Handle, bool, JavaThread*)+0x28
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x64620c]  ConstantPool::klass_at_impl(constantPoolHandle const&, int, JavaThread*)+0x680
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9d6c04]  InterpreterRuntime::_new(JavaThread*, ConstantPool*, int)+0x1f4
[0.081s][info][class,load,cause,native] 	j  java.util.concurrent.ConcurrentHashMap.values()Ljava/util/Collection;+12 java.base
[0.081s][info][class,load,cause,native] 	j  jdk.internal.loader.NativeLibraries.find(Ljava/lang/String;)J+18 java.base
[0.081s][info][class,load,cause,native] 	j  java.lang.ClassLoader.findNative(Ljava/lang/ClassLoader;Ljava/lang/String;)J+8 java.base
[0.081s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f2a1c]  JavaCalls::call_static(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x128
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f2c10]  JavaCalls::call_static(JavaValue*, Klass*, Symbol*, Symbol*, Handle, Handle, JavaThread*)+0x60
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfb9418]  NativeLookup::lookup_style(methodHandle const&, char*, char const*, int, bool, JavaThread*)+0x21c
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfb98a4]  NativeLookup::lookup_entry(methodHandle const&, JavaThread*)+0xdc
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfb9f3c]  NativeLookup::lookup_base(methodHandle const&, JavaThread*)+0x108
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfba274]  NativeLookup::lookup(methodHandle const&, JavaThread*)+0xc8
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e6130]  InterpreterRuntime::prepare_native_call(JavaThread*, Method*)+0x264
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.UnixNativeDispatcher.init()I+0 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.UnixNativeDispatcher.<clinit>()V+5 java.base
[0.081s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a9090]  InstanceKlass::call_class_initializer(JavaThread*)+0x3e8
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a68d8]  InstanceKlass::initialize_impl(JavaThread*)+0xc84
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a5bdc]  InstanceKlass::initialize(JavaThread*)+0x30
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdf7810]  LinkResolver::resolve_static_call(CallInfo&, LinkInfo const&, bool, JavaThread*)+0xb4
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdfbca8]  LinkResolver::resolve_invoke(CallInfo&, Handle, constantPoolHandle const&, int, Bytecodes::Code, JavaThread*)+0x190
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e05a0]  InterpreterRuntime::resolve_invoke(JavaThread*, Bytecodes::Code)+0x594
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e1944]  InterpreterRuntime::resolve_from_cache(JavaThread*, Bytecodes::Code)+0x20c
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.UnixFileSystem.<init>(Lsun/nio/fs/UnixFileSystemProvider;Ljava/lang/String;)V+79 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.BsdFileSystem.<init>(Lsun/nio/fs/UnixFileSystemProvider;Ljava/lang/String;)V+3 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystem.<init>(Lsun/nio/fs/UnixFileSystemProvider;Ljava/lang/String;)V+3 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(Ljava/lang/String;)Lsun/nio/fs/MacOSXFileSystem;+6 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(Ljava/lang/String;)Lsun/nio/fs/UnixFileSystem;+2 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.UnixFileSystemProvider.<init>()V+9 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.BsdFileSystemProvider.<init>()V+1 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystemProvider.<init>()V+1 java.base
[0.081s][info][class,load,cause,native] 	j  sun.nio.fs.DefaultFileSystemProvider.<clinit>()V+4 java.base
[0.081s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a9090]  InstanceKlass::call_class_initializer(JavaThread*)+0x3e8
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a68d8]  InstanceKlass::initialize_impl(JavaThread*)+0xc84
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a5bdc]  InstanceKlass::initialize(JavaThread*)+0x30
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdf7810]  LinkResolver::resolve_static_call(CallInfo&, LinkInfo const&, bool, JavaThread*)+0xb4
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdfbca8]  LinkResolver::resolve_invoke(CallInfo&, Handle, constantPoolHandle const&, int, Bytecodes::Code, JavaThread*)+0x190
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e05a0]  InterpreterRuntime::resolve_invoke(JavaThread*, Bytecodes::Code)+0x594
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e1944]  InterpreterRuntime::resolve_from_cache(JavaThread*, Bytecodes::Code)+0x20c
[0.081s][info][class,load,cause,native] 	j  java.nio.file.FileSystems.getDefault()Ljava/nio/file/FileSystem;+10 java.base
[0.081s][info][class,load,cause,native] 	j  java.nio.file.Path.of(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;+0 java.base
[0.081s][info][class,load,cause,native] 	j  jdk.internal.module.SystemModuleFinders.ofSystem()Ljava/lang/module/ModuleFinder;+29 java.base
[0.081s][info][class,load,cause,native] 	j  jdk.internal.module.ModuleBootstrap.boot2()Ljava/lang/ModuleLayer;+257 java.base
[0.081s][info][class,load,cause,native] 	j  jdk.internal.module.ModuleBootstrap.boot()Ljava/lang/ModuleLayer;+64 java.base
[0.081s][info][class,load,cause,native] 	j  java.lang.System.initPhase2(ZZ)I+0 java.base
[0.081s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f2a1c]  JavaCalls::call_static(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x128
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0x12ca5f8]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x9d8
[0.081s][info][class,load,cause,native] 	V  [libjvm.dylib+0xb12f2c]  JNI_CreateJavaVM+0x7c
[0.081s][info][class,load,cause,native] 	C  [libjli.dylib+0xa808]  JavaMain+0x104
[0.081s][info][class,load,cause,native] 	C  [libjli.dylib+0xd66c]  ThreadJavaMain+0xc
[0.081s][info][class,load,cause,native] 	C  [libsystem_pthread.dylib+0x6fa8]  _pthread_start+0x94
[0.082s][info][class,load,cause       ] Java stack when loading java.util.concurrent.ConcurrentHashMap$ValueIterator:
[0.082s][info][class,load,cause       ] 	at java.util.concurrent.ConcurrentHashMap$ValuesView.iterator(java.base/ConcurrentHashMap.java:4745)
[0.082s][info][class,load,cause       ] 	at jdk.internal.loader.NativeLibraries.find(java.base/NativeLibraries.java:102)
[0.082s][info][class,load,cause       ] 	at java.lang.ClassLoader.findNative(java.base/ClassLoader.java:2457)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.UnixNativeDispatcher.init(java.base/Native Method)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.UnixNativeDispatcher.<clinit>(java.base/UnixNativeDispatcher.java:817)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.UnixFileSystem.<init>(java.base/UnixFileSystem.java:96)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.BsdFileSystem.<init>(java.base/BsdFileSystem.java:50)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.MacOSXFileSystem.<init>(java.base/MacOSXFileSystem.java:52)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(java.base/MacOSXFileSystemProvider.java:44)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(java.base/MacOSXFileSystemProvider.java:37)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.UnixFileSystemProvider.<init>(java.base/UnixFileSystemProvider.java:78)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.BsdFileSystemProvider.<init>(java.base/BsdFileSystemProvider.java:38)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.MacOSXFileSystemProvider.<init>(java.base/MacOSXFileSystemProvider.java:39)
[0.082s][info][class,load,cause       ] 	at sun.nio.fs.DefaultFileSystemProvider.<clinit>(java.base/DefaultFileSystemProvider.java:35)
[0.082s][info][class,load,cause       ] 	at java.nio.file.FileSystems.getDefault(java.base/FileSystems.java:186)
[0.082s][info][class,load,cause       ] 	at java.nio.file.Path.of(java.base/Path.java:148)
[0.082s][info][class,load,cause       ] 	at jdk.internal.module.SystemModuleFinders.ofSystem(java.base/SystemModuleFinders.java:188)
[0.082s][info][class,load,cause       ] 	at jdk.internal.module.ModuleBootstrap.boot2(java.base/ModuleBootstrap.java:244)
[0.082s][info][class,load,cause       ] 	at jdk.internal.module.ModuleBootstrap.boot(java.base/ModuleBootstrap.java:174)
[0.082s][info][class,load,cause       ] 	at java.lang.System.initPhase2(java.base/System.java:2227)
[0.088s][info][class,load,cause,native] Native stack when loading java.util.concurrent.ConcurrentHashMap$ValueIterator:
[0.088s][info][class,load,cause,native] 	Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9b64e4]  InstanceKlass::print_class_load_logging(ClassLoaderData*, ModuleEntry const*, ClassFileStream const*) const+0x6c
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x596084]  ClassFileParser::fill_instance_klass(InstanceKlass*, bool, ClassInstanceInfo const&, JavaThread*)+0x1a98
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x594288]  ClassFileParser::create_instance_klass(bool, ClassInstanceInfo const&, JavaThread*)+0x88
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xd9ff38]  KlassFactory::create_from_stream(ClassFileStream*, Symbol*, ClassLoaderData*, ClassLoadInfo const&, JavaThread*)+0x1f4
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x5a5eb8]  ClassLoader::load_class(Symbol*, bool, JavaThread*)+0x3f4
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x1269ca8]  SystemDictionary::load_instance_class_impl(Symbol*, Handle, JavaThread*)+0x838
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x12671e0]  SystemDictionary::load_instance_class(Symbol*, Handle, JavaThread*)+0x28
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x126631c]  SystemDictionary::resolve_instance_class_or_null(Symbol*, Handle, Handle, JavaThread*)+0xb34
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x1264848]  SystemDictionary::resolve_or_fail(Symbol*, Handle, Handle, bool, JavaThread*)+0x28
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x64620c]  ConstantPool::klass_at_impl(constantPoolHandle const&, int, JavaThread*)+0x680
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9d6c04]  InterpreterRuntime::_new(JavaThread*, ConstantPool*, int)+0x1f4
[0.088s][info][class,load,cause,native] 	j  java.util.concurrent.ConcurrentHashMap$ValuesView.iterator()Ljava/util/Iterator;+21 java.base
[0.088s][info][class,load,cause,native] 	j  jdk.internal.loader.NativeLibraries.find(Ljava/lang/String;)J+23 java.base
[0.088s][info][class,load,cause,native] 	j  java.lang.ClassLoader.findNative(Ljava/lang/ClassLoader;Ljava/lang/String;)J+8 java.base
[0.088s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f2a1c]  JavaCalls::call_static(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x128
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f2c10]  JavaCalls::call_static(JavaValue*, Klass*, Symbol*, Symbol*, Handle, Handle, JavaThread*)+0x60
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfb9418]  NativeLookup::lookup_style(methodHandle const&, char*, char const*, int, bool, JavaThread*)+0x21c
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfb98a4]  NativeLookup::lookup_entry(methodHandle const&, JavaThread*)+0xdc
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfb9f3c]  NativeLookup::lookup_base(methodHandle const&, JavaThread*)+0x108
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xfba274]  NativeLookup::lookup(methodHandle const&, JavaThread*)+0xc8
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e6130]  InterpreterRuntime::prepare_native_call(JavaThread*, Method*)+0x264
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.UnixNativeDispatcher.init()I+0 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.UnixNativeDispatcher.<clinit>()V+5 java.base
[0.088s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a9090]  InstanceKlass::call_class_initializer(JavaThread*)+0x3e8
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a68d8]  InstanceKlass::initialize_impl(JavaThread*)+0xc84
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a5bdc]  InstanceKlass::initialize(JavaThread*)+0x30
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdf7810]  LinkResolver::resolve_static_call(CallInfo&, LinkInfo const&, bool, JavaThread*)+0xb4
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdfbca8]  LinkResolver::resolve_invoke(CallInfo&, Handle, constantPoolHandle const&, int, Bytecodes::Code, JavaThread*)+0x190
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e05a0]  InterpreterRuntime::resolve_invoke(JavaThread*, Bytecodes::Code)+0x594
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e1944]  InterpreterRuntime::resolve_from_cache(JavaThread*, Bytecodes::Code)+0x20c
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.UnixFileSystem.<init>(Lsun/nio/fs/UnixFileSystemProvider;Ljava/lang/String;)V+79 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.BsdFileSystem.<init>(Lsun/nio/fs/UnixFileSystemProvider;Ljava/lang/String;)V+3 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystem.<init>(Lsun/nio/fs/UnixFileSystemProvider;Ljava/lang/String;)V+3 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(Ljava/lang/String;)Lsun/nio/fs/MacOSXFileSystem;+6 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystemProvider.newFileSystem(Ljava/lang/String;)Lsun/nio/fs/UnixFileSystem;+2 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.UnixFileSystemProvider.<init>()V+9 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.BsdFileSystemProvider.<init>()V+1 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.MacOSXFileSystemProvider.<init>()V+1 java.base
[0.088s][info][class,load,cause,native] 	j  sun.nio.fs.DefaultFileSystemProvider.<clinit>()V+4 java.base
[0.088s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a9090]  InstanceKlass::call_class_initializer(JavaThread*)+0x3e8
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a68d8]  InstanceKlass::initialize_impl(JavaThread*)+0xc84
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9a5bdc]  InstanceKlass::initialize(JavaThread*)+0x30
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdf7810]  LinkResolver::resolve_static_call(CallInfo&, LinkInfo const&, bool, JavaThread*)+0xb4
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xdfbca8]  LinkResolver::resolve_invoke(CallInfo&, Handle, constantPoolHandle const&, int, Bytecodes::Code, JavaThread*)+0x190
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e05a0]  InterpreterRuntime::resolve_invoke(JavaThread*, Bytecodes::Code)+0x594
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9e1944]  InterpreterRuntime::resolve_from_cache(JavaThread*, Bytecodes::Code)+0x20c
[0.088s][info][class,load,cause,native] 	j  java.nio.file.FileSystems.getDefault()Ljava/nio/file/FileSystem;+10 java.base
[0.088s][info][class,load,cause,native] 	j  java.nio.file.Path.of(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;+0 java.base
[0.088s][info][class,load,cause,native] 	j  jdk.internal.module.SystemModuleFinders.ofSystem()Ljava/lang/module/ModuleFinder;+29 java.base
[0.088s][info][class,load,cause,native] 	j  jdk.internal.module.ModuleBootstrap.boot2()Ljava/lang/ModuleLayer;+257 java.base
[0.088s][info][class,load,cause,native] 	j  jdk.internal.module.ModuleBootstrap.boot()Ljava/lang/ModuleLayer;+64 java.base
[0.088s][info][class,load,cause,native] 	j  java.lang.System.initPhase2(ZZ)I+0 java.base
[0.088s][info][class,load,cause,native] 	v  ~StubRoutines::call_stub 0x000000010bef817c
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f3624]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x648
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x9f2a1c]  JavaCalls::call_static(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x128
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0x12ca5f8]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x9d8
[0.088s][info][class,load,cause,native] 	V  [libjvm.dylib+0xb12f2c]  JNI_CreateJavaVM+0x7c
[0.088s][info][class,load,cause,native] 	C  [libjli.dylib+0xa808]  JavaMain+0x104
[0.088s][info][class,load,cause,native] 	C  [libjli.dylib+0xd66c]  ThreadJavaMain+0xc
[0.088s][info][class,load,cause,native] 	C  [libsystem_pthread.dylib+0x6fa8]  _pthread_start+0x94
openjdk 22-internal 2024-03-19
OpenJDK Runtime Environment (fastdebug build 22-internal-2023-07-03-0601108.dnsimon...)
OpenJDK 64-Bit Server VM (fastdebug build 22-internal-2023-07-03-0601108.dnsimon..., mixed mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8193513](https://bugs.openjdk.org/browse/JDK-8193513): add support for printing a stack trace on class loading (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [e6ffca32](https://git.openjdk.org/jdk/pull/14553/files/e6ffca3279410d466bfd8d283be4e17e1e54706b)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14553/head:pull/14553` \
`$ git checkout pull/14553`

Update a local copy of the PR: \
`$ git checkout pull/14553` \
`$ git pull https://git.openjdk.org/jdk.git pull/14553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14553`

View PR using the GUI difftool: \
`$ git pr show -t 14553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14553.diff">https://git.openjdk.org/jdk/pull/14553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14553#issuecomment-1598429220)