### PR TITLE
8310354: G1: Annotate G1MMUTracker::when_sec with const

### DIFF
--- a/src/hotspot/share/gc/g1/g1MMUTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.cpp
@@ -136,7 +136,7 @@ void G1MMUTracker::add_pause(double start, double end) {
 //
 // When there are not enough GC events, i.e. we have a surplus budget, a new GC
 // pause can start right away, so return 0.
-double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
+double G1MMUTracker::when_sec(double current_timestamp, double pause_time) const {
   assert(pause_time > 0.0, "precondition");
 
   // If the pause is over the maximum, just assume that it's the maximum.
@@ -148,7 +148,7 @@ double G1MMUTracker::when_sec(double current_timestamp, double pause_time) {
   // Iterate from newest to oldest.
   for (int i = 0; i < _no_entries; ++i) {
     int index = trim_index(_head_index - i);
-    G1MMUTrackerElem *elem = &_array[index];
+    const G1MMUTrackerElem *elem = &_array[index];
     // Outside the window.
     if (elem->end_time() <= limit) {
       break;

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -35,9 +35,9 @@ private:
   double _end_time;
 
 public:
-  inline double start_time() { return _start_time; }
-  inline double end_time()   { return _end_time; }
-  inline double duration()   { return _end_time - _start_time; }
+  inline double start_time() const { return _start_time; }
+  inline double end_time()   const { return _end_time; }
+  inline double duration()   const { return _end_time - _start_time; }
 
   G1MMUTrackerElem() {
     _start_time = 0.0;
@@ -95,7 +95,7 @@ private:
   int _tail_index;
   int _no_entries;
 
-  inline int trim_index(int index) {
+  inline int trim_index(int index) const {
     return (index + QueueLength) % QueueLength;
   }
 
@@ -110,13 +110,13 @@ public:
 
   // Minimum delay required from current_timestamp until a GC pause of duration
   // pause_time may be scheduled without violating the MMU constraint.
-  double when_sec(double current_timestamp, double pause_time);
+  double when_sec(double current_timestamp, double pause_time) const;
 
   double max_gc_time() const {
     return _max_gc_time;
   }
 
-  double when_max_gc_sec(double current_time) {
+  double when_max_gc_sec(double current_time) const {
     return when_sec(current_time, max_gc_time());
   }
 };


### PR DESCRIPTION
Simply adding `const` to G1MMUTracker APIs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310354](https://bugs.openjdk.org/browse/JDK-8310354): G1: Annotate G1MMUTracker::when_sec with const (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14554/head:pull/14554` \
`$ git checkout pull/14554`

Update a local copy of the PR: \
`$ git checkout pull/14554` \
`$ git pull https://git.openjdk.org/jdk.git pull/14554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14554`

View PR using the GUI difftool: \
`$ git pr show -t 14554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14554.diff">https://git.openjdk.org/jdk/pull/14554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14554#issuecomment-1598478962)