### PR TITLE
8242152: SA does not include StackMapTables when dumping .class files

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
@@ -62,6 +62,7 @@ public class ConstMethod extends Metadata {
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type                  = db.lookupType("ConstMethod");
     constants                  = new MetadataField(type.getAddressField("_constants"), 0);
+    stackMapData               = type.getAddressField("_stackmap_data");
     constMethodSize            = new CIntField(type.getCIntegerField("_constMethod_size"), 0);
     flags                      = new CIntField(type.getCIntegerField("_flags._flags"), 0);
 
@@ -108,6 +109,8 @@ public class ConstMethod extends Metadata {
 
   // Fields
   private static MetadataField constants;
+  // Raw stackmap data for the method (#entries + entries)
+  private static AddressField stackMapData;
   private static CIntField constMethodSize;
   private static CIntField flags;
   private static CIntField codeSize;
@@ -134,6 +137,15 @@ public class ConstMethod extends Metadata {
   // Accessors for declared fields
   public ConstantPool getConstants() {
     return (ConstantPool) constants.getValue(this);
+  }
+
+  public boolean hasStackMapTable() {
+    return stackMapData.getValue(getAddress()) != null;
+  }
+
+  public U1Array getStackMapData() {
+    Address addr = stackMapData.getValue(getAddress());
+    return VMObjectFactory.newObject(U1Array.class, addr);
   }
 
   public long getConstMethodSize() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstMethod.java
@@ -109,8 +109,7 @@ public class ConstMethod extends Metadata {
 
   // Fields
   private static MetadataField constants;
-  // Raw stackmap data for the method (#entries + entries)
-  private static AddressField stackMapData;
+  private static AddressField stackMapData; // Raw stackmap data for the method (#entries + entries)
   private static CIntField constMethodSize;
   private static CIntField flags;
   private static CIntField codeSize;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Method.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Method.java
@@ -27,6 +27,7 @@ package sun.jvm.hotspot.oops;
 import java.io.PrintStream;
 import sun.jvm.hotspot.utilities.Observable;
 import sun.jvm.hotspot.utilities.Observer;
+import sun.jvm.hotspot.utilities.U1Array;
 
 import sun.jvm.hotspot.code.NMethod;
 import sun.jvm.hotspot.debugger.Address;
@@ -117,6 +118,12 @@ public class Method extends Metadata {
   }
   public ConstantPool getConstants()                  {
     return getConstMethod().getConstants();
+  }
+  public boolean      hasStackMapTable()              {
+    return getConstMethod().hasStackMapTable();
+  }
+  public U1Array      getStackMapData()               {
+    return getConstMethod().getStackMapData();
   }
   public MethodData   getMethodData()                 {
     Address addr = methodData.getValue(getAddress());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
@@ -170,7 +170,7 @@ public class ClassWriter implements /* imports */ ClassConstants
 
         // Code attributes
         Short stackMapTableIndex = utf8ToIndex.get("StackMapTable");
-        _stackMapTableIndex = (stackMapTableIndex != null)?
+        _stackMapTableIndex = (stackMapTableIndex != null) ?
                               stackMapTableIndex.shortValue() : 0;
         if (DEBUG) debugMessage("StackMapTable index = " + _stackMapTableIndex);
 
@@ -526,20 +526,20 @@ public class ClassWriter implements /* imports */ ClassConstants
             int stackMapAttrLen = 0;
 
             if (hasStackMapTable) {
-              if (DEBUG) debugMessage("\tmethod has stack map table");
-              stackMapData = m.getStackMapData();
-              if (DEBUG) debugMessage("\t\tstack map table length = " + stackMapData.length());
+                if (DEBUG) debugMessage("\tmethod has stack map table");
+                stackMapData = m.getStackMapData();
+                if (DEBUG) debugMessage("\t\tstack map table length = " + stackMapData.length());
 
-              stackMapAttrLen = stackMapData.length();
+                stackMapAttrLen = stackMapData.length();
 
-              codeSize += 2 /* stack map table attr index */ +
-                          4 /* stack map table attr length */ +
-                          stackMapAttrLen;
+                codeSize += 2 /* stack map table attr index */ +
+                            4 /* stack map table attr length */ +
+                            stackMapAttrLen;
 
-              if (DEBUG) debugMessage("\t\tstack map table attr size = " +
-                                      stackMapAttrLen);
+                if (DEBUG) debugMessage("\t\tstack map table attr size = " +
+                                        stackMapAttrLen);
 
-              codeAttrCount++;
+                codeAttrCount++;
             }
 
             boolean hasLineNumberTable = m.hasLineNumberTable();
@@ -630,13 +630,13 @@ public class ClassWriter implements /* imports */ ClassConstants
 
             // write StackMapTable, if available
             if (hasStackMapTable) {
-              writeIndex(_stackMapTableIndex);
-              dos.writeInt(stackMapAttrLen);
-              // We write bytes directly as stackMapData is
-              // raw data (#entries + entries)
-              for (int i = 0; i < stackMapData.length(); i++) {
-                dos.writeByte(stackMapData.at(i));
-              }
+                writeIndex(_stackMapTableIndex);
+                dos.writeInt(stackMapAttrLen);
+                // We write bytes directly as stackMapData is
+                // raw data (#entries + entries)
+                for (int i = 0; i < stackMapData.length(); i++) {
+                    dos.writeByte(stackMapData.at(i));
+                }
             }
 
             // write LineNumberTable, if available.

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
@@ -57,6 +57,7 @@ public class ClassWriter implements /* imports */ ClassConstants
     protected short  _constantValueIndex;
     protected short  _codeIndex;
     protected short  _exceptionsIndex;
+    protected short  _stackMapTableIndex;
     protected short  _lineNumberTableIndex;
     protected short  _localVariableTableIndex;
     protected short  _signatureIndex;
@@ -168,6 +169,11 @@ public class ClassWriter implements /* imports */ ClassConstants
         // Short deprecatedIndex = (Short) utf8ToIndex.get("Deprecated");
 
         // Code attributes
+        Short stackMapTableIndex = utf8ToIndex.get("StackMapTable");
+        _stackMapTableIndex = (stackMapTableIndex != null)?
+                              stackMapTableIndex.shortValue() : 0;
+        if (DEBUG) debugMessage("StackMapTable index = " + _stackMapTableIndex);
+
         Short lineNumberTableIndex = utf8ToIndex.get("LineNumberTable");
         _lineNumberTableIndex = (lineNumberTableIndex != null)?
                                        lineNumberTableIndex.shortValue() : 0;
@@ -515,6 +521,27 @@ public class ClassWriter implements /* imports */ ClassConstants
                                             2 /* catch_type   */);
             }
 
+            boolean hasStackMapTable = m.hasStackMapTable();
+            U1Array stackMapData = null;
+            int stackMapAttrLen = 0;
+
+            if (hasStackMapTable) {
+              if (DEBUG) debugMessage("\tmethod has stack map table");
+              stackMapData = m.getStackMapData();
+              if (DEBUG) debugMessage("\t\tstack map table length = " + stackMapData.length());
+
+              stackMapAttrLen = stackMapData.length();
+
+              codeSize += 2 /* stack map table attr index */ +
+                          4 /* stack map table attr length */ +
+                          stackMapAttrLen;
+
+              if (DEBUG) debugMessage("\t\tstack map table attr size = " +
+                                      stackMapAttrLen);
+
+              codeAttrCount++;
+            }
+
             boolean hasLineNumberTable = m.hasLineNumberTable();
             LineNumberTableElement[] lineNumberTable = null;
             int lineNumberAttrLen = 0;
@@ -600,6 +627,17 @@ public class ClassWriter implements /* imports */ ClassConstants
 
             dos.writeShort(codeAttrCount);
             if (DEBUG) debugMessage("\tcode attribute count = " + codeAttrCount);
+
+            // write StackMapTable, if available
+            if (hasStackMapTable) {
+              writeIndex(_stackMapTableIndex);
+              dos.writeInt(stackMapAttrLen);
+              // We write bytes directly as stackMapData is
+              // raw data (#entries + entries)
+              for (int i = 0; i < stackMapData.length(); i++) {
+                dos.writeByte(stackMapData.at(i));
+              }
+            }
 
             // write LineNumberTable, if available.
             if (hasLineNumberTable) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -86,6 +86,10 @@ public class ClhsdbDumpclass {
             System.err.println(out.getStderr());
             out.shouldHaveExitValue(0);
             out.shouldMatch("public class " + APP_DOT_CLASSNAME);
+            // StackMapTable might not be generated for a class
+            // containing only methods with sequential control flows.
+            // But the class used here (LingeredApp) is not such a case.
+            out.shouldContain("StackMapTable:");
             out.shouldNotContain("Error:");
         } catch (SkippedException se) {
             throw se;


### PR DESCRIPTION
This patch adds `StackMapTable` for the class files generated by `clhsdb`'s `buildreplayjars` command. This bug manifests itself during my diagnosing [JDK-8309751](https://bugs.openjdk.org/browse/JDK-8309751) and needs to be fixed first.

I have run jtreg test `tier1-3` of release build on x86 linux finding only one failure in `tier2` caused by [JDK-8309214](https://bugs.openjdk.org/browse/JDK-8309214). `jtreg:test/hotspot/jtreg/serviceability` and `jtreg:test/jdk/sun/tools/` also passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8242152](https://bugs.openjdk.org/browse/JDK-8242152): SA does not include StackMapTables when dumping .class files (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [f2d2340d](https://git.openjdk.org/jdk/pull/14556/files/f2d2340ddc6b737454e93974570d763db4b4f9dc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14556/head:pull/14556` \
`$ git checkout pull/14556`

Update a local copy of the PR: \
`$ git checkout pull/14556` \
`$ git pull https://git.openjdk.org/jdk.git pull/14556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14556`

View PR using the GUI difftool: \
`$ git pr show -t 14556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14556.diff">https://git.openjdk.org/jdk/pull/14556.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14556#issuecomment-1598614916)