### PR TITLE
8310369: UTIL_ARG_WITH fails when arg is disabled

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -509,7 +509,7 @@ AC_DEFUN([UTIL_CHECK_TYPE_directory],
     FAILURE="Directory $1 does not exist or is not readable"
   fi
 
-  if test "[x]ARG_CHECK_FOR_FILES" != x; then
+  if test "[x]ARG_CHECK_FOR_FILES" != "x:"; then
     for file in ARG_CHECK_FOR_FILES; do
       found_files=$($ECHO $(ls $1/$file 2> /dev/null))
       if test "x$found_files" = x; then
@@ -781,25 +781,25 @@ UTIL_DEFUN_NAMED([UTIL_ARG_WITH],
     else
       AC_MSG_RESULT([$ARG_RESULT, $REASON])
     fi
-  fi
 
-  # Verify value
-  # First use our dispatcher to verify that type requirements are satisfied
-  UTIL_CHECK_TYPE(ARG_TYPE, $ARG_RESULT)
+    # Verify value
+    # First use our dispatcher to verify that type requirements are satisfied
+    UTIL_CHECK_TYPE(ARG_TYPE, $ARG_RESULT)
 
-  if test "x$FAILURE" = x; then
-    # Execute custom verification payload, if present
-    RESULT="$ARG_RESULT"
+    if test "x$FAILURE" = x; then
+      # Execute custom verification payload, if present
+      RESULT="$ARG_RESULT"
 
-    ARG_CHECK_VALUE
+      ARG_CHECK_VALUE
 
-    ARG_RESULT="$RESULT"
-  fi
+      ARG_RESULT="$RESULT"
+    fi
 
-  if test "x$FAILURE" != x; then
-    AC_MSG_NOTICE([Invalid value for [--with-]ARG_NAME: "$ARG_RESULT"])
-    AC_MSG_NOTICE([$FAILURE])
-    AC_MSG_ERROR([Cannot continue])
+    if test "x$FAILURE" != x; then
+      AC_MSG_NOTICE([Invalid value for [--with-]ARG_NAME: "$ARG_RESULT"])
+      AC_MSG_NOTICE([$FAILURE])
+      AC_MSG_ERROR([Cannot continue])
+    fi
   fi
 
   # Execute result payloads, if present


### PR DESCRIPTION
I've recently tried to use UTIL_ARG_WITH for new configure arguments in a project repository and discovered some issues. The project in question may or may not end up in mainline at some point in the future, but I think fixing these general issues in UTIL_ARG_WITH is worth it independent of my specific use case.

For TYPE "directory" the check if the value is a valid directory is supposed to optionally check for files in the CHECK_FOR_FILES list. The default value of this list is ":" (due to autoconf peculiarities) but the check is performed if the value is non empty. This means that if you call UTIL_ARG_WITH with TYPE "directory" and no CHECK_FOR_FILES, it will always fail because there is no file ":" in the given directory. This patch changes the conditional to check for ":" instead of the empty string.

When an optional arg is defined, the validation check is still being performed when the arg has been disabled (--without-arg). This makes it impossible to disable something of for example TYPE "directory" as the directory check will fail. The current configure script in OpenJDK only has macro calls of type "string" and "literal" where this doesn't cause problems, because an empty string as value passes validation. This patch moves the validation so that it's only performed when the arg isn't disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310369](https://bugs.openjdk.org/browse/JDK-8310369): UTIL_ARG_WITH fails when arg is disabled (**Bug** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14558/head:pull/14558` \
`$ git checkout pull/14558`

Update a local copy of the PR: \
`$ git checkout pull/14558` \
`$ git pull https://git.openjdk.org/jdk.git pull/14558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14558`

View PR using the GUI difftool: \
`$ git pr show -t 14558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14558.diff">https://git.openjdk.org/jdk/pull/14558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14558#issuecomment-1598716830)