### PR TITLE
JDK-8310111: Shenandoah wastes memory when running with very large page sizes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -139,6 +139,11 @@ public:
   }
 };
 
+static void do_trace_pagesize(const char* description, size_t req_size, size_t req_page_size, const ReservedSpace* rs) {
+  os::trace_page_sizes_for_requested_size(description, req_size, rs->page_size(),  req_page_size,
+                                          rs->base(), rs->size());
+}
+
 jint ShenandoahHeap::initialize() {
   //
   // Figure out heap sizing
@@ -192,6 +197,7 @@ jint ShenandoahHeap::initialize() {
 
   assert((((size_t) base()) & ShenandoahHeapRegion::region_size_bytes_mask()) == 0,
          "Misaligned heap: " PTR_FORMAT, p2i(base()));
+  do_trace_pagesize("Heap", max_byte_size, heap_alignment, &heap_rs);
 
 #if SHENANDOAH_OPTIMIZED_MARKTASK
   // The optimized ShenandoahMarkTask takes some bits away from the full object bits.
@@ -215,8 +221,8 @@ jint ShenandoahHeap::initialize() {
   // Reserve and commit memory for bitmap(s)
   //
 
-  _bitmap_size = ShenandoahMarkBitMap::compute_size(heap_rs.size());
-  _bitmap_size = align_up(_bitmap_size, bitmap_page_size);
+  size_t bitmap_size_orig = ShenandoahMarkBitMap::compute_size(heap_rs.size());
+  _bitmap_size = align_up(bitmap_size_orig, bitmap_page_size);
 
   size_t bitmap_bytes_per_region = reg_size_bytes / ShenandoahMarkBitMap::heap_map_factor();
 
@@ -242,6 +248,7 @@ jint ShenandoahHeap::initialize() {
             _bitmap_bytes_per_slice, bitmap_page_size);
 
   ReservedSpace bitmap(_bitmap_size, bitmap_page_size);
+  do_trace_pagesize("Mark Bitmap", bitmap_size_orig, bitmap_page_size, &bitmap);
   MemTracker::record_virtual_memory_type(bitmap.base(), mtGC);
   _bitmap_region = MemRegion((HeapWord*) bitmap.base(), bitmap.size() / HeapWordSize);
   _bitmap_region_special = bitmap.special();
@@ -258,6 +265,7 @@ jint ShenandoahHeap::initialize() {
 
   if (ShenandoahVerify) {
     ReservedSpace verify_bitmap(_bitmap_size, bitmap_page_size);
+    do_trace_pagesize("Verify Bitmap", bitmap_size_orig, bitmap_page_size, &bitmap);
     if (!verify_bitmap.special()) {
       os::commit_memory_or_exit(verify_bitmap.base(), verify_bitmap.size(), bitmap_page_size, false,
                                 "Cannot commit verification bitmap memory");
@@ -270,6 +278,7 @@ jint ShenandoahHeap::initialize() {
 
   // Reserve aux bitmap for use in object_iterate(). We don't commit it here.
   ReservedSpace aux_bitmap(_bitmap_size, bitmap_page_size);
+  do_trace_pagesize("Aux Bitmap", bitmap_size_orig, bitmap_page_size, &bitmap);
   MemTracker::record_virtual_memory_type(aux_bitmap.base(), mtGC);
   _aux_bitmap_region = MemRegion((HeapWord*) aux_bitmap.base(), aux_bitmap.size() / HeapWordSize);
   _aux_bitmap_region_special = aux_bitmap.special();
@@ -279,10 +288,12 @@ jint ShenandoahHeap::initialize() {
   // Create regions and region sets
   //
   size_t region_align = align_up(sizeof(ShenandoahHeapRegion), SHENANDOAH_CACHE_LINE_SIZE);
-  size_t region_storage_size = align_up(region_align * _num_regions, region_page_size);
-  region_storage_size = align_up(region_storage_size, os::vm_allocation_granularity());
+  size_t region_storage_size_orig = region_align * _num_regions;
+  size_t region_storage_size = align_up(region_storage_size_orig,
+                                        MAX2(region_page_size, os::vm_allocation_granularity()));
 
   ReservedSpace region_storage(region_storage_size, region_page_size);
+  do_trace_pagesize("Region Storage", region_storage_size_orig, region_page_size, &region_storage);
   MemTracker::record_virtual_memory_type(region_storage.base(), mtGC);
   if (!region_storage.special()) {
     os::commit_memory_or_exit(region_storage.base(), region_storage_size, region_page_size, false,
@@ -298,6 +309,7 @@ jint ShenandoahHeap::initialize() {
 
     uintptr_t min = round_up_power_of_2(cset_align);
     uintptr_t max = (1u << 30u);
+    const ReservedSpace* rs = nullptr;
 
     for (uintptr_t addr = min; addr <= max; addr <<= 1u) {
       char* req_addr = (char*)addr;
@@ -306,6 +318,7 @@ jint ShenandoahHeap::initialize() {
       if (cset_rs.is_reserved()) {
         assert(cset_rs.base() == req_addr, "Allocated where requested: " PTR_FORMAT ", " PTR_FORMAT, p2i(cset_rs.base()), addr);
         _collection_set = new ShenandoahCollectionSet(this, cset_rs, sh_rs.base());
+        rs = &cset_rs;
         break;
       }
     }
@@ -313,7 +326,9 @@ jint ShenandoahHeap::initialize() {
     if (_collection_set == nullptr) {
       ReservedSpace cset_rs(cset_size, cset_align, os::vm_page_size());
       _collection_set = new ShenandoahCollectionSet(this, cset_rs, sh_rs.base());
+      rs = &cset_rs;
     }
+    do_trace_pagesize("Collection Set", cset_size, os::vm_page_size(), rs);
   }
 
   _regions = NEW_C_HEAP_ARRAY(ShenandoahHeapRegion*, _num_regions, mtGC);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -34,6 +34,7 @@
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "gc/shenandoah/shenandoahEvacOOMHandler.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
+#include "gc/shenandoah/shenandoahReservedSubSpace.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 #include "gc/shenandoah/shenandoahUnload.hpp"
 #include "memory/metaspace.hpp"
@@ -547,20 +548,16 @@ public:
 //
 private:
   ShenandoahMarkingContext* _marking_context;
-  MemRegion  _bitmap_region;
-  MemRegion  _aux_bitmap_region;
+  SubSpace   _bitmap_region;
+  SubSpace   _aux_bitmap_region;
   MarkBitMap _verification_bit_map;
   MarkBitMap _aux_bit_map;
 
-  size_t _bitmap_size;
   size_t _bitmap_regions_per_slice;
   size_t _bitmap_bytes_per_slice;
 
   size_t _pretouch_heap_page_size;
   size_t _pretouch_bitmap_page_size;
-
-  bool _bitmap_region_special;
-  bool _aux_bitmap_region_special;
 
   ShenandoahLiveData** _liveness_cache;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -549,8 +549,10 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
 
   // Make sure region size and heap size are page aligned.
   // If large pages are used, we ensure that region size is aligned to large page size if
-  // heap size is large enough to accommodate minimal number of regions. Otherwise, we align
-  // region size to regular page size.
+  // heap size is large enough to accommodate minimal number of regions. Otherwise, multiple
+  // regions may share one large page. This is allowed, but prevents us from uncommitting
+  // individual regions. Typically, this does not matter, since on most OSes large pages are
+  // "special": hotspot pre-commits them, and they cannot be uncommitted.
 
   // Figure out page size to use, and aligns up heap to page size
   size_t page_size = os::vm_page_size();

--- a/src/hotspot/share/gc/shenandoah/shenandoahReservedSubSpace.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReservedSubSpace.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/shenandoah/shenandoahReservedSubSpace.hpp"
+
+#include "runtime/os.hpp"
+#include "utilities/align.hpp"
+
+
+void SubSpace::split(size_t bytes, SubSpace& left, SubSpace& right) const {
+  assert(is_aligned(bytes, BytesPerWord), "Sanity");
+  size_t words = bytes / BytesPerWord;
+  if (is_null()) {
+    left = right = SubSpace();
+  } else {
+    SubSpace tmp = *this;
+    clamp(words, (size_t)0, word_size());
+    if (bytes == 0) {
+      left = SubSpace();
+      right = tmp;
+    } else if (bytes == byte_size()) {
+      left = tmp;
+      right = SubSpace();
+    } else {
+      left = SubSpace(MemRegion(start(), words), _special, _pagesize);
+      right = SubSpace(MemRegion(start() + words, word_size() - words), _special, _pagesize);
+    }
+  }
+}
+
+SubSpace SubSpace::first_part(size_t bytes) const {
+  SubSpace right, left;
+  split(bytes, right, left);
+  return right;
+}
+
+SubSpace SubSpace::aligned_start(size_t alignment) const {
+  SubSpace ss;
+  if (!is_null()) {
+    char* p = align_up((char*)start(), alignment);
+    if (p > (char*)end()) {
+      return SubSpace();
+    }
+    SubSpace dummy;
+    split(p - (char*)start(), dummy, ss);
+  }
+  return ss;
+}
+
+#ifdef ASSERT
+void SubSpace::verify() const {
+  if (!is_null()) {
+    assert(pagesize() > 0, "unknown pagesize");
+    assert(special() || is_aligned(start(), pagesize()), "must be special or page-aligned");
+  }
+}
+void SubSpace::verify_not_null() const {
+  assert(!is_empty() && !is_null(), "Empty");
+  verify();
+}
+#endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahReservedSubSpace.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReservedSubSpace.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHRESERVEDSUBSPACE_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHRESERVEDSUBSPACE_HPP
+
+#include "memory/memRegion.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Memory region that may or may not be its own page-aligned reserved space.
+// If "special", it may share a page with adjacent data and will be pre-committed.
+// If not "special", it is page-aligned and committable.
+class SubSpace : private MemRegion {
+
+  bool _special;
+  size_t _pagesize;
+
+public:
+
+  SubSpace() : MemRegion(), _special(false), _pagesize(0) {}
+  //SubSpace(const SubSpace& other) : MemRegion(other), _special(other._special), _pagesize(other._pagesize) {}
+  SubSpace(MemRegion mr, bool special, size_t pagesize) :
+    MemRegion(mr), _special(special), _pagesize(pagesize) {}
+
+  using MemRegion::is_empty;
+  using MemRegion::byte_size;
+  using MemRegion::word_size;
+  using MemRegion::start;
+  using MemRegion::end;
+
+  bool is_null() const      { return start() == nullptr; }
+  bool special() const      { return _special; }
+  size_t pagesize() const   { return _pagesize; }
+
+  MemRegion mr() const  { return (MemRegion) (*this); }
+
+  // Split region such that first_part=[orig.start, x), last_part=[x, orig.end).
+  // Splitting an empty regions results in two null regions.
+  // If x is end, last_part will be null. If x is 0, first part will be null.
+  void split(size_t byte_size, SubSpace& left, SubSpace& right) const;
+
+  // Returns a region whose start address is aligned up to alignment. If region
+  // is too small (or null), returns null region.
+  SubSpace aligned_start(size_t alignment) const;
+
+  SubSpace first_part(size_t byte_size) const;
+
+#ifdef ASSERT
+  void verify() const;
+  void verify_not_null() const;
+#endif
+};
+
+
+#endif // SHARE_GC_SHENANDOAH_SHENANDOAHRESERVEDSUBSPACE_HPP


### PR DESCRIPTION
This proposal changes the reservation of bitmaps and region storage to reduce the wastage associated with running with very large page sizes (e.g. 1GB on x64, 512M on arm64) for both non-THP- and THP-mode.

This patch does:
- introducing the notion of "allowed overdraft factor" - allocations for a given page size are rejected if they would cause more wastage than the factor allows
- if it makes sense, it places mark- and aux-bitmap into a contiguous region to let them share a ginourmous page. E.g. for a heap of 16G, both bitmaps would now share a single GB page.

Examples:

Note: annoyingly, huge page usage does not show up in RSS. I therefore use a script that parses /proc/pid/smaps and counts hugepage usage to count cost for the following examples:

Example 1:

A machine configured with 1G pages (and nothing else). Heap is allocated with 1G pages, the bitmaps fall back to 4K pages because JVM figures 1GB would be wasted:

```
thomas@starfish$ ./images/jdk/bin/java -Xmx4600m -Xlog:pagesize -XX:+UseShenandoahGC -XX:+UseLargePages
...
[0.028s][info][pagesize] Mark Bitmap: req_size=160M req_page_size=4K base=0x00007f8149fff000 size=160M page_size=4K
[0.028s][info][pagesize] Aux Bitmap: req_size=160M req_page_size=4K base=0x00007f813fffe000 size=160M page_size=4K
[0.028s][info][pagesize] Region Storage: req_size=320K req_page_size=4K base=0x00007f817c06f000 size=320K page_size=4K
```

Cost before: 8GB. Cost now: 5GB + (2*160M)

Example 2: JVM with 14GB heap: mark and aux bitmap together are large enough to justify another 1G page, so they share it. Notice how we also place the region storage on this page:

```
thomas@starfish:/shared/projects/openjdk/jdk-jdk/output-release$ ./images/jdk/bin/java -Xmx14g -Xlog:pagesize 
-XX:+UseShenandoahGC -XX:+UseLargePages -cp $REPROS_JAR de.stuefe.repros.Simple
[0.003s][info][pagesize] Heap: req_size=14G req_page_size=1G base=0x0000000480000000 size=14G page_size=1G
[0.003s][info][pagesize] Mark+Aux Bitmap: req_size=896M req_page_size=1G base=0x00007fee00000000 size=1G page_size=1G
[0.003s][info][pagesize] Region Storage: piggy-backing on Mark Bitmap: base=0x00007fee38000000 size=1792
<press key>
```

Cost before: 17GB. Cost now: 15GB.

From a bang-for-hugepages-buck multiples of 16GB are a sweet spot here since (on x64 with 1GB pages) since this allows us to put both 512m bitmaps onto a single huge page.

-----------

No test yet, since I wanted to see if people reject this proposal. It does add a bit of complexity. If this is well-received, I'll do some tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310111](https://bugs.openjdk.org/browse/JDK-8310111): Shenandoah wastes memory when running with very large page sizes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14559/head:pull/14559` \
`$ git checkout pull/14559`

Update a local copy of the PR: \
`$ git checkout pull/14559` \
`$ git pull https://git.openjdk.org/jdk.git pull/14559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14559`

View PR using the GUI difftool: \
`$ git pr show -t 14559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14559.diff">https://git.openjdk.org/jdk/pull/14559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14559#issuecomment-1598975938)