### PR TITLE
8310376: Extend SetupTarget macro with DIR parameter

### DIFF
--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,16 @@ _MAINSUPPORT_GMK := 1
 #   TARGET the makefile target
 #   ARGS arguments to the makefile
 #   DEPS the target(s) this new rule depends on
+#   DIR the directory of the makefile (defaults to $(TOPDIR)/make)
 #
 SetupTarget = $(NamedParamsMacroTemplate)
 define SetupTargetBody
+  ifeq ($$($1_DIR), )
+    $1_DIR := $(TOPDIR)/make
+  endif
+
   $1:
-	+($(CD) $(TOPDIR)/make && $(MAKE) $(MAKE_ARGS) -f $$($1_MAKEFILE).gmk $$($1_TARGET) $$($1_ARGS))
+	+($(CD) $$($1_DIR) && $(MAKE) $(MAKE_ARGS) -f $$($1_MAKEFILE).gmk $$($1_TARGET) $$($1_ARGS))
 
   ALL_TARGETS += $1
 


### PR DESCRIPTION
To allow for more flexibility when using the SetupTarget macro in a custom extension of Main.gmk, I would like to add a DIR parameter, which is the directory the sub make command CDs into before calling make. It defaults to $(TOPDIR)/make. This parameter should be set when the target makefile of the call is located in a different directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310376](https://bugs.openjdk.org/browse/JDK-8310376): Extend SetupTarget macro with DIR parameter (**Enhancement** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14560/head:pull/14560` \
`$ git checkout pull/14560`

Update a local copy of the PR: \
`$ git checkout pull/14560` \
`$ git pull https://git.openjdk.org/jdk.git pull/14560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14560`

View PR using the GUI difftool: \
`$ git pr show -t 14560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14560.diff">https://git.openjdk.org/jdk/pull/14560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14560#issuecomment-1598758646)