### PR TITLE
JDK-8310380: Handle problems in core-related tests on macOS when codesign tool does not work

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCoreMetaspace.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCoreMetaspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCoreMetaspace.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCoreMetaspace.java
@@ -23,7 +23,7 @@
 
 /**
  * @test TestJmapCoreMetaspace
- * @summary Test verifies that jhsdb jmap could generate heap dump from core when metspace is full
+ * @summary Test verifies that jhsdb jmap could generate heap dump from core when metaspace is full
  * @requires vm.hasSA
  * @library /test/lib
  * @run driver/timeout=480 TestJmapCore run metaspace

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
-                "isHardenedOSX");
+                "isHardenedOSX", "hasPlistEntriesOSX");
 
         public final List<String> methodNames;
 

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -53,7 +53,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
-                "isHardenedOSX", "hasPlistEntriesOSX");
+                "isHardenedOSX", "hasOSXPlistEntries");
 
         public final List<String> methodNames;
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -273,7 +273,7 @@ public class Platform {
         return codesignProcess;
     }
 
-    public static boolean hasPlistEntriesOSX() throws IOException {
+    public static boolean hasOSXPlistEntries() throws IOException {
         Process codesignProcess = launchCodesignOnJavaBinary();
         BufferedReader is = new BufferedReader(new InputStreamReader(codesignProcess.getInputStream()));
         String line;

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -260,7 +260,13 @@ public class Platform {
         return true;
     }
 
-    private static codesignProcess launchCodesignOnJavaBinary(String javaFileName) {
+    private static Process launchCodesignOnJavaBinary() throws IOException {
+        String jdkPath = System.getProperty("java.home");
+        Path javaPath = Paths.get(jdkPath + "/bin/java");
+        String javaFileName = javaPath.toAbsolutePath().toString();
+        if (Files.notExists(javaPath)) {
+            throw new FileNotFoundException("Could not find file " + javaFileName);
+        }
         ProcessBuilder pb = new ProcessBuilder("codesign", "--display", "--verbose", javaFileName);
         pb.redirectErrorStream(true); // redirect stderr to stdout
         Process codesignProcess = pb.start();
@@ -268,13 +274,7 @@ public class Platform {
     }
 
     public static boolean hasPlistEntriesOSX() throws IOException {
-        Path javaPath = Utils.javaPath();
-        String javaFileName = javaPath.toAbsolutePath().toString();
-        if (Files.notExists(javaPath)) {
-            throw new FileNotFoundException("Could not find file " + javaFileName);
-        }
-
-        Process codesignProcess = launchCodesignOnJavaBinary(javaFileName);
+        Process codesignProcess = launchCodesignOnJavaBinary();
         BufferedReader is = new BufferedReader(new InputStreamReader(codesignProcess.getInputStream()));
         String line;
         while ((line = is.readLine()) != null) {
@@ -299,14 +299,7 @@ public class Platform {
         if (getOsVersionMajor() == 10 && getOsVersionMinor() < 14) {
             return false; // assume not hardened
         }
-
-        Path javaPath = Utils.javaPath();
-        String javaFileName = javaPath.toAbsolutePath().toString();
-        if (Files.notExists(javaPath)) {
-            throw new FileNotFoundException("Could not find file " + javaFileName);
-        }
-
-        Process codesignProcess = launchCodesignOnJavaBinary(javaFileName);
+        Process codesignProcess = launchCodesignOnJavaBinary();
         BufferedReader is = new BufferedReader(new InputStreamReader(codesignProcess.getInputStream()));
         String line;
         boolean isHardened = false;

--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -1050,4 +1050,14 @@ public final class Utils {
     public static void fullAccess(Path file) throws IOException {
         grantFileAccess(file, false);
     }
+
+    /**
+     * Returns path to the Java binary.
+     *
+     * @return path to the Java binary
+     */
+    public static Path javaPath() {
+        String jdkPath = System.getProperty("java.home");
+        return Paths.get(jdkPath + "/bin/java");
+    }
 }

--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -1050,14 +1050,4 @@ public final class Utils {
     public static void fullAccess(Path file) throws IOException {
         grantFileAccess(file, false);
     }
-
-    /**
-     * Returns path to the Java binary.
-     *
-     * @return path to the Java binary
-     */
-    public static Path javaPath() {
-        String jdkPath = System.getProperty("java.home");
-        return Paths.get(jdkPath + "/bin/java");
-    }
 }

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -151,8 +151,8 @@ public class CoreUtils {
                     throw new SkippedException("Cannot produce core file with hardened binary on OSX 10.15 and later");
                 }
             } else {
-                // codesign has to add entitlements using the plist, if this is not present we might not generate a core file
-                if (!Platform.hasPlistEntriesOSX()) {
+                // codesign has to add entitlements using the plist. If this is not present we might not generate a core file.
+                if (!Platform.hasOSXPlistEntries()) {
                     throw new SkippedException("Cannot produce core file with binary having no plist entitlement entries");
                 }
             }

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -127,6 +127,8 @@ public class CoreUtils {
             }
 
             return coreFileLocation; // success!
+        } else {
+            System.out.println("Core file not found, try to find a reason for this");
         }
 
         // See if we can figure out the likely reason the core file was not found. Recover from
@@ -147,6 +149,11 @@ public class CoreUtils {
                 {
                     // We can't generate cores files with hardened binaries on OSX 10.15 and later.
                     throw new SkippedException("Cannot produce core file with hardened binary on OSX 10.15 and later");
+                }
+            } else {
+                // codesign has to add entitlements using the plist, if this is not present we might not generate a core file
+                if (!Platform.hasPlistEntriesOSX()) {
+                    throw new SkippedException("Cannot produce core file with binary having no plist entitlement entries");
                 }
             }
         } else if (Platform.isLinux()) {

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class CoreUtils {
 
             return coreFileLocation; // success!
         } else {
-            System.out.println("Core file not found, try to find a reason for this");
+            System.out.println("Core file not found. Trying to find a reason why...");
         }
 
         // See if we can figure out the likely reason the core file was not found. Recover from


### PR DESCRIPTION
Currently, a number of tests fail on macOS because they miss the core file (e.g. serviceability/sa/TestJmapCore.java).
The reason is that configure detects on some setups that codesign does not work ("checking if debug mode codesign is possible... no) .
So adding the needed entitlement to generate cores is not done in the build. This is currently not checked later in the tests.
But without the entitlement, a core is not generated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310380](https://bugs.openjdk.org/browse/JDK-8310380): Handle problems in core-related tests on macOS when codesign tool does not work (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [0d8c68c2](https://git.openjdk.org/jdk/pull/14562/files/0d8c68c2e554abc94542053802d45cba95fb2fc6)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [619b3578](https://git.openjdk.org/jdk/pull/14562/files/619b3578defdcecdf45ff75cb7a8c84ccc1b7b73)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14562/head:pull/14562` \
`$ git checkout pull/14562`

Update a local copy of the PR: \
`$ git checkout pull/14562` \
`$ git pull https://git.openjdk.org/jdk.git pull/14562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14562`

View PR using the GUI difftool: \
`$ git pr show -t 14562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14562.diff">https://git.openjdk.org/jdk/pull/14562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14562#issuecomment-1598798179)