### PR TITLE
8309670: java -help output for --module-path / -p is incomplete

### DIFF
--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -50,12 +50,14 @@ java.launcher.opt.footer = \
 \                  and ZIP archives to search for class files.\n\
 \    -p <module path>\n\
 \    --module-path <module path>...\n\
-\                  A {0} separated list of path elements, each element can be a module\n\
-\                  artifact, an exploded module, or directory containing modules.\n\
+\                  A {0} separated list of elements, each element is a file path\n\
+\                  to a module or a directory containing modules. Each module is either\n\
+\                  a modular JAR or an exploded-module directory.\n\
 \    --upgrade-module-path <module path>...\n\
-\                  A {0} separated list of directories, each directory\n\
-\                  is a directory of modules that replace upgradeable\n\
-\                  modules in the runtime image\n\
+\                  A {0} separated list of elements, each element is a file path\n\
+\                  to a module or a directory containing modules to replace\n\
+\                  upgradeable modules in the runtime image. Each module is either\n\
+\                  a modular JAR or an exploded-module directory.\n\
 \    --add-modules <module name>[,<module name>...]\n\
 \                  root modules to resolve in addition to the initial module.\n\
 \                  <module name> can also be ALL-DEFAULT, ALL-SYSTEM,\n\

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -50,8 +50,8 @@ java.launcher.opt.footer = \
 \                  and ZIP archives to search for class files.\n\
 \    -p <module path>\n\
 \    --module-path <module path>...\n\
-\                  A {0} separated list of directories, each directory\n\
-\                  is a directory of modules.\n\
+\                  A {0} separated list of path elements, each element can be a module\n\
+\                  artifact, an exploded module, or directory containing modules.\n\
 \    --upgrade-module-path <module path>...\n\
 \                  A {0} separated list of directories, each directory\n\
 \                  is a directory of modules that replace upgradeable\n\

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -530,20 +530,25 @@ The value \[dq]disabled\[dq] disables finalization, so that no
 finalizers are invoked.
 .TP
 \f[V]--module-path\f[R] \f[I]modulepath\f[R]... or \f[V]-p\f[R] \f[I]modulepath\f[R]
-Specifies a list of directories in which each directory is a directory
-of modules.
+Specifies where to find application modules with a list of path elements.
+The elements of a module path can be a file path to a module or a directory
+containing modules. Each module is either a modular JAR or an
+exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate directories in this list;
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
 on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP
 \f[V]--upgrade-module-path\f[R] \f[I]modulepath\f[R]...
-Specifies a list of directories in which each directory is a directory
-of modules that replace upgradeable modules in the runtime image.
+Specifies where to find module replacements of upgradeable modules in the
+runtime image with a list of path elements.
+The elements of a module path can be a file path to a module or a directory
+containing modules. Each module is either a modular JAR or an
+exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate directories in this list;
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
 on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP


### PR DESCRIPTION
Please review this update to `java`'s help output for `--module-path`/`-p`.

This PR also updates the output for the closely related `--upgrade-module-path` option.

Thanks in advance!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309670](https://bugs.openjdk.org/browse/JDK-8309670): java -help output for --module-path / -p is incomplete (**Bug** - P3)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [c45531b5](https://git.openjdk.org/jdk/pull/14564/files/c45531b5dc3c78cab285d994d23ee331b49ead78)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14564/head:pull/14564` \
`$ git checkout pull/14564`

Update a local copy of the PR: \
`$ git checkout pull/14564` \
`$ git pull https://git.openjdk.org/jdk.git pull/14564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14564`

View PR using the GUI difftool: \
`$ git pr show -t 14564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14564.diff">https://git.openjdk.org/jdk/pull/14564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14564#issuecomment-1598856415)