### PR TITLE
8310405: Linker.Option.firstVariadicArg should specify which index values are valid

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -416,8 +416,8 @@ import java.util.stream.Stream;
  * The native linker only supports linking the specialized form of a variadic function. A variadic function in its specialized
  * form can be linked using a function descriptor describing the specialized form. Additionally, the
  * {@link Linker.Option#firstVariadicArg(int)} linker option must be provided to indicate the first variadic parameter in
- * the parameter list. The corresponding argument layout, and all following argument layouts in the specialized function
- * descriptor, are called <em>variadic argument layouts</em>. For a prototype-less function, the index passed to
+ * the parameter list. The corresponding argument layout (if any), and all following argument layouts in the specialized
+ * function descriptor, are called <em>variadic argument layouts</em>. For a prototype-less function, the index passed to
  * {@link Linker.Option#firstVariadicArg(int)} should always be {@code 0}.
  * <p>
  * The native linker will reject an attempt to link a specialized function descriptor with any variadic argument layouts
@@ -644,20 +644,25 @@ public sealed interface Linker permits AbstractLinker {
             permits LinkerOptions.LinkerOptionImpl {
 
         /**
-         * {@return a linker option used to denote the index of the first variadic argument layout in the
-         *          function descriptor associated with a downcall linkage request}
+         * {@return a linker option used to denote the index indicating the start of the variadic arguments passed to the
+         *          function described by the function descriptor associated with a downcall linkage request}
          * <p>
-         * The {@code index} value must be greater than zero, and less than or equal to the number of argument layouts
-         * of the function descriptor that is used in the same linkage request as this option. When the {@code index} is
-         * equal to the number of argument layouts in the descriptor, it indicates a variadic function to which zero
-         * variadic arguments are passed. It is important to always use this linker option when linking a variadic function,
-         * as this affects the linking process on certain platforms (even if no variadic arguments are passed).
+         * The {@code index} value must conform to {@code 0 <= index <= N}, where {@code N} is the number of argument
+         * layouts of the function descriptor used in conjunction with this linker option. When the {@code index} is:
+         * <ul>
+         * <li>{@code 0}, all arguments passed to the function are passed as variadic arguments</li>
+         * <li>{@code N}, none of the arguments passed to the function are passed as variadic argument</li>
+         * <li>{@code n}, where {@code 0 < m < N}, the arguments {@code m..N} are passed as variadic arguments</li>
+         * </ul>
+         * It is important to always use this linker option when linking a <a href=Linker.html#variadic-funcs>variadic
+         * function</a>, even when none of the arguments are passed as variadic arguments (the second case in the list
+         * above), as this affects the linking process on certain platforms.
          *
          * @implNote The index value is validated when making a linkage request, which is when the function descriptor
-         * against which the index is validated is available.
+         *           against which the index is validated is available.
          *
-         * @param index the index of the first variadic argument layout in the function descriptor associated
-         *              with a downcall linkage request.
+         * @param index the index indicating the start of the variadic arguments passed to the function described by
+         *              the function descriptor used in conjunction with this linker option.
          */
         static Option firstVariadicArg(int index) {
             return new LinkerOptions.FirstVariadicArg(index);

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -655,7 +655,7 @@ public sealed interface Linker permits AbstractLinker {
          * <li>{@code n}, where {@code 0 < m < N}, the arguments {@code m..N} are passed as variadic arguments</li>
          * </ul>
          * It is important to always use this linker option when linking a <a href=Linker.html#variadic-funcs>variadic
-         * function</a>, even when none of the arguments are passed as variadic arguments (the second case in the list
+         * function</a>, even if no variadic argument is passed (the second case in the list
          * above), as this affects the linking process on certain platforms.
          *
          * @implNote The index value is validated when making a linkage request, which is when the function descriptor

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -656,7 +656,7 @@ public sealed interface Linker permits AbstractLinker {
          * </ul>
          * It is important to always use this linker option when linking a <a href=Linker.html#variadic-funcs>variadic
          * function</a>, even if no variadic argument is passed (the second case in the list
-         * above), as this affects the linking process on certain platforms.
+         * above), as this might still affect the calling convention on certain platforms.
          *
          * @implNote The index value is validated when making a linkage request, which is when the function descriptor
          *           against which the index is validated is available.

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -651,7 +651,7 @@ public sealed interface Linker permits AbstractLinker {
          * layouts of the function descriptor used in conjunction with this linker option. When the {@code index} is:
          * <ul>
          * <li>{@code 0}, all arguments passed to the function are passed as variadic arguments</li>
-         * <li>{@code N}, none of the arguments passed to the function are passed as variadic argument</li>
+         * <li>{@code N}, none of the arguments passed to the function are passed as variadic arguments</li>
          * <li>{@code n}, where {@code 0 < m < N}, the arguments {@code m..N} are passed as variadic arguments</li>
          * </ul>
          * It is important to always use this linker option when linking a <a href=Linker.html#variadic-funcs>variadic
@@ -661,8 +661,8 @@ public sealed interface Linker permits AbstractLinker {
          * @implNote The index value is validated when making a linkage request, which is when the function descriptor
          *           against which the index is validated is available.
          *
-         * @param index the index indicating the start of the variadic arguments passed to the function described by
-         *              the function descriptor used in conjunction with this linker option.
+         * @param index the index of the first variadic argument layout in the function descriptor associated
+         *              with a downcall linkage request.
          */
         static Option firstVariadicArg(int index) {
             return new LinkerOptions.FirstVariadicArg(index);

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -646,6 +646,16 @@ public sealed interface Linker permits AbstractLinker {
         /**
          * {@return a linker option used to denote the index of the first variadic argument layout in the
          *          function descriptor associated with a downcall linkage request}
+         * <p>
+         * The {@code index} value must be greater than zero, and less than or equal to the number of argument layouts
+         * of the function descriptor that is used in the same linkage request as this option. When the {@code index} is
+         * equal to the number of argument layouts in the descriptor, it indicates a variadic function to which zero
+         * variadic arguments are passed. It is important to always use this linker option when linking a variadic function,
+         * as this affects the linking process on certain platforms (even if no variadic arguments are passed).
+         *
+         * @implNote The index value is validated when making a linkage request, which is when the function descriptor
+         * against which the index is validated is available.
+         *
          * @param index the index of the first variadic argument layout in the function descriptor associated
          *              with a downcall linkage request.
          */


### PR DESCRIPTION
Improve the specification of `Linker.Option.firstVariadicArg`, by specifying more clearly which index values are valid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8310405](https://bugs.openjdk.org/browse/JDK-8310405): Linker.Option.firstVariadicArg should specify which index values are valid (**Enhancement** - P3)
 * [JDK-8310836](https://bugs.openjdk.org/browse/JDK-8310836): Linker.Option.firstVariadicArg should specify which index values are valid (**CSR**) (Withdrawn)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14565/head:pull/14565` \
`$ git checkout pull/14565`

Update a local copy of the PR: \
`$ git checkout pull/14565` \
`$ git pull https://git.openjdk.org/jdk.git pull/14565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14565`

View PR using the GUI difftool: \
`$ git pr show -t 14565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14565.diff">https://git.openjdk.org/jdk/pull/14565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14565#issuecomment-1599040933)