### PR TITLE
8310426: (ch) Channels.newInputStream transferTo cleanup

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -257,8 +257,8 @@ class ChannelInputStream extends InputStream {
     }
 
     /**
-     * Transfers all bytes to the given target channel. If the target channel is a
-     * selectable channel then it's in blocking mode.
+     * Transfers all bytes to the target channel's file. If the source channel
+     * is a selectable channel then it's in blocking mode.
      */
     private long implTransferTo(FileChannel fc) throws IOException {
         long initialPos = fc.position();

--- a/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ class ChannelOutputStream extends OutputStream {
     }
 
     /**
-     * @return The channel wrapped by this stream.
+     * Return the underlying channel.
      */
     WritableByteChannel channel() {
         return ch;

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelInputStream.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.IllegalBlockingModeException;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * An InputStream that reads bytes from a file channel.
+ */
+class FileChannelInputStream extends ChannelInputStream {
+    /**
+     * Initialize a FileChannelInputStream that reads from the given file channel.
+     */
+    FileChannelInputStream(FileChannel fc) {
+        super(fc);
+    }
+
+    @Override
+    FileChannel channel() {
+        return (FileChannel) super.channel();
+    }
+
+    @Override
+    public long transferTo(OutputStream out) throws IOException {
+        // transferTo(SocketChannel)
+        if (out instanceof SocketOutputStream sos) {
+            SocketChannel sc = sos.channel();
+            synchronized (sc.blockingLock()) {
+                if (!sc.isBlocking())
+                    throw new IllegalBlockingModeException();
+                return transferTo(sc);
+            }
+        }
+
+        // transferTo(WritableByteChannel)
+        if (out instanceof ChannelOutputStream cos) {
+            WritableByteChannel target = cos.channel();
+            if (target instanceof SelectableChannel sc) {
+                synchronized (sc.blockingLock()) {
+                    if (!sc.isBlocking())
+                        throw new IllegalBlockingModeException();
+                    return transferTo(target);
+                }
+            }
+            return transferTo(target);
+        }
+
+        // transferTo(FileChannel)
+        if (out instanceof FileOutputStream fos) {
+            return transferTo(fos.getChannel());
+        }
+
+        return super.transferTo(out);
+    }
+
+    /**
+     * Transfers all bytes to the given target channel.
+     */
+    private long transferTo(WritableByteChannel target) throws IOException {
+        FileChannel fc = channel();
+        long initialPos = fc.position();
+        long pos = initialPos;
+        try {
+            while (pos < fc.size()) {
+                pos += fc.transferTo(pos, Long.MAX_VALUE, target);
+            }
+        } finally {
+            fc.position(pos);
+        }
+        return pos - initialPos;
+    }
+}

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelOutputStream.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.nio.channels.FileChannel;
+
+/**
+ * An OutputStream that write bytes to a file channel.
+ */
+class FileChannelOutputStream extends ChannelOutputStream {
+    /**
+     * Initialize a FileChannelOutputStream that writes to the given file channel.
+     */
+    FileChannelOutputStream(FileChannel fc) {
+        super(fc);
+    }
+
+    @Override
+    FileChannel channel() {
+        return (FileChannel) super.channel();
+    }
+}

--- a/src/java.base/share/classes/sun/nio/ch/Streams.java
+++ b/src/java.base/share/classes/sun/nio/ch/Streams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package sun.nio.ch;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
@@ -39,7 +40,10 @@ public class Streams {
      * Return an input stream that reads bytes from the given channel.
      */
     public static InputStream of(ReadableByteChannel ch) {
-        if (ch instanceof SocketChannelImpl sc) {
+        // avoid switch expression due to recursive initialization issues
+        if (ch instanceof FileChannel fc) {
+            return new FileChannelInputStream(fc);
+        } else if (ch instanceof SocketChannelImpl sc) {
             return new SocketInputStream(sc);
         } else {
             return new ChannelInputStream(ch);
@@ -50,7 +54,10 @@ public class Streams {
      * Return an output stream that writes bytes to the given channel.
      */
     public static OutputStream of(WritableByteChannel ch) {
-        if (ch instanceof SocketChannelImpl sc) {
+        // avoid switch expression due to recursive initialization issues
+        if (ch instanceof FileChannel fc) {
+            return new FileChannelOutputStream(fc);
+        } else if (ch instanceof SocketChannelImpl sc) {
             return new SocketOutputStream(sc);
         } else {
             return new ChannelOutputStream(ch);


### PR DESCRIPTION
ChannelInputStream, the InputStream returned by Channels.newInputStream, implements the transferTo method with support for the cross product of many interesting underlying channels. It's getting a bit too unwieldy and can be simplified by introducing a FileChannelInputStream to wrap a FileChannel.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310426](https://bugs.openjdk.org/browse/JDK-8310426): (ch) Channels.newInputStream transferTo cleanup (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14566/head:pull/14566` \
`$ git checkout pull/14566`

Update a local copy of the PR: \
`$ git checkout pull/14566` \
`$ git pull https://git.openjdk.org/jdk.git pull/14566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14566`

View PR using the GUI difftool: \
`$ git pr show -t 14566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14566.diff">https://git.openjdk.org/jdk/pull/14566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14566#issuecomment-1599252845)