### PR TITLE
8310458: Fix build failure caused by JDK-8310049

### DIFF
--- a/test/jdk/java/nio/charset/Charset/NullCharsetName.java
+++ b/test/jdk/java/nio/charset/Charset/NullCharsetName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this PR which fixes the build failure caused by JDK-8310049 by adding a "," after the 2023.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310458](https://bugs.openjdk.org/browse/JDK-8310458): Fix build failure caused by JDK-8310049 (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14568/head:pull/14568` \
`$ git checkout pull/14568`

Update a local copy of the PR: \
`$ git checkout pull/14568` \
`$ git pull https://git.openjdk.org/jdk.git pull/14568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14568`

View PR using the GUI difftool: \
`$ git pr show -t 14568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14568.diff">https://git.openjdk.org/jdk/pull/14568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14568#issuecomment-1599267822)