### PR TITLE
8294316: SA core file support is broken on macosx-x64 starting with macOS 12.x

### DIFF
--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -297,9 +297,6 @@ static bool read_core_segments(struct ps_prochandle* ph) {
         print_debug("failed to read LC_SEGMENT_64 i = %d!\n", i);
         goto err;
       }
-      print_debug("LC_SEGMENT_64 added: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
-                  segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
-                  segcmd.filesize, &segcmd.segname[0]);
       // The base of the library is offset by a random amount which ends up as a load command with a
       // filesize of 0.  This must be ignored otherwise the base address of the library is wrong.
       if (segcmd.filesize != 0) {
@@ -307,9 +304,11 @@ static bool read_core_segments(struct ps_prochandle* ph) {
           print_debug("Failed to add map_info at i = %d\n", i);
           goto err;
         }
-      } else {
-        print_debug("Ignoring segment with filesize of 0");
       }
+      print_debug("LC_SEGMENT_64 %s: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
+                  segcmd.filesize == 0 ? "with filesize == 0 ignored" : "added",
+                  segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
+                  segcmd.filesize, &segcmd.segname[0]);
     } else if (lcmd.cmd == LC_THREAD || lcmd.cmd == LC_UNIXTHREAD) {
       typedef struct thread_fc {
         uint32_t  flavor;

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -299,11 +299,9 @@ static bool read_core_segments(struct ps_prochandle* ph) {
       }
       // The base of the library is offset by a random amount which ends up as a load command with a
       // filesize of 0.  This must be ignored otherwise the base address of the library is wrong.
-      if (segcmd.filesize != 0) {
-        if (add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
-          print_debug("Failed to add map_info at i = %d\n", i);
-          goto err;
-        }
+      if (segcmd.filesize != 0 && add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
+        print_debug("Failed to add map_info at i = %d\n", i);
+        goto err;
       }
       print_debug("LC_SEGMENT_64 %s: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
                   segcmd.filesize == 0 ? "with filesize == 0 ignored" : "added",

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -299,9 +299,11 @@ static bool read_core_segments(struct ps_prochandle* ph) {
       }
       // The base of the library is offset by a random amount which ends up as a load command with a
       // filesize of 0.  This must be ignored otherwise the base address of the library is wrong.
-      if (segcmd.filesize != 0 && add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
-        print_debug("Failed to add map_info at i = %d\n", i);
-        goto err;
+      if (segcmd.filesize != 0) {
+        if (add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
+          print_debug("Failed to add map_info at i = %d\n", i);
+          goto err;
+        }
       }
       print_debug("LC_SEGMENT_64 %s: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
                   segcmd.filesize == 0 ? "with filesize == 0 ignored" : "added",

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -297,13 +297,17 @@ static bool read_core_segments(struct ps_prochandle* ph) {
         print_debug("failed to read LC_SEGMENT_64 i = %d!\n", i);
         goto err;
       }
-      if (add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
-        print_debug("Failed to add map_info at i = %d\n", i);
-        goto err;
+      // The base of the library is offset by a random amount which ends up as a load command with a
+      // filesize of 0.  This must be ignored otherwise the base address of the library is wrong.
+      if (segcmd.filesize != 0) {
+        if (add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
+          print_debug("Failed to add map_info at i = %d\n", i);
+          goto err;
+        }
+        print_debug("LC_SEGMENT_64 added: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
+                    segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
+                    segcmd.filesize, &segcmd.segname[0]);
       }
-      print_debug("LC_SEGMENT_64 added: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
-                  segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
-                  segcmd.filesize, &segcmd.segname[0]);
     } else if (lcmd.cmd == LC_THREAD || lcmd.cmd == LC_UNIXTHREAD) {
       typedef struct thread_fc {
         uint32_t  flavor;

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -297,6 +297,9 @@ static bool read_core_segments(struct ps_prochandle* ph) {
         print_debug("failed to read LC_SEGMENT_64 i = %d!\n", i);
         goto err;
       }
+      print_debug("LC_SEGMENT_64 added: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
+                  segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
+                  segcmd.filesize, &segcmd.segname[0]);
       // The base of the library is offset by a random amount which ends up as a load command with a
       // filesize of 0.  This must be ignored otherwise the base address of the library is wrong.
       if (segcmd.filesize != 0) {
@@ -304,9 +307,8 @@ static bool read_core_segments(struct ps_prochandle* ph) {
           print_debug("Failed to add map_info at i = %d\n", i);
           goto err;
         }
-        print_debug("LC_SEGMENT_64 added: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
-                    segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
-                    segcmd.filesize, &segcmd.segname[0]);
+      } else {
+        print_debug("Ignoring segment with filesize of 0");
       }
     } else if (lcmd.cmd == LC_THREAD || lcmd.cmd == LC_UNIXTHREAD) {
       typedef struct thread_fc {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -121,13 +121,13 @@ serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 w
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
-serviceability/sa/ClhsdbCDSCore.java 8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#xcomp-core 8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbPmap.java#core 8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbPstack.java#core 8294316,8267433 macosx-x64
-serviceability/sa/TestJmapCore.java 8294316,8267433 macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core 8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8267433 macosx-x64
+serviceability/sa/ClhsdbPmap.java#core 8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#core 8267433 macosx-x64
+serviceability/sa/TestJmapCore.java 8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 


### PR DESCRIPTION
This is a minor fix to core file reading on macos x.  I can confirm that after this fix I can run the problem listed SA core file tests on Ventura.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294316](https://bugs.openjdk.org/browse/JDK-8294316): SA core file support is broken on macosx-x64 starting with macOS 12.x (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [bd45a311](https://git.openjdk.org/jdk/pull/14569/files/bd45a3114891536d68ee7a6329127193040f8769)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [2ebe4d09](https://git.openjdk.org/jdk/pull/14569/files/2ebe4d0986866e908ead53feebae2ea2d53bd67b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14569/head:pull/14569` \
`$ git checkout pull/14569`

Update a local copy of the PR: \
`$ git checkout pull/14569` \
`$ git pull https://git.openjdk.org/jdk.git pull/14569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14569`

View PR using the GUI difftool: \
`$ git pr show -t 14569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14569.diff">https://git.openjdk.org/jdk/pull/14569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14569#issuecomment-1599276254)