### PR TITLE
8310297: assert(static_cast<T1>(result) == thing) with ctw

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -817,16 +817,16 @@ static void initialize_static_primitive_field(fieldDescriptor* fd, Handle mirror
   BasicType t = fd->field_type();
   switch (t) {
   case T_BYTE:
-    mirror()->byte_field_put(fd->offset(), checked_cast<jbyte>(fd->int_initial_value()));
+    mirror()->byte_field_put(fd->offset(), (jbyte)(fd->int_initial_value()));
     break;
   case T_BOOLEAN:
-    mirror()->bool_field_put(fd->offset(), checked_cast<jboolean>(fd->int_initial_value()));
+    mirror()->bool_field_put(fd->offset(), (jboolean)(fd->int_initial_value()));
     break;
   case T_CHAR:
-    mirror()->char_field_put(fd->offset(), checked_cast<jchar>(fd->int_initial_value()));
+    mirror()->char_field_put(fd->offset(), (jchar)(fd->int_initial_value()));
     break;
   case T_SHORT:
-    mirror()->short_field_put(fd->offset(), checked_cast<jshort>(fd->int_initial_value()));
+    mirror()->short_field_put(fd->offset(), (jshort)(fd->int_initial_value()));
     break;
   case T_INT:
     mirror()->int_field_put(fd->offset(), fd->int_initial_value());

--- a/test/hotspot/jtreg/runtime/ConstantPool/ByteFieldInitTest.java
+++ b/test/hotspot/jtreg/runtime/ConstantPool/ByteFieldInitTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8310297
+ * @summary Negative fields shorter than an int may not be sign extended in cpool
+ *          but should in static field initializers. javac gives an error for this but
+ *          not other sources of bytecodes.  With checked_cast<> this crashes.
+ * @compile CompatByteFieldInit.jasm
+ * @run main ByteFieldInitTest
+ */
+
+import java.lang.reflect.Field;
+
+public class ByteFieldInitTest {
+
+    final static byte b = -128;     // compare with 0x80
+    final static short s = -32768;  // compare with 0x8000
+
+    public static void main(java.lang.String[] unused) throws Exception {
+        // javac is smart enough to complain about the other class's byte and short values when referred
+        // to directly.  With checked_cast<> loading this class should fail.
+        Class<?> c = Class.forName("CompatByteFieldInit");
+        Field cb = c.getDeclaredField("b");
+        Field cs = c.getDeclaredField("s");
+        if (b != cb.getByte(null) || s != cs.getShort(null)) {
+            throw new RuntimeException("constant pool init not compatible " + cb.getByte(null) + " " + cs.getShort(null));
+        } else {
+            System.out.println("Fields are same test passed");
+        }
+    }
+}
+
+

--- a/test/hotspot/jtreg/runtime/ConstantPool/CompatByteFieldInit.jasm
+++ b/test/hotspot/jtreg/runtime/ConstantPool/CompatByteFieldInit.jasm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+super class CompatByteFieldInit
+	version 65:0
+{
+  public static final Field b:B	= int 0x80;
+  public static final Field s:S	= int 0x8000;
+
+  Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+} // end Class CompatByteFieldInit


### PR DESCRIPTION
checked_cast<> doesn't work with the initializers in classfiles because even though javac will complain like:

ByteFieldInitTest.java:32: error: incompatible types: possible lossy conversion from int to byte
    static byte b = 0x80;
                    ^
1 error

classfiles can have this value and we've always treated this as a negative signed value.  Removed the checked_cast for javaClasses static final initializers.

Tested with tier1 on all platforms and added a test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310297](https://bugs.openjdk.org/browse/JDK-8310297): assert(static_cast&lt;T1&gt;(result) == thing) with ctw (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14571/head:pull/14571` \
`$ git checkout pull/14571`

Update a local copy of the PR: \
`$ git checkout pull/14571` \
`$ git pull https://git.openjdk.org/jdk.git pull/14571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14571`

View PR using the GUI difftool: \
`$ git pr show -t 14571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14571.diff">https://git.openjdk.org/jdk/pull/14571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14571#issuecomment-1599436517)