### PR TITLE
JDK-8310510: Remove WordsPerLong

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -245,9 +245,7 @@ inline intptr_t* frame::interpreter_frame_tos_address() const {
 }
 
 inline int frame::interpreter_frame_monitor_size() {
-  // Number of stack slots for a monitor.
-  return align_up(BasicObjectLock::size(),  // number of stack slots
-                  WordsPerLong);            // number of stack slots for a Java long
+  return BasicObjectLock::size();
 }
 
 inline int frame::interpreter_frame_monitor_size_in_bytes() {

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -249,9 +249,7 @@ inline void frame::interpreter_frame_set_monitor_end(BasicObjectLock* monitors) 
 }
 
 inline int frame::interpreter_frame_monitor_size() {
-  // Number of stack slots for a monitor
-  return align_up(BasicObjectLock::size() /* number of stack slots */,
-                  WordsPerLong /* Number of stack slots for a Java long. */);
+  return BasicObjectLock::size();
 }
 
 inline int frame::interpreter_frame_monitor_size_in_bytes() {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -243,8 +243,6 @@ const int BitsPerLong        = 1 << LogBitsPerLong;
 const int WordAlignmentMask  = (1 << LogBytesPerWord) - 1;
 const int LongAlignmentMask  = (1 << LogBytesPerLong) - 1;
 
-const int WordsPerLong       = 2;       // Number of stack entries for longs
-
 const int oopSize            = sizeof(char*); // Full-width oop
 extern int heapOopSize;                       // Oop within a java object
 const int wordSize           = sizeof(char*);


### PR DESCRIPTION
Trivial patch.

We have WordsPerLong defined as this:

```
const int WordsPerLong = 2; // Number of stack entries for longs
```

which is wrong for 64-bit platforms. Historically used only for ppc/s390.

Patch removes the unnecessary align (BasicLock is always 2 words, no need to align to 2) and removes WordsPerLong, since it is not needed anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310510](https://bugs.openjdk.org/browse/JDK-8310510): Remove WordsPerLong (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14580/head:pull/14580` \
`$ git checkout pull/14580`

Update a local copy of the PR: \
`$ git checkout pull/14580` \
`$ git pull https://git.openjdk.org/jdk.git pull/14580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14580`

View PR using the GUI difftool: \
`$ git pr show -t 14580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14580.diff">https://git.openjdk.org/jdk/pull/14580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14580#issuecomment-1600563258)