### PR TITLE
JDK-8310425: [JVMCI] compiler/runtime/TestConstantDynamic: lookupConstant returned an object of incorrect type: null

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -701,8 +701,8 @@ C2V_VMENTRY_NULL(jobject, resolvePossiblyCachedConstantInPool, (JNIEnv* env, job
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
   oop obj = cp->resolve_possibly_cached_constant_at(index, CHECK_NULL);
   constantTag tag = cp->tag_at(index);
-  if (tag.is_dynamic_constant() || tag.is_dynamic_constant_in_error()) {
-    if (obj == Universe::the_null_sentinel()) {
+  if (tag.is_dynamic_constant()) {
+    if (obj == nullptr) {
       return JVMCIENV->get_jobject(JVMCIENV->get_JavaConstant_NULL_POINTER());
     }
     BasicType bt = Signature::basic_type(cp->uncached_signature_ref_at(index));

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestDynamicConstant.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestDynamicConstant.java
@@ -249,6 +249,7 @@ public class TestDynamicConstant implements Opcodes {
                         long.class,
                         double.class,
                         String.class,
+                        Object.class,
                         List.class
         };
 
@@ -275,14 +276,20 @@ public class TestDynamicConstant implements Opcodes {
                 // with condy resolved via ConstantPool
                 Object expect = m.invoke(null);
                 Object actual;
-                if (lastConstant instanceof PrimitiveConstant) {
+                if (lastConstant == PrimitiveConstant.NULL_POINTER) {
+                    actual = null;
+                } else if (lastConstant instanceof PrimitiveConstant) {
                     actual = ((PrimitiveConstant) lastConstant).asBoxedPrimitive();
                 } else {
                     actual = ((HotSpotObjectConstant) lastConstant).asObject(type);
                 }
                 Assert.assertEquals(actual, expect, m + ":");
 
-                testLookupBootstrapMethodInvocation(condyType, metaAccess, testClass, getTagAt);
+                if (type != Object.class) {
+                    testLookupBootstrapMethodInvocation(condyType, metaAccess, testClass, getTagAt);
+                } else {
+                    // StringConcatFactoryStringConcatFactory cannot accept null constants
+                }
             }
         }
     }
@@ -347,6 +354,7 @@ public class TestDynamicConstant implements Opcodes {
     @SuppressWarnings("unused") public static long    getLongBSM   (MethodHandles.Lookup l, String name, Class<?> type) { return Long.MAX_VALUE; }
     @SuppressWarnings("unused") public static double  getDoubleBSM (MethodHandles.Lookup l, String name, Class<?> type) { return Double.MAX_VALUE; }
     @SuppressWarnings("unused") public static String  getStringBSM (MethodHandles.Lookup l, String name, Class<?> type) { return "a string"; }
+    @SuppressWarnings("unused") public static Object  getObjectBSM (MethodHandles.Lookup l, String name, Class<?> type) { return null; }
     @SuppressWarnings("unused") public static List<?> getListBSM   (MethodHandles.Lookup l, String name, Class<?> type) { return List.of("element"); }
 
 
@@ -359,6 +367,7 @@ public class TestDynamicConstant implements Opcodes {
     public static long    getLong   () { return Long.MAX_VALUE; }
     public static double  getDouble () { return Double.MAX_VALUE; }
     public static String  getString () { return "a string"; }
+    public static Object  getObject () { return null; }
     public static List<?> getList   () { return List.of("element"); }
 
     public static boolean getBoolean(boolean v1, boolean v2) { return v1 || v2; }
@@ -370,6 +379,7 @@ public class TestDynamicConstant implements Opcodes {
     public static long    getLong   (long v1, long v2)       { return v1 ^ v2; }
     public static double  getDouble (double v1, double v2)   { return v1 * v2; }
     public static String  getString (String v1, String v2)   { return v1 + v2; }
+    public static Object  getObject (Object v1, Object v2)   { return null; }
     public static List<?> getList   (List<?> v1, List<?> v2) { return List.of(v1, v2); }
     // @formatter:on
 }


### PR DESCRIPTION
Fix JVMCI handling of null dynamic constants and dynamic constant errors.

For null dynamic constants, the JVMCI code was checking for `Universe::the_null_sentinel` but `ConstantPool::resolve_possibly_cached_constant_at` returns `nullptr` for null constants.

In the case of errors thrown by a bootstrap method, `ConstantPool::resolve_possibly_cached_constant_at` already propagates the `BootstrapMethodError` so there's no need to check for `tag.is_dynamic_constant_in_error()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310425](https://bugs.openjdk.org/browse/JDK-8310425): [JVMCI] compiler/runtime/TestConstantDynamic: lookupConstant returned an object of incorrect type: null (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14582/head:pull/14582` \
`$ git checkout pull/14582`

Update a local copy of the PR: \
`$ git checkout pull/14582` \
`$ git pull https://git.openjdk.org/jdk.git pull/14582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14582`

View PR using the GUI difftool: \
`$ git pr show -t 14582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14582.diff">https://git.openjdk.org/jdk/pull/14582.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14582#issuecomment-1602177597)