### PR TITLE
8295210: IR framework should not whitelist -XX:-UseTLAB

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -119,7 +119,6 @@ public class TestFramework {
                     "Trace",
                     "Print",
                     "Verify",
-                    "TLAB",
                     "UseNewCode",
                     "Xmn",
                     "Xms",


### PR DESCRIPTION
Removed TLAB from the IR Framework whitelist. If TLAB allocations are disabled by `-XX:-UseTLAB` the IR verification can fail, therefore `"TLAB"` should not be withelisted. See [JDK-8295210](https://bugs.openjdk.org/browse/JDK-8295210) for an example of such a failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295210](https://bugs.openjdk.org/browse/JDK-8295210): IR framework should not whitelist -XX:-UseTLAB (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14583/head:pull/14583` \
`$ git checkout pull/14583`

Update a local copy of the PR: \
`$ git checkout pull/14583` \
`$ git pull https://git.openjdk.org/jdk.git pull/14583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14583`

View PR using the GUI difftool: \
`$ git pr show -t 14583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14583.diff">https://git.openjdk.org/jdk/pull/14583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14583#issuecomment-1600772108)