### PR TITLE
8310537: Fix -Wconversion warnings in gcUtil.hpp

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -300,11 +300,11 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
 
   virtual void clear_generation_free_space_flags();
 
-  float major_pause_old_slope() { return _major_pause_old_estimator->slope(); }
-  float major_pause_young_slope() {
+  double major_pause_old_slope() { return _major_pause_old_estimator->slope(); }
+  double major_pause_young_slope() {
     return _major_pause_young_estimator->slope();
   }
-  float major_collection_slope() { return _major_collection_estimator->slope();}
+  double major_collection_slope() { return _major_collection_estimator->slope();}
 
   // Given the amount of live data in the heap, should we
   // perform a Full GC?

--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -367,14 +367,14 @@ class AdaptiveSizePolicy : public CHeapObj<mtGC> {
     return _major_collection_estimator;
   }
 
-  float minor_pause_young_slope() {
+  double minor_pause_young_slope() {
     return _minor_pause_young_estimator->slope();
   }
 
-  float minor_collection_slope() { return _minor_collection_estimator->slope();}
-  float major_collection_slope() { return _major_collection_estimator->slope();}
+  double minor_collection_slope() { return _minor_collection_estimator->slope();}
+  double major_collection_slope() { return _major_collection_estimator->slope();}
 
-  float minor_pause_old_slope() {
+  double minor_pause_old_slope() {
     return _minor_pause_old_estimator->slope();
   }
 

--- a/src/hotspot/share/gc/shared/gcUtil.cpp
+++ b/src/hotspot/share/gc/shared/gcUtil.cpp
@@ -118,8 +118,8 @@ void LinearLeastSquareFit::update(double x, double y) {
   _sum_x_squared = _sum_x_squared + x * x;
   _sum_y = _sum_y + y;
   _sum_xy = _sum_xy + x * y;
-  _mean_x.sample((float)x);
-  _mean_y.sample((float)y);
+  _mean_x.sample((float)x);  // Used to track generation sizes so casting to float should
+  _mean_y.sample((float)y);  // not lose precision for valid samples.
   assert(_mean_x.count() == _mean_y.count(), "Incorrect count");
   if ( _mean_x.count() > 1 ) {
     double slope_denominator;

--- a/src/hotspot/share/gc/shared/gcUtil.cpp
+++ b/src/hotspot/share/gc/shared/gcUtil.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,10 +86,10 @@ void AdaptivePaddedAverage::sample(float new_sample) {
 
   // Now update the deviation and the padded average.
   float new_avg = average();
-  float new_dev = compute_adaptive_average(fabsd(new_sample - new_avg),
+  float new_dev = compute_adaptive_average((float)fabsd(new_sample - new_avg),
                                            deviation());
   set_deviation(new_dev);
-  set_padded_average(new_avg + padding() * new_dev);
+  set_padded_average(new_avg + (float)padding() * new_dev);
   _last_sample = new_sample;
 }
 
@@ -100,12 +100,12 @@ void AdaptivePaddedNoZeroDevAverage::sample(float new_sample) {
   float new_avg = average();
   if (new_sample != 0) {
     // We only create a new deviation if the sample is non-zero
-    float new_dev = compute_adaptive_average(fabsd(new_sample - new_avg),
+    float new_dev = compute_adaptive_average((float)fabsd(new_sample - new_avg),
                                              deviation());
 
     set_deviation(new_dev);
   }
-  set_padded_average(new_avg + padding() * deviation());
+  set_padded_average(new_avg + (float)padding() * deviation());
   _last_sample = new_sample;
 }
 
@@ -118,8 +118,8 @@ void LinearLeastSquareFit::update(double x, double y) {
   _sum_x_squared = _sum_x_squared + x * x;
   _sum_y = _sum_y + y;
   _sum_xy = _sum_xy + x * y;
-  _mean_x.sample(x);
-  _mean_y.sample(y);
+  _mean_x.sample((float)x);
+  _mean_y.sample((float)y);
   assert(_mean_x.count() == _mean_y.count(), "Incorrect count");
   if ( _mean_x.count() > 1 ) {
     double slope_denominator;

--- a/src/hotspot/share/gc/shared/gcUtil.cpp
+++ b/src/hotspot/share/gc/shared/gcUtil.cpp
@@ -86,7 +86,7 @@ void AdaptivePaddedAverage::sample(float new_sample) {
 
   // Now update the deviation and the padded average.
   float new_avg = average();
-  float new_dev = compute_adaptive_average((float)fabsd(new_sample - new_avg),
+  float new_dev = compute_adaptive_average(fabs(new_sample - new_avg),
                                            deviation());
   set_deviation(new_dev);
   set_padded_average(new_avg + (float)padding() * new_dev);
@@ -100,7 +100,7 @@ void AdaptivePaddedNoZeroDevAverage::sample(float new_sample) {
   float new_avg = average();
   if (new_sample != 0) {
     // We only create a new deviation if the sample is non-zero
-    float new_dev = compute_adaptive_average((float)fabsd(new_sample - new_avg),
+    float new_dev = compute_adaptive_average(fabs(new_sample - new_avg),
                                              deviation());
 
     set_deviation(new_dev);

--- a/src/hotspot/share/gc/shared/gcUtil.hpp
+++ b/src/hotspot/share/gc/shared/gcUtil.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ class AdaptiveWeightedAverage : public CHeapObj<mtGC> {
   static inline float exp_avg(float avg, float sample,
                                unsigned int weight) {
     assert(weight <= 100, "weight must be a percent");
-    return (100.0F - weight) * avg / 100.0F + weight * sample / 100.0F;
+    return (100.0F - (float)weight) * avg / 100.0F + (float)weight * sample / 100.0F;
   }
   static inline size_t exp_avg(size_t avg, size_t sample,
                                unsigned int weight) {

--- a/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
@@ -133,7 +133,7 @@ double WorkerDataArray<T>::average() const {
   if (contributing_threads == 0) {
     return 0.0;
   }
-  return sum() / (double) contributing_threads;
+  return (double) sum() / (double) contributing_threads;
 }
 
 template <typename T>
@@ -178,7 +178,7 @@ void WorkerDataArray<T>::print_summary_on(outputStream* out, bool print_sum) con
     }
     T diff = max - min;
     assert(contributing_threads != 0, "Must be since we found a used value for the start index");
-    double avg = sum / (double) contributing_threads;
+    double avg = (double) sum / (double) contributing_threads;
     WDAPrinter::summary(out, min, avg, max, diff, sum, print_sum);
     out->print_cr(", Workers: %d", contributing_threads);
   } else {


### PR DESCRIPTION
Please review small changes to fix -Wconversion warnings in gc code.  See CR for details.
Tested with tier1 on Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310537](https://bugs.openjdk.org/browse/JDK-8310537): Fix -Wconversion warnings in gcUtil.hpp (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [cf267363](https://git.openjdk.org/jdk/pull/14585/files/cf267363a80d452f68626d54cb11033ce5c44b92)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14585/head:pull/14585` \
`$ git checkout pull/14585`

Update a local copy of the PR: \
`$ git checkout pull/14585` \
`$ git pull https://git.openjdk.org/jdk.git pull/14585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14585`

View PR using the GUI difftool: \
`$ git pr show -t 14585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14585.diff">https://git.openjdk.org/jdk/pull/14585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14585#issuecomment-1600737119)