### PR TITLE
8295795: hsdis does not build with binutils 2.39+

### DIFF
--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -59,6 +59,7 @@
 
 #include <libiberty.h>
 #include <bfd.h>
+#include <bfdver.h>
 #include <dis-asm.h>
 
 #include "hsdis.h"
@@ -556,12 +557,31 @@ static void parse_fake_insn(disassembler_ftype dfn,
   dinfo->fprintf_func     = fprintf_func;
 }
 
+static fprintf_ftype target_fprintf_func = NULL;
+static int wrapper_fprintf_styled_ftype(void *v, enum disassembler_style, const char* fmt, ...) {
+  char buffer[1024] = {};
+  va_list args;
+  int r;
+  va_start(args, fmt);
+  r = vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  if (target_fprintf_func != NULL) {
+    return target_fprintf_func(v, "%s", buffer);
+  }
+  return r;
+}
+
 static void init_disassemble_info_from_bfd(struct disassemble_info* dinfo,
                                            void *stream,
                                            fprintf_ftype fprintf_func,
                                            bfd* abfd,
                                            char* disassembler_options) {
+  target_fprintf_func = fprintf_func;
+#if BFD_VERSION >= 239000000
+  init_disassemble_info(dinfo, stream, fprintf_func, wrapper_fprintf_styled_ftype);
+#else
   init_disassemble_info(dinfo, stream, fprintf_func);
+#endif
 
   dinfo->flavour = bfd_get_flavour(abfd);
   dinfo->arch = bfd_get_arch(abfd);


### PR DESCRIPTION
Hi, please consider if can we live with this as a temporary work around.

binutils essentially changed all to output to the styled fprintf.
WIth this hsdis is backwards compatible, but some minor post processing of format string in disassembler.cpp do not work.
This post process did not look super important, specially compared to not getting the instruction decoded at all.

Not sure if there is an issue with JMH in some case?

Penny for your thoughts!
@shipilev @theRealAph @magicus @luhenry 

Tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295795](https://bugs.openjdk.org/browse/JDK-8295795): hsdis does not build with binutils 2.39+ (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14587/head:pull/14587` \
`$ git checkout pull/14587`

Update a local copy of the PR: \
`$ git checkout pull/14587` \
`$ git pull https://git.openjdk.org/jdk.git pull/14587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14587`

View PR using the GUI difftool: \
`$ git pr show -t 14587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14587.diff">https://git.openjdk.org/jdk/pull/14587.diff</a>

</details>
