### PR TITLE
8310541: G1: Remove redundant check in G1Policy::need_to_start_conc_mark

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -707,7 +707,7 @@ bool G1Policy::need_to_start_conc_mark(const char* source, size_t alloc_word_siz
 
   bool result = false;
   if (marking_request_bytes > marking_initiating_used_threshold) {
-    result = collector_state()->in_young_only_phase() && !collector_state()->in_young_gc_before_mixed();
+    result = collector_state()->in_young_only_phase();
     log_debug(gc, ergo, ihop)("%s occupancy: " SIZE_FORMAT "B allocation request: " SIZE_FORMAT "B threshold: " SIZE_FORMAT "B (%1.2f) source: %s",
                               result ? "Request concurrent cycle initiation (occupancy higher than threshold)" : "Do not request concurrent cycle initiation (still doing mixed collections)",
                               cur_used_bytes, alloc_byte_size, marking_initiating_used_threshold, (double) marking_initiating_used_threshold / _g1h->capacity() * 100, source);


### PR DESCRIPTION
Simple removing a redundant check, which has already been covered in the early-return part.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310541](https://bugs.openjdk.org/browse/JDK-8310541): G1: Remove redundant check in G1Policy::need_to_start_conc_mark (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14588/head:pull/14588` \
`$ git checkout pull/14588`

Update a local copy of the PR: \
`$ git checkout pull/14588` \
`$ git pull https://git.openjdk.org/jdk.git pull/14588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14588`

View PR using the GUI difftool: \
`$ git pr show -t 14588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14588.diff">https://git.openjdk.org/jdk/pull/14588.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14588#issuecomment-1600857505)