### PR TITLE
8310530: PipedOutputStream.flush() accesses sink racily

### DIFF
--- a/src/java.base/share/classes/java/io/PipedOutputStream.java
+++ b/src/java.base/share/classes/java/io/PipedOutputStream.java
@@ -163,6 +163,7 @@ public class PipedOutputStream extends OutputStream {
      */
     @Override
     public synchronized void flush() throws IOException {
+        PipedInputStream sink = this.sink;
         if (sink != null) {
             synchronized (sink) {
                 sink.notifyAll();

--- a/src/java.base/share/classes/java/io/PipedOutputStream.java
+++ b/src/java.base/share/classes/java/io/PipedOutputStream.java
@@ -163,7 +163,7 @@ public class PipedOutputStream extends OutputStream {
      */
     @Override
     public synchronized void flush() throws IOException {
-        PipedInputStream sink = this.sink;
+        var sink = this.sink;
         if (sink != null) {
             synchronized (sink) {
                 sink.notifyAll();


### PR DESCRIPTION
Just a tiny clean-up to remove racy read within synchronized method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310530](https://bugs.openjdk.org/browse/JDK-8310530): PipedOutputStream.flush() accesses sink racily (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14589/head:pull/14589` \
`$ git checkout pull/14589`

Update a local copy of the PR: \
`$ git checkout pull/14589` \
`$ git pull https://git.openjdk.org/jdk.git pull/14589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14589`

View PR using the GUI difftool: \
`$ git pr show -t 14589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14589.diff">https://git.openjdk.org/jdk/pull/14589.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14589#issuecomment-1600908764)