### PR TITLE
JDK-8310549: avoid potential leaks in KeystoreImpl.m related to JNU_CHECK_EXCEPTION early returns

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -363,7 +363,9 @@ static void addIdentitiesToKeystore(JNIEnv *env, jobject keyStore)
             // Call back to the Java object to create Java objects corresponding to this security object.
             jlong nativeKeyRef = ptr_to_jlong(privateKeyRef);
             (*env)->CallVoidMethod(env, keyStore, jm_createKeyEntry, alias, creationDate, nativeKeyRef, certRefArray, javaCertArray);
-            JNU_CHECK_EXCEPTION(env);
+            if ((*env)->ExceptionCheck(env)) {
+                goto errOut;
+            }
         }
     } while (searchResult == noErr);
 
@@ -505,7 +507,9 @@ static void addCertificatesToKeystore(JNIEnv *env, jobject keyStore)
             // Call back to the Java object to create Java objects corresponding to this security object.
             jlong nativeRef = ptr_to_jlong(certRef);
             (*env)->CallVoidMethod(env, keyStore, jm_createTrustedCertEntry, alias, inputTrust, nativeRef, creationDate, certData);
-            JNU_CHECK_EXCEPTION(env);
+            if ((*env)->ExceptionCheck(env)) {
+                goto errOut;
+            }
         }
     } while (searchResult == noErr);
 


### PR DESCRIPTION
In src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m there are a few JNU_CHECK_EXCEPTION macro usages that could potentially cause leaks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310549](https://bugs.openjdk.org/browse/JDK-8310549): avoid potential leaks in KeystoreImpl.m related to JNU_CHECK_EXCEPTION early returns (**Bug** - P3)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14590/head:pull/14590` \
`$ git checkout pull/14590`

Update a local copy of the PR: \
`$ git checkout pull/14590` \
`$ git pull https://git.openjdk.org/jdk.git pull/14590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14590`

View PR using the GUI difftool: \
`$ git pr show -t 14590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14590.diff">https://git.openjdk.org/jdk/pull/14590.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14590#issuecomment-1600925893)