### PR TITLE
8310540: G1: Verification should use raw oop decode functions

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -618,7 +618,7 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
     if (CompressedOops::is_null(heap_oop)) {
       return;
     }
-    oop obj = CompressedOops::decode_not_null(heap_oop);
+    oop obj = CompressedOops::decode_raw_not_null(heap_oop);
 
     LiveChecker<T> live_check(this, _containing_obj, p, obj, _vo);
     if (live_check.failed()) {


### PR DESCRIPTION
Hi all,

  please review this PR that changes a `CompressedOops::decode_not_null` to a `decode_raw_not_null`. The reason is that doing so allows the method to proceed to print better debugging information compared to the failing assert in `decode_not_null`.

Testing: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310540](https://bugs.openjdk.org/browse/JDK-8310540): G1: Verification should use raw oop decode functions (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14592/head:pull/14592` \
`$ git checkout pull/14592`

Update a local copy of the PR: \
`$ git checkout pull/14592` \
`$ git pull https://git.openjdk.org/jdk.git pull/14592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14592`

View PR using the GUI difftool: \
`$ git pr show -t 14592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14592.diff">https://git.openjdk.org/jdk/pull/14592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14592#issuecomment-1601036111)