### PR TITLE
8308633: Increase precision of timestamps in g1 log

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -370,7 +370,7 @@ void G1GCPhaseTimes::trace_phase(WorkerDataArray<double>* phase, bool print_sum,
   }
 }
 
-#define TIME_FORMAT "%.1lfms"
+#define TIME_FORMAT "%.2lfms"
 
 void G1GCPhaseTimes::info_time(const char* name, double value) const {
   log_info(gc, phases)("  %s: " TIME_FORMAT, name, value);

--- a/src/hotspot/share/gc/shared/weakProcessorTimes.cpp
+++ b/src/hotspot/share/gc/shared/weakProcessorTimes.cpp
@@ -173,7 +173,7 @@ static const char* indent_str(size_t i) {
   return indents[MIN2(i, max_indents_index)];
 }
 
-#define TIME_FORMAT "%.1lfms"
+#define TIME_FORMAT "%.2lfms"
 
 void WeakProcessorTimes::log_summary(OopStorageSet::WeakId id, uint indent) const {
   LogTarget(Debug, gc, phases) lt;

--- a/src/hotspot/share/gc/shared/workerDataArray.cpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.cpp
@@ -36,11 +36,14 @@ double WorkerDataArray<double>::uninitialized() {
   return -1.0;
 }
 
+#define WDA_TIME_FORMAT "%4.2lf"
+
 template <>
 void WorkerDataArray<double>::WDAPrinter::summary(outputStream* out, double min, double avg, double max, double diff, double sum, bool print_sum) {
-  out->print(" Min: %4.1lf, Avg: %4.1lf, Max: %4.1lf, Diff: %4.1lf", min * MILLIUNITS, avg * MILLIUNITS, max * MILLIUNITS, diff* MILLIUNITS);
+  out->print(" Min: " WDA_TIME_FORMAT ", Avg: " WDA_TIME_FORMAT ", Max: " WDA_TIME_FORMAT ", Diff: " WDA_TIME_FORMAT,
+             min * MILLIUNITS, avg * MILLIUNITS, max * MILLIUNITS, diff* MILLIUNITS);
   if (print_sum) {
-    out->print(", Sum: %4.1lf", sum * MILLIUNITS);
+    out->print(", Sum: " WDA_TIME_FORMAT, sum * MILLIUNITS);
   }
 }
 
@@ -58,7 +61,7 @@ void WorkerDataArray<double>::WDAPrinter::details(const WorkerDataArray<double>*
   for (uint i = 0; i < phase->_length; ++i) {
     double value = phase->get(i);
     if (value != phase->uninitialized()) {
-      out->print(" %4.1lf", phase->get(i) * 1000.0);
+      out->print(" " WDA_TIME_FORMAT, phase->get(i) * 1000.0);
     } else {
       out->print(" -");
     }

--- a/test/hotspot/gtest/gc/shared/test_workerDataArray.cpp
+++ b/test/hotspot/gtest/gc/shared/test_workerDataArray.cpp
@@ -102,9 +102,9 @@ const char* WorkerDataArrayTest<double>::format_summary(
   double min, double avg, double max, double diff, double sum, size_t workers) {
 
   stringStream out;
-  out.print(" Min: %4.1lf"
-            ", Avg: %4.1lf, Max: %4.1lf"
-            ", Diff: %4.1lf, Sum: %4.1lf"
+  out.print(" Min: %4.2lf"
+            ", Avg: %4.2lf, Max: %4.2lf"
+            ", Diff: %4.2lf, Sum: %4.2lf"
             ", Workers: " SIZE_FORMAT "\n",
             min, avg, max, diff, sum, workers);
   return out.as_string();
@@ -278,12 +278,12 @@ class UninitializedDoubleElementWorkerDataArrayTest : public WorkerDataArrayTest
 
  private:
   virtual const char* expected_summary() {
-    return format_summary(5.1, 6.1, 7.2, 2.1, 12.3, 2);
+    return format_summary(5.10, 6.15, 7.20, 2.10, 12.30, 2);
   }
 
   virtual const char* expected_details() {
     stringStream out;
-    out.print(" %4.1lf - %4.1lf\n", 5.1, 7.2);
+    out.print(" %4.2lf - %4.2lf\n", 5.1, 7.2);
     return out.as_string();
   }
 };


### PR DESCRIPTION
Hi all,

  please review this improvement adding a digit to log timestamp to improve output. On modern machines, for some pauses, this can lead to sub-phase timings not adding up, and during development, extra work to evaluate different options.
Also that rounding error starts to matter for e.g. pauses < a few ms. 

I am aware that there is a duplication of the timestamp format in the files, and this change did not improve that as this would be a different issue. Not sure where to put such a global constant though, any suggestions?

Testing: gha, looking at log files

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308633](https://bugs.openjdk.org/browse/JDK-8308633): Increase precision of timestamps in g1 log (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [b843f5b0](https://git.openjdk.org/jdk/pull/14594/files/b843f5b0775c264f4cd8e1aa22ed4bb789c2e046)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14594/head:pull/14594` \
`$ git checkout pull/14594`

Update a local copy of the PR: \
`$ git checkout pull/14594` \
`$ git pull https://git.openjdk.org/jdk.git pull/14594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14594`

View PR using the GUI difftool: \
`$ git pr show -t 14594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14594.diff">https://git.openjdk.org/jdk/pull/14594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14594#issuecomment-1601058371)