### PR TITLE
8310428: Add CollectedHeap::reserved_range() API to return reserved heap memory range

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -333,7 +333,7 @@ size_t ArchiveHeapWriter::copy_one_source_obj_to_buffer(oop src_obj) {
 void ArchiveHeapWriter::set_requested_address(ArchiveHeapInfo* info) {
   assert(!info->is_used(), "only set once");
   assert(UseG1GC, "must be");
-  address heap_end = (address)G1CollectedHeap::heap()->reserved().end();
+  address heap_end = (address)G1CollectedHeap::heap()->reserved_region().end();
   log_info(cds, heap)("Heap end = %p", heap_end);
 
   size_t heap_region_byte_size = _buffer_used;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -212,8 +212,8 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
       _heap_end = CompressedOops::end();
     } else {
 #if INCLUDE_G1GC
-      address start = (address)G1CollectedHeap::heap()->reserved().start();
-      address end = (address)G1CollectedHeap::heap()->reserved().end();
+      address start = (address)G1CollectedHeap::heap()->reserved_region().start();
+      address end = (address)G1CollectedHeap::heap()->reserved_region().end();
       _heap_begin = HeapShared::to_requested_address(start);
       _heap_end = HeapShared::to_requested_address(end);
 #endif
@@ -1570,7 +1570,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
       assert((mapping_offset >> CompressedOops::shift()) << CompressedOops::shift() == mapping_offset, "must be");
     } else {
 #if INCLUDE_G1GC
-      mapping_offset = requested_base - (char*)G1CollectedHeap::heap()->reserved().start();
+      mapping_offset = requested_base - (char*)G1CollectedHeap::heap()->reserved_region().start();
 #endif
     }
 #endif // INCLUDE_CDS_JAVA_HEAP
@@ -2033,9 +2033,9 @@ bool FileMapInfo::can_use_heap_region() {
                 CompressedOops::mode(), p2i(CompressedOops::base()), CompressedOops::shift());
   log_info(cds)("    heap range = [" PTR_FORMAT " - "  PTR_FORMAT "]",
                 UseCompressedOops ? p2i(CompressedOops::begin()) :
-                                    UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().start()) : 0L,
+                                    UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved_region().start()) : 0L,
                 UseCompressedOops ? p2i(CompressedOops::end()) :
-                                    UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().end()) : 0L);
+                                    UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved_region().end()) : 0L);
 
   if (narrow_klass_base() != CompressedKlassPointers::base() ||
       narrow_klass_shift() != CompressedKlassPointers::shift()) {
@@ -2094,7 +2094,7 @@ bool FileMapInfo::map_heap_region() {
 
     // Make sure we map at the very top of the heap - see comments in
     // init_heap_region_relocation().
-    MemRegion heap_range = G1CollectedHeap::heap()->reserved();
+    MemRegion heap_range = G1CollectedHeap::heap()->reserved_region();
     assert(heap_range.contains(_mapped_heap_memregion), "must be");
 
     address heap_end = (address)heap_range.end();

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -532,9 +532,9 @@ void HeapShared::archive_objects(ArchiveHeapInfo *heap_info) {
 
     log_info(cds)("Heap range = [" PTR_FORMAT " - "  PTR_FORMAT "]",
                    UseCompressedOops ? p2i(CompressedOops::begin()) :
-                                       p2i((address)G1CollectedHeap::heap()->reserved().start()),
+                                       p2i((address)G1CollectedHeap::heap()->reserved_region().start()),
                    UseCompressedOops ? p2i(CompressedOops::end()) :
-                                       p2i((address)G1CollectedHeap::heap()->reserved().end()));
+                                       p2i((address)G1CollectedHeap::heap()->reserved_region().end()));
     copy_objects();
 
     CDSHeapVerifier::verify();
@@ -1700,8 +1700,8 @@ address HeapShared::to_requested_address(address dumptime_addr) {
 
   // With UseCompressedOops==false, actual_base is selected by the OS so
   // it's different across -Xshare:dump runs.
-  address actual_base = (address)G1CollectedHeap::heap()->reserved().start();
-  address actual_end  = (address)G1CollectedHeap::heap()->reserved().end();
+  address actual_base = (address)G1CollectedHeap::heap()->reserved_region().start();
+  address actual_end  = (address)G1CollectedHeap::heap()->reserved_region().end();
   assert(actual_base <= dumptime_addr && dumptime_addr <= actual_end, "must be an address in the heap");
 
   // We always write the objects as if the heap started at this address. This

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -532,7 +532,7 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   MutexLocker x(Heap_lock);
 
-  MemRegion reserved = _hrm.reserved();
+  MemRegion reserved = reserved_region();
 
   if (reserved.word_size() <= word_size) {
     log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = " SIZE_FORMAT
@@ -586,7 +586,7 @@ void G1CollectedHeap::populate_archive_regions_bot_part(MemRegion range) {
 
 void G1CollectedHeap::dealloc_archive_regions(MemRegion range) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
-  MemRegion reserved = _hrm.reserved();
+  MemRegion reserved = reserved_region();
   size_t size_used = 0;
   uint shrink_count = 0;
 
@@ -1445,12 +1445,12 @@ jint G1CollectedHeap::initialize() {
 
   FreeRegionList::set_unrealistically_long_length(max_regions() + 1);
 
-  _bot = new G1BlockOffsetTable(reserved(), bot_storage);
+  _bot = new G1BlockOffsetTable(reserved_region(), bot_storage);
 
   {
     size_t granularity = HeapRegion::GrainBytes;
 
-    _region_attr.initialize(reserved(), granularity);
+    _region_attr.initialize(reserved_region(), granularity);
   }
 
   _workers = new WorkerThreads("GC Thread", ParallelGCThreads);
@@ -2202,8 +2202,8 @@ void G1CollectedHeap::print_on(outputStream* st) const {
   st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
             capacity()/K, heap_used/K);
   st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
-            p2i(_hrm.reserved().start()),
-            p2i(_hrm.reserved().end()));
+            p2i(reserved_region().start()),
+            p2i(reserved_region().end()));
   st->cr();
   st->print("  region size " SIZE_FORMAT "K, ", HeapRegion::GrainBytes / K);
   uint young_regions = young_regions_count();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1045,12 +1045,8 @@ public:
   inline G1HeapRegionAttr region_attr(const void* obj) const;
   inline G1HeapRegionAttr region_attr(uint idx) const;
 
-  MemRegion reserved() const {
-    return _hrm.reserved();
-  }
-
   bool is_in_reserved(const void* addr) const {
-    return reserved().contains(addr);
+    return reserved_region().contains(addr);
   }
 
   G1CardTable* card_table() const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -121,12 +121,12 @@ inline void G1CollectedHeap::humongous_obj_regions_iterate(HeapRegion* start, co
 inline uint G1CollectedHeap::addr_to_region(const void* addr) const {
   assert(is_in_reserved(addr),
          "Cannot calculate region index for address " PTR_FORMAT " that is outside of the heap [" PTR_FORMAT ", " PTR_FORMAT ")",
-         p2i(addr), p2i(reserved().start()), p2i(reserved().end()));
-  return (uint)(pointer_delta(addr, reserved().start(), sizeof(uint8_t)) >> HeapRegion::LogOfHRGrainBytes);
+         p2i(addr), p2i(reserved_region().start()), p2i(reserved_region().end()));
+  return (uint)(pointer_delta(addr, reserved_region().start(), sizeof(uint8_t)) >> HeapRegion::LogOfHRGrainBytes);
 }
 
 inline HeapWord* G1CollectedHeap::bottom_addr_for_region(uint index) const {
-  return _hrm.reserved().start() + index * HeapRegion::GrainWords;
+  return reserved_region().start() + index * HeapRegion::GrainWords;
 }
 
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -368,7 +368,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
 
   _mark_bitmap(),
 
-  _heap(_g1h->reserved()),
+  _heap(_g1h->reserved_region()),
 
   _root_regions(_g1h->max_regions()),
 
@@ -416,7 +416,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
 {
   assert(CGC_lock != nullptr, "CGC_lock must be initialized");
 
-  _mark_bitmap.initialize(g1h->reserved(), bitmap_storage);
+  _mark_bitmap.initialize(g1h->reserved_region(), bitmap_storage);
 
   // Create & start ConcurrentMark thread.
   _cm_thread = new G1ConcurrentMarkThread(this);
@@ -2930,7 +2930,7 @@ G1PrintRegionLivenessInfoClosure::G1PrintRegionLivenessInfoClosure(const char* p
   }
 
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
-  MemRegion reserved = g1h->reserved();
+  MemRegion reserved = g1h->reserved_region();
   double now = os::elapsedTime();
 
   // Print the header of the output.

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -149,7 +149,7 @@ G1FullCollector::G1FullCollector(G1CollectedHeap* heap,
     _oop_queue_set.register_queue(i, marker(i)->oop_stack());
     _array_queue_set.register_queue(i, marker(i)->objarray_stack());
   }
-  _region_attr_table.initialize(heap->reserved(), HeapRegion::GrainBytes);
+  _region_attr_table.initialize(heap->reserved_region(), HeapRegion::GrainBytes);
 }
 
 G1FullCollector::~G1FullCollector() {

--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -156,7 +156,7 @@ HeapRegion* HeapRegionManager::new_heap_region(uint hrm_index) {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   HeapWord* bottom = g1h->bottom_addr_for_region(hrm_index);
   MemRegion mr(bottom, bottom + HeapRegion::GrainWords);
-  assert(reserved().contains(mr), "invariant");
+  assert(g1h->reserved_region().contains(mr), "invariant");
   return g1h->new_heap_region(hrm_index, mr);
 }
 

--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -243,8 +243,6 @@ public:
 
   MemoryUsage get_auxiliary_data_memory_usage() const;
 
-  MemRegion reserved() const { return MemRegion(heap_bottom(), heap_end()); }
-
   // Expand the sequence to reflect that the heap has grown. Either create new
   // HeapRegions, or re-use existing ones. Returns the number of regions the
   // sequence was expanded by. If a HeapRegion allocation fails, the resulting

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -186,7 +186,6 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool requires_barriers(stackChunkOop obj) const override;
 
-  MemRegion reserved_region() const { return _reserved; }
   HeapWord* base() const { return _reserved.start(); }
 
   // Memory allocation.   "gc_time_limit_was_exceeded" will

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHARED_COLLECTEDHEAP_HPP
 #define SHARE_GC_SHARED_COLLECTEDHEAP_HPP
 
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/gcWhen.hpp"
 #include "gc/shared/verifyOption.hpp"
@@ -32,6 +33,7 @@
 #include "memory/metaspace.hpp"
 #include "memory/universe.hpp"
 #include "oops/stackChunkOop.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/perfDataTypes.hpp"
 #include "runtime/safepoint.hpp"
@@ -207,6 +209,10 @@ class CollectedHeap : public CHeapObj<mtGC> {
   }
 
  public:
+  MemRegion reserved_region() const {
+    assert(!UseZGC, "Not supported for ZGC");
+    return _reserved;
+  }
 
   static inline size_t filler_array_max_size() {
     return _filler_array_max_size;

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -145,7 +145,6 @@ public:
   bool is_young_gen(const Generation* gen) const { return gen == _young_gen; }
   bool is_old_gen(const Generation* gen) const { return gen == _old_gen; }
 
-  MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   GenerationSpec* young_gen_spec() const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -467,7 +467,6 @@ public:
 
   bool requires_barriers(stackChunkOop obj) const override;
 
-  MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   void collect(GCCause::Cause cause) override;


### PR DESCRIPTION
Please review this patch to add a new API `CollectedHeap::reserved_range()`. The changes are extracted out from https://github.com/openjdk/jdk/pull/14520 as per the suggestion [here](https://github.com/openjdk/jdk/pull/14520#discussion_r1234991165). Support for ZGC is not implemented yet as it can have discontiguous heap regions and unlike other collectors, it does not set `CollectedHeap::_reserved`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310428](https://bugs.openjdk.org/browse/JDK-8310428): Add CollectedHeap::reserved_range() API to return reserved heap memory range (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14595/head:pull/14595` \
`$ git checkout pull/14595`

Update a local copy of the PR: \
`$ git checkout pull/14595` \
`$ git pull https://git.openjdk.org/jdk.git pull/14595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14595`

View PR using the GUI difftool: \
`$ git pr show -t 14595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14595.diff">https://git.openjdk.org/jdk/pull/14595.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14595#issuecomment-1601350272)