### PR TITLE
8310561: JFR: Unify decodeDescriptors(String, String)

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -418,7 +418,7 @@ public final class PrettyWriter extends EventPrintWriter {
         if (clazz != null) {
             String className = clazz.getName();
             if (className!= null && className.startsWith("[")) {
-                className = decodeDescriptors(className, arraySize > 0 ? Long.toString(arraySize) : "").getFirst();
+                className = ValueFormatter.decodeDescriptors(className, arraySize > 0 ? Long.toString(arraySize) : "").getFirst();
             }
             print(className);
             String description = object.getString("description");
@@ -463,7 +463,7 @@ public final class PrettyWriter extends EventPrintWriter {
         StringJoiner sj = new StringJoiner(", ");
         String md = m.getDescriptor().replace("/", ".");
         String parameter = md.substring(1, md.lastIndexOf(")"));
-        for (String qualifiedName : decodeDescriptors(parameter, "")) {
+        for (String qualifiedName : ValueFormatter.decodeDescriptors(parameter, "")) {
             String typeName = qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
             sj.add(typeName);
         }
@@ -484,58 +484,9 @@ public final class PrettyWriter extends EventPrintWriter {
         }
         String className = clazz.getName();
         if (className.startsWith("[")) {
-            className = decodeDescriptors(className, "").getFirst();
+            className = ValueFormatter.decodeDescriptors(className, "").getFirst();
         }
         println(className + " (classLoader = " + classLoaderName + ")" + postFix);
-    }
-
-    List<String> decodeDescriptors(String descriptor, String arraySize) {
-        List<String> descriptors = new ArrayList<>();
-        for (int index = 0; index < descriptor.length(); index++) {
-            String arrayBrackets = "";
-            while (descriptor.charAt(index) == '[') {
-                arrayBrackets = arrayBrackets +  "[" + arraySize + "]" ;
-                arraySize = "";
-                index++;
-            }
-            char c = descriptor.charAt(index);
-            String type;
-            switch (c) {
-            case 'L':
-                int endIndex = descriptor.indexOf(';', index);
-                type = descriptor.substring(index + 1, endIndex);
-                index = endIndex;
-                break;
-            case 'I':
-                type = "int";
-                break;
-            case 'J':
-                type = "long";
-                break;
-            case 'Z':
-                type = "boolean";
-                break;
-            case 'D':
-                type = "double";
-                break;
-            case 'F':
-                type = "float";
-                break;
-            case 'S':
-                type = "short";
-                break;
-            case 'C':
-                type = "char";
-                break;
-            case 'B':
-                type = "byte";
-                break;
-            default:
-                type = "<unknown-descriptor-type>";
-            }
-            descriptors.add(type + arrayBrackets);
-        }
-        return descriptors;
     }
 
     private void printThread(RecordedThread thread, String postFix) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -281,7 +281,7 @@ public final class ValueFormatter {
         return sb.toString();
     }
 
-    private static List<String> decodeDescriptors(String descriptor, String arraySize) {
+    public static List<String> decodeDescriptors(String descriptor, String arraySize) {
         List<String> descriptors = new ArrayList<>();
         for (int index = 0; index < descriptor.length(); index++) {
             String arrayBrackets = "";


### PR DESCRIPTION
Could I have a review of a fix that removes duplicated code.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310561](https://bugs.openjdk.org/browse/JDK-8310561): JFR: Unify decodeDescriptors(String, String) (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14598/head:pull/14598` \
`$ git checkout pull/14598`

Update a local copy of the PR: \
`$ git checkout pull/14598` \
`$ git pull https://git.openjdk.org/jdk.git pull/14598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14598`

View PR using the GUI difftool: \
`$ git pr show -t 14598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14598.diff">https://git.openjdk.org/jdk/pull/14598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14598#issuecomment-1601146451)