### PR TITLE
8292704: sun/security/tools/jarsigner/compatibility/Compatibility.java use wrong key size for EC

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8217375 8260286 8267319 8292704
+ * @bug 8217375 8260286 8267319
  * @summary This test is used to verify the compatibility of jarsigner across
  *     different JDK releases. It also can be used to check jar signing (w/
  *     and w/o TSA) and to verify some specific signing and digest algorithms.

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8217375 8260286 8267319
+ * @bug 8217375 8260286 8267319 8292704
  * @summary This test is used to verify the compatibility of jarsigner across
  *     different JDK releases. It also can be used to check jar signing (w/
  *     and w/o TSA) and to verify some specific signing and digest algorithms.
@@ -31,7 +31,7 @@
  *     its usages, please look through the README.
  *
  * @library /test/lib ../warnings
- * @compile -source 1.7 -target 1.7 JdkUtils.java
+ * @compile -source 1.8 -target 1.8 JdkUtils.java
  * @run main/manual/othervm Compatibility
  */
 
@@ -67,7 +67,6 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -460,7 +459,7 @@ public class Compatibility {
         if (RSA.equals(keyAlgorithm) || DSA.equals(keyAlgorithm)) {
             return new int[] { 1024, 2048, 0 }; // 0 is no keysize specified
         } else if (EC.equals(keyAlgorithm)) {
-            return new int[] { 384, 571, 0 }; // 0 is no keysize specified
+            return new int[] { 384, 521, 0 }; // 0 is no keysize specified
         } else {
             throw new RuntimeException("problem determining key sizes");
         }
@@ -717,7 +716,7 @@ public class Compatibility {
         try {
             String match = "^  ("
                     + "  Signature algorithm: " + signItem.certInfo.
-                            expectedSigalg() + ", " + signItem.certInfo.
+                            expectedSigalg(signItem) + ", " + signItem.certInfo.
                             expectedKeySize() + "-bit key"
                     + ")|("
                     + "  Digest algorithm: " + signItem.expectedDigestAlg()
@@ -845,6 +844,7 @@ public class Compatibility {
 
             if (isWeakAlg(signItem.expectedDigestAlg())
                     && line.contains(Test.WEAK_ALGORITHM_WARNING)) continue;
+            if (line.contains(Test.WEAK_KEY_WARNING)) continue;
             if (Test.CERTIFICATE_SELF_SIGNED.equals(line)) continue;
             if (Test.HAS_EXPIRED_CERT_VERIFYING_WARNING.equals(line)
                     && signItem.certInfo.expired) continue;
@@ -857,6 +857,7 @@ public class Compatibility {
     private static boolean isWeakAlg(String alg) {
         return SHA1.equals(alg);
     }
+
 
     // Using specified jarsigner to sign the pre-created jar with specified
     // algorithms.
@@ -1183,19 +1184,56 @@ public class Compatibility {
         }
 
         private String expectedSigalg() {
-            return (DEFAULT.equals(this.digestAlgorithm) ? this.digestAlgorithm
-                    : "SHA-256").replace("-", "") + "with" +
-                    keyAlgorithm + (EC.equals(keyAlgorithm) ? "DSA" : "");
+            return "SHA256with" + keyAlgorithm + (EC.equals(keyAlgorithm) ? "DSA" : "");
+        }
+
+        private String expectedSigalg(SignItem signer) {
+            if (!DEFAULT.equals(digestAlgorithm)) {
+                return "SHA256with" + keyAlgorithm + (EC.equals(keyAlgorithm) ? "DSA" : "");
+
+            } else {
+                // default algorithms documented for jarsigner here:
+                // https://docs.oracle.com/en/java/javase/17/docs/specs/man/jarsigner.html#supported-algorithms
+                // https://docs.oracle.com/en/java/javase/20/docs/specs/man/jarsigner.html#supported-algorithms
+                int expectedKeySize = expectedKeySize();
+                switch (keyAlgorithm) {
+                    case DSA:
+                        return "SHA256withDSA";
+                    case RSA: {
+                        if ((signer.jdkInfo.majorVersion >= 20 && expectedKeySize < 624)
+                                || (signer.jdkInfo.majorVersion < 20 && expectedKeySize <= 3072)) {
+                            return "SHA256withRSA";
+                        } else if (expectedKeySize <= 7680) {
+                            return "SHA384withRSA";
+                        } else {
+                            return "SHA512withRSA";
+                        }
+                    }
+                    case EC: {
+                        if (signer.jdkInfo.majorVersion < 20 && expectedKeySize < 384) {
+                            return "SHA256withECDSA";
+                        } else if (expectedKeySize < 512) {
+                            return "SHA384withECDSA";
+                        } else {
+                            return "SHA512withECDSA";
+                        }
+                    }
+                    default:
+                        throw new RuntimeException("Unsupported/expected key algorithm: " + keyAlgorithm);
+                }
+            }
         }
 
         private int expectedKeySize() {
             if (keySize != 0) return keySize;
 
             // defaults
-            if (RSA.equals(keyAlgorithm) || DSA.equals(keyAlgorithm)) {
-                return 3072;
+            if (RSA.equals(keyAlgorithm)) {
+                return jdkInfo.majorVersion >= 20 ? 3072 : 2048;
+            } else if (DSA.equals(keyAlgorithm)) {
+                return 2048;
             } else if (EC.equals(keyAlgorithm)) {
-                return 384;
+                return jdkInfo.majorVersion >= 20 ? 384 : 256;
             } else {
                 throw new RuntimeException("problem determining key size");
             }
@@ -1391,7 +1429,9 @@ public class Compatibility {
         }
 
         String expectedDigestAlg() {
-            return digestAlgorithm != null ? digestAlgorithm : "SHA-256";
+            return digestAlgorithm != null
+                    ? digestAlgorithm
+                    : jdkInfo.majorVersion >= 20 ? "SHA-384" : "SHA-256";
         }
 
         private SignItem tsaDigestAlgorithm(String tsaDigestAlgorithm) {
@@ -1540,7 +1580,7 @@ public class Compatibility {
         s_values_add.accept(i -> i.unsignedJar + " -> " + i.signedJar);
         s_values_add.accept(i -> i.certInfo.toString());
         s_values_add.accept(i -> i.jdkInfo.version);
-        s_values_add.accept(i -> i.certInfo.expectedSigalg());
+        s_values_add.accept(i -> i.certInfo.expectedSigalg(i));
         s_values_add.accept(i ->
                 null2Default(i.digestAlgorithm, i.expectedDigestAlg()));
         s_values_add.accept(i -> i.tsaIndex == -1 ? "" :

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -858,7 +858,6 @@ public class Compatibility {
         return SHA1.equals(alg);
     }
 
-
     // Using specified jarsigner to sign the pre-created jar with specified
     // algorithms.
     private static OutputAnalyzer signJar(String jarsignerPath, String sigalg,

--- a/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
@@ -148,6 +148,9 @@ public abstract class Test {
             = "algorithm is considered a security risk. "
             + "This algorithm will be disabled in a future update.";
 
+    static final String WEAK_KEY_WARNING
+            = "This key size will be disabled in a future update.";
+
     static final String JAR_SIGNED = "jar signed.";
 
     static final String JAR_VERIFIED = "jar verified.";


### PR DESCRIPTION
In this PR I updated the EC key size and updated the regular expressions used to parse the output of the jarsigner. In addition to updating default key sizes base on Java version, I also updated the logic for determining the default signing algorithm which is based on the version of jarsigner/java used to sign the jar file and the size of the key being used.

I ran this test with JDKs 17.0.8, 20.0.2, and 21b26.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292704](https://bugs.openjdk.org/browse/JDK-8292704): sun/security/tools/jarsigner/compatibility/Compatibility.java use wrong key size for EC (**Bug** - P3)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**) ⚠️ Review applies to [729f59c6](https://git.openjdk.org/jdk/pull/14602/files/729f59c6dbe2e6e3fbb7814ed0ea582a26662b91)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14602/head:pull/14602` \
`$ git checkout pull/14602`

Update a local copy of the PR: \
`$ git checkout pull/14602` \
`$ git pull https://git.openjdk.org/jdk.git pull/14602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14602`

View PR using the GUI difftool: \
`$ git pr show -t 14602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14602.diff">https://git.openjdk.org/jdk/pull/14602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14602#issuecomment-1601407779)