### PR TITLE
JDK-8310575: no `@since` for StandardDoclet

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
@@ -65,6 +65,8 @@ import jdk.javadoc.internal.doclets.formats.html.HtmlDoclet;
  *
  * @spec javadoc/doc-comment-spec.html Documentation Comment Specification for the Standard Doclet
  * @spec https://www.w3.org/TR/html52 HTML Standard
+ *
+ * @since 9
  */
 public class StandardDoclet implements Doclet {
 


### PR DESCRIPTION
Please review a trivial update to provide a previously-missing `@since` tag for `StandardDoclet`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310575](https://bugs.openjdk.org/browse/JDK-8310575): no `@since` for StandardDoclet (**Bug** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14603/head:pull/14603` \
`$ git checkout pull/14603`

Update a local copy of the PR: \
`$ git checkout pull/14603` \
`$ git pull https://git.openjdk.org/jdk.git pull/14603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14603`

View PR using the GUI difftool: \
`$ git pr show -t 14603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14603.diff">https://git.openjdk.org/jdk/pull/14603.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14603#issuecomment-1601460818)