### PR TITLE
8310577: Fix -Wconversion warnings in interpreter and oops

### DIFF
--- a/src/hotspot/share/code/stubs.cpp
+++ b/src/hotspot/share/code/stubs.cpp
@@ -67,7 +67,7 @@
 StubQueue::StubQueue(StubInterface* stub_interface, int buffer_size,
                      Mutex* lock, const char* name) : _mutex(lock) {
   intptr_t size = align_up(buffer_size, 2*BytesPerWord);
-  BufferBlob* blob = BufferBlob::create(name, size);
+  BufferBlob* blob = BufferBlob::create(name, checked_cast<int>(size));
   if( blob == nullptr) {
     vm_exit_out_of_memory(size, OOM_MALLOC_ERROR, "CodeCache: no room for %s", name);
   }

--- a/src/hotspot/share/code/stubs.hpp
+++ b/src/hotspot/share/code/stubs.hpp
@@ -155,7 +155,7 @@ class StubQueue: public CHeapObj<mtCode> {
 
   void  check_index(int i) const                 { assert(0 <= i && i < _buffer_limit && i % stub_alignment() == 0, "illegal index"); }
   bool  is_contiguous() const                    { return _queue_begin <= _queue_end; }
-  int   index_of(Stub* s) const                  { int i = (address)s - _stub_buffer; check_index(i); return i; }
+  int   index_of(Stub* s) const                  { int i = (int)((address)s - _stub_buffer); check_index(i); return i; }
   Stub* stub_at(int i) const                     { check_index(i); return (Stub*)(_stub_buffer + i); }
   Stub* current_stub() const                     { return stub_at(_queue_end); }
 

--- a/src/hotspot/share/interpreter/bytecodeHistogram.cpp
+++ b/src/hotspot/share/interpreter/bytecodeHistogram.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,14 +130,14 @@ void BytecodeHistogram::print(float cutoff) {
   while (i-- > 0) {
     HistoEntry* e = profile->at(i);
     int       abs = e->count();
-    float     rel = abs * 100.0F / tot;
+    float     rel = (float)abs * 100.0F / (float)tot;
     if (cutoff <= rel) {
       tty->print_cr("%10d  %7.2f%%    %02x    %s", abs, rel, e->index(), name_for(e->index()));
       abs_sum += abs;
     }
   }
   tty->print_cr("----------------------------------------------------------------------");
-  float rel_sum = abs_sum * 100.0F / tot;
+  float rel_sum = (float)abs_sum * 100.0F / (float)tot;
   tty->print_cr("%10d  %7.2f%%    (cutoff = %.2f%%)", abs_sum, rel_sum, cutoff);
   tty->cr();
 }
@@ -172,7 +172,7 @@ void BytecodePairHistogram::print(float cutoff) {
   while (i-- > 0) {
     HistoEntry* e = profile->at(i);
     int       abs = e->count();
-    float     rel = abs * 100.0F / tot;
+    float     rel = (float)abs * 100.0F / (float)tot;
     if (cutoff <= rel) {
       int   c1 = e->index() % number_of_codes;
       int   c2 = e->index() / number_of_codes;
@@ -181,7 +181,7 @@ void BytecodePairHistogram::print(float cutoff) {
     }
   }
   tty->print_cr("----------------------------------------------------------------------");
-  float rel_sum = abs_sum * 100.0F / tot;
+  float rel_sum = (float)abs_sum * 100.0F / (float)tot;
   tty->print_cr("%10d   %6.3f%%    (cutoff = %.3f%%)", abs_sum, rel_sum, cutoff);
   tty->cr();
 }

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -118,7 +118,7 @@ class BytecodePrinter {
       code = Bytecodes::code_at(method(), bcp);
     }
     _code = code;
-     int bci = bcp - method->code_base();
+     int bci = (int)(bcp - method->code_base());
     st->print("[%ld] ", (long) Thread::current()->osthread()->thread_id());
     if (Verbose) {
       st->print("%8d  %4d  " INTPTR_FORMAT " " INTPTR_FORMAT " %s",
@@ -147,7 +147,7 @@ class BytecodePrinter {
       code = Bytecodes::code_at(method(), bcp+1);
     }
     _code = code;
-    int bci = bcp - method->code_base();
+    int bci = (int)(bcp - method->code_base());
     // Print bytecode index and name
     if (ClassPrinter::has_mode(_flags, ClassPrinter::PRINT_BYTECODE_ADDR)) {
       st->print(INTPTR_FORMAT " ", p2i(bcp));

--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -353,7 +353,7 @@ static void print_local_var(outputStream *os, unsigned int bci, Method* method, 
 
 StackSlotAnalysisData::StackSlotAnalysisData(BasicType type) : _bci(INVALID), _type(type) {}
 
-StackSlotAnalysisData::StackSlotAnalysisData(int bci, BasicType type) : _bci(bci), _type(type) {
+StackSlotAnalysisData::StackSlotAnalysisData(int bci, BasicType type) : _bci((u2)bci), _type(type) {
   assert(bci >= 0, "BCI must be >= 0");
   assert(bci < 65536, "BCI must be < 65536");
 }
@@ -1081,7 +1081,7 @@ int ExceptionMessageBuilder::do_instruction(int bci) {
   }
 
   // If we have more than one branch target, process these too.
-  for (int64_t i = 0; i < dests.length(); ++i) {
+  for (int i = 0; i < dests.length(); ++i) {
     if (_stacks->at(dests.at(i)) == nullptr) {
       _added_one = true;
     }

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -385,9 +385,9 @@ int Bytecodes::special_length_at(Bytecodes::Code code, address bcp, address end)
       if (end != nullptr && aligned_bcp + 3*jintSize >= end) {
         return -1; // don't read past end of code buffer
       }
-      jlong lo = (jint)Bytes::get_Java_u4(aligned_bcp + 1*jintSize);
-      jlong hi = (jint)Bytes::get_Java_u4(aligned_bcp + 2*jintSize);
-      jlong len = (aligned_bcp - bcp) + (3 + hi - lo + 1)*jintSize;
+      int lo = Bytes::get_Java_u4(aligned_bcp + 1*jintSize);
+      int hi = Bytes::get_Java_u4(aligned_bcp + 2*jintSize);
+      int len = (int)(aligned_bcp - bcp) + (3 + hi - lo + 1)*jintSize;
       // only return len if it can be represented as a positive int;
       // return -1 otherwise
       return (len > 0 && len == (int)len) ? len : -1;
@@ -400,8 +400,8 @@ int Bytecodes::special_length_at(Bytecodes::Code code, address bcp, address end)
       if (end != nullptr && aligned_bcp + 2*jintSize >= end) {
         return -1; // don't read past end of code buffer
       }
-      jlong npairs = (jint)Bytes::get_Java_u4(aligned_bcp + jintSize);
-      jlong len = (aligned_bcp - bcp) + (2 + 2*npairs)*jintSize;
+      int npairs = Bytes::get_Java_u4(aligned_bcp + jintSize);
+      int len = (int)(aligned_bcp - bcp) + (2 + 2*npairs)*jintSize;
       // only return len if it can be represented as a positive int;
       // return -1 otherwise
       return (len > 0 && len == (int)len) ? len : -1;
@@ -439,7 +439,7 @@ void Bytecodes::def_flags(Code code, const char* format, const char* wide_format
   int len  = (format      != nullptr ? (int) strlen(format)      : 0);
   int wlen = (wide_format != nullptr ? (int) strlen(wide_format) : 0);
 #endif
-  int bc_flags = 0;
+  jchar bc_flags = 0;
   if (can_trap)           bc_flags |= _bc_can_trap;
   if (java_code != code)  bc_flags |= _bc_can_rewrite;
   _flags[(u1)code+0*(1<<BitsPerByte)] = compute_flags(format,      bc_flags);
@@ -469,9 +469,9 @@ void Bytecodes::def_flags(Code code, const char* format, const char* wide_format
 //
 // Note: For bytecodes with variable length, the format string is the empty string.
 
-int Bytecodes::compute_flags(const char* format, int more_flags) {
+jchar Bytecodes::compute_flags(const char* format, jchar more_flags) {
   if (format == nullptr)  return 0;  // not even more_flags
-  int flags = more_flags;
+  jchar flags = more_flags;
   const char* fp = format;
   switch (*fp) {
   case '\0':
@@ -491,11 +491,10 @@ int Bytecodes::compute_flags(const char* format, int more_flags) {
 
   int has_nbo = 0, has_jbo = 0, has_size = 0;
   for (;;) {
-    int this_flag = 0;
+    jchar this_flag = 0;
     char fc = *fp++;
     switch (fc) {
     case '\0':  // end of string
-      assert(flags == (jchar)flags, "change _format_flags");
       return flags;
 
     case '_': continue;         // ignore these

--- a/src/hotspot/share/interpreter/bytecodes.hpp
+++ b/src/hotspot/share/interpreter/bytecodes.hpp
@@ -310,7 +310,7 @@ class Bytecodes: AllStatic {
   static_assert(number_of_codes <= 256, "too many bytecodes");
 
   // Flag bits derived from format strings, can_trap, can_rewrite, etc.:
-  enum Flags {
+  enum Flags : jchar {
     // semantic flags:
     _bc_can_trap      = 1<<0,     // bytecode execution can trap or block
     _bc_can_rewrite   = 1<<1,     // bytecode execution has an alternate form
@@ -354,6 +354,7 @@ class Bytecodes: AllStatic {
   static bool        check_method(const Method* method, address bcp);
 #endif
   static bool check_must_rewrite(Bytecodes::Code bc);
+  static jchar compute_flags  (const char* format, jchar more_flags);  // compute the flags
 
  public:
   // Conversion
@@ -423,7 +424,6 @@ class Bytecodes: AllStatic {
                                                                                           code == _invokeinterface; }
   static bool        has_optional_appendix(Code code) { return code == _invokedynamic || code == _invokehandle; }
 
-  static int         compute_flags  (const char* format, int more_flags = 0);  // compute the flags
   static int         flags          (int code, bool is_wide) {
     assert(code == (u_char)code, "must be a byte");
     return _flags[code + (is_wide ? (1<<BitsPerByte) : 0)];

--- a/src/hotspot/share/interpreter/interpreter.hpp
+++ b/src/hotspot/share/interpreter/interpreter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ class InterpreterCodelet: public Stub {
   void    initialize(const char* description, Bytecodes::Code bytecode);
 
   // Interpreter-specific attributes
-  int         code_size() const                  { return code_end() - code_begin(); }
+  int         code_size() const                  { return (int)(code_end() - code_begin()); }
   const char* description() const                { return _description; }
   Bytecodes::Code bytecode() const               { return _bytecode; }
 #ifndef PRODUCT
@@ -109,7 +109,7 @@ class CodeletMark: ResourceMark {
   int codelet_size() {
     // Request the whole code buffer (minus a little for alignment).
     // The commit call below trims it back for each codelet.
-    int codelet_size = AbstractInterpreter::code()->available_space() - 2*K;
+    int codelet_size = AbstractInterpreter::code()->available_space() - (int)(2*K);
 
     // Guarantee there's a little bit of code space left.
     guarantee(codelet_size > 0 && (size_t)codelet_size > 2*K,

--- a/src/hotspot/share/interpreter/invocationCounter.cpp
+++ b/src/hotspot/share/interpreter/invocationCounter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ void InvocationCounter::decay() {
 
 void InvocationCounter::print() {
   uint counter = raw_counter();
-  tty->print_cr("invocation count: up = %d, limit = %d, carry = %s",
+  tty->print_cr("invocation count: up = %d, limit = " INTX_FORMAT ", carry = %s",
                                    extract_count(counter), limit(),
                                    extract_carry(counter) ? "true" : "false");
 }

--- a/src/hotspot/share/interpreter/invocationCounter.hpp
+++ b/src/hotspot/share/interpreter/invocationCounter.hpp
@@ -68,7 +68,7 @@ class InvocationCounter {
   // Accessors
   bool carry() const               { return (_counter & carry_mask) != 0; }
   uint count() const               { return _counter >> number_of_noncount_bits; }
-  uint limit() const               { return (uint)CompileThreshold; }
+  intx limit() const               { return CompileThreshold; }
   uint raw_counter() const         { return _counter; }
 
   void print();

--- a/src/hotspot/share/interpreter/invocationCounter.hpp
+++ b/src/hotspot/share/interpreter/invocationCounter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ class InvocationCounter {
   // Accessors
   bool carry() const               { return (_counter & carry_mask) != 0; }
   uint count() const               { return _counter >> number_of_noncount_bits; }
-  uint limit() const               { return CompileThreshold; }
+  uint limit() const               { return (uint)CompileThreshold; }
   uint raw_counter() const         { return _counter; }
 
   void print();

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -334,7 +334,7 @@ void OopMapCacheEntry::fill(const methodHandle& method, int bci) {
   // Flush entry to deallocate an existing entry
   flush();
   set_method(method());
-  set_bci(bci);
+  set_bci(checked_cast<unsigned short>(bci));  // bci is always u2
   if (method->is_native()) {
     // Native method activations have oops only among the parameters and one
     // extra oop following the parameters (the mirror for static native methods).

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -102,8 +102,8 @@ class InterpreterOopMap: ResourceObj {
   // access methods
   Method*        method() const                  { return _method; }
   void           set_method(Method* v)           { _method = v; }
-  int            bci() const                     { return _bci; }
-  void           set_bci(int v)                  { _bci = v; }
+  unsigned short bci() const                     { return _bci; }
+  void           set_bci(unsigned short v)       { _bci = v; }
   int            mask_size() const               { return _mask_size; }
   void           set_mask_size(int v)            { _mask_size = v; }
   // Test bit mask size and return either the in-line bit mask or allocated

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -181,13 +181,13 @@ void Rewriter::rewrite_member_reference(address bcp, int offset, bool reverse) {
   if (!reverse) {
     int  cp_index    = Bytes::get_Java_u2(p);
     int  cache_index = cp_entry_to_cp_cache(cp_index);
-    Bytes::put_native_u2(p, cache_index);
+    Bytes::put_native_u2(p, (u2)cache_index);
     if (!_method_handle_invokers.is_empty())
       maybe_rewrite_invokehandle(p - 1, cp_index, cache_index, reverse);
   } else {
     int cache_index = Bytes::get_native_u2(p);
     int pool_index = cp_cache_entry_pool_index(cache_index);
-    Bytes::put_Java_u2(p, pool_index);
+    Bytes::put_Java_u2(p, (u2)pool_index);
     if (!_method_handle_invokers.is_empty())
       maybe_rewrite_invokehandle(p - 1, pool_index, cache_index, reverse);
   }
@@ -206,7 +206,7 @@ void Rewriter::rewrite_invokespecial(address bcp, int offset, bool reverse, bool
       if (cache_index != (int)(jushort) cache_index) {
         *invokespecial_error = true;
       }
-      Bytes::put_native_u2(p, cache_index);
+      Bytes::put_native_u2(p, (u2)cache_index);
     } else {
       rewrite_member_reference(bcp, offset, reverse);
     }
@@ -295,7 +295,7 @@ void Rewriter::rewrite_invokedynamic(address bcp, int offset, bool reverse) {
     assert(_pool->tag_at(cp_index).is_invoke_dynamic(), "wrong index");
     // zero out 4 bytes
     Bytes::put_Java_u4(p, 0);
-    Bytes::put_Java_u2(p, cp_index);
+    Bytes::put_Java_u2(p, (u2)cp_index);
   }
 }
 
@@ -319,7 +319,7 @@ void Rewriter::maybe_rewrite_ldc(address bcp, int offset, bool is_wide,
       if (is_wide) {
         (*bcp) = Bytecodes::_fast_aldc_w;
         assert(ref_index == (u2)ref_index, "index overflow");
-        Bytes::put_native_u2(p, ref_index);
+        Bytes::put_native_u2(p, (u2)ref_index);
       } else {
         (*bcp) = Bytecodes::_fast_aldc;
         assert(ref_index == (u1)ref_index, "index overflow");
@@ -336,7 +336,7 @@ void Rewriter::maybe_rewrite_ldc(address bcp, int offset, bool is_wide,
       if (is_wide) {
         (*bcp) = Bytecodes::_ldc_w;
         assert(pool_index == (u2)pool_index, "index overflow");
-        Bytes::put_Java_u2(p, pool_index);
+        Bytes::put_Java_u2(p, (u2)pool_index);
       } else {
         (*bcp) = Bytecodes::_ldc;
         assert(pool_index == (u1)pool_index, "index overflow");

--- a/src/hotspot/share/interpreter/templateInterpreter.hpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.hpp
@@ -76,7 +76,7 @@ class DispatchTable {
   void       set_entry(int i, EntryPoint& entry);     // set    entry point for a given bytecode i
   address*   table_for(TosState state)          { return _table[state]; }
   address*   table_for()                        { return table_for((TosState)0); }
-  int        distance_from(address *table)      { return table - table_for(); }
+  int        distance_from(address *table)      { return (int)(table - table_for()); }
   int        distance_from(TosState state)      { return distance_from(table_for(state)); }
 
   // Comparison

--- a/src/hotspot/share/interpreter/templateTable.cpp
+++ b/src/hotspot/share/interpreter/templateTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,8 @@ void Template::initialize(int flags, TosState tos_in, TosState tos_out, generato
 
 
 Bytecodes::Code Template::bytecode() const {
-  int i = this - TemplateTable::_template_table;
-  if (i < 0 || i >= Bytecodes::number_of_codes) i = this - TemplateTable::_template_table_wide;
+  int i = (int)(this - TemplateTable::_template_table);
+  if (i < 0 || i >= Bytecodes::number_of_codes) i = (int)(this - TemplateTable::_template_table_wide);
   return Bytecodes::cast(i);
 }
 

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,7 +231,7 @@ class markWord {
   markWord set_marked()   { return markWord((value() & ~lock_mask_in_place) | marked_value); }
   markWord set_unmarked() { return markWord((value() & ~lock_mask_in_place) | unlocked_value); }
 
-  uint     age()           const { return mask_bits(value() >> age_shift, age_mask); }
+  uint     age()           const { return (uint) mask_bits(value() >> age_shift, age_mask); }
   markWord set_age(uint v) const {
     assert((v & ~age_mask) == 0, "shouldn't overflow age field");
     return markWord((value() & ~age_mask_in_place) | ((v & age_mask) << age_shift));

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -123,7 +123,7 @@ inline int stackChunkOopDesc::to_offset(intptr_t* p) const {
   assert(is_in_chunk(p)
     || (p >= start_address() && (p - start_address()) <= stack_size() + frame::metadata_words),
     "p: " PTR_FORMAT " start: " PTR_FORMAT " end: " PTR_FORMAT, p2i(p), p2i(start_address()), p2i(bottom_address()));
-  return p - start_address();
+  return (int)(p - start_address());
 }
 
 inline intptr_t* stackChunkOopDesc::from_offset(int offset) const {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -715,7 +715,7 @@ void basic_types_init(); // cannot define here; uses assert
 
 
 // NOTE: replicated in SA in vm/agent/sun/jvm/hotspot/runtime/BasicType.java
-enum BasicType {
+enum BasicType : u1 {
 // The values T_BOOLEAN..T_LONG (4..11) are derived from the JVMS.
   T_BOOLEAN     = JVM_T_BOOLEAN,
   T_CHAR        = JVM_T_CHAR,


### PR DESCRIPTION
Please review this change that's mostly casts and a few int type narrowing changes.  The casts are for size calculations between two addresses within the same area so can be int and are never going to be 64 bit.
I didn't change CompileThreshold to be 'int' because SA and JVMCI code expects it to be intx.  Maybe that should change though.
Tested with tier1 on Oracle platforms, and tier1-4 linux and windows x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310577](https://bugs.openjdk.org/browse/JDK-8310577): Fix -Wconversion warnings in interpreter and oops (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14604/head:pull/14604` \
`$ git checkout pull/14604`

Update a local copy of the PR: \
`$ git checkout pull/14604` \
`$ git pull https://git.openjdk.org/jdk.git pull/14604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14604`

View PR using the GUI difftool: \
`$ git pr show -t 14604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14604.diff">https://git.openjdk.org/jdk/pull/14604.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14604#issuecomment-1601594087)