### PR TITLE
8310586: ProblemList java/lang/ScopedValue/StressStackOverflow.java#default with virtual threads on linux-all

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -44,6 +44,8 @@ javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x
 
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
+java/lang/ScopedValue/StressStackOverflow.java#default 8309646 linux-all
+
 ##########
 ## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.


### PR DESCRIPTION
A trivial fix to ProblemList java/lang/ScopedValue/StressStackOverflow.java#default with virtual threads on linux-all

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310586](https://bugs.openjdk.org/browse/JDK-8310586): ProblemList java/lang/ScopedValue/StressStackOverflow.java#default with virtual threads on linux-all (**Sub-task** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14606/head:pull/14606` \
`$ git checkout pull/14606`

Update a local copy of the PR: \
`$ git checkout pull/14606` \
`$ git pull https://git.openjdk.org/jdk.git pull/14606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14606`

View PR using the GUI difftool: \
`$ git pr show -t 14606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14606.diff">https://git.openjdk.org/jdk/pull/14606.diff</a>

</details>
