### PR TITLE
8309909: remove test nsk.jvmti test objmonusage006 from ProblemList-Virtual.txt

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -57,10 +57,6 @@ vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal003/TestDescription.java 8300
 vmTestbase/nsk/jvmti/scenarios/allocation/AP11/ap11t001/TestDescription.java 8300712 generic-all
 
 ####
-## assert in src/hotspot/share/oops/instanceStackChunkKlass.cpp:1042
-vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage006/TestDescription.java 8300709 generic-all
-
-####
 ## NSK JDWP Tests failing with wrapper
 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java 8286789 generic-all


### PR DESCRIPTION
The following bug was closed as "Cannot Reproduce":
[8300709](https://bugs.openjdk.org/browse/JDK-8300709) nsk/jvmti/GetObjectMonitorUsage/objmonusage006 test asserts with virtual thread wrapper

I was not able to reproduce the assert in thousands mach5 runs on multiple debug builds.
Also, the original sources were significantly changed, so it is not clear anymore in what context the assert was fired.
The test is problem-listed in `ProblemList-Virtual.txt`.

This sub-task is to unproblem-list the test:
   `vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage006/TestDescription.java`
 
If the original asset is reproduced again then the plan is to reopen the [8300709](https://bugs.openjdk.org/browse/JDK-8300709) and update it with the details needed for issue investigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309909](https://bugs.openjdk.org/browse/JDK-8309909): remove test nsk.jvmti test objmonusage006 from ProblemList-Virtual.txt (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14610/head:pull/14610` \
`$ git checkout pull/14610`

Update a local copy of the PR: \
`$ git checkout pull/14610` \
`$ git pull https://git.openjdk.org/jdk.git pull/14610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14610`

View PR using the GUI difftool: \
`$ git pr show -t 14610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14610.diff">https://git.openjdk.org/jdk/pull/14610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14610#issuecomment-1602029548)