### PR TITLE
8310618: Test serviceability/sa/ClhsdbDumpclass.java fails after 8242152: 'StackMapTable:' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -75,6 +75,8 @@ public class ClhsdbDumpclass {
             // Run javap on the generated class file to make sure it's valid.
             JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("javap");
             launcher.addVMArgs(Utils.getTestJavaOpts());
+            // Let javap print additional info, e.g., StackMapTable
+            launcher.addToolArg("-verbose");
             launcher.addToolArg(classFile.toString());
             System.out.println("> javap " + classFile.toString());
             List<String> cmdStringList = Arrays.asList(launcher.getCommand());


### PR DESCRIPTION
This patch should fix [JDK-8310618](https://bugs.openjdk.org/browse/JDK-8310618). It attempts to correct my errors in fixing [JDK-8242152](https://bugs.openjdk.org/browse/JDK-8242152).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310618](https://bugs.openjdk.org/browse/JDK-8310618): Test serviceability/sa/ClhsdbDumpclass.java fails after 8242152: 'StackMapTable:' missing from stdout/stderr (**Bug** - P2)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14612/head:pull/14612` \
`$ git checkout pull/14612`

Update a local copy of the PR: \
`$ git checkout pull/14612` \
`$ git pull https://git.openjdk.org/jdk.git pull/14612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14612`

View PR using the GUI difftool: \
`$ git pr show -t 14612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14612.diff">https://git.openjdk.org/jdk/pull/14612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14612#issuecomment-1602309423)