### PR TITLE
8310628: GcInfoBuilder.c missing JNI Exception checks

### DIFF
--- a/src/jdk.management/share/native/libmanagement_ext/GcInfoBuilder.c
+++ b/src/jdk.management/share/native/libmanagement_ext/GcInfoBuilder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,9 @@ static void setLongValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Long";
     static const char* signature = "(J)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -138,7 +140,9 @@ static void setBooleanValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Boolean";
     static const char* signature = "(Z)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -147,7 +151,9 @@ static void setByteValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Byte";
     static const char* signature = "(B)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -156,7 +162,9 @@ static void setIntValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Integer";
     static const char* signature = "(I)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -165,7 +173,9 @@ static void setShortValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Short";
     static const char* signature = "(S)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -174,7 +184,9 @@ static void setDoubleValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Double";
     static const char* signature = "(D)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -183,7 +195,9 @@ static void setFloatValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Float";
     static const char* signature = "(D)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -192,7 +206,9 @@ static void setCharValueAtObjectArray(JNIEnv *env, jobjectArray array,
     static const char* class_name = "java/lang/Character";
     static const char* signature = "(C)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
-
+    if ((*env)->ExceptionCheck(env)) {
+        return;
+    }
     (*env)->SetObjectArrayElement(env, array, index, obj);
 }
 
@@ -292,6 +308,10 @@ JNIEXPORT jobject JNICALL Java_com_sun_management_internal_GcInfoBuilder_getLast
     }
     if (nativeTypes != NULL) {
         free(nativeTypes);
+    }
+    // Recognise possible Exception from the switch statement above:
+    if ((*env)->ExceptionCheck(env)) {
+        return NULL;
     }
 
     return JNU_NewObjectByName(env,


### PR DESCRIPTION
JNI calls were identified, where we do not check for a pending Exception afterwards.

(JDK-8162530 cleaned up up some of these kind of issues some years back, but more were found.)

I tested a code change to manually create an Exception before some of the new ExceptionCheck calls, and this is correctly recognised, we see an Exception thrown by the native getLastGcInfo0, e.g. 

java.lang.NullPointerException: XXX Test Exception
        at jdk.management/com.sun.management.internal.GcInfoBuilder.getLastGcInfo0(Native Method)
        at jdk.management/com.sun.management.internal.GcInfoBuilder.getLastGcInfo(GcInfoBuilder.java:77)
        at jdk.management/com.sun.management.internal.GarbageCollectorExtImpl.getLastGcInfo(GarbageCollectorExtImpl.java:69)
        at LastGCInfo.main(LastGCInfo.java:53)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1570)

Tested with all of test/jdk/com/sun/management including test/jdk/com/sun/management/GarbageCollectorMXBean/LastGCInfo.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310628](https://bugs.openjdk.org/browse/JDK-8310628): GcInfoBuilder.c missing JNI Exception checks (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14613/head:pull/14613` \
`$ git checkout pull/14613`

Update a local copy of the PR: \
`$ git checkout pull/14613` \
`$ git pull https://git.openjdk.org/jdk.git pull/14613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14613`

View PR using the GUI difftool: \
`$ git pr show -t 14613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14613.diff">https://git.openjdk.org/jdk/pull/14613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14613#issuecomment-1602455240)