### PR TITLE
8310581: retry_class_loading_during_parsing() is not used

### DIFF
--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -52,9 +52,6 @@ const char* C2Compiler::retry_no_locks_coarsening() {
 const char* C2Compiler::retry_no_iterative_escape_analysis() {
   return "retry without iterative escape analysis";
 }
-const char* C2Compiler::retry_class_loading_during_parsing() {
-  return "retry class loading during parsing";
-}
 
 void compiler_stubs_init(bool in_compiler_thread);
 
@@ -119,10 +116,6 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
 
     // Check result and retry if appropriate.
     if (C.failure_reason() != nullptr) {
-      if (C.failure_reason_is(retry_class_loading_during_parsing())) {
-        env->report_failure(C.failure_reason());
-        continue;  // retry
-      }
       if (C.failure_reason_is(retry_no_subsuming_loads())) {
         assert(subsume_loads, "must make progress");
         subsume_loads = false;

--- a/src/hotspot/share/opto/c2compiler.hpp
+++ b/src/hotspot/share/opto/c2compiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/c2compiler.hpp
+++ b/src/hotspot/share/opto/c2compiler.hpp
@@ -51,7 +51,6 @@ public:
   static const char* retry_no_escape_analysis();
   static const char* retry_no_iterative_escape_analysis();
   static const char* retry_no_locks_coarsening();
-  static const char* retry_class_loading_during_parsing();
 
   // Print compilation timers and statistics
   void print_timers();

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -769,12 +769,10 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
 
     JVMState* jvms = build_start_state(start(), tf());
     if ((jvms = cg->generate(jvms)) == nullptr) {
-      if (!failure_reason_is(C2Compiler::retry_class_loading_during_parsing())) {
-        assert(failure_reason() != nullptr, "expect reason for parse failure");
-        stringStream ss;
-        ss.print("method parse failed: %s", failure_reason());
-        record_method_not_compilable(ss.as_string());
-      }
+      assert(failure_reason() != nullptr, "expect reason for parse failure");
+      stringStream ss;
+      ss.print("method parse failed: %s", failure_reason());
+      record_method_not_compilable(ss.as_string());
       return;
     }
     GraphKit kit(jvms);


### PR DESCRIPTION
The failure recording for `retry_class_loading_during_parsing()` is removed in [JDK-8222446](https://bugs.openjdk.org/browse/JDK-8222446). As it is never used to set failure reason in the current code base, this function and the code checking for it should be removed.

Test `tier1-3` for release build on Linux x86-64 has done. The test failure is irrelevant to this patch (which is [JDK-8309214](https://bugs.openjdk.org/browse/JDK-8309214)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310581](https://bugs.openjdk.org/browse/JDK-8310581): retry_class_loading_during_parsing() is not used (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14615/head:pull/14615` \
`$ git checkout pull/14615`

Update a local copy of the PR: \
`$ git checkout pull/14615` \
`$ git pull https://git.openjdk.org/jdk.git pull/14615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14615`

View PR using the GUI difftool: \
`$ git pr show -t 14615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14615.diff">https://git.openjdk.org/jdk/pull/14615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14615#issuecomment-1602907961)