### PR TITLE
8222329: Readable read(CharBuffer) does not specify that 0 is returned when there is no remaining space in buffer

### DIFF
--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -189,14 +189,17 @@ public abstract class Reader implements Readable, Closeable {
      * Attempts to read characters into the specified character buffer.
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
-     * rewinding of the buffer is performed.
+     * rewinding of the buffer is performed.  If the specified character
+     * buffer is full, then no characters will be read and zero will be
+     * returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer, or
      *         -1 if this source of characters is at its end
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if target is null
-     * @throws java.nio.ReadOnlyBufferException if target is a read only buffer
+     * @throws java.nio.ReadOnlyBufferException if target is a read only buffer,
+     *         even if it is empty
      * @since 1.5
      */
     public int read(CharBuffer target) throws IOException {

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -191,7 +191,8 @@ public abstract class Reader implements Readable, Closeable {
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed.  If the specified character
      * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
-     * remaining}, then no characters will be read and zero will be returned.
+     * remaining} or or its {@linkplain java.nio.CharBuffer#length length}
+     * is zero, then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer,
@@ -199,7 +200,7 @@ public abstract class Reader implements Readable, Closeable {
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if target is null
      * @throws java.nio.ReadOnlyBufferException if target is a read only buffer,
-     *         even if it is empty
+     *         even if its length is zero
      * @since 1.5
      */
     public int read(CharBuffer target) throws IOException {

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -191,7 +191,7 @@ public abstract class Reader implements Readable, Closeable {
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed.  If the specified character
      * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
-     * remaining} or or its {@linkplain java.nio.CharBuffer#length length}
+     * remaining} or its {@linkplain java.nio.CharBuffer#length length}
      * is zero, then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -190,7 +190,7 @@ public abstract class Reader implements Readable, Closeable {
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed.  If the specified character
-     * buffer has no elements {@linkplain java.nio.Buffer#hasRemaining
+     * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
      * remaining}, then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -189,10 +189,10 @@ public abstract class Reader implements Readable, Closeable {
      * Attempts to read characters into the specified character buffer.
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
-     * rewinding of the buffer is performed.  If the specified character
-     * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
-     * remaining} or its {@linkplain java.nio.CharBuffer#length length}
-     * is zero, then no characters will be read and zero will be returned.
+     * rewinding of the buffer is performed. If the {@linkplain
+     * java.nio.CharBuffer#length length} of the specified character
+     * buffer is zero, then no characters will be read and zero will be
+     * returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer,

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -194,8 +194,8 @@ public abstract class Reader implements Readable, Closeable {
      * remaining}, then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into
-     * @return The number of characters added to the buffer, or
-     *         -1 if this source of characters is at its end
+     * @return The number of characters added to the buffer,
+     *         possibly zero, or -1 if this source of characters is at its end
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if target is null
      * @throws java.nio.ReadOnlyBufferException if target is a read only buffer,

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -190,8 +190,8 @@ public abstract class Reader implements Readable, Closeable {
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed.  If the specified character
-     * buffer is full, then no characters will be read and zero will be
-     * returned.
+     * buffer has no elements {@linkplain java.nio.Buffer#hasRemaining
+     * remaining}, then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer, or

--- a/src/java.base/share/classes/java/lang/Readable.java
+++ b/src/java.base/share/classes/java/lang/Readable.java
@@ -40,10 +40,10 @@ public interface Readable {
      * Attempts to read characters into the specified character buffer.
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
-     * rewinding of the buffer is performed. If the specified character
-     * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
-     * remaining} or its {@linkplain java.nio.CharBuffer#length length}
-     * is zero, then no characters will be read and zero will be returned.
+     * rewinding of the buffer is performed. If the {@linkplain
+     * java.nio.CharBuffer#length length} of the specified character
+     * buffer is zero, then no characters will be read and zero will be
+     * returned.
      *
      * @param cb the buffer to read characters into
      * @return The number of {@code char} values added to the buffer,

--- a/src/java.base/share/classes/java/lang/Readable.java
+++ b/src/java.base/share/classes/java/lang/Readable.java
@@ -41,8 +41,8 @@ public interface Readable {
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed. If the specified character
-     * buffer is full, then no characters will be read and zero will be
-     * returned.
+     * buffer has no elements {@linkplain java.nio.Buffer#hasRemaining
+     * remaining}, then no characters will be read and zero will be returned.
      *
      * @param cb the buffer to read characters into
      * @return The number of {@code char} values added to the buffer,

--- a/src/java.base/share/classes/java/lang/Readable.java
+++ b/src/java.base/share/classes/java/lang/Readable.java
@@ -41,7 +41,7 @@ public interface Readable {
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed. If the specified character
-     * buffer has no elements {@linkplain java.nio.Buffer#hasRemaining
+     * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
      * remaining}, then no characters will be read and zero will be returned.
      *
      * @param cb the buffer to read characters into

--- a/src/java.base/share/classes/java/lang/Readable.java
+++ b/src/java.base/share/classes/java/lang/Readable.java
@@ -42,7 +42,8 @@ public interface Readable {
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed. If the specified character
      * buffer has no space {@linkplain java.nio.Buffer#hasRemaining
-     * remaining}, then no characters will be read and zero will be returned.
+     * remaining} or its {@linkplain java.nio.CharBuffer#length length}
+     * is zero, then no characters will be read and zero will be returned.
      *
      * @param cb the buffer to read characters into
      * @return The number of {@code char} values added to the buffer,
@@ -50,7 +51,7 @@ public interface Readable {
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if cb is null
      * @throws java.nio.ReadOnlyBufferException if cb is a read only buffer,
-     *         even if it is empty
+     *         even if its length is zero
      */
     public int read(java.nio.CharBuffer cb) throws IOException;
 }

--- a/src/java.base/share/classes/java/lang/Readable.java
+++ b/src/java.base/share/classes/java/lang/Readable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,14 +40,17 @@ public interface Readable {
      * Attempts to read characters into the specified character buffer.
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
-     * rewinding of the buffer is performed.
+     * rewinding of the buffer is performed. If the specified character
+     * buffer is full, then no characters will be read and zero will be
+     * returned.
      *
      * @param cb the buffer to read characters into
      * @return The number of {@code char} values added to the buffer,
-     *                 or -1 if this source of characters is at its end
+     *         possibly zero, or -1 if this source of characters is at its end
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if cb is null
-     * @throws java.nio.ReadOnlyBufferException if cb is a read only buffer
+     * @throws java.nio.ReadOnlyBufferException if cb is a read only buffer,
+     *         even if it is empty
      */
     public int read(java.nio.CharBuffer cb) throws IOException;
 }

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -471,13 +471,16 @@ public abstract sealed class $Type$Buffer
      * Attempts to read characters into the specified character buffer.
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
-     * rewinding of the buffer is performed.
+     * rewinding of the buffer is performed. If the specified character
+     * buffer is full, then no characters will be read and zero will be
+     * returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer, or
      *         -1 if this source of characters is at its end
      * @throws IOException if an I/O error occurs
-     * @throws ReadOnlyBufferException if target is a read only buffer
+     * @throws ReadOnlyBufferException if target is a read only buffer,
+     *         even if it is empty
      * @since 1.5
      */
     public int read(CharBuffer target) throws IOException {

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -471,10 +471,9 @@ public abstract sealed class $Type$Buffer
      * Attempts to read characters into the specified character buffer.
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
-     * rewinding of the buffer is performed. If the specified character
-     * buffer has no space {@linkplain Buffer#hasRemaining remaining} or
-     * its {@linkplain #length length} is zero, then no characters will
-     * be read and zero will be returned.
+     * rewinding of the buffer is performed. If the {@linkplain #length
+     * length} of the specified character buffer is zero, then no characters
+     * will be read and zero will be returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer,

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -472,8 +472,8 @@ public abstract sealed class $Type$Buffer
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed. If the specified character
-     * buffer is full, then no characters will be read and zero will be
-     * returned.
+     * buffer has no elements {@linkplain Buffer#hasRemaining remaining},
+     * then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer, or

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -476,8 +476,8 @@ public abstract sealed class $Type$Buffer
      * then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into
-     * @return The number of characters added to the buffer, or
-     *         -1 if this source of characters is at its end
+     * @return The number of characters added to the buffer,
+     *         possibly zero, or -1 if this source of characters is at its end
      * @throws IOException if an I/O error occurs
      * @throws ReadOnlyBufferException if target is a read only buffer,
      *         even if it is empty

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -472,7 +472,7 @@ public abstract sealed class $Type$Buffer
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed. If the specified character
-     * buffer has no elements {@linkplain Buffer#hasRemaining remaining},
+     * buffer has no space {@linkplain Buffer#hasRemaining remaining},
      * then no characters will be read and zero will be returned.
      *
      * @param target the buffer to read characters into

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -472,15 +472,16 @@ public abstract sealed class $Type$Buffer
      * The buffer is used as a repository of characters as-is: the only
      * changes made are the results of a put operation. No flipping or
      * rewinding of the buffer is performed. If the specified character
-     * buffer has no space {@linkplain Buffer#hasRemaining remaining},
-     * then no characters will be read and zero will be returned.
+     * buffer has no space {@linkplain Buffer#hasRemaining remaining} or
+     * its {@linkplain #length length} is zero, then no characters will
+     * be read and zero will be returned.
      *
      * @param target the buffer to read characters into
      * @return The number of characters added to the buffer,
      *         possibly zero, or -1 if this source of characters is at its end
      * @throws IOException if an I/O error occurs
      * @throws ReadOnlyBufferException if target is a read only buffer,
-     *         even if it is empty
+     *         even if its length is zero
      * @since 1.5
      */
     public int read(CharBuffer target) throws IOException {


### PR DESCRIPTION
Clarify the behavior of `java.lang.Readable` when the specified `java.nio.CharBuffer` parameter is empty but read-only, and when it is full.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8310677](https://bugs.openjdk.org/browse/JDK-8310677) to be approved

### Issues
 * [JDK-8222329](https://bugs.openjdk.org/browse/JDK-8222329): Readable read(CharBuffer) does not specify that 0 is returned when there is no remaining space in buffer (**Enhancement** - P3)
 * [JDK-8310677](https://bugs.openjdk.org/browse/JDK-8310677): Readable read(CharBuffer) does not specify that 0 is returned when there is no remaining space in buffer (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [8bcf4674](https://git.openjdk.org/jdk/pull/14616/files/8bcf4674c24f72401ab80564541d724336a60d79)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14616/head:pull/14616` \
`$ git checkout pull/14616`

Update a local copy of the PR: \
`$ git checkout pull/14616` \
`$ git pull https://git.openjdk.org/jdk.git pull/14616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14616`

View PR using the GUI difftool: \
`$ git pr show -t 14616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14616.diff">https://git.openjdk.org/jdk/pull/14616.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14616#issuecomment-1603131006)