### PR TITLE
8279254: PKCS9Attribute SigningTime always encoded in UTFTime

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -463,8 +463,7 @@ public class PKCS9Attribute implements DerEncoder {
         case 5:     // signing time
             byte elemTag = elems[0].getTag();
             DerInputStream dis = new DerInputStream(elems[0].toByteArray());
-            value = (elemTag == DerValue.tag_GeneralizedTime) ?
-                    dis.getGeneralizedTime() : dis.getUTCTime();
+            value = dis.getTime();
             break;
 
         case 6:     // countersignature

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -570,7 +570,7 @@ public class PKCS9Attribute implements DerEncoder {
         case 5:     // signing time
             {
                 DerOutputStream temp2 = new DerOutputStream();
-                temp2.putUTCTime((Date) value);
+                temp2.putTime((Date) value);
                 temp.write(DerValue.tag_Set, temp2.toByteArray());
             }
             break;

--- a/src/java.base/share/classes/sun/security/util/DerInputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/DerInputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerInputStream.java
@@ -189,6 +189,10 @@ public class DerInputStream {
         return getDerValue().getGeneralString();
     }
 
+    public Date getTime() throws IOException {
+        return getDerValue().getTime();
+    }
+
     public Date getUTCTime() throws IOException {
         return getDerValue().getUTCTime();
     }

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -480,6 +480,15 @@ public final class DerOutputStream
         putLength(data.length);
         writeBytes(data);
         return this;
+    }
+
+    /**
+     * Takes a Date and chooses UTC or GeneralizedTime as per RFC 2630
+     */
+    public DerOutputStream putTime(Date d) {
+        Date low = new Date(1950,1,1);
+        Date high = new Date(2049,12,31);
+        return (d.before(low) || d.after(high)) ? putGeneralizedTime(d) : putUTCTime(d);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -486,7 +486,9 @@ public final class DerOutputStream
      * Takes a Date and chooses UTC or GeneralizedTime as per RFC 2630
      */
     public DerOutputStream putTime(Date d) {
+        @SuppressWarnings("deprecation")
         Date low = new Date(1950,1,1);
+        @SuppressWarnings("deprecation")
         Date high = new Date(2049,12,31);
         return (d.before(low) || d.after(high)) ? putGeneralizedTime(d) : putUTCTime(d);
     }

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -486,8 +486,8 @@ public final class DerOutputStream
      * Takes a Date and chooses UTC or GeneralizedTime as per RFC 2630
      */
     public DerOutputStream putTime(Date d) {
-        Date low = new Date(-631152000L); // Dates before 1/1/1950
-        Date high = new Date(2524607999L); // Dates after 12/31/2049
+        Date low = new Date(-631152000000L); // Dates before 1/1/1950
+        Date high = new Date(2524607999000L); // Dates after 12/31/2049
         return (d.before(low) || d.after(high)) ? putGeneralizedTime(d) : putUTCTime(d);
     }
 

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -483,12 +483,20 @@ public final class DerOutputStream
     }
 
     /**
+     * 1/1/1950 is the lowest date that RFC 2630 serializes to UTC time
+     */
+    private static final Date utcLow = new Date(-631152000000L); // Dates before 1/1/1950
+
+    /**
+     * 12/31/2049 is the highest date that RFC 2630 serializes to UTC time
+     */
+    private static final Date utcHigh = new Date(2524607999000L);
+
+    /**
      * Takes a Date and chooses UTC or GeneralizedTime as per RFC 2630
      */
     public DerOutputStream putTime(Date d) {
-        Date low = new Date(-631152000000L); // Dates before 1/1/1950
-        Date high = new Date(2524607999000L); // Dates after 12/31/2049
-        return (d.before(low) || d.after(high)) ? putGeneralizedTime(d) : putUTCTime(d);
+        return (d.before(utcLow) || d.after(utcHigh)) ? putGeneralizedTime(d) : putUTCTime(d);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -486,10 +486,8 @@ public final class DerOutputStream
      * Takes a Date and chooses UTC or GeneralizedTime as per RFC 2630
      */
     public DerOutputStream putTime(Date d) {
-        @SuppressWarnings("deprecation")
-        Date low = new Date(1950,1,1);
-        @SuppressWarnings("deprecation")
-        Date high = new Date(2049,12,31);
+        Date low = new Date(-631152000L); // Dates before 1/1/1950
+        Date high = new Date(2524607999L); // Dates after 12/31/2049
         return (d.before(low) || d.after(high)) ? putGeneralizedTime(d) : putUTCTime(d);
     }
 

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -1061,6 +1061,14 @@ public class DerValue {
     }
 
     /**
+     * Determines whether Date was encoded as UTC or Generalized time and
+     * calls getUTCTime or getGeneralizedTime accordingly
+     */
+    public Date getTime() throws IOException {
+        return (tag == tag_UtcTime) ? getUTCTime() : getGeneralizedTime();
+    }
+
+    /**
      * Returns a Date if the DerValue is UtcTime.
      *
      * @return the Date held in this DER value

--- a/test/jdk/sun/security/util/DerOutputStream/DerTimeEncoding.java
+++ b/test/jdk/sun/security/util/DerOutputStream/DerTimeEncoding.java
@@ -26,8 +26,7 @@
  * @bug 8279254
  * @summary Changed time encoding to correctly use UTC between 1950-2050 and GeneralizedTime otherwise
  * @library /test/lib
- * @modules java.base/sun.security.pkcs
-            java.base/sun.security.util
+ * @modules java.base/sun.security.util
  */
 
 import java.util.Date;

--- a/test/jdk/sun/security/util/DerOutputStream/DerTimeEncoding.java
+++ b/test/jdk/sun/security/util/DerOutputStream/DerTimeEncoding.java
@@ -37,7 +37,7 @@ public class DerTimeEncoding {
     public static void main(String args[]) throws Exception {
         //Check that dates after 2050 use GeneralizedTime
         DerOutputStream out = new DerOutputStream();
-        Date generalizedTimeDate = new Date(2055,3,17);
+        Date generalizedTimeDate = new Date(2688854400000L); // Test date is 3/17/2055
         out.putTime(generalizedTimeDate);
         DerValue val = new DerValue(out.toByteArray());
         if (val.tag != DerValue.tag_GeneralizedTime) {
@@ -47,7 +47,7 @@ public class DerTimeEncoding {
 
         //Check dates between 1950-2050 use UTC time
         out = new DerOutputStream();
-        Date utcDate = new Date(1977,9,3);
+        Date utcDate = new Date(242092800000L); //Test date is 9/3/1977
         out.putTime(utcDate);
         val = new DerValue(out.toByteArray());
         if (val.tag != DerValue.tag_UtcTime) {

--- a/test/jdk/sun/security/util/DerOutputStream/DerTimeEncoding.java
+++ b/test/jdk/sun/security/util/DerOutputStream/DerTimeEncoding.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8279254
+ * @summary Changed time encoding to correctly use UTC between 1950-2050 and GeneralizedTime otherwise
+ * @library /test/lib
+ * @modules java.base/sun.security.pkcs
+            java.base/sun.security.util
+ */
+
+import java.util.Date;
+import sun.security.util.DerOutputStream;
+import sun.security.util.DerValue;
+
+public class DerTimeEncoding {
+    public static void main(String args[]) throws Exception {
+        //Check that dates after 2050 use GeneralizedTime
+        DerOutputStream out = new DerOutputStream();
+        Date generalizedTimeDate = new Date(2055,3,17);
+        out.putTime(generalizedTimeDate);
+        DerValue val = new DerValue(out.toByteArray());
+        if (val.tag != DerValue.tag_GeneralizedTime) {
+            System.out.println("putTime incorrectly serialized to UTC time instead of GeneralizedTime");
+            throw new RuntimeException("Incorrect Der date format");
+        }
+
+        //Check dates between 1950-2050 use UTC time
+        out = new DerOutputStream();
+        Date utcDate = new Date(1977,9,3);
+        out.putTime(utcDate);
+        val = new DerValue(out.toByteArray());
+        if (val.tag != DerValue.tag_UtcTime) {
+            System.out.println("putTime incorrectly serialized to Generalized time instead of UTC time");
+            throw new RuntimeException("Incorrect Der date format");
+        }
+    }
+}


### PR DESCRIPTION
Added single-argument `putTime` method to `DerOutputStream` that selects the correct encoding based on the `Date` value. Similarly, a `getTime` method was added to `DerValue` to automatically call the correct decoding function based on the date type specified by the `tag`. Furthermore, the `encode` method in `PKCS9Attribute` was changed to utilize the new `putTime` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279254](https://bugs.openjdk.org/browse/JDK-8279254): PKCS9Attribute SigningTime always encoded in UTFTime (**Bug** - P3)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14617/head:pull/14617` \
`$ git checkout pull/14617`

Update a local copy of the PR: \
`$ git checkout pull/14617` \
`$ git pull https://git.openjdk.org/jdk.git pull/14617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14617`

View PR using the GUI difftool: \
`$ git pr show -t 14617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14617.diff">https://git.openjdk.org/jdk/pull/14617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14617#issuecomment-1603157828)