### PR TITLE
8310241: OffsetDateTime compareTo redundant computation

### DIFF
--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,26 +167,17 @@ public final class OffsetDateTime
      * Compares this {@code OffsetDateTime} to another date-time.
      * The comparison is based on the instant.
      *
-     * When two values represent the same instant, the local date-time is compared
-     * to distinguish them. This step is needed to make the ordering
-     * consistent with {@code equals()}.
-     *
      * @param datetime1  the first date-time to compare, not null
      * @param datetime2  the other date-time to compare to, not null
      * @return the comparator value, negative if less, positive if greater
      */
     private static int compareInstant(OffsetDateTime datetime1, OffsetDateTime datetime2) {
-        int cmp;
         if (datetime1.getOffset().equals(datetime2.getOffset())) {
-            cmp = 0;
-        } else {
-            cmp = Long.compare(datetime1.toEpochSecond(), datetime2.toEpochSecond());
-            if (cmp == 0) {
-                cmp = datetime1.toLocalTime().getNano() - datetime2.toLocalTime().getNano();
-            }
+            return datetime1.toLocalDateTime().compareTo(datetime2.toLocalDateTime());
         }
+        int cmp = Long.compare(datetime1.toEpochSecond(), datetime2.toEpochSecond());
         if (cmp == 0) {
-            cmp = datetime1.toLocalDateTime().compareTo(datetime2.toLocalDateTime());
+            cmp = datetime1.toLocalTime().getNano() - datetime2.toLocalTime().getNano();
         }
         return cmp;
     }
@@ -1814,7 +1805,17 @@ public final class OffsetDateTime
      */
     @Override
     public int compareTo(OffsetDateTime other) {
-        return compareInstant(this, other);
+        int cmp = getOffset().compareTo(other.getOffset());
+        if (cmp != 0) {
+            cmp = Long.compare(toEpochSecond(), other.toEpochSecond());
+            if (cmp == 0) {
+                cmp = toLocalTime().getNano() - other.toLocalTime().getNano();
+            }
+        }
+        if (cmp == 0) {
+            cmp = toLocalDateTime().compareTo(other.toLocalDateTime());
+        }
+        return cmp;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,17 +167,26 @@ public final class OffsetDateTime
      * Compares this {@code OffsetDateTime} to another date-time.
      * The comparison is based on the instant.
      *
+     * When two values represent the same instant, the local date-time is compared
+     * to distinguish them. This step is needed to make the ordering
+     * consistent with {@code equals()}.
+     *
      * @param datetime1  the first date-time to compare, not null
      * @param datetime2  the other date-time to compare to, not null
      * @return the comparator value, negative if less, positive if greater
      */
     private static int compareInstant(OffsetDateTime datetime1, OffsetDateTime datetime2) {
+        int cmp;
         if (datetime1.getOffset().equals(datetime2.getOffset())) {
-            return datetime1.toLocalDateTime().compareTo(datetime2.toLocalDateTime());
+            cmp = 0;
+        } else {
+            cmp = Long.compare(datetime1.toEpochSecond(), datetime2.toEpochSecond());
+            if (cmp == 0) {
+                cmp = datetime1.toLocalTime().getNano() - datetime2.toLocalTime().getNano();
+            }
         }
-        int cmp = Long.compare(datetime1.toEpochSecond(), datetime2.toEpochSecond());
         if (cmp == 0) {
-            cmp = datetime1.toLocalTime().getNano() - datetime2.toLocalTime().getNano();
+            cmp = datetime1.toLocalDateTime().compareTo(datetime2.toLocalDateTime());
         }
         return cmp;
     }
@@ -1805,11 +1814,7 @@ public final class OffsetDateTime
      */
     @Override
     public int compareTo(OffsetDateTime other) {
-        int cmp = compareInstant(this, other);
-        if (cmp == 0) {
-            cmp = toLocalDateTime().compareTo(other.toLocalDateTime());
-        }
-        return cmp;
+        return compareInstant(this, other);
     }
 
     //-----------------------------------------------------------------------

--- a/test/jdk/java/time/tck/java/time/TCKOffsetDateTime.java
+++ b/test/jdk/java/time/tck/java/time/TCKOffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1381,6 +1381,7 @@ public class TCKOffsetDateTime extends AbstractDateTimeTest {
         assertEquals(a.compareTo(a) == 0, true);
         assertEquals(b.compareTo(b) == 0, true);
         assertEquals(a.toInstant().compareTo(b.toInstant()) == 0, true);
+        assertEquals(OffsetDateTime.timeLineOrder().compare(a,b) == 0, true);
     }
 
     @Test


### PR DESCRIPTION
Remove a redundant comparison in java.time `OffsetDateTime.compareTo()`. 
If the `compareInstant` utility method returns 0 (equal), it compares the `LocalDateTime`.
However, `compareInstant` has already done that comparison; if it found equal, the `compareTo` method unnecessarily does it again.
The code is refactored in `compareTo` to do the comparison of `LocalDateTime` exactly once, if it is needed.

This case is NOT covered by an existing test in test/jdk/java/time/tck/java/time/TCKOffsetDateTime.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310241](https://bugs.openjdk.org/browse/JDK-8310241): OffsetDateTime compareTo redundant computation (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14618/head:pull/14618` \
`$ git checkout pull/14618`

Update a local copy of the PR: \
`$ git checkout pull/14618` \
`$ git pull https://git.openjdk.org/jdk.git pull/14618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14618`

View PR using the GUI difftool: \
`$ git pr show -t 14618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14618.diff">https://git.openjdk.org/jdk/pull/14618.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14618#issuecomment-1603183221)