### PR TITLE
8310606: Fix signed integer overflow, part 3

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -79,7 +79,7 @@ void VM_Version::initialize() {
   int dcache_line = VM_Version::dcache_line_size();
 
   // Limit AllocatePrefetchDistance so that it does not exceed the
-  // constraint.
+  // static constraint of 512 defined in runtime/globals.hpp.
   if (FLAG_IS_DEFAULT(AllocatePrefetchDistance))
     FLAG_SET_DEFAULT(AllocatePrefetchDistance, MIN2(512, 3*dcache_line));
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -79,7 +79,7 @@ void VM_Version::initialize() {
   int dcache_line = VM_Version::dcache_line_size();
 
   // Limit AllocatePrefetchDistance so that it does not exceed the
-  // constraint in AllocatePrefetchDistanceConstraintFunc.
+  // constraint.
   if (FLAG_IS_DEFAULT(AllocatePrefetchDistance))
     FLAG_SET_DEFAULT(AllocatePrefetchDistance, MIN2(512, 3*dcache_line));
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -275,7 +275,7 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(AllocatePrefetchStyle, 0);
   } else {
     // Limit AllocatePrefetchDistance so that it does not exceed the
-    // constraint.
+    // static constraint of 512 defined in runtime/globals.hpp.
     if (FLAG_IS_DEFAULT(AllocatePrefetchDistance)) {
       FLAG_SET_DEFAULT(AllocatePrefetchDistance, MIN2(512, 3 * (int)CacheLineSize));
     }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -275,7 +275,7 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(AllocatePrefetchStyle, 0);
   } else {
     // Limit AllocatePrefetchDistance so that it does not exceed the
-    // constraint in AllocatePrefetchDistanceConstraintFunc.
+    // constraint.
     if (FLAG_IS_DEFAULT(AllocatePrefetchDistance)) {
       FLAG_SET_DEFAULT(AllocatePrefetchDistance, MIN2(512, 3 * (int)CacheLineSize));
     }

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
@@ -351,12 +351,29 @@ RangeCheckEliminator::Bound *RangeCheckEliminator::get_bound(Value v) {
 
 // Update bound
 void RangeCheckEliminator::update_bound(IntegerStack &pushed, Value v, Instruction::Condition cond, Value value, int constant) {
+  assert(sizeof(constant) == sizeof(jint), "wrong size");
   if (cond == Instruction::gtr) {
     cond = Instruction::geq;
-    constant++;
+    if (constant == INT_MAX) {
+      if (value == nullptr) {
+        // Cannot represent c > INT_MAX, do not update bounds
+        return;
+      }
+      constant = java_add((jint)constant, 1); // Java wrap semantics
+    } else {
+      constant++;
+    }
   } else if (cond == Instruction::lss) {
     cond = Instruction::leq;
-    constant--;
+    if (constant == INT_MIN) {
+      if (value == nullptr) {
+        // Cannot represent c < INT_MIN, do not update bounds
+        return;
+      }
+      constant = java_subtract((jint)constant, 1); // Java wrap semantics
+    } else {
+      constant--;
+    }
   }
   Bound *bound = new Bound(cond, value, constant);
   update_bound(pushed, v, bound);
@@ -694,8 +711,7 @@ void RangeCheckEliminator::insert_deoptimization(ValueStack *state, Instruction 
     } else {
       assert(lower < 0, "");
       // Add 1
-      lower++;
-      lower = -lower;
+      lower = java_subtract(-1, (jint)lower); // lower++; lower = -lower;
       // Compare for smaller or equal 0
       insert_position = predicate_cmp_with_const(lower_instr, Instruction::leq, lower, state, insert_position, bci);
     }
@@ -739,7 +755,7 @@ void RangeCheckEliminator::insert_deoptimization(ValueStack *state, Instruction 
       insert_position = predicate_add(upper_instr, upper, Instruction::geq, length_instr, state, insert_position, bci);
     } else {
       assert(upper > 0, "");
-      upper = -upper;
+      upper = java_negate((jint)upper); // upper = -upper;
       // Compare for geq array.length
       insert_position = predicate_add(length_instr, upper, Instruction::leq, upper_instr, state, insert_position, bci);
     }

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -306,7 +306,7 @@ double CompilationPolicy::threshold_scale(CompLevel level, int feedback_k) {
   int comp_count = compiler_count(level);
   if (comp_count > 0) {
     double queue_size = CompileBroker::queue_size(level);
-    double k = queue_size / (feedback_k * comp_count) + 1;
+    double k = (double)queue_size / ((double)feedback_k * (double)comp_count) + 1;
 
     // Increase C1 compile threshold when the code cache is filled more
     // than specified by IncreaseFirstTierCompileThresholdAt percentage.

--- a/src/hotspot/share/jfr/leakprofiler/utilities/granularTimer.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/granularTimer.cpp
@@ -36,8 +36,8 @@ void GranularTimer::start(jlong duration_ticks, long granularity) {
   _granularity = granularity;
   _counter = granularity;
   _start_time_ticks = JfrTicks::now();
-  const jlong end_time_ticks = _start_time_ticks.value() + duration_ticks;
-  _finish_time_ticks = end_time_ticks < 0 ? JfrTicks(max_jlong) : JfrTicks(end_time_ticks);
+  const julong end_time_ticks = (julong)_start_time_ticks.value() + (julong)duration_ticks;
+  _finish_time_ticks = end_time_ticks > (julong)max_jlong ? JfrTicks(max_jlong) : JfrTicks(end_time_ticks);
   _finished = _finish_time_ticks == _start_time_ticks;
   assert(_finish_time_ticks.value() >= 0, "invariant");
   assert(_finish_time_ticks >= _start_time_ticks, "invariant");

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -898,7 +898,7 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
           if (con > add1Con) {
             // Creates "(x << (C2 - C1)) & -(1 << C2)"
             Node* lshift = phase->transform(new LShiftINode(add1->in(1), phase->intcon(con - add1Con)));
-            return new AndINode(lshift, phase->intcon(-(1 << con)));
+            return new AndINode(lshift, phase->intcon(java_negate((jint)(1 << con))));
           } else {
             assert(con < add1Con, "must be (%d < %d)", con, add1Con);
             // Creates "(x >> (C1 - C2)) & -(1 << C2)"

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -67,18 +67,6 @@ JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
   }
 }
 
-JVMFlag::Error AllocatePrefetchDistanceConstraintFunc(intx value, bool verbose) {
-  if (value < 0 || value > 512) {
-    JVMFlag::printError(verbose,
-                        "AllocatePrefetchDistance (" INTX_FORMAT ") must be "
-                        "between 0 and %d\n",
-                        AllocatePrefetchDistance, 512);
-    return JVMFlag::VIOLATES_CONSTRAINT;
-  }
-
-  return JVMFlag::SUCCESS;
-}
-
 JVMFlag::Error AllocatePrefetchStepSizeConstraintFunc(intx value, bool verbose) {
   if (AllocatePrefetchStyle == 3) {
     if (value % wordSize != 0) {

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
@@ -36,7 +36,6 @@
 
 #define COMPILER_CONSTRAINTS(f)                         \
   f(intx,  CICompilerCountConstraintFunc)               \
-  f(intx,  AllocatePrefetchDistanceConstraintFunc)      \
   f(intx,  AllocatePrefetchInstrConstraintFunc)         \
   f(intx,  AllocatePrefetchStepSizeConstraintFunc)      \
   f(intx,  CompileThresholdConstraintFunc)              \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1239,7 +1239,7 @@ const int ObjectAlignmentInBytes = 8;
   product(intx,  AllocatePrefetchDistance, -1,                              \
           "Distance to prefetch ahead of allocation pointer. "              \
           "-1: use system-specific value (automatically determined")        \
-          constraint(AllocatePrefetchDistanceConstraintFunc,AfterMemoryInit)\
+          range(-1, 512)                                                    \
                                                                             \
   product(intx,  AllocatePrefetchLines, 3,                                  \
           "Number of lines to prefetch ahead of array allocation pointer")  \


### PR DESCRIPTION
Most of these changes are straight-forward, but these could use some explaining:

AllocatePrefetchDistance was accessed before it's dynamic constraint function got run.  I changed it to use static constraints.

RangeCheckEliminator::update_bound(): for constant bounds with meaningless values, bail out.  For X + c bounds, use Java wrap-around semantics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310606](https://bugs.openjdk.org/browse/JDK-8310606): Fix signed integer overflow, part 3 (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [85868499](https://git.openjdk.org/jdk/pull/14619/files/8586849944055d28d9e1f67c66a79831ca2c9ec3)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [85868499](https://git.openjdk.org/jdk/pull/14619/files/8586849944055d28d9e1f67c66a79831ca2c9ec3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14619/head:pull/14619` \
`$ git checkout pull/14619`

Update a local copy of the PR: \
`$ git checkout pull/14619` \
`$ git pull https://git.openjdk.org/jdk.git pull/14619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14619`

View PR using the GUI difftool: \
`$ git pr show -t 14619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14619.diff">https://git.openjdk.org/jdk/pull/14619.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14619#issuecomment-1603241993)