### PR TITLE
JDK-8310066: Improve test coverage for JVMTI GetThreadState on carrier and mounted vthread

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -79,10 +79,10 @@ public class GetThreadStateMountedTest {
         final Object syncObj = new Object();
         Thread vthread = createPinnedVThread(() -> {
             ready.countDown();
-            synchronized(syncObj) {
+            synchronized (syncObj) {
             }
         });
-        synchronized(syncObj) {
+        synchronized (syncObj) {
             vthread.start();
             ready.await();
             Thread.sleep(500); // wait some time to ensure the thread is blocked on monitor

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -36,6 +36,14 @@
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.LockSupport;
 
+/**
+ * The test implements different scenarios to get desired JVMTI thread states.
+ * For each scenarios test also checks states after carrier and virtual threads suspend/resume
+ * and after virtual thread interrupt.
+ * Special handling is required for WAITING state scenarios:
+ * Spurious wakeups may cause unexpected thread state change and this causes test failure.
+ * To avoid this test thread should be suspended (i.e. carrier and/or mounted virtual thread is suspended).
+ */
 public class GetThreadStateMountedTest {
 
     static final int JVMTI_THREAD_STATE_RUNNABLE                 = 0x0004;
@@ -65,7 +73,7 @@ public class GetThreadStateMountedTest {
         });
         vthread.start();
         ready.await();
-        testThreadStates(vthread, true, JVMTI_THREAD_STATE_RUNNABLE);
+        testThreadStates(vthread, false, true, JVMTI_THREAD_STATE_RUNNABLE);
         stopFlag[0] = true;
         status.print();
     }
@@ -86,7 +94,7 @@ public class GetThreadStateMountedTest {
             vthread.start();
             ready.await();
             Thread.sleep(500); // wait some time to ensure the thread is blocked on monitor
-            testThreadStates(vthread, true, JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER);
+            testThreadStates(vthread, false, true, JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER);
         }
         status.print();
     }
@@ -99,35 +107,44 @@ public class GetThreadStateMountedTest {
         // JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT
         // Thread is waiting with a maximum time to wait specified. For example, Object.wait(long).
         TestStatus status = new TestStatus(withTimeout
-                                           ? ">>JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT"
-                                           : ">>JVMTI_THREAD_STATE_WAITING_INDEFINITELY");
+                                           ? "JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT"
+                                           : "JVMTI_THREAD_STATE_WAITING_INDEFINITELY");
         CountDownLatch ready = new CountDownLatch(1);
+        // Test thread exits by InterruptedException,
+        // stopFlag is to handle spurious wakeups.
+        final boolean[] stopFlag = new boolean[1];
         final Object syncObj = new Object();
         Thread vthread = createPinnedVThread(() -> {
             synchronized (syncObj) {
                 try {
                     ready.countDown();
-                    if (withTimeout) {
-                        syncObj.wait(60000);
-                    } else {
-                        syncObj.wait();
+                    while (!stopFlag[0]) {
+                        if (withTimeout) {
+                            syncObj.wait(60000);
+                        } else {
+                            syncObj.wait();
+                        }
                     }
                 } catch (InterruptedException ex) {
-                    // expected, ignore
+                    // expected after testThreadStates
                 }
             }
         });
         vthread.start();
         ready.await();
-        Thread.sleep(500); // wait some time to ensure the thread is blocked on Object.wait
+
+        // Suspend test thread in "waiting" state.
+        suspendWaiting(vthread);
+
         int expectedState = JVMTI_THREAD_STATE_WAITING
                 | JVMTI_THREAD_STATE_IN_OBJECT_WAIT
                 | (withTimeout
                     ? JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT
                     : JVMTI_THREAD_STATE_WAITING_INDEFINITELY);
-        testThreadStates(vthread, true, expectedState);
+        testThreadStates(vthread, true,  true, expectedState);
         // signal test thread to finish (for safety, Object.wait should throw InterruptedException)
         synchronized (syncObj) {
+            stopFlag[0] = true;
             syncObj.notifyAll();
         }
         status.print();
@@ -141,20 +158,31 @@ public class GetThreadStateMountedTest {
         // may have this state flag set instead of JVMTI_THREAD_STATE_SLEEPING.
         TestStatus status = new TestStatus("JVMTI_THREAD_STATE_SLEEPING");
         CountDownLatch ready = new CountDownLatch(1);
+        // Test thread exits by InterruptedException,
+        // stopFlag is to handle spurious wakeups.
+        final boolean[] stopFlag = new boolean[1];
         Thread vthread = createPinnedVThread(() -> {
             ready.countDown();
             try {
-                Thread.sleep(60000);
+                while (!stopFlag[0]) {
+                    Thread.sleep(60000);
+                }
             } catch (InterruptedException ex) {
                 // expected, ignore
             }
         });
         vthread.start();
         ready.await();
-        Thread.sleep(500); // wait some time to ensure the thread has reached waiting state
+
+        // Suspend test thread in "waiting" state.
+        suspendWaiting(vthread);
+
+        // vthread is suspended, set stopFlag before testThreadStates
+        stopFlag[0] = true;
+
         // don't test interrupt() - it causes thread state change for parked thread
         // even if it's suspended
-        testThreadStates(vthread, false,
+        testThreadStates(vthread, true, false,
                 JVMTI_THREAD_STATE_WAITING | JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT,
                 JVMTI_THREAD_STATE_SLEEPING | JVMTI_THREAD_STATE_PARKED);
         status.print();
@@ -165,16 +193,26 @@ public class GetThreadStateMountedTest {
         // Thread is parked, for example: LockSupport.park, LockSupport.parkUtil and LockSupport.parkNanos.
         TestStatus status = new TestStatus("JVMTI_THREAD_STATE_PARKED");
         CountDownLatch ready = new CountDownLatch(1);
+        final boolean[] stopFlag = new boolean[1];
+
         Thread vthread = createPinnedVThread(() -> {
             ready.countDown();
-            LockSupport.park(Thread.currentThread());
+            while (!stopFlag[0]) {
+                LockSupport.park(Thread.currentThread());
+            }
         });
         vthread.start();
         ready.await();
-        Thread.sleep(500); // wait some time to ensure the thread has reached waiting state
+
+        // Suspend test thread in "waiting" state.
+        suspendWaiting(vthread);
+
+        // vthread is suspended, set stopFlag before testThreadStates
+        stopFlag[0] = true;
+
         // don't test interrupt() - it causes thread state change for parked thread
         // even if it's suspended
-        testThreadStates(vthread, false,
+        testThreadStates(vthread, true, false,
                 JVMTI_THREAD_STATE_WAITING | JVMTI_THREAD_STATE_WAITING_INDEFINITELY | JVMTI_THREAD_STATE_PARKED);
         // allow test thread to finish
         LockSupport.unpark(vthread);
@@ -190,9 +228,10 @@ public class GetThreadStateMountedTest {
         while (!waitInNativeReady) {
             Thread.sleep(50);
         }
-        testThreadStates(vthread, true,
+        testThreadStates(vthread, false, true,
                 JVMTI_THREAD_STATE_RUNNABLE | JVMTI_THREAD_STATE_IN_NATIVE,
                 0);
+        endWait();
         status.print();
     }
 
@@ -223,14 +262,32 @@ public class GetThreadStateMountedTest {
         });
     }
 
+    // Native implementation of suspendWaiting.
+    // Returns false if the method is not able to reach the desired state in several tries.
+    private static native boolean trySuspendInWaitingState(Thread vthread);
+
+    // Suspends virtual thread and ensures it's suspended in "waiting" state
+    // (to handle possible spurious wakeups).
+    // throws an exception if the method is not able to reach the desired state in several tries.
+    private static void suspendWaiting(Thread vthread) {
+        boolean result = trySuspendInWaitingState(vthread);
+        if (!result) {
+            throw new RuntimeException("Failed to suspend thread in WAITING state");
+        }
+    }
+
     // Tests thread states (vthread and the carrier thread).
     // expectedStrong specifies value which must be present in vthreat state;
     // expectedWeak is a combination of bits which may be set in vthreat state
     // (at least one of the bit must set, but not all).
-    private static native void testThread(Thread vthread,
+    // Note: Last steps of the testing are interrupt/resume the virtual thread,
+    // so after the call vthread is interrupted.
+    private static native void testThread(Thread vthread, boolean isVThreadSuspended,
                                           boolean testInterrupt,
                                           int expectedStrong, int expectedWeak);
     private static native int getErrorCount();
+    // To retry test case when spurious wakeup detected.
+    private static native int resetErrorCount(int count);
 
     private static boolean waitInNativeReady = false;
 
@@ -240,16 +297,17 @@ public class GetThreadStateMountedTest {
     // Signals waitInNative() to exit.
     private static native void endWait();
 
-    private static void testThreadStates(Thread vthread,
+    private static void testThreadStates(Thread vthread, boolean isVThreadSuspended,
                                          boolean testInterrupt,
                                          int expectedStrong, int expectedWeak) {
         String name = vthread.toString();
         log("Thread " + name);
-        testThread(vthread, testInterrupt, expectedStrong, expectedWeak);
+        testThread(vthread, isVThreadSuspended, testInterrupt, expectedStrong, expectedWeak);
     }
 
-    private static void testThreadStates(Thread vthread, boolean testInterrupt, int expectedState) {
-        testThreadStates(vthread, testInterrupt, expectedState, 0);
+    private static void testThreadStates(Thread vthread, boolean isVThreadSuspended,
+                                         boolean testInterrupt, int expectedState) {
+        testThreadStates(vthread, isVThreadSuspended, testInterrupt, expectedState, 0);
     }
 
     // helper class to print status of each test

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.LockSupport;
 
 /**
  * The test implements different scenarios to get desired JVMTI thread states.
- * For each scenario test also checks states after carrier and virtual threads suspend/resume
+ * For each scenario the test also checks states after carrier and virtual threads suspend/resume
  * and after virtual thread interrupt.
  * Special handling is required for WAITING state scenarios:
  * Spurious wakeups may cause unexpected thread state change and this causes test failure.

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.locks.LockSupport;
  * and after virtual thread interrupt.
  * Special handling is required for WAITING state scenarios:
  * Spurious wakeups may cause unexpected thread state change and this causes test failure.
- * To avoid this test thread should be suspended (i.e. carrier and/or mounted virtual thread is suspended).
+ * To avoid this, the test thread should be suspended (i.e. carrier and/or mounted virtual thread is suspended).
  */
 public class GetThreadStateMountedTest {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.LockSupport;
 
 /**
  * The test implements different scenarios to get desired JVMTI thread states.
- * For each scenarios test also checks states after carrier and virtual threads suspend/resume
+ * For each scenario test also checks states after carrier and virtual threads suspend/resume
  * and after virtual thread interrupt.
  * Special handling is required for WAITING state scenarios:
  * Spurious wakeups may cause unexpected thread state change and this causes test failure.

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8309612 8310584
+ * @summary The test verifies that JVMTI GetThreadState function reports expected state
+ *          for mounted (pinned) virtual thread and its carrier thread
+ * @requires vm.jvmti
+ * @requires vm.continuations
+ * @run main/othervm/native
+ *      -agentlib:GetThreadStateMountedTest
+ *      GetThreadStateMountedTest
+ */
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.LockSupport;
+
+public class GetThreadStateMountedTest {
+
+    static final int JVMTI_THREAD_STATE_RUNNABLE                 = 0x0004;
+    static final int JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER = 0x0400;
+    static final int JVMTI_THREAD_STATE_WAITING                  = 0x0080;
+    static final int JVMTI_THREAD_STATE_WAITING_INDEFINITELY     = 0x0010;
+    static final int JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT     = 0x0020;
+    static final int JVMTI_THREAD_STATE_IN_OBJECT_WAIT           = 0x0100;
+    static final int JVMTI_THREAD_STATE_SLEEPING                 = 0x0040;
+    static final int JVMTI_THREAD_STATE_PARKED                   = 0x0200;
+    static final int JVMTI_THREAD_STATE_IN_NATIVE                = 0x400000;
+
+    static void runnable() throws Exception {
+        TestStatus status = new TestStatus("JVMTI_THREAD_STATE_RUNNABLE");
+        CountDownLatch ready = new CountDownLatch(1);
+        final boolean[] stopFlag = new boolean[1];
+        Thread vthread = createPinnedVThread(() -> {
+            ready.countDown();
+            int i = 0;
+            while (!stopFlag[0]) {
+                if (i < 200) {
+                    i++;
+                } else {
+                    i = 0;
+                }
+            }
+        });
+        vthread.start();
+        ready.await();
+        testThreadStates(vthread, true, JVMTI_THREAD_STATE_RUNNABLE);
+        stopFlag[0] = true;
+        status.print();
+    }
+
+    static void blockedOnMonitorEnter() throws Exception {
+        // JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER
+        // Thread is waiting to enter a synchronized block/method or,
+        // after an Object.wait(), waiting to re-enter a synchronized block/method.
+        TestStatus status = new TestStatus("JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER");
+        CountDownLatch ready = new CountDownLatch(1);
+        final Object syncObj = new Object();
+        Thread vthread = createPinnedVThread(() -> {
+            ready.countDown();
+            synchronized(syncObj) {
+            }
+        });
+        synchronized(syncObj) {
+            vthread.start();
+            ready.await();
+            Thread.sleep(500); // wait some time to ensure the thread is blocked on monitor
+            testThreadStates(vthread, true, JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER);
+        }
+        status.print();
+    }
+
+    static void waiting(boolean withTimeout) throws Exception {
+        // JVMTI_THREAD_STATE_WAITING
+        // Thread is waiting.
+        // JVMTI_THREAD_STATE_WAITING_INDEFINITELY
+        // Thread is waiting without a timeout. For example, Object.wait().
+        // JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT
+        // Thread is waiting with a maximum time to wait specified. For example, Object.wait(long).
+        TestStatus status = new TestStatus(withTimeout
+                                           ? ">>JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT"
+                                           : ">>JVMTI_THREAD_STATE_WAITING_INDEFINITELY");
+        CountDownLatch ready = new CountDownLatch(1);
+        final Object syncObj = new Object();
+        Thread vthread = createPinnedVThread(() -> {
+            synchronized (syncObj) {
+                try {
+                    ready.countDown();
+                    if (withTimeout) {
+                        syncObj.wait(60000);
+                    } else {
+                        syncObj.wait();
+                    }
+                } catch (InterruptedException ex) {
+                    // expected, ignore
+                }
+            }
+        });
+        vthread.start();
+        ready.await();
+        Thread.sleep(500); // wait some time to ensure the thread is blocked on Object.wait
+        int expectedState = JVMTI_THREAD_STATE_WAITING
+                | JVMTI_THREAD_STATE_IN_OBJECT_WAIT
+                | (withTimeout
+                    ? JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT
+                    : JVMTI_THREAD_STATE_WAITING_INDEFINITELY);
+        testThreadStates(vthread, true, expectedState);
+        // signal test thread to finish (for safety, Object.wait should throw InterruptedException)
+        synchronized (syncObj) {
+            syncObj.notifyAll();
+        }
+        status.print();
+    }
+
+    static void sleeping() throws Exception {
+        // JVMTI_THREAD_STATE_SLEEPING
+        // Thread is sleeping -- Thread.sleep.
+        // JVMTI_THREAD_STATE_PARKED
+        // A virtual thread that is sleeping, in Thread.sleep,
+        // may have this state flag set instead of JVMTI_THREAD_STATE_SLEEPING.
+        TestStatus status = new TestStatus("JVMTI_THREAD_STATE_SLEEPING");
+        CountDownLatch ready = new CountDownLatch(1);
+        Thread vthread = createPinnedVThread(() -> {
+            ready.countDown();
+            try {
+                Thread.sleep(60000);
+            } catch (InterruptedException ex) {
+                // expected, ignore
+            }
+        });
+        vthread.start();
+        ready.await();
+        Thread.sleep(500); // wait some time to ensure the thread has reached waiting state
+        // don't test interrupt() - it causes thread state change for parked thread
+        // even if it's suspended
+        testThreadStates(vthread, false,
+                JVMTI_THREAD_STATE_WAITING | JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT,
+                JVMTI_THREAD_STATE_SLEEPING | JVMTI_THREAD_STATE_PARKED);
+        status.print();
+    }
+
+    static void parked() throws Exception {
+        // JVMTI_THREAD_STATE_PARKED
+        // Thread is parked, for example: LockSupport.park, LockSupport.parkUtil and LockSupport.parkNanos.
+        TestStatus status = new TestStatus("JVMTI_THREAD_STATE_PARKED");
+        CountDownLatch ready = new CountDownLatch(1);
+        Thread vthread = createPinnedVThread(() -> {
+            ready.countDown();
+            LockSupport.park(Thread.currentThread());
+        });
+        vthread.start();
+        ready.await();
+        Thread.sleep(500); // wait some time to ensure the thread has reached waiting state
+        // don't test interrupt() - it causes thread state change for parked thread
+        // even if it's suspended
+        testThreadStates(vthread, false,
+                JVMTI_THREAD_STATE_WAITING | JVMTI_THREAD_STATE_WAITING_INDEFINITELY | JVMTI_THREAD_STATE_PARKED);
+        // allow test thread to finish
+        LockSupport.unpark(vthread);
+        status.print();
+    }
+
+    static void inNative() throws Exception {
+        TestStatus status = new TestStatus("JVMTI_THREAD_STATE_IN_NATIVE");
+        Thread vthread = createPinnedVThread(() -> {
+            waitInNative();
+        });
+        vthread.start();
+        while (!waitInNativeReady) {
+            Thread.sleep(50);
+        }
+        testThreadStates(vthread, true,
+                JVMTI_THREAD_STATE_RUNNABLE | JVMTI_THREAD_STATE_IN_NATIVE,
+                0);
+        status.print();
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        runnable();
+        /* "waiting" test cases fail due JDK-8310584
+        blockedOnMonitorEnter();
+        waiting(false);
+        waiting(true);
+        sleeping();
+        parked();
+        */
+        inNative();
+
+        int errCount = getErrorCount();
+        if (errCount > 0) {
+            throw new RuntimeException("Test failed, " + errCount + " errors");
+        }
+    }
+
+    private static Thread createPinnedVThread(Runnable runnable) {
+        final Object syncObj = new Object();
+        return Thread.ofVirtual().unstarted(() -> {
+            synchronized (syncObj) {
+                runnable.run();
+            }
+        });
+    }
+
+    // Tests thread states (vthread and the carrier thread).
+    // expectedStrong specifies value which must be present in vthreat state;
+    // expectedWeak is a combination of bits which may be set in vthreat state
+    // (at least one of the bit must set, but not all).
+    private static native void testThread(Thread vthread,
+                                          boolean testInterrupt,
+                                          int expectedStrong, int expectedWeak);
+    private static native int getErrorCount();
+
+    private static boolean waitInNativeReady = false;
+
+    // Sets waitInNativeReady static field to true
+    // and then waits until endWait() method is called.
+    private static native void waitInNative();
+    // Signals waitInNative() to exit.
+    private static native void endWait();
+
+    private static void testThreadStates(Thread vthread,
+                                         boolean testInterrupt,
+                                         int expectedStrong, int expectedWeak) {
+        String name = vthread.toString();
+        log("Thread " + name);
+        testThread(vthread, testInterrupt, expectedStrong, expectedWeak);
+    }
+
+    private static void testThreadStates(Thread vthread, boolean testInterrupt, int expectedState) {
+        testThreadStates(vthread, testInterrupt, expectedState, 0);
+    }
+
+    // helper class to print status of each test
+    private static class TestStatus {
+        private final String name;
+        private final int startErrorCount;
+        TestStatus(String name) {
+            this.name = name;
+            startErrorCount = getErrorCount();
+            log(">>" + name);
+        }
+        void print() {
+            log("<<" + name + (startErrorCount == getErrorCount() ? " - OK" : " - FAILED"));
+            log("");
+        }
+    }
+
+    private static void log(Object s) {
+        System.out.println(s);
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/libGetThreadStateMountedTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/libGetThreadStateMountedTest.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+#include <jvmti.h>
+#include <jvmti_common.h>
+#include <atomic>
+
+static jvmtiEnv *jvmti = nullptr;
+static jint error_count = 0;
+
+extern "C" JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
+  if (vm->GetEnv((void **)&jvmti, JVMTI_VERSION) != JNI_OK) {
+    LOG("Could not initialize JVMTI\n");
+    return JNI_ERR;
+  }
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_support_virtual_threads = 1;
+  caps.can_suspend = 1;
+  caps.can_signal_thread = 1;
+  jvmtiError err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("JVMTI AddCapabilities error: %d\n", err);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+
+static void verify_thread_state(const char *name, JNIEnv* jni,
+  jthread thread, jint expected_strong, jint expected_weak)
+{
+  jint state = get_thread_state(jvmti, jni, thread);
+  LOG("%s state(%x): %s\n", name, state, TranslateState(state));
+  bool failed = false;
+  // check 1: all expected_strong bits are set
+  jint actual_strong = state & expected_strong;
+  if (actual_strong != expected_strong) {
+    failed = true;
+    jint missed = expected_strong - actual_strong;
+    LOG("  ERROR: some mandatory bits are not set (%x): %s\n",
+       missed, TranslateState(missed));
+  }
+  // check 2: no bits other than (expected_strong | expected_weak) are set
+  jint actual_full = state & (expected_strong | expected_weak);
+  if (actual_full != state) {
+    failed = true;
+    jint unexpected = state - actual_full;
+    LOG("  ERROR: some unexpected bits are set (%x): %s\n",
+       unexpected, TranslateState(unexpected));
+  }
+  // check 3: expected_weak checks
+  if (expected_weak != 0) {
+    // check 3a: at least 1 bit from expected_weak is set
+    if ((state & expected_weak) == 0) {
+      failed = true;
+      LOG("  ERROR: no expected 'weak' bits are set\n");
+    }
+    // check 3b: not all expected_weak bits are set
+    if ((state & expected_weak) == expected_weak) {
+      failed = true;
+      LOG("  ERROR: all expected 'weak' bits are set\n");
+    }
+  }
+
+  if (failed) {
+    LOG("  expected 'strong' state (%x): %s\n", expected_strong, TranslateState(expected_strong));
+    LOG("  expected 'weak' state (%x): %s\n", expected_weak, TranslateState(expected_weak));
+    error_count++;
+  }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_GetThreadStateMountedTest_testThread(
+  JNIEnv* jni, jclass clazz, jthread vthread, jboolean test_interrupt,
+  jint expected_strong, jint expected_weak)
+{
+  jint exp_ct_state = JVMTI_THREAD_STATE_ALIVE
+                      | JVMTI_THREAD_STATE_WAITING
+                      | JVMTI_THREAD_STATE_WAITING_INDEFINITELY;
+  jint exp_vt_state = expected_strong
+                      | JVMTI_THREAD_STATE_ALIVE;
+
+  jthread cthread = get_carrier_thread(jvmti, jni, vthread);
+
+  verify_thread_state("cthread", jni, cthread,
+                      exp_ct_state, 0);
+  verify_thread_state("vthread", jni, vthread,
+                      exp_vt_state, expected_weak);
+
+  // suspend ctread and verify
+  LOG("suspend cthread\n");
+  suspend_thread(jvmti, jni, cthread);
+  verify_thread_state("cthread", jni, cthread,
+                      exp_ct_state | JVMTI_THREAD_STATE_SUSPENDED, 0);
+  verify_thread_state("vthread", jni, vthread,
+                      exp_vt_state, expected_weak);
+
+  // suspend vtread and verify
+  LOG("suspend vthread\n");
+  suspend_thread(jvmti, jni, vthread);
+  verify_thread_state("cthread", jni, cthread,
+                      exp_ct_state | JVMTI_THREAD_STATE_SUSPENDED, 0);
+  verify_thread_state("vthread", jni, vthread,
+                      exp_vt_state | JVMTI_THREAD_STATE_SUSPENDED, expected_weak);
+
+  // resume cthread and verify
+  LOG("resume cthread\n");
+  resume_thread(jvmti, jni, cthread);
+  verify_thread_state("cthread", jni, cthread,
+                      exp_ct_state, 0);
+  verify_thread_state("vthread", jni, vthread,
+                      exp_vt_state | JVMTI_THREAD_STATE_SUSPENDED, expected_weak);
+
+  if (test_interrupt) {
+    // interrupt vthread (while it's suspended)
+    LOG("interrupt vthread\n");
+    check_jvmti_status(jni, jvmti->InterruptThread(vthread), "error in JVMTI InterruptThread");
+    verify_thread_state("cthread", jni, cthread,
+                        exp_ct_state, 0);
+    verify_thread_state("vthread", jni, vthread,
+                        exp_vt_state | JVMTI_THREAD_STATE_SUSPENDED | JVMTI_THREAD_STATE_INTERRUPTED,
+                        expected_weak);
+  }
+
+  // resume vthread;
+  LOG("resume vthread\n");
+  resume_thread(jvmti, jni, vthread);
+
+  // don't verify thread state after InterruptThread and ResumeThread
+}
+
+extern "C" JNIEXPORT int JNICALL
+Java_GetThreadStateMountedTest_getErrorCount(JNIEnv* jni, jclass clazz) {
+  return error_count;
+}
+
+
+static std::atomic<bool> time_to_exit(false);
+
+extern "C" JNIEXPORT void JNICALL
+Java_GetThreadStateMountedTest_waitInNative(JNIEnv* jni, jclass clazz) {
+  // Notify main thread that we are ready
+  jfieldID fid = jni->GetStaticFieldID(clazz, "waitInNativeReady", "Z");
+  if (fid == nullptr) {
+    jni->FatalError("cannot get waitInNativeReady field");
+    return;
+  }
+  jni->SetStaticBooleanField(clazz, fid, JNI_TRUE);
+
+  while (!time_to_exit) {
+    sleep_ms(100);
+  }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_GetThreadStateMountedTest_endWait(JNIEnv* jni, jclass clazz) {
+  time_to_exit = true;
+}


### PR DESCRIPTION
This is follow-up JDK-8307153/JDK-8309612 (JVMTI GetThreadState on carrier should return STATE_WAITING)
New test tests GetThreadState for different thread states.
The test detected a bug in the implementation, new issue is created: JDK-8310584
Corresponding testcases are commented now in the test, fix for JDK-8310584 will uncomment them

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310066](https://bugs.openjdk.org/browse/JDK-8310066): Improve test coverage for JVMTI GetThreadState on carrier and mounted vthread (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [8918411b](https://git.openjdk.org/jdk/pull/14622/files/8918411bdaa4882ba998a9ba4ae777273a0e54b2)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14622/head:pull/14622` \
`$ git checkout pull/14622`

Update a local copy of the PR: \
`$ git checkout pull/14622` \
`$ git pull https://git.openjdk.org/jdk.git pull/14622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14622`

View PR using the GUI difftool: \
`$ git pr show -t 14622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14622.diff">https://git.openjdk.org/jdk/pull/14622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14622#issuecomment-1603590882)