### PR TITLE
8310731: Configure a javax.net.ssl.SNIMatcher for the HTTP/1.1 test servers in java/net/httpclient tests

### DIFF
--- a/test/jdk/java/net/httpclient/AsFileDownloadTest.java
+++ b/test/jdk/java/net/httpclient/AsFileDownloadTest.java
@@ -24,7 +24,6 @@
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,6 +52,7 @@ import javax.net.ssl.SSLContext;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.util.FileUtils;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2Handler;
@@ -75,6 +75,7 @@ import static org.testng.Assert.fail;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
  *        jdk.test.lib.Platform jdk.test.lib.util.FileUtils
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm AsFileDownloadTest
  * @run testng/othervm/java.security.policy=AsFileDownloadTest.policy AsFileDownloadTest
  */
@@ -322,7 +323,7 @@ public class AsFileDownloadTest {
         httpURI = "http://" + serverAuthority(httpTestServer) + "/http1/afdt";
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsTestServer.createContext("/https1/afdt", new Http1FileDispoHandler());
         httpsURI = "https://" + serverAuthority(httpsTestServer) + "/https1/afdt";
 

--- a/test/jdk/java/net/httpclient/AuthFilterCacheTest.java
+++ b/test/jdk/java/net/httpclient/AuthFilterCacheTest.java
@@ -35,6 +35,7 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -51,7 +52,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  * @summary AuthenticationFilter.Cache::remove may throw ConcurrentModificationException
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
- *        DigestEchoServer
+ *        DigestEchoServer jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm -Dtest.requiresHost=true
  * -Djdk.tracePinnedThreads=full
  * -Djdk.httpclient.HttpClient.log=headers
@@ -133,7 +134,7 @@ public class AuthFilterCacheTest implements HttpServerAdapters {
             // HTTPS/1.1
             HttpsServer sserver1 = HttpsServer.create(sa, 100);
             sserver1.setExecutor(serverExecutor);
-            sserver1.setHttpsConfigurator(new HttpsConfigurator(context));
+            sserver1.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), context));
             https1Server = HttpTestServer.of(sserver1);
             https1Server.addHandler(new TestHandler(), "/AuthFilterCacheTest/https1/");
             https1Server.start();

--- a/test/jdk/java/net/httpclient/ConcurrentResponses.java
+++ b/test/jdk/java/net/httpclient/ConcurrentResponses.java
@@ -28,6 +28,7 @@
  *          unprocessed HTTP data
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm
  *      -Djdk.tracePinnedThreads=full
  *      -Djdk.httpclient.HttpClient.log=headers,errors,channel
@@ -55,7 +56,6 @@ import javax.net.ssl.SSLContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -64,6 +64,8 @@ import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse.BodySubscribers;
+
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2Handler;
@@ -291,7 +293,7 @@ public class ConcurrentResponses {
         httpChunkedURI = "http://" + serverAuthority(httpTestServer) + "/http1/chunked";
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsTestServer.createContext("/https1/fixed", new Http1FixedHandler());
         httpsFixedURI = "https://" + serverAuthority(httpsTestServer) + "/https1/fixed";
         httpsTestServer.createContext("/https1/chunked", new Http1ChunkedHandler());

--- a/test/jdk/java/net/httpclient/CustomResponseSubscriber.java
+++ b/test/jdk/java/net/httpclient/CustomResponseSubscriber.java
@@ -26,6 +26,7 @@
  * @summary Tests response body subscribers's onComplete is not invoked before onSubscribe
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm CustomResponseSubscriber
  */
 
@@ -43,7 +44,6 @@ import java.util.concurrent.Flow;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -52,6 +52,8 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse.BodySubscribers;
+
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2Handler;
@@ -200,7 +202,7 @@ public class CustomResponseSubscriber {
         httpURI_chunk = "http://" + serverAuthority(httpTestServer) + "/http1/chunk";
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsTestServer.createContext("/https1/fixed", h1_fixedLengthHandler);
         httpsTestServer.createContext("/https1/chunk", h1_chunkHandler);
         httpsURI_fixed = "https://" + serverAuthority(httpsTestServer) + "/https1/fixed";

--- a/test/jdk/java/net/httpclient/ExpectContinue.java
+++ b/test/jdk/java/net/httpclient/ExpectContinue.java
@@ -24,17 +24,16 @@
 /*
  * @test
  * @summary Basic test for Expect 100-Continue ( HTTP/1.1 only )
- * @modules java.net.http
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.common.TestServerConfigurator
+ * @modules java.net.http/jdk.internal.net.http.common
  *          jdk.httpserver
- * @library /test/lib
- * @build jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm ExpectContinue
  */
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +48,8 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.List;
 import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -148,7 +149,7 @@ public class ExpectContinue {
         httpURI = "http://" + serverAuthority(httpTestServer) + "/http1/ec";
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsTestServer.createContext("/https1/ec", new Http1ExpectContinueHandler());
         httpsURI = "https://" + serverAuthority(httpsTestServer) + "/https1/ec";
 

--- a/test/jdk/java/net/httpclient/HttpRedirectTest.java
+++ b/test/jdk/java/net/httpclient/HttpRedirectTest.java
@@ -20,9 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.AfterClass;
@@ -60,7 +59,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 /**
  * @test
@@ -69,6 +67,7 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext DigestEchoServer HttpRedirectTest
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm -Dtest.requiresHost=true
  *                   -Djdk.httpclient.HttpClient.log=headers
  *                   -Djdk.internal.httpclient.debug=false
@@ -175,7 +174,7 @@ public class HttpRedirectTest implements HttpServerAdapters {
             // HTTPS/1.1
             HttpsServer sserver1 = HttpsServer.create(sa, 100);
             sserver1.setExecutor(executor);
-            sserver1.setHttpsConfigurator(new HttpsConfigurator(context));
+            sserver1.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), context));
             https1Server = HttpTestServer.of(sserver1);
             https1Server.addHandler(new HttpTestRedirectHandler("https", https1Server),
                     "/HttpRedirectTest/https1/");

--- a/test/jdk/java/net/httpclient/HttpSlowServerTest.java
+++ b/test/jdk/java/net/httpclient/HttpSlowServerTest.java
@@ -20,9 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 
 import javax.net.ssl.SSLContext;
@@ -51,7 +50,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 
@@ -62,6 +60,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
  *        DigestEchoServer HttpSlowServerTest
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run main/othervm -Dtest.requiresHost=true
  *                   -Djdk.httpclient.HttpClient.log=headers
  *                   -Djdk.internal.httpclient.debug=false
@@ -138,7 +137,7 @@ public class HttpSlowServerTest implements HttpServerAdapters {
             // HTTPS/1.1
             HttpsServer sserver1 = HttpsServer.create(sa, 100);
             sserver1.setExecutor(executor);
-            sserver1.setHttpsConfigurator(new HttpsConfigurator(context));
+            sserver1.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), context));
             https1Server = HttpTestServer.of(sserver1);
             https1Server.addHandler(new HttpTestSlowHandler(), "/HttpSlowServerTest/https1/");
             https1Server.start();

--- a/test/jdk/java/net/httpclient/ImmutableFlowItems.java
+++ b/test/jdk/java/net/httpclient/ImmutableFlowItems.java
@@ -27,6 +27,7 @@
  *          and that the buffers are read-only
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm ImmutableFlowItems
  */
 
@@ -43,7 +44,6 @@ import java.util.concurrent.Flow;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -53,6 +53,8 @@ import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse.BodySubscribers;
 import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2Handler;
@@ -189,7 +191,7 @@ public class ImmutableFlowItems {
         httpURI_chunk = "http://" + serverAuthority(httpTestServer) + "/http1/chunk";
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsTestServer.createContext("/https1/fixed", h1_fixedLengthHandler);
         httpsTestServer.createContext("/https1/chunk", h1_chunkHandler);
         httpsURI_fixed = "https://" + serverAuthority(httpsTestServer) + "/https1/fixed";

--- a/test/jdk/java/net/httpclient/LargeHandshakeTest.java
+++ b/test/jdk/java/net/httpclient/LargeHandshakeTest.java
@@ -20,8 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -61,7 +59,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 
@@ -82,6 +80,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
  *        DigestEchoServer
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run main/othervm -Dtest.requiresHost=true
  *                   -Djdk.httpclient.HttpClient.log=headers
  *                   -Djdk.internal.httpclient.debug=true
@@ -1011,7 +1010,7 @@ public class LargeHandshakeTest implements HttpServerAdapters {
             // HTTPS/1.1
             HttpsServer sserver1 = HttpsServer.create(sa, 100);
             sserver1.setExecutor(executor);
-            sserver1.setHttpsConfigurator(new HttpsConfigurator(context));
+            sserver1.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), context));
             https1Server = HttpTestServer.of(sserver1);
             https1Server.addHandler(new HttpTestLargeHandler(), "/LargeHandshakeTest/https1/");
             https1Server.start();

--- a/test/jdk/java/net/httpclient/LargeResponseTest.java
+++ b/test/jdk/java/net/httpclient/LargeResponseTest.java
@@ -20,9 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 
 import javax.net.ssl.SSLContext;
@@ -38,7 +37,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
@@ -51,7 +49,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 
@@ -64,6 +61,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters
  *        jdk.test.lib.net.SimpleSSLContext DigestEchoServer
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run main/othervm -Dtest.requiresHost=true
  *                   -Djdk.httpclient.HttpClient.log=headers
  *                   -Djdk.internal.httpclient.debug=true
@@ -136,7 +134,7 @@ public class LargeResponseTest implements HttpServerAdapters {
             // HTTPS/1.1
             HttpsServer sserver1 = HttpsServer.create(sa, 100);
             sserver1.setExecutor(executor);
-            sserver1.setHttpsConfigurator(new HttpsConfigurator(context));
+            sserver1.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), context));
             https1Server = HttpTestServer.of(sserver1);
             https1Server.addHandler(new HttpTestLargeHandler(), "/LargeResponseTest/https1/");
             https1Server.start();

--- a/test/jdk/java/net/httpclient/LightWeightHttpServer.java
+++ b/test/jdk/java/net/httpclient/LightWeightHttpServer.java
@@ -33,7 +33,6 @@ import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,6 +49,8 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 
 public class LightWeightHttpServer {
@@ -111,7 +112,7 @@ public class LightWeightHttpServer {
         httpServer.setExecutor(executor);
         httpsServer.setExecutor(executor);
         ctx = new SimpleSSLContext().get();
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(ctx));
+        httpsServer.setHttpsConfigurator(new TestServerConfigurator(addr.getAddress(), ctx));
         httpServer.start();
         httpsServer.start();
 

--- a/test/jdk/java/net/httpclient/MappingResponseSubscriber.java
+++ b/test/jdk/java/net/httpclient/MappingResponseSubscriber.java
@@ -26,6 +26,7 @@
  * @summary Tests mapped response subscriber
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
+ *        jdk.httpclient.test.lib.common.TestServerConfigurator
  * @run testng/othervm
  *       -Djdk.internal.httpclient.debug=true
  *      MappingResponseSubscriber
@@ -46,7 +47,6 @@ import java.util.concurrent.Flow;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -59,6 +59,7 @@ import  java.net.http.HttpResponse.BodySubscriber;
 import java.util.function.Function;
 import javax.net.ssl.SSLContext;
 
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.internal.net.http.common.OperationTrackers.Tracker;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
@@ -230,7 +231,7 @@ public class MappingResponseSubscriber {
         httpURI_chunk = "http://" + serverAuthority(httpTestServer) + "/http1/chunk";
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsTestServer.createContext("/https1/fixed", h1_fixedLengthHandler);
         httpsTestServer.createContext("/https1/chunk", h1_chunkHandler);
         httpsURI_fixed = "https://" + serverAuthority(httpsTestServer) + "/https1/fixed";

--- a/test/jdk/java/net/httpclient/RequestBodyTest.java
+++ b/test/jdk/java/net/httpclient/RequestBodyTest.java
@@ -59,14 +59,14 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @bug 8087112
- * @modules java.net.http
+ * @modules java.net.http/jdk.internal.net.http.common
  *          java.logging
  *          jdk.httpserver
- * @library /test/lib
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @compile ../../../com/sun/net/httpserver/LogFilter.java
  * @compile ../../../com/sun/net/httpserver/EchoHandler.java
  * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
- * @build jdk.test.lib.net.SimpleSSLContext
+ * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.common.TestServerConfigurator
  * @build LightWeightHttpServer
  * @build jdk.test.lib.Platform
  * @build jdk.test.lib.util.FileUtils

--- a/test/jdk/java/net/httpclient/RequestBodyTest.policy
+++ b/test/jdk/java/net/httpclient/RequestBodyTest.policy
@@ -33,6 +33,11 @@ grant codeBase "file:${test.classes}/../../../../test/lib/-" {
     permission java.io.FilePermission "${test.src}/../../../../lib/jdk/test/lib/net/testkeys", "read";
 };
 
+// for jdk/httpclient/test/lib/* classes
+grant codeBase "file:${test.classes}/../../../../test/jdk/java/net/httpclient/lib/-" {
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.common";
+};
+
 grant codeBase "file:${test.classes}/*" {
     permission java.io.FilePermission "${test.src}${/}docs${/}files${/}smallfile.txt", "read";
     permission java.io.FilePermission "${test.src}${/}docs${/}files${/}notsobigfile.txt", "read";
@@ -52,4 +57,6 @@ grant codeBase "file:${test.classes}/*" {
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";
+
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.common";
 };

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -30,7 +30,6 @@ import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import jdk.httpclient.test.lib.http2.Http2Handler;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
@@ -798,14 +797,14 @@ public interface HttpServerAdapters {
                     return HttpTestServer.of(underlying);
                 }
                 case HTTP_1_1 ->  {
-                    InetSocketAddress sa = new InetSocketAddress(
-                            InetAddress.getLoopbackAddress(), 0);
+                    InetAddress loopback = InetAddress.getLoopbackAddress();
+                    InetSocketAddress sa = new InetSocketAddress(loopback, 0);
                     HttpServer underlying;
                     if (sslContext == null) {
                         underlying = HttpServer.create(sa, 0); // HTTP
                     } else {
                         HttpsServer https = HttpsServer.create(sa, 0); // HTTPS
-                        https.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+                        https.setHttpsConfigurator(new TestServerConfigurator(loopback, sslContext));
                         underlying = https;
                     }
                     if (executor != null) {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/ServerNameMatcher.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/ServerNameMatcher.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.httpclient.test.lib.common;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.StandardConstants;
+
+import jdk.internal.net.http.common.Logger;
+import jdk.internal.net.http.common.Utils;
+
+/**
+ * A (server side) SNI host name matcher. Implementation is based on the expectations set in
+ * section 3 of RFC-6066.
+ * A server can be configured with an instance of this class.
+ * <p>
+ * The RFC states:
+ * {@code
+ * Currently, the only server names supported are DNS hostnames; however, this does not imply
+ * any dependency of TLS on DNS,
+ * ....
+ * TLS MAY treat provided server names as opaque data and pass the names and types to the application.
+ * }
+ * <p>
+ * The implementation in this class doesn't mandate the configured/recognized SNI host name as DNS
+ * resolvable. However, the {@code ServerNameMatcher} can be configured to treat the SNI host name
+ * as DNS resolvable by passing {@code true} to the {@code attemptDNSResolution} parameter of
+ * the {@link #ServerNameMatcher(boolean, String) constructor}
+ */
+public class ServerNameMatcher extends SNIMatcher {
+
+    private final Logger debug;
+    private final boolean attemptDNSResolution;
+    private final Set<String> recognizedSNINames;
+
+    /**
+     * Creates a ServerNameMatcher which recognizes the passed {@code recognizedSNIName}
+     *
+     * @param recognizedSNIName The SNI host name
+     */
+    public ServerNameMatcher(final String recognizedSNIName) {
+        this(false, recognizedSNIName);
+    }
+
+    /**
+     * Creates a ServerNameMatcher which recognizes the passed SNI host name
+     * If {@code attemptDNSResolution} is {@code true}, then when
+     * {@link #matches(SNIServerName) matching} a client requested SNI name against the server
+     * recognized SNI name, the implementation will, as a last resort do a DNS resolution of the
+     * client requested SNI name and the server recognized SNI name and compare them to
+     * try and find a match. If {@code attemptDNSResolution} is false, then no DNS resolution is
+     * attempted and instead the SNI names are literally compared.
+     *
+     * @param attemptDNSResolution If true then a DNS resolution will be attempted during
+     *                             {@link #matches(SNIServerName) SNI matching}
+     * @param recognizedSNIName    SNI host name
+     */
+    public ServerNameMatcher(final boolean attemptDNSResolution,
+                             final String recognizedSNIName) {
+        super(StandardConstants.SNI_HOST_NAME);
+        Objects.requireNonNull(recognizedSNIName);
+        this.debug = Utils.getDebugLogger(() -> "SNIMatcher");
+        this.recognizedSNINames = Set.of(recognizedSNIName);
+        this.attemptDNSResolution = attemptDNSResolution;
+    }
+
+    /**
+     * @param clientRequestedSNI the SNI name requested by the client
+     *                           {@return true if the {@code clientRequestedSNI} is recognized by
+     *                           the server. false otherwise}
+     */
+    @Override
+    public boolean matches(final SNIServerName clientRequestedSNI) {
+        Objects.requireNonNull(clientRequestedSNI);
+        if (!SNIHostName.class.isInstance(clientRequestedSNI)) {
+            if (debug.on()) {
+                debug.log("SNI match (against " + recognizedSNINames + ")" +
+                        " failed - not a SNIHostName: " + clientRequestedSNI);
+            }
+            // we only support SNIHostName type
+            return false;
+        }
+        final String requestedName = ((SNIHostName) clientRequestedSNI).getAsciiName();
+        if (recognizedSNINames.contains(requestedName)) {
+            if (debug.on()) {
+                debug.log("SNI match (against " + recognizedSNINames + ") passed: "
+                        + clientRequestedSNI);
+            }
+            return true;
+        }
+        if (attemptDNSResolution) {
+            final boolean res = matchesAfterDNSResolution(requestedName);
+            if (debug.on()) {
+                debug.log("SNI match (against " + recognizedSNINames + ") "
+                        + (res ? "passed" : "failed") + ": " + clientRequestedSNI);
+            }
+            return res;
+        }
+        if (debug.on()) {
+            debug.log("SNI match (against " + recognizedSNINames + ") failed: " + clientRequestedSNI);
+        }
+        return false;
+    }
+
+    private boolean matchesAfterDNSResolution(final String clientRequestedSNI) {
+        final InetAddress clientRequestedAddr;
+        try {
+            clientRequestedAddr = InetAddress.getByName(clientRequestedSNI);
+        } catch (IOException e) {
+            return false;
+        }
+        for (final String recognizedSNIName : recognizedSNINames) {
+            final InetAddress serverRecognizedAddr;
+            try {
+                serverRecognizedAddr = InetAddress.getByName(recognizedSNIName);
+            } catch (IOException e) {
+                // try next
+                continue;
+            }
+            if (serverRecognizedAddr.equals(clientRequestedAddr)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/TestServerConfigurator.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/TestServerConfigurator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.httpclient.test.lib.common;
+
+import java.net.InetAddress;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsParameters;
+
+/**
+ * A {@link HttpsConfigurator} that can be used with the HTTP1 test server over HTTPS.
+ * This configurator {@link #configure(HttpsParameters) configures} the server's
+ * {@link HttpsParameters} with the necessary {@link SSLParameters} including a
+ * {@link SNIMatcher}
+ */
+public final class TestServerConfigurator extends HttpsConfigurator {
+
+    private final InetAddress serverAddr;
+
+    /**
+     * Creates a Https configuration, with the given {@link SSLContext}.
+     *
+     * @param serverAddr the address to which the server is bound
+     * @param context    the {@code SSLContext} to use for this configurator
+     * @throws NullPointerException if no {@code SSLContext} supplied
+     */
+    public TestServerConfigurator(final InetAddress serverAddr, final SSLContext context) {
+        super(context);
+        this.serverAddr = serverAddr;
+    }
+
+    @Override
+    public void configure(final HttpsParameters params) {
+        final SSLParameters sslParams = getSSLContext().getDefaultSSLParameters();
+        @SuppressWarnings("removal") final SecurityManager sm = System.getSecurityManager();
+        final String hostname;
+        if (sm == null) {
+            hostname = serverAddr.getHostName();
+        } else {
+            final PrivilegedAction<String> action = () -> serverAddr.getHostName();
+            hostname = AccessController.doPrivileged(action);
+        }
+        final List<SNIMatcher> sniMatchers = List.of(new ServerNameMatcher(hostname));
+        sslParams.setSNIMatchers(sniMatchers);
+        // configure the server with these custom SSLParameters
+        params.setSSLParameters(sslParams);
+    }
+}

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -25,18 +25,18 @@
  * @test
  * @bug 8245245
  * @summary Test for Websocket URI encoding during HandShake
- * @library /test/lib
- * @build jdk.test.lib.net.SimpleSSLContext
- * @modules java.net.http
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.common.TestServerConfigurator
+ * @modules java.net.http/jdk.internal.net.http.common
  *          jdk.httpserver
  * @run testng/othervm -Djdk.internal.httpclient.debug=true HandshakeUrlEncodingTest
  */
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import com.sun.net.httpserver.HttpExchange;
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.net.URIBuilder;
 import org.testng.annotations.AfterTest;
@@ -154,7 +154,7 @@ public class HandshakeUrlEncodingTest {
         httpTestServer.createContext("/", new UrlHandler());
 
         httpsTestServer = HttpsServer.create(sa, 10);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsURI = URIBuilder.newBuilder()
                              .scheme("wss")
                              .host("localhost")

--- a/test/jdk/java/net/httpclient/websocket/WSHandshakeExceptionTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WSHandshakeExceptionTest.java
@@ -25,16 +25,15 @@
  * @test
  * @bug 8240666
  * @summary Basic test for WebSocketHandshakeException
- * @library /test/lib
- * @build jdk.test.lib.net.SimpleSSLContext
- * @modules java.net.http
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.common.TestServerConfigurator
+ * @modules java.net.http/jdk.internal.net.http.common
  *          jdk.httpserver
  * @run testng/othervm -Djdk.internal.httpclient.debug=true WSHandshakeExceptionTest
  */
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import com.sun.net.httpserver.HttpExchange;
 
@@ -47,6 +46,8 @@ import java.net.InetAddress;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
 import java.net.http.WebSocketHandshakeException;
+
+import jdk.httpclient.test.lib.common.TestServerConfigurator;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -172,7 +173,7 @@ public class WSHandshakeExceptionTest {
         httpTestServer.createContext("/nonutf8body", new BodyHandler());
 
         httpsTestServer = HttpsServer.create(sa, 0);
-        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsTestServer.setHttpsConfigurator(new TestServerConfigurator(sa.getAddress(), sslContext));
         httpsURI = "wss://localhost:" + httpsTestServer.getAddress().getPort() + "/";
         httpsNonUtf8URI = "wss://localhost:" + httpsTestServer.getAddress().getPort() + "/nonutf8body";
         httpsTestServer.createContext("/nonutf8body", new BodyHandler());


### PR DESCRIPTION
Can I please get a review of this test-only change which addresses https://bugs.openjdk.org/browse/JDK-8310731?

As noted in that issue, before the changes in this PR, the test servers that we created for HTTP/1.1 testing in `java/net/httpclient` tests weren't configured to use a `javax.net.ssl.SNIMatcher` which resulted in the SNI name extension from the client being ignored. The commit in this PR addresses that by configuring such instances with a relevant `SNIMatcher`. 

No new tests have been added given the nature of this change, but existing tests in `java/net/httpclient` continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310731](https://bugs.openjdk.org/browse/JDK-8310731): Configure a javax.net.ssl.SNIMatcher for the HTTP/1.1 test servers in java/net/httpclient tests (**Task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14626/head:pull/14626` \
`$ git checkout pull/14626`

Update a local copy of the PR: \
`$ git checkout pull/14626` \
`$ git pull https://git.openjdk.org/jdk.git pull/14626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14626`

View PR using the GUI difftool: \
`$ git pr show -t 14626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14626.diff">https://git.openjdk.org/jdk/pull/14626.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14626#issuecomment-1604230147)