### PR TITLE
8310735: Build failure after JDK-8310577 with GCC8

### DIFF
--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -281,7 +281,7 @@ class ShortLoopOptimizer : public ValueNumberingVisitor {
   }
   void      kill_array(ValueType* type)                   {
     current_map()->kill_array(type);
-    BasicType basic_type = as_BasicType(type); assert(basic_type >= 0 && basic_type < T_VOID, "Invalid type");
+    BasicType basic_type = as_BasicType(type); assert(basic_type < T_VOID, "Invalid type");
     _has_indexed_store[basic_type] = true;
   }
 
@@ -298,12 +298,12 @@ class ShortLoopOptimizer : public ValueNumberingVisitor {
   }
 
   bool has_field_store(BasicType type) {
-    assert(type >= 0 && type < T_VOID, "Invalid type");
+    assert(type < T_VOID, "Invalid type");
     return _has_field_store[type];
   }
 
   bool has_indexed_store(BasicType type) {
-    assert(type >= 0 && type < T_VOID, "Invalid type");
+    assert(type < T_VOID, "Invalid type");
     return _has_indexed_store[type];
   }
 

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -138,7 +138,7 @@ class arrayOopDesc : public oopDesc {
   // overflow. We also need to make sure that this will not overflow a size_t on
   // 32 bit platforms when we convert it to a byte size.
   static int32_t max_array_length(BasicType type) {
-    assert(type >= 0 && type < T_CONFLICT, "wrong type");
+    assert(type < T_CONFLICT, "wrong type");
     assert(type2aelembytes(type) != 0, "wrong type");
 
     const size_t max_element_words_per_size_t =


### PR DESCRIPTION
Since `enum BasicType` had been changed to `enum BasicType : u1`, `basic_type >= 0` would be always true.
So it's safe to remove such conditions in these asserts.
Thanks.