### PR TITLE
8310682: No package-info (and @since) for package jdk.nio.mapmode

### DIFF
--- a/src/jdk.nio.mapmode/share/classes/jdk/nio/mapmode/package-info.java
+++ b/src/jdk.nio.mapmode/share/classes/jdk/nio/mapmode/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * JDK-specific map modes for use with
+ * {@linkplain java.nio.channels.FileChannel#map FileChannel::map}.
+ *
+ * @since 14
+ */
+
+package jdk.nio.mapmode;


### PR DESCRIPTION
Add `package-info.java` for package `jdk.nio.mapmode`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310682](https://bugs.openjdk.org/browse/JDK-8310682): No package-info (and @since) for package jdk.nio.mapmode (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14628/head:pull/14628` \
`$ git checkout pull/14628`

Update a local copy of the PR: \
`$ git checkout pull/14628` \
`$ git pull https://git.openjdk.org/jdk.git pull/14628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14628`

View PR using the GUI difftool: \
`$ git pr show -t 14628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14628.diff">https://git.openjdk.org/jdk/pull/14628.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14628#issuecomment-1604527700)