### PR TITLE
8310816: GcInfoBuilder float/double signature mismatch

### DIFF
--- a/src/jdk.management/share/native/libmanagement_ext/GcInfoBuilder.c
+++ b/src/jdk.management/share/native/libmanagement_ext/GcInfoBuilder.c
@@ -193,7 +193,7 @@ static void setDoubleValueAtObjectArray(JNIEnv *env, jobjectArray array,
 static void setFloatValueAtObjectArray(JNIEnv *env, jobjectArray array,
                                        jsize index, jfloat value) {
     static const char* class_name = "java/lang/Float";
-    static const char* signature = "(D)V";
+    static const char* signature = "(F)V";
     jobject obj = JNU_NewObjectByName(env, class_name, signature, value);
     if ((*env)->ExceptionCheck(env)) {
         return;


### PR DESCRIPTION
Simple typo in a signature which is passed to JNU_NewObjectByName.  The method clearly intentds to pass Float, but uses Double.

This code is probably not invoked, unless there is a GC MXBean with such fields.  I see no straightforward way of testing this explicitly, but the change is tiny.

All tests in test/jdk/com/sun/management still pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310816](https://bugs.openjdk.org/browse/JDK-8310816): GcInfoBuilder float/double signature mismatch (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14631/head:pull/14631` \
`$ git checkout pull/14631`

Update a local copy of the PR: \
`$ git checkout pull/14631` \
`$ git pull https://git.openjdk.org/jdk.git pull/14631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14631`

View PR using the GUI difftool: \
`$ git pr show -t 14631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14631.diff">https://git.openjdk.org/jdk/pull/14631.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14631#issuecomment-1604752452)