### PR TITLE
8310585: GetThreadState spec mentions undefined JVMTI_THREAD_STATE_MONITOR_WAITING

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -1416,7 +1416,7 @@ jvmtiEnv *jvmti;
         <example>
             JVMTI_THREAD_STATE_ALIVE + JVMTI_THREAD_STATE_WAITING +
                 JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT +
-                JVMTI_THREAD_STATE_MONITOR_WAITING
+                JVMTI_THREAD_STATE_IN_OBJECT_WAIT
         </example>
         The state of a thread suspended while runnable would be:
         <example>


### PR DESCRIPTION
Trivial fix in JVMTI spec.
As it's just a typo, CSR is not required

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310585](https://bugs.openjdk.org/browse/JDK-8310585): GetThreadState spec mentions undefined JVMTI_THREAD_STATE_MONITOR_WAITING (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14634/head:pull/14634` \
`$ git checkout pull/14634`

Update a local copy of the PR: \
`$ git checkout pull/14634` \
`$ git pull https://git.openjdk.org/jdk.git pull/14634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14634`

View PR using the GUI difftool: \
`$ git pr show -t 14634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14634.diff">https://git.openjdk.org/jdk/pull/14634.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14634#issuecomment-1605091458)