### PR TITLE
8310848: Convert ClassDesc and MethodTypeDesc to be stored in static final fields

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/components/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/snippet-files/PackageSnippets.java
@@ -25,6 +25,7 @@
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
 
+import java.lang.constant.ConstantDescs;
 import java.lang.reflect.AccessFlag;
 import java.util.ArrayDeque;
 import java.util.Map;
@@ -97,10 +98,13 @@ class PackageSnippets {
     // @end
     @interface Test{}
 
+    private static final ClassDesc CD_Foo = ClassDesc.of("Foo");
+    private static final ClassDesc CD_Bar = ClassDesc.of("Bar");
+
     void singleClassRemap(ClassModel... allMyClasses) {
         // @start region="singleClassRemap"
         var classRemapper = ClassRemapper.of(
-                Map.of(ClassDesc.of("Foo"), ClassDesc.of("Bar")));
+                Map.of(CD_Foo, CD_Bar));
 
         for (var classModel : allMyClasses) {
             byte[] newBytes = classRemapper.remapClass(classModel);
@@ -203,7 +207,7 @@ class PackageSnippets {
                                     !(cle instanceof FieldModel fm
                                             && !targetFieldNames.contains(fm.fieldName().stringValue()))
                                     && !(cle instanceof MethodModel mm
-                                            && !"<init>".equals(mm.methodName().stringValue())
+                                            && !ConstantDescs.INIT_NAME.equals(mm.methodName().stringValue())
                                             && !targetMethods.contains(mm.methodName().stringValue() + mm.methodType().stringValue())))
                             //and instrumentor class references remapped to target class
                             .andThen(instrumentorClassRemapper)))));

--- a/src/java.base/share/classes/jdk/internal/classfile/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/snippet-files/PackageSnippets.java
@@ -26,11 +26,11 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Set;
 
 import java.lang.reflect.AccessFlag;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -124,26 +124,33 @@ class PackageSnippets {
         // @end
     }
 
+    private static final ClassDesc CD_Hello = ClassDesc.of("Hello");
+    private static final ClassDesc CD_Foo = ClassDesc.of("Foo");
+    private static final ClassDesc CD_Bar = ClassDesc.of("Bar");
+    private static final ClassDesc CD_System = ClassDesc.of("java.lang.System");
+    private static final ClassDesc CD_PrintStream = ClassDesc.of("java.io.PrintStream");
+    private static final MethodTypeDesc MTD_void_StringArray = MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String.arrayType());
+    private static final MethodTypeDesc MTD_void_String = MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String);
+
     void writeHelloWorld() {
         // @start region="helloWorld"
-        byte[] bytes = Classfile.build(ClassDesc.of("Hello"), cb -> {
+        byte[] bytes = Classfile.build(CD_Hello, cb -> {
             cb.withFlags(AccessFlag.PUBLIC);
-            cb.withMethod("<init>", MethodTypeDesc.of(ConstantDescs.CD_void), Classfile.ACC_PUBLIC,
+            cb.withMethod(ConstantDescs.INIT_NAME, ConstantDescs.MTD_void, Classfile.ACC_PUBLIC,
                           mb -> mb.withCode(
                                   b -> b.aload(0)
-                                        .invokespecial(ConstantDescs.CD_Object, "<init>",
-                                                       MethodTypeDesc.of(ConstantDescs.CD_void))
+                                        .invokespecial(ConstantDescs.CD_Object, ConstantDescs.INIT_NAME,
+                                                       ConstantDescs.MTD_void)
                                         .returnInstruction(TypeKind.VoidType)
                           )
               )
-              .withMethod("main", MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String.arrayType()),
+              .withMethod("main", MTD_void_StringArray,
                           Classfile.ACC_PUBLIC,
                           mb -> mb.withFlags(AccessFlag.STATIC, AccessFlag.PUBLIC)
                                   .withCode(
-                                  b -> b.getstatic(ClassDesc.of("java.lang.System"), "out", ClassDesc.of("java.io.PrintStream"))
+                                  b -> b.getstatic(CD_System, "out", CD_PrintStream)
                                         .constantInstruction(Opcode.LDC, "Hello World")
-                                        .invokevirtual(ClassDesc.of("java.io.PrintStream"), "println",
-                                                       MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String))
+                                        .invokevirtual(CD_PrintStream, "println", MTD_void_String)
                                         .returnInstruction(TypeKind.VoidType)
             ));
         });
@@ -180,7 +187,7 @@ class PackageSnippets {
             if (e instanceof InvokeInstruction i
                     && i.owner().asInternalName().equals("Foo")
                     && i.opcode() == Opcode.INVOKESTATIC)
-                        b.invokeInstruction(i.opcode(), ClassDesc.of("Bar"), i.name().stringValue(), i.typeSymbol(), i.isInterface());
+                        b.invokeInstruction(i.opcode(), CD_Bar, i.name().stringValue(), i.typeSymbol(), i.isInterface());
             else b.with(e);
         };
         // @end
@@ -190,10 +197,9 @@ class PackageSnippets {
         // @start region="instrumentCallsTransform"
         CodeTransform instrumentCalls = (b, e) -> {
             if (e instanceof InvokeInstruction i) {
-                b.getstatic(ClassDesc.of("java.lang.System"), "out", ClassDesc.of("java.io.PrintStream"))
+                b.getstatic(CD_System, "out", CD_PrintStream)
                  .constantInstruction(Opcode.LDC, i.name().stringValue())
-                 .invokevirtual(ClassDesc.of("java.io.PrintStream"), "println",
-                                MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String));
+                 .invokevirtual(CD_PrintStream, "println", MTD_void_String);
             }
             b.with(e);
         };
@@ -215,7 +221,7 @@ class PackageSnippets {
                                               for (CodeElement e : xm) {
                                                   if (e instanceof InvokeInstruction i && i.owner().asInternalName().equals("Foo")
                                                                                && i.opcode() == Opcode.INVOKESTATIC)
-                                                              codeBuilder.invokeInstruction(i.opcode(), ClassDesc.of("Bar"),
+                                                              codeBuilder.invokeInstruction(i.opcode(), CD_Bar,
                                                                                             i.name().stringValue(), i.typeSymbol(), i.isInterface());
                                                   else codeBuilder.with(e);
                                               }});
@@ -266,7 +272,7 @@ class PackageSnippets {
                                                 && mm.methodType().stringValue().equals(inv.type().stringValue())) {
 
                                                 //store stacked method parameters into locals
-                                                var storeStack = new LinkedList<StoreInstruction>();
+                                                var storeStack = new ArrayDeque<StoreInstruction>();
                                                 int slot = 0;
                                                 if (!mm.flags().has(AccessFlag.STATIC))
                                                     storeStack.add(StoreInstruction.of(TypeKind.ReferenceType, slot++));
@@ -301,7 +307,7 @@ class PackageSnippets {
                                     !(cle instanceof FieldModel fm
                                             && !targetFieldNames.contains(fm.fieldName().stringValue()))
                                     && !(cle instanceof MethodModel mm
-                                            && !"<init>".equals(mm.methodName().stringValue())
+                                            && !ConstantDescs.INIT_NAME.equals(mm.methodName().stringValue())
                                             && !targetMethods.contains(mm.methodName().stringValue() + mm.methodType().stringValue())))
                             //and instrumentor class references remapped to target class
                             .andThen(instrumentorClassRemapper)))));

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
@@ -81,6 +81,7 @@ import jdk.internal.classfile.TypeKind;
 import static jdk.internal.classfile.Classfile.*;
 import jdk.internal.classfile.CodeBuilder;
 
+import jdk.internal.vm.annotation.Stable;
 import jdk.tools.jlink.internal.ModuleSorter;
 import jdk.tools.jlink.plugin.PluginException;
 import jdk.tools.jlink.plugin.ResourcePool;
@@ -118,6 +119,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
             ClassDesc.ofInternalName("jdk/internal/module/SystemModules");
     private static final ClassDesc CD_SYSTEM_MODULES_MAP =
             ClassDesc.ofInternalName(SYSTEM_MODULES_MAP_CLASSNAME);
+    private static final MethodTypeDesc MTD_StringArray = MethodTypeDesc.of(CD_String.arrayType());
+    private static final MethodTypeDesc MTD_SystemModules = MethodTypeDesc.of(CD_SYSTEM_MODULES);
     private boolean enabled;
 
     public SystemModulesPlugin() {
@@ -516,6 +519,17 @@ public final class SystemModulesPlugin extends AbstractPlugin {
             ClassDesc.ofInternalName("jdk/internal/module/ModuleHashes");
         private static final ClassDesc CD_MODULE_RESOLUTION =
             ClassDesc.ofInternalName("jdk/internal/module/ModuleResolution");
+        private static final ClassDesc CD_Map_Entry = ClassDesc.ofInternalName("java/util/Map$Entry");
+        private static final MethodTypeDesc MTD_boolean = MethodTypeDesc.of(CD_boolean);
+        private static final MethodTypeDesc MTD_ModuleDescriptorArray = MethodTypeDesc.of(CD_MODULE_DESCRIPTOR.arrayType());
+        private static final MethodTypeDesc MTD_ModuleTargetArray = MethodTypeDesc.of(CD_MODULE_TARGET.arrayType());
+        private static final MethodTypeDesc MTD_void_String = MethodTypeDesc.of(CD_void, CD_String);
+        private static final MethodTypeDesc MTD_void_int = MethodTypeDesc.of(CD_void, CD_int);
+        private static final MethodTypeDesc MTD_ModuleHashesArray = MethodTypeDesc.of(CD_MODULE_HASHES.arrayType());
+        private static final MethodTypeDesc MTD_ModuleResolutionArray = MethodTypeDesc.of(CD_MODULE_RESOLUTION.arrayType());
+        private static final MethodTypeDesc MTD_Map = MethodTypeDesc.of(CD_Map);
+        private static final MethodTypeDesc MTD_MapEntry_Object_Object = MethodTypeDesc.of(CD_Map_Entry, CD_Object, CD_Object);
+        private static final MethodTypeDesc MTD_Map_MapEntryArray = MethodTypeDesc.of(CD_Map, CD_Map_Entry.arrayType());
 
         private static final int MAX_LOCAL_VARS = 256;
 
@@ -616,13 +630,13 @@ public final class SystemModulesPlugin extends AbstractPlugin {
          */
         private void genConstructor(ClassBuilder clb) {
             clb.withMethodBody(
-                    "<init>",
-                    MethodTypeDesc.of(CD_void),
+                    INIT_NAME,
+                    MTD_void,
                     ACC_PUBLIC,
                     cob -> cob.aload(0)
                               .invokespecial(CD_Object,
-                                             "<init>",
-                                             MethodTypeDesc.of(CD_void))
+                                             INIT_NAME,
+                                             MTD_void)
                               .return_());
         }
 
@@ -638,7 +652,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
 
             clb.withMethodBody(
                     "hasSplitPackages",
-                    MethodTypeDesc.of(CD_boolean),
+                    MTD_boolean,
                     ACC_PUBLIC,
                     cob -> cob.constantInstruction(hasSplitPackages ? 1 : 0)
                               .ireturn());
@@ -656,7 +670,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
 
             clb.withMethodBody(
                     "hasIncubatorModules",
-                    MethodTypeDesc.of(CD_boolean),
+                    MTD_boolean,
                     ACC_PUBLIC,
                     cob -> cob.constantInstruction(hasIncubatorModules ? 1 : 0)
                               .ireturn());
@@ -668,7 +682,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
         private void genModuleDescriptorsMethod(ClassBuilder clb) {
             clb.withMethodBody(
                     "moduleDescriptors",
-                    MethodTypeDesc.of(CD_MODULE_DESCRIPTOR.arrayType()),
+                    MTD_ModuleDescriptorArray,
                     ACC_PUBLIC,
                     cob -> {
                         cob.constantInstruction(moduleInfos.size())
@@ -693,7 +707,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
         private void genModuleTargetsMethod(ClassBuilder clb) {
             clb.withMethodBody(
                     "moduleTargets",
-                    MethodTypeDesc.of(CD_MODULE_TARGET.arrayType()),
+                    MTD_ModuleTargetArray,
                     ACC_PUBLIC,
                     cob -> {
                         cob.constantInstruction(moduleInfos.size())
@@ -726,8 +740,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                                    .dup()
                                    .constantInstruction(minfo.target().targetPlatform())
                                    .invokespecial(CD_MODULE_TARGET,
-                                                  "<init>",
-                                                  MethodTypeDesc.of(CD_void, CD_String));
+                                                  INIT_NAME,
+                                                  MTD_void_String);
 
                                 cob.aastore();
                             }
@@ -744,7 +758,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
         private void genModuleHashesMethod(ClassBuilder clb) {
             clb.withMethodBody(
                     "moduleHashes",
-                    MethodTypeDesc.of(CD_MODULE_HASHES.arrayType()),
+                    MTD_ModuleHashesArray,
                     ACC_PUBLIC,
                     cob -> {
                         cob.constantInstruction(moduleInfos.size())
@@ -771,7 +785,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
         private void genModuleResolutionsMethod(ClassBuilder clb) {
             clb.withMethodBody(
                     "moduleResolutions",
-                    MethodTypeDesc.of(CD_MODULE_RESOLUTION.arrayType()),
+                    MTD_ModuleResolutionArray,
                     ACC_PUBLIC,
                     cob -> {
                         cob.constantInstruction(moduleInfos.size())
@@ -787,8 +801,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                                    .dup()
                                    .constantInstruction(minfo.moduleResolution().value())
                                    .invokespecial(CD_MODULE_RESOLUTION,
-                                                  "<init>",
-                                                  MethodTypeDesc.of(CD_void, CD_int))
+                                                  INIT_NAME,
+                                                  MTD_void_int)
                                    .aastore();
                             }
                         }
@@ -822,7 +836,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                               boolean dedup) {
             clb.withMethodBody(
                     methodName,
-                    MethodTypeDesc.of(CD_Map),
+                    MTD_Map,
                     ACC_PUBLIC,
                     cob -> {
 
@@ -852,7 +866,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
 
                         // new Map$Entry[size]
                         cob.constantInstruction(map.size())
-                           .anewarray(ClassDesc.ofInternalName("java/util/Map$Entry"));
+                           .anewarray(CD_Map_Entry);
 
                         int index = 0;
                         for (var e : new TreeMap<>(map).entrySet()) {
@@ -871,11 +885,9 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                                 cob.aload(varIndex);
                             }
 
-                            MethodTypeDesc desc = MethodTypeDesc.ofDescriptor(
-                                    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map$Entry;");
                             cob.invokestatic(CD_Map,
                                              "entry",
-                                             desc,
+                                             MTD_MapEntry_Object_Object,
                                              true)
                                .aastore();
                             index++;
@@ -884,8 +896,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                         // invoke Map.ofEntries(Map$Entry[])
                         cob.invokestatic(CD_Map,
                                          "ofEntries",
-                                         MethodTypeDesc.ofDescriptor(
-                                                 "([Ljava/util/Map$Entry;)Ljava/util/Map;"),
+                                         MTD_Map_MapEntryArray,
                                          true)
                            .areturn();
                     });
@@ -895,37 +906,9 @@ public final class SystemModulesPlugin extends AbstractPlugin {
          * Generate code to generate an immutable set.
          */
         private void genImmutableSet(CodeBuilder cob, Set<String> set) {
-            int size = set.size();
-
-            // use Set.of(Object[]) when there are more than 2 elements
-            // use Set.of(Object) or Set.of(Object, Object) when fewer
-            if (size > 2) {
-                cob.constantInstruction(size)
-                   .anewarray(CD_String);
-                int i = 0;
-                for (String element : sorted(set)) {
-                    cob.dup()
-                       .constantInstruction(i)
-                       .constantInstruction(element)
-                       .aastore();
-                    i++;
-                }
-                cob.invokestatic(CD_Set,
-                                 "of",
-                                 MethodTypeDesc.ofDescriptor(
-                                         "([Ljava/lang/Object;)Ljava/util/Set;"),
-                                 true);
-            } else {
-                for (String element : sorted(set)) {
-                    cob.constantInstruction(element);
-                }
-                var mtdArgs = new ClassDesc[size];
-                Arrays.fill(mtdArgs, CD_Object);
-                cob.invokestatic(CD_Set,
-                                 "of",
-                                 MethodTypeDesc.of(CD_Set, mtdArgs),
-                                 true);
-            }
+            new SetBuilder<>(set, 0, () -> {
+                throw new IllegalStateException();
+            }).generateSetOf(cob);
         }
 
         class ModuleDescriptorBuilder {
@@ -968,6 +951,9 @@ public final class SystemModulesPlugin extends AbstractPlugin {
             static final MethodTypeDesc MTD_SET = MethodTypeDesc.of(CD_MODULE_BUILDER, CD_Set);
             static final MethodTypeDesc MTD_STRING = MethodTypeDesc.of(CD_MODULE_BUILDER, CD_String);
             static final MethodTypeDesc MTD_BOOLEAN = MethodTypeDesc.of(CD_MODULE_BUILDER, CD_boolean);
+            static final MethodTypeDesc MTD_void_String = MethodTypeDesc.of(CD_void, CD_String);
+            static final MethodTypeDesc MTD_ModuleDescriptor_int = MethodTypeDesc.of(CD_MODULE_DESCRIPTOR, CD_int);
+            static final MethodTypeDesc MTD_List_ObjectArray = MethodTypeDesc.of(CD_List, CD_Object.arrayType());
 
             final CodeBuilder cob;
             final ModuleDescriptor md;
@@ -1020,8 +1006,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                    .dup()
                    .constantInstruction(md.name())
                    .invokespecial(CD_MODULE_BUILDER,
-                                  "<init>",
-                                  MethodTypeDesc.of(CD_void, CD_String))
+                                  INIT_NAME,
+                                  MTD_void_String)
                    .astore(BUILDER_VAR);
 
                 if (md.isOpen()) {
@@ -1057,7 +1043,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                    .constantInstruction(md.hashCode())
                    .invokevirtual(CD_MODULE_BUILDER,
                                   "build",
-                                  MethodTypeDesc.of(CD_MODULE_DESCRIPTOR, CD_int))
+                                  MTD_ModuleDescriptor_int)
                    .aastore();
             }
 
@@ -1283,8 +1269,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 }
                 cob.invokestatic(CD_List,
                                  "of",
-                                 MethodTypeDesc.ofDescriptor(
-                                        "([Ljava/lang/Object;)Ljava/util/List;"),
+                                 MTD_List_ObjectArray,
                                  true)
                    .invokestatic(CD_MODULE_BUILDER,
                                  "newProvides",
@@ -1343,6 +1328,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                 ClassDesc.ofInternalName("jdk/internal/module/ModuleHashes$Builder");
             static final MethodTypeDesc STRING_BYTE_ARRAY_SIG =
                 MethodTypeDesc.of(MODULE_HASHES_BUILDER, CD_String, CD_byte.arrayType());
+            static final MethodTypeDesc MTD_void_String_int = MethodTypeDesc.of(CD_void, CD_String, CD_int);
+            static final MethodTypeDesc MTD_ModuleHashes = MethodTypeDesc.of(CD_MODULE_HASHES);
 
             final ModuleHashes recordedHashes;
             final CodeBuilder cob;
@@ -1385,8 +1372,8 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                    .constantInstruction(recordedHashes.algorithm())
                    .constantInstruction(((4 * recordedHashes.names().size()) / 3) + 1)
                    .invokespecial(MODULE_HASHES_BUILDER,
-                                  "<init>",
-                                  MethodTypeDesc.of(CD_void, CD_String, CD_int))
+                                  INIT_NAME,
+                                  MTD_void_String_int)
                    .astore(BUILDER_VAR)
                    .aload(BUILDER_VAR);
             }
@@ -1402,7 +1389,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                    .aload(BUILDER_VAR)
                    .invokevirtual(MODULE_HASHES_BUILDER,
                                   "build",
-                                  MethodTypeDesc.of(CD_MODULE_HASHES))
+                                  MTD_ModuleHashes)
                    .aastore();
             }
 
@@ -1551,6 +1538,19 @@ public final class SystemModulesPlugin extends AbstractPlugin {
          * it will use a new local variable retrieved from the nextLocalVar
          */
         static class SetBuilder<T extends Comparable<T>> {
+            private static final MethodTypeDesc MTD_Set_ObjectArray = MethodTypeDesc.of(
+                    CD_Set, CD_Object.arrayType());
+            private static @Stable final MethodTypeDesc[] SET_OF_MTDS = new MethodTypeDesc[11];
+
+            private static MethodTypeDesc setOfType(int count) {
+                var ret = SET_OF_MTDS[count];
+                if (ret != null)
+                    return ret;
+                var mtdArgs = new ClassDesc[count];
+                Arrays.fill(mtdArgs, CD_Object);
+                return SET_OF_MTDS[count] = MethodTypeDesc.of(CD_Set, mtdArgs);
+            }
+
             private final Set<T> elements;
             private final int defaultVarIndex;
             private final IntSupplier nextLocalVar;
@@ -1601,26 +1601,27 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                         index = defaultVarIndex;
                     }
 
-                    generateSetOf(cob, index);
+                    generateSetOf(cob);
+                    cob.astore(index);
                 }
                 return index;
             }
 
-            private void generateSetOf(CodeBuilder cob, int index) {
-                if (elements.size() <= 10) {
+            void generateSetOf(CodeBuilder cob) {
+                int count = elements.size();
+                if (count <= 10) {
                     // call Set.of(e1, e2, ...)
                     for (T t : sorted(elements)) {
                         visitElement(t, cob);
                     }
-                    var mtdArgs = new ClassDesc[elements.size()];
-                    Arrays.fill(mtdArgs, CD_Object);
+
                     cob.invokestatic(CD_Set,
                                      "of",
-                                     MethodTypeDesc.of(CD_Set, mtdArgs),
+                                     setOfType(count),
                                      true);
                 } else {
                     // call Set.of(E... elements)
-                    cob.constantInstruction(elements.size())
+                    cob.constantInstruction(count)
                        .anewarray(CD_String);
                     int arrayIndex = 0;
                     for (T t : sorted(elements)) {
@@ -1632,11 +1633,9 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                     }
                     cob.invokestatic(CD_Set,
                                      "of",
-                                     MethodTypeDesc.ofDescriptor(
-                                            "([Ljava/lang/Object;)Ljava/util/Set;"),
+                                     MTD_Set_ObjectArray,
                                      true);
                 }
-                cob.astore(index);
             }
         }
 
@@ -1683,43 +1682,43 @@ public final class SystemModulesPlugin extends AbstractPlugin {
 
                           // <init>
                           .withMethodBody(
-                                  "<init>",
-                                  MethodTypeDesc.of(CD_void),
+                                  INIT_NAME,
+                                  MTD_void,
                                   0,
                                   cob -> cob.aload(0)
                                             .invokespecial(CD_Object,
-                                                           "<init>",
-                                                           MethodTypeDesc.of(CD_void))
+                                                           INIT_NAME,
+                                                           MTD_void)
                                             .return_())
 
                           // allSystemModules()
                           .withMethodBody(
                                   "allSystemModules",
-                                  MethodTypeDesc.of(CD_SYSTEM_MODULES),
+                                  MTD_SystemModules,
                                   ACC_STATIC,
                                   cob -> cob.new_(allSystemModules)
                                             .dup()
                                             .invokespecial(allSystemModules,
-                                                           "<init>",
-                                                           MethodTypeDesc.of(CD_void))
+                                                           INIT_NAME,
+                                                           MTD_void)
                                             .areturn())
 
                           // defaultSystemModules()
                           .withMethodBody(
                                   "defaultSystemModules",
-                                   MethodTypeDesc.of(CD_SYSTEM_MODULES),
+                                   MTD_SystemModules,
                                    ACC_STATIC,
                                    cob -> cob.new_(defaultSystemModules)
                                              .dup()
                                              .invokespecial(defaultSystemModules,
-                                                            "<init>",
-                                                            MethodTypeDesc.of(CD_void))
+                                                            INIT_NAME,
+                                                            MTD_void)
                                              .areturn())
 
                           // moduleNames()
                           .withMethodBody(
                                   "moduleNames",
-                                  MethodTypeDesc.of(CD_String.arrayType()),
+                                  MTD_StringArray,
                                   ACC_STATIC,
                                   cob -> {
                                       cob.constantInstruction(map.size());
@@ -1740,7 +1739,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
                           // classNames()
                           .withMethodBody(
                                   "classNames",
-                                  MethodTypeDesc.of(CD_String.arrayType()),
+                                  MTD_StringArray,
                                   ACC_STATIC,
                                   cob -> {
                                       cob.constantInstruction(map.size())

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
@@ -26,7 +26,6 @@ package jdk.jshell.execution;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
-import java.lang.constant.MethodTypeDesc;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -77,13 +76,12 @@ public class LocalExecutionControl extends DirectExecutionControl {
     private static final String CANCEL_CLASS = "REPL.$Cancel$";
     private static final ClassDesc CD_Cancel = ClassDesc.of(CANCEL_CLASS);
     private static final ClassDesc CD_ThreadDeath = ClassDesc.of("java.lang.ThreadDeath");
-    private static final MethodTypeDesc MTD_void = MethodTypeDesc.of(ConstantDescs.CD_void);
 
     private static byte[] instrument(byte[] classFile) {
         return Classfile.parse(classFile)
                         .transform(ClassTransform.transformingMethodBodies((cob, coe) -> {
                             if (coe instanceof BranchInstruction)
-                                cob.invokestatic(CD_Cancel, "stopCheck", MTD_void);
+                                cob.invokestatic(CD_Cancel, "stopCheck", ConstantDescs.MTD_void);
                             cob.with(coe);
                         }));
     }
@@ -92,11 +90,11 @@ public class LocalExecutionControl extends DirectExecutionControl {
         return new ClassBytecodes(CANCEL_CLASS, Classfile.build(CD_Cancel, clb ->
              clb.withFlags(Classfile.ACC_PUBLIC)
                 .withField("allStop", ConstantDescs.CD_boolean, Classfile.ACC_PUBLIC | Classfile.ACC_STATIC | Classfile.ACC_VOLATILE)
-                .withMethodBody("stopCheck", MTD_void, Classfile.ACC_PUBLIC | Classfile.ACC_STATIC, cob ->
+                .withMethodBody("stopCheck", ConstantDescs.MTD_void, Classfile.ACC_PUBLIC | Classfile.ACC_STATIC, cob ->
                         cob.getstatic(CD_Cancel, "allStop", ConstantDescs.CD_boolean)
                            .ifThenElse(tb -> tb.new_(CD_ThreadDeath)
                                                .dup()
-                                               .invokespecial(CD_ThreadDeath, "<init>", MTD_void)
+                                               .invokespecial(CD_ThreadDeath, ConstantDescs.INIT_NAME, ConstantDescs.MTD_void)
                                                .athrow(),
                                        eb -> eb.return_()))));
     }

--- a/test/micro/org/openjdk/bench/jdk/classfile/TestConstants.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/TestConstants.java
@@ -27,14 +27,18 @@ package org.openjdk.bench.jdk.classfile;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 
+import static java.lang.constant.ConstantDescs.CD_String;
+import static java.lang.constant.ConstantDescs.CD_void;
+
 /**
  * TestConstants
  */
 public class TestConstants {
+    public static final ClassDesc CD_MyClass = ClassDesc.of("MyClass");
     public static final ClassDesc CD_System = ClassDesc.of("java.lang.System");
     public static final ClassDesc CD_PrintStream = ClassDesc.of("java.io.PrintStream");
     public static final ClassDesc CD_ArrayList = ClassDesc.of("java.util.ArrayList");
 
-    public static final MethodTypeDesc MTD_INT_VOID = MethodTypeDesc.ofDescriptor("(I)V");
-    public static final MethodTypeDesc MTD_VOID = MethodTypeDesc.ofDescriptor("()V");
+    public static final MethodTypeDesc MTD_void_int = MethodTypeDesc.ofDescriptor("(I)V");
+    public static final MethodTypeDesc MTD_void_StringArray = MethodTypeDesc.of(CD_void, CD_String.arrayType());
 }


### PR DESCRIPTION
This would encourage Classfile API users to use the descriptors as constants, which can improve performance by avoiding repeated validation and reusing cached descriptor strings for MethodTypeDesc. This patch updates usages in the main codebase and benchmarks; tests are left untouched.