### PR TITLE
8310849: Pattern matching for instanceof and arrayType cleanup in j.l.invoke and j.l.reflect

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1576,10 +1576,8 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     private static Class<?> toClass(Type o) {
-        if (o instanceof GenericArrayType)
-            return Array.newInstance(toClass(((GenericArrayType)o).getGenericComponentType()),
-                                     0)
-                .getClass();
+        if (o instanceof GenericArrayType gat)
+            return toClass(gat.getGenericComponentType()).arrayType();
         return (Class<?>)o;
      }
 
@@ -3000,8 +2998,8 @@ public final class Class<T> implements java.io.Serializable,
                 // need for a URL connection
                 if (cl == null) {
                     return BootLoader.findResourceAsStream(mn, name);
-                } else if (cl instanceof BuiltinClassLoader) {
-                    return ((BuiltinClassLoader) cl).findResourceAsStream(mn, name);
+                } else if (cl instanceof BuiltinClassLoader bcl) {
+                    return bcl.findResourceAsStream(mn, name);
                 } else {
                     URL url = cl.findResource(mn, name);
                     return (url != null) ? url.openStream() : null;

--- a/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,8 +124,8 @@ abstract non-sealed class BoundMethodHandle extends MethodHandle {
     /*non-public*/
     static BoundMethodHandle.SpeciesData speciesDataFor(LambdaForm form) {
         Object c = form.names[0].constraint;
-        if (c instanceof SpeciesData) {
-            return (SpeciesData) c;
+        if (c instanceof SpeciesData sd) {
+            return sd;
         }
         // if there is no BMH constraint, then use the null constraint
         return SPECIALIZER.topSpecies();
@@ -153,8 +153,8 @@ abstract non-sealed class BoundMethodHandle extends MethodHandle {
         for (int i = 0; i < count; ++i) {
             Object theArg = arg(i);
             sb.append("\n  ").append(prefix).append(i);
-            if (indentLevel >= 0 && theArg instanceof MethodHandle) {
-                sb.append(": MethodHandle = {").append(((MethodHandle)theArg).debugString(indentLevel+1));
+            if (indentLevel >= 0 && theArg instanceof MethodHandle mh) {
+                sb.append(": MethodHandle = {").append(mh.debugString(indentLevel+1));
                 sb.append("\n  ").append(prefix).append("}");
             } else {
                 sb.append(": ( ").append(theArg).append(" )");

--- a/src/java.base/share/classes/java/lang/invoke/CallSite.java
+++ b/src/java.base/share/classes/java/lang/invoke/CallSite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -315,8 +315,8 @@ abstract sealed class CallSite permits ConstantCallSite, MutableCallSite, Volati
         try {
             Object binding = BootstrapMethodInvoker.invoke(
                     CallSite.class, bootstrapMethod, name, type, info, callerClass);
-            if (binding instanceof CallSite) {
-                site = (CallSite) binding;
+            if (binding instanceof CallSite cs) {
+                site = cs;
             } else {
                 // See the "Linking Exceptions" section for the invokedynamic
                 // instruction in JVMS 6.5.

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -265,11 +265,10 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof ClassSpecializer.SpeciesData)) {
+            if (!(obj instanceof ClassSpecializer<?, ?, ?>.SpeciesData that)) {
                 return false;
             }
-            @SuppressWarnings("rawtypes")
-            ClassSpecializer.SpeciesData that = (ClassSpecializer.SpeciesData) obj;
+
             return this.outer() == that.outer() && this.key.equals(that.key);
         }
 
@@ -656,8 +655,8 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
                     for (X x : types) {
                         String vn = name;
                         Class<?> vt;
-                        if (x instanceof Class) {
-                            vt = (Class<?>) x;
+                        if (x instanceof Class<?> cl) {
+                            vt = cl;
                             // make the names friendlier if debugging
                             assert((vn = vn + "_" + (i++)) != null);
                         } else {

--- a/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,7 @@ package java.lang.invoke;
 
 import java.security.*;
 import java.lang.reflect.*;
-import java.lang.invoke.MethodHandleNatives.Constants;
 import java.lang.invoke.MethodHandles.Lookup;
-import static java.lang.invoke.MethodHandleStatics.*;
 
 /*
  * Auxiliary to MethodHandleInfo, wants to nest in MethodHandleInfo but must be non-public.
@@ -132,11 +130,11 @@ final class InfoFromMemberName implements MethodHandleInfo {
     }
 
     private static MemberName convertToMemberName(byte refKind, Member mem) throws IllegalAccessException {
-        if (mem instanceof Method) {
+        if (mem instanceof Method mth) {
             boolean wantSpecial = (refKind == REF_invokeSpecial);
-            return new MemberName((Method) mem, wantSpecial);
-        } else if (mem instanceof Constructor) {
-            return new MemberName((Constructor) mem);
+            return new MemberName(mth, wantSpecial);
+        } else if (mem instanceof Constructor<?> ctor) {
+            return new MemberName(ctor);
         } else if (mem instanceof Field) {
             boolean isSetter = (refKind == REF_putField || refKind == REF_putStatic);
             return new MemberName((Field) mem, isSetter);

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -804,8 +804,8 @@ class InvokerBytecodeGenerator {
                 case SELECT_ALTERNATIVE:
                     assert lambdaForm.isSelectAlternative(i);
                     if (PROFILE_GWT) {
-                        assert(name.arguments[0] instanceof Name &&
-                                ((Name)name.arguments[0]).refersTo(MethodHandleImpl.class, "profileBoolean"));
+                        assert(name.arguments[0] instanceof Name n &&
+                                n.refersTo(MethodHandleImpl.class, "profileBoolean"));
                         mv.visitAnnotation(INJECTEDPROFILE_SIG, true);
                     }
                     onStack = emitSelectAlternative(name, lambdaForm.names[i+1]);

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -30,7 +30,6 @@ import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Hidden;
 import jdk.internal.vm.annotation.Stable;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 
 import static java.lang.invoke.MethodHandleStatics.*;
@@ -244,7 +243,7 @@ class Invokers {
                 throw newIllegalArgumentException("need homogeneous rest arguments", restargType);
         }
         if (argType == Object.class)  return Object[].class;
-        return Array.newInstance(argType, 0).getClass();
+        return argType.arrayType();
     }
 
     public String toString() {

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -949,8 +949,8 @@ class LambdaForm {
         Object[] arguments = Arrays.copyOf(name.arguments, name.arguments.length, Object[].class);
         for (int i = 0; i < arguments.length; i++) {
             Object a = arguments[i];
-            if (a instanceof Name) {
-                int i2 = ((Name)a).index();
+            if (a instanceof Name n) {
+                int i2 = n.index();
                 assert(names[i2] == a);
                 a = values[i2];
                 arguments[i] = a;
@@ -1061,7 +1061,7 @@ class LambdaForm {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof LambdaForm && equals((LambdaForm)obj);
+        return obj instanceof LambdaForm lf && equals(lf);
     }
     public boolean equals(LambdaForm that) {
         if (this.result != that.result)  return false;
@@ -1362,7 +1362,7 @@ class LambdaForm {
         }
         Name(MethodType functionType, Object... arguments) {
             this(new NamedFunction(functionType), arguments);
-            assert(arguments[0] instanceof Name && ((Name)arguments[0]).type == L_TYPE);
+            assert(arguments[0] instanceof Name name && name.type == L_TYPE);
         }
         Name(MemberName function, Object... arguments) {
             this(new NamedFunction(function), arguments);
@@ -1524,7 +1524,7 @@ class LambdaForm {
             Object c = constraint;
             if (c == null)
                 return s;
-            if (c instanceof Class)  c = ((Class<?>)c).getSimpleName();
+            if (c instanceof Class<?> cl)  c = cl.getSimpleName();
             return s + "/" + c;
         }
         public String exprString() {
@@ -1556,8 +1556,8 @@ class LambdaForm {
         }
 
         private static boolean typesMatch(BasicType parameterType, Object object) {
-            if (object instanceof Name) {
-                return ((Name)object).type == parameterType;
+            if (object instanceof Name name) {
+                return name.type == parameterType;
             }
             switch (parameterType) {
                 case I_TYPE:  return object instanceof Integer;
@@ -1608,7 +1608,7 @@ class LambdaForm {
         }
         @Override
         public boolean equals(Object x) {
-            return x instanceof Name && equals((Name)x);
+            return x instanceof Name n && equals(n);
         }
         @Override
         public int hashCode() {

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,10 +101,10 @@ class LambdaFormEditor {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof TransformKey) {
-                return equals((TransformKey) obj);
+            if (obj instanceof TransformKey key) {
+                return equals(key);
             }
-            return obj instanceof Transform && equals((Transform)obj);
+            return obj instanceof Transform transform && equals(transform);
         }
 
         private boolean equals(TransformKey that) {
@@ -354,10 +354,10 @@ class LambdaFormEditor {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof TransformKey) {
-                return equals((TransformKey) obj);
+            if (obj instanceof TransformKey key) {
+                return equals(key);
             }
-            return obj instanceof Transform && equals((Transform)obj);
+            return obj instanceof Transform transform && equals(transform);
         }
 
         private boolean equals(TransformKey that) {

--- a/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ final class LambdaProxyClassArchive {
      */
     static boolean loadedByBuiltinLoader(Class<?> cls) {
         ClassLoader cl = cls.getClassLoader();
-        return (cl == null || (cl instanceof BuiltinClassLoader)) ? true : false;
+        return cl == null || (cl instanceof BuiltinClassLoader);
     }
 
     private static native void addToArchive(Class<?> caller,

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,8 +135,8 @@ final class MemberName implements Member, Cloneable {
         {
             // Get a snapshot of type which doesn't get changed by racing threads.
             final Object type = this.type;
-            if (type instanceof MethodType) {
-                return (MethodType) type;
+            if (type instanceof MethodType mt) {
+                return mt;
             }
         }
 
@@ -173,8 +173,8 @@ final class MemberName implements Member, Cloneable {
 
         // Get a snapshot of type which doesn't get changed by racing threads.
         final Object type = this.type;
-        if (type instanceof String) {
-            return (String) type;
+        if (type instanceof String str) {
+            return str;
         } else {
             return getMethodType().toMethodDescriptorString();
         }
@@ -211,8 +211,8 @@ final class MemberName implements Member, Cloneable {
         {
             // Get a snapshot of type which doesn't get changed by racing threads.
             final Object type = this.type;
-            if (type instanceof Class<?>) {
-                return (Class<?>) type;
+            if (type instanceof Class<?> cl) {
+                return cl;
             }
         }
 
@@ -725,7 +725,7 @@ final class MemberName implements Member, Cloneable {
 
     @Override
     public boolean equals(Object that) {
-        return (that instanceof MemberName && this.equals((MemberName)that));
+        return that instanceof MemberName mn && this.equals(mn);
     }
 
     /** Decide if two member names have exactly the same symbolic content.
@@ -808,8 +808,8 @@ final class MemberName implements Member, Cloneable {
     void checkForTypeAlias(Class<?> refc) {
         if (isInvocable()) {
             MethodType type;
-            if (this.type instanceof MethodType)
-                type = (MethodType) this.type;
+            if (this.type instanceof MethodType mt)
+                type = mt;
             else
                 this.type = type = getMethodType();
             if (type.erase() == type)  return;
@@ -817,8 +817,8 @@ final class MemberName implements Member, Cloneable {
             throw new LinkageError("bad method type alias: "+type+" not visible from "+refc);
         } else {
             Class<?> type;
-            if (this.type instanceof Class<?>)
-                type = (Class<?>) this.type;
+            if (this.type instanceof Class<?> cl)
+                type = cl;
             else
                 this.type = type = getFieldType();
             if (VerifyAccess.isTypeVisible(type, refc))  return;
@@ -863,8 +863,8 @@ final class MemberName implements Member, Cloneable {
         return buf.toString();
     }
     private static String getName(Object obj) {
-        if (obj instanceof Class<?>)
-            return ((Class<?>)obj).getName();
+        if (obj instanceof Class<?> cl)
+            return cl.getName();
         return String.valueOf(obj);
     }
 
@@ -915,8 +915,8 @@ final class MemberName implements Member, Cloneable {
             ex = new NoSuchMethodException(message);
         else
             ex = new NoSuchFieldException(message);
-        if (resolution instanceof Throwable)
-            ex.initCause((Throwable) resolution);
+        if (resolution instanceof Throwable res)
+            ex.initCause(res);
         return ex;
     }
 
@@ -992,7 +992,7 @@ final class MemberName implements Member, Cloneable {
             if (result.isResolved())
                 return result;
             ReflectiveOperationException ex = result.makeAccessException();
-            if (ex instanceof IllegalAccessException)  throw (IllegalAccessException) ex;
+            if (ex instanceof IllegalAccessException iae)  throw iae;
             throw nsmClass.cast(ex);
         }
         /** Produce a resolved version of the given member.

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -576,8 +576,8 @@ abstract class MethodHandleImpl {
             return;
         } else if (av == null) {
             throw new NullPointerException("null array reference");
-        } else if (av instanceof Object[]) {
-            int len = ((Object[])av).length;
+        } else if (av instanceof Object[] array) {
+            int len = array.length;
             if (len == n)  return;
         } else {
             int len = java.lang.reflect.Array.getLength(av);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,10 +350,10 @@ class MethodHandleNatives {
     }
 
     private static String staticArglistForTrace(Object staticArguments) {
-        if (staticArguments instanceof Object[])
-            return "BSA="+java.util.Arrays.asList((Object[]) staticArguments);
-        if (staticArguments instanceof int[])
-            return "BSA@"+java.util.Arrays.toString((int[]) staticArguments);
+        if (staticArguments instanceof Object[] array)
+            return "BSA="+java.util.Arrays.asList(array);
+        if (staticArguments instanceof int[] array)
+            return "BSA@"+java.util.Arrays.toString(array);
         if (staticArguments == null)
             return "BSA0=null";
         return "BSA1="+staticArguments;
@@ -509,8 +509,8 @@ class MethodHandleNatives {
         throw new LinkageError("no such method "+defc.getName()+"."+name+type);
     }
     private static MethodType fixMethodType(Class<?> callerClass, Object type) {
-        if (type instanceof MethodType)
-            return (MethodType) type;
+        if (type instanceof MethodType mt)
+            return mt;
         else
             return MethodType.fromDescriptor((String)type, callerClass.getClassLoader());
     }
@@ -637,8 +637,8 @@ class MethodHandleNatives {
         LinkageError err;
         if (ex instanceof IllegalAccessException) {
             Throwable cause = ex.getCause();
-            if (cause instanceof AbstractMethodError) {
-                return (AbstractMethodError) cause;
+            if (cause instanceof AbstractMethodError ame) {
+                return ame;
             } else {
                 err = new IllegalAccessError(ex.getMessage());
             }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
@@ -185,8 +185,8 @@ class MethodHandleStatics {
     /** Propagate unchecked exceptions and errors, but wrap anything checked and throw that instead. */
     /*non-public*/
     static Error uncaughtException(Throwable ex) {
-        if (ex instanceof Error)  throw (Error) ex;
-        if (ex instanceof RuntimeException)  throw (RuntimeException) ex;
+        if (ex instanceof Error error)  throw error;
+        if (ex instanceof RuntimeException re)  throw re;
         throw new InternalError("uncaught exception", ex);
     }
     private static String message(String message, Object obj) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4254,14 +4254,14 @@ return mh1;
             }
             MemberName resolved = resolveOrFail(refKind, member);
             mh = getDirectMethodForConstant(refKind, defc, resolved);
-            if (mh instanceof DirectMethodHandle
+            if (mh instanceof DirectMethodHandle dmh
                     && canBeCached(refKind, defc, resolved)) {
                 MemberName key = mh.internalMemberName();
                 if (key != null) {
                     key = key.asNormalOriginal();
                 }
                 if (member.equals(key)) {  // better safe than sorry
-                    LOOKASIDE_TABLE.put(key, (DirectMethodHandle) mh);
+                    LOOKASIDE_TABLE.put(key, dmh);
                 }
             }
             return mh;

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -893,14 +893,11 @@ class MethodType
         if (this == x) {
             return true;
         }
-        if (x instanceof MethodType) {
-            return equals((MethodType)x);
+        if (x instanceof MethodType mt) {
+            return equals(mt);
         }
-        if (x instanceof ConcurrentWeakInternSet.WeakEntry) {
-            Object o = ((ConcurrentWeakInternSet.WeakEntry)x).get();
-            if (o instanceof MethodType) {
-                return equals((MethodType)o);
-            }
+        if (x instanceof ConcurrentWeakInternSet.WeakEntry<?> e && e.get() instanceof MethodType mt) {
+            return equals(mt);
         }
         return false;
     }
@@ -1483,8 +1480,8 @@ s.writeObject(this.parameterArray());
             @Override
             public boolean equals(Object obj) {
                 Object mine = get();
-                if (obj instanceof WeakEntry) {
-                    Object that = ((WeakEntry) obj).get();
+                if (obj instanceof WeakEntry<?> we) {
+                    Object that = we.get();
                     return (that == null || mine == null) ? (this == obj) : mine.equals(that);
                 }
                 return (mine == null) ? (obj == null) : mine.equals(obj);

--- a/src/java.base/share/classes/java/lang/invoke/SerializedLambda.java
+++ b/src/java.base/share/classes/java/lang/invoke/SerializedLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,8 +280,8 @@ public final class SerializedLambda implements Serializable {
             throw new InvalidObjectException("ReflectiveOperationException during deserialization", roe);
         } catch (PrivilegedActionException e) {
             Exception cause = e.getException();
-            if (cause instanceof RuntimeException)
-                throw (RuntimeException) cause;
+            if (cause instanceof RuntimeException re)
+                throw re;
             else
                 throw new RuntimeException("Exception in SerializedLambda.readResolve", e);
         }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -635,8 +635,8 @@ final class VarHandles {
             } else {
                 throw new AssertionError("Cannot get here");
             }
-        } else if (handle instanceof DelegatingMethodHandle) {
-            return exceptionTypes(((DelegatingMethodHandle)handle).getTarget());
+        } else if (handle instanceof DelegatingMethodHandle delegatingMh) {
+            return exceptionTypes(delegatingMh.getTarget());
         } else if (handle instanceof NativeMethodHandle) {
             return new Class<?>[0];
         }

--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -685,8 +685,8 @@ public class AccessibleObject implements AnnotatedElement {
      */
     private boolean isAccessChecked(Class<?> caller, Class<?> targetClass) {
         Object cache = accessCheckCache;  // read volatile
-        if (cache instanceof Cache) {
-            return ((Cache) cache).isCacheFor(caller, targetClass);
+        if (cache instanceof Cache c) {
+            return c.isCacheFor(caller, targetClass);
         }
         return false;
     }

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,9 +366,9 @@ public interface AnnotatedElement {
          T[] result = getDeclaredAnnotationsByType(annotationClass);
 
          if (result.length == 0 && // Neither directly nor indirectly present
-             this instanceof Class && // the element is a class
+             this instanceof Class<?> cls && // the element is a class
              AnnotationType.getInstance(annotationClass).isInherited()) { // Inheritable
-             Class<?> superClass = ((Class<?>) this).getSuperclass();
+             Class<?> superClass = cls.getSuperclass();
              if (superClass != null) {
                  // Determine if the annotation is associated with the
                  // superclass

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1052,8 +1052,8 @@ public class Proxy implements java.io.Serializable {
             throw new InternalError(e.toString(), e);
         } catch (InvocationTargetException e) {
             Throwable t = e.getCause();
-            if (t instanceof RuntimeException) {
-                throw (RuntimeException) t;
+            if (t instanceof RuntimeException re) {
+                throw re;
             } else {
                 throw new InternalError(t.toString(), t);
             }

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class BytecodeDescriptor {
             int start, int end, ClassLoader loader) {
         String str = bytecodeSignature;
         int[] i = {start};
-        ArrayList<Class<?>> ptypes = new ArrayList<Class<?>>();
+        var ptypes = new ArrayList<Class<?>>();
         if (i[0] < end && str.charAt(i[0]) == '(') {
             ++i[0];  // skip '('
             while (i[0] < end && str.charAt(i[0]) != ')') {
@@ -97,7 +97,7 @@ public class BytecodeDescriptor {
         } else if (c == '[') {
             Class<?> t = parseSig(str, i, end, loader);
             if (t != null)
-                t = java.lang.reflect.Array.newInstance(t, 0).getClass();
+                t = t.arrayType();
             return t;
         } else {
             return Wrapper.forBasicType(c).primitiveType();
@@ -114,10 +114,10 @@ public class BytecodeDescriptor {
     }
 
     public static String unparse(Object type) {
-        if (type instanceof Class<?>)
-            return unparse((Class<?>) type);
-        if (type instanceof MethodType)
-            return ((MethodType) type).toMethodDescriptorString();
+        if (type instanceof Class<?> cl)
+            return unparse(cl);
+        if (type instanceof MethodType mt)
+            return mt.toMethodDescriptorString();
         return (String) type;
     }
 

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeName.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -354,8 +354,8 @@ public class BytecodeName {
         Object[] components0 = components;
         for (int i = 0; i < components.length; i++) {
             Object c = components[i];
-            if (c instanceof String) {
-                String mc = toBytecodeName((String) c);
+            if (c instanceof String s) {
+                String mc = toBytecodeName(s);
                 if (i == 0 && components.length == 1)
                     return mc;  // usual case
                 if ((Object)mc != c) {
@@ -376,8 +376,8 @@ public class BytecodeName {
         }
         int slen = 0;
         for (Object c : components) {
-            if (c instanceof String)
-                slen += String.valueOf(c).length();
+            if (c instanceof String s)
+                slen += s.length();
             else
                 slen += 1;
         }
@@ -408,9 +408,8 @@ public class BytecodeName {
     public static String toDisplayName(String s) {
         Object[] components = parseBytecodeName(s);
         for (int i = 0; i < components.length; i++) {
-            if (!(components[i] instanceof String))
+            if (!(components[i] instanceof String sn))
                 continue;
-            String sn = (String) components[i];
             // note that the name is already demangled!
             //sn = toSourceName(sn);
             if (!isJavaIdent(sn) || sn.indexOf('$') >=0 ) {

--- a/src/java.base/share/classes/sun/invoke/util/ValueConversions.java
+++ b/src/java.base/share/classes/sun/invoke/util/ValueConversions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,8 @@ public class ValueConversions {
         return x;
     }
     static int unboxInteger(Object x, boolean cast) {
-        if (x instanceof Integer)
-            return (Integer) x;
+        if (x instanceof Integer i)
+            return i;
         return primitiveConversion(Wrapper.INT, x, cast).intValue();
     }
 
@@ -85,8 +85,8 @@ public class ValueConversions {
         return x;
     }
     static byte unboxByte(Object x, boolean cast) {
-        if (x instanceof Byte)
-            return (Byte) x;
+        if (x instanceof Byte b)
+            return b;
         return primitiveConversion(Wrapper.BYTE, x, cast).byteValue();
     }
 
@@ -94,8 +94,8 @@ public class ValueConversions {
         return x;
     }
     static short unboxShort(Object x, boolean cast) {
-        if (x instanceof Short)
-            return (Short) x;
+        if (x instanceof Short s)
+            return s;
         return primitiveConversion(Wrapper.SHORT, x, cast).shortValue();
     }
 
@@ -103,8 +103,8 @@ public class ValueConversions {
         return x;
     }
     static boolean unboxBoolean(Object x, boolean cast) {
-        if (x instanceof Boolean)
-            return (Boolean) x;
+        if (x instanceof Boolean b)
+            return b;
         return (primitiveConversion(Wrapper.BOOLEAN, x, cast).intValue() & 1) != 0;
     }
 
@@ -112,8 +112,8 @@ public class ValueConversions {
         return x;
     }
     static char unboxCharacter(Object x, boolean cast) {
-        if (x instanceof Character)
-            return (Character) x;
+        if (x instanceof Character c)
+            return c;
         return (char) primitiveConversion(Wrapper.CHAR, x, cast).intValue();
     }
 
@@ -121,8 +121,8 @@ public class ValueConversions {
         return x;
     }
     static long unboxLong(Object x, boolean cast) {
-        if (x instanceof Long)
-            return (Long) x;
+        if (x instanceof Long l)
+            return l;
         return primitiveConversion(Wrapper.LONG, x, cast).longValue();
     }
 
@@ -130,8 +130,8 @@ public class ValueConversions {
         return x;
     }
     static float unboxFloat(Object x, boolean cast) {
-        if (x instanceof Float)
-            return (Float) x;
+        if (x instanceof Float f)
+            return f;
         return primitiveConversion(Wrapper.FLOAT, x, cast).floatValue();
     }
 
@@ -139,8 +139,8 @@ public class ValueConversions {
         return x;
     }
     static double unboxDouble(Object x, boolean cast) {
-        if (x instanceof Double)
-            return (Double) x;
+        if (x instanceof Double d)
+            return d;
         return primitiveConversion(Wrapper.DOUBLE, x, cast).doubleValue();
     }
 
@@ -236,12 +236,12 @@ public class ValueConversions {
             if (!cast)  return null;
             return ZERO_INT;
         }
-        if (x instanceof Number) {
-            res = (Number) x;
-        } else if (x instanceof Boolean) {
-            res = ((boolean)x ? ONE_INT : ZERO_INT);
-        } else if (x instanceof Character) {
-            res = (int)(char)x;
+        if (x instanceof Number n) {
+            res = n;
+        } else if (x instanceof Boolean b) {
+            res = b ? ONE_INT : ZERO_INT;
+        } else if (x instanceof Character c) {
+            res = (int) c;
         } else {
             // this will fail with the required ClassCastException:
             res = (Number) x;
@@ -259,16 +259,16 @@ public class ValueConversions {
      * Byte, Short, Character, or Integer.
      */
     public static int widenSubword(Object x) {
-        if (x instanceof Integer)
-            return (int) x;
-        else if (x instanceof Boolean)
-            return fromBoolean((boolean) x);
-        else if (x instanceof Character)
-            return (char) x;
-        else if (x instanceof Short)
-            return (short) x;
-        else if (x instanceof Byte)
-            return (byte) x;
+        if (x instanceof Integer i)
+            return i;
+        else if (x instanceof Boolean b)
+            return fromBoolean(b);
+        else if (x instanceof Character c)
+            return c;
+        else if (x instanceof Short s)
+            return s;
+        else if (x instanceof Byte b)
+            return b;
         else
             // Fail with a ClassCastException.
             return (int) x;

--- a/src/java.base/share/classes/sun/invoke/util/Wrapper.java
+++ b/src/java.base/share/classes/sun/invoke/util/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -580,9 +580,9 @@ public enum Wrapper {
     }
 
     private static Number numberValue(Object x) {
-        if (x instanceof Number)     return (Number)x;
-        if (x instanceof Character)  return (int)(Character)x;
-        if (x instanceof Boolean)    return (Boolean)x ? 1 : 0;
+        if (x instanceof Number n)     return n;
+        if (x instanceof Character c)  return (int) c;
+        if (x instanceof Boolean b)    return b ? 1 : 0;
         // Remaining allowed case of void:  Must be a null reference.
         return (Number)x;
     }

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,8 +95,8 @@ public final class AnnotatedTypeFactory {
         } else if (type instanceof ParameterizedType t) {
             if (t.getOwnerType() == null)
                 return addTo;
-            if (t.getRawType() instanceof Class
-                    && Modifier.isStatic(((Class) t.getRawType()).getModifiers()))
+            if (t.getRawType() instanceof Class<?> c
+                    && Modifier.isStatic(c.getModifiers()))
                 return addTo;
             return nestingForType(t.getOwnerType(), addTo.pushInner());
         }
@@ -178,10 +178,9 @@ public final class AnnotatedTypeFactory {
 
         @Override
         public AnnotatedType getAnnotatedOwnerType() {
-            if (!(type instanceof Class<?>))
+            if (!(type instanceof Class<?> nested))
                 throw new IllegalStateException("Can't compute owner");
 
-            Class<?> nested = (Class<?>)type;
             Class<?> owner = nested.getDeclaringClass();
             if (owner == null) // top-level, local or anonymous
                 return null;
@@ -250,12 +249,11 @@ public final class AnnotatedTypeFactory {
 
         @Override
         public boolean equals(Object o) {
-            if (o instanceof AnnotatedType &&
+            if (o instanceof AnnotatedType that &&
                 !(o instanceof AnnotatedArrayType) &&
                 !(o instanceof AnnotatedTypeVariable) &&
                 !(o instanceof AnnotatedParameterizedType) &&
                 !(o instanceof AnnotatedWildcardType)) {
-                AnnotatedType that = (AnnotatedType) o;
                 return equalsTypeAndAnnotations(that);
             } else {
                 return false;

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -434,8 +434,8 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
 
         // Check for array of string, class, enum const, annotation,
         // or ExceptionProxy
-        if (v1 instanceof Object[] && v2 instanceof Object[])
-            return Arrays.equals((Object[]) v1, (Object[]) v2);
+        if (v1 instanceof Object[] a1 && v2 instanceof Object[] a2)
+            return Arrays.equals(a1, a2);
 
         // Check for ill formed annotation(s)
         if (v2.getClass() != type)

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -445,9 +445,8 @@ public class AnnotationParser {
     }
     static Class<?> toClass(Type o) {
         if (o instanceof GenericArrayType gat)
-            return Array.newInstance(toClass(gat.getGenericComponentType()), 0)
-                .getClass();
-        return (Class)o;
+            return toClass(gat.getGenericComponentType()).arrayType();
+        return (Class<?>) o;
     }
 
     /**

--- a/src/java.base/share/classes/sun/reflect/generics/factory/CoreReflectionFactory.java
+++ b/src/java.base/share/classes/sun/reflect/generics/factory/CoreReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package sun.reflect.generics.factory;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Method;
@@ -59,12 +58,12 @@ public class CoreReflectionFactory implements GenericsFactory {
 
 
     private ClassLoader getDeclsLoader() {
-        if (decl instanceof Class) {return ((Class) decl).getClassLoader();}
-        if (decl instanceof Method) {
-            return ((Method) decl).getDeclaringClass().getClassLoader();
+        if (decl instanceof Class<?> c) {return c.getClassLoader();}
+        if (decl instanceof Method m) {
+            return m.getDeclaringClass().getClassLoader();
         }
         assert decl instanceof Constructor : "Constructor expected";
-        return ((Constructor) decl).getDeclaringClass().getClassLoader();
+        return ((Constructor<?>) decl).getDeclaringClass().getClassLoader();
 
     }
 
@@ -119,8 +118,8 @@ public class CoreReflectionFactory implements GenericsFactory {
     }
 
     public Type makeArrayType(Type componentType){
-        if (componentType instanceof Class<?>)
-            return Array.newInstance((Class<?>) componentType, 0).getClass();
+        if (componentType instanceof Class<?> ct)
+            return ct.arrayType();
         else
             return GenericArrayTypeImpl.make(componentType);
     }

--- a/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/GenericArrayTypeImpl.java
+++ b/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/GenericArrayTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,9 +70,7 @@ public class GenericArrayTypeImpl
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof GenericArrayType) {
-            GenericArrayType that = (GenericArrayType) o;
-
+        if (o instanceof GenericArrayType that) {
             return Objects.equals(genericComponentType, that.getGenericComponentType());
         } else
             return false;

--- a/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl.java
+++ b/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,9 +165,8 @@ public class ParameterizedTypeImpl implements ParameterizedType {
      */
     @Override
     public boolean equals(Object o) {
-        if (o instanceof ParameterizedType) {
+        if (o instanceof ParameterizedType that) {
             // Check that information is equivalent
-            ParameterizedType that = (ParameterizedType) o;
 
             if (this == that)
                 return true;
@@ -219,10 +218,10 @@ public class ParameterizedTypeImpl implements ParameterizedType {
 
             sb.append("$");
 
-            if (ownerType instanceof ParameterizedTypeImpl) {
+            if (ownerType instanceof ParameterizedTypeImpl pt) {
                 // Find simple name of nested type by removing the
                 // shared prefix with owner.
-                sb.append(rawType.getName().replace( ((ParameterizedTypeImpl)ownerType).rawType.getName() + "$",
+                sb.append(rawType.getName().replace(pt.rawType.getName() + "$",
                                          ""));
             } else
                sb.append(rawType.getSimpleName());

--- a/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/TypeVariableImpl.java
+++ b/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/TypeVariableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ public class TypeVariableImpl<D extends GenericDeclaration>
             throw new AssertionError("Unexpected kind of GenericDeclaration" +
                     decl.getClass().toString());
         }
-        return new TypeVariableImpl<T>(decl, name, bs, f);
+        return new TypeVariableImpl<>(decl, name, bs, f);
     }
 
 
@@ -121,8 +121,8 @@ public class TypeVariableImpl<D extends GenericDeclaration>
      */
     public Type[] getBounds() {
         Object[] value = bounds;
-        if (value instanceof FieldTypeSignature[]) {
-            value = reifyBounds((FieldTypeSignature[])value);
+        if (value instanceof FieldTypeSignature[] sigs) {
+            value = reifyBounds(sigs);
             bounds = value;
         }
         return (Type[])value.clone();
@@ -137,8 +137,8 @@ public class TypeVariableImpl<D extends GenericDeclaration>
      * @since 1.5
      */
     public D getGenericDeclaration() {
-        if (genericDeclaration instanceof Class)
-            ReflectUtil.checkPackageAccess((Class)genericDeclaration);
+        if (genericDeclaration instanceof Class<?> c)
+            ReflectUtil.checkPackageAccess(c);
         else if ((genericDeclaration instanceof Method) ||
                 (genericDeclaration instanceof Constructor))
             ReflectUtil.conservativeCheckMemberAccess((Member)genericDeclaration);
@@ -159,9 +159,8 @@ public class TypeVariableImpl<D extends GenericDeclaration>
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof TypeVariable &&
+        if (o instanceof TypeVariable<?> that &&
                 o.getClass() == TypeVariableImpl.class) {
-            TypeVariable<?> that = (TypeVariable<?>) o;
 
             GenericDeclaration thatDecl = that.getGenericDeclaration();
             String thatName = that.getName();

--- a/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/WildcardTypeImpl.java
+++ b/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/WildcardTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,8 +101,8 @@ public class WildcardTypeImpl extends LazyReflectiveObjectGenerator
      */
     public Type[] getUpperBounds() {
         Object[] value = upperBounds;
-        if (value instanceof FieldTypeSignature[]) {
-            value = reifyBounds((FieldTypeSignature[])value);
+        if (value instanceof FieldTypeSignature[] sigs) {
+            value = reifyBounds(sigs);
             upperBounds = value;
         }
         return (Type[])value.clone();
@@ -132,8 +132,8 @@ public class WildcardTypeImpl extends LazyReflectiveObjectGenerator
      */
     public Type[] getLowerBounds() {
         Object[] value = lowerBounds;
-        if (value instanceof FieldTypeSignature[]) {
-            value = reifyBounds((FieldTypeSignature[])value);
+        if (value instanceof FieldTypeSignature[] sigs) {
+            value = reifyBounds(sigs);
             lowerBounds = value;
         }
         return (Type[])value.clone();
@@ -168,8 +168,7 @@ public class WildcardTypeImpl extends LazyReflectiveObjectGenerator
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof WildcardType) {
-            WildcardType that = (WildcardType) o;
+        if (o instanceof WildcardType that) {
             return
                 Arrays.equals(this.getLowerBounds(),
                               that.getLowerBounds()) &&

--- a/src/java.base/share/classes/sun/reflect/misc/MethodUtil.java
+++ b/src/java.base/share/classes/sun/reflect/misc/MethodUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,14 +98,14 @@ public final class MethodUtil extends SecureClassLoader {
         } catch (InvocationTargetException ie) {
             Throwable t = ie.getCause();
 
-            if (t instanceof InvocationTargetException) {
-                throw (InvocationTargetException)t;
-            } else if (t instanceof IllegalAccessException) {
-                throw (IllegalAccessException)t;
-            } else if (t instanceof RuntimeException) {
-                throw (RuntimeException)t;
-            } else if (t instanceof Error) {
-                throw (Error)t;
+            if (t instanceof InvocationTargetException ite) {
+                throw ite;
+            } else if (t instanceof IllegalAccessException iae) {
+                throw iae;
+            } else if (t instanceof RuntimeException re) {
+                throw re;
+            } else if (t instanceof Error error) {
+                throw error;
             } else {
                 throw new Error("Unexpected invocation error", t);
             }


### PR DESCRIPTION
This patch touches java.lang.reflect and java.lang.invoke packages. It replaces instanceof + cast with pattern matching and updates  Array.newInstance().getClass() patterns with arrayType() for obtaining array types of a class.