### PR TITLE
JDK-8310861: Improve location reporting for javac serial lint warnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -5165,15 +5165,19 @@ public class Check {
                     String name = enclosed.getSimpleName().toString();
                     switch(enclosed.getKind()) {
                     case FIELD -> {
+                        var field = (VarSymbol)enclosed;
                         if (serialFieldNames.contains(name)) {
-                            log.warning(LintCategory.SERIAL, tree.pos(),
+                            log.warning(LintCategory.SERIAL,
+                                        TreeInfo.diagnosticPositionFor(field, tree),
                                         Warnings.IneffectualSerialFieldEnum(name));
                         }
                     }
 
                     case METHOD -> {
+                        var method = (MethodSymbol)enclosed;
                         if (serialMethodNames.contains(name)) {
-                            log.warning(LintCategory.SERIAL, tree.pos(),
+                            log.warning(LintCategory.SERIAL,
+                                        TreeInfo.diagnosticPositionFor(method, tree),
                                         Warnings.IneffectualSerialMethodEnum(name));
                         }
                     }
@@ -5293,9 +5297,11 @@ public class Check {
                     String name = enclosed.getSimpleName().toString();
                     switch(enclosed.getKind()) {
                     case FIELD -> {
+                        var field = (VarSymbol)enclosed;
                         switch(name) {
                         case "serialPersistentFields" -> {
-                            log.warning(LintCategory.SERIAL, tree.pos(),
+                            log.warning(LintCategory.SERIAL,
+                                        TreeInfo.diagnosticPositionFor(field, tree),
                                         Warnings.IneffectualSerialFieldRecord);
                         }
 
@@ -5303,7 +5309,7 @@ public class Check {
                             // Could generate additional warning that
                             // svuid value is not checked to match for
                             // records.
-                            checkSerialVersionUID(tree, e, (VarSymbol)enclosed);
+                            checkSerialVersionUID(tree, e, field);
                         }
 
                         }
@@ -5314,9 +5320,11 @@ public class Check {
                         switch(name) {
                         case "writeReplace" -> checkWriteReplace(tree, e, method);
                         case "readResolve"  -> checkReadResolve(tree, e, method);
+
                         default -> {
                             if (serialMethodNames.contains(name)) {
-                                log.warning(LintCategory.SERIAL, tree.pos(),
+                                log.warning(LintCategory.SERIAL,
+                                            TreeInfo.diagnosticPositionFor(method, tree),
                                             Warnings.IneffectualSerialMethodRecord(name));
                             }
                         }
@@ -5394,7 +5402,8 @@ public class Check {
         private void checkExternalizable(JCClassDecl tree, Element enclosing, MethodSymbol method) {
             // If the enclosing class is externalizable, warn for the method
             if (isExternalizable((Type)enclosing.asType())) {
-                log.warning(LintCategory.SERIAL, tree.pos(),
+                log.warning(LintCategory.SERIAL,
+                            TreeInfo.diagnosticPositionFor(method, tree),
                             Warnings.IneffectualSerialMethodExternalizable(method.getSimpleName()));
             }
             return;

--- a/test/langtools/tools/javac/warnings/Serial/CtorAccess.java
+++ b/test/langtools/tools/javac/warnings/Serial/CtorAccess.java
@@ -2,6 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8202056
  * @compile/ref=CtorAccess.out -XDrawDiagnostics -Xlint:serial CtorAccess.java
+ * @compile/ref=empty.out      -XDrawDiagnostics               CtorAccess.java
  */
 
 import java.io.*;

--- a/test/langtools/tools/javac/warnings/Serial/CtorAccess.out
+++ b/test/langtools/tools/javac/warnings/Serial/CtorAccess.out
@@ -1,3 +1,3 @@
-CtorAccess.java:15:12: compiler.warn.serializable.missing.access.no.arg.ctor: CtorAccess
-CtorAccess.java:30:5: compiler.warn.serializable.missing.access.no.arg.ctor: CtorAccess.MemberSuper
+CtorAccess.java:16:12: compiler.warn.serializable.missing.access.no.arg.ctor: CtorAccess
+CtorAccess.java:31:5: compiler.warn.serializable.missing.access.no.arg.ctor: CtorAccess.MemberSuper
 2 warnings

--- a/test/langtools/tools/javac/warnings/Serial/EnumSerial.java
+++ b/test/langtools/tools/javac/warnings/Serial/EnumSerial.java
@@ -2,6 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8202056
  * @compile/ref=EnumSerial.out -XDrawDiagnostics -Xlint:serial EnumSerial.java
+ * @compile/ref=empty.out -XDrawDiagnostics               EnumSerial.java
  */
 
 import java.io.*;

--- a/test/langtools/tools/javac/warnings/Serial/EnumSerial.out
+++ b/test/langtools/tools/javac/warnings/Serial/EnumSerial.out
@@ -1,8 +1,8 @@
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.field.enum: serialVersionUID
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.field.enum: serialPersistentFields
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.method.enum: writeObject
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.method.enum: writeReplace
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.method.enum: readObject
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.method.enum: readObjectNoData
-EnumSerial.java:9:1: compiler.warn.ineffectual.serial.method.enum: readResolve
+EnumSerial.java:16:31: compiler.warn.ineffectual.serial.field.enum: serialVersionUID
+EnumSerial.java:17:46: compiler.warn.ineffectual.serial.field.enum: serialPersistentFields
+EnumSerial.java:19:18: compiler.warn.ineffectual.serial.method.enum: writeObject
+EnumSerial.java:23:20: compiler.warn.ineffectual.serial.method.enum: writeReplace
+EnumSerial.java:27:18: compiler.warn.ineffectual.serial.method.enum: readObject
+EnumSerial.java:32:18: compiler.warn.ineffectual.serial.method.enum: readObjectNoData
+EnumSerial.java:36:20: compiler.warn.ineffectual.serial.method.enum: readResolve
 7 warnings

--- a/test/langtools/tools/javac/warnings/Serial/Extern.java
+++ b/test/langtools/tools/javac/warnings/Serial/Extern.java
@@ -2,6 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8202056
  * @compile/ref=Extern.out -XDrawDiagnostics -Xlint:serial Extern.java
+ * @compile/ref=empty.out  -XDrawDiagnostics               Extern.java
  */
 
 import java.io.*;

--- a/test/langtools/tools/javac/warnings/Serial/Extern.out
+++ b/test/langtools/tools/javac/warnings/Serial/Extern.out
@@ -1,6 +1,6 @@
-Extern.java:9:1: compiler.warn.externalizable.missing.public.no.arg.ctor
-Extern.java:9:1: compiler.warn.ineffectual.serial.field.externalizable
-Extern.java:9:1: compiler.warn.ineffectual.serial.method.externalizable: readObject
-Extern.java:9:1: compiler.warn.ineffectual.serial.method.externalizable: writeObject
-Extern.java:9:1: compiler.warn.ineffectual.serial.method.externalizable: readObjectNoData
+Extern.java:10:1: compiler.warn.externalizable.missing.public.no.arg.ctor
+Extern.java:10:1: compiler.warn.ineffectual.serial.field.externalizable
+Extern.java:28:18: compiler.warn.ineffectual.serial.method.externalizable: readObject
+Extern.java:34:18: compiler.warn.ineffectual.serial.method.externalizable: writeObject
+Extern.java:39:18: compiler.warn.ineffectual.serial.method.externalizable: readObjectNoData
 5 warnings

--- a/test/langtools/tools/javac/warnings/Serial/RecordSerial.java
+++ b/test/langtools/tools/javac/warnings/Serial/RecordSerial.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8202056
+ * @bug 8202056 8310861
  * @compile/ref=RecordSerial.out -XDrawDiagnostics -Xlint:serial RecordSerial.java
  */
 
@@ -40,5 +40,14 @@ record RecordSerial(int foo) implements Serializable {
     // (possibly) effective
     private Object readResolve() throws ObjectStreamException {
         return null;
+    }
+
+    // meaningless Externalizable methods, no warning generated
+    public void writeExternal(ObjectOutput oo) {
+        ;
+    }
+
+    public void readExternal(ObjectInput oi) {
+        ;
     }
 }

--- a/test/langtools/tools/javac/warnings/Serial/RecordSerial.out
+++ b/test/langtools/tools/javac/warnings/Serial/RecordSerial.out
@@ -1,5 +1,5 @@
-RecordSerial.java:9:1: compiler.warn.ineffectual.serial.field.record
-RecordSerial.java:9:1: compiler.warn.ineffectual.serial.method.record: writeObject
-RecordSerial.java:9:1: compiler.warn.ineffectual.serial.method.record: readObject
-RecordSerial.java:9:1: compiler.warn.ineffectual.serial.method.record: readObjectNoData
+RecordSerial.java:17:46: compiler.warn.ineffectual.serial.field.record
+RecordSerial.java:20:18: compiler.warn.ineffectual.serial.method.record: writeObject
+RecordSerial.java:30:18: compiler.warn.ineffectual.serial.method.record: readObject
+RecordSerial.java:36:18: compiler.warn.ineffectual.serial.method.record: readObjectNoData
 4 warnings


### PR DESCRIPTION
For a subset of the expanded serial lint warnings ([JDK-8202056](https://bugs.openjdk.org/browse/JDK-8202056), [JDK-8160675](https://bugs.openjdk.org/browse/JDK-8160675)), javac uses the location of the enclosing type rather than the method or field in question.

This PR addresses this by using the idiom of finding the method/field's tree within the type tree being checked.

All langtools regression tests pass when run locally; the intention is to backport this fix to JDK 21 as well.