### PR TITLE
8310863: Build failure after  JDK- 8305341

### DIFF
--- a/src/java.prefs/windows/native/libprefs/WindowsPreferences.c
+++ b/src/java.prefs/windows/native/libprefs/WindowsPreferences.c
@@ -23,7 +23,6 @@
  * questions.
  */
 
-#include <stdalign.h>
 #include <stdlib.h>
 #include <windows.h>
 #include "jni.h"
@@ -50,7 +49,7 @@ Java_java_util_prefs_WindowsPreferences_WindowsRegOpenKey(JNIEnv* env,
     int errorCode = RegOpenKeyEx((HKEY) hKey, str, 0, securityMask, &handle);
     (*env)->ReleaseByteArrayElements(env, lpSubKey, str, 0);
 
-    alignas(8) jlong tmp[2];
+    _Alignas(8) jlong tmp[2];
     tmp[0] = (jlong) handle;
     tmp[1] = errorCode;
     jlongArray result = (*env)->NewLongArray(env, 2);
@@ -79,7 +78,7 @@ Java_java_util_prefs_WindowsPreferences_WindowsRegCreateKeyEx(JNIEnv* env,
         NULL, &handle, &lpdwDisposition);
     (*env)->ReleaseByteArrayElements(env, lpSubKey, str, 0);
 
-    alignas(8) jlong tmp[3];
+    _Alignas(8) jlong tmp[3];
     tmp[0] = (jlong) handle;
     tmp[1] = errorCode;
     tmp[2] = lpdwDisposition;
@@ -197,7 +196,7 @@ Java_java_util_prefs_WindowsPreferences_WindowsRegQueryInfoKey(JNIEnv* env,
         &valuesNumber, &maxValueNameLength,
         NULL, NULL, NULL);
 
-    alignas(8) jlong tmp[5];
+    _Alignas(8) jlong tmp[5];
     tmp[0] = subKeysNumber;
     tmp[1] = errorCode;
     tmp[2] = valuesNumber;

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#include <stdalign.h>
-
 #include "sun_security_jgss_wrapper_GSSLibStub.h"
 #include "NativeUtil.h"
 #include "NativeFunc.h"
@@ -1191,7 +1189,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_inquireContext(JNIEnv *env,
   OM_uint32 flags;
   int isInitiator, isEstablished;
 #if defined (_WIN32) && defined (_MSC_VER)
-  alignas(8)
+  _Alignas(8)
 #endif
   jlong result[6];
   jlongArray jresult;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/ArrayReferenceImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ArrayReferenceImpl.c
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#include <stdalign.h>
-
 #include "util.h"
 #include "ArrayReferenceImpl.h"
 #include "inStream.h"
@@ -418,7 +416,7 @@ readLongComponents(JNIEnv *env, PacketInputStream *in,
 {
     int i;
 #if defined (_WIN32) && defined (_MSC_VER)
-    alignas(8)
+    _Alignas(8)
 #endif
     jlong component;
 
@@ -449,7 +447,7 @@ readDoubleComponents(JNIEnv *env, PacketInputStream *in,
 {
     int i;
 #if defined (_WIN32) && defined (_MSC_VER)
-    alignas(8)
+    _Alignas(8)
 #endif
     jdouble component;
 


### PR DESCRIPTION
Build failure after JDK- 8305341

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310863](https://bugs.openjdk.org/browse/JDK-8310863): Build failure after  JDK- 8305341 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14645/head:pull/14645` \
`$ git checkout pull/14645`

Update a local copy of the PR: \
`$ git checkout pull/14645` \
`$ git pull https://git.openjdk.org/jdk.git pull/14645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14645`

View PR using the GUI difftool: \
`$ git pr show -t 14645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14645.diff">https://git.openjdk.org/jdk/pull/14645.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14645#issuecomment-1606505643)