### PR TITLE
8310868: Thread.interrupt() method's javadoc has an incorrect {@link}

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1689,7 +1689,7 @@ public class Thread implements Runnable {
      *
      * @implNote In the JDK Reference Implementation, interruption of a thread
      * that is not alive still records that the interrupt request was made and
-     * will report it via {@link #interrupted} and {@link #isInterrupted()}.
+     * will report it via {@link #interrupted()} and {@link #isInterrupted()}.
      *
      * @throws  SecurityException
      *          if the current thread cannot modify this thread


### PR DESCRIPTION
Can I please get a review of this trivial change which fixes a javadoc issue reported in https://bugs.openjdk.org/browse/JDK-8310868?

I ran `make docs-image` locally with this change and the link is now correctly rendered in the generated javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310868](https://bugs.openjdk.org/browse/JDK-8310868): Thread.interrupt() method's javadoc has an incorrect {@link} (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14646/head:pull/14646` \
`$ git checkout pull/14646`

Update a local copy of the PR: \
`$ git checkout pull/14646` \
`$ git pull https://git.openjdk.org/jdk.git pull/14646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14646`

View PR using the GUI difftool: \
`$ git pr show -t 14646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14646.diff">https://git.openjdk.org/jdk/pull/14646.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14646#issuecomment-1606712120)