### PR TITLE
8309889: [s390] Missing return statement after calling jump_to_native_invoker method in generate_method_handle_dispatch.

### DIFF
--- a/src/hotspot/cpu/s390/methodHandles_s390.cpp
+++ b/src/hotspot/cpu/s390/methodHandles_s390.cpp
@@ -387,6 +387,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
   } else if (iid == vmIntrinsics::_linkToNative) {
     assert(for_compiler_entry, "only compiler entry is supported");
     jump_to_native_invoker(_masm, member_reg, temp1);
+    return;
   }
 
   // The method is a member invoker used by direct method handles.


### PR DESCRIPTION
Missing return statement after calling jump_to_native_invoker method in generate_method_handle_dispatch, it leads to assert(is_valid()) failed: invalid register.

Ran tier1 test cases passing with release, fastdebug and slowdebug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309889](https://bugs.openjdk.org/browse/JDK-8309889): [s390] Missing return statement after calling jump_to_native_invoker method in generate_method_handle_dispatch. (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14647/head:pull/14647` \
`$ git checkout pull/14647`

Update a local copy of the PR: \
`$ git checkout pull/14647` \
`$ git pull https://git.openjdk.org/jdk.git pull/14647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14647`

View PR using the GUI difftool: \
`$ git pr show -t 14647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14647.diff">https://git.openjdk.org/jdk/pull/14647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14647#issuecomment-1606720927)