### PR TITLE
8310489: New test runtime/ClassInitErrors/TestStackOverflowDuringInit.java failed

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -32,7 +32,7 @@
  * @requires vm.flagless
  * @comment This test could easily be perturbed so don't allow flag settings.
  *
- * @run main/othervm TestStackOverflowDuringInit
+ * @run main/othervm -Xss160K -Xint TestStackOverflowDuringInit
  */
 
 import java.io.ByteArrayOutputStream;
@@ -40,22 +40,44 @@ import java.io.PrintStream;
 
 public class TestStackOverflowDuringInit {
 
-    // Test case is fuzzed/obfuscated
+    // The setup for this is somewhat intricate. We need to trigger a
+    // StackOverflowError during execution of the static initializer
+    // for a class, but we need there to be insufficient stack left
+    // for the creation of the ExceptionInInitializerError that would
+    // occur in that case. So we can't just recurse in a static initializer
+    // as that would unwind all the way allowing plenty of stack for the
+    // EIIE. Instead we recurse outside of a static initializer context
+    // and have a finally clause that will trigger class initialization
+    // of another class, which is where we will fail to create the EIIE.
+    // Even then this is non-trivial, only the use of Long.valueOf from
+    // the original reproducer seems to trigger SOE in just the right places.
+
+    static void recurse() {
+        try {
+            // This will initialize Long but not touch LongCache.
+            Long.valueOf(1024L);
+            recurse();
+        } finally {
+            // This will require initializing LongCache, which will
+            // initially fail due to StackOverflowError and so LongCache
+            // will be marked erroneous. As we unwind and again execute this
+            // we will throw NoClassDefFoundError due to the erroneous
+            // state of LongCache.
+            Long.valueOf(0);
+        }
+    }
 
     public static void main(String[] args) throws Exception {
         String expected = "java.lang.NoClassDefFoundError: Could not initialize class java.lang.Long$LongCache";
         String cause = "Caused by: java.lang.StackOverflowError";
 
-        TestStackOverflowDuringInit i = new TestStackOverflowDuringInit();
         try {
-            i.j();
+            recurse();
         } catch (Throwable ex) {
             //            ex.printStackTrace();
             verify_stack(ex, expected, cause);
         }
     }
-
-    void j() { ((e) new a()).g = 0; }
 
     private static void verify_stack(Throwable e, String expected, String cause) throws Exception {
         ByteArrayOutputStream byteOS = new ByteArrayOutputStream();
@@ -70,22 +92,3 @@ public class TestStackOverflowDuringInit {
         }
     }
 }
-
-class a {
-    Boolean b;
-    {
-        try {
-            Long.valueOf(509505376256L);
-            Boolean c =
-                true ? new d().b
-                : 5 != ((e)java.util.HashSet.newHashSet(301758).clone()).f;
-        } finally {
-            Long.valueOf(0);
-        }
-    }
-}
-class e extends a {
-    double g;
-    int f;
-}
-class d extends a {}


### PR DESCRIPTION
I haven't been able to reproduce the failure outside of the occasional CI failures we have, but I have done some further analysis.

I've extracted the key aspects of the test and put them in a simplified "non fuzzed" form so that it is much easier to see what the test does and what it expects to happen. I've also tweak the running the test so that it uses the minimum amount of stack (so we get stackoverflow sooner) and runs in interpreted mode (so we eliminate any potential JIT oddities with inlining etc.). Hopefully this will be more stable - otherwise I will just delete the test.

Testing:
 - 50x on each x64 platform in our CI

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310489](https://bugs.openjdk.org/browse/JDK-8310489): New test runtime/ClassInitErrors/TestStackOverflowDuringInit.java failed (**Bug** - P2)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14648/head:pull/14648` \
`$ git checkout pull/14648`

Update a local copy of the PR: \
`$ git checkout pull/14648` \
`$ git pull https://git.openjdk.org/jdk.git pull/14648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14648`

View PR using the GUI difftool: \
`$ git pr show -t 14648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14648.diff">https://git.openjdk.org/jdk/pull/14648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14648#issuecomment-1606771583)