### PR TITLE
8295191: IR framework timeout options expect ms instead of s

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -139,8 +139,8 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DShuffleTests=false`: Disables the random execution order of all tests (such a shuffling is always done by default).
 - `-DDumpReplay=true`: Add the `DumpReplay` directive to the test VM.
 - `-DGCAfter=true`: Perform `System.gc()` after each test (slows the execution down).
-- `-DTestCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a normal `@Test` annotated method.
-- `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
+- `-DTestCompilationTimeout=20`: Change the default waiting time (default: 10s) for a compilation of a normal `@Test` annotated method.
+- `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10s) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
 - `-DIgnoreCompilerControls=true`: Ignore all compiler controls applied in the framework. This includes any compiler control annotations (`@DontCompile`, `@DontInline`, `@ForceCompile`, `@ForceInline`, `@ForceCompileStaticInitializer`), the exclusion of `@Run` and `@Check` methods from compilation, and the directive to not inline `@Test` annotated methods.
 - `-DExcludeRandom=true`: Randomly exclude some methods from compilation.
 - `-DPreferCommandLineFlags=true`: Prefer flags set via the command line over flags specified by the tests.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -139,8 +139,8 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DShuffleTests=false`: Disables the random execution order of all tests (such a shuffling is always done by default).
 - `-DDumpReplay=true`: Add the `DumpReplay` directive to the test VM.
 - `-DGCAfter=true`: Perform `System.gc()` after each test (slows the execution down).
-- `-DTestCompilationTimeout=20000`: Change the default waiting time (default: 10000ms) for a compilation of a normal `@Test` annotated method.
-- `-DWaitForCompilationTimeout=20000`: Change the default waiting time (default: 10000ms) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
+- `-DTestCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a normal `@Test` annotated method.
+- `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
 - `-DIgnoreCompilerControls=true`: Ignore all compiler controls applied in the framework. This includes any compiler control annotations (`@DontCompile`, `@DontInline`, `@ForceCompile`, `@ForceInline`, `@ForceCompileStaticInitializer`), the exclusion of `@Run` and `@Check` methods from compilation, and the directive to not inline `@Test` annotated methods.
 - `-DExcludeRandom=true`: Randomly exclude some methods from compilation.
 - `-DPreferCommandLineFlags=true`: Prefer flags set via the command line over flags specified by the tests.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -139,8 +139,8 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DShuffleTests=false`: Disables the random execution order of all tests (such a shuffling is always done by default).
 - `-DDumpReplay=true`: Add the `DumpReplay` directive to the test VM.
 - `-DGCAfter=true`: Perform `System.gc()` after each test (slows the execution down).
-- `-DTestCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a normal `@Test` annotated method.
-- `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
+- `-DTestCompilationTimeout=20000`: Change the default waiting time (default: 10000ms) for a compilation of a normal `@Test` annotated method.
+- `-DWaitForCompilationTimeout=20000`: Change the default waiting time (default: 10000ms) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
 - `-DIgnoreCompilerControls=true`: Ignore all compiler controls applied in the framework. This includes any compiler control annotations (`@DontCompile`, `@DontInline`, `@ForceCompile`, `@ForceInline`, `@ForceCompileStaticInitializer`), the exclusion of `@Run` and `@Check` methods from compilation, and the directive to not inline `@Test` annotated methods.
 - `-DExcludeRandom=true`: Randomly exclude some methods from compilation.
 - `-DPreferCommandLineFlags=true`: Prefer flags set via the command line over flags specified by the tests.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -139,8 +139,8 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DShuffleTests=false`: Disables the random execution order of all tests (such a shuffling is always done by default).
 - `-DDumpReplay=true`: Add the `DumpReplay` directive to the test VM.
 - `-DGCAfter=true`: Perform `System.gc()` after each test (slows the execution down).
-- `-DTestCompilationTimeout=20`: Change the default waiting time (default: 10s) for a compilation of a normal `@Test` annotated method.
-- `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10s) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
+- `-DTestCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a normal `@Test` annotated method.
+- `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10ms) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
 - `-DIgnoreCompilerControls=true`: Ignore all compiler controls applied in the framework. This includes any compiler control annotations (`@DontCompile`, `@DontInline`, `@ForceCompile`, `@ForceInline`, `@ForceCompileStaticInitializer`), the exclusion of `@Run` and `@Check` methods from compilation, and the directive to not inline `@Test` annotated methods.
 - `-DExcludeRandom=true`: Randomly exclude some methods from compilation.
 - `-DPreferCommandLineFlags=true`: Prefer flags set via the command line over flags specified by the tests.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/AbstractTest.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/AbstractTest.java
@@ -37,8 +37,8 @@ import java.lang.reflect.Modifier;
  */
 abstract class AbstractTest {
     protected static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
-    protected static final int TEST_COMPILATION_TIMEOUT = Integer.parseInt(System.getProperty("TestCompilationTimeout", "10000"));
-    protected static final int WAIT_FOR_COMPILATION_TIMEOUT = Integer.parseInt(System.getProperty("WaitForCompilationTimeout", "10000"));
+    protected static final int TEST_COMPILATION_TIMEOUT_MS = Integer.parseInt(System.getProperty("TestCompilationTimeout", "10")) * 1000;
+    protected static final int WAIT_FOR_COMPILATION_TIMEOUT_MS = Integer.parseInt(System.getProperty("WaitForCompilationTimeout", "10")) * 1000;
     protected static final boolean VERIFY_OOPS = (Boolean)WHITE_BOX.getVMFlag("VerifyOops");
 
     protected final int warmupIterations;
@@ -149,10 +149,10 @@ abstract class AbstractTest {
                 break;
             }
             elapsed = System.currentTimeMillis() - started;
-        } while (elapsed < TEST_COMPILATION_TIMEOUT);
-        TestRun.check(elapsed < TEST_COMPILATION_TIMEOUT,
+        } while (elapsed < TEST_COMPILATION_TIMEOUT_MS);
+        TestRun.check(elapsed < TEST_COMPILATION_TIMEOUT_MS,
                       "Could not compile " + testMethod + " at level " + test.getCompLevel() + " after "
-                      + TEST_COMPILATION_TIMEOUT/1000 + "s. Last compilation level: " + lastCompilationLevel);
+                      + TEST_COMPILATION_TIMEOUT_MS/1000 + "s. Last compilation level: " + lastCompilationLevel);
         checkCompilationLevel(test);
     }
 
@@ -194,9 +194,9 @@ abstract class AbstractTest {
                 // Don't wait for compilation if -Xcomp is enabled or if we are randomly excluding methods from compilation.
                 return;
             }
-        } while (elapsed < WAIT_FOR_COMPILATION_TIMEOUT);
+        } while (elapsed < WAIT_FOR_COMPILATION_TIMEOUT_MS);
         throw new TestRunException(testMethod + " not compiled after waiting for "
-                                   + WAIT_FOR_COMPILATION_TIMEOUT/1000 + " s");
+                                   + WAIT_FOR_COMPILATION_TIMEOUT_MS/1000 + " s");
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/CustomRunTest.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/CustomRunTest.java
@@ -133,11 +133,11 @@ class CustomRunTest extends AbstractTest {
         executor.shutdown();
         int timeout;
         if (anyCompileMethod && anyWaitForCompilation) {
-            timeout = Math.max(WAIT_FOR_COMPILATION_TIMEOUT, TEST_COMPILATION_TIMEOUT) + 5000;
+            timeout = Math.max(WAIT_FOR_COMPILATION_TIMEOUT_MS, TEST_COMPILATION_TIMEOUT_MS) + 5000;
         } else if (anyWaitForCompilation) {
-            timeout = WAIT_FOR_COMPILATION_TIMEOUT + 5000;
+            timeout = WAIT_FOR_COMPILATION_TIMEOUT_MS + 5000;
         } else {
-            timeout = TEST_COMPILATION_TIMEOUT + 5000;
+            timeout = TEST_COMPILATION_TIMEOUT_MS + 5000;
         }
         try {
             executor.awaitTermination(timeout, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
The flags `-DTestCompilationTimeout` and `-DWaitForCompilationTimeout` expect values in ms. The example in the README was misleading as one could infer from "default: 10s" that the flag expects values in ms. Therefore I changed the values and units in the example to ms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295191](https://bugs.openjdk.org/browse/JDK-8295191): IR framework timeout options expect ms instead of s (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14649/head:pull/14649` \
`$ git checkout pull/14649`

Update a local copy of the PR: \
`$ git checkout pull/14649` \
`$ git pull https://git.openjdk.org/jdk.git pull/14649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14649`

View PR using the GUI difftool: \
`$ git pr show -t 14649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14649.diff">https://git.openjdk.org/jdk/pull/14649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14649#issuecomment-1607216513)