### PR TITLE
8310873: Re-enable locked_create_entry symbol check in runtime/NMT/CheckForProperDetailStackTrace.java for RISC-V

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
+++ b/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,7 @@ public class CheckForProperDetailStackTrace {
             // It's ok for ARM not to have symbols, because it does not support NMT detail
             // when targeting thumb2. It's also ok for Windows not to have symbols, because
             // they are only available if the symbols file is included with the build.
-            if (Platform.isWindows() || Platform.isARM() || Platform.isRISCV64()) {
+            if (Platform.isWindows() || Platform.isARM()) {
                 return; // we are done
             }
             output.reportDiagnosticSummary();


### PR DESCRIPTION
The `Platform.isRISCV64()` check was once added in our internal development. The reason was that we have different C Frame and Java Frame layouts at first. So we could not get the right stacks without the RISC-V specific `get_native_stack`. After defining RISC-V related `get_native_stack` method (refactored by https://github.com/openjdk/jdk-sandbox/commit/db2415748747a0912749bb8fc160a8948021a924), it could return the expected symbols. So we can remove the platform check for RISC-V safely.

runtime/NMT/CheckForProperDetailStackTrace.java still passed without `Platform.isRISCV64()` check.

Testing:
- [x] fastdebug  build (cross/native compile)
- [x] release  build (cross/native compile)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310873](https://bugs.openjdk.org/browse/JDK-8310873): Re-enable locked_create_entry symbol check in runtime/NMT/CheckForProperDetailStackTrace.java for RISC-V (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14650/head:pull/14650` \
`$ git checkout pull/14650`

Update a local copy of the PR: \
`$ git checkout pull/14650` \
`$ git pull https://git.openjdk.org/jdk.git pull/14650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14650`

View PR using the GUI difftool: \
`$ git pr show -t 14650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14650.diff">https://git.openjdk.org/jdk/pull/14650.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14650#issuecomment-1607068358)