### PR TITLE
8310728: Enable Zc:inline flag in Visual Studio build

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -560,8 +560,8 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
         -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -MP"
-    TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:wchar_t-"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -MP"
+    TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -Zc:wchar_t-"
   fi
 
   # CFLAGS C language level for JDK sources (hotspot only uses C++)

--- a/src/hotspot/os/windows/gc/x/xVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/x/xVirtualMemory_windows.cpp
@@ -27,7 +27,7 @@
 #include "gc/x/xLargePages.inline.hpp"
 #include "gc/x/xMapper_windows.hpp"
 #include "gc/x/xSyscall_windows.hpp"
-#include "gc/x/xVirtualMemory.hpp"
+#include "gc/x/xVirtualMemory.inline.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 

--- a/src/hotspot/share/gc/x/xPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/x/xPhysicalMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 #include "gc/x/xArray.inline.hpp"
 #include "gc/x/xGlobals.hpp"
 #include "gc/x/xLargePages.inline.hpp"
+#include "gc/x/xList.inline.hpp"
 #include "gc/x/xNUMA.inline.hpp"
 #include "gc/x/xPhysicalMemory.inline.hpp"
 #include "logging/log.hpp"


### PR DESCRIPTION
Enabling `Zc:inline` flag improves C++11 standard compliance, reduces the size of obj files produced by the build by 200+MB, and might also improve build speed.

2 files failed to compile with the flag added; see JBS for details if you're interested. This PR fixes the compilation issues.

Tier1-4 builds and Tier1-2 tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310728](https://bugs.openjdk.org/browse/JDK-8310728): Enable Zc:inline flag in Visual Studio build (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14651/head:pull/14651` \
`$ git checkout pull/14651`

Update a local copy of the PR: \
`$ git checkout pull/14651` \
`$ git pull https://git.openjdk.org/jdk.git pull/14651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14651`

View PR using the GUI difftool: \
`$ git pr show -t 14651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14651.diff">https://git.openjdk.org/jdk/pull/14651.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14651#issuecomment-1607394907)