### PR TITLE
8310828: java.sql java.sql.rowset packages have no `@since` info

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/package-info.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -69,8 +69,9 @@
  * classes so that any developer can extend them to provide additional features
  * while maintaining the core required standard functionality and compatibility. It
  * is anticipated that many vendors and developers will extend the standard feature
- * set to their their particular needs. The website for JDBC Technology will
+ * set to their particular needs. The website for JDBC Technology will
  * provider a portal where implementations can be listed, similar to the way it
  * provides a site for JDBC drivers.
+ * @since 1.5
  */
  package com.sun.rowset;

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/providers/package-info.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/providers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,5 +154,6 @@
  *  ability to get any updates back to the original data source. Another possibility
  *  is a more formal synchronization mechanism such as SyncML
  *  (<a href="http://www.syncml.org/">http://www.syncml.org/</a>)   <br>
+ * @since 1.5
  */
 package com.sun.rowset.providers;

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/package-info.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/package-info.java
@@ -146,7 +146,7 @@
  * <p>
  * A compliant JDBC {@code RowSet} implementation <b>must</b> implement one or more
  * standard interfaces specified in this package and <b>may</b> extend the
- * {@link BaseRowSet} abstract class. For example, a
+ * {@link javax.sql.rowset.BaseRowSet} abstract class. For example, a
  * {@code CachedRowSet} implementation must implement the {@code CachedRowSet}
  * interface and extend the {@code BaseRowSet} abstract class. The
  * {@code BaseRowSet} class provides the standard architecture on which all
@@ -283,5 +283,6 @@
  * <li><a href="http://docs.oracle.com/javase/tutorial/jdbc/basics/rowset.html">
  * JDBC RowSet Tutorial</a>
  *</ul>
+ * @since 1.5
  */
 package javax.sql.rowset;

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/package-info.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,5 +224,6 @@
  * object that is associated with the {@code Connection} object being
  * used. So, in other words, if no map is specified, the connection's type
  * map can be used by default.
+ * @since 1.5
  */
 package javax.sql.rowset.serial;

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/spi/package-info.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -476,5 +476,6 @@
  * <li><a href="http://docs.oracle.com/javase/tutorial/jdbc/">DataSource for JDBC
  * Connections</a>
  * </ul>
+ * @since 1.5
  */
 package javax.sql.rowset.spi;

--- a/src/java.sql/share/classes/java/sql/package-info.java
+++ b/src/java.sql/share/classes/java/sql/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -338,5 +338,6 @@
  *
  *  <li>&ldquo;<i>JDBC API Tutorial and Reference, Third Edition</i>&rdquo;
  * </ul>
+ * @since 1.1
  */
 package java.sql;

--- a/src/java.sql/share/classes/javax/sql/package-info.java
+++ b/src/java.sql/share/classes/javax/sql/package-info.java
@@ -173,7 +173,6 @@
  * each {@code XAConnection} object creates an {@code XAResource} object
  * that the transaction manager uses to manage the connection.
  *
- *
  * <H2>Rowsets</H2>
  * The {@code RowSet} interface works with various other classes and
  * interfaces behind the scenes. These can be grouped into three categories.
@@ -248,7 +247,6 @@
  * for its rowset.  The rowset's internal state is also updated, either by the
  * reader or directly by the method {@code RowSet.execute}.
  *
- *
  * <LI>{@code RowSetWriter}<br>
  * A disconnected {@code RowSet} object that has implemented the
  * {@code RowSetInternal} interface can call on its writer (the
@@ -265,14 +263,12 @@
  * <LI>Close the connection
  * </UL>
  *
- *
  * </UL>
  * </OL>
  * <p>
  * The {@code RowSet} interface may be implemented in any number of
  * ways, and anyone may write an implementation. Developers are encouraged
  * to use their imaginations in coming up with new ways to use rowsets.
- *
  *
  * <h2>Package Specification</h2>
  *

--- a/src/java.sql/share/classes/javax/sql/package-info.java
+++ b/src/java.sql/share/classes/javax/sql/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,5 +289,6 @@
  * <ul>
  * <li>&ldquo;<i>JDBC&#8482;API Tutorial and Reference, Third Edition</i>&rdquo;
  * </ul>
+ * @since 1.4
  */
 package javax.sql;


### PR DESCRIPTION
Hi all,

Please review this trivial change which adds the `@since` javadoc tag to the various ` java.sql `and `java.sql.rowset` packages.

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310828](https://bugs.openjdk.org/browse/JDK-8310828): java.sql java.sql.rowset packages have no `@since` info (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14652/head:pull/14652` \
`$ git checkout pull/14652`

Update a local copy of the PR: \
`$ git checkout pull/14652` \
`$ git pull https://git.openjdk.org/jdk.git pull/14652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14652`

View PR using the GUI difftool: \
`$ git pr show -t 14652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14652.diff">https://git.openjdk.org/jdk/pull/14652.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14652#issuecomment-1608009681)