### PR TITLE
8310070: Test: javax/net/ssl/DTLS/DTLSWontNegotiateV10.java timed out

### DIFF
--- a/test/jdk/javax/net/ssl/DTLS/DTLSWontNegotiateV10.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSWontNegotiateV10.java
@@ -48,6 +48,8 @@ public class DTLSWontNegotiateV10 {
     private static final String DTLS = "DTLS";
     private static final String DTLSV_1_2 = "DTLSv1.2";
 
+    private static final int READ_TIMEOUT_SECS = Integer.getInteger("readtimeout", 30);
+
     public static void main(String[] args) throws Exception {
         if (args[0].equals(DTLSV_1_0)) {
             SecurityUtils.removeFromDisabledTlsAlgs(DTLSV_1_0);
@@ -63,20 +65,43 @@ public class DTLSWontNegotiateV10 {
         } else {
             // server process
             // args: protocol
-            try (DTLSServer server = new DTLSServer(args[0])) {
-                List<String> command = List.of(
-                        Path.of(System.getProperty("java.home"), "bin", "java").toString(),
-                        "DTLSWontNegotiateV10",
-                        // if server is "DTLS" then the client should be v1.0 and vice versa
-                        args[0].equals(DTLS) ? DTLSV_1_0 : DTLS,
-                        Integer.toString(server.getListeningPortNumber())
-                );
+            final int totalAttempts = 5;
+            int tries;
+            for (tries = 0 ; tries < totalAttempts ; ++tries) {
+                try {
+                    System.out.printf("Starting server %d/%d attempts%n", tries+1, totalAttempts);
+                    runServer(args[0]);
+                    break;
+                } catch (SocketTimeoutException exc) {
+                    System.out.println("The server timed-out waiting for packets from the client.");
+                }
+            }
+            if (tries == totalAttempts) {
+                throw new RuntimeException("The server/client communications timed-out after " + totalAttempts + " tries.");
+            }
+        }
+    }
 
-                ProcessBuilder builder = new ProcessBuilder(command);
-                Process p = builder.inheritIO().start();
-                server.run();
-                p.destroy();
-                System.out.println("Success: DTLSv1.0 connection was not established.");
+    private static void runServer(String protocol) throws Exception {
+        // args: protocol
+        Process clientProcess = null;
+        try (DTLSServer server = new DTLSServer(protocol)) {
+            List<String> command = List.of(
+                    Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                    "DTLSWontNegotiateV10",
+                    // if server is "DTLS" then the client should be v1.0 and vice versa
+                    protocol.equals(DTLS) ? DTLSV_1_0 : DTLS,
+                    Integer.toString(server.getListeningPortNumber())
+            );
+
+            ProcessBuilder builder = new ProcessBuilder(command);
+            clientProcess = builder.inheritIO().start();
+            server.run();
+            System.out.println("Success: DTLSv1.0 connection was not established.");
+
+        } finally {
+            if (clientProcess != null) {
+                clientProcess.destroy();
             }
         }
     }
@@ -89,6 +114,9 @@ public class DTLSWontNegotiateV10 {
         public DTLSClient(String protocol, int portNumber) throws Exception {
             super(true, protocol);
             remotePort = portNumber;
+            socket.setSoTimeout(READ_TIMEOUT_SECS * 1000);
+            log("Client listening on port " + socket.getLocalPort()
+                    + ". Sending data to server port " + remotePort);
             log("Enabled protocols: " + String.join(" ", engine.getEnabledProtocols()));
         }
 
@@ -287,6 +315,8 @@ public class DTLSWontNegotiateV10 {
 
         public DTLSServer(String protocol) throws Exception {
             super(false, protocol);
+            socket.setSoTimeout(READ_TIMEOUT_SECS * 1000);
+            log("Server listening on port: " + socket.getLocalPort());
             log("Enabled protocols: " + String.join(" ", engine.getEnabledProtocols()));
         }
 


### PR DESCRIPTION
In this PR, I updated the test to use read time-outs. The test is restarted if the read operations time-out within (default) 30 seconds. The test makes 5 attempts before giving up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310070](https://bugs.openjdk.org/browse/JDK-8310070): Test: javax/net/ssl/DTLS/DTLSWontNegotiateV10.java timed out (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14658/head:pull/14658` \
`$ git checkout pull/14658`

Update a local copy of the PR: \
`$ git checkout pull/14658` \
`$ git pull https://git.openjdk.org/jdk.git pull/14658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14658`

View PR using the GUI difftool: \
`$ git pr show -t 14658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14658.diff">https://git.openjdk.org/jdk/pull/14658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14658#issuecomment-1607942409)