### PR TITLE
JDK-8310909: java.io.InvalidObjectException has redundant `@since` tag

### DIFF
--- a/src/java.base/share/classes/java/io/InvalidObjectException.java
+++ b/src/java.base/share/classes/java/io/InvalidObjectException.java
@@ -31,8 +31,6 @@ package java.io;
  *
  * @see ObjectInputValidation
  * @since 1.1
- *
- * @since   1.1
  */
 public class InvalidObjectException extends ObjectStreamException {
 


### PR DESCRIPTION
Please review a trivial update to remove a redundant `@since` tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310909](https://bugs.openjdk.org/browse/JDK-8310909): java.io.InvalidObjectException has redundant `@since` tag (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14662/head:pull/14662` \
`$ git checkout pull/14662`

Update a local copy of the PR: \
`$ git checkout pull/14662` \
`$ git pull https://git.openjdk.org/jdk.git pull/14662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14662`

View PR using the GUI difftool: \
`$ git pr show -t 14662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14662.diff">https://git.openjdk.org/jdk/pull/14662.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14662#issuecomment-1608028671)