### PR TITLE
JDK-8310908: Non-standard `@since` tag in `com.sun.java.accessibility.util.package-info`

### DIFF
--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/package-info.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/package-info.java
@@ -62,6 +62,6 @@
  * <p>The class {@code Translator} provides a translation to interface {@code Accessible}
  * for objects that do not implement interface {@code Accessible}.
  *
- * @since JDK1.7
+ * @since 1.7
  */
 package com.sun.java.accessibility.util;


### PR DESCRIPTION
Please review a trivial update to normalize an `@since` tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310908](https://bugs.openjdk.org/browse/JDK-8310908): Non-standard `@since` tag in `com.sun.java.accessibility.util.package-info` (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14663/head:pull/14663` \
`$ git checkout pull/14663`

Update a local copy of the PR: \
`$ git checkout pull/14663` \
`$ git pull https://git.openjdk.org/jdk.git pull/14663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14663`

View PR using the GUI difftool: \
`$ git pr show -t 14663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14663.diff">https://git.openjdk.org/jdk/pull/14663.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14663#issuecomment-1608042373)