### PR TITLE
8310914: Remove 2 malformed java/foreign ProblemList entries

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -472,13 +472,6 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 
 ############################################################################
 
-# jdk_foreign
-
-java/foreign/callarranger/TestAarch64CallArranger.java generic-x86
-java/foreign/TestLargeSegmentCopy.java generic-x86
-
-############################################################################
-
 # jdk_lang
 
 java/lang/ProcessHandle/InfoTest.java                           8211847 aix-ppc64


### PR DESCRIPTION
Remove 2 malformed problem list entries. These entries are considered malformed according to [1] since they are missing a bug number. 

The `java/foreign/callarranger/TestAarch64CallArranger.java` test was removed, and the `java/foreign/TestLargeSegmentCopy.java` disables x86 in the jtreg test header using `@requires sun.arch.data.model == "64"`, so neither of these entries are needed.

Testing: `jdk_foreign` test suite (which contains these tests)

[1]: https://openjdk.org/jtreg/faq.html#what-is-a-problemlist.txt-file

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310914](https://bugs.openjdk.org/browse/JDK-8310914): Remove 2 malformed java/foreign ProblemList entries (**Bug** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14664/head:pull/14664` \
`$ git checkout pull/14664`

Update a local copy of the PR: \
`$ git checkout pull/14664` \
`$ git pull https://git.openjdk.org/jdk.git pull/14664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14664`

View PR using the GUI difftool: \
`$ git pr show -t 14664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14664.diff">https://git.openjdk.org/jdk/pull/14664.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14664#issuecomment-1608284352)