### PR TITLE
8310920: Fix -Wconversion warnings in command line flags

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -579,7 +579,7 @@ JVMFlag* JVMFlag::find_flag(const char* name, size_t length, bool allow_locked, 
 }
 
 JVMFlag* JVMFlag::fuzzy_match(const char* name, size_t length, bool allow_locked) {
-  double VMOptionsFuzzyMatchSimilarity = 0.7f;
+  double VMOptionsFuzzyMatchSimilarity = 0.7;
   JVMFlag* match = nullptr;
   double score;
   double max_score = -1;

--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -579,10 +579,10 @@ JVMFlag* JVMFlag::find_flag(const char* name, size_t length, bool allow_locked, 
 }
 
 JVMFlag* JVMFlag::fuzzy_match(const char* name, size_t length, bool allow_locked) {
-  float VMOptionsFuzzyMatchSimilarity = 0.7f;
+  double VMOptionsFuzzyMatchSimilarity = 0.7f;
   JVMFlag* match = nullptr;
-  float score;
-  float max_score = -1;
+  double score;
+  double max_score = -1;
 
   for (JVMFlag* current = &flagTable[0]; current->_name != nullptr; current++) {
     score = StringUtils::similarity(current->_name, strlen(current->_name), name, length);

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -64,7 +64,7 @@ public:
     verbose |= (origin == JVMFlagOrigin::ERGONOMIC);
     T value = *((T*)value_addr);
     const JVMTypedFlagLimit<T>* constraint = (const JVMTypedFlagLimit<T>*)JVMFlagLimit::get_constraint(flag);
-    if (constraint != nullptr && constraint->phase() <= static_cast<int>(JVMFlagLimit::validating_phase())) {
+    if (constraint != nullptr && constraint->phase() <= JVMFlagLimit::validating_phase()) {
       JVMFlag::Error err = typed_check_constraint(constraint->constraint_func(), value, verbose);
       if (err != JVMFlag::SUCCESS) {
         if (origin == JVMFlagOrigin::ERGONOMIC) {

--- a/src/hotspot/share/runtime/flags/jvmFlagLimit.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLimit.cpp
@@ -79,13 +79,13 @@ public:
   static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, T min, T max) {
     return p;
   }
-  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, char phase) {
+  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase) {
     return p;
   }
-  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, T min, T max, ConstraintMarker dummy2, short func, char phase) {
+  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, T min, T max, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase) {
     return p;
   }
-  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, char phase, T min, T max) {
+  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase, T min, T max) {
     return p;
   }
 };
@@ -98,7 +98,7 @@ public:
 #define FLAG_LIMIT_PTR(         type, name, ...)       ), LimitGetter<type>::get_limit(&limit_##name, 0
 #define FLAG_LIMIT_PTR_NONE(    type, name, ...)       ), LimitGetter<type>::no_limit(0
 #define APPLY_FLAG_RANGE(...)                          , __VA_ARGS__
-#define APPLY_FLAG_CONSTRAINT(func, phase)             , next_two_args_are_constraint, (short)CONSTRAINT_ENUM(func), (char)JVMFlagConstraintPhase::phase
+#define APPLY_FLAG_CONSTRAINT(func, phase)             , next_two_args_are_constraint, (short)CONSTRAINT_ENUM(func), JVMFlagConstraintPhase::phase
 
 constexpr JVMTypedFlagLimit<int> limit_dummy
 (
@@ -179,7 +179,7 @@ bool JVMFlagLimit::check_all_constraints(JVMFlagConstraintPhase phase) {
   for (int i = 0; i < NUM_JVMFlagsEnum; i++) {
     JVMFlagsEnum flag_enum = static_cast<JVMFlagsEnum>(i);
     const JVMFlagLimit* constraint = get_constraint_at(flag_enum);
-    if (constraint != nullptr && constraint->phase() == static_cast<char>(phase) &&
+    if (constraint != nullptr && constraint->phase() == phase &&
         JVMFlagAccess::check_constraint(JVMFlag::flag_from_enum(flag_enum),
                                         constraint->constraint_func(), true) != JVMFlag::SUCCESS) {
       status = false;

--- a/src/hotspot/share/runtime/flags/jvmFlagLimit.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLimit.cpp
@@ -79,13 +79,13 @@ public:
   static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, T min, T max) {
     return p;
   }
-  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, int phase) {
+  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, char phase) {
     return p;
   }
-  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, T min, T max, ConstraintMarker dummy2, short func, int phase) {
+  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, T min, T max, ConstraintMarker dummy2, short func, char phase) {
     return p;
   }
-  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, int phase, T min, T max) {
+  static constexpr const JVMFlagLimit* get_limit(const JVMTypedFlagLimit<T>* p, int dummy, ConstraintMarker dummy2, short func, char phase, T min, T max) {
     return p;
   }
 };
@@ -98,7 +98,7 @@ public:
 #define FLAG_LIMIT_PTR(         type, name, ...)       ), LimitGetter<type>::get_limit(&limit_##name, 0
 #define FLAG_LIMIT_PTR_NONE(    type, name, ...)       ), LimitGetter<type>::no_limit(0
 #define APPLY_FLAG_RANGE(...)                          , __VA_ARGS__
-#define APPLY_FLAG_CONSTRAINT(func, phase)             , next_two_args_are_constraint, (short)CONSTRAINT_ENUM(func), int(JVMFlagConstraintPhase::phase)
+#define APPLY_FLAG_CONSTRAINT(func, phase)             , next_two_args_are_constraint, (short)CONSTRAINT_ENUM(func), (char)JVMFlagConstraintPhase::phase
 
 constexpr JVMTypedFlagLimit<int> limit_dummy
 (
@@ -179,7 +179,7 @@ bool JVMFlagLimit::check_all_constraints(JVMFlagConstraintPhase phase) {
   for (int i = 0; i < NUM_JVMFlagsEnum; i++) {
     JVMFlagsEnum flag_enum = static_cast<JVMFlagsEnum>(i);
     const JVMFlagLimit* constraint = get_constraint_at(flag_enum);
-    if (constraint != nullptr && constraint->phase() == static_cast<int>(phase) &&
+    if (constraint != nullptr && constraint->phase() == static_cast<char>(phase) &&
         JVMFlagAccess::check_constraint(JVMFlag::flag_from_enum(flag_enum),
                                         constraint->constraint_func(), true) != JVMFlag::SUCCESS) {
       status = false;

--- a/src/hotspot/share/runtime/flags/jvmFlagLimit.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLimit.hpp
@@ -30,7 +30,7 @@
 class outputStream;
 template <typename T> class JVMTypedFlagLimit;
 
-enum class JVMFlagConstraintPhase : int {
+enum class JVMFlagConstraintPhase : char {
   // Will be validated during argument processing (Arguments::parse_argument).
   AtParse         = 0,
   // Will be validated inside Threads::create_vm(), right after Arguments::apply_ergo().
@@ -103,7 +103,7 @@ public:
   char phase() const { return _phase; }
   char kind()  const { return _kind; }
 
-  constexpr JVMFlagLimit(int type_enum, short func, short phase, short kind)
+  constexpr JVMFlagLimit(int type_enum, short func, char phase, char kind)
     : _constraint_func(func), _phase(phase), _kind(kind) DEBUG_ONLY(COMMA _type_enum(type_enum)) {}
 
   static const JVMFlagLimit* get_range(const JVMFlag* flag) {
@@ -162,15 +162,15 @@ public:
     JVMFlagLimit(type_enum, 0, 0, HAS_RANGE), _min(min), _max(max) {}
 
   // constraint only
-  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, int phase) :
+  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, char phase) :
     JVMFlagLimit(type_enum, func, phase, HAS_CONSTRAINT), _min(0), _max(0) {}
 
   // range and constraint
-  constexpr JVMTypedFlagLimit(int type_enum, T min, T max, ConstraintMarker dummy2, short func, int phase)  :
+  constexpr JVMTypedFlagLimit(int type_enum, T min, T max, ConstraintMarker dummy2, short func, char phase)  :
     JVMFlagLimit(type_enum, func, phase, HAS_RANGE | HAS_CONSTRAINT), _min(min), _max(max) {}
 
   // constraint and range
-  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, int phase, T min, T max)  :
+  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, char phase, T min, T max)  :
     JVMFlagLimit(type_enum, func, phase, HAS_RANGE | HAS_CONSTRAINT), _min(min), _max(max) {}
 
   T min() const { return _min; }

--- a/src/hotspot/share/runtime/flags/jvmFlagLimit.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLimit.hpp
@@ -67,7 +67,7 @@ template <typename T> class JVMTypedFlagLimit;
 
 class JVMFlagLimit {
   short _constraint_func;
-  char  _phase;
+  JVMFlagConstraintPhase  _phase;
   char  _kind;
 
 #ifdef ASSERT
@@ -100,10 +100,10 @@ private:
 
 public:
   void* constraint_func() const;
-  char phase() const { return _phase; }
+  JVMFlagConstraintPhase phase() const { return _phase; }
   char kind()  const { return _kind; }
 
-  constexpr JVMFlagLimit(int type_enum, short func, char phase, char kind)
+  constexpr JVMFlagLimit(int type_enum, short func, JVMFlagConstraintPhase phase, char kind)
     : _constraint_func(func), _phase(phase), _kind(kind) DEBUG_ONLY(COMMA _type_enum(type_enum)) {}
 
   static const JVMFlagLimit* get_range(const JVMFlag* flag) {
@@ -155,22 +155,22 @@ public:
   // dummy - no range or constraint. This object will not be emitted into the .o file
   // because we declare it as "const" but has no reference to it.
   constexpr JVMTypedFlagLimit(int type_enum) :
-  JVMFlagLimit(0, 0, 0, 0), _min(0), _max(0) {}
+  JVMFlagLimit(0, 0, JVMFlagConstraintPhase::AtParse, 0), _min(0), _max(0) {}
 
   // range only
   constexpr JVMTypedFlagLimit(int type_enum, T min, T max) :
-    JVMFlagLimit(type_enum, 0, 0, HAS_RANGE), _min(min), _max(max) {}
+    JVMFlagLimit(type_enum, 0, JVMFlagConstraintPhase::AtParse, HAS_RANGE), _min(min), _max(max) {}
 
   // constraint only
-  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, char phase) :
+  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase) :
     JVMFlagLimit(type_enum, func, phase, HAS_CONSTRAINT), _min(0), _max(0) {}
 
   // range and constraint
-  constexpr JVMTypedFlagLimit(int type_enum, T min, T max, ConstraintMarker dummy2, short func, char phase)  :
+  constexpr JVMTypedFlagLimit(int type_enum, T min, T max, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase)  :
     JVMFlagLimit(type_enum, func, phase, HAS_RANGE | HAS_CONSTRAINT), _min(min), _max(max) {}
 
   // constraint and range
-  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, char phase, T min, T max)  :
+  constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase, T min, T max)  :
     JVMFlagLimit(type_enum, func, phase, HAS_RANGE | HAS_CONSTRAINT), _min(min), _max(max) {}
 
   T min() const { return _min; }


### PR DESCRIPTION
This is broken out from but tested with the PR from https://github.com/openjdk/jdk/pull/14659

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310920](https://bugs.openjdk.org/browse/JDK-8310920): Fix -Wconversion warnings in command line flags (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [19baa252](https://git.openjdk.org/jdk/pull/14665/files/19baa252ea9a8554a6caa8dc3e1f4c87f9890cf4)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [95ee731c](https://git.openjdk.org/jdk/pull/14665/files/95ee731cebb418805f2aab8efbefda8adb14b1af)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14665/head:pull/14665` \
`$ git checkout pull/14665`

Update a local copy of the PR: \
`$ git checkout pull/14665` \
`$ git pull https://git.openjdk.org/jdk.git pull/14665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14665`

View PR using the GUI difftool: \
`$ git pr show -t 14665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14665.diff">https://git.openjdk.org/jdk/pull/14665.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14665#issuecomment-1608210272)