### PR TITLE
8310921: Fix -Wconversion warnings from GenerateOopMap

### DIFF
--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -660,7 +660,7 @@ void GenerateOopMap::restore_state(BasicBlock *bb)
 }
 
 int GenerateOopMap::next_bb_start_pc(BasicBlock *bb) {
- int bbNum = (int)(bb - _basic_blocks + 1);
+ intptr_t bbNum = bb - _basic_blocks + 1;
  if (bbNum == _bb_count)
     return method()->code_size();
 
@@ -2057,7 +2057,7 @@ void GenerateOopMap::print_time() {
   tty->print_cr ("---------------------------");
   tty->print_cr ("  Total : %3.3f sec.", GenerateOopMap::_total_oopmap_time.seconds());
   tty->print_cr ("  (%3.0f bytecodes per sec) ",
-  (float)GenerateOopMap::_total_byte_count / GenerateOopMap::_total_oopmap_time.seconds());
+  (double)GenerateOopMap::_total_byte_count / GenerateOopMap::_total_oopmap_time.seconds());
 }
 
 //

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -223,7 +223,7 @@ int RetTableEntry::_init_nof_jsrs = 5;
 
 RetTableEntry::RetTableEntry(int target, RetTableEntry *next) {
   _target_bci = target;
-  _jsrs = new GrowableArray<intptr_t>(_init_nof_jsrs);
+  _jsrs = new GrowableArray<int>(_init_nof_jsrs);
   _next = next;
 }
 
@@ -660,7 +660,7 @@ void GenerateOopMap::restore_state(BasicBlock *bb)
 }
 
 int GenerateOopMap::next_bb_start_pc(BasicBlock *bb) {
- int bbNum = bb - _basic_blocks + 1;
+ int bbNum = (int)(bb - _basic_blocks + 1);
  if (bbNum == _bb_count)
     return method()->code_size();
 
@@ -2057,7 +2057,7 @@ void GenerateOopMap::print_time() {
   tty->print_cr ("---------------------------");
   tty->print_cr ("  Total : %3.3f sec.", GenerateOopMap::_total_oopmap_time.seconds());
   tty->print_cr ("  (%3.0f bytecodes per sec) ",
-  GenerateOopMap::_total_byte_count / GenerateOopMap::_total_oopmap_time.seconds());
+  (float)GenerateOopMap::_total_byte_count / GenerateOopMap::_total_oopmap_time.seconds());
 }
 
 //
@@ -2101,7 +2101,7 @@ bool GenerateOopMap::compute_map(Thread* current) {
   _report_result  = false;
   _report_result_for_send = false;
   _new_var_map    = nullptr;
-  _ret_adr_tos    = new GrowableArray<intptr_t>(5);  // 5 seems like a good number;
+  _ret_adr_tos    = new GrowableArray<int>(5);  // 5 seems like a good number;
   _did_rewriting  = false;
   _did_relocation = false;
 
@@ -2401,16 +2401,16 @@ bool GenerateOopMap::rewrite_load_or_store(BytecodeStream *bcs, Bytecodes::Code 
   // Patch either directly in Method* or in temp. buffer
   if (newIlen == 1) {
     assert(varNo < 4, "varNo too large");
-    *bcp = bc0 + varNo;
+    *bcp = (u1)(bc0 + varNo);
   } else if (newIlen == 2) {
     assert(varNo < 256, "2-byte index needed!");
     *(bcp + 0) = bcN;
-    *(bcp + 1) = varNo;
+    *(bcp + 1) = (u1)varNo;
   } else {
     assert(newIlen == 4, "Wrong instruction length");
     *(bcp + 0) = Bytecodes::_wide;
     *(bcp + 1) = bcN;
-    Bytes::put_Java_u2(bcp+2, varNo);
+    Bytes::put_Java_u2(bcp+2, (u2)varNo);
   }
 
   if (newIlen != ilen) {

--- a/src/hotspot/share/oops/generateOopMap.hpp
+++ b/src/hotspot/share/oops/generateOopMap.hpp
@@ -53,7 +53,7 @@ class RetTableEntry : public ResourceObj {
  private:
   static int _init_nof_jsrs;                      // Default size of jsrs list
   int _target_bci;                                // Target PC address of jump (bytecode index)
-  GrowableArray<intptr_t> * _jsrs;                     // List of return addresses  (bytecode index)
+  GrowableArray<int> * _jsrs;                     // List of return addresses  (bytecode index)
   RetTableEntry *_next;                           // Link to next entry
  public:
    RetTableEntry(int target, RetTableEntry *next);
@@ -441,7 +441,7 @@ class GenerateOopMap {
   bool is_aload                             (BytecodeStream *itr, int *index);
 
   // List of bci's where a return address is on top of the stack
-  GrowableArray<intptr_t> *_ret_adr_tos;
+  GrowableArray<int>* _ret_adr_tos;
 
   bool stack_top_holds_ret_addr             (int bci);
   void compute_ret_adr_at_TOS               ();


### PR DESCRIPTION
This is broken out from but tested with the PR from https://github.com/openjdk/jdk/pull/14659

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310921](https://bugs.openjdk.org/browse/JDK-8310921): Fix -Wconversion warnings from GenerateOopMap (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [3902331a](https://git.openjdk.org/jdk/pull/14666/files/3902331a342f6e0c8637adaf38a48776e7f7690a)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14666/head:pull/14666` \
`$ git checkout pull/14666`

Update a local copy of the PR: \
`$ git checkout pull/14666` \
`$ git pull https://git.openjdk.org/jdk.git pull/14666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14666`

View PR using the GUI difftool: \
`$ git pr show -t 14666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14666.diff">https://git.openjdk.org/jdk/pull/14666.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14666#issuecomment-1608218763)