### PR TITLE
JDK-8310922: java/lang/Class/forName/ForNameNames.java fails after being added by JDK-8310242

### DIFF
--- a/test/jdk/java/lang/Class/forName/ForNameNames.java
+++ b/test/jdk/java/lang/Class/forName/ForNameNames.java
@@ -43,7 +43,7 @@ public class ForNameNames {
                 Arguments.of("java.lang.String", String.class),
                 Arguments.of("[Ljava.lang.String;", String[].class),
                 Arguments.of("ForNameNames$Inner", Inner.class),
-                Arguments.of("[LForNameNames$Inner;", Inner.class),
+                Arguments.of("[LForNameNames$Inner;", Inner[].class),
                 Arguments.of("[[I", int[][].class)
         );
     }


### PR DESCRIPTION
A trivial fix to correct the expected result to be `Inner[].class`.   I missed the rerun of the test to verify the last-minute edit to the test by JDK-8310242.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310922](https://bugs.openjdk.org/browse/JDK-8310922): java/lang/Class/forName/ForNameNames.java fails after being added by JDK-8310242 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14667/head:pull/14667` \
`$ git checkout pull/14667`

Update a local copy of the PR: \
`$ git checkout pull/14667` \
`$ git pull https://git.openjdk.org/jdk.git pull/14667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14667`

View PR using the GUI difftool: \
`$ git pr show -t 14667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14667.diff">https://git.openjdk.org/jdk/pull/14667.diff</a>

</details>
