### PR TITLE
JDK-8310814: Clarify the targetName parameter of Lookup::findClass

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2844,10 +2844,16 @@ assertEquals("[x, y, z]", pb.command().toString());
          * Such a resolution, as specified in JVMS {@jvms 5.4.3.1}, attempts to locate and load the class,
          * and then determines whether the class is accessible to this lookup object.
          * <p>
+         * For a class or an interface, the name is the {@linkplain ClassLoader##binary-name binary name}.
+         * For an array class of {@code n} dimensions, the name begins with {@code n} occurrences
+         * of {@code '['} and followed by the element type as encoded in the
+         * {@linkplain Class##nameFormat table} specified in {@link Class#getName}.
+         * <p>
          * The lookup context here is determined by the {@linkplain #lookupClass() lookup class},
          * its class loader, and the {@linkplain #lookupModes() lookup modes}.
          *
-         * @param targetName the fully qualified name of the class to be looked up.
+         * @param targetName the {@linkplain ClassLoader##binary-name binary name} of the class
+         *                   or the string representing an array class
          * @return the requested class.
          * @throws SecurityException if a security manager is present and it
          *                           <a href="MethodHandles.Lookup.html#secmgr">refuses access</a>


### PR DESCRIPTION
This PR updates the spec of `Lookup::findClass` to reflect the current behavior that requires a binary name or a string representing an array class in the form as returned by `Class::getName`.    

`test/jdk/java/lang/invoke/accessClassAndFindClass/TestFindClass.java` already covers the test cases of a nested class and an array class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8310833](https://bugs.openjdk.org/browse/JDK-8310833) to be approved

### Issues
 * [JDK-8310814](https://bugs.openjdk.org/browse/JDK-8310814): Clarify the targetName parameter of Lookup::findClass (**Bug** - P4)
 * [JDK-8310833](https://bugs.openjdk.org/browse/JDK-8310833): Clarify the targetName parameter of Lookup::findClass (**CSR**)

### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14668/head:pull/14668` \
`$ git checkout pull/14668`

Update a local copy of the PR: \
`$ git checkout pull/14668` \
`$ git pull https://git.openjdk.org/jdk.git pull/14668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14668`

View PR using the GUI difftool: \
`$ git pr show -t 14668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14668.diff">https://git.openjdk.org/jdk/pull/14668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14668#issuecomment-1608308805)