### PR TITLE
8309209: C2 failed "assert(_stack_guard_state == stack_guard_reserved_disabled) failed: inconsistent state"

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -694,8 +694,9 @@ void InterpreterMacroAssembler::remove_activation(
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
-    ldr(rscratch1, Address(rthread, JavaThread::stack_guard_state_offset()));
-    cmp(rscratch1, (u1)StackOverflow::stack_guard_enabled);
+    assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
+    ldrw(rscratch1, Address(rthread, JavaThread::stack_guard_state_offset()));
+    cmpw(rscratch1, (u1)StackOverflow::stack_guard_enabled);
     br(Assembler::EQ, no_reserved_zone_enabling);
 
     // look for an overflow into the stack reserved zone, i.e.

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -693,6 +693,11 @@ void InterpreterMacroAssembler::remove_activation(
     // testing if reserved zone needs to be re-enabled
     Label no_reserved_zone_enabling;
 
+    // check if already enabled - if so no re-enabling needed
+    ldr(rscratch1, Address(rthread, JavaThread::stack_guard_state_offset()));
+    cmp(rscratch1, (u1)StackOverflow::stack_guard_enabled);
+    br(Assembler::EQ, no_reserved_zone_enabling);
+
     // look for an overflow into the stack reserved zone, i.e.
     // interpreter_frame_sender_sp <= JavaThread::reserved_stack_activation
     ldr(rscratch1, Address(rthread, JavaThread::reserved_stack_activation_offset()));

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -888,6 +888,11 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     // Test if reserved zone needs to be enabled.
     Label no_reserved_zone_enabling;
 
+    // check if already enabled - if so no re-enabling needed
+    lwz(R0, in_bytes(JavaThread::stack_guard_state_offset()), R16_thread);
+    cmpwi(CCR0, R0, StackOverflow::stack_guard_enabled);
+    beq_predict_taken(CCR0, no_reserved_zone_enabling);
+
     // Compare frame pointers. There is no good stack pointer, as with stack
     // frame compression we can get different SPs when we do calls. A subsequent
     // call could have a smaller SP, so that this compare succeeds for an

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -889,6 +889,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
+    assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
     lwz(R0, in_bytes(JavaThread::stack_guard_state_offset()), R16_thread);
     cmpwi(CCR0, R0, StackOverflow::stack_guard_enabled);
     beq_predict_taken(CCR0, no_reserved_zone_enabling);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -765,7 +765,7 @@ void InterpreterMacroAssembler::remove_activation(
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
-    ldw(t0, Address(xthread, JavaThread::stack_guard_state_offset()));
+    lw(t0, Address(xthread, JavaThread::stack_guard_state_offset()));
     subw(t0, t0, StackOverflow::stack_guard_enabled);
     beqz(t0, no_reserved_zone_enabling);
 

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -765,8 +765,8 @@ void InterpreterMacroAssembler::remove_activation(
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
-    ld(t0, Address(xthread, JavaThread::stack_guard_state_offset()));
-    sub(t0, t0, StackOverflow::stack_guard_enabled);
+    ldw(t0, Address(xthread, JavaThread::stack_guard_state_offset()));
+    subw(t0, t0, StackOverflow::stack_guard_enabled);
     beqz(t0, no_reserved_zone_enabling);
 
     ld(t0, Address(xthread, JavaThread::reserved_stack_activation_offset()));

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -765,8 +765,9 @@ void InterpreterMacroAssembler::remove_activation(
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
-    ld(t0, Address(rthread, JavaThread::stack_guard_state_offset()));
-    beq(t0, StackOverflow::stack_guard_enabled, no_reserved_zone_enabling);
+    ld(t0, Address(xthread, JavaThread::stack_guard_state_offset()));
+    sub(t0, t0, StackOverflow::stack_guard_enabled);
+    beqz(t0, no_reserved_zone_enabling);
 
     ld(t0, Address(xthread, JavaThread::reserved_stack_activation_offset()));
     ble(t1, t0, no_reserved_zone_enabling);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -765,6 +765,7 @@ void InterpreterMacroAssembler::remove_activation(
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
+    assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
     lw(t0, Address(xthread, JavaThread::stack_guard_state_offset()));
     subw(t0, t0, StackOverflow::stack_guard_enabled);
     beqz(t0, no_reserved_zone_enabling);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -764,6 +764,10 @@ void InterpreterMacroAssembler::remove_activation(
     // testing if reserved zone needs to be re-enabled
     Label no_reserved_zone_enabling;
 
+    // check if already enabled - if so no re-enabling needed
+    ld(t0, Address(rthread, JavaThread::stack_guard_state_offset()));
+    beq(t0, StackOverflow::stack_guard_enabled, no_reserved_zone_enabling);
+
     ld(t0, Address(xthread, JavaThread::reserved_stack_activation_offset()));
     ble(t1, t0, no_reserved_zone_enabling);
 

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -953,7 +953,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     Label no_reserved_zone_enabling;
 
     // check if already enabled - if so no re-enabling needed
-    guarantee(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
+    assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
     z_ly(Z_R0, Address(Z_thread, JavaThread::stack_guard_state_offset()));
     compare32_and_branch(Z_R0, StackOverflow::stack_guard_enabled, bcondEqual, no_reserved_zone_enabling);
 

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -952,6 +952,11 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     // Test if reserved zone needs to be enabled.
     Label no_reserved_zone_enabling;
 
+    // check if already enabled - if so no re-enabling needed
+    guarantee(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
+    z_ly(Z_R0, Address(Z_thread, JavaThread::stack_guard_state_offset()));
+    compare32_and_branch(Z_R0, StackOverflow::stack_guard_enabled, bcondEqual, no_reserved_zone_enabling);
+
     // Compare frame pointers. There is no good stack pointer, as with stack
     // frame compression we can get different SPs when we do calls. A subsequent
     // call could have a smaller SP, so that this compare succeeds for an

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1151,6 +1151,8 @@ void InterpreterMacroAssembler::remove_activation(
 
     NOT_LP64(get_thread(rthread);)
 
+    // check if already enabled - if so no re-enabling needed
+    assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
     cmpl(Address(rthread, JavaThread::stack_guard_state_offset()), StackOverflow::stack_guard_enabled);
     jcc(Assembler::equal, no_reserved_zone_enabling);
 


### PR DESCRIPTION
This appears to be the same kind of issue as reported in [JDK-8146697](https://bugs.openjdk.org/browse/JDK-8146697) way back in Java 9, which was only "fixed" on x86.  The current failure was seen on Aarch64. It seems prudent to apply the same changes to all the other platforms. I've done Aarch64, and took a guess at RISC-V but do not know PPC or S390, so I am looking to others to provide the appropriate equivalent code changes there.

Testing so far is Aarch64 only:
- Tiers 1-3
- 50x the closed stackoverflow test that failed previously
- 25x vmTestbase/nsk/stress/stack/*

As these failures are so rare, passing tests don't really tell us much. This is more an attempt at additional robustness.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309209](https://bugs.openjdk.org/browse/JDK-8309209): C2 failed "assert(_stack_guard_state == stack_guard_reserved_disabled) failed: inconsistent state" (**Bug** - P3)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [1d001c3b](https://git.openjdk.org/jdk/pull/14669/files/1d001c3b91864263c9d1a8539077a232fc34535e)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [1d001c3b](https://git.openjdk.org/jdk/pull/14669/files/1d001c3b91864263c9d1a8539077a232fc34535e)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`
 * Martin Doerr `<mdoerr@openjdk.org>`
 * Amit Kumar `<amitkumar@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14669/head:pull/14669` \
`$ git checkout pull/14669`

Update a local copy of the PR: \
`$ git checkout pull/14669` \
`$ git pull https://git.openjdk.org/jdk.git pull/14669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14669`

View PR using the GUI difftool: \
`$ git pr show -t 14669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14669.diff">https://git.openjdk.org/jdk/pull/14669.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14669#issuecomment-1608866044)