### PR TITLE
8309902: C2: assert(false) failed: Bad graph detected in build_loop_late after JDK-8305189

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2043,12 +2043,6 @@ bool IdealLoopTree::is_invariant(Node* n) const {
 // to the new stride.
 void PhaseIdealLoop::update_main_loop_assertion_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init,
                                                            const int stride_con) {
-  if (init->Opcode() == Op_CastII) {
-    // skip over the cast added by PhaseIdealLoop::cast_incr_before_loop() when pre/post/main loops are created because
-    // it can get in the way of type propagation
-    assert(((CastIINode*)init)->carry_dependency() && loop_head->skip_predicates() == init->in(0), "casted iv phi from pre loop expected");
-    init = init->in(1);
-  }
   Node* entry = ctrl;
   Node* prev_proj = ctrl;
   LoopNode* outer_loop_head = loop_head->skip_strip_mined();

--- a/test/hotspot/jtreg/compiler/loopopts/TestAssertPredicatePeeling.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestAssertPredicatePeeling.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309902
+ * @summary C2: assert(false) failed: Bad graph detected in build_loop_late after JDK-8305189
+ * @run main/othervm  -Xcomp -XX:CompileCommand=compileonly,TestAssertPredicatePeeling::* TestAssertPredicatePeeling
+ */
+
+
+public class TestAssertPredicatePeeling {
+    static volatile long instanceCount;
+
+    public static void main(String[] strArr) {
+        test();
+    }
+
+    static int test() {
+        int i2 = 2, i17 = 3, i18 = 2, iArr[] = new int[10];
+
+        int i15 = 1;
+        while (i15 < 100000) {
+            for (int i16 = i15; i16 < 1; ++i16) {
+                try {
+                    iArr[i16] = 5 / iArr[6];
+                    i17 = iArr[5] / i2;
+                    i2 = i15;
+                } catch (ArithmeticException a_e) {
+                }
+                instanceCount -= i15;
+            }
+            i15++;
+        }
+        return i17;
+    }
+}
+


### PR DESCRIPTION
The crash happens after the following steps:

1- pre/main/post loops are created with assert predicates above the main loop.

2- the main loop is peeled

3- as a consequence, the `OpaqueZeroTripGuard` for the main loop is removed

4- That allows narrowing of the type of the CastII that was added right
  after the zero trip guard during pre/main/post loops creation
  
5- The CastII feeds into a range check CastII for the peeled iteration
  that becomes top because the narrowed type of the first CastII
  conflicts with the type recorded in the range check CastII.
  
6- The assert predicate that should fold to protect the range check
  CastII doesn't because of the fix for JDK-8282592: on assert
  predicate updates, the CastII at the zero trip guard is skipped. So
  the range check CastII sees the narrowing of the type of the CastII
  at the zero trip guard but the assert predicate doesn't.
  
The fix I propose is to revert that part of the change from
JDK-8282592 so both the range check CastII and the assert predicate
have the CastII at the zero trip guard as input and observe its type
updates. I went back to that bug and tried to reproduce the failure
again but couldn't. Reverting JDK-8281429 causes the bug to reproduce
again. I tried tweaking the test so the crash reproduces with
JDK-8281429 applied but couldn't.

This is caused by JDK-8305189 because step 3- happens because of
it. Before JDK-8305189, 3- happened after loop opts are over. I think
what happened then was that a template assertion predicate that was in
the process of having its `OpaqueLoopInit` and `OpaqueLoopStride`
removed constant folded so the crash wouldn't reproduce.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309902](https://bugs.openjdk.org/browse/JDK-8309902): C2: assert(false) failed: Bad graph detected in build_loop_late after JDK-8305189 (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14672/head:pull/14672` \
`$ git checkout pull/14672`

Update a local copy of the PR: \
`$ git checkout pull/14672` \
`$ git pull https://git.openjdk.org/jdk.git pull/14672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14672`

View PR using the GUI difftool: \
`$ git pr show -t 14672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14672.diff">https://git.openjdk.org/jdk/pull/14672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14672#issuecomment-1609204650)