### PR TITLE
8310946: G1: Refactor G1Policy::next_gc_should_be_mixed

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -334,7 +334,7 @@ public:
   void record_concurrent_mark_cleanup_start();
   void record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_sets);
 
-  bool next_gc_should_be_mixed(const char* no_candidates_str) const;
+  bool next_gc_should_be_mixed() const;
 
   // Amount of allowed waste in bytes in the collection set.
   size_t allowed_waste_in_collection_set() const;


### PR DESCRIPTION
Simple restructuring around `next_gc_should_be_mixed`.

(After such refactoring, I also tend to think this predicate makes more sense in the caller context, i.e. `bool is_next_gc_mixed = has_marking_candidates();`. For example, one of the call site even asserts `assert(!candidates()->has_more_marking_candidates(),`. Ofc, this is rather subjective.)

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310946](https://bugs.openjdk.org/browse/JDK-8310946): G1: Refactor G1Policy::next_gc_should_be_mixed (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14673/head:pull/14673` \
`$ git checkout pull/14673`

Update a local copy of the PR: \
`$ git checkout pull/14673` \
`$ git pull https://git.openjdk.org/jdk.git pull/14673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14673`

View PR using the GUI difftool: \
`$ git pr show -t 14673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14673.diff">https://git.openjdk.org/jdk/pull/14673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14673#issuecomment-1609367702)