### PR TITLE
8310939: [c1] The visibility of write-volatile requires membar_volatile instead of membar

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2976,6 +2976,10 @@ void LIR_Assembler::membar_release() {
   __ membar(Assembler::LoadStore|Assembler::StoreStore);
 }
 
+void LIR_Assembler::membar_volatile() {
+  __ membar(Assembler::StoreLoad);
+}
+
 void LIR_Assembler::membar_loadload() {
   __ membar(Assembler::LoadLoad);
 }

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -2697,6 +2697,10 @@ void LIR_Assembler::membar_release() {
   __ membar(MacroAssembler::Membar_mask_bits(MacroAssembler::StoreStore | MacroAssembler::LoadStore), Rtemp);
 }
 
+void LIR_Assembler::membar_volatile() {
+  __ membar(MacroAssembler::StoreLoad, Rtemp);
+}
+
 void LIR_Assembler::membar_loadload() {
   __ membar(MacroAssembler::LoadLoad, Rtemp);
 }

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2910,6 +2910,10 @@ void LIR_Assembler::membar_release() {
   __ release();
 }
 
+void LIR_Assembler::membar_volatile() {
+  __ membar(Assembler::StoreLoad);
+}
+
 void LIR_Assembler::membar_loadload() {
   __ membar(Assembler::LoadLoad);
 }

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1918,6 +1918,10 @@ void LIR_Assembler::membar_release() {
   __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
 }
 
+void LIR_Assembler::membar_volatile() {
+  __ membar(MacroAssembler::StoreLoad);
+}
+
 void LIR_Assembler::membar_loadload() {
   __ membar(MacroAssembler::LoadLoad);
 }

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2886,6 +2886,10 @@ void LIR_Assembler::membar_release() {
   __ z_release();
 }
 
+void LIR_Assembler::membar_volatile() {
+  __ z_fence();
+}
+
 void LIR_Assembler::membar_loadload() {
   __ z_acquire();
 }

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -4000,6 +4000,10 @@ void LIR_Assembler::membar_release() {
   // No x86 machines currently require store fences
 }
 
+void LIR_Assembler::membar_volatile() {
+  __ membar( Assembler::Membar_mask_bits(Assembler::StoreLoad));
+}
+
 void LIR_Assembler::membar_loadload() {
   // no-op
   //__ membar(Assembler::Membar_mask_bits(Assembler::loadload));

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -873,6 +873,7 @@ void InstructionPrinter::do_MemBar(MemBar* x) {
   switch (code) {
   case lir_membar_acquire   : output()->print("membar_acquire"); break;
   case lir_membar_release   : output()->print("membar_release"); break;
+  case lir_membar_volatile  : output()->print("membar_volatile"); break;
   case lir_membar           : output()->print("membar"); break;
   case lir_membar_loadload  : output()->print("membar_loadload"); break;
   case lir_membar_storestore: output()->print("membar_storestore"); break;

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -403,6 +403,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_membar:                   // result and info always invalid
     case lir_membar_acquire:           // result and info always invalid
     case lir_membar_release:           // result and info always invalid
+    case lir_membar_volatile:          // result and info always invalid
     case lir_membar_loadload:          // result and info always invalid
     case lir_membar_storestore:        // result and info always invalid
     case lir_membar_loadstore:         // result and info always invalid
@@ -1695,6 +1696,7 @@ const char * LIR_Op::name() const {
      case lir_membar:                s = "membar";        break;
      case lir_membar_acquire:        s = "membar_acquire"; break;
      case lir_membar_release:        s = "membar_release"; break;
+     case lir_membar_volatile:       s = "membar_volatile"; break;
      case lir_membar_loadload:       s = "membar_loadload";   break;
      case lir_membar_storestore:     s = "membar_storestore"; break;
      case lir_membar_loadstore:      s = "membar_loadstore";  break;

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -918,6 +918,7 @@ enum LIR_Code {
       , lir_membar
       , lir_membar_acquire
       , lir_membar_release
+      , lir_membar_volatile
       , lir_membar_loadload
       , lir_membar_storestore
       , lir_membar_loadstore
@@ -2181,6 +2182,7 @@ class LIR_List: public CompilationResourceObj {
   void membar()                                  { append(new LIR_Op0(lir_membar)); }
   void membar_acquire()                          { append(new LIR_Op0(lir_membar_acquire)); }
   void membar_release()                          { append(new LIR_Op0(lir_membar_release)); }
+  void membar_volatile()                         { append(new LIR_Op0(lir_membar_volatile)); }
   void membar_loadload()                         { append(new LIR_Op0(lir_membar_loadload)); }
   void membar_storestore()                       { append(new LIR_Op0(lir_membar_storestore)); }
   void membar_loadstore()                        { append(new LIR_Op0(lir_membar_loadstore)); }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -649,6 +649,10 @@ void LIR_Assembler::emit_op0(LIR_Op0* op) {
       membar_release();
       break;
 
+    case lir_membar_volatile:
+      membar_volatile();
+      break;
+
     case lir_membar_loadload:
       membar_loadload();
       break;

--- a/src/hotspot/share/c1/c1_LIRAssembler.hpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.hpp
@@ -246,6 +246,7 @@ class LIR_Assembler: public CompilationResourceObj {
   void membar();
   void membar_acquire();
   void membar_release();
+  void membar_volatile();
   void membar_loadload();
   void membar_storestore();
   void membar_loadstore();

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3542,6 +3542,7 @@ void LIRGenerator::do_MemBar(MemBar* x) {
   switch(code) {
   case lir_membar_acquire   : __ membar_acquire(); break;
   case lir_membar_release   : __ membar_release(); break;
+  case lir_membar_volatile  : __ membar_volatile(); break;
   case lir_membar           : __ membar(); break;
   case lir_membar_loadload  : __ membar_loadload(); break;
   case lir_membar_storestore: __ membar_storestore(); break;

--- a/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
@@ -161,7 +161,7 @@ void BarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) {
   }
 
   if (is_volatile && !support_IRIW_for_not_multiple_copy_atomic_cpu) {
-    __ membar();
+    __ membar_volatile();
   }
 }
 


### PR DESCRIPTION
For c1 now, a volatile write case:

membar_release // LoadStore | StoreStore
write volatile
membar

Just like c2, here `membar` should be defined `membar_volatile` clearly, then for risc-v, ppc and loongarch can use StoreLoad for `membar_volatile` for better performance.

Testing:
GHA testing
jtreg tier1-3 for loongarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310939](https://bugs.openjdk.org/browse/JDK-8310939): [c1] The visibility of write-volatile requires membar_volatile instead of membar (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14677/head:pull/14677` \
`$ git checkout pull/14677`

Update a local copy of the PR: \
`$ git checkout pull/14677` \
`$ git pull https://git.openjdk.org/jdk.git pull/14677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14677`

View PR using the GUI difftool: \
`$ git pr show -t 14677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14677.diff">https://git.openjdk.org/jdk/pull/14677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14677#issuecomment-1609444638)