### PR TITLE
8310974: NMT: Arena diffs miss the scale

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -494,7 +494,7 @@ void MemSummaryDiffReporter::print_arena_diff(size_t current_amount, size_t curr
   out->print("arena=" SIZE_FORMAT "%s", amount_in_current_scale(current_amount), scale);
   int64_t amount_diff = diff_in_current_scale(current_amount, early_amount);
   if (amount_diff != 0) {
-    out->print(" " INT64_PLUS_FORMAT "d%s", amount_diff, scale);
+    out->print(" " INT64_PLUS_FORMAT "%s", amount_diff, scale);
   }
 
   out->print(" #" SIZE_FORMAT "", current_count);

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -492,8 +492,9 @@ void MemSummaryDiffReporter::print_arena_diff(size_t current_amount, size_t curr
   const char* scale = current_scale();
   outputStream* out = output();
   out->print("arena=" SIZE_FORMAT "%s", amount_in_current_scale(current_amount), scale);
-  if (diff_in_current_scale(current_amount, early_amount) != 0) {
-    out->print(" " INT64_PLUS_FORMAT "d%s", diff_in_current_scale(current_amount, early_amount), scale);
+  int64_t amount_diff = diff_in_current_scale(current_amount, early_amount);
+  if (amount_diff != 0) {
+    out->print(" " INT64_PLUS_FORMAT "d%s", amount_diff, scale);
   }
 
   out->print(" #" SIZE_FORMAT "", current_count);

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -493,7 +493,7 @@ void MemSummaryDiffReporter::print_arena_diff(size_t current_amount, size_t curr
   outputStream* out = output();
   out->print("arena=" SIZE_FORMAT "%s", amount_in_current_scale(current_amount), scale);
   if (diff_in_current_scale(current_amount, early_amount) != 0) {
-    out->print(" " INT64_PLUS_FORMAT "d", diff_in_current_scale(current_amount, early_amount));
+    out->print(" " INT64_PLUS_FORMAT "d%s", diff_in_current_scale(current_amount, early_amount), scale);
   }
 
   out->print(" #" SIZE_FORMAT "", current_count);


### PR DESCRIPTION
We noticed this in one of the NMT logs:

```
Compiler (reserved=175324KB +135838KB, committed=175324KB +135838KB)
    (malloc=29999KB +5558KB #23578 +8965)
    (arena=145325KB +130279 #17 -5)
```

The +130279 should actually be +130279KB. 

I looked at all current uses of `diff_in_current_scale` and `amount_in_current_scale`, and all them seem to be printed with scale. So we have only this one spot missing.

Note this also fixes the stray `d` leftover from [JDK-8281213](https://bugs.openjdk.org/browse/JDK-8281213).

Sample excerpt before:

```
-                  Compiler (reserved=1623KB +453KB, committed=1623KB +453KB)
                            (malloc=16KB +1KB #110 +19)
                            (arena=1608KB +452d #10 +5)
```

...and after:

```
-                  Compiler (reserved=220KB -537KB, committed=220KB -537KB)
                            (malloc=25KB +8KB #228 +110)
                            (arena=196KB -546KB #4 -1)
```

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `runtime/NMT`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310974](https://bugs.openjdk.org/browse/JDK-8310974): NMT: Arena diffs miss the scale (**Bug** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14680/head:pull/14680` \
`$ git checkout pull/14680`

Update a local copy of the PR: \
`$ git checkout pull/14680` \
`$ git pull https://git.openjdk.org/jdk.git pull/14680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14680`

View PR using the GUI difftool: \
`$ git pr show -t 14680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14680.diff">https://git.openjdk.org/jdk/pull/14680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14680#issuecomment-1609833599)