### PR TITLE
JDK-8310830: typo in the parameter name in @throws of ClassDesc::ofDescriptor

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -150,7 +150,7 @@ public sealed interface ClassDesc
      * @param descriptor a field descriptor string
      * @return a {@linkplain ClassDesc} describing the desired class
      * @throws NullPointerException if the argument is {@code null}
-     * @throws IllegalArgumentException if the name string is not in the
+     * @throws IllegalArgumentException if the descriptor string is not in the
      * correct format
      * @jvms 4.3.2 Field Descriptors
      * @jvms 4.4.1 The CONSTANT_Class_info Structure


### PR DESCRIPTION
Typo fix. I didn't see any other instances of similar typos in the class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310830](https://bugs.openjdk.org/browse/JDK-8310830): typo in the parameter name in @throws of ClassDesc::ofDescriptor (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14683/head:pull/14683` \
`$ git checkout pull/14683`

Update a local copy of the PR: \
`$ git checkout pull/14683` \
`$ git pull https://git.openjdk.org/jdk.git pull/14683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14683`

View PR using the GUI difftool: \
`$ git pr show -t 14683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14683.diff">https://git.openjdk.org/jdk/pull/14683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14683#issuecomment-1610079806)