### PR TITLE
8310982: jdk/internal/util/ArchTest.java fails after JDK-8308452 failed with Method isARM()

### DIFF
--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @test
- * @bug 8304915 8308452
+ * @bug 8304915 8308452 8310982
  * @summary Verify Architecture enum maps to system property os.arch
  * @modules java.base/jdk.internal.util
  * @modules java.base/jdk.internal.misc

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -75,7 +75,7 @@ public class ArchTest {
         return Stream.of(
                 Arguments.of("aarch64", AARCH64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isAARCH64()),
                 Arguments.of("amd64", X64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isX64()),
-                Arguments.of("arm", ARM, 32, ByteOrder.LITTLE_ENDIAN, Architecture.isAARCH64()),
+                Arguments.of("arm", ARM, 32, ByteOrder.LITTLE_ENDIAN, Architecture.isARM()),
                 Arguments.of("i386", X86, 32, ByteOrder.LITTLE_ENDIAN, Architecture.isX86()),
                 Arguments.of("loongarch64", LOONGARCH64, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isLOONGARCH64()),
                 Arguments.of("mips64el", MIPS64EL, 64, ByteOrder.LITTLE_ENDIAN, Architecture.isMIPS64EL()),


### PR DESCRIPTION
Fix a test bug when run on aarch64, it was supposed to confirm it was not running on Arm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310982](https://bugs.openjdk.org/browse/JDK-8310982): jdk/internal/util/ArchTest.java fails after JDK-8308452 failed with Method isARM() (**Bug** - P2)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14685/head:pull/14685` \
`$ git checkout pull/14685`

Update a local copy of the PR: \
`$ git checkout pull/14685` \
`$ git pull https://git.openjdk.org/jdk.git pull/14685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14685`

View PR using the GUI difftool: \
`$ git pr show -t 14685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14685.diff">https://git.openjdk.org/jdk/pull/14685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14685#issuecomment-1610135035)