### PR TITLE
8311007: jdk/jfr/tool/TestView.java can't find event

### DIFF
--- a/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
@@ -96,12 +96,12 @@ public class TestJcmdView {
             systemGC.await();
             gcHeapSummary.await();
             oldCollection.countDown();
-            // Wait for Instant.now() to advance 1 s passed the last event timestamp.
+            // Wait for Instant.now() to advance 1 s past the last event timestamp.
             // The rationale for this is twofold:
             // - DcmdView starts one second before Instant.now() (to make the command
             //   responsive for the user).
-            // - Instant.now() and the event timestamp uses different time source
-            //   and they need to synchronize
+            // - Instant.now() and the event timestamp use different time sources
+            //   and they need to synchronize.
             Instant end = lastTimestamp.plusSeconds(1);
             while (Instant.now().isBefore(end)) {
                 Thread.sleep(10);

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
@@ -23,9 +23,12 @@
 
 package jdk.jfr.jcmd;
 
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingStream;
 import jdk.test.lib.process.OutputAnalyzer;
 /**
@@ -40,6 +43,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  *                   -XX:+UseG1GC jdk.jfr.jcmd.TestJcmdView
  */
 public class TestJcmdView {
+    private static volatile Instant lastTimestamp;
 
     public static void main(String... args) throws Throwable {
         CountDownLatch jvmInformation = new CountDownLatch(1);
@@ -60,22 +64,27 @@ public class TestJcmdView {
             rs.onEvent("jdk.JVMInformation", e -> {
                 jvmInformation.countDown();
                 System.out.println(e);
+                storeLastTimestamp(e);
             });
             rs.onEvent("jdk.SystemGC", e -> {
                 systemGC.countDown();
                 System.out.println(e);
+                storeLastTimestamp(e);
             });
             rs.onEvent("jdk.GCHeapSummary", e -> {
                 gcHeapSummary.countDown();
                 System.out.println(e);
+                storeLastTimestamp(e);
             });
             rs.onEvent("jdk.OldGarbageCollection", e -> {
                 oldCollection.countDown();
                 System.out.println(e);
+                storeLastTimestamp(e);
             });
             rs.onEvent("jdk.GarbageCollection", e-> {
                 garbageCollection.countDown();
                 System.out.println(e);
+                storeLastTimestamp(e);
             });
             rs.startAsync();
             // Emit some GC events
@@ -87,6 +96,16 @@ public class TestJcmdView {
             systemGC.await();
             gcHeapSummary.await();
             oldCollection.countDown();
+            // Wait for Instant.now() to advance 1 s passed the last event timestamp.
+            // The rationale for this is twofold:
+            // - DcmdView starts one second before Instant.now() (to make the command
+            //   responsive for the user).
+            // - Instant.now() and the event timestamp uses different time source
+            //   and they need to synchronize
+            Instant end = lastTimestamp.plusSeconds(1);
+            while (Instant.now().isBefore(end)) {
+                Thread.sleep(10);
+            }
             // Test events that are in the current chunk
             testEventType();
             testFormView();
@@ -98,6 +117,13 @@ public class TestJcmdView {
             testEventType();
             testFormView();
             testTableView();
+        }
+    }
+
+    private static void storeLastTimestamp(RecordedEvent e) {
+        Instant time = e.getEndTime();
+        if (lastTimestamp == null || time.isAfter(lastTimestamp)) {
+            lastTimestamp = time;
         }
     }
 

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdView.java
@@ -25,7 +25,6 @@ package jdk.jfr.jcmd;
 
 import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;


### PR DESCRIPTION
Could I have a review of a test fix that ensures that the event timestamp are in sync. with the timestamp used by 'jcmd view'.

Testing: test/jdk/jdk/jfr/jcmd/TestJcmdView.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311007](https://bugs.openjdk.org/browse/JDK-8311007): jdk/jfr/tool/TestView.java can't find event (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14686/head:pull/14686` \
`$ git checkout pull/14686`

Update a local copy of the PR: \
`$ git checkout pull/14686` \
`$ git pull https://git.openjdk.org/jdk.git pull/14686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14686`

View PR using the GUI difftool: \
`$ git pr show -t 14686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14686.diff">https://git.openjdk.org/jdk/pull/14686.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14686#issuecomment-1610771120)