### PR TITLE
8311020: Typo cleanup in Classfile API

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/AccessFlags.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/AccessFlags.java
@@ -30,9 +30,8 @@ import java.lang.reflect.AccessFlag;
 
 /**
  * Models the access flags for a class, method, or field.  Delivered as a
- *  {@link jdk.internal.classfile.ClassElement}, {@link jdk.internal.classfile.FieldElement}, or
- *  {@link jdk.internal.classfile.MethodElement} when traversing
- *  the corresponding model type.
+ * {@link ClassElement}, {@link FieldElement}, or {@link MethodElement}
+ * when traversing the corresponding model type.
  */
 public sealed interface AccessFlags
         extends ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
@@ -653,7 +653,7 @@ public class Attributes {
                 }
             };
 
-    /** Attribute mapper for the {@code SourceDebug} attribute */
+    /** Attribute mapper for the {@code SourceDebugExtension} attribute */
     public static final AttributeMapper<SourceDebugExtensionAttribute>
             SOURCE_DEBUG_EXTENSION = new AbstractAttributeMapper<>(NAME_SOURCE_DEBUG_EXTENSION, Classfile.JAVA_5_VERSION) {
                 @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/ClassHierarchyResolver.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/ClassHierarchyResolver.java
@@ -59,6 +59,7 @@ public interface ClassHierarchyResolver {
      * {@return the {@link ClassHierarchyInfo} for a given class name, or null
      * if the name is unknown to the resolver}
      * @param classDesc descriptor of the class
+     * @throws IllegalArgumentException if a class shouldn't be queried for hierarchy
      */
     ClassHierarchyInfo getClassInfo(ClassDesc classDesc);
 

--- a/src/java.base/share/classes/jdk/internal/classfile/ClassModel.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/ClassModel.java
@@ -91,7 +91,7 @@ public sealed interface ClassModel
      *
      * @param debugOutput handler to receive debug information
      * @param classHierarchyResolver class hierarchy resolver to provide
-     *                               additional information about the class hiearchy
+     *                               additional information about the class hierarchy
      * @return a list of verification errors, or an empty list if no errors are
      * found
      */

--- a/src/java.base/share/classes/jdk/internal/classfile/ClassfileBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/ClassfileBuilder.java
@@ -40,9 +40,8 @@ import jdk.internal.classfile.constantpool.ConstantPoolBuilder;
  *
  * @see ClassfileTransform
  */
-public
-interface ClassfileBuilder<E extends ClassfileElement, B extends ClassfileBuilder<E, B>>
-        extends Consumer<E> {
+public sealed interface ClassfileBuilder<E extends ClassfileElement, B extends ClassfileBuilder<E, B>>
+        extends Consumer<E> permits ClassBuilder, FieldBuilder, MethodBuilder, CodeBuilder {
 
     /**
      * Integrate the {@link ClassfileElement} into the entity being built.

--- a/src/java.base/share/classes/jdk/internal/classfile/Label.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Label.java
@@ -28,7 +28,7 @@ import jdk.internal.classfile.impl.LabelImpl;
 
 /**
  * A marker for a position within the instructions of a method body.  The
- * assocation between a label's identity and the position it represents is
+ * association between a label's identity and the position it represents is
  * managed by the entity managing the method body (a {@link CodeModel} or {@link
  * CodeBuilder}), not the label itself; this allows the same label to have a
  * meaning both in an existing method (as managed by a {@linkplain CodeModel})

--- a/src/java.base/share/classes/jdk/internal/classfile/MethodSignature.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/MethodSignature.java
@@ -82,7 +82,7 @@ public sealed interface MethodSignature
     /**
      * @return method signature
      * @param typeParameters signatures for the type parameters
-     * @param exceptions sigantures for the exceptions
+     * @param exceptions signatures for the exceptions
      * @param result signature for the return type
      * @param arguments signatures for the method arguments
      */

--- a/src/java.base/share/classes/jdk/internal/classfile/TypeAnnotation.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/TypeAnnotation.java
@@ -454,7 +454,7 @@ public sealed interface TypeAnnotation
             permits TargetInfoImpl.LocalVarTargetImpl {
 
         /**
-         * @return the table of local variable location/indicies.
+         * @return the table of local variable location/indices.
          */
         List<LocalVarTargetInfo> table();
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/InnerClassInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/InnerClassInfo.java
@@ -54,8 +54,7 @@ public sealed interface InnerClassInfo
     Optional<ClassEntry> outerClass();
 
     /**
-     * {@return the name of the class or interface of which this class is a
-     * member, if it is a member of a class or interface}
+     * {@return the simple name of this class, or empty if this class is anonymous}
      */
     Optional<Utf8Entry> innerName();
 

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/MethodParametersAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/MethodParametersAttribute.java
@@ -45,7 +45,7 @@ public sealed interface MethodParametersAttribute
 
     /**
      * {@return information about the parameters of the method}  The i'th entry
-     * in the list correponds to the i'th parameter in the method declaration.
+     * in the list corresponds to the i'th parameter in the method declaration.
      */
     List<MethodParameterInfo> parameters();
 

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleExportInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleExportInfo.java
@@ -40,7 +40,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models a single "exports" declaration in the {@link jdk.internal.classfile.attribute.ModuleAttribute}.
+ * Models a single "exports" declaration in the {@link ModuleAttribute}.
  */
 public sealed interface ModuleExportInfo
         permits UnboundAttribute.UnboundModuleExportInfo {

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleHashInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleHashInfo.java
@@ -30,7 +30,7 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 /**
- * Models hash information for a single module in the {@link jdk.internal.classfile.attribute.ModuleHashesAttribute}.
+ * Models hash information for a single module in the {@link ModuleHashesAttribute}.
  */
 public sealed interface ModuleHashInfo
         permits UnboundAttribute.UnboundModuleHashInfo {

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleOpenInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleOpenInfo.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models a single "opens" declaration in the {@link jdk.internal.classfile.attribute.ModuleAttribute}.
+ * Models a single "opens" declaration in the {@link ModuleAttribute}.
  */
 public sealed interface ModuleOpenInfo
         permits UnboundAttribute.UnboundModuleOpenInfo {

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleProvideInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleProvideInfo.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models a single "provides" declaration in the {@link jdk.internal.classfile.attribute.ModuleAttribute}.
+ * Models a single "provides" declaration in the {@link ModuleAttribute}.
  */
 public sealed interface ModuleProvideInfo
         permits UnboundAttribute.UnboundModuleProvideInfo {

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleRequireInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleRequireInfo.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models a single "requires" declaration in the {@link jdk.internal.classfile.attribute.ModuleAttribute}.
+ * Models a single "requires" declaration in the {@link ModuleAttribute}.
  */
 public sealed interface ModuleRequireInfo
         permits UnboundAttribute.UnboundModuleRequiresInfo {

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleResolutionAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/ModuleResolutionAttribute.java
@@ -77,7 +77,7 @@ public sealed interface ModuleResolutionAttribute
 
     /**
      * {@return a {@code ModuleResolution} attribute}
-     * @param resolutionFlags the resolution falgs
+     * @param resolutionFlags the resolution flags
      */
     static ModuleResolutionAttribute of(int resolutionFlags) {
         return new UnboundAttribute.UnboundModuleResolutionAttribute(resolutionFlags);

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/SignatureAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/SignatureAttribute.java
@@ -55,7 +55,7 @@ public sealed interface SignatureAttribute
     Utf8Entry signature();
 
     /**
-     * Parse the siganture as a class signature.
+     * Parse the signature as a class signature.
      * @return the class signature
      */
     default ClassSignature asClassSignature() {
@@ -71,7 +71,7 @@ public sealed interface SignatureAttribute
     }
 
     /**
-     * Parse the siganture as a type signature.
+     * Parse the signature as a type signature.
      * @return the type signature
      */
     default Signature asTypeSignature() {

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/SourceDebugExtensionAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/SourceDebugExtensionAttribute.java
@@ -31,7 +31,9 @@ import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 /**
- * SourceDebugExtensionAttribute.
+ * Models the {@code SourceDebugExtension} attribute (@@@ need reference).
+ * Delivered as a {@link jdk.internal.classfile.ClassElement} when traversing the elements of
+ * a {@link jdk.internal.classfile.ClassModel}.
  */
 public sealed interface SourceDebugExtensionAttribute
         extends Attribute<SourceDebugExtensionAttribute>, ClassElement

--- a/src/java.base/share/classes/jdk/internal/classfile/attribute/SourceIDAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/attribute/SourceIDAttribute.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 /**
- * Models the {@code SourceFile} attribute (@@@ reference needed), which can
+ * Models the {@code SourceID} attribute (@@@ reference needed), which can
  * appear on classes. Delivered as a {@link jdk.internal.classfile.ClassElement} when
  * traversing a {@link ClassModel}.
  */

--- a/src/java.base/share/classes/jdk/internal/classfile/components/package-info.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/package-info.java
@@ -72,7 +72,7 @@
  * Arrays of reference types are always decomposed, mapped as the base reference
  * types and composed back to arrays.
  * <p>
- * Single class remappigng example:
+ * Single class remapping example:
  * {@snippet lang="java" class="PackageSnippets" region="singleClassRemap"}
  * <p>
  * Remapping of all classes under specific package:
@@ -90,7 +90,7 @@
  *
  * <h3>{@link CodeRelabeler}</h3>
  * {@link CodeRelabeler} is a {@link jdk.internal.classfile.CodeTransform}
- * replacing all occurences of {@link jdk.internal.classfile.Label} in the
+ * replacing all occurrences of {@link jdk.internal.classfile.Label} in the
  * transformed code with new instances.
  * All {@link jdk.internal.classfile.instruction.LabelTarget} instructions are
  * adjusted accordingly.

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassHierarchyImpl.java
@@ -103,14 +103,14 @@ public final class ClassHierarchyImpl {
     }
 
     public boolean isAssignableFrom(ClassDesc thisClass, ClassDesc fromClass) {
-        //extra check if fromClass is an interface is necessay to handle situation when thisClass might not been fully resolved and so it is potentially an unidentified interface
-        //this special corner-case handling has been added based on better success rate of constructing stack maps with simulated broken resulution of classes and interfaces
+        //extra check if fromClass is an interface is necessary to handle situation when thisClass might not been fully resolved and so it is potentially an unidentified interface
+        //this special corner-case handling has been added based on better success rate of constructing stack maps with simulated broken resolution of classes and interfaces
         if (isInterface(fromClass)) return resolve(thisClass).superClass() == null;
         //regular calculation of assignability is based on common ancestor calculation
         var anc = commonAncestor(thisClass, fromClass);
         //if common ancestor does not exist (as the class hierarchy could not be fully resolved) we optimistically assume the classes might be accessible
         //if common ancestor is equal to thisClass then the classes are clearly accessible
-        //if other common ancestor is calculated (which works even when their grand-parents could not be resolved) then it is clear that thisClass could not be asigned from fromClass
+        //if other common ancestor is calculated (which works even when their grandparents could not be resolved) then it is clear that thisClass could not be assigned from fromClass
         return anc == null || thisClass.equals(anc);
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassPrinterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassPrinterImpl.java
@@ -497,7 +497,7 @@ public final class ClassPrinterImpl {
             case OfBoolean cv -> leafs("boolean", String.valueOf((int)cv.constantValue() != 0));
             case OfClass clv -> leafs("class", clv.className().stringValue());
             case OfEnum ev -> leafs("enum class", ev.className().stringValue(),
-                                    "contant name", ev.constantName().stringValue());
+                                    "constant name", ev.constantName().stringValue());
             case OfAnnotation av -> leafs("annotation class", av.annotation().className().stringValue());
             case OfArray av -> new Node[]{new ListNodeImpl(FLOW, "array", av.values().stream().map(
                     ev -> new MapNodeImpl(FLOW, "value").with(elementValueToTree(ev))))};
@@ -535,7 +535,7 @@ public final class ClassPrinterImpl {
                 case ObjectVerificationTypeInfo o ->
                     ret.accept(o.className().name().stringValue());
                 case UninitializedVerificationTypeInfo u ->
-                    ret.accept("UNITIALIZED @" + lr.labelToBci(u.newTarget()));
+                    ret.accept("UNINITIALIZED @" + lr.labelToBci(u.newTarget()));
             }
         });
     }
@@ -914,7 +914,7 @@ public final class ClassPrinterImpl {
                             "method type", ema.enclosingMethodType()
                                     .map(Utf8Entry::stringValue).orElse("null")));
                 case ExceptionsAttribute exa ->
-                    nodes.add(list("excceptions", "exc", exa.exceptions().stream()
+                    nodes.add(list("exceptions", "exc", exa.exceptions().stream()
                             .map(e -> e.name().stringValue())));
                 case InnerClassesAttribute ica ->
                     nodes.add(new ListNodeImpl(BLOCK, "inner classes", ica.classes().stream()

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -205,14 +205,14 @@ public final class StackMapGenerator {
      * New <code>Generator</code> instance must be created for each individual class/method.
      * Instance contains only immutable results, all the calculations are processed during instance construction.
      *
-     * @param labelContext <code>LableContext</code> instance used to resolve or patch <code>ExceptionHandler</code>
+     * @param labelContext <code>LabelContext</code> instance used to resolve or patch <code>ExceptionHandler</code>
      * labels to bytecode offsets (or vice versa)
      * @param thisClass class to generate stack maps for
      * @param methodName method name to generate stack maps for
      * @param methodDesc method descriptor to generate stack maps for
      * @param isStatic information whether the method is static
      * @param bytecode R/W <code>ByteBuffer</code> wrapping method bytecode, the content is altered in case <code>Generator</code> detects  and patches dead code
-     * @param cp R/W <code>ConstantPoolBuilder</code> instance used to resolve all involved CP entries and also generate new entries referenced from the generted stack maps
+     * @param cp R/W <code>ConstantPoolBuilder</code> instance used to resolve all involved CP entries and also generate new entries referenced from the generated stack maps
      * @param handlers R/W <code>ExceptionHandler</code> list used to detect mandatory frame offsets as well as to determine stack maps in exception handlers
      * and also to be altered when dead code is detected and must be excluded from exception handlers
      */
@@ -826,7 +826,7 @@ public final class StackMapGenerator {
         /**
      * Throws <code>java.lang.VerifyError</code> with given error message
      * @param msg error message
-     * @param offset bytecode offset where the error occured
+     * @param offset bytecode offset where the error occurred
      */
     private void generatorError(String msg, int offset) {
         var sb = new StringBuilder("%s at bytecode offset %d of method %s(%s)".formatted(
@@ -1291,7 +1291,7 @@ public final class StackMapGenerator {
             return new Type(ITEM_UNINITIALIZED, null, bci);
         }
 
-        @Override //mandatory overrride to avoid use of method reference during JDK bootstrap
+        @Override //mandatory override to avoid use of method reference during JDK bootstrap
         public boolean equals(Object o) {
             return (o instanceof Type t) && t.tag == tag && t.bci == bci && Objects.equals(sym, t.sym);
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationType.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationType.java
@@ -116,7 +116,7 @@ class VerificationType {
                             Category1                    = (Category1Flag         << BitsPerByte) | Primitive,
                             Category2                    = (Category2Flag         << BitsPerByte) | Primitive,
                             Category2_2nd            = (Category2_2ndFlag << BitsPerByte) | Primitive,
-                            // Primitive values (type descriminator stored in most-signifcant bytes)
+                            // Primitive values (type discriminator stored in most-significant bytes)
                             // Bogus needs the " | Primitive".    Else, isReference(Bogus) returns TRUE.
                             Bogus                            = (ITEM_Bogus            << 2 * BitsPerByte) | Primitive,
                             Boolean                        = (ITEM_Boolean        << 2 * BitsPerByte) | Category1,
@@ -131,7 +131,7 @@ class VerificationType {
                             Double_2nd                 = (ITEM_Double_2nd << 2 * BitsPerByte) | Category2_2nd,
                             // Used by Uninitialized (second and third bytes hold the bci)
                             BciMask                        = 0xffff << BitsPerByte,
-                            // A bci of -1 is an Unintialized-This
+                            // A bci of -1 is an Uninitialized-This
                             BciForThis = 0xffff,
                             // Query values
                             ReferenceQuery         = (ReferenceFlag         << BitsPerByte) | TypeQuery,
@@ -212,7 +212,7 @@ class VerificationType {
         // the 'query' types should technically return 'false' here, if we
         // allow this to return true, we can perform the test using only
         // 2 operations rather than 8 (3 masks, 3 compares and 2 logical 'ands').
-        // Since noone should call this on a query type anyway, this is ok.
+        // Since no one should call this on a query type anyway, this is ok.
         if(is_check()) context.verifyError("Must not be a check type (wrong value returned)");
         // should only return false if it's a primitive, and the category1 flag
         // is not set.

--- a/src/java.base/share/classes/jdk/internal/classfile/instruction/ExceptionCatch.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/instruction/ExceptionCatch.java
@@ -67,8 +67,8 @@ public sealed interface ExceptionCatch extends PseudoInstruction
     /**
      * {@return an exception table pseudo-instruction}
      * @param handler the handler for the exception
-     * @param tryStart the beginning of the instruction range for the gaurded instructions
-     * @param tryEnd the end of the instruction range for the gaurded instructions
+     * @param tryStart the beginning of the instruction range for the guarded instructions
+     * @param tryEnd the end of the instruction range for the guarded instructions
      * @param catchTypeEntry the type of exception to catch, or empty if this
      *                       handler is unconditional
      */

--- a/src/java.base/share/classes/jdk/internal/classfile/instruction/LoadInstruction.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/instruction/LoadInstruction.java
@@ -50,7 +50,7 @@ public sealed interface LoadInstruction extends Instruction
      * {@return a local variable load instruction}
      *
      * @param kind the type of the value to be loaded
-     * @param slot the local varaible slot to load from
+     * @param slot the local variable slot to load from
      */
     static LoadInstruction of(TypeKind kind, int slot) {
         return of(BytecodeHelpers.loadOpcode(kind, slot), slot);
@@ -61,7 +61,7 @@ public sealed interface LoadInstruction extends Instruction
      *
      * @param op the opcode for the specific type of load instruction,
      *           which must be of kind {@link Opcode.Kind#LOAD}
-     * @param slot the local varaible slot to load from
+     * @param slot the local variable slot to load from
      */
     static LoadInstruction of(Opcode op, int slot) {
         Util.checkKind(op, Opcode.Kind.LOAD);

--- a/src/java.base/share/classes/jdk/internal/classfile/instruction/NewMultiArrayInstruction.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/instruction/NewMultiArrayInstruction.java
@@ -45,7 +45,7 @@ public sealed interface NewMultiArrayInstruction extends Instruction
     ClassEntry arrayType();
 
     /**
-     * {@return the number of dimensions of the aray}
+     * {@return the number of dimensions of the array}
      */
     int dimensions();
 

--- a/src/java.base/share/classes/jdk/internal/classfile/instruction/StoreInstruction.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/instruction/StoreInstruction.java
@@ -48,7 +48,7 @@ public sealed interface StoreInstruction extends Instruction
      * {@return a local variable store instruction}
      *
      * @param kind the type of the value to be stored
-     * @param slot the local varaible slot to store to
+     * @param slot the local variable slot to store to
      */
     static StoreInstruction of(TypeKind kind, int slot) {
         return of(BytecodeHelpers.storeOpcode(kind, slot), slot);
@@ -59,7 +59,7 @@ public sealed interface StoreInstruction extends Instruction
      *
      * @param op the opcode for the specific type of store instruction,
      *           which must be of kind {@link Opcode.Kind#STORE}
-     * @param slot the local varaible slot to store to
+     * @param slot the local variable slot to store to
      */
     static StoreInstruction of(Opcode op, int slot) {
         Util.checkKind(op, Opcode.Kind.STORE);

--- a/test/jdk/jdk/classfile/ClassPrinterTest.java
+++ b/test/jdk/jdk/classfile/ClassPrinterTest.java
@@ -227,12 +227,12 @@ class ClassPrinterTest {
                         flags: [PROTECTED]
                         method type: (ZLjava/lang/Throwable;)Ljava/lang/Void;
                         attributes: [AnnotationDefault, RuntimeVisibleParameterAnnotations, RuntimeInvisibleParameterAnnotations, Exceptions, Code]
-                        annotation default: {array: [{boolean: true}, {byte: 12}, {char: 99}, {class: LPhee;}, {double: 1.3}, {enum class: LBoo;, contant name: BOO}, {float: 3.7}, {int: 33}, {long: 3333}, {short: 25}, {string: BOO}, {annotation class: LPhoo;}]}
+                        annotation default: {array: [{boolean: true}, {byte: 12}, {char: 99}, {class: LPhee;}, {double: 1.3}, {enum class: LBoo;, constant name: BOO}, {float: 3.7}, {int: 33}, {long: 3333}, {short: 25}, {string: BOO}, {annotation class: LPhoo;}]}
                         visible parameter annotations:
                             parameter 1: [{annotation class: LPhoo;, values: [{name: flfl, value: {float: 22.0}}, {name: frfl, value: {float: 11.0}}]}]
                         invisible parameter annotations:
                             parameter 1: [{annotation class: LPhoo;, values: [{name: flfl, value: {float: '-22.0'}}, {name: frfl, value: {float: '-11.0'}}]}]
-                        excceptions: [Phoo, Boo, Bee]
+                        exceptions: [Phoo, Boo, Bee]
                         code:
                             max stack: 1
                             max locals: 3
@@ -459,12 +459,12 @@ class ClassPrinterTest {
                             "flags": ["PROTECTED"],
                             "method type": "(ZLjava/lang/Throwable;)Ljava/lang/Void;",
                             "attributes": ["AnnotationDefault", "RuntimeVisibleParameterAnnotations", "RuntimeInvisibleParameterAnnotations", "Exceptions", "Code"],
-                            "annotation default": {"array": [{"boolean": "true"}, {"byte": "12"}, {"char": "99"}, {"class": "LPhee;"}, {"double": "1.3"}, {"enum class": "LBoo;", "contant name": "BOO"}, {"float": "3.7"}, {"int": "33"}, {"long": "3333"}, {"short": "25"}, {"string": "BOO"}, {"annotation class": "LPhoo;"}]},
+                            "annotation default": {"array": [{"boolean": "true"}, {"byte": "12"}, {"char": "99"}, {"class": "LPhee;"}, {"double": "1.3"}, {"enum class": "LBoo;", "constant name": "BOO"}, {"float": "3.7"}, {"int": "33"}, {"long": "3333"}, {"short": "25"}, {"string": "BOO"}, {"annotation class": "LPhoo;"}]},
                             "visible parameter annotations": {
                                 "parameter 1": [{"annotation class": "LPhoo;", "values": [{"name": "flfl", "value": {"float": "22.0"}}, {"name": "frfl", "value": {"float": "11.0"}}]}]},
                             "invisible parameter annotations": {
                                 "parameter 1": [{"annotation class": "LPhoo;", "values": [{"name": "flfl", "value": {"float": "-22.0"}}, {"name": "frfl", "value": {"float": "-11.0"}}]}]},
-                            "excceptions": ["Phoo", "Boo", "Bee"],
+                            "exceptions": ["Phoo", "Boo", "Bee"],
                             "code": {
                                 "max stack": 1,
                                 "max locals": 3,
@@ -696,12 +696,12 @@ class ClassPrinterTest {
                             <flags><flag>PROTECTED</flag></flags>
                             <method_type>(ZLjava/lang/Throwable;)Ljava/lang/Void;</method_type>
                             <attributes><attribute>AnnotationDefault</attribute><attribute>RuntimeVisibleParameterAnnotations</attribute><attribute>RuntimeInvisibleParameterAnnotations</attribute><attribute>Exceptions</attribute><attribute>Code</attribute></attributes>
-                            <annotation_default><array><value><boolean>true</boolean></value><value><byte>12</byte></value><value><char>99</char></value><value><class>LPhee;</class></value><value><double>1.3</double></value><value><enum_class>LBoo;</enum_class><contant_name>BOO</contant_name></value><value><float>3.7</float></value><value><int>33</int></value><value><long>3333</long></value><value><short>25</short></value><value><string>BOO</string></value><value><annotation_class>LPhoo;</annotation_class></value></array></annotation_default>
+                            <annotation_default><array><value><boolean>true</boolean></value><value><byte>12</byte></value><value><char>99</char></value><value><class>LPhee;</class></value><value><double>1.3</double></value><value><enum_class>LBoo;</enum_class><constant_name>BOO</constant_name></value><value><float>3.7</float></value><value><int>33</int></value><value><long>3333</long></value><value><short>25</short></value><value><string>BOO</string></value><value><annotation_class>LPhoo;</annotation_class></value></array></annotation_default>
                             <visible_parameter_annotations>
                                 <parameter_1><anno><annotation_class>LPhoo;</annotation_class><values><pair><name>flfl</name><value><float>22.0</float></value></pair><pair><name>frfl</name><value><float>11.0</float></value></pair></values></anno></parameter_1></visible_parameter_annotations>
                             <invisible_parameter_annotations>
                                 <parameter_1><anno><annotation_class>LPhoo;</annotation_class><values><pair><name>flfl</name><value><float>-22.0</float></value></pair><pair><name>frfl</name><value><float>-11.0</float></value></pair></values></anno></parameter_1></invisible_parameter_annotations>
-                            <excceptions><exc>Phoo</exc><exc>Boo</exc><exc>Bee</exc></excceptions>
+                            <exceptions><exc>Phoo</exc><exc>Boo</exc><exc>Bee</exc></exceptions>
                             <code>
                                 <max_stack>1</max_stack>
                                 <max_locals>3</max_locals>

--- a/test/jdk/jdk/classfile/examples/ModuleExamples.java
+++ b/test/jdk/jdk/classfile/examples/ModuleExamples.java
@@ -61,7 +61,7 @@ public class ModuleExamples {
         System.out.println("Exports: " + ma.exports());
 
         ModuleMainClassAttribute mmca = cm.findAttribute(Attributes.MODULE_MAIN_CLASS).orElse(null);
-        System.out.println("Does the module have a MainClassAttribte?: " + (mmca != null));
+        System.out.println("Does the module have a MainClassAttribute?: " + (mmca != null));
 
         ModulePackagesAttribute mmp = cm.findAttribute(Attributes.MODULE_PACKAGES).orElseThrow();
         System.out.println("Packages?: " + mmp.packages());


### PR DESCRIPTION
This is a cleanup patch that fixes:
1. `ClassfileBuilder` should be sealed but was not; it's now sealed.
2. Various typo fixes, including spelling errors, wrong descriptions, and unnecessary full qualifications for classes in the same package.

Requesting a review from @asotona. There's a few other more complex issues discovered, which I will describe on the mailing list to elicit a discussion for best solutions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311020](https://bugs.openjdk.org/browse/JDK-8311020): Typo cleanup in Classfile API (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14687/head:pull/14687` \
`$ git checkout pull/14687`

Update a local copy of the PR: \
`$ git checkout pull/14687` \
`$ git pull https://git.openjdk.org/jdk.git pull/14687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14687`

View PR using the GUI difftool: \
`$ git pr show -t 14687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14687.diff">https://git.openjdk.org/jdk/pull/14687.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14687#issuecomment-1610817449)