### PR TITLE
8311010: C1 array access causes SIGSEGV due to lack of range check

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/RangeCheckOverflow.java
+++ b/test/hotspot/jtreg/compiler/c1/RangeCheckOverflow.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8311010
+ * @summary C1 array access causes SIGSEGV due to lack of range check
+ * @requires vm.compiler1.enabled
+ * @library /test/lib
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+TieredCompilation -XX:+RangeCheckElimination
+ *                   -XX:CompileCommand=compileonly,*RangeCheckOverflow.test
+ *                   compiler.c1.RangeCheckOverflow
+ */
+
+package compiler.c1;
+
+public class RangeCheckOverflow {
+    static int b = 0;
+
+    private static void test() {
+        int[] a = { 11 } ;
+        for (int i = -1; i <= 0; i++) {
+            for (int j = -3; j <= 2147483646 * i - 3; j++) {
+                b += a[j + 3];
+            }
+        }
+    }
+    public static void main(String... args) {
+        try {
+            test();
+        } catch(ArrayIndexOutOfBoundsException e) {
+            System.out.println("Expected");
+        }
+    }
+}


### PR DESCRIPTION
```java
      int[] a = { 11 } ;
        for (int i = -1; i <= 0; i++) {
            // Insert deopt check
            if (2147483646 * i >=1) { goto deopt_stub;}
            for (int j = -3; j <= 2147483646 * i - 3; j++) {
                b += a[j + 3];
            }
        }
```
C1 eliminates range check before accessing array and inserts a deoptimization check before loop header, because he did the following deduction:
```
   lower - const <= x <= upper - const
   lower <= x + const <= upper
```
 This is wrong, because (lower - const + const) and  (upper -  const + const) may overflow/underflow, e.g.
```
    -3 <= x     <= min_jint - 3
    0  <= x + 3 <= min_jint    (wrong)
```
The proposed change is to assume the worst case whenever upper or lower is found, which may be somewhat conservative.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311010](https://bugs.openjdk.org/browse/JDK-8311010): C1 array access causes SIGSEGV due to lack of range check (**Bug** - P4)


### Contributors
 * Sendao Yan `<yansendao.ysd@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14689/head:pull/14689` \
`$ git checkout pull/14689`

Update a local copy of the PR: \
`$ git checkout pull/14689` \
`$ git pull https://git.openjdk.org/jdk.git pull/14689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14689`

View PR using the GUI difftool: \
`$ git pr show -t 14689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14689.diff">https://git.openjdk.org/jdk/pull/14689.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14689#issuecomment-1611048354)