### PR TITLE
8309302: java/net/Socket/Timeouts.java fails with AssertionError on test temporal post condition

### DIFF
--- a/test/jdk/java/net/Socket/Timeouts.java
+++ b/test/jdk/java/net/Socket/Timeouts.java
@@ -137,7 +137,7 @@ public class Timeouts {
             long startMillis = millisTime();
             expectThrows(SocketTimeoutException.class, () -> s2.getInputStream().read());
             int timeout = s2.getSoTimeout();
-            checkDuration(startMillis, timeout-100, timeout+2000);
+            checkDuration(startMillis, timeout-100, timeout+20_000);
         });
     }
 
@@ -307,7 +307,7 @@ public class Timeouts {
                 fail();
             } catch (SocketTimeoutException expected) {
                 int timeout = ss.getSoTimeout();
-                checkDuration(startMillis, timeout-100, timeout+2000);
+                checkDuration(startMillis, timeout-100, timeout+20_000);
             }
         }
     }
@@ -385,7 +385,7 @@ public class Timeouts {
                 ss.accept().close();
                 fail();
             } catch (SocketException expected) {
-                checkDuration(startMillis, delay-100, delay+2000);
+                checkDuration(startMillis, delay-100, delay+20_000);
             }
         }
     }
@@ -407,7 +407,7 @@ public class Timeouts {
             } catch (SocketTimeoutException expected) {
                 // accept should have blocked for 2 seconds
                 int timeout = ss.getSoTimeout();
-                checkDuration(startMillis, timeout-100, timeout+2000);
+                checkDuration(startMillis, timeout-100, timeout+20_000);
                 assertTrue(Thread.currentThread().isInterrupted());
             } finally {
                 Thread.interrupted(); // clear interrupt status
@@ -433,7 +433,7 @@ public class Timeouts {
             } catch (SocketTimeoutException expected) {
                 // accept should have blocked for 4 seconds
                 int timeout = ss.getSoTimeout();
-                checkDuration(startMillis, timeout-100, timeout+2000);
+                checkDuration(startMillis, timeout-100, timeout+20_000);
                 assertTrue(Thread.currentThread().isInterrupted());
             } finally {
                 interrupter.cancel(true);
@@ -463,7 +463,7 @@ public class Timeouts {
 
             // should get here in 4 seconds, not 8 seconds
             int timeout = ss.getSoTimeout();
-            checkDuration(startMillis, timeout-100, timeout+2000);
+            checkDuration(startMillis, timeout-100, timeout+20_000);
         } finally {
             pool.shutdown();
         }
@@ -505,7 +505,7 @@ public class Timeouts {
 
             // should get here in 4 seconds, not 8 seconds
             int timeout = ss.getSoTimeout();
-            checkDuration(startMillis, timeout-100, timeout+2000);
+            checkDuration(startMillis, timeout-100, timeout+20_000);
         } finally {
             pool.shutdown();
         }


### PR DESCRIPTION
Bumped timeout limit to `+20_000` to deal with occasional failure and bring the test in line with other tests like [SleepWithDuration](https://github.com/openjdk/jdk/blob/c3f10e847999ec254893de5a1a5de32fd07f715a/test/jdk/java/lang/Thread/SleepWithDuration.java#L46) and [JoinWithDuration](https://github.com/openjdk/jdk/blob/c3f10e847999ec254893de5a1a5de32fd07f715a/test/jdk/java/lang/Thread/JoinWithDuration.java#L67) .

I had considered making a Util class to contain `checkDuration` but decided against it because as far as I'm aware it is only these 3 classes that would share it, though I would be open to adding it if people think it adds value

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309302](https://bugs.openjdk.org/browse/JDK-8309302): java/net/Socket/Timeouts.java fails with AssertionError on test temporal post condition (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14690/head:pull/14690` \
`$ git checkout pull/14690`

Update a local copy of the PR: \
`$ git checkout pull/14690` \
`$ git pull https://git.openjdk.org/jdk.git pull/14690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14690`

View PR using the GUI difftool: \
`$ git pr show -t 14690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14690.diff">https://git.openjdk.org/jdk/pull/14690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14690#issuecomment-1611110902)