### PR TITLE
8311030: ResourceBundle.handleKeySet() is racy

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -2346,9 +2346,10 @@ public abstract class ResourceBundle {
      * @since 1.6
      */
     protected Set<String> handleKeySet() {
-        if (keySet == null) {
+      Set<String> keySet = this.keySet;
+      if (keySet == null) {
             synchronized (this) {
-                if (keySet == null) {
+                if ((keySet = this.keySet) == null) {
                     Set<String> keys = new HashSet<>();
                     Enumeration<String> enumKeys = getKeys();
                     while (enumKeys.hasMoreElements()) {
@@ -2357,7 +2358,7 @@ public abstract class ResourceBundle {
                             keys.add(key);
                         }
                     }
-                    keySet = keys;
+                    this.keySet = keySet = keys;
                 }
             }
         }


### PR DESCRIPTION
Double-checked locking should rely on local variable to avoid racy reads from volatile field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311030](https://bugs.openjdk.org/browse/JDK-8311030): ResourceBundle.handleKeySet() is racy (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14692/head:pull/14692` \
`$ git checkout pull/14692`

Update a local copy of the PR: \
`$ git checkout pull/14692` \
`$ git pull https://git.openjdk.org/jdk.git pull/14692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14692`

View PR using the GUI difftool: \
`$ git pr show -t 14692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14692.diff">https://git.openjdk.org/jdk/pull/14692.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14692#issuecomment-1611214372)