### PR TITLE
8311032: Empty value for java.protocol.handler.pkgs system property can lead to unnecessary classloading attempts of protocol handlers

### DIFF
--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1433,7 +1433,7 @@ public final class URL implements java.io.Serializable {
     private static URLStreamHandler lookupViaProperty(String protocol) {
         String packagePrefixList =
                 GetPropertyAction.privilegedGetProperty(protocolPathProp);
-        if (packagePrefixList == null) {
+        if (packagePrefixList == null || packagePrefixList.isEmpty()) {
             // not set
             return null;
         }
@@ -1442,6 +1442,9 @@ public final class URL implements java.io.Serializable {
         URLStreamHandler handler = null;
         for (int i=0; handler == null && i<packagePrefixes.length; i++) {
             String packagePrefix = packagePrefixes[i].trim();
+            if (packagePrefix.isEmpty()) {
+                continue;
+            }
             try {
                 String clsName = packagePrefix + "." + protocol + ".Handler";
                 Class<?> cls = null;


### PR DESCRIPTION
Can I please get a review for this change which proposes to address https://bugs.openjdk.org/browse/JDK-8311032?

The commit in this PR skips the class lookups when the package name prefix is empty, either due to the `java.protocol.handler.pkgs` system property value being empty or due to individual parts of the `|` delimited value being empty.

This avoids potentially expensive classloading attempts for a class name of the form `.foo.Handler`, which is bound to fail.

No new jtreg test has been added given the nature of the change. There's already an existing test `test/jdk/java/net/URL/HandlersPkgPrefix/HandlersPkgPrefix.java` which tests different values for the `java.protocol.handler.pkgs` system property (including empty value) and that test continues to pass with this change.

tier testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311032](https://bugs.openjdk.org/browse/JDK-8311032): Empty value for java.protocol.handler.pkgs system property can lead to unnecessary classloading attempts of protocol handlers (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14693/head:pull/14693` \
`$ git checkout pull/14693`

Update a local copy of the PR: \
`$ git checkout pull/14693` \
`$ git pull https://git.openjdk.org/jdk.git pull/14693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14693`

View PR using the GUI difftool: \
`$ git pr show -t 14693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14693.diff">https://git.openjdk.org/jdk/pull/14693.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14693#issuecomment-1611225255)