### PR TITLE
8310929: Optimization for Integer.toString

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.misc.VM;
+import jdk.internal.util.ByteArray;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
@@ -453,16 +454,104 @@ public final class Integer extends Number
      */
     @IntrinsicCandidate
     public static String toString(int i) {
-        int size = stringSize(i);
-        if (COMPACT_STRINGS) {
-            byte[] buf = new byte[size];
-            getChars(i, size, buf);
-            return new String(buf, LATIN1);
-        } else {
+        if (!COMPACT_STRINGS) {
+            int size = stringSize(i);
             byte[] buf = new byte[size * 2];
             StringUTF16.getChars(i, size, buf);
             return new String(buf, UTF16);
         }
+
+        if (i == Integer.MIN_VALUE) {
+            return "-2147483648";
+        }
+
+        boolean negative = i < 0;
+        if (negative) {
+            i = -i;
+        }
+        final int[] digits = DecimalDigits.DIGITS;
+
+        int off = 0;
+        final int q1 = i / 1000;
+
+        byte[] buf;
+        if (q1 == 0) {
+            int v = digits[i];
+            final int start = v >> 24;
+            buf = new byte[(negative ? 4 : 3) - start];
+            if (negative) {
+                buf[0] = '-';
+                off = 1;
+            }
+
+            if (start == 0) {
+                buf[off] = (byte) (v >> 16);
+                ByteArray.setShort(buf, off + 1, (short) v);
+            } else if (start == 1) {
+                ByteArray.setShort(buf, off, (short) v);
+            } else {
+                buf[off] = (byte) v;
+            }
+        } else {
+            final int r1 = i - q1 * 1000;
+            final int q2 = q1 / 1000;
+            final int v1 = digits[r1];
+            if (q2 == 0) {
+                final int v2 = digits[q1];
+                int start = v2 >> 24;
+
+                buf = new byte[(negative ? 7 : 6) - start];
+                if (negative) {
+                    buf[0] = '-';
+                    off = 1;
+                }
+
+                if (start == 0) {
+                    ByteArray.setShort(buf, off, (short) (v2 >> 8));
+                    off += 2;
+                } else if (start == 1) {
+                    buf[off++] = (byte) (v2 >> 8);
+                }
+                ByteArray.setInt(buf, off, v2 << 24 | (v1 & 0xffffff));
+            } else {
+                final int r2 = q1 - q2 * 1000;
+                final int q3 = q2 / 1000;
+                final int v2 = digits[r2];
+                if (q3 == 0) {
+                    int v = digits[q2];
+                    final int start = v >> 24;
+
+                    buf = new byte[(negative ? 10 : 9) - start];
+                    if (negative) {
+                        buf[0] = '-';
+                        off = 1;
+                    }
+
+                    if (start == 0) {
+                        buf[off] = (byte) (v >> 16);
+                        ByteArray.setShort(buf, off + 1, (short) v);
+                        off += 3;
+                    } else if (start == 1) {
+                        ByteArray.setShort(buf, off, (short) v);
+                        off += 2;
+                    } else {
+                        buf[off++] = (byte) v;
+                    }
+                } else {
+                    buf = new byte[negative ? 11 : 10];
+                    if (negative) {
+                        buf[0] = '-';
+                        off = 1;
+                    }
+                    ByteArray.setInt(buf, off, ((q3 + '0') << 24) | (digits[q2 - q3 * 1000] & 0xffffff));
+                    off += 4;
+                }
+
+                ByteArray.setShort(buf, off, (short) (v2 >> 8));
+                ByteArray.setInt(buf, off + 2, (v2 << 24) | (v1 & 0xffffff));
+            }
+        }
+        return new String(buf, LATIN1);
     }
 
     /**
@@ -1049,6 +1138,66 @@ public final class Integer extends Number
         }
 
         private IntegerCache() {}
+    }
+
+    /**
+     * cache array for 0-999 digits
+     */
+    static final class DecimalDigits {
+        /**
+         * Use the four bytes of int to represent one blank_size byte and three ascii bytes. The four bytes are:
+         * <pre>
+         *     blank_size, c0, c1, c2
+         * </pre>
+         * The logic for calculating blank_size is
+         * <pre>
+         *     blank_size = value < 10 ? 2 : (value < 100 ? 1 : 0)
+         * </pre>
+         * The 1000 elements are as follows :
+         * <pre>
+         *       0 -> 2 0 0 0 -> (2 << 24) | ('0' << 16) | ('0' << 8) | '0' -> 0x2303030
+         *       1 -> 2 0 0 1 -> (2 << 24) | ('0' << 16) | ('0' << 8) | '1' -> 0x2303031
+         *       2 -> 2 0 0 2 -> (2 << 24) | ('0' << 16) | ('0' << 8) | '2' -> 0x2303032
+         *
+         *     ...
+         *
+         *      10 -> 1 0 1 0 -> (1 << 24) | ('0' << 16) | ('1' << 8) | '0' -> 0x1303130
+         *      11 -> 1 0 1 1 -> (1 << 24) | ('0' << 16) | ('1' << 8) | '1' -> 0x1303131
+         *      12 -> 1 0 1 2 -> (1 << 24) | ('0' << 16) | ('1' << 8) | '2' -> 0x1303132
+         *
+         *     ...
+         *
+         *     100 -> 0 1 0 0 -> (0 << 24) | ('1' << 16) | ('0' << 8) | '0' -> 0x313030
+         *     101 -> 0 1 0 1 -> (0 << 24) | ('1' << 16) | ('0' << 8) | '1' -> 0x313031
+         *     102 -> 0 1 0 2 -> (0 << 24) | ('1' << 16) | ('0' << 8) | '2' -> 0x313032
+         *
+         *     ...
+         *
+         *     997 -> 0 9 9 7 -> (0 << 24) | ('9' << 16) | ('9' << 8) | '7' -> 0x393937
+         *     998 -> 0 9 9 8 -> (0 << 24) | ('9' << 16) | ('9' << 8) | '8' -> 0x393938
+         *     999 -> 0 9 9 9 -> (0 << 24) | ('9' << 16) | ('9' << 8) | '9' -> 0x393939
+         * </pre>
+         */
+        @Stable
+        static final int[] DIGITS;
+
+        static {
+            int[] digits = new int[1000];
+            for (int i = 0; i < 10; i++) {
+                int i100 = i * 100;
+                for (int j = 0; j < 10; j++) {
+                    int j10 = j * 10;
+                    for (int k = 0; k < 10; k++) {
+                        digits[i100 + j10 + k]
+                                = ((i == 0 && j == 0) ? 2 : (i == 0) ? 1 : 0) << 24
+                                | ((i + '0') << 16)
+                                | ((j + '0') << 8)
+                                | (k + '0');
+                    }
+                }
+            }
+            DIGITS = digits;
+        }
     }
 
     /**


### PR DESCRIPTION
Speed up Integer.toString with a precomputed cache array of length 1000, use division by 1000, so that each iteration can calculate three digits.  

this optimization can also be used in StringBuilder#appent(int) and Long#toString.

# Benchmark Result

```
make test TEST="micro:java.lang.Integers.toString*"
```

## [aliyun_ecs_c8i.xlarge](https://help.aliyun.com/document_detail/25378.html#c8i)
* cpu : intel xeon sapphire rapids (x64)
``` diff
-Benchmark               (size)  Mode  Cnt  Score   Error  Units (baseline)
-Integers.toStringBig       500  avgt   15  6.811 ± 0.016  us/op
-Integers.toStringSmall     500  avgt   15  4.794 ± 0.011  us/op
-Integers.toStringTiny      500  avgt   15  3.752 ± 0.065  us/op

+Benchmark               (size)  Mode  Cnt  Score   Error  Units (PR)
+Integers.toStringBig       500  avgt   15  5.164 ± 0.052  us/op +31.89%
+Integers.toStringSmall     500  avgt   15  3.844 ± 0.025  us/op +24.71%
+Integers.toStringTiny      500  avgt   15  3.453 ± 0.027  us/op +8.65%
```

### [aliyun_ecs_c8a.xlarge](https://help.aliyun.com/document_detail/25378.html#c8a)
* cpu : amd epc genoa (x64)
``` diff
-Benchmark               (size)  Mode  Cnt  Score   Error  Units (baseline)
-Integers.toStringBig       500  avgt   15  6.762 ± 0.018  us/op
-Integers.toStringSmall     500  avgt   15  4.481 ± 0.004  us/op
-Integers.toStringTiny      500  avgt   15  2.761 ± 0.012  us/op

+Benchmark               (size)  Mode  Cnt  Score   Error  Units (PR)
+Integers.toStringBig       500  avgt   15  5.063 ± 0.175  us/op +33.55%
+Integers.toStringSmall     500  avgt   15  3.498 ± 0.123  us/op +28.10%
+Integers.toStringTiny      500  avgt   15  2.743 ± 0.147  us/op +0.65%
```

## [aliyun_ecs_c8y.xlarge](https://help.aliyun.com/document_detail/25378.html#c8y)
* cpu : aliyun yitian 710 (aarch64)
``` diff
-Benchmark               (size)  Mode  Cnt   Score   Error  Units (baseline)
-Integers.toStringBig       500  avgt   15  12.081 ± 0.377  us/op
-Integers.toStringSmall     500  avgt   15   7.119 ± 0.177  us/op
-Integers.toStringTiny      500  avgt   15   6.323 ± 0.239  us/op

+Benchmark               (size)  Mode  Cnt  Score   Error  Units (PR)
+Integers.toStringBig       500  avgt   15  8.157 ± 0.274  us/op +48.10%
+Integers.toStringSmall     500  avgt   15  7.207 ± 0.330  us/op -1.22%
+Integers.toStringTiny      500  avgt   15  6.912 ± 0.199  us/op -8.52%
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14696/head:pull/14696` \
`$ git checkout pull/14696`

Update a local copy of the PR: \
`$ git checkout pull/14696` \
`$ git pull https://git.openjdk.org/jdk.git pull/14696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14696`

View PR using the GUI difftool: \
`$ git pr show -t 14696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14696.diff">https://git.openjdk.org/jdk/pull/14696.diff</a>

</details>
