### PR TITLE
8311064: Windows builds fail without precompiled headers after JDK-8310728

### DIFF
--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -27,7 +27,7 @@
 #include "gc/z/zLargePages.inline.hpp"
 #include "gc/z/zMapper_windows.hpp"
 #include "gc/z/zSyscall_windows.hpp"
-#include "gc/z/zVirtualMemory.hpp"
+#include "gc/z/zVirtualMemory.inline.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5451,6 +5451,10 @@ void Parker::unpark() {
   SetEvent(_ParkHandle);
 }
 
+PlatformMutex::~PlatformMutex() {
+  DeleteCriticalSection(&_mutex);
+}
+
 // Platform Monitor implementation
 
 // Must already be locked

--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -65,10 +65,6 @@ inline PlatformMutex::PlatformMutex() {
   InitializeCriticalSection(&_mutex);
 }
 
-inline PlatformMutex::~PlatformMutex() {
-  DeleteCriticalSection(&_mutex);
-}
-
 inline PlatformMonitor::PlatformMonitor() {
   InitializeConditionVariable(&_cond);
 }

--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -27,6 +27,7 @@
 #include "gc/z/zArray.inline.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zLargePages.inline.hpp"
+#include "gc/z/zList.inline.hpp"
 #include "gc/z/zNUMA.inline.hpp"
 #include "gc/z/zPhysicalMemory.inline.hpp"
 #include "logging/log.hpp"


### PR DESCRIPTION
Please review this change to fix Windows build without precompiled headers.

After JDK-8310728:
> the compiler enforces the C++11 requirement that all functions declared inline must have a definition available in the same translation unit if they're used

When precompiled headers are used, more headers are automatically included, which allowed the build to pass without this change.

This PR adds 2 includes and un-inlines `PlatformMutex` destructor, which was needed by 3 files and not easily exposed.

Windows build passes with this change, both with and without precompiled headers. Full tier1-5 build in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311064](https://bugs.openjdk.org/browse/JDK-8311064): Windows builds fail without precompiled headers after JDK-8310728 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14701/head:pull/14701` \
`$ git checkout pull/14701`

Update a local copy of the PR: \
`$ git checkout pull/14701` \
`$ git pull https://git.openjdk.org/jdk.git pull/14701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14701`

View PR using the GUI difftool: \
`$ git pr show -t 14701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14701.diff">https://git.openjdk.org/jdk/pull/14701.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14701#issuecomment-1612128517)