### PR TITLE
8311081:KeytoolReaderP12Test.java fail on localized Windows platform

### DIFF
--- a/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,6 +118,7 @@ public class KeytoolReaderP12Test {
             throws IOException {
         convertToPFX(name);
         final String[] command = new String[]{"-debug", "-list", "-v",
+            "-J-Duser.language=en", "-J-Duser.country=US",
             "-keystore", WORKING_DIRECTORY + File.separator + name,
             "-storetype", "pkcs12", "-storepass", password};
         runAndValidate(command, expectedValues);
@@ -128,6 +129,7 @@ public class KeytoolReaderP12Test {
             throws IOException {
         convertToPFX(name);
         final String[] command = new String[]{"-debug", "-export", "-alias",
+            "-J-Duser.language=en", "-J-Duser.country=US",
             alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
             "-storepass", password, "-storetype", "pkcs12", "-rfc"};
         runAndValidate(command, expectedValues);


### PR DESCRIPTION
Failed tests call java.lang.ProcessBuilder in direct to execute keytool, so not used command options specified when jtreg command run.
To run non-localized tests, the locale options should be added in ProcessBuilder.

Could you review this fix, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14703/head:pull/14703` \
`$ git checkout pull/14703`

Update a local copy of the PR: \
`$ git checkout pull/14703` \
`$ git pull https://git.openjdk.org/jdk.git pull/14703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14703`

View PR using the GUI difftool: \
`$ git pr show -t 14703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14703.diff">https://git.openjdk.org/jdk/pull/14703.diff</a>

</details>
