### PR TITLE
JDK-8310919: runtime/ErrorHandling/TestAbortVmOnException.java times out due to core dumps taking a long time on OSX

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
@@ -61,12 +61,13 @@ public class TestAbortVmOnException {
         if (exceptionMessage == null) {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                 "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash",
-                TestAbortVmOnException.class.getName(), withMessage ? "throwExceptionWithMessage" : "throwException").start();
+                "-XX:CompileCommand=compileonly,TestAbortVmOnException::*", TestAbortVmOnException.class.getName(),
+                withMessage ? "throwExceptionWithMessage" : "throwException").start();
         } else {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                 "-XX:AbortVMOnException=" + exceptionName, "-XX:AbortVMOnExceptionMessage=" + exceptionMessage,
-                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash", TestAbortVmOnException.class.getName(),
-                withMessage ? "throwExceptionWithMessage" : "throwException").start();
+                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash", "-XX:CompileCommand=compileonly,TestAbortVmOnException::*",
+                TestAbortVmOnException.class.getName(),withMessage ? "throwExceptionWithMessage" : "throwException").start();
         }
     }
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
@@ -60,12 +60,12 @@ public class TestAbortVmOnException {
     private static Process runProcess(String exceptionName, boolean withMessage, String exceptionMessage) throws IOException {
         if (exceptionMessage == null) {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
-                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", TestAbortVmOnException.class.getName(),
-                withMessage ? "throwExceptionWithMessage" : "throwException").start();
+                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash",
+                TestAbortVmOnException.class.getName(), withMessage ? "throwExceptionWithMessage" : "throwException").start();
         } else {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                 "-XX:AbortVMOnException=" + exceptionName, "-XX:AbortVMOnExceptionMessage=" + exceptionMessage,
-                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", TestAbortVmOnException.class.getName(),
+                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash", TestAbortVmOnException.class.getName(),
                 withMessage ? "throwExceptionWithMessage" : "throwException").start();
         }
     }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
@@ -60,13 +60,13 @@ public class TestAbortVmOnException {
     private static Process runProcess(String exceptionName, boolean withMessage, String exceptionMessage) throws IOException {
         if (exceptionMessage == null) {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
-                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash",
+                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash",
                 "-XX:CompileCommand=compileonly,TestAbortVmOnException::*", TestAbortVmOnException.class.getName(),
                 withMessage ? "throwExceptionWithMessage" : "throwException").start();
         } else {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                 "-XX:AbortVMOnException=" + exceptionName, "-XX:AbortVMOnExceptionMessage=" + exceptionMessage,
-                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash", "-XX:CompileCommand=compileonly,TestAbortVmOnException::*",
+                "-Xcomp", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash", "-XX:CompileCommand=compileonly,TestAbortVmOnException::*",
                 TestAbortVmOnException.class.getName(),withMessage ? "throwExceptionWithMessage" : "throwException").start();
         }
     }


### PR DESCRIPTION
Sometimes the test `runtime/ErrorHandling/TestAbortVmOnException.java` times out on MacOS.

This is due to the fact that the test crashes 3 times by design creating a core dump every time and sometimes on MacOS it takes a long time to create core dumps.

Since there is no reason for these crashes to have core dumps, we avoid creating them by using the `-XX:-CreateCoredumpOnCrash` flag.

Additionally adding `-XX:CompileCommand=compileonly,TestAbortVmOnException::*` to restrict the compilation only to `TestAbortVmOnException` methods and thus make the test faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310919](https://bugs.openjdk.org/browse/JDK-8310919): runtime/ErrorHandling/TestAbortVmOnException.java times out due to core dumps taking a long time on OSX (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14704/head:pull/14704` \
`$ git checkout pull/14704`

Update a local copy of the PR: \
`$ git checkout pull/14704` \
`$ git pull https://git.openjdk.org/jdk.git pull/14704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14704`

View PR using the GUI difftool: \
`$ git pr show -t 14704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14704.diff">https://git.openjdk.org/jdk/pull/14704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14704#issuecomment-1612824667)