### PR TITLE
8311085: Remove implementation detail writeTo from LocalVariable(Type)

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractBoundLocalVariable.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractBoundLocalVariable.java
@@ -24,7 +24,6 @@
  */
 package jdk.internal.classfile.impl;
 
-import jdk.internal.classfile.BufWriter;
 import jdk.internal.classfile.Label;
 import jdk.internal.classfile.constantpool.Utf8Entry;
 
@@ -78,27 +77,5 @@ public class AbstractBoundLocalVariable
 
     public int slot() {
         return code.classReader.readU2(offset + 8);
-    }
-
-    public boolean writeTo(BufWriter b) {
-        var lc = ((BufWriterImpl)b).labelContext();
-        int startBci = lc.labelToBci(startScope());
-        int endBci = lc.labelToBci(endScope());
-        if (startBci == -1 || endBci == -1) {
-            return false;
-        }
-        int length = endBci - startBci;
-        b.writeU2(startBci);
-        b.writeU2(length);
-        if (b.canWriteDirect(code.constantPool())) {
-            b.writeU2(nameIndex());
-            b.writeU2(secondaryIndex());
-        }
-        else {
-            b.writeIndex(name());
-            b.writeIndex(secondaryEntry());
-        }
-        b.writeU2(slot());
-        return true;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPseudoInstruction.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPseudoInstruction.java
@@ -26,7 +26,6 @@ package jdk.internal.classfile.impl;
 
 import java.util.Optional;
 
-import jdk.internal.classfile.BufWriter;
 import jdk.internal.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.instruction.CharacterRange;
@@ -187,22 +186,6 @@ public abstract sealed class AbstractPseudoInstruction
 
         public Label endScope() {
             return endScope;
-        }
-
-        public boolean writeTo(BufWriter b) {
-            var lc = ((BufWriterImpl)b).labelContext();
-            int startBci = lc.labelToBci(startScope());
-            int endBci = lc.labelToBci(endScope());
-            if (startBci == -1 || endBci == -1) {
-                return false;
-            }
-            int length = endBci - startBci;
-            b.writeU2(startBci);
-            b.writeU2(length);
-            b.writeIndex(name);
-            b.writeIndex(descriptor);
-            b.writeU2(slot());
-            return true;
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/instruction/LocalVariable.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/instruction/LocalVariable.java
@@ -26,7 +26,6 @@ package jdk.internal.classfile.instruction;
 
 import java.lang.constant.ClassDesc;
 
-import jdk.internal.classfile.BufWriter;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.CodeElement;
 import jdk.internal.classfile.CodeModel;
@@ -79,8 +78,6 @@ public sealed interface LocalVariable extends PseudoInstruction
      * {@return the end range of the local variable scope}
      */
     Label endScope();
-
-    boolean writeTo(BufWriter buf);
 
     /**
      * {@return a local variable pseudo-instruction}

--- a/src/java.base/share/classes/jdk/internal/classfile/instruction/LocalVariableType.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/instruction/LocalVariableType.java
@@ -24,7 +24,6 @@
  */
 package jdk.internal.classfile.instruction;
 
-import jdk.internal.classfile.BufWriter;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.CodeElement;
 import jdk.internal.classfile.CodeModel;
@@ -76,8 +75,6 @@ public sealed interface LocalVariableType extends PseudoInstruction
      * {@return the end range of the local variable scope}
      */
     Label endScope();
-
-    boolean writeTo(BufWriter buf);
 
     /**
      * {@return a local variable type pseudo-instruction}


### PR DESCRIPTION
`LocalVariable` and `LocalVariableType` includes `writeTo(BufWriter)`, which should be implementation details.

See https://mail.openjdk.org/pipermail/classfile-api-dev/2023-June/000381.html for context.

This patch moves the implementation to `DirectCodeBuilder`'s original use sites; the old `b.canWriteDirect` branch   is redundant, as `writeIndex`'s implementation already performs such an optimization.