### PR TITLE
8311087: PhiNode::wait_for_region_igvn should break early

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1941,25 +1941,25 @@ bool PhiNode::wait_for_region_igvn(PhaseGVN* phase) {
     Node* rc = r->in(j);
     Node* n = in(j);
 
-    if (rc == nullptr || !rc->is_Proj()) continue;
+    if (rc == nullptr || !rc->is_Proj()) { continue; }
     if (worklist.member(rc)) {
       delay = true;
       break;
     }
 
-    if (rc->in(0) == nullptr || !rc->in(0)->is_If()) continue;
+    if (rc->in(0) == nullptr || !rc->in(0)->is_If()) { continue; }
     if (worklist.member(rc->in(0))) {
       delay = true;
       break;
     }
 
-    if (rc->in(0)->in(1) == nullptr || !rc->in(0)->in(1)->is_Bool()) continue;
+    if (rc->in(0)->in(1) == nullptr || !rc->in(0)->in(1)->is_Bool()) { continue; }
     if (worklist.member(rc->in(0)->in(1))) {
       delay = true;
       break;
     }
 
-    if (rc->in(0)->in(1)->in(1) == nullptr || !rc->in(0)->in(1)->in(1)->is_Cmp()) continue;
+    if (rc->in(0)->in(1)->in(1) == nullptr || !rc->in(0)->in(1)->in(1)->is_Cmp()) { continue; }
     if (worklist.member(rc->in(0)->in(1)->in(1))) {
       delay = true;
       break;

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1940,28 +1940,32 @@ bool PhiNode::wait_for_region_igvn(PhaseGVN* phase) {
   for (uint j = 1; j < req(); j++) {
     Node* rc = r->in(j);
     Node* n = in(j);
-    if (rc != nullptr &&
-        rc->is_Proj()) {
-      if (worklist.member(rc)) {
-        delay = true;
-      } else if (rc->in(0) != nullptr &&
-                 rc->in(0)->is_If()) {
-        if (worklist.member(rc->in(0))) {
-          delay = true;
-        } else if (rc->in(0)->in(1) != nullptr &&
-                   rc->in(0)->in(1)->is_Bool()) {
-          if (worklist.member(rc->in(0)->in(1))) {
-            delay = true;
-          } else if (rc->in(0)->in(1)->in(1) != nullptr &&
-                     rc->in(0)->in(1)->in(1)->is_Cmp()) {
-            if (worklist.member(rc->in(0)->in(1)->in(1))) {
-              delay = true;
-            }
-          }
-        }
-      }
+
+    if (rc == nullptr || !rc->is_Proj()) continue;
+    if (worklist.member(rc)) {
+      delay = true;
+      break;
+    }
+
+    if (rc->in(0) == nullptr || !rc->in(0)->is_If()) continue;
+    if (worklist.member(rc->in(0))) {
+      delay = true;
+      break;
+    }
+
+    if (rc->in(0)->in(1) == nullptr || !rc->in(0)->in(1)->is_Bool()) continue;
+    if (worklist.member(rc->in(0)->in(1))) {
+      delay = true;
+      break;
+    }
+
+    if (rc->in(0)->in(1)->in(1) == nullptr || !rc->in(0)->in(1)->in(1)->is_Cmp()) continue;
+    if (worklist.member(rc->in(0)->in(1)->in(1))) {
+      delay = true;
+      break;
     }
   }
+
   if (delay) {
     worklist.push(this);
   }


### PR DESCRIPTION
Hi, please consider this PR.

Instead of continuing the loop we break after setting `delay = true`. I also flattened out the indentation by transforming `A && B` into `!A || !B` and `continue`ing if so. This makes the code a bit longer, but clearer imho.

I've run `TestCastIIAfterUnrollingInOuterLoop`, which is the test that was added along with this method. I'm also running tier1.

Thanks,
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311087](https://bugs.openjdk.org/browse/JDK-8311087): PhiNode::wait_for_region_igvn should break early (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [9dc51e1c](https://git.openjdk.org/jdk/pull/14707/files/9dc51e1c700217dff61339c6fac4eb6ee2916fa6)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14707/head:pull/14707` \
`$ git checkout pull/14707`

Update a local copy of the PR: \
`$ git checkout pull/14707` \
`$ git pull https://git.openjdk.org/jdk.git pull/14707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14707`

View PR using the GUI difftool: \
`$ git pr show -t 14707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14707.diff">https://git.openjdk.org/jdk/pull/14707.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14707#issuecomment-1612869076)