### PR TITLE
8311000: missing @since info in jdk.management

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java
+++ b/src/jdk.management/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java
+++ b/src/jdk.management/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java
@@ -80,6 +80,8 @@ import com.sun.management.internal.GarbageCollectionNotifInfoCompositeData;
  *             the notification are provided in the {@linkplain #getGcAction action} String
  *       </li>
  * </ul>
+ *
+ * @since 1.7
  **/
 
 public class GarbageCollectionNotificationInfo implements  CompositeDataView {


### PR DESCRIPTION
Simple addition of a doc tag.  

src/share/classes/com/sun/management/GarbageCollectionNotificationInfo.java is introduced in jdk7 by
7036199: Adding a notification to the implementation of GarbageCollectorMXBeans

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311000](https://bugs.openjdk.org/browse/JDK-8311000): missing @since info in jdk.management (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [b4c36af7](https://git.openjdk.org/jdk/pull/14708/files/b4c36af7c5f1baa5165da2f8ec138b5a39ff253b)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to [b4c36af7](https://git.openjdk.org/jdk/pull/14708/files/b4c36af7c5f1baa5165da2f8ec138b5a39ff253b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14708/head:pull/14708` \
`$ git checkout pull/14708`

Update a local copy of the PR: \
`$ git checkout pull/14708` \
`$ git pull https://git.openjdk.org/jdk.git pull/14708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14708`

View PR using the GUI difftool: \
`$ git pr show -t 14708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14708.diff">https://git.openjdk.org/jdk/pull/14708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14708#issuecomment-1613007568)