### PR TITLE
8311077: Fix -Wconversion warnings in jvmti code.

### DIFF
--- a/src/hotspot/share/oops/constMethod.hpp
+++ b/src/hotspot/share/oops/constMethod.hpp
@@ -324,7 +324,7 @@ public:
   static bool is_read_only_by_default() { return true; }
 
   // code size
-  int code_size() const                          { return _code_size; }
+  u2 code_size() const                          { return _code_size; }
   void set_code_size(int size) {
     assert(max_method_code_size < (1 << 16),
            "u2 is too small to hold method code size in general");

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -587,16 +587,16 @@ class ConstantPool : public Metadata {
            "Corrupted CP operands");
     return operand_offset_at(operands(), bsms_attribute_index);
   }
-  int operand_bootstrap_method_ref_index_at(int bsms_attribute_index) {
+  u2 operand_bootstrap_method_ref_index_at(int bsms_attribute_index) {
     int offset = operand_offset_at(bsms_attribute_index);
     return operands()->at(offset + _indy_bsm_offset);
   }
-  int operand_argument_count_at(int bsms_attribute_index) {
+  u2 operand_argument_count_at(int bsms_attribute_index) {
     int offset = operand_offset_at(bsms_attribute_index);
-    int argc = operands()->at(offset + _indy_argc_offset);
+    u2 argc = operands()->at(offset + _indy_argc_offset);
     return argc;
   }
-  int operand_argument_index_at(int bsms_attribute_index, int j) {
+  u2 operand_argument_index_at(int bsms_attribute_index, int j) {
     int offset = operand_offset_at(bsms_attribute_index);
     return operands()->at(offset + _indy_argv_offset + j);
   }
@@ -618,21 +618,21 @@ class ConstantPool : public Metadata {
   // Shrink the operands array to a smaller array with new_len length
   void shrink_operands(int new_len, TRAPS);
 
-  int bootstrap_method_ref_index_at(int which) {
+  u2 bootstrap_method_ref_index_at(int which) {
     assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
     int op_base = bootstrap_operand_base(which);
     return operands()->at(op_base + _indy_bsm_offset);
   }
-  int bootstrap_argument_count_at(int which) {
+  u2 bootstrap_argument_count_at(int which) {
     assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
     int op_base = bootstrap_operand_base(which);
-    int argc = operands()->at(op_base + _indy_argc_offset);
+    u2 argc = operands()->at(op_base + _indy_argc_offset);
     DEBUG_ONLY(int end_offset = op_base + _indy_argv_offset + argc;
                int next_offset = bootstrap_operand_limit(which));
     assert(end_offset == next_offset, "matched ending");
     return argc;
   }
-  int bootstrap_argument_index_at(int which, int j) {
+  u2 bootstrap_argument_index_at(int which, int j) {
     int op_base = bootstrap_operand_base(which);
     DEBUG_ONLY(int argc = operands()->at(op_base + _indy_argc_offset));
     assert((uint)j < (uint)argc, "oob");

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -140,18 +140,18 @@ class JavaFieldStream : public FieldStreamBase {
  public:
   JavaFieldStream(const InstanceKlass* k): FieldStreamBase(k->fieldinfo_stream(), k->constants(), 0, k->java_fields_count()) {}
 
-  int name_index() const {
+  u2 name_index() const {
     assert(!field()->field_flags().is_injected(), "regular only");
     return field()->name_index();
   }
 
-  int signature_index() const {
+  u2 signature_index() const {
     assert(!field()->field_flags().is_injected(), "regular only");
     return field()->signature_index();
     return -1;
   }
 
-  int generic_signature_index() const {
+  u2 generic_signature_index() const {
     assert(!field()->field_flags().is_injected(), "regular only");
     if (field()->field_flags().is_generic()) {
       return field()->generic_signature_index();
@@ -159,7 +159,7 @@ class JavaFieldStream : public FieldStreamBase {
     return 0;
   }
 
-  int initval_index() const {
+  u2 initval_index() const {
     assert(!field()->field_flags().is_injected(), "regular only");
     return field()->initializer_index();
   }

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -254,7 +254,7 @@ class Method : public Metadata {
   void set_orig_method_idnum(u2 idnum)   { constMethod()->set_orig_method_idnum(idnum); }
 
   // code size
-  int code_size() const                  { return constMethod()->code_size(); }
+  u2 code_size() const                   { return constMethod()->code_size(); }
 
   // method size in words
   int method_size() const                { return sizeof(Method)/wordSize + ( is_native() ? 2 : 0 ); }
@@ -265,13 +265,13 @@ class Method : public Metadata {
 
   // max stack
   // return original max stack size for method verification
-  int  verifier_max_stack() const                { return constMethod()->max_stack(); }
-  int           max_stack() const                { return constMethod()->max_stack() + extra_stack_entries(); }
-  void      set_max_stack(int size)              {        constMethod()->set_max_stack(size); }
+  u2  verifier_max_stack() const               { return constMethod()->max_stack(); }
+  int          max_stack() const               { return constMethod()->max_stack() + extra_stack_entries(); }
+  void      set_max_stack(int size)            {        constMethod()->set_max_stack(size); }
 
   // max locals
-  int  max_locals() const                        { return constMethod()->max_locals(); }
-  void set_max_locals(int size)                  { constMethod()->set_max_locals(size); }
+  u2  max_locals() const                       { return constMethod()->max_locals(); }
+  void set_max_locals(int size)                { constMethod()->set_max_locals(size); }
 
   int highest_comp_level() const;
   void set_highest_comp_level(int level);
@@ -520,18 +520,18 @@ public:
   int method_parameters_length() const
                          { return constMethod()->method_parameters_length(); }
   MethodParametersElement* method_parameters_start() const
-                          { return constMethod()->method_parameters_start(); }
+                         { return constMethod()->method_parameters_start(); }
 
   // checked exceptions
-  int checked_exceptions_length() const
+  u2 checked_exceptions_length() const
                          { return constMethod()->checked_exceptions_length(); }
   CheckedExceptionElement* checked_exceptions_start() const
-                          { return constMethod()->checked_exceptions_start(); }
+                         { return constMethod()->checked_exceptions_start(); }
 
   // localvariable table
   bool has_localvariable_table() const
                           { return constMethod()->has_localvariable_table(); }
-  int localvariable_table_length() const
+  u2 localvariable_table_length() const
                         { return constMethod()->localvariable_table_length(); }
   LocalVariableTableElement* localvariable_table_start() const
                          { return constMethod()->localvariable_table_start(); }
@@ -1038,7 +1038,7 @@ class ExceptionTable : public StackObj {
     }
   }
 
-  int length() const {
+  u2 length() const {
     return _length;
   }
 

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -64,15 +64,15 @@ void JvmtiClassFileReconstituter::write_field_infos() {
   // Compute the real number of Java fields
   int java_fields = ik()->java_fields_count();
 
-  write_u2(java_fields);
+  write_u2(checked_cast<u2>(java_fields));
   for (JavaFieldStream fs(ik()); !fs.done(); fs.next()) {
     AccessFlags access_flags = fs.access_flags();
-    int name_index = fs.name_index();
-    int signature_index = fs.signature_index();
-    int initial_value_index = fs.initval_index();
+    u2 name_index = fs.name_index();
+    u2 signature_index = fs.signature_index();
+    u2 initial_value_index = fs.initval_index();
     guarantee(name_index != 0 && signature_index != 0, "bad constant pool index for field");
     // int offset = ik()->field_offset( index );
-    int generic_signature_index = fs.generic_signature_index();
+    u2 generic_signature_index = fs.generic_signature_index();
     AnnotationArray* anno = fields_anno == nullptr ? nullptr : fields_anno->at(fs.index());
     AnnotationArray* type_anno = fields_type_anno == nullptr ? nullptr : fields_type_anno->at(fs.index());
 
@@ -84,10 +84,10 @@ void JvmtiClassFileReconstituter::write_field_infos() {
     // JVMSpec|         attribute_info attributes[attributes_count];
     // JVMSpec|   }
 
-    write_u2(access_flags.as_int() & JVM_RECOGNIZED_FIELD_MODIFIERS);
+    write_u2(access_flags.get_flags() & JVM_RECOGNIZED_FIELD_MODIFIERS);
     write_u2(name_index);
     write_u2(signature_index);
-    int attr_count = 0;
+    u2 attr_count = 0;
     if (initial_value_index != 0) {
       ++attr_count;
     }
@@ -147,11 +147,11 @@ void JvmtiClassFileReconstituter::write_code_attribute(const methodHandle& metho
   ConstMethod* const_method = method->constMethod();
   u2 line_num_cnt = 0;
   int stackmap_len = 0;
-  int local_variable_table_length = 0;
-  int local_variable_type_table_length = 0;
+  u2 local_variable_table_length = 0;
+  u2 local_variable_type_table_length = 0;
 
   // compute number and length of attributes
-  int attr_count = 0;
+  u2 attr_count = 0;
   int attr_size = 0;
   if (const_method->has_linenumber_table()) {
     line_num_cnt = line_number_table_entries(method);
@@ -229,7 +229,7 @@ void JvmtiClassFileReconstituter::write_code_attribute(const methodHandle& metho
   }
 
   ExceptionTable exception_table(method());
-  int exception_table_length = exception_table.length();
+  u2 exception_table_length = exception_table.length();
   int code_size = const_method->code_size();
   int size =
     2+2+4 +                                // max_stack, max_locals, code_length
@@ -276,7 +276,7 @@ void JvmtiClassFileReconstituter::write_code_attribute(const methodHandle& metho
 // JVMSpec|   }
 void JvmtiClassFileReconstituter::write_exceptions_attribute(ConstMethod* const_method) {
   CheckedExceptionElement* checked_exceptions = const_method->checked_exceptions_start();
-  int checked_exceptions_length = const_method->checked_exceptions_length();
+  u2 checked_exceptions_length = const_method->checked_exceptions_length();
   int size =
     2 +                                    // number_of_exceptions
     2 * checked_exceptions_length;         // exception_index_table
@@ -307,7 +307,7 @@ void JvmtiClassFileReconstituter::write_method_parameter_attribute(const ConstMe
 
   write_attribute_name_index("MethodParameters");
   write_u4(size);
-  write_u1(length);
+  write_u1((u1)length);
   for (int index = 0; index < length; index++) {
     write_u2(parameters[index].name_cp_index);
     write_u2(parameters[index].flags);
@@ -361,7 +361,7 @@ void JvmtiClassFileReconstituter::write_signature_attribute(u2 generic_signature
 // Compute the number of entries in the InnerClasses attribute
 u2 JvmtiClassFileReconstituter::inner_classes_attribute_length() {
   InnerClassesIterator iter(ik());
-  return iter.length();
+  return checked_cast<u2>(iter.length());
 }
 
 // Write an annotation attribute.  The VM stores them in raw form, so all we need
@@ -396,15 +396,15 @@ void JvmtiClassFileReconstituter::write_bootstrapmethod_attribute() {
   // calculate length of attribute
   int length = sizeof(u2); // num_bootstrap_methods
   for (int n = 0; n < num_bootstrap_methods; n++) {
-    u2 num_bootstrap_arguments = cpool()->operand_argument_count_at(n);
+    int num_bootstrap_arguments = cpool()->operand_argument_count_at(n);
     length += sizeof(u2); // bootstrap_method_ref
     length += sizeof(u2); // num_bootstrap_arguments
-    length += sizeof(u2) * num_bootstrap_arguments; // bootstrap_arguments[num_bootstrap_arguments]
+    length += (int)sizeof(u2) * num_bootstrap_arguments; // bootstrap_arguments[num_bootstrap_arguments]
   }
   write_u4(length);
 
   // write attribute
-  write_u2(num_bootstrap_methods);
+  write_u2(checked_cast<u2>(num_bootstrap_methods));
   for (int n = 0; n < num_bootstrap_methods; n++) {
     u2 bootstrap_method_ref = cpool()->operand_bootstrap_method_ref_index_at(n);
     u2 num_bootstrap_arguments = cpool()->operand_argument_count_at(n);
@@ -424,7 +424,7 @@ void JvmtiClassFileReconstituter::write_bootstrapmethod_attribute() {
 //  }
 void JvmtiClassFileReconstituter::write_nest_host_attribute() {
   int length = sizeof(u2);
-  int host_class_index = ik()->nest_host_index();
+  u2 host_class_index = ik()->nest_host_index();
 
   write_attribute_name_index("NestHost");
   write_u4(length);
@@ -444,7 +444,7 @@ void JvmtiClassFileReconstituter::write_nest_members_attribute() {
 
   write_attribute_name_index("NestMembers");
   write_u4(length);
-  write_u2(number_of_classes);
+  write_u2(checked_cast<u2>(number_of_classes));
   for (int i = 0; i < number_of_classes; i++) {
     u2 class_cp_index = nest_members->at(i);
     write_u2(class_cp_index);
@@ -464,7 +464,7 @@ void JvmtiClassFileReconstituter::write_permitted_subclasses_attribute() {
 
   write_attribute_name_index("PermittedSubclasses");
   write_u4(length);
-  write_u2(number_of_classes);
+  write_u2(checked_cast<u2>(number_of_classes));
   for (int i = 0; i < number_of_classes; i++) {
     u2 class_cp_index = permitted_subclasses->at(i);
     write_u2(class_cp_index);
@@ -488,7 +488,7 @@ void JvmtiClassFileReconstituter::write_record_attribute() {
   int number_of_components = components->length();
 
   // Each component has a u2 for name, descr, attribute count
-  int length = sizeof(u2) + (sizeof(u2) * 3 * number_of_components);
+  int length = checked_cast<int>(sizeof(u2) + (sizeof(u2) * 3 * number_of_components));
   for (int x = 0; x < number_of_components; x++) {
     RecordComponent* component = components->at(x);
     if (component->generic_signature_index() != 0) {
@@ -505,7 +505,7 @@ void JvmtiClassFileReconstituter::write_record_attribute() {
 
   write_attribute_name_index("Record");
   write_u4(length);
-  write_u2(number_of_components);
+  write_u2(checked_cast<u2>(number_of_components));
   for (int i = 0; i < number_of_components; i++) {
     RecordComponent* component = components->at(i);
     write_u2(component->name_index());
@@ -538,7 +538,7 @@ void JvmtiClassFileReconstituter::write_inner_classes_attribute(int length) {
   InnerClassesIterator iter(ik());
   guarantee(iter.length() != 0 && iter.length() == length,
             "caller must check");
-  u2 entry_count = length / InstanceKlass::inner_class_next_offset;
+  u2 entry_count = checked_cast<u2>(length / InstanceKlass::inner_class_next_offset);
   u4 size = 2 + entry_count * (2+2+2+2);
 
   write_attribute_name_index("InnerClasses");
@@ -592,8 +592,8 @@ void JvmtiClassFileReconstituter::write_line_number_table_attribute(const method
 
   CompressedLineNumberReadStream stream(method->compressed_linenumber_table());
   while (stream.read_pair()) {
-    write_u2(stream.bci());
-    write_u2(stream.line());
+    write_u2(checked_cast<u2>(stream.bci()));
+    write_u2(checked_cast<u2>(stream.line()));
   }
 }
 
@@ -736,7 +736,7 @@ void JvmtiClassFileReconstituter::write_method_info(const methodHandle& method) 
     ++attr_count;     // has RuntimeVisibleTypeAnnotations attribute
   }
 
-  write_u2(attr_count);
+  write_u2(checked_cast<u2>(attr_count));
   if (const_method->code_size() > 0) {
     write_code_attribute(method);
   }
@@ -776,7 +776,7 @@ void JvmtiClassFileReconstituter::write_class_attributes() {
   AnnotationArray* anno = ik()->class_annotations();
   AnnotationArray* type_anno = ik()->class_type_annotations();
 
-  int attr_count = 0;
+  u2 attr_count = 0;
   if (generic_signature != nullptr) {
     ++attr_count;
   }
@@ -867,7 +867,7 @@ void JvmtiClassFileReconstituter::write_method_infos() {
     }
   }
 
-  write_u2(num_methods - num_overpass);
+  write_u2(checked_cast<u2>(num_methods - num_overpass));
   if (JvmtiExport::can_maintain_original_method_order()) {
     int index;
     int original_index;
@@ -911,7 +911,7 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
 
   // JVMSpec|           u2 constant_pool_count;
   // JVMSpec|           cp_info constant_pool[constant_pool_count-1];
-  write_u2(cpool()->length());
+  write_u2(checked_cast<u2>(cpool()->length()));
   copy_cpool_bytes(writeable_address(cpool_size()));
 
   // JVMSpec|           u2 access_flags;
@@ -928,7 +928,7 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
   // JVMSpec|           u2 interfaces[interfaces_count];
   Array<InstanceKlass*>* interfaces =  ik()->local_interfaces();
   int num_interfaces = interfaces->length();
-  write_u2(num_interfaces);
+  write_u2(checked_cast<u2>(num_interfaces));
   for (int index = 0; index < num_interfaces; index++) {
     HandleMark hm(thread());
     InstanceKlass* iik = interfaces->at(index);

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -271,9 +271,7 @@ void JvmtiCodeBlobEvents::build_jvmti_addr_location_map(nmethod *nm,
 
   if (!mh->is_native()) {
     PcDesc *pcd;
-    int pcds_in_method;
-
-    pcds_in_method = (nm->scopes_pcs_end() - nm->scopes_pcs_begin());
+    int pcds_in_method = pointer_delta_as_int(nm->scopes_pcs_end(), nm->scopes_pcs_begin());
     map = NEW_C_HEAP_ARRAY(jvmtiAddrLocationMap, pcds_in_method, mtInternal);
 
     address scopes_data = nm->scopes_data_begin();

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -145,7 +145,7 @@ JvmtiEnvBase::phase() {
 
 bool
 JvmtiEnvBase::is_valid() {
-  jint value = 0;
+  jlong value = 0;
 
   // This object might not be a JvmtiEnvBase so we can't assume
   // the _magic field is properly aligned. Get the value in a safe
@@ -796,7 +796,7 @@ JvmtiEnvBase::get_vthread_state(oop thread_oop, JavaThread* java_thread) {
     // This call can trigger a safepoint, so thread_oop must not be used after it.
     state = get_thread_state_base(ct_oop, java_thread) & ~filtered_bits;
   } else {
-    jshort vt_state = java_lang_VirtualThread::state(thread_oop);
+    int vt_state = java_lang_VirtualThread::state(thread_oop);
     state = (jint)java_lang_VirtualThread::map_state_to_thread_status(vt_state);
   }
   if (ext_suspended && ((state & JVMTI_THREAD_STATE_ALIVE) != 0)) {
@@ -2549,7 +2549,7 @@ VirtualThreadGetFrameLocationClosure::do_thread(Thread *target) {
 void
 VirtualThreadGetThreadStateClosure::do_thread(Thread *target) {
   assert(target->is_Java_thread(), "just checking");
-  jshort vthread_state = java_lang_VirtualThread::state(_vthread_h());
+  int vthread_state = java_lang_VirtualThread::state(_vthread_h());
   oop carrier_thread_oop = java_lang_VirtualThread::carrier_thread(_vthread_h());
   jint state;
 

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -175,7 +175,7 @@ void JvmtiEnvThreadState::set_agent_thread_local_storage_data (void *data) {
 void JvmtiEnvThreadState::compare_and_set_current_location(Method* new_method,
                                                            address new_location, jvmtiEvent event) {
 
-  int new_bci = new_location - new_method->code_base();
+  int new_bci = pointer_delta_as_int(new_location, new_method->code_base());
 
   // The method is identified and stored as a jmethodID which is safe in this
   // case because the class cannot be unloaded while a method is executing.

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -910,7 +910,7 @@ class JvmtiClassFileLoadHookPoster : public StackObj {
     _data_ptr = data_ptr;
     _end_ptr = end_ptr;
     _thread = JavaThread::current();
-    _curr_len = *end_ptr - *data_ptr;
+    _curr_len = pointer_delta_as_int(*end_ptr, *data_ptr);
     _curr_data = *data_ptr;
     _curr_env = nullptr;
     _cached_class_file_ptr = cache_ptr;

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,7 @@ jvmtiCapabilities *JvmtiManageCapabilities::exclude(const jvmtiCapabilities *a, 
   char *resultp = (char *)result;
 
   for (int i = 0; i < CAPA_SIZE; ++i) {
-    *resultp++ = *ap++ & ~*bp++;
+    *resultp++ = *ap++ & (char)~*bp++;
   }
 
   return result;

--- a/src/hotspot/share/prims/jvmtiRawMonitor.cpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.cpp
@@ -80,7 +80,7 @@ JvmtiRawMonitor::~JvmtiRawMonitor() {
 
 bool
 JvmtiRawMonitor::is_valid() {
-  int value = 0;
+  uint64_t value = 0;
 
   // This object might not be a JvmtiRawMonitor so we can't assume
   // the _magic field is properly aligned. Get the value in a safe
@@ -382,7 +382,7 @@ int JvmtiRawMonitor::raw_wait(jlong millis, Thread* self) {
   self->_ParkEvent->reset();
   OrderAccess::fence();
 
-  intptr_t save = _recursions;
+  int save = _recursions;
   _recursions = 0;
   ret = simple_wait(self, millis);
 

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -622,7 +622,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
 } // end append_entry()
 
 
-int VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& scratch_cp,
+u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& scratch_cp,
       int ref_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
   int new_ref_i = ref_i;
@@ -647,7 +647,9 @@ int VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& 
     }
   }
 
-  return new_ref_i;
+  // constant pool indices are u2, unless the merged constant pool overflows which
+  // we don't check for.
+  return checked_cast<u2>(new_ref_i);
 } // end find_or_append_indirect_entry()
 
 
@@ -657,9 +659,9 @@ int VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& 
 void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, int old_bs_i,
        constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
-  int old_ref_i = scratch_cp->operand_bootstrap_method_ref_index_at(old_bs_i);
-  int new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
-                                                merge_cp_length_p);
+  u2 old_ref_i = scratch_cp->operand_bootstrap_method_ref_index_at(old_bs_i);
+  u2 new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
+                                               merge_cp_length_p);
   if (new_ref_i != old_ref_i) {
     log_trace(redefine, class, constantpool)
       ("operands entry@%d bootstrap method ref_index change: %d to %d", _operands_cur_length, old_ref_i, new_ref_i);
@@ -671,16 +673,16 @@ void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, in
   // However, the operand_offset_at(0) was set in the extend_operands() call.
   int new_base = (new_bs_i == 0) ? (*merge_cp_p)->operand_offset_at(0)
                                  : (*merge_cp_p)->operand_next_offset_at(new_bs_i - 1);
-  int argc     = scratch_cp->operand_argument_count_at(old_bs_i);
+  u2 argc      = scratch_cp->operand_argument_count_at(old_bs_i);
 
   ConstantPool::operand_offset_at_put(merge_ops, _operands_cur_length, new_base);
   merge_ops->at_put(new_base++, new_ref_i);
   merge_ops->at_put(new_base++, argc);
 
   for (int i = 0; i < argc; i++) {
-    int old_arg_ref_i = scratch_cp->operand_argument_index_at(old_bs_i, i);
-    int new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
-                                                      merge_cp_length_p);
+    u2 old_arg_ref_i = scratch_cp->operand_argument_index_at(old_bs_i, i);
+    u2 new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
+                                                     merge_cp_length_p);
     merge_ops->at_put(new_base++, new_arg_ref_i);
     if (new_arg_ref_i != old_arg_ref_i) {
       log_trace(redefine, class, constantpool)
@@ -1234,7 +1236,7 @@ jvmtiError VM_RedefineClasses::compare_and_normalize_class_versions(
 // Find new constant pool index value for old constant pool index value
 // by searching the index map. Returns zero (0) if there is no mapped
 // value for the old constant pool index.
-int VM_RedefineClasses::find_new_index(int old_index) {
+u2 VM_RedefineClasses::find_new_index(int old_index) {
   if (_index_map_count == 0) {
     // map is empty so nothing can be found
     return 0;
@@ -1253,7 +1255,9 @@ int VM_RedefineClasses::find_new_index(int old_index) {
     return 0;
   }
 
-  return value;
+  // constant pool indices are u2, unless the merged constant pool overflows which
+  // we don't check for.
+  return checked_cast<u2>(value);
 } // end find_new_index()
 
 
@@ -2188,8 +2192,8 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
     switch (c) {
       case Bytecodes::_ldc:
       {
-        int cp_index = *(bcp + 1);
-        int new_index = find_new_index(cp_index);
+        u1 cp_index = *(bcp + 1);
+        u2 new_index = find_new_index(cp_index);
 
         if (StressLdcRewrite && new_index == 0) {
           // If we are stressing ldc -> ldc_w rewriting, then we
@@ -2203,7 +2207,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
             // unless we are trying to stress ldc -> ldc_w rewriting
             log_trace(redefine, class, constantpool)
               ("%s@" INTPTR_FORMAT " old=%d, new=%d", Bytecodes::name(c), p2i(bcp), cp_index, new_index);
-            *(bcp + 1) = new_index;
+            *(bcp + 1) = (u1)new_index;
           } else {
             log_trace(redefine, class, constantpool)
               ("%s->ldc_w@" INTPTR_FORMAT " old=%d, new=%d", Bytecodes::name(c), p2i(bcp), cp_index, new_index);
@@ -2262,7 +2266,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
       {
         address p = bcp + 1;
         int cp_index = Bytes::get_Java_u2(p);
-        int new_index = find_new_index(cp_index);
+        u2 new_index = find_new_index(cp_index);
         if (new_index != 0) {
           // the original index is mapped so update w/ new value
           log_trace(redefine, class, constantpool)
@@ -3600,7 +3604,7 @@ void VM_RedefineClasses::set_new_constant_pool(
     if (cur_index == 0) {
       continue;  // JVM spec. allows null inner class refs so skip it
     }
-    int new_index = find_new_index(cur_index);
+    u2 new_index = find_new_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("inner_class_info change: %d to %d", cur_index, new_index);
       iter.set_inner_class_info_index(new_index);
@@ -3626,7 +3630,7 @@ void VM_RedefineClasses::set_new_constant_pool(
     methodHandle method(THREAD, methods->at(i));
     method->set_constants(scratch_cp());
 
-    int new_index = find_new_index(method->name_index());
+    u2 new_index = find_new_index(method->name_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-name_index change: %d to %d", method->name_index(), new_index);
@@ -3671,7 +3675,7 @@ void VM_RedefineClasses::set_new_constant_pool(
 
     for (int j = 0; j < ext_length; j ++) {
       int cur_index = ex_table.catch_type_index(j);
-      int new_index = find_new_index(cur_index);
+      u2 new_index = find_new_index(cur_index);
       if (new_index != 0) {
         log_trace(redefine, class, constantpool)("ext-klass_index change: %d to %d", cur_index, new_index);
         ex_table.set_catch_type_index(j, new_index);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -432,11 +432,11 @@ class VM_RedefineClasses: public VM_Operation {
   void append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   void finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS);
-  int find_or_append_indirect_entry(const constantPoolHandle& scratch_cp, int scratch_i,
+  u2 find_or_append_indirect_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
   int find_or_append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  int find_new_index(int old_index);
+  u2 find_new_index(int old_index);
   int find_new_operand_index(int old_bootstrap_spec_index);
   bool is_unresolved_class_mismatch(const constantPoolHandle& cp1, int index1,
     const constantPoolHandle& cp2, int index2);

--- a/src/hotspot/share/prims/jvmtiTrace.cpp
+++ b/src/hotspot/share/prims/jvmtiTrace.cpp
@@ -202,7 +202,7 @@ void JvmtiTrace::initialize() {
             if (op == '+') {
               _trace_flags[i] |= bits;
             } else {
-              _trace_flags[i] &= ~bits;
+              _trace_flags[i] &= (jbyte)~bits;
             }
             _on = true;
           }
@@ -231,7 +231,7 @@ void JvmtiTrace::initialize() {
           if (op == '+') {
             _event_trace_flags[i] |= bits;
           } else {
-            _event_trace_flags[i] &= ~bits;
+            _event_trace_flags[i] &= (jbyte)~bits;
           }
           _on = true;
         }

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -75,8 +75,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
   case Bytecodes::_multianewarray : // fall through
   case Bytecodes::_checkcast      : // fall through
   case Bytecodes::_instanceof     : {
-    u2 cpi_old = s_old->get_index_u2();
-    u2 cpi_new = s_new->get_index_u2();
+    int cpi_old = s_old->get_index_u2();
+    int cpi_new = s_new->get_index_u2();
     if (old_cp->klass_at_noresolve(cpi_old) != new_cp->klass_at_noresolve(cpi_new))
         return false;
     if (c_old == Bytecodes::_multianewarray &&
@@ -155,8 +155,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
   }
 
   case Bytecodes::_ldc2_w : {
-    u2 cpi_old = s_old->get_index_u2();
-    u2 cpi_new = s_new->get_index_u2();
+    int cpi_old = s_old->get_index_u2();
+    int cpi_new = s_new->get_index_u2();
     constantTag tag_old = old_cp->tag_at(cpi_old);
     constantTag tag_new = new_cp->tag_at(cpi_new);
     if (tag_old.value() != tag_new.value())

--- a/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
+++ b/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,12 +84,12 @@ class jfieldIDWorkaround: AllStatic {
     uintptr_t as_uint = (uintptr_t) id;
     return ((as_uint & checked_mask_in_place) != 0);
   }
-  static intptr_t raw_instance_offset(jfieldID id) {
+  static int raw_instance_offset(jfieldID id) {
     uintptr_t result = (uintptr_t) id >> address_shift;
     if (VerifyJNIFields && is_checked_jfieldID(id)) {
       result &= small_offset_mask;  // cut off the hash bits
     }
-    return (intptr_t)result;
+    return (int)result;
   }
   static intptr_t encode_klass_hash(Klass* k, intptr_t offset);
   static bool             klass_hash_ok(Klass* k, jfieldID id);
@@ -124,7 +124,7 @@ class jfieldIDWorkaround: AllStatic {
     return result;
   }
 
-  static intptr_t from_instance_jfieldID(Klass* k, jfieldID id) {
+  static int from_instance_jfieldID(Klass* k, jfieldID id) {
 #ifndef ASSERT
     // always verify in debug mode; switchable in anything else
     if (VerifyJNIFields)


### PR DESCRIPTION
Please review change for mostly fixing return types in the constant pool and metadata to fix -Wconversion warnings in JVMTI code.
Tested with tier1-4.