### PR TITLE
8311038: Incorrect exhaustivity computation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -844,6 +844,8 @@ public class Flow {
                     for (Type sup : types.directSupertypes(bpOne.type)) {
                         ClassSymbol clazz = (ClassSymbol) sup.tsym;
 
+                        clazz.complete();
+
                         if (clazz.isSealed() && clazz.isAbstract() &&
                             //if a binding pattern for clazz already exists, no need to analyze it again:
                             !existingBindings.contains(clazz)) {
@@ -891,7 +893,9 @@ public class Flow {
                                     }
 
                                     if (reduces) {
-                                        bindings.append(pdOther);
+                                        if (!types.isSubtype(types.erasure(clazz.type), types.erasure(bpOther.type))) {
+                                            bindings.append(pdOther);
+                                        }
                                     }
                                 }
                             }
@@ -925,6 +929,8 @@ public class Flow {
                 ClassSymbol current = permittedSubtypesClosure.head;
 
                 permittedSubtypesClosure = permittedSubtypesClosure.tail;
+
+                current.complete();
 
                 if (current.isSealed() && current.isAbstract()) {
                     for (Symbol sym : current.permitted) {

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -1944,6 +1944,26 @@ public class Exhaustiveness extends TestRunner {
                                System.out.println("C2");
                        }
                    }
+               }
+               """);
+    }
+
+    @Test //JDK-8311038
+    public void testReducesTooMuch(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   void test(Rec r) {
+                       switch (r) {
+                           case Rec(String s) ->
+                               System.out.println("I2" + s.toString());
+                           case Rec(Object o) ->
+                               System.out.println("I2");
+                       }
+                   }
+                   record Rec(Object o) {}
                }
                """);
     }


### PR DESCRIPTION
Consider this code:
```
public class Test {

    record Rec(Object t) {}

    private void test2() {
        Rec r = new Rec("test");
        int res = switch (r) {
            case Rec(String x): {
                yield x.length();
            }
            case Rec(Object x): {
                yield -3;
            }
        };
    }

}
```

It is obviously exhaustive (there's `Rec(Object x)`, which is unconditional on `Rec`), but javac fails to compile this code:
```
/tmp/Test.java:7: error: the switch expression does not cover all possible input values
        int res = switch (r) {
                  ^
1 error
```

The cause seems to be that when binding patterns for the (nested) `String` and `Object` are reduced, they are reduced to `String` and `ConstantDesc`, which is no longer exhaustive for `Object`.

This is a result of this code:
https://github.com/openjdk/jdk/blob/07734f6dde2b29574b6ef98eeb9e007d8801a3ea/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java#L886
which is intended to help with patterns that don't stand directly in the selector's hierarchy, like:
https://github.com/openjdk/jdk/blob/07734f6dde2b29574b6ef98eeb9e007d8801a3ea/test/langtools/tools/javac/patterns/Exhaustiveness.java#L1494
where `I3` is only related to the selector (`I`) via a permitted subtype.

Part of the problem is that `Object` is removed from the pattern set - adding `ConstantDesc` is not a problem. The proposal in this patch is to keep supertypes of the type that is being added in the pattern set. This will lead to pattern set `ConstantDesc`, `Object` and `String`, which should be OK for correctness, although generally enhancing the pattern set might slow down the processing.

There are two complicating factors, which make the observed bug surprising and difficult to diagnose:
 - if (in this example) `ConstantDesc` has not been completed yet, `.isSealed()` will return `false` for it, and the code will compile. This may happen when `x.length()` is removed/replaced in the example. This patch proposes to complete the Symbols before checking for sealedness.
 - it appears to be difficult to reproduce with a synthetic testcase, due to variations in ordering in maps. Hence this patch is using `String` in the testcase, as opposed to a test-only class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311038](https://bugs.openjdk.org/browse/JDK-8311038): Incorrect exhaustivity computation (**Bug** - P2)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14711/head:pull/14711` \
`$ git checkout pull/14711`

Update a local copy of the PR: \
`$ git checkout pull/14711` \
`$ git pull https://git.openjdk.org/jdk.git pull/14711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14711`

View PR using the GUI difftool: \
`$ git pr show -t 14711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14711.diff">https://git.openjdk.org/jdk/pull/14711.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14711#issuecomment-1613187356)