### PR TITLE
automatically balance code segment sizes

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -306,8 +306,8 @@ void CodeCache::initialize_heaps() {
   FLAG_SET_ERGO(NonNMethodCodeHeapSize,  segments_val_min_max[(int)CodeBlobType::NonNMethod][0]);
 
   assert(NonProfiledCodeHeapSize + ProfiledCodeHeapSize + NonNMethodCodeHeapSize == ReservedCodeCacheSize,
-        "Invalid code heap sizes: %lu + %lu + %lu != %lu",
-        (uintx)NonProfiledCodeHeapSize, (uintx)ProfiledCodeHeapSize, (uintx)NonNMethodCodeHeapSize, (uintx)ReservedCodeCacheSize);
+        "Invalid code heap sizes: %d + %d + %d != %d",
+        (int)NonProfiledCodeHeapSize, (int)ProfiledCodeHeapSize, (int)NonNMethodCodeHeapSize, (int)ReservedCodeCacheSize);
 
   ReservedCodeSpace rs = reserve_heap_memory(cache_size);
   ReservedSpace profiled_space      = rs.first_part(ProfiledCodeHeapSize);

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -163,6 +163,7 @@ public class CheckSegmentedCodeCache {
                                                    "-XX:ReservedCodeCacheSize=" + minSize,
                                                    "-XX:InitialCodeCacheSize=100K",
                                                    "-version");
-        failsWith(pb, "Not enough space in non-nmethod code heap to run VM");
+        //failsWith(pb, "Not enough space in non-nmethod code heap to run VM");
+        failsWith(pb, "Invalid code heap sizes");
     }
 }


### PR DESCRIPTION
With this change I am reworking CodeCache::initialize_heaps. Besides code heap segments allocating, this function does a long massage on CodeHeap sizes - this is the part I want to change.

The current algorithm is:
- if NonNMethodCodeHeapSize is not set up on the command line, add a space there for C1 and C2
Then, deal with possible gap: ReservedCodeCacheSize - (NonProfiledCodeHeapSize + ProfiledCodeHeapSize + NonNMethodCodeHeapSize)
- if none of NonNMethodCodeHeapSize|ProfiledCodeHeapSize|NonProfiledCodeHeapSize is set on the command line,
	- if ReservedCodeCacheSize is large enough, allocate the standard NonNMethodCodeHeap and divide the rest between ProfiledCodeHeapSize and NonProfiledCodeHeap
	- if ReservedCodeCacheSize is very small, allocate vm_page_size (why?) for both ProfiledCodeHeapSize and NonProfiledCodeHeap, and give the rest for NonNMethodCodeHeap (hope it is positive)
- if only one of NonProfiledCodeHeapSize or ProfiledCodeHeapSize is set in the command line, fix the gap by correcting the one that is not set, and fix the remaining part by account of NonNMethodCodeHeapSize (no matter if it is set up or not)
- if only NonNMethodCodeHeapSize is set, split the remaining part in between ProfiledCodeHeapSize and NonProfiledCodeHeap
- at last, if there is no need in NonNMethodCodeHeap or ProfiledCodeHeap, the memory is assigned to to its sibling
	- (note: interpreter mode and client mode is actually not treated properly)

What I do not like here is the manual algorithm which is now difficult to understand now, and it will becomes completely unsustainable when adding a new code segment.
I want to depersonalize the segment resizing algorithm, make it work for any number of segments, and move it to a separate function.

With a new approach the balance() function derives proper values from the matrix:
```
   {
     {NonProfiledCodeHeapSize, max_size1, min_size1}, // non-profiled nmethod segment
     {ProfiledCodeHeapSize,    max_size2, min_size2}, // profiled nmethod segment
     {NonNMethodCodeHeapSize,  max_size3, min_size3}, // non-nmethod segment
   }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14712/head:pull/14712` \
`$ git checkout pull/14712`

Update a local copy of the PR: \
`$ git checkout pull/14712` \
`$ git pull https://git.openjdk.org/jdk.git pull/14712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14712`

View PR using the GUI difftool: \
`$ git pr show -t 14712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14712.diff">https://git.openjdk.org/jdk/pull/14712.diff</a>

</details>
