### PR TITLE
8310661: JFR: Replace JVM.getJVM() with JVM

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -74,42 +74,30 @@
  * Thread remains _thread_in_native
  */
 
-NO_TRANSITION(void, jfr_register_natives(JNIEnv* env, jclass jvmclass))
+NO_TRANSITION(void, jfr_register_natives(JNIEnv* env, jclass jvm))
   JfrJniMethodRegistration register_native_methods(env);
 NO_TRANSITION_END
 
-NO_TRANSITION(jboolean, jfr_is_enabled())
-  return Jfr::is_enabled() ? JNI_TRUE : JNI_FALSE;
-NO_TRANSITION_END
-
-NO_TRANSITION(jboolean, jfr_is_disabled())
-  return Jfr::is_disabled() ? JNI_TRUE : JNI_FALSE;
-NO_TRANSITION_END
-
-NO_TRANSITION(jboolean, jfr_is_started())
-  return JfrRecorder::is_created() ? JNI_TRUE : JNI_FALSE;
-NO_TRANSITION_END
-
-NO_TRANSITION(jstring, jfr_get_pid(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jstring, jfr_get_pid(JNIEnv* env, jclass jvm))
   char pid_buf[32] = { 0 };
   jio_snprintf(pid_buf, sizeof(pid_buf), "%d", os::current_process_id());
   jstring pid_string = env->NewStringUTF(pid_buf);
   return pid_string; // exception pending if null
 NO_TRANSITION_END
 
-NO_TRANSITION(jlong, jfr_elapsed_frequency(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jlong, jfr_elapsed_frequency(JNIEnv* env, jclass jvm))
   return JfrTime::frequency();
 NO_TRANSITION_END
 
-NO_TRANSITION(jlong, jfr_elapsed_counter(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jlong, jfr_elapsed_counter(JNIEnv* env, jclass jvm))
   return JfrTicks::now();
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_retransform_classes(JNIEnv* env, jobject jvm, jobjectArray classes))
+NO_TRANSITION(void, jfr_retransform_classes(JNIEnv* env, jclass jvm, jobjectArray classes))
   JfrJvmtiAgent::retransform_classes(env, classes, JavaThread::thread_from_jni_environment(env));
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_enabled(JNIEnv* env, jobject jvm, jlong event_type_id, jboolean enabled))
+NO_TRANSITION(void, jfr_set_enabled(JNIEnv* env, jclass jvm, jlong event_type_id, jboolean enabled))
   JfrEventSetting::set_enabled(event_type_id, JNI_TRUE == enabled);
   if (EventOldObjectSample::eventId == event_type_id) {
     ThreadInVMfromNative transition(JavaThread::thread_from_jni_environment(env));
@@ -121,39 +109,39 @@ NO_TRANSITION(void, jfr_set_enabled(JNIEnv* env, jobject jvm, jlong event_type_i
   }
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_file_notification(JNIEnv* env, jobject jvm, jlong threshold))
+NO_TRANSITION(void, jfr_set_file_notification(JNIEnv* env, jclass jvm, jlong threshold))
   JfrChunkRotation::set_threshold(threshold);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_stack_depth(JNIEnv* env, jobject jvm, jint depth))
+NO_TRANSITION(void, jfr_set_stack_depth(JNIEnv* env, jclass jvm, jint depth))
   JfrOptionSet::set_stackdepth((jlong)depth);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_stacktrace_enabled(JNIEnv* env, jobject jvm, jlong event_type_id, jboolean enabled))
+NO_TRANSITION(void, jfr_set_stacktrace_enabled(JNIEnv* env, jclass jvm, jlong event_type_id, jboolean enabled))
   JfrEventSetting::set_stacktrace(event_type_id, JNI_TRUE == enabled);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_global_buffer_count(JNIEnv* env, jobject jvm, jlong count))
+NO_TRANSITION(void, jfr_set_global_buffer_count(JNIEnv* env, jclass jvm, jlong count))
   JfrOptionSet::set_num_global_buffers(count);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_global_buffer_size(JNIEnv* env, jobject jvm, jlong size))
+NO_TRANSITION(void, jfr_set_global_buffer_size(JNIEnv* env, jclass jvm, jlong size))
 JfrOptionSet::set_global_buffer_size(size);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_thread_buffer_size(JNIEnv* env, jobject jvm, jlong size))
+NO_TRANSITION(void, jfr_set_thread_buffer_size(JNIEnv* env, jclass jvm, jlong size))
   JfrOptionSet::set_thread_buffer_size(size);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_memory_size(JNIEnv* env, jobject jvm, jlong size))
+NO_TRANSITION(void, jfr_set_memory_size(JNIEnv* env, jclass jvm, jlong size))
   JfrOptionSet::set_memory_size(size);
 NO_TRANSITION_END
 
-NO_TRANSITION(jboolean, jfr_set_threshold(JNIEnv* env, jobject jvm, jlong event_type_id, jlong thresholdTicks))
+NO_TRANSITION(jboolean, jfr_set_threshold(JNIEnv* env, jclass jvm, jlong event_type_id, jlong thresholdTicks))
   return JfrEventSetting::set_threshold(event_type_id, thresholdTicks) ? JNI_TRUE : JNI_FALSE;
 NO_TRANSITION_END
 
-NO_TRANSITION(jboolean, jfr_allow_event_retransforms(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jboolean, jfr_allow_event_retransforms(JNIEnv* env, jclass jvm))
   return JfrOptionSet::allow_event_retransforms() ? JNI_TRUE : JNI_FALSE;
 NO_TRANSITION_END
 
@@ -161,28 +149,28 @@ NO_TRANSITION(jboolean, jfr_is_available(JNIEnv* env, jclass jvm))
   return !Jfr::is_disabled() ? JNI_TRUE : JNI_FALSE;
 NO_TRANSITION_END
 
-NO_TRANSITION(jlong, jfr_get_unloaded_event_classes_count(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jlong, jfr_get_unloaded_event_classes_count(JNIEnv* env, jclass jvm))
   return JfrKlassUnloading::event_class_count();
 NO_TRANSITION_END
 
-NO_TRANSITION(jdouble, jfr_time_conv_factor(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jdouble, jfr_time_conv_factor(JNIEnv* env, jclass jvm))
   return (jdouble)JfrTimeConverter::nano_to_counter_multiplier();
 NO_TRANSITION_END
 
-NO_TRANSITION(jboolean, jfr_set_cutoff(JNIEnv* env, jobject jvm, jlong event_type_id, jlong cutoff_ticks))
+NO_TRANSITION(jboolean, jfr_set_cutoff(JNIEnv* env, jclass jvm, jlong event_type_id, jlong cutoff_ticks))
   return JfrEventSetting::set_cutoff(event_type_id, cutoff_ticks) ? JNI_TRUE : JNI_FALSE;
 NO_TRANSITION_END
 
-NO_TRANSITION(jboolean, jfr_set_throttle(JNIEnv* env, jobject jvm, jlong event_type_id, jlong event_sample_size, jlong period_ms))
+NO_TRANSITION(jboolean, jfr_set_throttle(JNIEnv* env, jclass jvm, jlong event_type_id, jlong event_sample_size, jlong period_ms))
   JfrEventThrottler::configure(static_cast<JfrEventId>(event_type_id), event_sample_size, period_ms);
   return JNI_TRUE;
 NO_TRANSITION_END
 
-NO_TRANSITION(jboolean, jfr_should_rotate_disk(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jboolean, jfr_should_rotate_disk(JNIEnv* env, jclass jvm))
   return JfrChunkRotation::should_rotate() ? JNI_TRUE : JNI_FALSE;
 NO_TRANSITION_END
 
-NO_TRANSITION(jlong, jfr_get_type_id_from_string(JNIEnv * env, jobject jvm, jstring type))
+NO_TRANSITION(jlong, jfr_get_type_id_from_string(JNIEnv * env, jclass jvm, jstring type))
   const char* type_name = env->GetStringUTFChars(type, nullptr);
   jlong id = JfrType::name_to_id(type_name);
   env->ReleaseStringUTFChars(type, type_name);
@@ -198,7 +186,7 @@ NO_TRANSITION_END
  * Current JavaThread available as "thread" variable
  */
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_create_jfr(JNIEnv* env, jobject jvm, jboolean simulate_failure))
+JVM_ENTRY_NO_ENV(jboolean, jfr_create_jfr(JNIEnv* env, jclass jvm, jboolean simulate_failure))
   if (JfrRecorder::is_created()) {
     return JNI_TRUE;
   }
@@ -211,39 +199,39 @@ JVM_ENTRY_NO_ENV(jboolean, jfr_create_jfr(JNIEnv* env, jobject jvm, jboolean sim
   return JNI_TRUE;
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_destroy_jfr(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(jboolean, jfr_destroy_jfr(JNIEnv* env, jclass jvm))
   JfrRecorder::destroy();
   return JNI_TRUE;
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_begin_recording(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(void, jfr_begin_recording(JNIEnv* env, jclass jvm))
   if (JfrRecorder::is_recording()) {
     return;
   }
   JfrRecorder::start_recording();
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_is_recording(JNIEnv * env, jobject jvm))
+JVM_ENTRY_NO_ENV(jboolean, jfr_is_recording(JNIEnv * env, jclass jvm))
   return JfrRecorder::is_recording() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_end_recording(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(void, jfr_end_recording(JNIEnv* env, jclass jvm))
   if (!JfrRecorder::is_recording()) {
     return;
   }
   JfrRecorder::stop_recording();
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_mark_chunk_final(JNIEnv * env, jobject jvm))
+JVM_ENTRY_NO_ENV(void, jfr_mark_chunk_final(JNIEnv * env, jclass jvm))
   JfrRepository::mark_chunk_final();
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_emit_event(JNIEnv* env, jobject jvm, jlong event_type_id, jlong timestamp, jlong periodic_type))
+JVM_ENTRY_NO_ENV(jboolean, jfr_emit_event(JNIEnv* env, jclass jvm, jlong event_type_id, jlong timestamp, jlong periodic_type))
   JfrPeriodicEventSet::requestEvent((JfrEventId)event_type_id, timestamp, static_cast<PeriodicType>(periodic_type));
   return thread->has_pending_exception() ? JNI_FALSE : JNI_TRUE;
 JVM_END
 
-JVM_ENTRY_NO_ENV(jobject, jfr_get_all_event_classes(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(jobject, jfr_get_all_event_classes(JNIEnv* env, jclass jvm))
   return JdkJfrEvent::get_all_klasses(thread);
 JVM_END
 
@@ -251,27 +239,27 @@ JVM_ENTRY_NO_ENV(jlong, jfr_class_id(JNIEnv* env, jclass jvm, jclass jc))
   return JfrTraceId::load(jc);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip))
+JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id(JNIEnv* env, jclass jvm, jint skip))
   return JfrStackTraceRepository::record(thread, skip);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_log(JNIEnv* env, jobject jvm, jint tag_set, jint level, jstring message))
+JVM_ENTRY_NO_ENV(void, jfr_log(JNIEnv* env, jclass jvm, jint tag_set, jint level, jstring message))
   JfrJavaLog::log(tag_set, level, message, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_log_event(JNIEnv* env, jobject jvm, jint level, jobjectArray lines, jboolean system))
+JVM_ENTRY_NO_ENV(void, jfr_log_event(JNIEnv* env, jclass jvm, jint level, jobjectArray lines, jboolean system))
   JfrJavaLog::log_event(env, level, lines, system == JNI_TRUE, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_subscribe_log_level(JNIEnv* env, jobject jvm, jobject log_tag, jint id))
+JVM_ENTRY_NO_ENV(void, jfr_subscribe_log_level(JNIEnv* env, jclass jvm, jobject log_tag, jint id))
   JfrJavaLog::subscribe_log_level(log_tag, id, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_set_output(JNIEnv* env, jobject jvm, jstring path))
+JVM_ENTRY_NO_ENV(void, jfr_set_output(JNIEnv* env, jclass jvm, jstring path))
   JfrRepository::set_chunk_path(path, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_set_method_sampling_period(JNIEnv* env, jobject jvm, jlong type, jlong periodMillis))
+JVM_ENTRY_NO_ENV(void, jfr_set_method_sampling_period(JNIEnv* env, jclass jvm, jlong type, jlong periodMillis))
   if (periodMillis < 0) {
     periodMillis = 0;
   }
@@ -285,36 +273,36 @@ JVM_ENTRY_NO_ENV(void, jfr_set_method_sampling_period(JNIEnv* env, jobject jvm, 
   }
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_store_metadata_descriptor(JNIEnv* env, jobject jvm, jbyteArray descriptor))
+JVM_ENTRY_NO_ENV(void, jfr_store_metadata_descriptor(JNIEnv* env, jclass jvm, jbyteArray descriptor))
   JfrMetadataEvent::update(descriptor);
 JVM_END
 
 // trace thread id for a thread object
-JVM_ENTRY_NO_ENV(jlong, jfr_id_for_thread(JNIEnv* env, jobject jvm, jobject t))
+JVM_ENTRY_NO_ENV(jlong, jfr_id_for_thread(JNIEnv* env, jclass jvm, jobject t))
   return JfrJavaSupport::jfr_thread_id(thread, t);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jobject, jfr_get_event_writer(JNIEnv* env, jclass cls))
+JVM_ENTRY_NO_ENV(jobject, jfr_get_event_writer(JNIEnv* env, jclass jvm))
   return JfrJavaEventWriter::event_writer(thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jobject, jfr_new_event_writer(JNIEnv* env, jclass cls))
+JVM_ENTRY_NO_ENV(jobject, jfr_new_event_writer(JNIEnv* env, jclass jvm))
   return JfrJavaEventWriter::new_event_writer(thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_event_writer_flush(JNIEnv* env, jclass cls, jobject writer, jint used_size, jint requested_size))
+JVM_ENTRY_NO_ENV(jboolean, jfr_event_writer_flush(JNIEnv* env, jclass jvm, jobject writer, jint used_size, jint requested_size))
   return JfrJavaEventWriter::flush(writer, used_size, requested_size, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_flush(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(void, jfr_flush(JNIEnv* env, jclass jvm))
   JfrRepository::flush(thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_set_repository_location(JNIEnv* env, jobject repo, jstring location))
+JVM_ENTRY_NO_ENV(void, jfr_set_repository_location(JNIEnv* env, jclass jvm, jstring location))
   return JfrRepository::set_path(location, thread);
 JVM_END
 
-NO_TRANSITION(void, jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath))
+NO_TRANSITION(void, jfr_set_dump_path(JNIEnv* env, jclass jvm, jstring dumppath))
   if (dumppath == nullptr) {
     JfrEmergencyDump::set_dump_path(nullptr);
   } else {
@@ -324,19 +312,19 @@ NO_TRANSITION(void, jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath
   }
 NO_TRANSITION_END
 
-NO_TRANSITION(jstring, jfr_get_dump_path(JNIEnv* env, jobject jvm))
+NO_TRANSITION(jstring, jfr_get_dump_path(JNIEnv* env, jclass jvm))
   return env->NewStringUTF(JfrEmergencyDump::get_dump_path());
 NO_TRANSITION_END
 
-JVM_ENTRY_NO_ENV(void, jfr_uncaught_exception(JNIEnv* env, jobject jvm, jobject t, jthrowable throwable))
+JVM_ENTRY_NO_ENV(void, jfr_uncaught_exception(JNIEnv* env, jclass jvm, jobject t, jthrowable throwable))
   JfrJavaSupport::uncaught_exception(throwable, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_abort(JNIEnv* env, jobject jvm, jstring errorMsg))
+JVM_ENTRY_NO_ENV(void, jfr_abort(JNIEnv* env, jclass jvm, jstring errorMsg))
   JfrJavaSupport::abort(errorMsg, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jlong, jfr_type_id(JNIEnv* env, jobject jvm, jclass jc))
+JVM_ENTRY_NO_ENV(jlong, jfr_type_id(JNIEnv* env, jclass jvm, jclass jc))
   return JfrTraceId::load_raw(jc);
 JVM_END
 
@@ -344,47 +332,47 @@ JVM_ENTRY_NO_ENV(jboolean, jfr_add_string_constant(JNIEnv* env, jclass jvm, jlon
   return JfrStringPool::add(id, string, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_set_force_instrumentation(JNIEnv* env, jobject jvm, jboolean force_instrumentation))
+JVM_ENTRY_NO_ENV(void, jfr_set_force_instrumentation(JNIEnv* env, jclass jvm, jboolean force_instrumentation))
   JfrEventClassTransformer::set_force_instrumentation(force_instrumentation == JNI_TRUE);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_emit_old_object_samples(JNIEnv* env, jobject jvm, jlong cutoff_ticks, jboolean emit_all, jboolean skip_bfs))
+JVM_ENTRY_NO_ENV(void, jfr_emit_old_object_samples(JNIEnv* env, jclass jvm, jlong cutoff_ticks, jboolean emit_all, jboolean skip_bfs))
   LeakProfiler::emit_events(cutoff_ticks, emit_all == JNI_TRUE, skip_bfs == JNI_TRUE);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_exclude_thread(JNIEnv* env, jobject jvm, jobject t))
+JVM_ENTRY_NO_ENV(void, jfr_exclude_thread(JNIEnv* env, jclass jvm, jobject t))
   JfrJavaSupport::exclude(thread, t);
 JVM_END
 
-JVM_ENTRY_NO_ENV(void, jfr_include_thread(JNIEnv* env, jobject jvm, jobject t))
+JVM_ENTRY_NO_ENV(void, jfr_include_thread(JNIEnv* env, jclass jvm, jobject t))
   JfrJavaSupport::include(thread, t);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_is_thread_excluded(JNIEnv* env, jobject jvm, jobject t))
+JVM_ENTRY_NO_ENV(jboolean, jfr_is_thread_excluded(JNIEnv* env, jclass jvm, jobject t))
   return JfrJavaSupport::is_excluded(t);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jlong, jfr_chunk_start_nanos(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(jlong, jfr_chunk_start_nanos(JNIEnv* env, jclass jvm))
   return JfrRepository::current_chunk_start_nanos();
 JVM_END
 
-JVM_ENTRY_NO_ENV(jobject, jfr_get_configuration(JNIEnv * env, jobject jvm, jobject clazz))
+JVM_ENTRY_NO_ENV(jobject, jfr_get_configuration(JNIEnv * env, jclass jvm, jobject clazz))
   return JfrJavaSupport::get_configuration(clazz, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_set_configuration(JNIEnv * env, jobject jvm, jobject clazz, jobject configuration))
+JVM_ENTRY_NO_ENV(jboolean, jfr_set_configuration(JNIEnv * env, jclass jvm, jobject clazz, jobject configuration))
   return JfrJavaSupport::set_configuration(clazz, configuration, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_is_class_excluded(JNIEnv * env, jobject jvm, jclass clazz))
+JVM_ENTRY_NO_ENV(jboolean, jfr_is_class_excluded(JNIEnv * env, jclass jvm, jclass clazz))
   return JdkJfrEvent::is_excluded(clazz);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_is_class_instrumented(JNIEnv* env, jobject jvm, jclass clazz))
+JVM_ENTRY_NO_ENV(jboolean, jfr_is_class_instrumented(JNIEnv* env, jclass jvm, jclass clazz))
   return JfrJavaSupport::is_instrumented(clazz, thread);
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, jfr_is_containerized(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(jboolean, jfr_is_containerized(JNIEnv* env, jclass jvm))
 #ifdef LINUX
   return OSContainer::is_containerized();
 #else
@@ -392,7 +380,7 @@ JVM_ENTRY_NO_ENV(jboolean, jfr_is_containerized(JNIEnv* env, jobject jvm))
 #endif
 JVM_END
 
-JVM_ENTRY_NO_ENV(jlong, jfr_host_total_memory(JNIEnv* env, jobject jvm))
+JVM_ENTRY_NO_ENV(jlong, jfr_host_total_memory(JNIEnv* env, jclass jvm))
 #ifdef LINUX
   // We want the host memory, not the container limit.
   // os::physical_memory() would return the container limit.

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,132 +35,126 @@
 extern "C" {
 #endif
 
-jboolean JNICALL jfr_is_enabled();
+jlong JNICALL jfr_elapsed_counter(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_is_disabled();
+jboolean JNICALL jfr_create_jfr(JNIEnv* env, jclass jvm, jboolean simulate_failure);
 
-jboolean JNICALL jfr_is_started();
+jboolean JNICALL jfr_destroy_jfr(JNIEnv* env, jclass jvm);
 
-jlong JNICALL jfr_elapsed_counter(JNIEnv* env, jobject jvm);
+void JNICALL jfr_begin_recording(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_create_jfr(JNIEnv* env, jobject jvm, jboolean simulate_failure);
+jboolean JNICALL jfr_is_recording(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_destroy_jfr(JNIEnv* env, jobject jvm);
+void JNICALL jfr_end_recording(JNIEnv* env, jclass jvm);
 
-void JNICALL jfr_begin_recording(JNIEnv* env, jobject jvm);
+void JNICALL jfr_mark_chunk_final(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_is_recording(JNIEnv* env, jobject jvm);
+jboolean JNICALL jfr_emit_event(JNIEnv* env, jclass jvm, jlong eventTypeId, jlong timeStamp, jlong when);
 
-void JNICALL jfr_end_recording(JNIEnv* env, jobject jvm);
-
-void JNICALL jfr_mark_chunk_final(JNIEnv* env, jobject jvm);
-
-jboolean JNICALL jfr_emit_event(JNIEnv* env, jobject jvm, jlong eventTypeId, jlong timeStamp, jlong when);
-
-jobject JNICALL jfr_get_all_event_classes(JNIEnv* env, jobject jvm);
+jobject JNICALL jfr_get_all_event_classes(JNIEnv* env, jclass jvm);
 
 jlong JNICALL jfr_class_id(JNIEnv* env, jclass jvm, jclass jc);
 
-jstring JNICALL jfr_get_pid(JNIEnv* env, jobject jvm);
+jstring JNICALL jfr_get_pid(JNIEnv* env, jclass jvm);
 
-jlong JNICALL jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip);
+jlong JNICALL jfr_stacktrace_id(JNIEnv* env, jclass jvm, jint skip);
 
-jlong JNICALL jfr_elapsed_frequency(JNIEnv* env, jobject jvm);
+jlong JNICALL jfr_elapsed_frequency(JNIEnv* env, jclass jvm);
 
-void JNICALL jfr_subscribe_log_level(JNIEnv* env, jobject jvm, jobject log_tag, jint id);
+void JNICALL jfr_subscribe_log_level(JNIEnv* env, jclass jvm, jobject log_tag, jint id);
 
-void JNICALL jfr_log(JNIEnv* env, jobject jvm, jint tag_set, jint level, jstring message);
+void JNICALL jfr_log(JNIEnv* env, jclass jvm, jint tag_set, jint level, jstring message);
 
-void JNICALL jfr_log_event(JNIEnv* env, jobject jvm, jint level, jobjectArray lines, jboolean system);
+void JNICALL jfr_log_event(JNIEnv* env, jclass jvm, jint level, jobjectArray lines, jboolean system);
 
-void JNICALL jfr_retransform_classes(JNIEnv* env, jobject jvm, jobjectArray classes);
+void JNICALL jfr_retransform_classes(JNIEnv* env, jclass jvm, jobjectArray classes);
 
-void JNICALL jfr_set_enabled(JNIEnv* env, jobject jvm, jlong event_type_id, jboolean enabled);
+void JNICALL jfr_set_enabled(JNIEnv* env, jclass jvm, jlong event_type_id, jboolean enabled);
 
-void JNICALL jfr_set_file_notification(JNIEnv* env, jobject jvm, jlong delta);
+void JNICALL jfr_set_file_notification(JNIEnv* env, jclass jvm, jlong delta);
 
-void JNICALL jfr_set_global_buffer_count(JNIEnv* env, jobject jvm, jlong count);
+void JNICALL jfr_set_global_buffer_count(JNIEnv* env, jclass jvm, jlong count);
 
-void JNICALL jfr_set_global_buffer_size(JNIEnv* env, jobject jvm, jlong size);
+void JNICALL jfr_set_global_buffer_size(JNIEnv* env, jclass jvm, jlong size);
 
-void JNICALL jfr_set_method_sampling_period(JNIEnv* env, jobject jvm, jlong type, jlong periodMillis);
+void JNICALL jfr_set_method_sampling_period(JNIEnv* env, jclass jvm, jlong type, jlong periodMillis);
 
-void JNICALL jfr_set_output(JNIEnv* env, jobject jvm, jstring path);
+void JNICALL jfr_set_output(JNIEnv* env, jclass jvm, jstring path);
 
-void JNICALL jfr_set_stack_depth(JNIEnv* env, jobject jvm, jint depth);
+void JNICALL jfr_set_stack_depth(JNIEnv* env, jclass jvm, jint depth);
 
-void JNICALL jfr_set_stacktrace_enabled(JNIEnv* env, jobject jvm, jlong event_type_id, jboolean enabled);
+void JNICALL jfr_set_stacktrace_enabled(JNIEnv* env, jclass jvm, jlong event_type_id, jboolean enabled);
 
-void JNICALL jfr_set_thread_buffer_size(JNIEnv* env, jobject jvm, jlong size);
+void JNICALL jfr_set_thread_buffer_size(JNIEnv* env, jclass jvm, jlong size);
 
-void JNICALL jfr_set_memory_size(JNIEnv* env, jobject jvm, jlong size);
+void JNICALL jfr_set_memory_size(JNIEnv* env, jclass jvm, jlong size);
 
-jboolean JNICALL jfr_set_threshold(JNIEnv* env, jobject jvm, jlong event_type_id, jlong thresholdTicks);
+jboolean JNICALL jfr_set_threshold(JNIEnv* env, jclass jvm, jlong event_type_id, jlong thresholdTicks);
 
-void JNICALL jfr_store_metadata_descriptor(JNIEnv* env, jobject jvm, jbyteArray descriptor);
+void JNICALL jfr_store_metadata_descriptor(JNIEnv* env, jclass jvm, jbyteArray descriptor);
 
-jlong JNICALL jfr_id_for_thread(JNIEnv* env, jobject jvm, jobject t);
+jlong JNICALL jfr_id_for_thread(JNIEnv* env, jclass jvm, jobject t);
 
-jboolean JNICALL jfr_allow_event_retransforms(JNIEnv* env, jobject jvm);
+jboolean JNICALL jfr_allow_event_retransforms(JNIEnv* env, jclass jvm);
 
 jboolean JNICALL jfr_is_available(JNIEnv* env, jclass jvm);
 
-jdouble JNICALL jfr_time_conv_factor(JNIEnv* env, jobject jvm);
+jdouble JNICALL jfr_time_conv_factor(JNIEnv* env, jclass jvm);
 
 jlong JNICALL jfr_type_id(JNIEnv* env, jobject jvm, jclass jc);
 
-void JNICALL jfr_set_repository_location(JNIEnv* env, jobject repo, jstring location);
+void JNICALL jfr_set_repository_location(JNIEnv* env, jclass jvm, jstring location);
 
-void JNICALL jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath);
+void JNICALL jfr_set_dump_path(JNIEnv* env, jclass jvm, jstring dumppath);
 
-jstring JNICALL jfr_get_dump_path(JNIEnv* env, jobject jvm);
+jstring JNICALL jfr_get_dump_path(JNIEnv* env, jclass jvm);
 
-jobject JNICALL jfr_get_event_writer(JNIEnv* env, jclass cls);
+jobject JNICALL jfr_get_event_writer(JNIEnv* env, jclass jvm);
 
-jobject JNICALL jfr_new_event_writer(JNIEnv* env, jclass cls);
+jobject JNICALL jfr_new_event_writer(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_event_writer_flush(JNIEnv* env, jclass cls, jobject writer, jint used_size, jint requested_size);
+jboolean JNICALL jfr_event_writer_flush(JNIEnv* env, jclass jvm, jobject writer, jint used_size, jint requested_size);
 
-void JNICALL jfr_flush(JNIEnv* env, jobject jvm);
-void JNICALL jfr_abort(JNIEnv* env, jobject jvm, jstring errorMsg);
+void JNICALL jfr_flush(JNIEnv* env, jclass jvm);
+void JNICALL jfr_abort(JNIEnv* env, jclass jvm, jstring errorMsg);
 
 jboolean JNICALL jfr_add_string_constant(JNIEnv* env, jclass jvm, jlong id, jstring string);
 
-void JNICALL jfr_uncaught_exception(JNIEnv* env, jobject jvm, jobject thread, jthrowable throwable);
+void JNICALL jfr_uncaught_exception(JNIEnv* env, jclass jvm, jobject thread, jthrowable throwable);
 
-void JNICALL jfr_set_force_instrumentation(JNIEnv* env, jobject jvm, jboolean force);
+void JNICALL jfr_set_force_instrumentation(JNIEnv* env, jclass jvm, jboolean force);
 
-jlong JNICALL jfr_get_unloaded_event_classes_count(JNIEnv* env, jobject jvm);
+jlong JNICALL jfr_get_unloaded_event_classes_count(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_set_cutoff(JNIEnv* env, jobject jvm, jlong event_type_id, jlong cutoff_ticks);
+jboolean JNICALL jfr_set_cutoff(JNIEnv* env, jclass jvm, jlong event_type_id, jlong cutoff_ticks);
 
-jboolean JNICALL jfr_set_throttle(JNIEnv* env, jobject jvm, jlong event_type_id, jlong event_sample_size, jlong period_ms);
+jboolean JNICALL jfr_set_throttle(JNIEnv* env, jclass jvm, jlong event_type_id, jlong event_sample_size, jlong period_ms);
 
-void JNICALL jfr_emit_old_object_samples(JNIEnv* env, jobject jvm, jlong cutoff_ticks, jboolean, jboolean);
+void JNICALL jfr_emit_old_object_samples(JNIEnv* env, jclass jvm, jlong cutoff_ticks, jboolean, jboolean);
 
-jboolean JNICALL jfr_should_rotate_disk(JNIEnv* env, jobject jvm);
+jboolean JNICALL jfr_should_rotate_disk(JNIEnv* env, jclass jvm);
 
-void JNICALL jfr_exclude_thread(JNIEnv* env, jobject jvm, jobject t);
+void JNICALL jfr_exclude_thread(JNIEnv* env, jclass jvm, jobject t);
 
-void JNICALL jfr_include_thread(JNIEnv* env, jobject jvm, jobject t);
+void JNICALL jfr_include_thread(JNIEnv* env, jclass jvm, jobject t);
 
-jboolean JNICALL jfr_is_thread_excluded(JNIEnv* env, jobject jvm, jobject t);
+jboolean JNICALL jfr_is_thread_excluded(JNIEnv* env, jclass jvm, jobject t);
 
-jlong JNICALL jfr_chunk_start_nanos(JNIEnv* env, jobject jvm);
+jlong JNICALL jfr_chunk_start_nanos(JNIEnv* env, jclass jvm);
 
-jobject JNICALL jfr_get_configuration(JNIEnv* env, jobject jvm, jobject clazz);
+jobject JNICALL jfr_get_configuration(JNIEnv* env, jclass jvm, jobject clazz);
 
-jboolean JNICALL jfr_set_configuration(JNIEnv* env, jobject jvm, jobject clazz, jobject configuration);
+jboolean JNICALL jfr_set_configuration(JNIEnv* env, jclass jvm, jobject clazz, jobject configuration);
 
-jlong JNICALL jfr_get_type_id_from_string(JNIEnv* env, jobject jvm, jstring type);
+jlong JNICALL jfr_get_type_id_from_string(JNIEnv* env, jclass jvm, jstring type);
 
-jboolean JNICALL jfr_is_class_excluded(JNIEnv* env, jobject jvm, jclass clazz);
+jboolean JNICALL jfr_is_class_excluded(JNIEnv* env, jclass jvm, jclass clazz);
 
-jboolean JNICALL jfr_is_class_instrumented(JNIEnv* env, jobject jvm, jclass clazz);
+jboolean JNICALL jfr_is_class_instrumented(JNIEnv* env, jclass jvm, jclass clazz);
 
-jboolean JNICALL jfr_is_containerized(JNIEnv* env, jobject jvm);
+jboolean JNICALL jfr_is_containerized(JNIEnv* env, jclass jvm);
 
-jlong JNICALL jfr_host_total_memory(JNIEnv* env, jobject jvm);
+jlong JNICALL jfr_host_total_memory(JNIEnv* env, jclass jvm);
 
 #ifdef __cplusplus
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorder.java
@@ -325,7 +325,7 @@ public final class FlightRecorder {
         if (JVMSupport.isNotAvailable()) {
             return false;
         }
-        return JVM.getJVM().isAvailable();
+        return JVM.isAvailable();
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterKey.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,12 @@ public final class EventWriterKey {
     }
 
     private static long createKey() {
-        JVM jvm = JVM.getJVM();
         long r = mixMurmur64(System.identityHashCode(new Object()));
-        r = 31 * r + mixMurmur64(jvm.getPid().hashCode());
+        r = 31 * r + mixMurmur64(JVM.getPid().hashCode());
         r = 31 * r + mixMurmur64(System.nanoTime());
         r = 31 * r + mixMurmur64(Thread.currentThread().threadId());
         r = 31 * r + mixMurmur64(System.currentTimeMillis());
-        r = 31 * r + mixMurmur64(jvm.getTypeId(JVM.class));
+        r = 31 * r + mixMurmur64(JVM.getTypeId(JVM.class));
         r = 31 * r + mixMurmur64(JVM.counterTime());
         return mixMurmur64(r);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public final class JVM {
      */
     public static final Object CHUNK_ROTATION_MONITOR = new ChunkRotationMonitor();
 
-    private volatile boolean nativeOK;
+    private volatile static boolean nativeOK;
 
     private static native void registerNatives();
 
@@ -63,37 +63,25 @@ public final class JVM {
     }
 
     /**
-     * Get the one and only JVM.
-     *
-     * @return the JVM
-     */
-    public static JVM getJVM() {
-        return jvm;
-    }
-
-    private JVM() {
-    }
-
-    /**
      * Marks current chunk as final
      * <p>
      * This allows streaming clients to read the chunk header and
      * close the stream when no more data will be written into
      * the current repository.
      */
-    public native void markChunkFinal();
+    public static native void markChunkFinal();
 
     /**
      * Begin recording events
      *
      * Requires that JFR has been started with {@link #createNativeJFR()}
      */
-    public native void beginRecording();
+    public static native void beginRecording();
 
     /**
      * Return true if the JVM is recording
      */
-    public native boolean isRecording();
+    public static native boolean isRecording();
 
     /**
      * End recording events, which includes flushing data in thread buffers
@@ -101,7 +89,7 @@ public final class JVM {
      * Requires that JFR has been started with {@link #createNativeJFR()}
      *
      */
-    public native void endRecording();
+    public static native void endRecording();
 
     /**
      * Return ticks
@@ -122,21 +110,21 @@ public final class JVM {
      *
      * @return true if the event was committed
      */
-    public native boolean emitEvent(long eventTypeId, long timestamp, long periodicType);
+    public static native boolean emitEvent(long eventTypeId, long timestamp, long periodicType);
 
     /**
      * Return a list of all classes deriving from {@link jdk.internal.event.Event}
      *
      * @return list of event classes.
      */
-    public native List<Class<? extends jdk.internal.event.Event>> getAllEventClasses();
+    public static native List<Class<? extends jdk.internal.event.Event>> getAllEventClasses();
 
     /**
      * Return a count of the number of unloaded classes deriving from {@link Event}
      *
      * @return number of unloaded event classes.
      */
-    public native long getUnloadedEventClassCount();
+    public static native long getUnloadedEventClassCount();
 
     /**
      * Return a unique identifier for a class. The class is marked as being
@@ -154,7 +142,7 @@ public final class JVM {
      *
      * @return process identifier
      */
-    public native String getPid();
+    public static native String getPid();
 
     /**
      * Return unique identifier for stack trace.
@@ -164,7 +152,7 @@ public final class JVM {
      * @param skipCount number of frames to skip
      * @return a unique stack trace identifier
      */
-    public native long getStackTraceId(int skipCount);
+    public static native long getStackTraceId(int skipCount);
 
     /**
      * Return identifier for thread
@@ -172,14 +160,14 @@ public final class JVM {
      * @param t thread
      * @return a unique thread identifier
      */
-    public native long getThreadId(Thread t);
+    public static native long getThreadId(Thread t);
 
     /**
      * Frequency, ticks per second
      *
      * @return frequency
      */
-    public native long getTicksFrequency();
+    public static native long getTicksFrequency();
 
     /**
      * Write message to log. Should swallow null or empty message, and be able
@@ -218,7 +206,7 @@ public final class JVM {
      *
      * @throws IllegalStateException if wrong JVMTI phase.
      */
-     public synchronized native void retransformClasses(Class<?>[] classes);
+     public static synchronized native void retransformClasses(Class<?>[] classes);
 
     /**
      * Enable event
@@ -227,14 +215,14 @@ public final class JVM {
      *
      * @param enabled enable event
      */
-    public native void setEnabled(long eventTypeId, boolean enabled);
+    public static native void setEnabled(long eventTypeId, boolean enabled);
 
     /**
      * Interval at which the JVM should notify on {@link #FILE_DELTA_CHANGE}
      *
      * @param delta number of bytes, reset after file rotation
      */
-    public native void setFileNotification(long delta);
+    public static native void setFileNotification(long delta);
 
     /**
      * Set the number of global buffers to use
@@ -244,7 +232,7 @@ public final class JVM {
      * @throws IllegalArgumentException if count is not within a valid range
      * @throws IllegalStateException if value can't be changed
      */
-    public native void setGlobalBufferCount(long count) throws IllegalArgumentException, IllegalStateException;
+    public static native void setGlobalBufferCount(long count) throws IllegalArgumentException, IllegalStateException;
 
     /**
      * Set size of a global buffer
@@ -254,7 +242,7 @@ public final class JVM {
      * @throws IllegalArgumentException if buffer size is not within a valid
      *         range
      */
-    public native void setGlobalBufferSize(long size) throws IllegalArgumentException;
+    public static native void setGlobalBufferSize(long size) throws IllegalArgumentException;
 
     /**
      * Set overall memory size
@@ -264,7 +252,7 @@ public final class JVM {
      * @throws IllegalArgumentException if memory size is not within a valid
      *         range
      */
-    public native void setMemorySize(long size) throws IllegalArgumentException;
+    public static native void setMemorySize(long size) throws IllegalArgumentException;
 
     /**
      * Set period for method samples, in milliseconds.
@@ -273,7 +261,7 @@ public final class JVM {
      *
      * @param periodMillis the sampling period
      */
-    public native void setMethodSamplingPeriod(long type, long periodMillis);
+    public static native void setMethodSamplingPeriod(long type, long periodMillis);
 
     /**
      * Sets the file where data should be written.
@@ -298,7 +286,7 @@ public final class JVM {
      * @param file the file where data should be written, or null if it should
      *        not be copied out (in memory).
      */
-    public native void setOutput(String file);
+    public static native void setOutput(String file);
 
     /**
      * Controls if a class deriving from jdk.jfr.Event should
@@ -306,7 +294,7 @@ public final class JVM {
      *
      * @param force, true to force initialization, false otherwise
      */
-    public native void setForceInstrumentation(boolean force);
+    public static native void setForceInstrumentation(boolean force);
 
     /**
      * Turn on/off compressed integers.
@@ -316,7 +304,7 @@ public final class JVM {
      *
      * @throws IllegalStateException if state can't be changed.
      */
-    public native void setCompressedIntegers(boolean compressed) throws IllegalStateException;
+    public static native void setCompressedIntegers(boolean compressed) throws IllegalStateException;
 
     /**
      * Set stack depth.
@@ -326,7 +314,7 @@ public final class JVM {
      * @throws IllegalArgumentException if not within a valid range
      * @throws IllegalStateException if depth can't be changed
      */
-    public native void setStackDepth(int depth) throws IllegalArgumentException, IllegalStateException;
+    public static native void setStackDepth(int depth) throws IllegalArgumentException, IllegalStateException;
 
     /**
      * Turn on stack trace for an event
@@ -335,7 +323,7 @@ public final class JVM {
      *
      * @param enabled if stack traces should be enabled
      */
-    public native void setStackTraceEnabled(long eventTypeId, boolean enabled);
+    public static native void setStackTraceEnabled(long eventTypeId, boolean enabled);
 
     /**
      * Set thread buffer size.
@@ -345,7 +333,7 @@ public final class JVM {
      * @throws IllegalArgumentException if size is not within a valid range
      * @throws IllegalStateException if size can't be changed
      */
-    public native void setThreadBufferSize(long size) throws IllegalArgumentException, IllegalStateException;
+    public static native void setThreadBufferSize(long size) throws IllegalArgumentException, IllegalStateException;
 
     /**
      * Set threshold for event,
@@ -356,7 +344,7 @@ public final class JVM {
      * @param ticks threshold in ticks,
      * @return true, if it could be set
      */
-    public native boolean setThreshold(long eventTypeId, long ticks);
+    public static native boolean setThreshold(long eventTypeId, long ticks);
 
     /**
      * Store the metadata descriptor that is to be written at the end of a
@@ -367,7 +355,7 @@ public final class JVM {
      *
      * @param bytes binary representation of metadata descriptor
      */
-    public native void storeMetadataDescriptor(byte[] bytes);
+    public static native void storeMetadataDescriptor(byte[] bytes);
 
     /**
      * If the JVM supports JVM TI and retransformation has not been disabled this
@@ -376,7 +364,7 @@ public final class JVM {
      *
      * @return if transform is allowed
      */
-    public native boolean getAllowedToDoEventRetransforms();
+    public static native boolean getAllowedToDoEventRetransforms();
 
     /**
      * Set up native resources, data structures, threads etc. for JFR
@@ -387,7 +375,7 @@ public final class JVM {
      * @throws IllegalStateException if native part of JFR could not be created.
      *
      */
-    private native boolean createJFR(boolean simulateFailure) throws IllegalStateException;
+    static native boolean createJFR(boolean simulateFailure) throws IllegalStateException;
 
     /**
      * Destroys native part of JFR. If already destroy, call is ignored.
@@ -397,37 +385,19 @@ public final class JVM {
      * @return if an instance was actually destroyed.
      *
      */
-    private native boolean destroyJFR();
-
-    public boolean createFailedNativeJFR() throws IllegalStateException {
-        return createJFR(true);
-    }
-
-    public void createNativeJFR() {
-        nativeOK = createJFR(false);
-    }
-
-    public boolean destroyNativeJFR() {
-        boolean result = destroyJFR();
-        nativeOK = !result;
-        return result;
-    }
-
-    public boolean hasNativeJFR() {
-        return nativeOK;
-    }
+    static native boolean destroyJFR();
 
     /**
      * Cheap test to check if JFR functionality is available.
      *
      * @return
      */
-    public native boolean isAvailable();
+    public static native boolean isAvailable();
 
     /**
      * To convert ticks to wall clock time.
      */
-    public native double getTimeConversionFactor();
+    public static native double getTimeConversionFactor();
 
     /**
      * Return a unique identifier for a class. Compared to {@link #getClassId(Class)},
@@ -437,7 +407,7 @@ public final class JVM {
      *
      * @return a unique class identifier
      */
-    public native long getTypeId(Class<?> clazz);
+    public static native long getTypeId(Class<?> clazz);
 
     /**
      * Fast path fetching the EventWriter using VM intrinsics
@@ -468,35 +438,35 @@ public final class JVM {
      * the generation id.
      *
      */
-    public native void flush();
+    public static native void flush();
 
     /**
      * Sets the location of the disk repository.
      *
      * @param dirText
      */
-    public native void setRepositoryLocation(String dirText);
+    public static native void setRepositoryLocation(String dirText);
 
     /**
      * Sets the path to emergency dump.
      *
      * @param dumpPathText
      */
-    public native void setDumpPath(String dumpPathText);
+    public static native void setDumpPath(String dumpPathText);
 
     /**
      * Gets the path to emergency dump.
      *
      * @return The path to emergency dump.
      */
-    public native String getDumpPath();
+    public static native String getDumpPath();
 
    /**
     * Access to VM termination support.
     *
     * @param errorMsg descriptive message to be include in VM termination sequence
     */
-    public native void abort(String errorMsg);
+    public static native void abort(String errorMsg);
 
     /**
      * Adds a string to the string constant pool.
@@ -511,7 +481,7 @@ public final class JVM {
      */
     public static native boolean addStringConstant(long id, String s);
 
-    public native void uncaughtException(Thread thread, Throwable t);
+    public static native void uncaughtException(Thread thread, Throwable t);
 
     /**
      * Sets cutoff for event.
@@ -524,7 +494,7 @@ public final class JVM {
      * @param cutoffTicks cutoff in ticks,
      * @return true, if it could be set
      */
-    public native boolean setCutoff(long eventTypeId, long cutoffTicks);
+    public static native boolean setCutoff(long eventTypeId, long cutoffTicks);
 
     /**
      * Sets the event emission rate in event sample size per time unit.
@@ -536,7 +506,7 @@ public final class JVM {
      * @param period_ms time period in milliseconds
      * @return true, if it could be set
      */
-    public native boolean setThrottle(long eventTypeId, long eventSampleSize, long period_ms);
+    public static native boolean setThrottle(long eventTypeId, long eventSampleSize, long period_ms);
 
     /**
      * Emit old object sample events.
@@ -545,33 +515,33 @@ public final class JVM {
      * @param emitAll emit all samples in old object queue
      * @param skipBFS don't use BFS when searching for path to GC root
      */
-    public native void emitOldObjectSamples(long cutoff, boolean emitAll, boolean skipBFS);
+    public static native void emitOldObjectSamples(long cutoff, boolean emitAll, boolean skipBFS);
 
     /**
      * Test if a chunk rotation is warranted.
      *
      * @return if it is time to perform a chunk rotation
      */
-    public native boolean shouldRotateDisk();
+    public static native boolean shouldRotateDisk();
 
     /**
      * Exclude a thread from the jfr system
      *
      */
-    public native void exclude(Thread thread);
+    public static native void exclude(Thread thread);
 
     /**
      * Include a thread back into the jfr system
      *
      */
-    public native void include(Thread thread);
+    public static native void include(Thread thread);
 
     /**
      * Test if a thread is currently excluded from the jfr system.
      *
      * @return is thread currently excluded
      */
-    public native boolean isExcluded(Thread thread);
+    public static native boolean isExcluded(Thread thread);
 
     /**
      * Test if a class is excluded from the jfr system.
@@ -580,7 +550,7 @@ public final class JVM {
      *
      * @return is class excluded
      */
-    public native boolean isExcluded(Class<? extends jdk.internal.event.Event> eventClass);
+    public static native boolean isExcluded(Class<? extends jdk.internal.event.Event> eventClass);
 
     /**
      * Test if a class is instrumented.
@@ -589,14 +559,14 @@ public final class JVM {
      *
      * @return is class instrumented
      */
-    public native boolean isInstrumented(Class<? extends jdk.internal.event.Event> eventClass);
+    public static native boolean isInstrumented(Class<? extends jdk.internal.event.Event> eventClass);
 
     /**
      * Get the start time in nanos from the header of the current chunk
      *
      * @return start time of the recording in nanos, -1 in case of in-memory
      */
-    public native long getChunkStartNanos();
+    public static native long getChunkStartNanos();
 
     /**
      * Stores an EventConfiguration to the configuration field of an event class.
@@ -607,7 +577,7 @@ public final class JVM {
      *
      * @return if the field could be set
      */
-    public native boolean setConfiguration(Class<? extends jdk.internal.event.Event> eventClass, EventConfiguration configuration);
+    public static native boolean setConfiguration(Class<? extends jdk.internal.event.Event> eventClass, EventConfiguration configuration);
 
     /**
      * Retrieves the EventConfiguration for an event class.
@@ -616,7 +586,7 @@ public final class JVM {
      *
      * @return the configuration, may be {@code null}
      */
-    public native Object getConfiguration(Class<? extends jdk.internal.event.Event> eventClass);
+    public static native Object getConfiguration(Class<? extends jdk.internal.event.Event> eventClass);
 
     /**
      * Returns the id for the Java types defined in metadata.xml.
@@ -625,7 +595,7 @@ public final class JVM {
      *
      * @return the id, or a negative value if it does not exists.
      */
-    public native long getTypeId(String name);
+    public static native long getTypeId(String name);
 
     /**
      * Returns {@code true}, if the JVM is running in a container, {@code false} otherwise.
@@ -634,11 +604,11 @@ public final class JVM {
      * which is questionable, but Container.metrics() returns {@code null}, so events
      * can't be emitted anyway.
      */
-    public native boolean isContainerized();
+    public static native boolean isContainerized();
 
     /**
      * Returns the total amount of memory of the host system whether or not this
      * JVM runs in a container.
      */
-    public native long hostTotalMemory();
+    public static native long hostTotalMemory();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -53,7 +53,6 @@ import jdk.jfr.internal.util.Utils;
 
 public final class MetadataRepository {
 
-    private static final JVM jvm = JVM.getJVM();
     private static final MetadataRepository instance = new MetadataRepository();
 
     private final List<EventType> nativeEventTypes = new ArrayList<>(150);
@@ -135,7 +134,7 @@ public final class MetadataRepository {
 
     public synchronized EventType register(Class<? extends jdk.internal.event.Event> eventClass, List<AnnotationElement> dynamicAnnotations, List<ValueDescriptor> dynamicFields) {
         SecuritySupport.checkRegisterPermission();
-        if (jvm.isExcluded(eventClass)) {
+        if (JVM.isExcluded(eventClass)) {
             // Event classes are marked as excluded during class load
             // if they override methods in the jdk.jfr.Event class, i.e. commit().
             // An excluded class lacks a configuration field and can't be used by JFR.
@@ -154,7 +153,7 @@ public final class MetadataRepository {
         }
         configuration.getPlatformEventType().setRegistered(true);
         TypeLibrary.addType(configuration.getPlatformEventType());
-        if (jvm.isRecording()) {
+        if (JVM.isRecording()) {
             settingsManager.setEventControl(configuration.getEventControl(), true, JVM.counterTime());
             settingsManager.updateRetransform(Collections.singletonList((eventClass)));
        }
@@ -210,7 +209,7 @@ public final class MetadataRepository {
         PlatformEventType pe = configuration.getPlatformEventType();
         pe.setRegistered(true);
         // If class is instrumented or should not be instrumented, mark as instrumented.
-        if (jvm.isInstrumented(eventClass) || !JVMSupport.shouldInstrument(pe.isJDK(), pe.getName())) {
+        if (JVM.isInstrumented(eventClass) || !JVMSupport.shouldInstrument(pe.isJDK(), pe.getName())) {
             pe.setInstrumented();
         }
         JVMSupport.setConfiguration(eventClass, configuration);
@@ -228,7 +227,7 @@ public final class MetadataRepository {
     }
 
     public synchronized List<EventControl> getEventControls() {
-        List<Class<? extends jdk.internal.event.Event>> eventClasses = jvm.getAllEventClasses();
+        List<Class<? extends jdk.internal.event.Event>> eventClasses = JVM.getAllEventClasses();
         ArrayList<EventControl> controls = new ArrayList<>(eventClasses.size() + nativeControls.size());
         controls.addAll(nativeControls);
         for (Class<? extends jdk.internal.event.Event> clazz : eventClasses) {
@@ -241,12 +240,12 @@ public final class MetadataRepository {
     }
 
     private void storeDescriptorInJVM() throws InternalError {
-        jvm.storeMetadataDescriptor(getBinaryRepresentation());
+        JVM.storeMetadataDescriptor(getBinaryRepresentation());
         staleMetadata = false;
     }
 
     private static List<EventConfiguration> getEventConfigurations() {
-        List<Class<? extends jdk.internal.event.Event>> allEventClasses = jvm.getAllEventClasses();
+        List<Class<? extends jdk.internal.event.Event>> allEventClasses = JVM.getAllEventClasses();
         List<EventConfiguration> eventConfigurations = new ArrayList<>(allEventClasses.size());
         for (Class<? extends jdk.internal.event.Event> clazz : allEventClasses) {
             EventConfiguration ec = JVMSupport.getConfiguration(clazz);
@@ -293,7 +292,7 @@ public final class MetadataRepository {
         if (staleMetadata) {
             storeDescriptorInJVM();
         }
-        jvm.setOutput(filename);
+        JVM.setOutput(filename);
         // Each chunk needs a unique start timestamp and
         // if the clock resolution is low, two chunks may
         // get the same timestamp. Utils.getChunkStartNanos()
@@ -313,10 +312,10 @@ public final class MetadataRepository {
     }
 
     private void unregisterUnloaded() {
-        long unloaded = jvm.getUnloadedEventClassCount();
+        long unloaded = JVM.getUnloadedEventClassCount();
         if (this.lastUnloaded != unloaded) {
             this.lastUnloaded = unloaded;
-            List<Class<? extends jdk.internal.event.Event>> eventClasses = jvm.getAllEventClasses();
+            List<Class<? extends jdk.internal.event.Event>> eventClasses = JVM.getAllEventClasses();
             HashSet<Long> knownIds = new HashSet<>(eventClasses.size());
             for (Class<? extends jdk.internal.event.Event>  ec: eventClasses) {
                 knownIds.add(Type.getTypeId(ec));
@@ -351,7 +350,7 @@ public final class MetadataRepository {
         if (staleMetadata) {
             storeDescriptorInJVM();
         }
-        jvm.flush();
+        JVM.flush();
     }
 
     static void unhideInternalTypes() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/OldObjectSample.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/OldObjectSample.java
@@ -83,7 +83,7 @@ public final class OldObjectSample {
     public static void emit(long ticks) {
         boolean emitAll = WhiteBox.getWriteAllObjectSamples();
         boolean skipBFS = WhiteBox.getSkipBFS();
-        JVM.getJVM().emitOldObjectSamples(ticks, emitAll, skipBFS);
+        JVM.emitOldObjectSamples(ticks, emitAll, skipBFS);
     }
 
     public static void updateSettingPathToGcRoots(Map<String, String> s, Boolean pathToGcRoots) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import static java.nio.file.LinkOption.*;
  */
 public final class Options {
 
-    private static final JVM jvm = JVM.getJVM();
     private static final long WAIT_INTERVAL = 1000; // ms;
 
     private static final long MIN_MAX_CHUNKSIZE = 1024 * 1024;
@@ -72,7 +71,7 @@ public final class Options {
         if (max < MIN_MAX_CHUNKSIZE) {
             throw new IllegalArgumentException("Max chunk size must be at least " + MIN_MAX_CHUNKSIZE);
         }
-        jvm.setFileNotification(max);
+        JVM.setFileNotification(max);
         maxChunkSize = max;
     }
 
@@ -81,7 +80,7 @@ public final class Options {
     }
 
     public static synchronized void setMemorySize(long memSize) {
-        jvm.setMemorySize(memSize);
+        JVM.setMemorySize(memSize);
         memorySize = memSize;
     }
 
@@ -90,7 +89,7 @@ public final class Options {
     }
 
     public static synchronized void setThreadBufferSize(long threadBufSize) {
-        jvm.setThreadBufferSize(threadBufSize);
+        JVM.setThreadBufferSize(threadBufSize);
         threadBufferSize = threadBufSize;
     }
 
@@ -103,7 +102,7 @@ public final class Options {
     }
 
     public static synchronized void setGlobalBufferCount(long globalBufCount) {
-        jvm.setGlobalBufferCount(globalBufCount);
+        JVM.setGlobalBufferCount(globalBufCount);
         globalBufferCount = globalBufCount;
     }
 
@@ -112,7 +111,7 @@ public final class Options {
     }
 
     public static synchronized void setGlobalBufferSize(long globalBufsize) {
-        jvm.setGlobalBufferSize(globalBufsize);
+        JVM.setGlobalBufferSize(globalBufsize);
         globalBufferSize = globalBufsize;
     }
 
@@ -124,15 +123,15 @@ public final class Options {
                 throw new IOException("Cannot write JFR emergency dump to " + path.toString());
             }
         }
-        jvm.setDumpPath(path == null ? null : path.toString());
+        JVM.setDumpPath(path == null ? null : path.toString());
     }
 
     public static synchronized SafePath getDumpPath() {
-        return new SafePath(jvm.getDumpPath());
+        return new SafePath(JVM.getDumpPath());
     }
 
     public static synchronized void setStackDepth(Integer stackTraceDepth) {
-        jvm.setStackDepth(stackTraceDepth);
+        JVM.setStackDepth(stackTraceDepth);
         stackDepth = stackTraceDepth;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
@@ -150,13 +150,13 @@ public final class PlatformEventType extends Type {
     public void setCutoff(long cutoffNanos) {
         if (isJVM) {
             long cutoffTicks = JVMSupport.nanosToTicks(cutoffNanos);
-            JVM.getJVM().setCutoff(getId(), cutoffTicks);
+            JVM.setCutoff(getId(), cutoffTicks);
         }
     }
 
     public void setThrottle(long eventSampleSize, long period_ms) {
         if (isJVM) {
-            JVM.getJVM().setThrottle(getId(), eventSampleSize, period_ms);
+            JVM.setThrottle(getId(), eventSampleSize, period_ms);
         }
     }
 
@@ -207,9 +207,9 @@ public final class PlatformEventType extends Type {
         if (isJVM) {
             if (isMethodSampling) {
                 long p = enabled ? period : 0;
-                JVM.getJVM().setMethodSamplingPeriod(getId(), p);
+                JVM.setMethodSamplingPeriod(getId(), p);
             } else {
-                JVM.getJVM().setEnabled(getId(), enabled);
+                JVM.setEnabled(getId(), enabled);
             }
         }
         if (changed) {
@@ -220,7 +220,7 @@ public final class PlatformEventType extends Type {
     public void setPeriod(long periodMillis, boolean beginChunk, boolean endChunk) {
         if (isMethodSampling) {
             long p = enabled ? periodMillis : 0;
-            JVM.getJVM().setMethodSamplingPeriod(getId(), p);
+            JVM.setMethodSamplingPeriod(getId(), p);
         }
         this.beginChunk = beginChunk;
         this.endChunk = endChunk;
@@ -234,14 +234,14 @@ public final class PlatformEventType extends Type {
     public void setStackTraceEnabled(boolean stackTraceEnabled) {
         this.stackTraceEnabled = stackTraceEnabled;
         if (isJVM) {
-            JVM.getJVM().setStackTraceEnabled(getId(), stackTraceEnabled);
+            JVM.setStackTraceEnabled(getId(), stackTraceEnabled);
         }
     }
 
     public void setThreshold(long thresholdNanos) {
         this.thresholdTicks = JVMSupport.nanosToTicks(thresholdNanos);
         if (isJVM) {
-            JVM.getJVM().setThreshold(getId(), thresholdTicks);
+            JVM.setThreshold(getId(), thresholdTicks);
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -66,7 +66,6 @@ public final class PlatformRecorder {
     private final ArrayList<PlatformRecording> recordings = new ArrayList<>();
     private static final List<SecureRecorderListener> changeListeners = new ArrayList<>();
     private final Repository repository;
-    private static final JVM jvm = JVM.getJVM();
     private final Thread shutdownHook;
 
     private Timer timer;
@@ -79,7 +78,7 @@ public final class PlatformRecorder {
         repository = Repository.getRepository();
         Logger.log(JFR_SYSTEM, INFO, "Initialized disk repository");
         repository.ensureRepository();
-        jvm.createNativeJFR();
+        JVMSupport.createJFR();
         Logger.log(JFR_SYSTEM, INFO, "Created native");
         JDKEvents.initialize();
         Logger.log(JFR_SYSTEM, INFO, "Registered JDK events");
@@ -97,7 +96,7 @@ public final class PlatformRecorder {
             Thread t = SecuritySupport.createThreadWitNoPermissions("Permissionless thread", ()-> {
                 result.add(new Timer("JFR Recording Scheduler", true));
             });
-            jvm.exclude(t);
+            JVM.exclude(t);
             t.start();
             t.join();
             return result.getFirst();
@@ -207,11 +206,11 @@ public final class PlatformRecorder {
 
         JDKEvents.remove();
 
-        if (jvm.hasNativeJFR()) {
-            if (jvm.isRecording()) {
-                jvm.endRecording();
+        if (JVMSupport.hasJFR()) {
+            if (JVM.isRecording()) {
+                JVM.endRecording();
             }
-            jvm.destroyNativeJFR();
+            JVMSupport.destroyJFR();
         }
         repository.clear();
     }
@@ -244,7 +243,7 @@ public final class PlatformRecorder {
                 MetadataRepository.getInstance().setOutput(null);
             }
             currentChunk = newChunk;
-            jvm.beginRecording();
+            JVM.beginRecording();
             startNanos = JVMSupport.getChunkStartNanos();
             startTime = Utils.epochNanosToInstant(startNanos);
             if (currentChunk != null) {
@@ -320,7 +319,7 @@ public final class PlatformRecorder {
             PeriodicEvents.doChunkEnd();
             if (recording.isToDisk()) {
                 if (inShutdown) {
-                    jvm.markChunkFinal();
+                    JVM.markChunkFinal();
                 }
                 stopTime = MetadataRepository.getInstance().setOutput(null);
                 finishChunk(currentChunk, stopTime, null);
@@ -329,7 +328,7 @@ public final class PlatformRecorder {
                 // last memory
                 stopTime = dumpMemoryToDestination(recording);
             }
-            jvm.endRecording();
+            JVM.endRecording();
             recording.setStopTime(stopTime);
             disableEvents();
             setRunPeriodicTask(false);
@@ -495,12 +494,12 @@ public final class PlatformRecorder {
     }
 
     private void periodicTask() {
-        if (!jvm.hasNativeJFR()) {
+        if (!JVMSupport.hasJFR()) {
             return;
         }
         while (true) {
             synchronized (this) {
-                if (jvm.shouldRotateDisk()) {
+                if (JVM.shouldRotateDisk()) {
                     rotateDisk();
                 }
                 if (isToDisk()) {
@@ -658,7 +657,7 @@ public final class PlatformRecorder {
             }
         }
         if (disk) {
-            jvm.markChunkFinal();
+            JVM.markChunkFinal();
             rotateDisk();
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -39,7 +39,6 @@ import jdk.jfr.internal.util.ValueFormatter;
 public final class Repository {
 
     private static final int MAX_REPO_CREATION_RETRIES = 1000;
-    private static final JVM jvm = JVM.getJVM();
     private static final Repository instance = new Repository();
 
     private static final String JFR_REPOSITORY_LOCATION_PROPERTY = "jdk.jfr.repository";
@@ -86,7 +85,7 @@ public final class Repository {
         try {
             if (!SecuritySupport.existDirectory(repository)) {
                 this.repository = createRepository(baseLocation);
-                jvm.setRepositoryLocation(repository.toString());
+                JVM.setRepositoryLocation(repository.toString());
                 SecuritySupport.setProperty(JFR_REPOSITORY_LOCATION_PROPERTY, repository.toString());
                 cleanupDirectories.add(repository);
                 chunkFilename = null;
@@ -99,7 +98,7 @@ public final class Repository {
         } catch (Exception e) {
             String errorMsg = String.format("Could not create chunk in repository %s, %s: %s", repository, e.getClass(), e.getMessage());
             Logger.log(LogTag.JFR, LogLevel.ERROR, errorMsg);
-            jvm.abort(errorMsg);
+            JVM.abort(errorMsg);
             throw new InternalError("Could not abort after JFR disk creation error");
         }
     }
@@ -108,7 +107,7 @@ public final class Repository {
         SafePath canonicalBaseRepositoryPath = createRealBasePath(basePath);
         SafePath f = null;
 
-        String basename = ValueFormatter.formatDateTime(LocalDateTime.now()) + "_" + JVM.getJVM().getPid();
+        String basename = ValueFormatter.formatDateTime(LocalDateTime.now()) + "_" + JVM.getPid();
         String name = basename;
 
         int i = 0;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -135,7 +135,7 @@ final class SettingsManager {
         // store settings so they are available if a new event class is loaded
         availableSettings = createSettingsMap(activeSettings);
         List<EventControl> eventControls = MetadataRepository.getInstance().getEventControls();
-        if (!JVM.getJVM().isRecording()) {
+        if (!JVM.isRecording()) {
             for (EventControl ec : eventControls) {
                 ec.disable();
             }
@@ -148,8 +148,8 @@ final class SettingsManager {
                 setEventControl(ec, writeSettingEvents, timestamp);
             }
         }
-        if (JVM.getJVM().getAllowedToDoEventRetransforms()) {
-            updateRetransform(JVM.getJVM().getAllEventClasses());
+        if (JVM.getAllowedToDoEventRetransforms()) {
+            updateRetransform(JVM.getAllEventClasses());
         }
     }
 
@@ -169,7 +169,7 @@ final class SettingsManager {
             }
         }
         if (!classes.isEmpty()) {
-            JVM.getJVM().retransformClasses(classes.toArray(new Class<?>[0]));
+            JVM.retransformClasses(classes.toArray(new Class<?>[0]));
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ShutdownHook.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ShutdownHook.java
@@ -104,7 +104,7 @@ final class ShutdownHook implements Runnable {
     static final class ExceptionHandler implements Thread.UncaughtExceptionHandler {
         @Override
         public void uncaughtException(Thread t, Throwable e) {
-            JVM.getJVM().uncaughtException(t, e);
+            JVM.uncaughtException(t, e);
         }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
@@ -76,7 +76,7 @@ public class Type implements Comparable<Type> {
     }
 
     private static Type createKnownType(String name, Class<?> clazz) {
-        long id = JVM.getJVM().getTypeId(name);
+        long id = JVM.getTypeId(name);
         Type t =  new Type(name, null, id, null);
         knownTypes.put(t, clazz);
         return t;
@@ -122,7 +122,7 @@ public class Type implements Comparable<Type> {
 
     public static long getTypeId(Class<?> clazz) {
         Type type = Type.getKnownType(clazz);
-        return type == null ? JVM.getJVM().getTypeId(clazz) : type.getId();
+        return type == null ? JVM.getTypeId(clazz) : type.getId();
     }
 
     static Collection<Type> getKnownTypes() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -113,20 +113,19 @@ public final class EventDirectoryStream extends AbstractEventStream {
 
     @Override
     protected void process() throws IOException {
-        JVM jvm = JVM.getJVM();
         Thread t = Thread.currentThread();
         try {
-            if (jvm.isExcluded(t)) {
+            if (JVM.isExcluded(t)) {
                 threadExclusionLevel++;
             } else {
-                jvm.exclude(t);
+                JVM.exclude(t);
             }
             processRecursionSafe();
         } finally {
             if (threadExclusionLevel > 0) {
                 threadExclusionLevel--;
             } else {
-                jvm.include(t);
+                JVM.include(t);
             }
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -117,10 +117,10 @@ abstract class AbstractDCmd {
 
     public String getPid() {
         // Invoking ProcessHandle.current().pid() would require loading more
-        // classes during startup so instead JVM.getJVM().getPid() is used.
+        // classes during startup so instead JVM.getPid() is used.
         // The pid will not be exposed to running Java application, only when starting
         // JFR from command line (-XX:StartFlightRecording) or jcmd (JFR.start and JFR.check)
-        return JVM.getJVM().getPid();
+        return JVM.getPid();
     }
 
     protected final SafePath resolvePath(Recording recording, String filename) throws InvalidPathException {
@@ -294,7 +294,7 @@ abstract class AbstractDCmd {
                     i++;
                 } else if (nc == 'p') {
                     if (pid == null) {
-                        pid = JVM.getJVM().getPid();
+                        pid = JVM.getPid();
                     }
                     sb.append(pid);
                     i++;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -289,12 +289,11 @@ final class DCmdStart extends AbstractDCmd {
         if (!hasJDKEvents(settings)) {
             return;
         }
-        JVM jvm = JVM.getJVM();
         try {
-            jvm.setForceInstrumentation(true);
+            JVM.setForceInstrumentation(true);
             FlightRecorder.getFlightRecorder();
         } finally {
-            jvm.setForceInstrumentation(false);
+            JVM.setForceInstrumentation(false);
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ public final class EventWriter {
     // Event may not exceed size for a padded integer
     private static final long MAX_EVENT_SIZE = (1 << 28) -1;
     private static final Unsafe unsafe = Unsafe.getUnsafe();
-    private static final JVM jvm = JVM.getJVM();
 
     // The JVM needs access to these values. Don't remove
     private final long threadID;
@@ -178,7 +177,7 @@ public final class EventWriter {
         if (athread == null) {
             putLong(0L);
         } else {
-            putLong(jvm.getThreadId(athread));
+            putLong(JVM.getThreadId(athread));
         }
     }
 
@@ -192,7 +191,7 @@ public final class EventWriter {
 
     public void putStackTrace() {
         if (eventType.getStackTraceEnabled()) {
-            putLong(jvm.getStackTraceId(eventType.getStackTraceOffset()));
+            putLong(JVM.getStackTraceId(eventType.getStackTraceOffset()));
         } else {
             putLong(0L);
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,6 @@ public final class JDKEvents {
     };
 
     private static final Class<?>[] targetClasses = new Class<?>[instrumentationClasses.length];
-    private static final JVM jvm = JVM.getJVM();
     private static final Runnable emitExceptionStatistics = JDKEvents::emitExceptionStatistics;
     private static final Runnable emitDirectBufferStatistics = JDKEvents::emitDirectBufferStatistics;
     private static final Runnable emitContainerConfiguration = JDKEvents::emitContainerConfiguration;
@@ -171,7 +170,7 @@ public final class JDKEvents {
             list.add(java.lang.Throwable.class);
             list.add(java.lang.Error.class);
             Logger.log(LogTag.JFR_SYSTEM, LogLevel.INFO, "Retransformed JDK classes");
-            jvm.retransformClasses(list.toArray(new Class<?>[list.size()]));
+            JVM.retransformClasses(list.toArray(new Class<?>[list.size()]));
         } catch (IllegalStateException ise) {
             throw ise;
         } catch (Exception e) {
@@ -180,7 +179,7 @@ public final class JDKEvents {
     }
 
     private static void initializeContainerEvents() {
-        if (JVM.getJVM().isContainerized() ) {
+        if (JVM.isContainerized() ) {
             Logger.log(LogTag.JFR_SYSTEM, LogLevel.DEBUG, "JVM is containerized");
             containerMetrics = Container.metrics();
             if (containerMetrics != null) {
@@ -219,7 +218,7 @@ public final class JDKEvents {
             t.memorySoftLimit = containerMetrics.getMemorySoftLimit();
             t.memoryLimit = containerMetrics.getMemoryLimit();
             t.swapMemoryLimit = containerMetrics.getMemoryAndSwapLimit();
-            t.hostTotalMemory = JVM.getJVM().hostTotalMemory();
+            t.hostTotalMemory = JVM.hostTotalMemory();
             t.commit();
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/JVMEventTask.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/JVMEventTask.java
@@ -51,7 +51,7 @@ final class JVMEventTask extends EventTask {
     public void execute(long timestamp, PeriodicType periodicType) {
         try {
             lock.lock();
-            JVM.getJVM().emitEvent(getEventType().getId(), timestamp, periodicType.ordinal());
+            JVM.emitEvent(getEventType().getId(), timestamp, periodicType.ordinal());
         } finally {
             lock.unlock();
         }

--- a/test/jdk/jdk/jfr/api/metadata/eventtype/TestUnloadingEventClass.java
+++ b/test/jdk/jdk/jfr/api/metadata/eventtype/TestUnloadingEventClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,6 @@ public class TestUnloadingEventClass {
         }
     }
 
-    private static final JVM jvm = JVM.getJVM();
     public static ClassLoader myClassLoader;
 
     public static void main(String[] args) throws Throwable {
@@ -134,7 +133,7 @@ public class TestUnloadingEventClass {
     }
 
     private static void unLoadEventClass() throws Exception {
-        long firstCount = jvm.getUnloadedEventClassCount();
+        long firstCount = JVM.getUnloadedEventClassCount();
         System.out.println("Initial unloaded count: " + firstCount);
         myClassLoader = null;
         System.out.println("Cleared reference to MyClassLoader");
@@ -143,12 +142,12 @@ public class TestUnloadingEventClass {
             System.out.println("GC triggered");
             System.gc();
             Thread.sleep(1000);
-            newCount = jvm.getUnloadedEventClassCount();
+            newCount = JVM.getUnloadedEventClassCount();
             System.out.println("Unloaded count: " + newCount);
         } while (firstCount + 1 != newCount);
         System.out.println("Event class unloaded!");
         System.out.println("Event classes currently on the heap:");
-        for (Class<?> eventClass : JVM.getJVM().getAllEventClasses()) {
+        for (Class<?> eventClass : JVM.getAllEventClasses()) {
             System.out.println(eventClass + " " + (eventClass.getClassLoader() != null ? eventClass.getClassLoader().getName() : null));
         }
 

--- a/test/jdk/jdk/jfr/event/profiling/TestNative.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class TestNative {
 
     public static void nativeMethod() {
         while (alive) {
-            JVM.getJVM().getPid();
+            JVM.getPid();
         }
     }
 }

--- a/test/jdk/jdk/jfr/jvm/TestBeginAndEnd.java
+++ b/test/jdk/jdk/jfr/jvm/TestBeginAndEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package jdk.jfr.jvm;
 
+import jdk.jfr.internal.JVMSupport;
 import jdk.jfr.internal.JVM;
 
 /**
@@ -37,11 +38,10 @@ public class TestBeginAndEnd {
     private final static long MAX_CHUNK_SIZE = 12 * 1024 * 1024;
 
     public static void main(String... args) {
-        JVM jvm = JVM.getJVM();
-        jvm.createNativeJFR();
-        jvm.setFileNotification(MAX_CHUNK_SIZE);
-        jvm.beginRecording();
-        jvm.endRecording();
-        jvm.destroyNativeJFR();
+        JVMSupport.createJFR();
+        JVM.setFileNotification(MAX_CHUNK_SIZE);
+        JVM.beginRecording();
+        JVM.endRecording();
+        JVMSupport.destroyJFR();
     }
 }

--- a/test/jdk/jdk/jfr/jvm/TestClassId.java
+++ b/test/jdk/jdk/jfr/jvm/TestClassId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import static jdk.test.lib.Asserts.assertGreaterThan;
 import static jdk.test.lib.Asserts.assertNE;
 
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.JVMSupport;
 import jdk.jfr.internal.Type;
 
 /**
@@ -41,11 +42,9 @@ public class TestClassId {
 
     public static void main(String... args) {
         assertClassIds();
-        JVM jvm = JVM.getJVM();
-        jvm.createNativeJFR();
+        JVMSupport.createJFR();
         assertClassIds();
-        jvm.destroyNativeJFR();
-        assertClassIds();
+        JVMSupport.destroyJFR();
     }
 
     private static void assertClassIds() {

--- a/test/jdk/jdk/jfr/jvm/TestClearStaleConstants.java
+++ b/test/jdk/jdk/jfr/jvm/TestClearStaleConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,9 +66,8 @@ public final class TestClearStaleConstants {
         firstClassLoader = new TestClassLoader();
         // define a  class using a class loader under a recording
         Class<?> clz = recordClassDefinition(firstClassLoader);
-        JVM jvm = JVM.getJVM();
         // we will now tag the defined and loaded clz as being in use (no recordings are running here)
-        jvm.getClassId(clz);
+        JVM.getClassId(clz);
         // null out for unload to occur
         firstClassLoader = null;
         clz = null;

--- a/test/jdk/jdk/jfr/jvm/TestCounterTime.java
+++ b/test/jdk/jdk/jfr/jvm/TestCounterTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.jvm;
 import static jdk.test.lib.Asserts.assertGreaterThan;
 
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.JVMSupport;
 
 /**
  * @test TestCounterTime
@@ -41,11 +42,10 @@ public class TestCounterTime {
         // Not enabled
         assertCounterTime();
 
-        JVM jvm = JVM.getJVM();
-        jvm.createNativeJFR();
+        JVMSupport.createJFR();
         assertCounterTime();
         // Enabled
-        jvm.destroyNativeJFR();
+        JVMSupport.destroyJFR();
     }
 
     private static void assertCounterTime() throws InterruptedException {

--- a/test/jdk/jdk/jfr/jvm/TestCreateNative.java
+++ b/test/jdk/jdk/jfr/jvm/TestCreateNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ import java.nio.file.Paths;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.Recording;
-import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.JVMSupport;
 
 /**
  * @test
@@ -44,11 +44,10 @@ public class TestCreateNative {
     // all native structures after they are setup, as if something went wrong
     // at the last step.
     public static void main(String... args) throws Exception {
-        JVM jvm = JVM.getJVM();
         // Ensure that repeated failures can be handled
         for (int i = 1; i < 4; i++) {
             System.out.println("About to try failed initialization, attempt " + i + " out of 3");
-            assertFailedInitialization(jvm);
+            assertFailedInitialization();
             System.out.println("As expected, initialization failed.");
         }
         // Ensure that Flight Recorder can be initialized properly after failures
@@ -60,9 +59,9 @@ public class TestCreateNative {
         r.close();
     }
 
-    private static void assertFailedInitialization(JVM jvm) throws Exception {
+    private static void assertFailedInitialization() throws Exception {
         try {
-            jvm.createFailedNativeJFR();
+            JVMSupport.createFailedNativeJFR();
             throw new Exception("Expected failure when creating native JFR");
         } catch (IllegalStateException ise) {
             String message = ise.getMessage();

--- a/test/jdk/jdk/jfr/jvm/TestGetAllEventClasses.java
+++ b/test/jdk/jdk/jfr/jvm/TestGetAllEventClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package jdk.jfr.jvm;
 
 import jdk.jfr.Event;
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.JVMSupport;
 
 import java.util.List;
 
@@ -42,38 +43,37 @@ import java.util.List;
 public class TestGetAllEventClasses {
 
     public static void main(String... args) throws ClassNotFoundException {
-        JVM jvm = JVM.getJVM();
         // before creating  native
-        assertEmptyEventList(jvm);
-        jvm.createNativeJFR();
+        assertEmptyEventList();
+        JVMSupport.createJFR();
         // after creating native
-        assertEmptyEventList(jvm);
+        assertEmptyEventList();
 
         // Test event class load is triggered and only once
         Class<? extends Event> clazz = initialize("jdk.jfr.jvm.HelloWorldEvent1");
         // check that the event class is registered
-        assertEventsIncluded(jvm, clazz);
+        assertEventsIncluded(clazz);
         // second active use of the same event class should not add another class
         // to the list - it would already be loaded
         clazz = initialize(clazz);
-        assertEventsIncluded(jvm, clazz);
+        assertEventsIncluded(clazz);
 
         // second event class
         Class<? extends Event> clazz2 = initialize("jdk.jfr.jvm.HelloWorldEvent2");
         // the list of event classes should now have two classes registered
-        assertEventsIncluded(jvm, clazz, clazz2);
+        assertEventsIncluded(clazz, clazz2);
 
         // verify that an abstract event class is not included
         Class<? extends Event> abstractClass = initialize(MyAbstractEvent.class); // to run <clinit>
-        assertEventsExcluded(jvm, abstractClass);
+        assertEventsExcluded(abstractClass);
 
         // verify that a class that is yet to run its <clinit> is not included in the list of event classes
-        assertEventsExcluded(jvm, MyUnInitializedEvent.class);
+        assertEventsExcluded(MyUnInitializedEvent.class);
 
         // ensure old classes are not lost
-        assertEventsIncluded(jvm, clazz, clazz2);
+        assertEventsIncluded(clazz, clazz2);
 
-        jvm.destroyNativeJFR();
+        JVMSupport.destroyJFR();
     }
 
     private static Class<? extends Event> initialize(String name) throws ClassNotFoundException {
@@ -85,26 +85,26 @@ public class TestGetAllEventClasses {
         return initialize(event.getName());
     }
 
-    private static void assertEmptyEventList(JVM jvm) {
-        if (!jvm.getAllEventClasses().isEmpty()) {
+    private static void assertEmptyEventList() {
+        if (!JVM.getAllEventClasses().isEmpty()) {
             throw new AssertionError("should not have any event classes registered!");
         }
     }
 
     @SafeVarargs
-    private static void assertEventsExcluded(JVM jvm, Class<? extends Event>... targetEvents) {
-        assertEvents(jvm, false, targetEvents);
+    private static void assertEventsExcluded(Class<? extends Event>... targetEvents) {
+        assertEvents(false, targetEvents);
     }
 
     @SafeVarargs
-    private static void assertEventsIncluded(JVM jvm, Class<? extends Event>... targetEvents) {
-        assertEvents(jvm, true, targetEvents);
+    private static void assertEventsIncluded(Class<? extends Event>... targetEvents) {
+        assertEvents(true, targetEvents);
     }
 
     @SafeVarargs
     @SuppressWarnings("rawtypes")
-    private static void assertEvents(JVM jvm, boolean inclusion, Class<? extends Event>... targetEvents) {
-        final List list = jvm.getAllEventClasses();
+    private static void assertEvents(boolean inclusion, Class<? extends Event>... targetEvents) {
+        final List list = JVM.getAllEventClasses();
         for (Class<? extends Event> ev : targetEvents) {
            if (list.contains(ev)) {
                if (inclusion) {

--- a/test/jdk/jdk/jfr/jvm/TestGetEventWriterReflection.java
+++ b/test/jdk/jdk/jfr/jvm/TestGetEventWriterReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ public class TestGetEventWriterReflection {
     private static void testReflectionGetDeclaredFieldSetAccessible() throws Exception {
         try {
             Class<?> c = Class.forName("jdk.jfr.internal.event.EventWriter");
-            Field field = c.getDeclaredField("jvm");
+            Field field = c.getDeclaredField("unsafe");
             field.setAccessible(true);
             throw new RuntimeException("Should not reach here " + field);
         } catch (InaccessibleObjectException ioe) {

--- a/test/jdk/jdk/jfr/jvm/TestGetStackTraceId.java
+++ b/test/jdk/jdk/jfr/jvm/TestGetStackTraceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ public class TestGetStackTraceId {
 
     public static void main(String... args) {
         FlightRecorder.getFlightRecorder();
-        JVM jvm = JVM.getJVM();
 
         long id10 = getStackIdOfDepth(10);
         assertValid(id10);
@@ -49,11 +48,11 @@ public class TestGetStackTraceId {
 
         Asserts.assertNotEquals(id5, id10, "Different stack depth must return different stack trace ids");
 
-        assertMaxSkip(jvm);
+        assertMaxSkip();
     }
 
-    private static void assertMaxSkip(JVM jvm) {
-        Asserts.assertEquals(jvm.getStackTraceId(Integer.MAX_VALUE), 0L, "Insane skip level "
+    private static void assertMaxSkip() {
+        Asserts.assertEquals(JVM.getStackTraceId(Integer.MAX_VALUE), 0L, "Insane skip level "
                 + Integer.MAX_VALUE + " should not return a valid stack trace id");
     }
 
@@ -65,6 +64,6 @@ public class TestGetStackTraceId {
         if (depth > 0) {
             return getStackIdOfDepth(depth - 1);
         }
-        return JVM.getJVM().getStackTraceId(0);
+        return JVM.getStackTraceId(0);
     }
 }

--- a/test/jdk/jdk/jfr/jvm/TestJFRIntrinsic.java
+++ b/test/jdk/jdk/jfr/jvm/TestJFRIntrinsic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.JVMSupport;
 import jdk.test.lib.Platform;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.whitebox.code.NMethod;
@@ -64,7 +65,7 @@ public class TestJFRIntrinsic {
     }
 
     public static void main(String... args) throws Exception {
-        JVM.getJVM().createNativeJFR();
+        JVMSupport.createJFR();
         TestJFRIntrinsic ti = new TestJFRIntrinsic();
         Method classid = TestJFRIntrinsic.class.getDeclaredMethod("getClassIdIntrinsic",  Class.class);
         ti.runIntrinsicTest(classid);

--- a/test/jdk/jdk/jfr/jvm/TestPid.java
+++ b/test/jdk/jdk/jfr/jvm/TestPid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,7 @@ public class TestPid {
 
     public static void main(String... args) throws InterruptedException {
 
-        JVM jvm = JVM.getJVM();
-        String pid = jvm.getPid();
+        String pid = JVM.getPid();
 
         try {
             String managementPid = String.valueOf(ProcessHandle.current().pid());

--- a/test/jdk/jdk/jfr/jvm/TestThreadExclusion.java
+++ b/test/jdk/jdk/jfr/jvm/TestThreadExclusion.java
@@ -54,7 +54,6 @@ public class TestThreadExclusion {
     private final static String EVENT_NAME_THREAD_START = EventNames.ThreadStart;
     private final static String EVENT_NAME_THREAD_END = EventNames.ThreadEnd;
     private static final String THREAD_NAME_PREFIX = "TestThread-";
-    private static JVM jvm;
 
     public static void main(String[] args) throws Throwable {
         // Test Java Thread Start event
@@ -84,10 +83,9 @@ public class TestThreadExclusion {
 
     private static LatchedThread[] startThreads() {
         LatchedThread threads[] = new LatchedThread[10];
-        jvm = JVM.getJVM();
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new LatchedThread(THREAD_NAME_PREFIX + i, false);
-            jvm.exclude(threads[i].getThread());
+            JVM.exclude(threads[i].getThread());
             threads[i].start();
             System.out.println("Started thread id=" + threads[i].getId());
         }
@@ -104,7 +102,7 @@ public class TestThreadExclusion {
 
     private static void stopThreads(LatchedThread[] threads) {
         for (LatchedThread t : threads) {
-            assertTrue(jvm.isExcluded(t.getThread()), "Thread " + t.getThread() + "should be excluded");
+            assertTrue(JVM.isExcluded(t.getThread()), "Thread " + t.getThread() + "should be excluded");
             try {
                 t.stopAndJoin();
             } catch (InterruptedException e) {

--- a/test/jdk/jdk/jfr/jvm/TestUnloadEventClassCount.java
+++ b/test/jdk/jdk/jfr/jvm/TestUnloadEventClassCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class TestUnloadEventClassCount {
         FlightRecorder.getFlightRecorder();
         myClassLoader = createClassLoaderWithEventClass();
         System.out.println("MyClassLoader instance created");
-        long initialCount = JVM.getJVM().getUnloadedEventClassCount();
+        long initialCount = JVM.getUnloadedEventClassCount();
         System.out.println("Initiali unloaded count is " + initialCount);
         myClassLoader = null;
         System.out.println("Reference to class loader cleared");
@@ -73,7 +73,7 @@ public class TestUnloadEventClassCount {
         do {
             System.gc();
             System.out.println("GC triggered");
-            count = JVM.getJVM().getUnloadedEventClassCount();
+            count = JVM.getUnloadedEventClassCount();
             System.out.println("Unloaded count was " + count);
             Thread.sleep(1000); // sleep to reduce log
         } while (count != initialCount + 1);

--- a/test/jdk/jdk/jfr/jvm/TestVirtualThreadExclusion.java
+++ b/test/jdk/jdk/jfr/jvm/TestVirtualThreadExclusion.java
@@ -54,7 +54,6 @@ public class TestVirtualThreadExclusion {
     private final static String EVENT_NAME_VIRTUAL_THREAD_START = EventNames.VirtualThreadStart;
     private final static String EVENT_NAME_VIRTUAL_THREAD_END = EventNames.VirtualThreadEnd;
     private static final String THREAD_NAME_PREFIX = "TestVirtualThread-";
-    private static JVM jvm;
 
     public static void main(String[] args) throws Throwable {
         // Test Java Thread Start event
@@ -84,10 +83,9 @@ public class TestVirtualThreadExclusion {
 
     private static LatchedThread[] startThreads() {
         LatchedThread threads[] = new LatchedThread[10];
-        jvm = JVM.getJVM();
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new LatchedThread(THREAD_NAME_PREFIX + i, true);
-            jvm.exclude(threads[i].getThread());
+            JVM.exclude(threads[i].getThread());
             threads[i].start();
             System.out.println("Started virtual thread id=" + threads[i].getId());
         }
@@ -104,7 +102,7 @@ public class TestVirtualThreadExclusion {
 
     private static void stopThreads(LatchedThread[] threads) {
         for (LatchedThread t : threads) {
-            assertTrue(jvm.isExcluded(t.getThread()), "Virtual Thread " + t.getThread() + "should be excluded");
+            assertTrue(JVM.isExcluded(t.getThread()), "Virtual Thread " + t.getThread() + "should be excluded");
             try {
                 t.stopAndJoin();
             } catch (InterruptedException e) {


### PR DESCRIPTION
Could I have a review of a change that makes instance methods in the JVM class static. 

Today some methods are static, others are not, which means the JVM object needs to be stored and passed around. A singleton object may have made sense in JDK 8 so JVM::getJVM() could be made caller sensitive, similar to Unsafe::getUnsafe(), but not anymore. The jdk.jfr.internal package is protected by the module system. 

Testing: jdk/jdk/jfr tier1 + tier2

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310661](https://bugs.openjdk.org/browse/JDK-8310661): JFR: Replace JVM.getJVM() with JVM (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14713/head:pull/14713` \
`$ git checkout pull/14713`

Update a local copy of the PR: \
`$ git checkout pull/14713` \
`$ git pull https://git.openjdk.org/jdk.git pull/14713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14713`

View PR using the GUI difftool: \
`$ git pr show -t 14713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14713.diff">https://git.openjdk.org/jdk/pull/14713.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14713#issuecomment-1614566256)