### PR TITLE
8310988: Missing @since tags in java.management.rmi

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl_Stub.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl_Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl_Stub.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl_Stub.java
@@ -29,6 +29,8 @@ package javax.management.remote.rmi;
 
 /**
  * RMIConnectionImpl remote stub.
+ *
+ * @since 1.5
  */
 @SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
 public final class RMIConnectionImpl_Stub

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIServerImpl_Stub.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIServerImpl_Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIServerImpl_Stub.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIServerImpl_Stub.java
@@ -29,6 +29,8 @@ package javax.management.remote.rmi;
 
 /**
  * RMIServerImpl remote stub.
+ *
+ * @since 1.5
  */
 @SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
 public final class RMIServerImpl_Stub


### PR DESCRIPTION
Simple doc tag addition.

These are files which describe an interface that has been with us since 1.5.  The files themselves were previously generated at build time, but have been in the repo since jdk15.  But the API is since 1.5.

The other file mentioned in the bug is not a public class and has no javadoc generated, ignoring that one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310988](https://bugs.openjdk.org/browse/JDK-8310988): Missing @since tags in java.management.rmi (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [5bc9cc12](https://git.openjdk.org/jdk/pull/14714/files/5bc9cc12c1345a578190f667f3d29b22a3ae89c0)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [5bc9cc12](https://git.openjdk.org/jdk/pull/14714/files/5bc9cc12c1345a578190f667f3d29b22a3ae89c0)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [5bc9cc12](https://git.openjdk.org/jdk/pull/14714/files/5bc9cc12c1345a578190f667f3d29b22a3ae89c0)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to [5bc9cc12](https://git.openjdk.org/jdk/pull/14714/files/5bc9cc12c1345a578190f667f3d29b22a3ae89c0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14714/head:pull/14714` \
`$ git checkout pull/14714`

Update a local copy of the PR: \
`$ git checkout pull/14714` \
`$ git pull https://git.openjdk.org/jdk.git pull/14714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14714`

View PR using the GUI difftool: \
`$ git pr show -t 14714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14714.diff">https://git.openjdk.org/jdk/pull/14714.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14714#issuecomment-1613484477)