### PR TITLE
6960866: [Fmt-Ch] ChoiceFormat claims impossible and unimplemented functionality

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -343,10 +343,6 @@ public class ChoiceFormat extends NumberFormat {
      * If the limit array is not in ascending order, the results of formatting
      * will be incorrect.
      * @param formats are the formats you want to use for each limit.
-     * They can be either Format objects or Strings.
-     * When formatting with object Y,
-     * if the object is a NumberFormat, then ((NumberFormat) Y).format(X)
-     * is called. Otherwise Y.toString() is called.
      * @throws    NullPointerException if {@code limits} or
      *            {@code formats} is {@code null}
      */


### PR DESCRIPTION
Please review this PR, which clarifies the parameter description of ChoiceFormat.setChoices().

`ChoiceFormat.setChoices(double[] limits, String[] formats)` claims that `formats` can either be "Format objects or Strings". It also claims that "When formatting with object Y, if the object is a NumberFormat, then ((NumberFormat) Y).format(X) is called. Otherwise Y.toString() is called".

This is not true as `formats` is an array of Strings. Thus, the second claim is impossible and unimplemented in the method itself.

The unimplemented specification should be removed from the parameter description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8311106](https://bugs.openjdk.org/browse/JDK-8311106) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-6960866](https://bugs.openjdk.org/browse/JDK-6960866): [Fmt-Ch] ChoiceFormat claims impossible and unimplemented functionality (**Bug** - P4)
 * [JDK-8311106](https://bugs.openjdk.org/browse/JDK-8311106): [Fmt-Ch] ChoiceFormat claims impossible and unimplemented functionality (**CSR**)

### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14715/head:pull/14715` \
`$ git checkout pull/14715`

Update a local copy of the PR: \
`$ git checkout pull/14715` \
`$ git pull https://git.openjdk.org/jdk.git pull/14715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14715`

View PR using the GUI difftool: \
`$ git pr show -t 14715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14715.diff">https://git.openjdk.org/jdk/pull/14715.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14715#issuecomment-1613597899)