### PR TITLE
JDK-8311115: Type in java.lang.reflect.AccessFlag.METHOD_PARAMETER

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -539,7 +539,7 @@ public enum AccessFlag {
         INNER_CLASS,
 
         /**
-         * Method parameter loccation.
+         * Method parameter location.
          * @jvms 4.7.24. The MethodParameters Attribute
          */
         METHOD_PARAMETER,


### PR DESCRIPTION
Typo fix; running a spell check over the comments and strings in the file, didn't notice any other problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311115](https://bugs.openjdk.org/browse/JDK-8311115): Type in java.lang.reflect.AccessFlag.METHOD_PARAMETER (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14717/head:pull/14717` \
`$ git checkout pull/14717`

Update a local copy of the PR: \
`$ git checkout pull/14717` \
`$ git pull https://git.openjdk.org/jdk.git pull/14717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14717`

View PR using the GUI difftool: \
`$ git pr show -t 14717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14717.diff">https://git.openjdk.org/jdk/pull/14717.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14717#issuecomment-1613761557)