### PR TITLE
8254566: Clarify the spec of ClassLoader::getClassLoadingLock for non-parallel capable loader

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -647,6 +647,8 @@ public abstract class ClassLoader {
 
     /**
      * Returns the lock object for class loading operations.
+     *
+     * @implSpec
      * If this {@code ClassLoader} object is registered as parallel capable,
      * this method returns a dedicated object associated with the specified
      * class name. Otherwise, this method returns this {@code ClassLoader} object.

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -653,11 +653,12 @@ public abstract class ClassLoader {
      *
      * @apiNote
      * This method allows parallel capable class loaders to implement
-     * finer-grained locking scheme such that multiple threads may load classes
+     * finer-grained locking schemes such that multiple threads may load classes
      * concurrently without deadlocks.  For non-parallel-capable class loaders,
-     * the {@code ClassLoader} object is held during the class loading operations.
-     * Class loaders with non-hierarchical delegation should be {@linkplain
-     * #registerAsParallelCapable() registered as parallel capable} to prevent deadlocks.
+     * the {@code ClassLoader} object is synchronized on during the class loading
+     * operations.  Class loaders with non-hierarchical delegation should be
+     * {@linkplain #registerAsParallelCapable() registered as parallel capable}
+     * to prevent deadlocks.
      *
      * @param  className
      *         The name of the to-be-loaded class

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -647,11 +647,17 @@ public abstract class ClassLoader {
 
     /**
      * Returns the lock object for class loading operations.
-     * For backward compatibility, the default implementation of this method
-     * behaves as follows. If this ClassLoader object is registered as
-     * parallel capable, the method returns a dedicated object associated
-     * with the specified class name. Otherwise, the method returns this
-     * ClassLoader object.
+     * If this {@code ClassLoader} object is registered as parallel capable,
+     * this method returns a dedicated object associated with the specified
+     * class name. Otherwise, this method returns this {@code ClassLoader} object.
+     *
+     * @apiNote
+     * This method allows parallel capable class loaders to implement
+     * finer-grained locking scheme such that multiple threads may load classes
+     * concurrently without deadlocks.  For non-parallel-capable class loaders,
+     * the {@code ClassLoader} object is held during the class loading operations.
+     * Class loaders with non-hierarchical delegation should be {@linkplain
+     * #registerAsParallelCapable() registered as parallel capable} to prevent deadlocks.
      *
      * @param  className
      *         The name of the to-be-loaded class
@@ -659,7 +665,7 @@ public abstract class ClassLoader {
      * @return the lock for class loading operations
      *
      * @throws NullPointerException
-     *         If registered as parallel capable and {@code className} is null
+     *         If registered as parallel capable and {@code className} is {@code null}
      *
      * @see #loadClass(String, boolean)
      *


### PR DESCRIPTION
The spec of `ClassLoader::getClassLoadingLock` is unclear that this method is intended for parallel-capable class loader implementations to provide an alternate implementation.   For non-parallel-capable class loaders, this method should return this `ClassLoader` object.   The javadoc uses "the default implementation" which could be interpreted that non-parallel-capable class loaders can also override this implementation, which is not the intent.  See https://openjdk.org/groups/core-libs/ClassLoaderProposal.html.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8311128](https://bugs.openjdk.org/browse/JDK-8311128) to be approved

### Issues
 * [JDK-8254566](https://bugs.openjdk.org/browse/JDK-8254566): Clarify the spec of ClassLoader::getClassLoadingLock for non-parallel capable loader (**Bug** - P4)
 * [JDK-8311128](https://bugs.openjdk.org/browse/JDK-8311128): Clarify the spec of ClassLoader::getClassLoadingLock for non-parallel capable loader (**CSR**)

### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [e9607f4a](https://git.openjdk.org/jdk/pull/14720/files/e9607f4ad163909d920c3f87bd6814864e0283be)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14720/head:pull/14720` \
`$ git checkout pull/14720`

Update a local copy of the PR: \
`$ git checkout pull/14720` \
`$ git pull https://git.openjdk.org/jdk.git pull/14720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14720`

View PR using the GUI difftool: \
`$ git pr show -t 14720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14720.diff">https://git.openjdk.org/jdk/pull/14720.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14720#issuecomment-1613928684)