### PR TITLE
8308745: ObjArrayKlass::allocate_objArray_klass may call into java while holding a lock

### DIFF
--- a/make/replay_pid577069.log
+++ b/make/replay_pid577069.log
@@ -1,0 +1,1903 @@
+version 2
+JvmtiExport can_access_local_variables 0
+JvmtiExport can_hotswap_or_post_breakpoint 0
+JvmtiExport can_post_on_exceptions 0
+# 180 ciObject found
+instanceKlass jdk/internal/org/objectweb/asm/MethodWriter
+ciInstanceKlass java/lang/Cloneable 1 0 7 100 1 100 1 1 1
+instanceKlass  @bci com/sun/tools/javac/comp/Attr visitIf (Lcom/sun/tools/javac/tree/JCTree$JCIf;)V 286 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Attr$$Lambda+0x0000000801129988
+instanceKlass com/sun/tools/javac/comp/Flow$BaseAnalyzer$PendingExit
+instanceKlass  @bci com/sun/tools/javac/comp/Attr bindingEnv (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/comp/Env; 47 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Attr$$Lambda+0x0000000801127258
+instanceKlass  @bci com/sun/tools/javac/code/Types$MembersClosureCache$MembersScope combine (Ljava/util/function/Predicate;)Ljava/util/function/Predicate; 1 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Types$MembersClosureCache$MembersScope$$Lambda+0x0000000801126ff8
+instanceKlass com/sun/tools/javac/code/Flags
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkOverrideClashes (Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;Lcom/sun/tools/javac/code/Type;Lcom/sun/tools/javac/code/Symbol$MethodSymbol;)V 45 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Check$$Lambda+0x0000000801126ba8
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodCheckContext
+instanceKlass com/sun/tools/javac/comp/Resolve$6
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve superclasses (Lcom/sun/tools/javac/code/Type;)Ljava/lang/Iterable; 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x0000000801125da0
+instanceKlass com/sun/tools/javac/code/Symbol$1
+instanceKlass  @bci com/sun/tools/javac/code/Scope$CompoundScope lambda$getSymbols$1 (Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/util/Iterator; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$CompoundScope$$Lambda+0x0000000801125940
+instanceKlass  @bci com/sun/tools/javac/code/Scope$CompoundScope getSymbols (Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$CompoundScope$$Lambda+0x00000008011256f0
+instanceKlass com/sun/tools/javac/comp/Check$DefaultMethodClashFilter
+instanceKlass com/sun/tools/javac/comp/Check$ClashFilter
+instanceKlass com/sun/tools/javac/code/Types$TypePair
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 15 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x0000000801123e80
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 10 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x0000000801123c30
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 5 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x00000008011239f8
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 0 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x00000008011237d0
+instanceKlass  @bci com/sun/tools/javac/comp/Attr attribClass (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 749 <appendix> argL0 ; # com/sun/tools/javac/comp/Attr$$Lambda+0x0000000801123588
+instanceKlass  @bci com/sun/tools/javac/comp/Attr attribClass (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 739 <appendix> argL0 ; # com/sun/tools/javac/comp/Attr$$Lambda+0x0000000801123330
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations annotationTargetType (Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/code/Attribute$Compound;Lcom/sun/tools/javac/code/Symbol;)Lcom/sun/tools/javac/code/TypeAnnotations$AnnotationType; 64 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x0000000801122c88
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations annotationTargetType (Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/code/Attribute$Compound;Lcom/sun/tools/javac/code/Symbol;)Lcom/sun/tools/javac/code/TypeAnnotations$AnnotationType; 50 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x0000000801122838
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations annotationTargets (Lcom/sun/tools/javac/code/Symbol$TypeSymbol;)Lcom/sun/tools/javac/util/List; 56 <appendix> argL0 ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x0000000801122390
+instanceKlass com/sun/tools/javac/code/TypeAnnotationPosition
+instanceKlass  @bci com/sun/tools/javac/code/Type constValue ()Ljava/lang/Object; 3 <appendix> argL0 ; # com/sun/tools/javac/code/Type$$Lambda+0x0000000801121870
+instanceKlass  @bci java/util/function/Function identity ()Ljava/util/function/Function; 0 <appendix> argL0 ; # java/util/function/Function$$Lambda+0x0000000801064de8
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodResolutionContext$Candidate
+instanceKlass com/sun/tools/javac/code/Types$ImplementationCache$Entry
+instanceKlass  @bci com/sun/tools/javac/code/Types membersClosure (Lcom/sun/tools/javac/code/Type;Z)Lcom/sun/tools/javac/code/Scope$CompoundScope; 15 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Types$$Lambda+0x0000000801120d70
+instanceKlass com/sun/tools/javac/comp/Resolve$LookupFilter
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodResolutionContext
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$ProxyType resolve ()Lcom/sun/tools/javac/code/Type; 8 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$ProxyType$$Lambda+0x000000080111d698
+instanceKlass com/sun/tools/javac/jvm/ClassReader$CompleterDeproxy
+instanceKlass  @bci com/sun/tools/javac/comp/Annotate annotateLater (Lcom/sun/tools/javac/util/List;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;)V 32 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Annotate$$Lambda+0x000000080111d230
+instanceKlass  @cpi com/sun/tools/javac/comp/Annotate 1386 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000080111cc00
+instanceKlass  @bci com/sun/tools/javac/comp/Annotate annotateLater (Lcom/sun/tools/javac/util/List;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;)V 19 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Annotate$$Lambda+0x000000080111d000
+instanceKlass com/sun/tools/javac/code/SymbolMetadata
+instanceKlass com/sun/tools/javac/comp/TypeEnter$1
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkUniqueImport (Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/code/Symbol;Z)Z 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Check$$Lambda+0x000000080111f738
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkImportsUnique (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;)V 90 <appendix> argL0 ; # com/sun/tools/javac/comp/Check$$Lambda+0x000000080111f4e0
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter complete (Lcom/sun/tools/javac/code/Symbol;)V 191 <appendix> argL0 ; # com/sun/tools/javac/comp/TypeEnter$$Lambda+0x000000080111f2b8
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter defaultConstructor (Lcom/sun/tools/javac/tree/TreeMaker;Lcom/sun/tools/javac/comp/TypeEnter$DefaultConstructorHelper;)Lcom/sun/tools/javac/tree/JCTree; 144 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$$Lambda+0x000000080111f068
+instanceKlass com/sun/tools/javac/comp/TypeEnter$BasicConstructorHelper
+instanceKlass  @bci com/sun/tools/javac/code/Symbol$VarSymbol setLazyConstValue (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/comp/Attr;Lcom/sun/tools/javac/tree/JCTree$JCVariableDecl;)V 5 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symbol$VarSymbol$$Lambda+0x000000080111ebb0
+instanceKlass  @bci com/sun/tools/javac/code/Types$TypeMapping visit (Lcom/sun/tools/javac/util/List;Ljava/lang/Object;)Lcom/sun/tools/javac/util/List; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Types$TypeMapping$$Lambda+0x000000080111e960
+instanceKlass com/sun/tools/javac/util/Iterators$1
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope lambda$getSymbolsByName$3 (Lcom/sun/tools/javac/util/List;)Ljava/util/Iterator; 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000080111e498
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope lambda$getSymbolsByName$3 (Lcom/sun/tools/javac/util/List;)Ljava/util/Iterator; 1 <appendix> argL0 ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000080111e250
+instanceKlass  @cpi com/sun/tools/javac/code/Scope$FilterImportScope 171 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000080111c800
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 62 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000080111e000
+instanceKlass  @bci com/sun/tools/javac/code/Scope$CompoundScope lambda$getSymbolsByName$3 (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/util/Iterator; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$CompoundScope$$Lambda+0x000000080111bd00
+instanceKlass  @bci com/sun/tools/javac/code/Scope$CompoundScope getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$CompoundScope$$Lambda+0x000000080111bab0
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations validateTypeAnnotationsSignatures (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)V 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000080111b880
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations organizeTypeAnnotationsSignatures (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)V 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000080111b650
+instanceKlass  @bci com/sun/tools/javac/code/Scope$NamedImportScope lambda$getSymbolsByName$1 ([Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/util/Iterator; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$NamedImportScope$$Lambda+0x000000080111b400
+instanceKlass  @bci com/sun/tools/javac/code/Scope$NamedImportScope getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 29 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$NamedImportScope$$Lambda+0x000000080111b1b0
+instanceKlass com/sun/tools/javac/jvm/ClassReader$28
+instanceKlass java/lang/invoke/VarHandle$AccessDescriptor
+instanceKlass java/lang/invoke/VarForm
+instanceKlass java/lang/invoke/VarHandleGuards
+instanceKlass java/lang/ClassValue$Version
+instanceKlass java/lang/ClassValue$Identity
+instanceKlass java/lang/ClassValue
+instanceKlass java/lang/invoke/VarHandles
+instanceKlass jdk/internal/util/ByteArray
+instanceKlass java/io/DataInput
+instanceKlass  @bci com/sun/tools/javac/comp/Annotate queueScanTreeAndTypeAnnotate (Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;)V 12 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Annotate$$Lambda+0x000000080111ab20
+instanceKlass com/sun/tools/javac/code/Types$25
+instanceKlass com/sun/tools/javac/jvm/Code$1
+instanceKlass  @bci com/sun/tools/javac/jvm/PoolReader getType (I)Lcom/sun/tools/javac/code/Type; 14 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/PoolReader$$Lambda+0x0000000801119060
+instanceKlass  @bci com/sun/tools/javac/code/Scope$ScopeImpl remove (Lcom/sun/tools/javac/code/Symbol;)V 21 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$ScopeImpl$$Lambda+0x0000000801118e00
+instanceKlass  @bci java/util/stream/MatchOps makeRef (Ljava/util/function/Predicate;Ljava/util/stream/MatchOps$MatchKind;)Ljava/util/stream/TerminalOp; 20 <bsm> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000080111c400
+instanceKlass java/lang/invoke/MethodHandle$1
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader readInnerClasses (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 67 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x0000000801118bd0
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader readInnerClasses (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 41 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x00000008011189a0
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$11 read (Lcom/sun/tools/javac/code/Symbol;I)V 74 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$11$$Lambda+0x0000000801118208
+instanceKlass  @cpi com/sun/tools/javac/jvm/PoolReader 361 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000080111c000
+instanceKlass com/sun/tools/javac/util/Name$NameMapper
+instanceKlass  @bci com/sun/tools/javac/code/Symtab lookupPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;Z)Lcom/sun/tools/javac/code/Symbol$PackageSymbol; 112 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x0000000801111c00
+instanceKlass  @cpi com/sun/tools/javac/code/Symtab 1376 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801111800
+instanceKlass  @bci com/sun/tools/javac/code/Symtab lookupPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;Z)Lcom/sun/tools/javac/code/Symbol$PackageSymbol; 101 <appendix> argL0 ; # com/sun/tools/javac/code/Symtab$$Lambda+0x0000000801113bb8
+instanceKlass com/sun/tools/javac/tree/TreeMaker$2
+instanceKlass java/util/LinkedList$Node
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder classFileNotFound (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)Lcom/sun/tools/javac/code/Symbol$CompletionFailure; 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x0000000801113578
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder loadClass (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$ClassSymbol; 28 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x0000000801113348
+instanceKlass com/sun/tools/javac/comp/MatchBindingsComputer$1
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkDeprecated (Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/code/Symbol;)V 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Check$$Lambda+0x0000000801112f08
+instanceKlass com/sun/tools/javac/comp/Attr$13
+instanceKlass com/sun/tools/javac/code/Scope$FilterImportScope$SymbolImporter
+instanceKlass com/sun/tools/javac/code/ClassFinder$2
+instanceKlass java/util/stream/Node$Builder
+instanceKlass java/util/stream/Node$OfDouble
+instanceKlass java/util/stream/Node$OfLong
+instanceKlass java/util/stream/Node$OfInt
+instanceKlass java/util/stream/Node$OfPrimitive
+instanceKlass java/util/stream/Nodes$EmptyNode
+instanceKlass java/util/stream/Node
+instanceKlass java/util/stream/Nodes
+instanceKlass  @bci java/util/stream/ReferencePipeline toArray ()[Ljava/lang/Object; 1 <appendix> argL0 ; # java/util/stream/ReferencePipeline$$Lambda+0x0000000801063978
+instanceKlass java/util/ImmutableCollections$Access$1
+instanceKlass jdk/internal/access/JavaUtilCollectionAccess
+instanceKlass java/util/ImmutableCollections$Access
+instanceKlass  @bci java/nio/file/Files asUncheckedRunnable (Ljava/io/Closeable;)Ljava/lang/Runnable; 1 <appendix> member <vmtarget> ; # java/nio/file/Files$$Lambda+0x00000008010630f0
+instanceKlass java/nio/file/Files$2
+instanceKlass java/nio/file/Files$AcceptAllFilter
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$ImportsPhase resolveImports (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;Lcom/sun/tools/javac/comp/Env;)V 89 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$ImportsPhase$$Lambda+0x0000000801112230
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$ImportsPhase resolveImports (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;Lcom/sun/tools/javac/comp/Env;)V 77 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$ImportsPhase$$Lambda+0x0000000801112000
+instanceKlass com/sun/tools/javac/code/Scope$ImportFilter
+instanceKlass com/sun/tools/javac/code/Scope$ScopeImpl$2
+instanceKlass  @bci com/sun/tools/javac/code/Scope$ScopeImpl getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$ScopeImpl$$Lambda+0x0000000801117860
+instanceKlass com/sun/tools/javac/comp/Check$6
+instanceKlass com/sun/tools/javac/util/Pair
+instanceKlass com/sun/tools/javac/comp/AttrContext
+instanceKlass  @bci com/sun/tools/javac/comp/Enter visitTopLevel (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;)V 287 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Enter$$Lambda+0x0000000801116238
+instanceKlass  @cpi com/sun/tools/javac/comp/TypeEnter$ImportsPhase 646 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801111400
+instanceKlass  @bci com/sun/tools/javac/comp/Enter visitTopLevel (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;)V 273 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Enter$$Lambda+0x0000000801115fd8
+instanceKlass com/sun/tools/javac/code/Scope$ScopeImpl$1
+instanceKlass  @bci com/sun/tools/javac/code/Scope$ScopeImpl getSymbols (Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$ScopeImpl$$Lambda+0x0000000801115b10
+instanceKlass com/sun/tools/javac/code/ClassFinder$1
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder list (Ljavax/tools/JavaFileManager$Location;Lcom/sun/tools/javac/code/Symbol$PackageSymbol;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/Iterable; 26 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x0000000801115200
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager pathsAndContainers (Ljavax/tools/JavaFileManager$Location;Lcom/sun/tools/javac/file/RelativePath$RelativeDirectory;)Ljava/util/List; 22 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x0000000801114fb0
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager indexPathsAndContainersByRelativeDirectory (Ljavax/tools/JavaFileManager$Location;)Ljava/util/Map; 213 <appendix> argL0 ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x0000000801114d78
+instanceKlass  @cpi java/nio/file/Files 1114 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801111000
+instanceKlass com/sun/tools/javac/file/JavacFileManager$PathAndContainer
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager pathsAndContainers (Ljavax/tools/JavaFileManager$Location;Lcom/sun/tools/javac/file/RelativePath$RelativeDirectory;)Ljava/util/List; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x00000008011148e8
+instanceKlass java/util/RegularEnumSet$EnumSetIterator
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder fillIn (Lcom/sun/tools/javac/code/Symbol$PackageSymbol;)V 27 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x00000008011146b8
+instanceKlass  @bci com/sun/tools/javac/comp/Modules completeModule (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)V 327 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x0000000801114488
+instanceKlass  @bci com/sun/tools/javac/comp/Modules initVisiblePackages (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Ljava/util/Collection;)V 103 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x0000000801114248
+instanceKlass  @cpi com/sun/tools/javac/comp/Annotate 1383 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801110c00
+instanceKlass  @bci com/sun/tools/javac/comp/Modules initAddExports ()V 369 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x0000000801114000
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 22 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000044
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 17 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000042
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 12 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x80000003f
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 7 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x800000047
+instanceKlass java/util/StringJoiner
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 965 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110fcb8
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 955 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110fa60
+instanceKlass com/sun/tools/javac/jvm/ClassReader$AnnotationDeproxy
+instanceKlass com/sun/tools/javac/jvm/ClassReader$ProxyVisitor
+instanceKlass javax/lang/model/element/ModuleElement$OpensDirective
+instanceKlass  @bci java/util/stream/MatchOps makeRef (Ljava/util/function/Predicate;Ljava/util/stream/MatchOps$MatchKind;)Ljava/util/stream/TerminalOp; 20 <appendix> member <vmtarget> ; # java/util/stream/MatchOps$$Lambda+0x00000008010624e0
+instanceKlass java/util/stream/MatchOps$BooleanTerminalSink
+instanceKlass java/util/stream/MatchOps$MatchOp
+instanceKlass java/util/stream/MatchOps
+instanceKlass  @bci com/sun/tools/javac/comp/Modules lambda$setupAllModules$8 (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)Z 11 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110e910
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 403 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110e6b8
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 332 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110e460
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 288 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110e208
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 282 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110dfa8
+instanceKlass  @cpi com/sun/tools/javac/comp/Modules 1540 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801110800
+instanceKlass  @bci com/sun/tools/javac/comp/Modules completeModule (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)V 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110dd68
+instanceKlass com/sun/tools/javac/jvm/ClassReader$UsesProvidesCompleter
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader readClass (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 426 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000080110d8f8
+instanceKlass com/sun/tools/javac/jvm/ClassReader$InterimProvidesDirective
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 1005 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000080110d4b0
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 947 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000080110d280
+instanceKlass com/sun/tools/javac/jvm/ClassReader$InterimUsesDirective
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 858 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000080110ce38
+instanceKlass javax/lang/model/element/ModuleElement$ExportsDirective
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 170 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000080110c538
+instanceKlass  @cpi com/sun/tools/javac/jvm/ClassReader$24 376 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801110400
+instanceKlass java/util/function/IntFunction
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 58 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000080110c308
+instanceKlass  @cpi com/sun/tools/javac/jvm/ClassReader$24 369 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801110000
+instanceKlass com/sun/tools/javac/jvm/PoolReader$Utf8Mapper
+instanceKlass com/sun/tools/javac/jvm/ClassReader$SourceFileObject
+instanceKlass com/sun/tools/javac/jvm/PoolReader$ImmutablePoolHelper
+instanceKlass java/util/BitSet
+instanceKlass com/sun/tools/javac/jvm/PoolReader
+instanceKlass com/sun/tools/javac/comp/Modules$3
+instanceKlass com/sun/tools/javac/code/ModuleFinder$1
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_WORD ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x00000008010613f0
+instanceKlass jdk/internal/jrtfs/JrtFileAttributes
+instanceKlass  @bci java/util/stream/StreamSpliterators$WrappingSpliterator initPartialTraversalState ()V 37 <appendix> member <vmtarget> ; # java/util/stream/StreamSpliterators$WrappingSpliterator$$Lambda+0x000000080105fe18
+instanceKlass java/util/function/BooleanSupplier
+instanceKlass  @bci java/util/stream/StreamSpliterators$WrappingSpliterator initPartialTraversalState ()V 24 <appendix> member <vmtarget> ; # java/util/stream/StreamSpliterators$WrappingSpliterator$$Lambda+0x000000080105f958
+instanceKlass java/util/stream/StreamSpliterators
+instanceKlass java/util/stream/AbstractSpinedBuffer
+instanceKlass jdk/internal/jrtfs/JrtDirectoryStream$1
+instanceKlass java/util/stream/StreamSpliterators$AbstractWrappingSpliterator
+instanceKlass  @bci java/util/stream/AbstractPipeline spliterator ()Ljava/util/Spliterator; 103 <appendix> member <vmtarget> ; # java/util/stream/AbstractPipeline$$Lambda+0x000000080105e860
+instanceKlass  @bci jdk/internal/jrtfs/JrtFileSystem iteratorOf (Ljdk/internal/jrtfs/JrtPath;Ljava/nio/file/DirectoryStream$Filter;)Ljava/util/Iterator; 82 <appendix> member <vmtarget> ; # jdk/internal/jrtfs/JrtFileSystem$$Lambda+0x000000080105e600
+instanceKlass  @bci jdk/internal/jrtfs/JrtFileSystem iteratorOf (Ljdk/internal/jrtfs/JrtPath;Ljava/nio/file/DirectoryStream$Filter;)Ljava/util/Iterator; 71 <appendix> member <vmtarget> ; # jdk/internal/jrtfs/JrtFileSystem$$Lambda+0x000000080105e3b0
+instanceKlass java/util/ArrayList$ArrayListSpliterator
+instanceKlass  @bci jdk/internal/jimage/ImageReader$SharedImageReader handleModulesSubTree (Ljava/lang/String;Ljdk/internal/jimage/ImageLocation;)Ljdk/internal/jimage/ImageReader$Node; 37 <appendix> member <vmtarget> ; # jdk/internal/jimage/ImageReader$SharedImageReader$$Lambda+0x000000080105ddf0
+instanceKlass jdk/internal/jimage/ImageReader$SharedImageReader$LocationVisitor
+instanceKlass jdk/internal/jrtfs/JrtDirectoryStream
+instanceKlass  @bci com/sun/tools/javac/file/Locations$SystemModulesLocationHandler initSystemModules ()V 254 <appendix> argL0 ; # com/sun/tools/javac/file/Locations$SystemModulesLocationHandler$$Lambda+0x000000080110ad38
+instanceKlass com/sun/tools/javac/file/JavacFileManager$DirectoryContainer
+instanceKlass  @bci com/sun/tools/javac/comp/Modules initModules (Lcom/sun/tools/javac/util/List;)V 30 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000080110a638
+instanceKlass com/sun/tools/javac/tree/JCTree$1
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 19 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000080105d700
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000080105d4b0
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000080105d278
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000080105d050
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser merge (Lcom/sun/tools/javac/util/ListBuffer;Lcom/sun/tools/javac/util/ListBuffer;)Z 55 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x0000000801108c50
+instanceKlass com/sun/tools/javac/util/Position$LineMapImpl
+instanceKlass com/sun/tools/javac/util/Position$LineMap
+instanceKlass com/sun/tools/javac/util/Position
+instanceKlass  @bci com/sun/tools/javac/tree/TreeMaker TopLevel (Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit; 96 <appendix> member <vmtarget> ; # com/sun/tools/javac/tree/TreeMaker$$Lambda+0x0000000801106f70
+instanceKlass com/sun/tools/javac/tree/TreeInfo$2
+instanceKlass com/sun/tools/javac/tree/TreeInfo
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser arguments ()Lcom/sun/tools/javac/util/List; 80 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x0000000801106038
+instanceKlass com/sun/tools/javac/parser/JavacParser$2
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser accept (Lcom/sun/tools/javac/parser/Tokens$TokenKind;)V 2 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x0000000801105790
+instanceKlass com/sun/tools/javac/resources/CompilerProperties$Errors
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser <init> (Lcom/sun/tools/javac/parser/ParserFactory;Lcom/sun/tools/javac/parser/Lexer;ZZZZ)V 59 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x0000000801104820
+instanceKlass com/sun/tools/javac/parser/JavacParser$ErrorRecoveryAction
+instanceKlass com/sun/tools/javac/parser/JavacParser$AbstractEndPosTable
+instanceKlass com/sun/tools/javac/tree/EndPosTable
+instanceKlass com/sun/tools/javac/parser/JavacParser
+instanceKlass com/sun/tools/javac/parser/Scanner
+instanceKlass com/sun/source/tree/LineMap
+instanceKlass java/nio/file/attribute/FileTime
+instanceKlass com/sun/tools/javac/file/BaseFileManager$ContentCacheEntry
+instanceKlass java/nio/DirectByteBuffer$Deallocator
+instanceKlass sun/nio/ch/Util$BufferCache
+instanceKlass sun/nio/ch/Util
+instanceKlass sun/nio/ch/IOStatus
+instanceKlass sun/nio/ch/NativeThread
+instanceKlass java/nio/channels/NetworkChannel
+instanceKlass sun/nio/ch/SelChImpl
+instanceKlass sun/nio/ch/Streams
+instanceKlass java/nio/channels/Channels
+instanceKlass sun/nio/ch/FileChannelImpl$Closer
+instanceKlass sun/nio/ch/NativeThreadSet
+instanceKlass sun/nio/ch/IOUtil
+instanceKlass sun/nio/ch/NativeDispatcher
+instanceKlass sun/nio/fs/UnixChannelFactory$Flags
+instanceKlass sun/nio/fs/UnixChannelFactory
+instanceKlass sun/nio/fs/UnixFileModeAttribute
+instanceKlass com/sun/tools/javac/util/DiagnosticSource
+instanceKlass com/sun/tools/javac/main/JavaCompiler$InitialFileParser
+instanceKlass com/sun/tools/javac/main/JavaCompiler$InitialFileParserIntf
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$DiscoveredProcessors$ProcessorStateIterator
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$DiscoveredProcessors
+instanceKlass com/sun/tools/javac/util/Iterators$CompoundIterator
+instanceKlass  @bci com/sun/tools/javac/processing/JavacProcessingEnvironment initProcessorIterator (Ljava/lang/Iterable;)V 256 <appendix> argL0 ; # com/sun/tools/javac/processing/JavacProcessingEnvironment$$Lambda+0x0000000801100d00
+instanceKlass javax/annotation/processing/Processor
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$ServiceIterator
+instanceKlass com/sun/tools/javac/file/PathFileObject
+instanceKlass jdk/internal/loader/URLClassPath$Loader
+instanceKlass jdk/internal/loader/URLClassPath$3
+instanceKlass java/net/URLClassLoader$3$1
+instanceKlass java/net/URLClassLoader$3
+instanceKlass com/sun/tools/javac/file/JavacFileManager$3
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager asFiles (Ljava/lang/Iterable;)Ljava/lang/Iterable; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x00000008010ff4e8
+instanceKlass com/sun/tools/javac/model/JavacTypes
+instanceKlass com/sun/tools/javac/processing/JavacMessager
+instanceKlass java/util/Collections$SynchronizedMap
+instanceKlass java/util/Collections$SynchronizedCollection
+instanceKlass com/sun/tools/javac/processing/JavacFiler
+instanceKlass com/sun/tools/javac/util/ForwardingDiagnosticFormatter$ForwardingConfiguration
+instanceKlass com/sun/tools/javac/code/Types$DefaultSymbolVisitor
+instanceKlass com/sun/tools/javac/util/ForwardingDiagnosticFormatter
+instanceKlass  @bci com/sun/tools/javac/main/JavaCompiler <init> (Lcom/sun/tools/javac/util/Context;)V 400 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/JavaCompiler$$Lambda+0x00000008010fc0e8
+instanceKlass com/sun/tools/javac/code/ModuleFinder$ModuleNameFromSourceReader
+instanceKlass  @bci com/sun/tools/javac/main/JavaCompiler <init> (Lcom/sun/tools/javac/util/Context;)V 387 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/JavaCompiler$$Lambda+0x00000008010fbcb0
+instanceKlass com/sun/tools/javac/comp/Modules$PackageNameFinder
+instanceKlass com/sun/tools/javac/api/ClientCodeWrapper
+instanceKlass com/sun/tools/javac/api/MultiTaskListener
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder <init> (Lcom/sun/tools/javac/util/Context;)V 330 <appendix> argL0 ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x00000008010fb1a0
+instanceKlass jdk/internal/jimage/ImageReader$Node
+instanceKlass jdk/internal/jrtfs/SystemImage$2
+instanceKlass  @bci jdk/internal/jrtfs/SystemImage <clinit> ()V 0 <appendix> argL0 ; # jdk/internal/jrtfs/SystemImage$$Lambda+0x0000000801056b98
+instanceKlass jdk/internal/jrtfs/SystemImage
+instanceKlass jdk/internal/jrtfs/JrtPath
+instanceKlass java/nio/charset/CharsetDecoder
+instanceKlass java/util/TimSort
+instanceKlass java/util/Arrays$LegacyMergeSort
+instanceKlass java/util/AbstractMap$SimpleEntry
+instanceKlass jdk/internal/jimage/ImageBufferCache$2
+instanceKlass jdk/internal/jimage/ImageBufferCache
+instanceKlass jdk/internal/loader/Resource
+instanceKlass sun/net/www/ParseUtil
+instanceKlass sun/net/www/MessageHeader
+instanceKlass  @bci sun/net/www/protocol/jrt/JavaRuntimeURLConnection <clinit> ()V 0 <appendix> argL0 ; # sun/net/www/protocol/jrt/JavaRuntimeURLConnection$$Lambda+0x0000000801054288
+instanceKlass java/net/URLConnection
+instanceKlass jdk/internal/loader/URLClassPath$1
+instanceKlass java/lang/CompoundEnumeration
+instanceKlass jdk/internal/loader/BuiltinClassLoader$1
+instanceKlass java/util/Collections$EmptyEnumeration
+instanceKlass jdk/internal/loader/BuiltinClassLoader$2
+instanceKlass java/nio/channels/AsynchronousFileChannel
+instanceKlass java/nio/channels/AsynchronousChannel
+instanceKlass java/util/concurrent/ExecutorService
+instanceKlass java/util/concurrent/Executor
+instanceKlass java/nio/channels/spi/AbstractInterruptibleChannel
+instanceKlass java/nio/channels/InterruptibleChannel
+instanceKlass java/nio/channels/ScatteringByteChannel
+instanceKlass java/nio/channels/GatheringByteChannel
+instanceKlass java/nio/file/FileStore
+instanceKlass java/nio/file/DirectoryStream
+instanceKlass java/nio/file/DirectoryStream$Filter
+instanceKlass java/nio/channels/SeekableByteChannel
+instanceKlass java/nio/channels/ByteChannel
+instanceKlass java/nio/channels/WritableByteChannel
+instanceKlass java/nio/channels/ReadableByteChannel
+instanceKlass java/nio/channels/Channel
+instanceKlass java/nio/file/attribute/FileAttribute
+instanceKlass java/util/ServiceLoader$3
+instanceKlass java/nio/file/spi/FileSystemProvider$1
+instanceKlass com/sun/tools/javac/file/JRTIndex
+instanceKlass com/sun/tools/javac/jvm/ClassReader$AttributeReader
+instanceKlass com/sun/tools/javac/comp/Analyzer$2
+instanceKlass com/sun/tools/javac/comp/Analyzer$1
+instanceKlass com/sun/tools/javac/comp/Analyzer$StatementAnalyzer
+instanceKlass com/sun/tools/javac/comp/Analyzer$DeferredAnalysisHelper
+instanceKlass com/sun/tools/javac/comp/Analyzer
+instanceKlass  @bci com/sun/tools/javac/code/Symtab <init> (Lcom/sun/tools/javac/util/Context;)V 2295 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010f2ea0
+instanceKlass com/sun/tools/javac/code/Symtab$2
+instanceKlass com/sun/tools/javac/code/Symtab$1
+instanceKlass  @bci com/sun/tools/javac/code/Symtab doEnterClass (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 8 <appendix> argL0 ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010f2188
+instanceKlass  @bci com/sun/tools/javac/code/Symtab getClass (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$ClassSymbol; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010f1f58
+instanceKlass  @bci com/sun/tools/javac/code/Symtab enterPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$PackageSymbol; 29 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010f1d28
+instanceKlass com/sun/tools/javac/jvm/JNIWriter
+instanceKlass com/sun/tools/javac/jvm/Code
+instanceKlass com/sun/tools/javac/jvm/PoolWriter$WriteablePoolHelper
+instanceKlass com/sun/tools/javac/code/Types$SignatureGenerator
+instanceKlass com/sun/tools/javac/jvm/PoolWriter
+instanceKlass com/sun/tools/javac/code/Preview$1
+instanceKlass com/sun/tools/javac/comp/ConstFold
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initBinaryOperators ()V 1049 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x00000008010ef7b8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initBinaryOperators ()V 951 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x00000008010ef560
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initBinaryOperators ()V 855 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x00000008010ef308
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$BinaryNumericOperator <init> (Lcom/sun/tools/javac/comp/Operators;Lcom/sun/tools/javac/tree/JCTree$Tag;)V 3 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$BinaryNumericOperator$$Lambda+0x00000008010eee30
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$BinaryOperatorHelper addBinaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$BinaryOperatorHelper; 11 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000008010ec800
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$BinaryOperatorHelper addBinaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$BinaryOperatorHelper; 11 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Operators$BinaryOperatorHelper$$Lambda+0x00000008010ee980
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initUnaryOperators ()V 180 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x00000008010ebad8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$UnaryOperatorHelper addUnaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$UnaryOperatorHelper; 9 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000008010ec400
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$UnaryOperatorHelper addUnaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$UnaryOperatorHelper; 9 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Operators$UnaryOperatorHelper$$Lambda+0x00000008010eb8a8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 192 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010eb460
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 173 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010eb218
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 154 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010eafd0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 135 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010ead88
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 116 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010eab40
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 97 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010ea8f8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 79 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010ea6b0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 61 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010ea468
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 43 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010ea220
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 25 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010e9fd8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 7 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x00000008010e9d90
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$UnaryNumericOperator <init> (Lcom/sun/tools/javac/comp/Operators;Lcom/sun/tools/javac/tree/JCTree$Tag;)V 3 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$UnaryNumericOperator$$Lambda+0x00000008010e98e8
+instanceKlass  @cpi com/sun/tools/javac/comp/Operators$BinaryNumericOperator 72 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000008010ec000
+instanceKlass  @bci com/sun/tools/javac/code/Symbol$MethodSymbol <clinit> ()V 0 <appendix> argL0 ; # com/sun/tools/javac/code/Symbol$MethodSymbol$$Lambda+0x00000008010e9010
+instanceKlass com/sun/tools/javac/comp/Operators$OperatorHelper
+instanceKlass com/sun/tools/javac/comp/Operators
+instanceKlass com/sun/tools/javac/comp/Lower$EnumMapping
+instanceKlass com/sun/tools/javac/jvm/PoolConstant$Dynamic
+instanceKlass com/sun/tools/javac/jvm/StringConcat
+instanceKlass com/sun/tools/javac/jvm/Items$Item
+instanceKlass com/sun/tools/javac/jvm/Gen$GenFinalizer
+instanceKlass com/sun/tools/javac/jvm/ClassWriter$AttributeWriter
+instanceKlass com/sun/tools/javac/jvm/ClassFile
+instanceKlass com/sun/tools/javac/code/ModuleFinder$ModuleLocationIterator
+instanceKlass com/sun/tools/javac/code/ModuleFinder
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$3
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$2
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$1
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$Handler
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler
+instanceKlass com/sun/tools/javac/comp/Flow$PatternDescription
+instanceKlass com/sun/tools/javac/comp/Flow
+instanceKlass com/sun/tools/javac/comp/Infer$GraphStrategy
+instanceKlass com/sun/tools/javac/comp/InferenceContext
+instanceKlass com/sun/tools/javac/comp/Infer$IncorporationEngine
+instanceKlass com/sun/tools/javac/code/Type$UndetVar$UndetVarListener
+instanceKlass javax/lang/model/element/TypeParameterElement
+instanceKlass com/sun/tools/javac/comp/Infer
+instanceKlass com/sun/tools/javac/parser/UnicodeReader
+instanceKlass com/sun/tools/javac/parser/ScannerFactory
+instanceKlass com/sun/tools/javac/util/MandatoryWarningHandler
+instanceKlass com/sun/tools/javac/code/Preview
+instanceKlass com/sun/tools/javac/parser/Tokens$Token
+instanceKlass com/sun/tools/javac/parser/Tokens
+instanceKlass com/sun/tools/javac/tree/DocTreeMaker$SentenceBreaker
+instanceKlass com/sun/tools/javac/parser/ReferenceParser
+instanceKlass com/sun/tools/javac/model/JavacElements
+instanceKlass com/sun/source/doctree/DocTreeVisitor
+instanceKlass com/sun/tools/javac/tree/DocCommentTable
+instanceKlass com/sun/source/util/DocSourcePositions
+instanceKlass com/sun/source/tree/Scope
+instanceKlass com/sun/source/util/SourcePositions
+instanceKlass com/sun/source/doctree/AttributeTree
+instanceKlass com/sun/source/doctree/AuthorTree
+instanceKlass com/sun/source/doctree/CommentTree
+instanceKlass com/sun/source/doctree/DeprecatedTree
+instanceKlass com/sun/source/doctree/DocRootTree
+instanceKlass com/sun/source/doctree/DocTypeTree
+instanceKlass com/sun/source/doctree/EndElementTree
+instanceKlass com/sun/source/doctree/EntityTree
+instanceKlass com/sun/source/doctree/ErroneousTree
+instanceKlass com/sun/source/doctree/EscapeTree
+instanceKlass com/sun/source/doctree/HiddenTree
+instanceKlass com/sun/source/doctree/IdentifierTree
+instanceKlass com/sun/source/doctree/IndexTree
+instanceKlass com/sun/source/doctree/InheritDocTree
+instanceKlass com/sun/source/doctree/LinkTree
+instanceKlass com/sun/source/doctree/LiteralTree
+instanceKlass com/sun/source/doctree/ParamTree
+instanceKlass com/sun/source/doctree/ProvidesTree
+instanceKlass com/sun/source/doctree/SeeTree
+instanceKlass com/sun/source/doctree/SerialTree
+instanceKlass com/sun/source/doctree/SerialDataTree
+instanceKlass com/sun/source/doctree/SerialFieldTree
+instanceKlass com/sun/source/doctree/SinceTree
+instanceKlass com/sun/source/doctree/SnippetTree
+instanceKlass com/sun/source/doctree/SpecTree
+instanceKlass com/sun/source/doctree/StartElementTree
+instanceKlass com/sun/source/doctree/SummaryTree
+instanceKlass com/sun/source/doctree/SystemPropertyTree
+instanceKlass com/sun/source/doctree/TextTree
+instanceKlass com/sun/source/doctree/ThrowsTree
+instanceKlass com/sun/source/doctree/UnknownBlockTagTree
+instanceKlass com/sun/source/doctree/UnknownInlineTagTree
+instanceKlass com/sun/source/doctree/UsesTree
+instanceKlass com/sun/source/doctree/VersionTree
+instanceKlass com/sun/source/doctree/ValueTree
+instanceKlass com/sun/source/doctree/ReturnTree
+instanceKlass com/sun/source/doctree/InlineTagTree
+instanceKlass com/sun/source/doctree/BlockTagTree
+instanceKlass com/sun/source/doctree/ReferenceTree
+instanceKlass com/sun/source/doctree/DocCommentTree
+instanceKlass com/sun/source/doctree/DocTree
+instanceKlass com/sun/tools/javac/parser/Tokens$Comment
+instanceKlass com/sun/tools/javac/tree/DocTreeMaker
+instanceKlass com/sun/source/util/DocTreeFactory
+instanceKlass com/sun/tools/javac/parser/Lexer
+instanceKlass com/sun/tools/javac/parser/ParserFactory
+instanceKlass com/sun/tools/javac/util/Dependencies
+instanceKlass com/sun/tools/javac/comp/TypeEnvs
+instanceKlass com/sun/tools/javac/code/TypeAnnotations
+instanceKlass com/sun/tools/javac/code/DeferredLintHandler$1
+instanceKlass com/sun/tools/javac/code/DeferredLintHandler
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$ImportsPhase <init> (Lcom/sun/tools/javac/comp/TypeEnter;)V 23 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$ImportsPhase$$Lambda+0x00000008010d10b8
+instanceKlass com/sun/tools/javac/comp/TypeEnter$DefaultConstructorHelper
+instanceKlass com/sun/tools/javac/util/GraphUtils$DependencyKind
+instanceKlass com/sun/tools/javac/comp/TypeEnter$Phase
+instanceKlass com/sun/tools/javac/comp/TypeEnter
+instanceKlass  @bci com/sun/tools/javac/code/Types <init> (Lcom/sun/tools/javac/util/Context;)V 360 <appendix> argL0 ; # com/sun/tools/javac/code/Types$$Lambda+0x00000008010ce9a8
+instanceKlass java/util/function/BiPredicate
+instanceKlass com/sun/tools/javac/code/Types$CandidatesCache
+instanceKlass com/sun/tools/javac/code/Types$ImplementationCache
+instanceKlass com/sun/tools/javac/code/Types$3
+instanceKlass com/sun/tools/javac/code/Types$DescriptorCache
+instanceKlass com/sun/tools/javac/code/Types
+instanceKlass com/sun/tools/javac/tree/TreeMaker$AnnotationBuilder
+instanceKlass com/sun/tools/javac/tree/TreeMaker
+instanceKlass com/sun/tools/javac/tree/JCTree$Factory
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$4
+instanceKlass com/sun/tools/javac/tree/TreeCopier
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$DeferredAttrContext
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$DeferredStuckPolicy
+instanceKlass com/sun/tools/javac/comp/AttrRecover
+instanceKlass com/sun/tools/javac/comp/Resolve$ReferenceLookupResult
+instanceKlass com/sun/tools/javac/api/Formattable$LocalizedString
+instanceKlass com/sun/tools/javac/comp/Resolve$10
+instanceKlass com/sun/tools/javac/comp/Resolve$9
+instanceKlass com/sun/tools/javac/comp/Resolve$8
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve <init> (Lcom/sun/tools/javac/util/Context;)V 96 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x00000008010bf4a8
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve <init> (Lcom/sun/tools/javac/util/Context;)V 86 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x00000008010bf278
+instanceKlass com/sun/tools/javac/comp/Resolve$7
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve <init> (Lcom/sun/tools/javac/util/Context;)V 64 <appendix> argL0 ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x00000008010bee18
+instanceKlass com/sun/tools/javac/comp/Env
+instanceKlass com/sun/tools/javac/comp/Resolve$AbstractMethodCheck
+instanceKlass com/sun/tools/javac/comp/Resolve$2
+instanceKlass com/sun/tools/javac/code/Scope$ScopeListener
+instanceKlass com/sun/tools/javac/comp/Resolve$LookupHelper
+instanceKlass com/sun/tools/javac/comp/Resolve$ReferenceChooser
+instanceKlass com/sun/tools/javac/comp/Resolve$LogResolveHelper
+instanceKlass com/sun/tools/javac/comp/Resolve$RecoveryLoadClass
+instanceKlass com/sun/tools/javac/comp/Resolve
+instanceKlass  @bci com/sun/tools/javac/comp/Check <init> (Lcom/sun/tools/javac/util/Context;)V 62 <appendix> argL0 ; # com/sun/tools/javac/comp/Check$$Lambda+0x00000008010b7ca0
+instanceKlass com/sun/tools/javac/comp/Check$1
+instanceKlass com/sun/tools/javac/util/Warner
+instanceKlass com/sun/tools/javac/comp/Check
+instanceKlass com/sun/tools/javac/comp/Modules$1
+instanceKlass  @bci com/sun/tools/javac/comp/Modules <clinit> ()V 0 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x00000008010b3560
+instanceKlass  @cpi com/sun/tools/javac/comp/Modules 1618 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000008010b4000
+instanceKlass com/sun/tools/javac/util/Iterators
+instanceKlass com/sun/tools/javac/code/Directive
+instanceKlass javax/lang/model/element/ModuleElement$RequiresDirective
+instanceKlass javax/lang/model/element/ModuleElement$Directive
+instanceKlass  @bci com/sun/tools/javac/code/Symtab enterModule (Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$ModuleSymbol; 37 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010b1b70
+instanceKlass  @bci com/sun/tools/javac/code/Symtab addRootPackageFor (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)V 36 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010b1930
+instanceKlass  @bci com/sun/tools/javac/code/Symtab doEnterPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/code/Symbol$PackageSymbol;)V 8 <appendix> argL0 ; # com/sun/tools/javac/code/Symtab$$Lambda+0x00000008010b16e8
+instanceKlass com/sun/tools/javac/code/Scope$ScopeListenerList
+instanceKlass com/sun/tools/javac/code/Scope$Entry
+instanceKlass com/sun/tools/javac/comp/Annotate$AnnotationTypeMetadata
+instanceKlass com/sun/tools/javac/api/Formattable
+instanceKlass com/sun/tools/javac/code/Kinds$KindSelector
+instanceKlass com/sun/tools/javac/code/MissingInfoHandler
+instanceKlass com/sun/tools/javac/code/TypeMetadata
+instanceKlass javax/lang/model/type/NullType
+instanceKlass com/sun/tools/javac/code/Symtab
+instanceKlass com/sun/tools/javac/comp/MatchBindingsComputer$MatchBindings
+instanceKlass com/sun/source/util/SimpleTreeVisitor
+instanceKlass javax/lang/model/element/RecordComponentElement
+instanceKlass com/sun/tools/javac/comp/Check$NestedCheckContext
+instanceKlass javax/lang/model/type/IntersectionType
+instanceKlass javax/lang/model/type/UnionType
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodCheck
+instanceKlass com/sun/tools/javac/comp/Attr$ResultInfo
+instanceKlass com/sun/tools/javac/code/Types$DefaultTypeVisitor
+instanceKlass com/sun/tools/javac/comp/Annotate$2
+instanceKlass com/sun/tools/javac/comp/Check$CheckContext
+instanceKlass javax/lang/model/element/AnnotationMirror
+instanceKlass com/sun/tools/javac/comp/Annotate
+instanceKlass com/sun/tools/javac/util/ByteBuffer
+instanceKlass com/sun/tools/javac/code/Attribute
+instanceKlass javax/lang/model/element/AnnotationValue
+instanceKlass javax/lang/model/type/PrimitiveType
+instanceKlass com/sun/tools/javac/comp/Annotate$AnnotationTypeCompleter
+instanceKlass com/sun/tools/javac/jvm/ClassReader
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder <init> (Lcom/sun/tools/javac/util/Context;)V 23 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x0000000801093ae0
+instanceKlass com/sun/tools/javac/code/Scope
+instanceKlass com/sun/tools/javac/code/ClassFinder
+instanceKlass com/sun/tools/javac/util/Convert
+instanceKlass com/sun/tools/javac/util/ArrayUtils
+instanceKlass com/sun/tools/javac/util/Name
+instanceKlass javax/lang/model/element/Name
+instanceKlass com/sun/tools/javac/util/Name$Table
+instanceKlass com/sun/tools/javac/util/Names
+instanceKlass com/sun/tools/javac/code/Symbol$Completer$1
+instanceKlass  @bci com/sun/tools/javac/main/JavaCompiler <init> (Lcom/sun/tools/javac/util/Context;)V 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/JavaCompiler$$Lambda+0x0000000801090f10
+instanceKlass javax/lang/model/element/ModuleElement
+instanceKlass com/sun/tools/javac/parser/Parser
+instanceKlass javax/lang/model/element/PackageElement
+instanceKlass com/sun/tools/javac/main/JavaCompiler
+instanceKlass com/sun/tools/javac/code/Lint$AugmentVisitor
+instanceKlass com/sun/tools/javac/code/Attribute$Visitor
+instanceKlass com/sun/tools/javac/resources/CompilerProperties$Fragments
+instanceKlass com/sun/tools/javac/code/Symbol$Completer
+instanceKlass javax/lang/model/element/TypeElement
+instanceKlass javax/lang/model/element/QualifiedNameable
+instanceKlass com/sun/source/tree/IntersectionTypeTree
+instanceKlass com/sun/source/tree/UnionTypeTree
+instanceKlass com/sun/source/tree/ParameterizedTypeTree
+instanceKlass com/sun/source/tree/ArrayTypeTree
+instanceKlass com/sun/source/tree/PrimitiveTypeTree
+instanceKlass com/sun/source/tree/IdentifierTree
+instanceKlass com/sun/source/tree/MemberReferenceTree
+instanceKlass com/sun/source/tree/MemberSelectTree
+instanceKlass com/sun/source/tree/ArrayAccessTree
+instanceKlass com/sun/source/tree/DeconstructionPatternTree
+instanceKlass com/sun/source/tree/InstanceOfTree
+instanceKlass com/sun/source/tree/CompoundAssignmentTree
+instanceKlass com/sun/source/tree/AssignmentTree
+instanceKlass com/sun/source/tree/ParenthesizedTree
+instanceKlass com/sun/source/tree/LambdaExpressionTree
+instanceKlass com/sun/source/tree/MethodInvocationTree
+instanceKlass com/sun/source/tree/ExpressionStatementTree
+instanceKlass com/sun/source/tree/ConditionalExpressionTree
+instanceKlass com/sun/source/tree/LabeledStatementTree
+instanceKlass com/sun/source/tree/EnhancedForLoopTree
+instanceKlass com/sun/source/tree/DoWhileLoopTree
+instanceKlass com/sun/source/tree/EmptyStatementTree
+instanceKlass com/sun/source/tree/VariableTree
+instanceKlass com/sun/source/tree/MethodTree
+instanceKlass com/sun/source/tree/ClassTree
+instanceKlass com/sun/source/tree/ModuleTree
+instanceKlass com/sun/source/tree/PackageTree
+instanceKlass com/sun/source/tree/YieldTree
+instanceKlass com/sun/source/tree/ErroneousTree
+instanceKlass com/sun/source/tree/UsesTree
+instanceKlass com/sun/source/tree/RequiresTree
+instanceKlass com/sun/source/tree/ProvidesTree
+instanceKlass com/sun/source/tree/OpensTree
+instanceKlass com/sun/source/tree/ExportsTree
+instanceKlass com/sun/source/tree/DirectiveTree
+instanceKlass com/sun/source/tree/AnnotatedTypeTree
+instanceKlass com/sun/source/tree/ModifiersTree
+instanceKlass com/sun/source/tree/TypeParameterTree
+instanceKlass com/sun/source/tree/LiteralTree
+instanceKlass com/sun/source/tree/PatternCaseLabelTree
+instanceKlass com/sun/source/tree/ConstantCaseLabelTree
+instanceKlass com/sun/source/tree/DefaultCaseLabelTree
+instanceKlass com/sun/source/tree/CaseLabelTree
+instanceKlass com/sun/source/tree/BindingPatternTree
+instanceKlass com/sun/source/tree/StringTemplateTree
+instanceKlass com/sun/source/tree/AnyPatternTree
+instanceKlass com/sun/source/tree/PatternTree
+instanceKlass com/sun/source/tree/TypeCastTree
+instanceKlass com/sun/source/tree/BinaryTree
+instanceKlass com/sun/source/tree/UnaryTree
+instanceKlass com/sun/source/tree/NewArrayTree
+instanceKlass com/sun/source/tree/NewClassTree
+instanceKlass com/sun/source/tree/AssertTree
+instanceKlass com/sun/source/tree/ThrowTree
+instanceKlass com/sun/source/tree/ReturnTree
+instanceKlass com/sun/source/tree/ContinueTree
+instanceKlass com/sun/source/tree/BreakTree
+instanceKlass com/sun/source/tree/IfTree
+instanceKlass com/sun/source/tree/CatchTree
+instanceKlass com/sun/source/tree/TryTree
+instanceKlass com/sun/source/tree/SynchronizedTree
+instanceKlass com/sun/source/tree/CaseTree
+instanceKlass com/sun/source/tree/SwitchExpressionTree
+instanceKlass com/sun/source/tree/SwitchTree
+instanceKlass com/sun/source/tree/ForLoopTree
+instanceKlass com/sun/source/tree/WhileLoopTree
+instanceKlass com/sun/source/tree/ImportTree
+instanceKlass com/sun/source/tree/BlockTree
+instanceKlass com/sun/source/tree/StatementTree
+instanceKlass com/sun/source/tree/WildcardTree
+instanceKlass com/sun/source/tree/AnnotationTree
+instanceKlass  @bci java/util/regex/Pattern ALL ()Ljava/util/regex/Pattern$CharPredicate; 0 <appendix> argL0 ; # java/util/regex/Pattern$$Lambda+0x000000080104de18
+instanceKlass javax/annotation/processing/Messager
+instanceKlass javax/annotation/processing/RoundEnvironment
+instanceKlass javax/annotation/processing/Filer
+instanceKlass com/sun/tools/javac/tree/JCTree$Visitor
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment
+instanceKlass javax/annotation/processing/ProcessingEnvironment
+instanceKlass java/util/Collections$EmptyIterator
+instanceKlass com/sun/tools/javac/platform/PlatformDescription
+instanceKlass  @bci javax/lang/model/SourceVersion getLatestSupported ()Ljavax/lang/model/SourceVersion; 19 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x0000000801031800
+instanceKlass  @bci javax/lang/model/SourceVersion getLatestSupported ()Ljavax/lang/model/SourceVersion; 19 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x0000000801031400
+instanceKlass java/lang/invoke/MethodHandles$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x0000000801031000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x0000000801030c00
+instanceKlass  @bci javax/lang/model/SourceVersion getLatestSupported ()Ljavax/lang/model/SourceVersion; 19 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x0000000801030800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x0000000801030400
+instanceKlass java/lang/Runtime$Version
+instanceKlass  @bci com/sun/tools/javac/main/Arguments validate ()Z 1359 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x0000000801034000
+instanceKlass java/util/stream/ForEachOps$ForEachOp
+instanceKlass java/util/stream/ForEachOps
+instanceKlass  @bci com/sun/tools/javac/main/Arguments checkOptionAllowed (ZLcom/sun/tools/javac/main/Arguments$ErrorReporter;[Lcom/sun/tools/javac/main/Option;)V 33 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x0000000801029d28
+instanceKlass  @cpi com/sun/tools/javac/code/Symtab 1365 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801030000
+instanceKlass  @bci com/sun/tools/javac/main/Arguments checkOptionAllowed (ZLcom/sun/tools/javac/main/Arguments$ErrorReporter;[Lcom/sun/tools/javac/main/Option;)V 17 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x0000000801029ac8
+instanceKlass  @cpi com/sun/tools/javac/comp/Check 4208 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801028c00
+instanceKlass  @bci com/sun/tools/javac/main/Arguments validate ()Z 1269 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x0000000801029898
+instanceKlass java/util/Collections$1
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo isFile (Ljava/nio/file/Path;)Z 5 <appendix> argL0 ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x0000000801029250
+instanceKlass  @cpi com/sun/tools/javac/file/CacheFSInfo 178 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801028800
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo getCanonicalFile (Ljava/nio/file/Path;)Ljava/nio/file/Path; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x0000000801029000
+instanceKlass sun/nio/fs/UnixFileAttributes$UnixAsBasicFileAttributes
+instanceKlass sun/nio/fs/AbstractBasicFileAttributeView
+instanceKlass sun/nio/fs/DynamicFileAttributeView
+instanceKlass sun/nio/fs/UnixFileAttributeViews
+instanceKlass java/nio/file/attribute/UserDefinedFileAttributeView
+instanceKlass java/nio/file/attribute/DosFileAttributeView
+instanceKlass java/nio/file/attribute/BasicFileAttributeView
+instanceKlass java/nio/file/attribute/FileAttributeView
+instanceKlass java/nio/file/attribute/AttributeView
+instanceKlass java/nio/file/attribute/DosFileAttributes
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo getAttributes (Ljava/nio/file/Path;)Ljava/util/Optional; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x000000080102fbe0
+instanceKlass  @cpi com/sun/tools/javac/comp/TypeEnter 825 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801028400
+instanceKlass com/sun/tools/javac/util/ListBuffer$1
+instanceKlass com/sun/tools/javac/file/BaseFileManager$3
+instanceKlass java/util/LinkedHashMap$LinkedHashIterator
+instanceKlass com/sun/tools/javac/main/DelegatingJavaFileManager
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager <init> (Lcom/sun/tools/javac/util/Context;ZLjava/nio/charset/Charset;)V 6 <appendix> argL0 ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000080102e6d0
+instanceKlass com/sun/tools/javac/file/Locations$ModuleTable
+instanceKlass  @bci com/sun/tools/javac/file/Locations$ModuleSourcePathLocationHandler <init> (Lcom/sun/tools/javac/file/Locations;)V 23 <appendix> argL0 ; # com/sun/tools/javac/file/Locations$ModuleSourcePathLocationHandler$$Lambda+0x000000080102dc70
+instanceKlass  @bci com/sun/tools/javac/file/Locations <init> ()V 5 <appendix> argL0 ; # com/sun/tools/javac/file/Locations$$Lambda+0x000000080102cdc0
+instanceKlass javax/tools/StandardJavaFileManager$PathFactory
+instanceKlass com/sun/tools/javac/file/Locations$LocationHandler
+instanceKlass com/sun/tools/javac/file/Locations
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo preRegister (Lcom/sun/tools/javac/util/Context;)V 3 <appendix> argL0 ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x0000000801021b40
+instanceKlass com/sun/tools/javac/file/FSInfo
+instanceKlass  @bci com/sun/tools/javac/main/Arguments handleReleaseOptions (Ljava/util/function/Predicate;)Z 22 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x0000000801021468
+instanceKlass com/sun/tools/javac/main/Arguments$ErrorReporter
+instanceKlass  @bci com/sun/tools/javac/main/Arguments processArgs (Ljava/lang/Iterable;Ljava/util/Set;Lcom/sun/tools/javac/main/OptionHelper;ZZ)Z 24 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x0000000801028000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x0000000801020c00
+instanceKlass  @bci com/sun/tools/javac/main/Arguments processArgs (Ljava/lang/Iterable;Ljava/util/Set;Lcom/sun/tools/javac/main/OptionHelper;ZZ)Z 24 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801020800
+instanceKlass  @bci com/sun/tools/javac/main/Arguments processArgs (Ljava/lang/Iterable;Ljava/util/Set;Lcom/sun/tools/javac/main/OptionHelper;ZZ)Z 24 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x0000000801021000
+instanceKlass  @cpi com/sun/tools/javac/main/Arguments 1127 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801020400
+instanceKlass sun/nio/fs/NativeBuffer$Deallocator
+instanceKlass sun/nio/fs/NativeBuffer
+instanceKlass java/lang/ThreadLocal$ThreadLocalMap
+instanceKlass java/lang/ThreadLocal
+instanceKlass sun/nio/fs/NativeBuffers
+instanceKlass java/nio/file/Files
+instanceKlass java/nio/file/CopyOption
+instanceKlass  @bci java/util/regex/Pattern DOT ()Ljava/util/regex/Pattern$CharPredicate; 0 <appendix> argL0 ; # java/util/regex/Pattern$$Lambda+0x000000080104c588
+instanceKlass  @bci java/util/regex/Pattern Single (I)Ljava/util/regex/Pattern$BmpCharPredicate; 1 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x80000002a
+instanceKlass  @bci java/util/regex/Pattern negate (Ljava/util/regex/Pattern$CharPredicate;)Ljava/util/regex/Pattern$CharPredicate; 1 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000032
+instanceKlass java/util/regex/Pattern$BitClass
+instanceKlass com/sun/tools/doclint/DocLint$1
+instanceKlass java/util/ServiceLoader$ProviderImpl
+instanceKlass java/util/ServiceLoader$1
+instanceKlass java/security/PrivilegedExceptionAction
+instanceKlass com/sun/source/tree/CompilationUnitTree
+instanceKlass com/sun/source/util/TreePath
+instanceKlass com/sun/source/util/JavacTask
+instanceKlass javax/tools/JavaCompiler$CompilationTask
+instanceKlass java/util/concurrent/Callable
+instanceKlass javax/lang/model/util/Types
+instanceKlass javax/lang/model/util/Elements
+instanceKlass com/sun/source/util/Trees
+instanceKlass com/sun/source/util/TaskListener
+instanceKlass com/sun/source/util/TreeScanner
+instanceKlass com/sun/source/tree/TreeVisitor
+instanceKlass  @bci com/sun/tools/doclint/DocLint newDocLint ()Lcom/sun/tools/doclint/DocLint; 17 <appendix> argL0 ; # com/sun/tools/doclint/DocLint$$Lambda+0x00000008010259f8
+instanceKlass java/util/ServiceLoader$Provider
+instanceKlass java/util/ServiceLoader$ProviderSpliterator
+instanceKlass java/util/ServiceLoader$2
+instanceKlass java/util/ServiceLoader$LazyClassPathLookupIterator
+instanceKlass java/util/concurrent/CopyOnWriteArrayList$COWIterator
+instanceKlass java/util/Spliterators$1Adapter
+instanceKlass java/util/ServiceLoader$ModuleServicesLookupIterator
+instanceKlass java/util/ServiceLoader
+instanceKlass com/sun/tools/doclint/DocLint
+instanceKlass com/sun/source/util/Plugin
+instanceKlass java/util/JumboEnumSet$EnumSetIterator
+instanceKlass com/sun/tools/javac/main/Arguments
+instanceKlass java/lang/Process
+instanceKlass java/lang/ProcessEnvironment$ExternalData
+instanceKlass java/lang/ProcessEnvironment
+instanceKlass java/io/Reader
+instanceKlass java/lang/Readable
+instanceKlass jdk/internal/opt/CommandLine
+instanceKlass  @bci com/sun/tools/javac/util/Log <init> (Lcom/sun/tools/javac/util/Context;Ljava/util/Map;)V 124 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Log$$Lambda+0x0000000801024350
+instanceKlass javax/tools/DiagnosticListener
+instanceKlass  @bci com/sun/tools/javac/util/JCDiagnostic$Factory <init> (Lcom/sun/tools/javac/util/Context;)V 31 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/JCDiagnostic$Factory$$Lambda+0x000000080101fd88
+instanceKlass com/sun/tools/javac/util/JCDiagnostic
+instanceKlass  @cpi com/sun/tools/javac/code/Symtab 1394 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x0000000801020000
+instanceKlass javax/lang/model/element/ExecutableElement
+instanceKlass javax/lang/model/element/Parameterizable
+instanceKlass javax/lang/model/element/VariableElement
+instanceKlass javax/lang/model/type/ArrayType
+instanceKlass javax/lang/model/type/NoType
+instanceKlass javax/lang/model/type/WildcardType
+instanceKlass javax/lang/model/type/TypeVariable
+instanceKlass javax/lang/model/type/ExecutableType
+instanceKlass com/sun/tools/javac/jvm/PoolConstant$LoadableConstant
+instanceKlass javax/lang/model/type/ErrorType
+instanceKlass javax/lang/model/type/DeclaredType
+instanceKlass javax/lang/model/type/ReferenceType
+instanceKlass javax/lang/model/type/TypeMirror
+instanceKlass com/sun/tools/javac/code/AnnoConstruct
+instanceKlass javax/lang/model/element/Element
+instanceKlass javax/lang/model/AnnotatedConstruct
+instanceKlass com/sun/tools/javac/jvm/PoolConstant
+instanceKlass com/sun/tools/javac/util/AbstractDiagnosticFormatter$SimpleConfiguration
+instanceKlass com/sun/source/tree/ExpressionTree
+instanceKlass com/sun/tools/javac/tree/JCTree
+instanceKlass com/sun/source/tree/Tree
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter$Configuration
+instanceKlass com/sun/tools/javac/code/Printer
+instanceKlass com/sun/tools/javac/code/Symbol$Visitor
+instanceKlass com/sun/tools/javac/code/Type$Visitor
+instanceKlass com/sun/tools/javac/util/AbstractDiagnosticFormatter
+instanceKlass com/sun/tools/javac/util/Options
+instanceKlass  @bci jdk/internal/module/SystemModuleFinders$SystemModuleReader open (Ljava/lang/String;)Ljava/util/Optional; 6 <appendix> member <vmtarget> ; # jdk/internal/module/SystemModuleFinders$SystemModuleReader$$Lambda+0x0000000801049bb8
+instanceKlass jdk/internal/module/Checks
+instanceKlass jdk/internal/module/Resources
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleProviderHelper loadPropertyResourceBundle (Ljava/lang/Module;Ljava/lang/Module;Ljava/lang/String;Ljava/util/Locale;)Ljava/util/ResourceBundle; 14 <appendix> member <vmtarget> ; # java/util/ResourceBundle$ResourceBundleProviderHelper$$Lambda+0x0000000801049988
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleProviderHelper newResourceBundle (Ljava/lang/Class;)Ljava/util/ResourceBundle; 22 <appendix> member <vmtarget> ; # java/util/ResourceBundle$ResourceBundleProviderHelper$$Lambda+0x800000012
+instanceKlass java/security/Security$1
+instanceKlass jdk/internal/access/JavaSecurityPropertiesAccess
+instanceKlass java/util/concurrent/ConcurrentHashMap$MapEntry
+instanceKlass java/io/FileInputStream$1
+instanceKlass java/lang/StringUTF16
+instanceKlass java/util/Properties$LineReader
+instanceKlass  @bci java/security/Security <clinit> ()V 9 <appendix> argL0 ; # java/security/Security$$Lambda+0x80000000b
+instanceKlass java/security/Security
+instanceKlass sun/security/util/SecurityProperties
+instanceKlass sun/security/util/FilePermCompat
+instanceKlass sun/security/util/SecurityConstants
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleProviderHelper loadResourceBundle (Ljava/lang/Module;Ljava/lang/Module;Ljava/lang/String;Ljava/util/Locale;)Ljava/util/ResourceBundle; 13 <appendix> member <vmtarget> ; # java/util/ResourceBundle$ResourceBundleProviderHelper$$Lambda+0x0000000801048570
+instanceKlass java/util/ResourceBundle$ResourceBundleProviderHelper
+instanceKlass java/util/ResourceBundle$3
+instanceKlass java/util/ResourceBundle$CacheKeyReference
+instanceKlass java/util/ResourceBundle$CacheKey
+instanceKlass  @bci java/util/ResourceBundle getLoader (Ljava/lang/Module;)Ljava/lang/ClassLoader; 6 <appendix> member <vmtarget> ; # java/util/ResourceBundle$$Lambda+0x0000000801047a68
+instanceKlass sun/util/locale/LocaleObjectCache
+instanceKlass java/util/ResourceBundle$Control
+instanceKlass java/util/ResourceBundle$1
+instanceKlass jdk/internal/access/JavaUtilResourceBundleAccess
+instanceKlass com/sun/tools/javac/util/List$2
+instanceKlass sun/util/locale/LocaleUtils
+instanceKlass  @bci com/sun/tools/javac/util/JavacMessages add (Ljava/lang/String;)V 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/JavacMessages$$Lambda+0x00000008010163b0
+instanceKlass java/util/ResourceBundle
+instanceKlass com/sun/tools/javac/util/JavacMessages$ResourceBundleHelper
+instanceKlass java/util/Locale
+instanceKlass com/sun/tools/javac/util/JavacMessages
+instanceKlass com/sun/tools/javac/api/Messages
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$Factory
+instanceKlass java/io/PrintWriter$1
+instanceKlass jdk/internal/access/JavaIOPrintWriterAccess
+instanceKlass javax/tools/Diagnostic
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter
+instanceKlass com/sun/tools/javac/util/Log$DiagnosticHandler
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition
+instanceKlass com/sun/tools/javac/util/AbstractLog
+instanceKlass jdk/internal/foreign/MemorySessionImpl
+instanceKlass java/lang/foreign/MemorySegment$Scope
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager preRegister (Lcom/sun/tools/javac/util/Context;)V 3 <appendix> argL0 ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000080100ed88
+instanceKlass sun/invoke/util/VerifyAccess$1
+instanceKlass com/sun/tools/javac/util/Context$Factory
+instanceKlass com/sun/tools/javac/file/JavacFileManager$1
+instanceKlass  @bci java/util/stream/Collectors toCollection (Ljava/util/function/Supplier;)Ljava/util/stream/Collector; 10 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x0000000801045d08
+instanceKlass  @bci java/util/stream/Collectors toCollection (Ljava/util/function/Supplier;)Ljava/util/stream/Collector; 5 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x0000000801045ad0
+instanceKlass  @bci com/sun/tools/javac/main/Option getOptions (Lcom/sun/tools/javac/main/Option$OptionGroup;)Ljava/util/Set; 17 <appendix> argL0 ; # com/sun/tools/javac/main/Option$$Lambda+0x000000080100e6e8
+instanceKlass  @bci com/sun/tools/javac/main/Option getOptions (Lcom/sun/tools/javac/main/Option$OptionGroup;)Ljava/util/Set; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Option$$Lambda+0x000000080100e488
+instanceKlass java/util/Spliterators$ArraySpliterator
+instanceKlass com/sun/tools/javac/util/Context$Key
+instanceKlass com/sun/tools/javac/code/Lint
+instanceKlass java/util/Arrays$ArrayItr
+instanceKlass com/sun/tools/javac/util/Assert
+instanceKlass java/util/regex/ASCII
+instanceKlass java/util/regex/IntHashSet
+instanceKlass java/util/regex/Matcher
+instanceKlass java/util/regex/MatchResult
+instanceKlass java/util/regex/Pattern$TreeInfo
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_SPACE ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x800000027
+instanceKlass java/util/regex/Pattern$BmpCharPredicate
+instanceKlass java/util/regex/Pattern$CharPredicate
+instanceKlass java/util/regex/CharPredicates
+instanceKlass java/util/regex/Pattern$Node
+instanceKlass java/util/regex/Pattern
+instanceKlass com/sun/tools/javac/file/RelativePath
+instanceKlass javax/tools/JavaFileObject
+instanceKlass javax/tools/JavaFileManager$Location
+instanceKlass javax/tools/FileObject
+instanceKlass com/sun/tools/javac/file/JavacFileManager$Container
+instanceKlass com/sun/tools/javac/file/BaseFileManager
+instanceKlass javax/tools/StandardJavaFileManager
+instanceKlass javax/tools/JavaFileManager
+instanceKlass javax/tools/OptionChecker
+instanceKlass com/sun/tools/javac/util/Context
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticInfo
+instanceKlass com/sun/tools/javac/main/OptionHelper
+instanceKlass com/sun/tools/javac/main/Main
+instanceKlass java/lang/NamedPackage
+instanceKlass com/sun/tools/javac/Main
+instanceKlass sun/security/util/Debug
+instanceKlass java/security/SecureClassLoader$DebugHolder
+instanceKlass java/security/Permission
+instanceKlass java/security/Guard
+instanceKlass java/security/PermissionCollection
+instanceKlass java/security/SecureClassLoader$1
+instanceKlass sun/net/util/URLUtil
+instanceKlass sun/net/util/IPAddressUtil$MASKS
+instanceKlass sun/net/util/IPAddressUtil
+instanceKlass java/net/URLStreamHandler
+instanceKlass jdk/internal/jimage/ImageLocation
+instanceKlass jdk/internal/jimage/decompressor/Decompressor
+instanceKlass jdk/internal/jimage/ImageStringsReader
+instanceKlass jdk/internal/jimage/ImageStrings
+instanceKlass jdk/internal/jimage/ImageHeader
+instanceKlass java/nio/Bits$1
+instanceKlass jdk/internal/misc/VM$BufferPool
+instanceKlass java/nio/Bits
+instanceKlass sun/nio/ch/DirectBuffer
+instanceKlass jdk/internal/jimage/NativeImageBuffer$1
+instanceKlass jdk/internal/jimage/NativeImageBuffer
+instanceKlass jdk/internal/jimage/BasicImageReader$1
+instanceKlass jdk/internal/jimage/BasicImageReader
+instanceKlass jdk/internal/jimage/ImageReader
+instanceKlass jdk/internal/jimage/ImageReaderFactory$1
+instanceKlass java/net/URI$Parser
+instanceKlass sun/nio/fs/UnixMountEntry
+instanceKlass sun/nio/fs/UnixFileStoreAttributes
+instanceKlass sun/nio/fs/UnixFileAttributes
+instanceKlass java/nio/file/attribute/PosixFileAttributes
+instanceKlass java/nio/file/attribute/BasicFileAttributes
+instanceKlass java/util/Enumeration
+instanceKlass java/util/concurrent/ConcurrentHashMap$Traverser
+instanceKlass jdk/internal/loader/NativeLibraries$3
+instanceKlass jdk/internal/loader/NativeLibrary
+instanceKlass java/util/ArrayDeque$DeqIterator
+instanceKlass jdk/internal/loader/NativeLibraries$NativeLibraryContext$1
+instanceKlass jdk/internal/loader/NativeLibraries$NativeLibraryContext
+instanceKlass jdk/internal/loader/NativeLibraries$2
+instanceKlass jdk/internal/loader/NativeLibraries$1
+instanceKlass jdk/internal/loader/NativeLibraries$LibraryPaths
+instanceKlass sun/nio/fs/UnixNativeDispatcher
+instanceKlass sun/nio/fs/Util
+instanceKlass sun/nio/fs/UnixPath
+instanceKlass java/nio/file/FileSystem
+instanceKlass java/nio/file/OpenOption
+instanceKlass java/nio/file/spi/FileSystemProvider
+instanceKlass sun/nio/fs/DefaultFileSystemProvider
+instanceKlass java/nio/file/FileSystems$DefaultFileSystemHolder$1
+instanceKlass java/nio/file/FileSystems$DefaultFileSystemHolder
+instanceKlass java/nio/file/FileSystems
+instanceKlass java/nio/file/Paths
+instanceKlass jdk/internal/jimage/ImageReaderFactory
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemImage
+instanceKlass jdk/internal/module/ModulePatcher$PatchedModuleReader
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemModuleReader
+instanceKlass java/lang/module/ModuleReader
+instanceKlass jdk/internal/loader/BuiltinClassLoader$5
+instanceKlass sun/launcher/LauncherHelper
+instanceKlass java/lang/invoke/StringConcatFactory
+instanceKlass jdk/internal/module/ModuleBootstrap$SafeModuleFinder
+instanceKlass java/lang/ModuleLayer$Controller
+instanceKlass java/util/concurrent/CopyOnWriteArrayList
+instanceKlass jdk/internal/module/ServicesCatalog$ServiceProvider
+instanceKlass jdk/internal/loader/AbstractClassLoaderValue$Memoizer
+instanceKlass jdk/internal/module/ModuleLoaderMap$Modules
+instanceKlass jdk/internal/module/ModuleLoaderMap
+instanceKlass java/util/Collections$UnmodifiableCollection$1
+instanceKlass java/util/SequencedMap
+instanceKlass java/util/SequencedSet
+instanceKlass java/util/ImmutableCollections$ListItr
+instanceKlass java/util/ListIterator
+instanceKlass java/lang/module/ModuleFinder$1
+instanceKlass java/nio/file/Path
+instanceKlass java/nio/file/Watchable
+instanceKlass java/lang/module/Resolver
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 43 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x80000004d
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 38 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x80000004f
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 16 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x80000004e
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 11 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x800000050
+instanceKlass java/util/stream/FindOps$FindOp
+instanceKlass java/util/stream/FindOps$FindSink
+instanceKlass java/util/stream/FindOps
+instanceKlass  @bci jdk/internal/module/DefaultRoots exportsAPI (Ljava/lang/module/ModuleDescriptor;)Z 9 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000056
+instanceKlass java/util/stream/Sink$ChainedReference
+instanceKlass java/util/stream/ReduceOps$AccumulatingSink
+instanceKlass java/util/stream/TerminalSink
+instanceKlass java/util/stream/Sink
+instanceKlass java/util/function/Consumer
+instanceKlass java/util/stream/ReduceOps$Box
+instanceKlass java/util/stream/ReduceOps$ReduceOp
+instanceKlass java/util/stream/TerminalOp
+instanceKlass java/util/stream/ReduceOps
+instanceKlass  @bci java/util/stream/Collectors castingIdentity ()Ljava/util/function/Function; 0 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000043
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000041
+instanceKlass java/util/function/BinaryOperator
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x80000003a
+instanceKlass java/util/function/BiConsumer
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000046
+instanceKlass java/util/stream/Collector
+instanceKlass java/util/Collections$UnmodifiableCollection
+instanceKlass java/util/stream/Collectors
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 42 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000053
+instanceKlass java/util/concurrent/ForkJoinPool$ManagedBlocker
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 32 <appendix> member <vmtarget> ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000057
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer$Node
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 21 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000054
+instanceKlass java/lang/ref/Cleaner$Cleanable
+instanceKlass jdk/internal/ref/CleanerImpl
+instanceKlass java/lang/ref/Cleaner$1
+instanceKlass java/lang/ref/Cleaner
+instanceKlass jdk/internal/ref/CleanerFactory$1
+instanceKlass java/util/concurrent/ThreadFactory
+instanceKlass jdk/internal/ref/CleanerFactory
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser <init> (Lcom/sun/tools/javac/parser/ParserFactory;Lcom/sun/tools/javac/parser/Lexer;ZZZZ)V 59 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x0000000801000800
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 11 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000055
+instanceKlass java/lang/invoke/LambdaProxyClassArchive
+instanceKlass java/lang/invoke/InfoFromMemberName
+instanceKlass java/lang/invoke/MethodHandleInfo
+instanceKlass jdk/internal/org/objectweb/asm/ConstantDynamic
+instanceKlass jdk/internal/org/objectweb/asm/Handle
+instanceKlass sun/security/action/GetBooleanAction
+instanceKlass java/lang/invoke/AbstractValidatingLambdaMetafactory
+instanceKlass java/lang/invoke/BootstrapMethodInvoker
+instanceKlass java/util/function/Predicate
+instanceKlass java/lang/WeakPairMap$Pair$Lookup
+instanceKlass java/lang/WeakPairMap$Pair
+instanceKlass java/lang/WeakPairMap
+instanceKlass java/lang/Module$ReflectionData
+instanceKlass java/lang/invoke/LambdaMetafactory
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x0000000801000400
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassDefiner
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassFile
+instanceKlass jdk/internal/org/objectweb/asm/Handler
+instanceKlass jdk/internal/org/objectweb/asm/Attribute
+instanceKlass jdk/internal/org/objectweb/asm/FieldVisitor
+instanceKlass java/util/ArrayList$Itr
+instanceKlass sun/invoke/empty/Empty
+instanceKlass sun/invoke/util/VerifyType
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$ClassData
+instanceKlass jdk/internal/org/objectweb/asm/AnnotationVisitor
+instanceKlass jdk/internal/org/objectweb/asm/Frame
+instanceKlass jdk/internal/org/objectweb/asm/Label
+instanceKlass jdk/internal/org/objectweb/asm/Type
+instanceKlass jdk/internal/org/objectweb/asm/MethodVisitor
+instanceKlass sun/invoke/util/BytecodeDescriptor
+instanceKlass jdk/internal/org/objectweb/asm/ByteVector
+instanceKlass jdk/internal/org/objectweb/asm/Symbol
+instanceKlass jdk/internal/org/objectweb/asm/SymbolTable
+instanceKlass jdk/internal/org/objectweb/asm/ClassVisitor
+instanceKlass java/lang/invoke/LambdaFormBuffer
+instanceKlass java/lang/invoke/LambdaFormEditor$TransformKey
+instanceKlass java/lang/invoke/LambdaFormEditor
+instanceKlass java/lang/invoke/Invokers$Holder
+instanceKlass java/lang/invoke/DelegatingMethodHandle$Holder
+instanceKlass java/lang/invoke/DirectMethodHandle$2
+instanceKlass java/lang/invoke/ClassSpecializer$Factory
+instanceKlass java/lang/invoke/ClassSpecializer$SpeciesData
+instanceKlass java/lang/invoke/ClassSpecializer$1
+instanceKlass java/lang/invoke/ClassSpecializer
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$1
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator
+instanceKlass java/lang/invoke/LambdaForm$Holder
+instanceKlass java/lang/invoke/LambdaForm$Name
+instanceKlass java/lang/reflect/Array
+instanceKlass java/lang/invoke/Invokers
+instanceKlass sun/invoke/util/ValueConversions
+instanceKlass java/lang/invoke/DirectMethodHandle$Holder
+instanceKlass java/lang/Void
+instanceKlass sun/invoke/util/Wrapper$Format
+instanceKlass java/lang/invoke/MethodHandleImpl$1
+instanceKlass jdk/internal/access/JavaLangInvokeAccess
+instanceKlass java/lang/invoke/LambdaForm$NamedFunction
+instanceKlass java/lang/invoke/MethodHandleImpl
+instanceKlass jdk/internal/reflect/MethodHandleAccessorFactory$LazyStaticHolder
+instanceKlass java/lang/invoke/MethodTypeForm
+instanceKlass java/lang/invoke/MethodType$ConcurrentWeakInternSet
+instanceKlass jdk/internal/reflect/MethodHandleAccessorFactory
+instanceKlass sun/reflect/annotation/AnnotationParser
+instanceKlass java/lang/Class$3
+instanceKlass java/lang/PublicMethods$Key
+instanceKlass java/lang/PublicMethods$MethodList
+instanceKlass java/lang/Class$Atomic
+instanceKlass java/lang/Class$ReflectionData
+instanceKlass java/util/EnumMap$1
+instanceKlass java/util/stream/StreamOpFlag$MaskBuilder
+instanceKlass java/util/stream/Stream
+instanceKlass java/util/stream/BaseStream
+instanceKlass java/util/stream/PipelineHelper
+instanceKlass java/util/stream/StreamSupport
+instanceKlass java/util/Spliterators$IteratorSpliterator
+instanceKlass java/util/Spliterator$OfDouble
+instanceKlass java/util/Spliterator$OfLong
+instanceKlass java/util/Spliterator$OfInt
+instanceKlass java/util/Spliterator$OfPrimitive
+instanceKlass java/util/Spliterator
+instanceKlass java/util/Spliterators$EmptySpliterator
+instanceKlass java/util/Spliterators
+instanceKlass jdk/internal/module/DefaultRoots
+instanceKlass jdk/internal/loader/BuiltinClassLoader$LoadedModule
+instanceKlass java/lang/Module$EnableNativeAccess
+instanceKlass jdk/internal/loader/BootLoader
+instanceKlass java/util/Optional
+instanceKlass jdk/internal/module/ModuleResolution
+instanceKlass jdk/internal/module/ModuleHashes$Builder
+instanceKlass java/util/ImmutableCollections$Set12$1
+instanceKlass java/lang/reflect/AccessFlag$18
+instanceKlass java/lang/reflect/AccessFlag$17
+instanceKlass java/lang/reflect/AccessFlag$16
+instanceKlass java/lang/reflect/AccessFlag$15
+instanceKlass java/lang/reflect/AccessFlag$14
+instanceKlass java/lang/reflect/AccessFlag$13
+instanceKlass java/lang/reflect/AccessFlag$12
+instanceKlass java/lang/reflect/AccessFlag$11
+instanceKlass java/lang/reflect/AccessFlag$10
+instanceKlass java/lang/reflect/AccessFlag$9
+instanceKlass java/lang/reflect/AccessFlag$8
+instanceKlass java/lang/reflect/AccessFlag$7
+instanceKlass java/lang/reflect/AccessFlag$6
+instanceKlass java/lang/reflect/AccessFlag$5
+instanceKlass java/lang/reflect/AccessFlag$4
+instanceKlass java/lang/reflect/AccessFlag$3
+instanceKlass java/lang/reflect/AccessFlag$2
+instanceKlass java/lang/reflect/AccessFlag$1
+instanceKlass java/util/ImmutableCollections$SetN$SetNIterator
+instanceKlass jdk/internal/module/Builder
+instanceKlass jdk/internal/module/SystemModules$all
+instanceKlass jdk/internal/module/SystemModules
+instanceKlass jdk/internal/module/SystemModulesMap
+instanceKlass jdk/internal/module/SystemModuleFinders
+instanceKlass jdk/internal/loader/AbstractClassLoaderValue
+instanceKlass jdk/internal/module/ServicesCatalog
+instanceKlass java/util/Deque
+instanceKlass java/util/Queue
+instanceKlass java/net/URL$3
+instanceKlass jdk/internal/access/JavaNetURLAccess
+instanceKlass java/net/URL$DefaultFactory
+instanceKlass java/net/URLStreamHandlerFactory
+instanceKlass jdk/internal/loader/URLClassPath
+instanceKlass java/util/concurrent/ConcurrentHashMap$CollectionView
+instanceKlass jdk/internal/loader/ClassLoaderHelper
+instanceKlass jdk/internal/loader/NativeLibraries
+instanceKlass java/security/Principal
+instanceKlass java/security/ProtectionDomain$Key
+instanceKlass java/security/ProtectionDomain$JavaSecurityAccessImpl
+instanceKlass jdk/internal/access/JavaSecurityAccess
+instanceKlass java/lang/ClassLoader$ParallelLoaders
+instanceKlass java/security/cert/Certificate
+instanceKlass jdk/internal/loader/ArchivedClassLoaders
+instanceKlass java/net/URI$1
+instanceKlass jdk/internal/access/JavaNetUriAccess
+instanceKlass jdk/internal/module/ArchivedBootLayer
+instanceKlass jdk/internal/module/ModuleBootstrap$Counters
+instanceKlass jdk/internal/module/ModulePatcher
+instanceKlass java/io/FileSystem
+instanceKlass java/io/DefaultFileSystem
+instanceKlass java/io/File
+instanceKlass java/lang/module/ModuleDescriptor$1
+instanceKlass jdk/internal/access/JavaLangModuleAccess
+instanceKlass java/lang/reflect/Modifier
+instanceKlass sun/invoke/util/VerifyAccess
+instanceKlass java/util/KeyValueHolder
+instanceKlass java/util/ImmutableCollections$MapN$MapNIterator
+instanceKlass java/lang/StrictMath
+instanceKlass java/lang/invoke/MethodHandles$Lookup
+instanceKlass java/lang/invoke/MemberName$Factory
+instanceKlass java/lang/invoke/MethodHandles
+instanceKlass jdk/internal/module/ModuleBootstrap
+instanceKlass java/util/HexFormat
+instanceKlass jdk/internal/util/ClassFileDumper
+instanceKlass sun/security/action/GetPropertyAction
+instanceKlass java/lang/invoke/MethodHandleStatics
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer$ConditionObject
+instanceKlass java/util/concurrent/locks/Condition
+instanceKlass jdk/internal/misc/Blocker
+instanceKlass java/util/Collections
+instanceKlass java/lang/Thread$ThreadIdentifiers
+instanceKlass jdk/internal/misc/OSEnvironment
+instanceKlass jdk/internal/misc/Signal$NativeHandler
+instanceKlass java/util/Hashtable$Entry
+instanceKlass jdk/internal/misc/Signal
+instanceKlass java/lang/Terminator$1
+instanceKlass jdk/internal/misc/Signal$Handler
+instanceKlass java/lang/Terminator
+instanceKlass java/nio/ByteOrder
+instanceKlass java/nio/Buffer$2
+instanceKlass jdk/internal/access/JavaNioAccess
+instanceKlass java/nio/Buffer$1
+instanceKlass jdk/internal/misc/ScopedMemoryAccess
+instanceKlass java/nio/charset/CoderResult
+instanceKlass sun/nio/cs/Surrogate
+instanceKlass sun/nio/cs/Surrogate$Parser
+instanceKlass java/nio/charset/CodingErrorAction
+instanceKlass java/nio/charset/CharsetEncoder
+instanceKlass java/io/Writer
+instanceKlass java/io/PrintStream$1
+instanceKlass jdk/internal/access/JavaIOPrintStreamAccess
+instanceKlass jdk/internal/misc/InternalLock
+instanceKlass java/io/OutputStream
+instanceKlass java/io/Flushable
+instanceKlass java/io/FileDescriptor$1
+instanceKlass jdk/internal/access/JavaIOFileDescriptorAccess
+instanceKlass java/io/FileDescriptor
+instanceKlass jdk/internal/util/StaticProperty
+instanceKlass java/util/HashMap$HashIterator
+instanceKlass java/util/concurrent/locks/LockSupport
+instanceKlass java/util/concurrent/ConcurrentHashMap$Node
+instanceKlass java/util/concurrent/ConcurrentHashMap$CounterCell
+instanceKlass java/util/concurrent/locks/ReentrantLock
+instanceKlass java/util/concurrent/locks/Lock
+instanceKlass java/lang/CharacterData
+instanceKlass java/lang/Runtime
+instanceKlass java/lang/VersionProps
+instanceKlass java/lang/StringConcatHelper
+instanceKlass java/lang/StringCoding
+instanceKlass java/nio/charset/StandardCharsets
+instanceKlass sun/nio/cs/HistoricallyNamedCharset
+instanceKlass jdk/internal/util/ArraysSupport
+instanceKlass java/util/Arrays
+instanceKlass jdk/internal/util/Preconditions$3
+instanceKlass jdk/internal/util/Preconditions$2
+instanceKlass jdk/internal/util/Preconditions$4
+instanceKlass java/util/function/BiFunction
+instanceKlass jdk/internal/util/Preconditions$1
+instanceKlass jdk/internal/util/Preconditions
+instanceKlass java/nio/charset/spi/CharsetProvider
+instanceKlass java/nio/charset/Charset
+instanceKlass jdk/internal/util/SystemProps$Raw
+instanceKlass jdk/internal/util/SystemProps
+instanceKlass java/lang/System$2
+instanceKlass jdk/internal/access/JavaLangAccess
+instanceKlass java/lang/ref/NativeReferenceQueue$Lock
+instanceKlass java/lang/ref/ReferenceQueue
+instanceKlass java/lang/ref/Reference$1
+instanceKlass jdk/internal/access/JavaLangRefAccess
+instanceKlass jdk/internal/reflect/ReflectionFactory
+instanceKlass java/lang/Math
+instanceKlass java/lang/StringLatin1
+instanceKlass jdk/internal/reflect/Reflection
+instanceKlass jdk/internal/reflect/ReflectionFactory$GetReflectionFactoryAction
+instanceKlass java/security/PrivilegedAction
+instanceKlass jdk/internal/access/SharedSecrets
+instanceKlass java/lang/reflect/ReflectAccess
+instanceKlass jdk/internal/access/JavaLangReflectAccess
+instanceKlass java/util/Objects
+instanceKlass jdk/internal/misc/CDS
+instanceKlass java/lang/Module$ArchivedData
+instanceKlass jdk/internal/misc/VM
+instanceKlass java/lang/String$CaseInsensitiveComparator
+instanceKlass java/util/Comparator
+instanceKlass java/io/ObjectStreamField
+instanceKlass jdk/internal/math/FDBigInteger
+instanceKlass java/lang/ModuleLayer
+instanceKlass java/util/ImmutableCollections
+instanceKlass jdk/internal/module/ModuleLoaderMap$Mapper
+instanceKlass java/util/function/Function
+instanceKlass java/lang/module/ResolvedModule
+instanceKlass java/lang/module/Configuration
+instanceKlass java/lang/module/ModuleDescriptor$Opens
+instanceKlass java/util/HashMap$Node
+instanceKlass java/util/Map$Entry
+instanceKlass java/util/Collections$UnmodifiableMap
+instanceKlass jdk/internal/module/ModuleHashes
+instanceKlass jdk/internal/module/ModuleTarget
+instanceKlass java/lang/module/ModuleDescriptor$Exports
+instanceKlass jdk/internal/module/SystemModuleFinders$3
+instanceKlass jdk/internal/module/ModuleHashes$HashSupplier
+instanceKlass jdk/internal/module/SystemModuleFinders$2
+instanceKlass java/util/function/Supplier
+instanceKlass java/net/URI
+instanceKlass java/lang/module/ModuleDescriptor$Provides
+instanceKlass java/lang/module/ModuleDescriptor$Requires
+instanceKlass java/lang/module/ModuleDescriptor$Version
+instanceKlass java/lang/module/ModuleDescriptor
+instanceKlass java/lang/module/ModuleReference
+instanceKlass java/util/Set
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemModuleFinder
+instanceKlass java/lang/module/ModuleFinder
+instanceKlass jdk/internal/module/ArchivedModuleGraph
+instanceKlass sun/util/locale/BaseLocale
+instanceKlass java/util/jar/Attributes$Name
+instanceKlass java/lang/Character$CharacterCache
+instanceKlass java/lang/Short$ShortCache
+instanceKlass java/lang/Byte$ByteCache
+instanceKlass java/lang/Long$LongCache
+instanceKlass java/lang/Integer$IntegerCache
+instanceKlass jdk/internal/vm/FillerObject
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorPayload
+instanceKlass jdk/internal/vm/vector/VectorSupport
+instanceKlass java/lang/reflect/RecordComponent
+instanceKlass java/util/Iterator
+instanceKlass java/lang/Number
+instanceKlass java/lang/Character
+instanceKlass java/lang/Boolean
+instanceKlass java/util/concurrent/locks/AbstractOwnableSynchronizer
+instanceKlass java/lang/LiveStackFrame
+instanceKlass java/lang/StackFrameInfo
+instanceKlass java/lang/StackWalker$StackFrame
+instanceKlass java/lang/StackStreamFactory$AbstractStackWalker
+instanceKlass java/lang/StackWalker
+instanceKlass java/nio/Buffer
+instanceKlass java/lang/StackTraceElement
+instanceKlass java/util/RandomAccess
+instanceKlass java/util/List
+instanceKlass java/util/SequencedCollection
+instanceKlass java/util/AbstractCollection
+instanceKlass java/util/Collection
+instanceKlass java/lang/Iterable
+instanceKlass java/util/concurrent/ConcurrentMap
+instanceKlass java/util/AbstractMap
+instanceKlass java/security/CodeSource
+instanceKlass jdk/internal/loader/ClassLoaders
+instanceKlass java/util/jar/Manifest
+instanceKlass java/lang/Enum
+instanceKlass java/net/URL
+instanceKlass java/io/InputStream
+instanceKlass java/io/Closeable
+instanceKlass java/lang/AutoCloseable
+instanceKlass jdk/internal/module/Modules
+instanceKlass jdk/internal/misc/Unsafe
+instanceKlass jdk/internal/misc/UnsafeConstants
+instanceKlass java/lang/AbstractStringBuilder
+instanceKlass java/lang/Appendable
+instanceKlass java/lang/AssertionStatusDirectives
+instanceKlass java/lang/invoke/MethodHandleNatives$CallSiteContext
+instanceKlass jdk/internal/foreign/abi/ABIDescriptor
+instanceKlass jdk/internal/foreign/abi/NativeEntryPoint
+instanceKlass java/lang/invoke/CallSite
+instanceKlass java/lang/invoke/MethodType
+instanceKlass java/lang/invoke/TypeDescriptor$OfMethod
+instanceKlass java/lang/invoke/LambdaForm
+instanceKlass java/lang/invoke/MethodHandleNatives
+instanceKlass java/lang/invoke/ResolvedMethodName
+instanceKlass java/lang/invoke/MemberName
+instanceKlass java/lang/invoke/VarHandle
+instanceKlass java/lang/invoke/MethodHandle
+instanceKlass jdk/internal/reflect/CallerSensitive
+instanceKlass java/lang/annotation/Annotation
+instanceKlass jdk/internal/reflect/FieldAccessor
+instanceKlass jdk/internal/reflect/ConstantPool
+instanceKlass jdk/internal/reflect/ConstructorAccessor
+instanceKlass jdk/internal/reflect/MethodAccessor
+instanceKlass jdk/internal/reflect/MagicAccessorImpl
+instanceKlass jdk/internal/vm/StackChunk
+instanceKlass jdk/internal/vm/Continuation
+instanceKlass jdk/internal/vm/ContinuationScope
+instanceKlass java/lang/reflect/Parameter
+instanceKlass java/lang/reflect/Member
+instanceKlass java/lang/reflect/AccessibleObject
+instanceKlass java/lang/Module
+instanceKlass java/util/Map
+instanceKlass java/util/Dictionary
+instanceKlass java/lang/ThreadGroup
+instanceKlass java/lang/Thread$UncaughtExceptionHandler
+instanceKlass java/lang/Thread$Constants
+instanceKlass java/lang/Thread$FieldHolder
+instanceKlass java/lang/Thread
+instanceKlass java/lang/Runnable
+instanceKlass java/lang/ref/Reference
+instanceKlass java/lang/Record
+instanceKlass java/security/AccessController
+instanceKlass java/security/AccessControlContext
+instanceKlass java/security/ProtectionDomain
+instanceKlass java/lang/SecurityManager
+instanceKlass java/lang/Throwable
+instanceKlass java/lang/System
+instanceKlass java/lang/ClassLoader
+instanceKlass java/lang/Cloneable
+instanceKlass java/lang/Class
+instanceKlass java/lang/invoke/TypeDescriptor$OfField
+instanceKlass java/lang/invoke/TypeDescriptor
+instanceKlass java/lang/reflect/Type
+instanceKlass java/lang/reflect/GenericDeclaration
+instanceKlass java/lang/reflect/AnnotatedElement
+instanceKlass java/lang/String
+instanceKlass java/lang/constant/ConstantDesc
+instanceKlass java/lang/constant/Constable
+instanceKlass java/lang/CharSequence
+instanceKlass java/lang/Comparable
+instanceKlass java/io/Serializable
+ciInstanceKlass java/lang/Object 1 1 124 7 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 100 1 10 7 12 1 1 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 3 8 1 7 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 3 1 1
+ciInstanceKlass java/io/Serializable 1 0 7 100 1 100 1 1 1
+ciInstanceKlass java/lang/System 1 1 834 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 10 7 12 1 1 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 10 100 12 1 1 1 18 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 1 9 12 1 1 8 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 9 12 1 1 8 1 10 12 1 1 10 100 12 1 1 1 8 1 10 12 1 7 1 10 12 1 8 1 10 12 1 10 12 1 1 100 1 10 12 10 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 100 1 100 1 8 1 10 12 1 10 12 1 1 7 1 10 12 1 100 1 8 1 10 10 12 1 100 1 8 1 10 8 1 10 7 12 1 1 8 1 10 12 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 100 1 18 12 1 100 1 9 100 12 1 1 1 10 12 1 100 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 7 1 10 12 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 7 12 1 1 1 7 1 8 1 10 9 12 1 9 12 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 8 1 11 12 1 10 12 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 1 7 1 11 12 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 11 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 8 1 9 12 1 8 1 10 7 12 1 1 8 1 7 1 9 7 12 1 1 1 10 12 1 7 1 9 12 10 9 12 7 1 10 12 9 12 1 1 8 1 10 12 1 1 8 1 10 7 12 1 1 10 12 1 10 12 1 1 11 7 12 1 1 10 12 10 7 12 1 1 1 9 12 1 1 7 1 8 1 10 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 8 1 8 1 10 8 1 8 1 8 1 8 1 10 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 7 1 8 1 10 10 10 12 1 1 10 12 1 1 8 1 10 12 1 8 1 8 1 10 12 1 10 7 12 1 1 1 10 12 1 1 7 1 10 10 12 1 10 12 1 9 12 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 1 1 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/System in Ljava/io/InputStream; java/io/BufferedInputStream
+staticfield java/lang/System out Ljava/io/PrintStream; java/io/PrintStream
+staticfield java/lang/System err Ljava/io/PrintStream; java/io/PrintStream
+ciInstanceKlass java/lang/SecurityManager 0 0 576 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 1 10 100 1 10 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 100 1 8 1 10 9 12 1 1 9 12 1 8 1 9 12 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 100 1 10 10 12 1 1 100 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 7 12 1 1 1 10 12 1 1 8 1 100 1 8 1 10 8 1 8 1 8 1 8 1 8 1 10 100 12 1 1 8 1 100 1 8 1 8 1 10 8 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 100 12 1 1 11 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 18 12 1 1 11 12 1 1 18 18 11 12 1 18 12 1 11 12 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 100 1 10 100 12 1 1 10 12 1 10 12 1 18 12 1 18 10 100 12 1 1 1 18 12 1 10 12 1 18 18 8 1 10 12 1 9 12 1 1 11 7 12 1 1 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 8 1 100 1 10 9 12 1 8 1 10 12 1 8 1 100 1 10 10 100 12 1 1 10 100 1 9 7 12 1 1 1 11 12 1 1 10 12 1 11 12 1 10 12 1 7 1 10 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 7 12 1 1 1 16 1 16 15 10 12 16 1 15 10 12 16 15 11 7 1 16 1 16 1 15 10 12 16 15 10 12 16 15 10 12 1 16 1 15 11 12 1 15 10 12 16 15 10 16 1 15 10 100 12 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/security/AccessController 1 1 295 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 7 1 7 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 9 100 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 10 100 1 10 11 7 12 1 1 1 10 7 12 1 1 11 7 1 100 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 8 1 10 100 12 1 1 1 8 1 7 1 10 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 3 1 1 1
+staticfield java/security/AccessController $assertionsDisabled Z 1
+ciInstanceKlass java/security/ProtectionDomain 1 1 348 10 7 12 1 1 1 9 7 12 1 1 1 7 1 10 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 7 1 9 12 1 9 12 1 1 7 1 9 12 1 1 9 12 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 9 12 1 9 100 12 1 1 10 12 1 1 10 100 1 10 12 1 1 8 1 7 1 8 1 10 12 1 10 11 10 7 12 1 1 1 10 12 1 1 8 1 11 8 1 10 12 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 8 1 8 1 10 7 12 1 1 1 9 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 100 1 18 12 1 1 10 7 12 1 1 1 10 7 1 10 12 1 10 12 1 1 11 100 12 1 1 11 12 1 100 1 11 7 12 1 1 1 10 12 1 10 11 12 1 1 11 12 1 1 10 12 1 10 7 12 1 1 10 100 12 1 1 11 12 1 10 12 10 12 1 8 1 8 1 10 7 12 1 1 1 7 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 7 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 100 1 1 16 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/security/ProtectionDomain filePermCompatInPD Z 0
+ciInstanceKlass java/security/CodeSource 1 1 398 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 100 12 1 1 10 100 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 7 1 10 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 8 1 8 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 10 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 100 1 10 12 1 10 12 10 12 1 1 10 100 12 1 1 10 12 1 7 1 10 12 10 100 12 1 1 1 10 8 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 100 1 7 1 8 1 8 1 10 10 12 1 1 10 100 12 1 1 1 7 1 10 12 10 12 1 1 11 7 12 1 1 10 10 12 1 11 10 12 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 11 12 1 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Boolean 1 1 152 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 8 1 10 7 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 9 100 12 1 1 9 12 10 100 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Boolean TRUE Ljava/lang/Boolean; java/lang/Boolean
+staticfield java/lang/Boolean FALSE Ljava/lang/Boolean; java/lang/Boolean
+staticfield java/lang/Boolean TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Comparable 1 0 12 100 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/constant/Constable 1 0 11 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/util/Map 1 1 263 11 7 12 1 1 1 11 12 1 1 10 100 12 1 1 11 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 7 1 11 12 1 11 12 1 100 1 100 1 10 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 11 12 1 10 12 1 1 11 12 1 11 100 12 1 9 7 12 1 1 1 100 1 10 12 7 1 7 1 10 12 1 7 1 10 100 1 11 12 1 11 12 1 1 11 12 1 1 100 1 11 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Class 1 1 1674 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 8 1 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 7 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 10 12 1 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 8 1 8 1 8 1 10 100 12 1 1 1 11 12 1 1 8 1 10 12 1 10 11 100 12 1 1 1 11 7 12 1 1 1 11 8 1 18 8 1 10 12 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 18 12 1 1 10 7 12 1 1 1 10 7 12 1 10 12 1 1 10 7 1 7 1 10 12 1 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 100 1 100 1 10 10 12 1 1 10 12 1 1 100 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 100 1 10 12 1 10 12 1 10 12 1 1 10 9 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 1 10 100 12 1 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 9 100 12 1 1 1 9 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 7 1 10 10 10 12 1 1 10 12 1 1 10 12 10 10 12 1 1 7 1 8 1 10 10 12 1 1 10 12 1 100 1 11 12 1 10 100 12 1 1 10 12 1 10 12 1 10 100 12 1 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 7 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 10 12 11 7 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 10 12 1 1 7 1 10 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 11 100 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 1 10 12 1 9 12 1 1 7 1 10 9 12 1 1 10 12 7 1 10 12 1 9 12 1 10 100 12 1 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 10 12 1 1 100 1 10 8 1 10 12 1 11 11 12 1 1 11 7 12 1 1 11 12 1 8 1 10 12 1 10 12 1 1 9 12 1 9 12 1 1 10 7 12 1 1 9 12 1 10 12 1 1 10 10 12 1 10 7 12 1 1 1 10 100 12 1 1 10 100 12 1 1 9 12 1 1 10 12 1 9 12 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 100 1 10 10 12 1 1 7 1 10 12 1 1 100 11 7 1 9 12 1 1 9 12 1 7 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 100 1 10 10 12 1 1 10 10 12 1 1 10 12 10 10 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 8 10 100 8 1 18 8 1 8 1 10 12 1 9 12 1 9 12 1 1 10 12 1 7 1 7 1 10 12 1 9 12 1 1 7 1 10 10 12 1 10 7 1 9 12 1 8 1 10 12 1 7 1 10 12 1 10 12 1 1 100 1 7 1 9 12 1 100 1 8 1 10 10 7 12 1 1 1 10 12 11 7 12 1 1 1 10 12 1 10 12 1 1 10 8 1 8 1 10 12 1 1 9 100 12 1 1 11 12 7 1 11 7 12 1 1 9 12 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 9 12 1 9 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 12 1 100 1 11 12 1 10 100 12 1 1 1 10 12 1 11 12 1 10 100 12 1 1 1 10 12 1 10 100 12 1 1 1 11 12 1 11 12 1 1 10 12 1 10 12 1 1 9 12 1 1 9 100 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 100 1 10 12 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 18 12 1 1 11 12 1 1 18 11 12 1 18 12 1 11 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 8 1 10 12 1 7 1 9 12 1 1 7 1 7 1 7 1 7 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 11 12 16 1 16 15 16 15 10 12 16 16 15 10 12 16 15 16 1 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 100 1 100 1 1 100 1 100 1 1
+staticfield java/lang/Class EMPTY_CLASS_ARRAY [Ljava/lang/Class; 0 [Ljava/lang/Class;
+staticfield java/lang/Class serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+ciInstanceKlass java/lang/reflect/AnnotatedElement 1 1 164 11 7 12 1 1 1 11 12 1 1 7 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 11 12 1 1 11 7 12 1 1 10 7 12 1 1 1 10 12 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 18 12 1 18 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 7 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 16 15 16 1 16 1 15 11 12 16 16 1 15 10 100 12 1 1 1 16 1 15 10 100 12 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor 1 0 17 100 1 100 1 1 1 1 1 1 100 1 100 1 1 1 1
+ciInstanceKlass java/lang/reflect/GenericDeclaration 1 0 30 7 1 7 1 7 1 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1
+ciInstanceKlass java/lang/reflect/Type 1 1 17 11 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor$OfField 1 0 21 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StringBuilder 1 1 422 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 100 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 100 1 100 1 8 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 7 1 7 1 7 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/CharSequence 1 1 131 11 7 12 1 1 1 18 12 1 1 100 1 10 100 12 1 1 1 18 10 100 12 1 1 1 11 12 1 1 11 7 1 11 12 1 1 10 100 12 1 1 1 11 12 1 1 100 1 10 12 1 1 10 100 12 1 1 1 100 1 10 10 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 11 12 16 15 11 12 15 10 100 12 1 1 1 1 1 100 1 100 1 1 100 1 1 100 1 100 1 1
+instanceKlass java/lang/StringBuilder
+instanceKlass java/lang/StringBuffer
+ciInstanceKlass java/lang/AbstractStringBuilder 1 1 605 7 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 7 1 3 3 10 12 1 10 12 1 1 11 7 1 100 1 7 1 10 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 8 1 10 10 12 1 1 100 1 10 12 10 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 100 1 10 10 7 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 10 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 100 1 100 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 18 12 1 1 100 1 10 100 12 1 1 1 18 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 10 12 1 10 12 10 12 1 10 10 10 12 1 10 5 0 10 10 12 1 1 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 100 1 10 12 100 1 10 100 1 10 7 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 7 1 1 16 1 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/AbstractStringBuilder EMPTYVALUE [B 0
+ciInstanceKlass java/lang/Appendable 1 0 14 100 1 100 1 1 1 1 100 1 1 1 1 1
+ciInstanceKlass java/lang/AutoCloseable 1 0 12 100 1 100 1 1 1 1 100 1 1 1
+ciInstanceKlass java/io/Closeable 1 0 14 100 1 100 1 100 1 1 1 1 100 1 1 1
+instanceKlass java/security/PrivilegedActionException
+instanceKlass com/sun/tools/javac/jvm/JNIWriter$TypeSignature$SignatureException
+instanceKlass com/sun/tools/javac/jvm/ModuleNameReader$BadClassFile
+instanceKlass java/lang/CloneNotSupportedException
+instanceKlass com/sun/tools/javac/parser/ReferenceParser$ParseException
+instanceKlass com/sun/tools/javac/util/ByteBuffer$UnderflowException
+instanceKlass com/sun/tools/javac/util/InvalidUtfException
+instanceKlass jdk/javadoc/internal/doclint/DocLint$BadArgs
+instanceKlass java/net/URISyntaxException
+instanceKlass java/security/GeneralSecurityException
+instanceKlass java/io/IOException
+instanceKlass jdk/internal/opt/CommandLine$UnmatchedQuote
+instanceKlass com/sun/tools/javac/main/Option$InvalidValueException
+instanceKlass java/lang/ReflectiveOperationException
+instanceKlass java/lang/RuntimeException
+ciInstanceKlass java/lang/Exception 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/Exception
+instanceKlass java/lang/Error
+ciInstanceKlass java/lang/Throwable 1 1 404 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 8 1 10 100 12 1 1 10 10 12 1 100 1 8 1 10 10 12 1 1 10 7 12 1 1 10 12 1 8 1 9 7 12 1 1 1 10 12 1 1 100 1 10 12 10 12 1 10 100 12 1 1 1 100 1 10 12 10 12 1 10 12 1 100 1 10 10 7 12 1 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 8 1 8 1 9 12 1 1 10 12 1 1 100 1 10 11 12 1 8 1 8 1 10 7 12 1 1 8 1 10 12 1 8 1 100 1 10 12 1 9 12 1 1 10 12 1 10 7 12 1 9 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 100 12 1 1 10 12 1 1 7 1 10 100 12 1 1 1 10 12 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 8 1 10 12 1 1 8 1 10 10 9 100 12 1 1 1 8 1 10 12 1 1 11 10 100 1 8 1 10 11 12 1 1 8 1 9 12 1 10 100 12 1 1 11 9 12 1 1 11 12 1 1 100 10 12 1 10 12 1 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Throwable UNASSIGNED_STACK [Ljava/lang/StackTraceElement; 0 [Ljava/lang/StackTraceElement;
+staticfield java/lang/Throwable SUPPRESSED_SENTINEL Ljava/util/List; java/util/Collections$EmptyList
+staticfield java/lang/Throwable EMPTY_THROWABLE_ARRAY [Ljava/lang/Throwable; 0 [Ljava/lang/Throwable;
+staticfield java/lang/Throwable $assertionsDisabled Z 1
+ciInstanceKlass java/util/Properties 1 1 690 10 7 12 1 1 1 100 1 10 7 12 1 1 7 1 10 12 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 8 1 10 12 1 7 1 10 12 10 12 1 1 9 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 7 1 3 10 10 100 12 1 1 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 10 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 10 12 1 10 12 1 1 100 1 9 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 9 12 1 1 100 1 7 1 10 12 1 7 1 11 100 12 1 1 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 11 12 1 10 12 1 1 8 1 10 12 1 10 100 12 1 1 10 12 1 100 1 10 10 12 1 10 12 1 100 1 10 10 12 1 1 10 7 12 1 1 9 100 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 100 1 100 1 10 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 1 10 12 1 1 100 1 10 10 12 1 11 7 12 1 1 10 100 12 1 1 1 8 1 10 100 12 1 1 11 11 100 1 8 1 10 100 1 11 10 12 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 10 11 12 1 4 11 10 12 1 1 10 100 12 1 1 11 12 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 10 12 1 10 10 100 12 1 1 1 100 1 6 0 10 12 1 1 11 100 12 1 1 1 10 12 1 10 12 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+staticfield java/util/Properties UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+instanceKlass java/util/Hashtable
+ciInstanceKlass java/util/Dictionary 1 1 36 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/Properties
+ciInstanceKlass java/util/Hashtable 1 1 516 7 1 10 7 12 1 1 1 9 7 12 1 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 8 1 10 12 1 9 12 1 1 7 1 9 12 1 1 4 10 7 12 1 1 1 9 12 1 4 10 12 1 11 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 1 100 1 10 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 10 12 1 3 9 12 1 9 12 1 3 10 12 1 10 12 1 10 12 1 1 11 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 11 12 1 100 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 9 12 9 12 1 1 10 100 1 7 1 10 12 1 10 8 1 10 10 12 1 8 1 10 8 1 10 100 12 1 1 1 100 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 1 100 1 10 100 1 10 10 12 1 1 11 12 1 1 11 12 1 7 1 10 10 10 100 12 1 1 11 100 12 1 1 1 100 1 10 11 100 12 1 1 11 100 12 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 8 10 100 12 1 1 100 1 8 1 10 4 4 10 12 1 1 10 12 1 8 1 4 10 12 10 100 12 1 1 1 100 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 7 1 7 1 1 1 1 1 1 5 0 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 7 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/String 1 1 1443 10 7 12 1 1 1 8 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 10 7 12 1 1 1 10 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 10 12 9 7 12 1 1 10 12 1 1 3 10 12 1 1 100 1 11 12 1 1 11 12 1 11 12 1 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 11 12 1 1 10 12 1 1 10 12 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 100 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 100 1 100 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 100 1 11 10 7 12 1 1 11 12 1 11 12 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 3 3 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 10 12 1 8 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 7 1 10 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 10 12 1 100 1 10 10 12 1 1 10 12 1 1 10 7 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 11 7 1 11 12 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 9 12 1 1 11 100 12 1 1 1 10 12 10 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 10 10 12 1 10 12 10 10 12 10 10 12 1 10 12 1 10 10 12 10 7 12 1 1 1 10 12 10 10 12 10 12 1 10 12 10 12 10 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 10 7 12 1 1 1 10 12 1 1 10 10 7 12 1 1 1 11 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 7 1 8 1 10 10 10 12 1 10 12 1 1 8 1 10 12 1 3 3 10 12 1 10 12 1 1 10 12 7 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 7 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 10 12 1 10 12 1 1 10 10 100 12 1 1 1 10 12 1 10 12 1 10 10 12 10 12 1 1 10 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 10 12 1 1 10 10 12 1 8 1 10 12 1 1 18 12 1 1 11 100 12 1 1 1 7 1 3 18 12 1 18 12 1 8 1 10 100 12 1 1 1 11 12 1 1 10 12 10 10 12 1 10 11 12 1 1 10 12 1 1 11 12 1 18 3 11 10 12 1 11 11 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 11 100 12 1 100 1 100 1 10 12 100 1 10 10 100 12 1 1 1 100 1 10 100 1 10 10 12 1 10 10 12 1 8 1 10 10 12 1 8 1 8 1 10 12 1 10 12 1 10 10 12 10 7 12 1 1 10 7 12 1 1 10 7 12 1 1 8 1 10 12 1 10 12 1 10 9 12 1 10 12 9 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 100 12 1 1 1 10 12 10 12 1 1 10 12 10 10 12 10 12 7 1 9 12 1 1 7 1 10 7 1 7 1 7 1 7 1 1 1 1 1 1 5 0 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 12 15 10 12 15 10 12 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1 1
+staticfield java/lang/String COMPACT_STRINGS Z 1
+staticfield java/lang/String serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+staticfield java/lang/String CASE_INSENSITIVE_ORDER Ljava/util/Comparator; java/lang/String$CaseInsensitiveComparator
+ciInstanceKlass java/lang/constant/ConstantDesc 1 0 37 100 1 100 1 1 1 1 100 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/InternalError 0 0 34 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass com/sun/tools/javac/file/PathFileObject$CannotCreateUriError
+instanceKlass java/util/ServiceConfigurationError
+instanceKlass com/sun/tools/javac/processing/ServiceProxy$ServiceConfigurationError
+instanceKlass com/sun/tools/javac/util/Abort
+instanceKlass java/lang/AssertionError
+instanceKlass com/sun/tools/javac/processing/AnnotationProcessingError
+instanceKlass com/sun/tools/javac/util/FatalError
+instanceKlass java/lang/VirtualMachineError
+instanceKlass java/lang/LinkageError
+ciInstanceKlass java/lang/Error 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/StackOverflowError
+instanceKlass java/lang/OutOfMemoryError
+instanceKlass java/lang/InternalError
+ciInstanceKlass java/lang/VirtualMachineError 1 1 34 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/Iterator 1 1 53 100 1 8 1 10 12 1 1 10 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass sun/nio/ch/ChannelInputStream
+instanceKlass java/io/FilterInputStream
+instanceKlass java/io/FileInputStream
+instanceKlass java/io/ByteArrayInputStream
+ciInstanceKlass java/io/InputStream 1 1 195 7 1 10 7 12 1 1 1 100 1 10 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 100 1 3 10 12 1 1 100 1 8 1 10 12 1 10 100 12 1 1 1 3 7 1 8 1 10 10 100 12 1 1 1 7 1 10 11 7 12 1 1 1 10 12 1 1 11 12 1 1 11 7 12 1 1 1 11 12 1 1 100 1 10 7 12 1 1 1 5 0 10 12 1 10 12 1 1 100 1 10 8 1 10 8 1 8 1 10 12 1 1 10 100 12 1 1 1 7 1 5 0 10 12 1 100 1 7 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/misc/Unsafe 1 1 1287 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 10 10 12 1 1 10 12 1 1 5 0 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 5 0 5 0 5 0 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 7 1 8 1 10 100 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 9 12 1 100 1 10 10 12 1 1 8 1 10 8 1 8 1 10 12 1 1 9 7 12 1 1 1 9 7 1 9 7 1 9 7 1 9 9 7 1 9 7 1 9 7 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 5 0 5 0 9 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 3 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 100 1 10 9 12 1 5 0 10 12 1 1 5 0 10 12 1 5 0 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 5 0 5 0 5 0 10 12 1 1 10 12 1 10 12 1 10 12 10 100 12 1 1 8 1 100 1 11 12 1 1 8 1 11 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 1 10 12 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/misc/Unsafe theUnsafe Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield jdk/internal/misc/Unsafe ARRAY_BOOLEAN_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_BYTE_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_SHORT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_CHAR_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_INT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_LONG_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_FLOAT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_DOUBLE_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_OBJECT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_BOOLEAN_INDEX_SCALE I 1
+staticfield jdk/internal/misc/Unsafe ARRAY_BYTE_INDEX_SCALE I 1
+staticfield jdk/internal/misc/Unsafe ARRAY_SHORT_INDEX_SCALE I 2
+staticfield jdk/internal/misc/Unsafe ARRAY_CHAR_INDEX_SCALE I 2
+staticfield jdk/internal/misc/Unsafe ARRAY_INT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ARRAY_LONG_INDEX_SCALE I 8
+staticfield jdk/internal/misc/Unsafe ARRAY_FLOAT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ARRAY_DOUBLE_INDEX_SCALE I 8
+staticfield jdk/internal/misc/Unsafe ARRAY_OBJECT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ADDRESS_SIZE I 8
+instanceKlass jdk/internal/reflect/DelegatingClassLoader
+instanceKlass java/security/SecureClassLoader
+ciInstanceKlass java/lang/ClassLoader 1 1 1108 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 10 7 12 1 10 7 1 10 7 1 7 1 7 1 10 12 1 10 12 1 9 12 1 1 10 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 7 1 10 12 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 1 9 12 10 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 7 1 7 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 100 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 10 10 12 1 1 10 12 1 1 7 1 8 1 10 8 1 10 12 1 10 12 1 100 1 8 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 7 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 12 1 10 12 1 1 8 1 8 1 10 7 12 1 1 100 1 10 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 10 7 1 7 1 10 12 1 1 10 12 1 10 7 1 10 12 1 100 1 18 12 1 10 100 12 1 1 1 10 100 12 1 1 1 10 7 12 1 1 10 12 1 10 12 1 100 1 10 12 1 8 1 10 10 12 1 1 10 12 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 8 1 100 1 10 10 12 1 9 12 1 10 7 12 1 1 10 12 1 7 1 8 1 10 12 1 10 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 7 1 100 1 10 12 1 1 7 1 7 1 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 100 1 18 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 18 12 1 11 100 12 1 1 1 100 1 10 12 1 1 10 12 1 10 11 12 1 1 10 18 10 12 1 1 11 7 12 1 18 12 1 11 12 1 1 10 12 10 12 1 1 10 12 1 1 100 1 8 1 10 10 12 1 8 1 8 1 10 100 12 1 1 10 12 1 100 1 10 10 12 1 8 1 8 1 8 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 11 7 12 1 1 100 1 10 11 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 9 12 1 1 9 12 9 12 1 9 12 1 9 12 1 8 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 11 12 1 1 10 100 12 1 1 1 100 1 10 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 10 12 16 1 16 15 10 12 16 1 16 1 15 10 12 16 15 10 12 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/ClassLoader nocerts [Ljava/security/cert/Certificate; 0 [Ljava/security/cert/Certificate;
+staticfield java/lang/ClassLoader $assertionsDisabled Z 1
+ciInstanceKlass java/lang/reflect/Constructor 1 1 439 10 100 12 1 1 1 10 100 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 100 1 8 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 8 1 10 10 12 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 7 12 1 1 10 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+instanceKlass java/lang/reflect/Executable
+instanceKlass java/lang/reflect/Field
+ciInstanceKlass java/lang/reflect/AccessibleObject 1 1 400 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 7 1 10 7 12 1 1 1 11 12 1 7 1 10 12 1 7 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 7 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 100 1 10 12 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 10 7 1 100 1 8 1 10 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 100 1 8 1 10 11 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 100 1 10 12 1 7 1 10 12 1 10 12 1 1 10 100 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 10 100 12 1 1 8 1 10 100 12 1 1 1 8 1 10 7 12 1 1 1 9 12 1 7 1 10 7 1 10 10 7 12 1 1 1 7 1 10 10 7 12 1 1 1 7 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/reflect/AccessibleObject reflectionFactory Ljdk/internal/reflect/ReflectionFactory; jdk/internal/reflect/ReflectionFactory
+instanceKlass java/lang/reflect/Constructor
+instanceKlass java/lang/reflect/Method
+ciInstanceKlass java/lang/reflect/Executable 1 1 577 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 7 12 1 1 1 10 12 1 8 1 10 10 12 1 1 10 12 1 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 8 1 8 1 8 1 10 100 12 1 1 1 11 12 1 1 7 1 8 1 8 1 10 12 1 7 1 8 1 10 12 1 8 1 11 100 12 1 1 1 7 1 11 7 12 1 1 1 11 12 1 8 1 18 8 1 10 12 1 10 12 1 1 18 8 1 10 12 1 100 1 10 12 1 10 12 1 11 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 1 10 10 12 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 10 12 1 8 1 10 12 1 10 12 1 3 100 1 8 1 10 12 1 10 12 1 10 10 12 1 10 12 1 1 8 1 8 1 8 1 9 12 1 1 9 12 1 10 12 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 100 1 10 12 1 10 12 1 1 100 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 9 12 1 10 10 10 10 100 12 1 1 1 10 12 1 9 12 1 10 12 1 1 9 12 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 16 15 16 1 16 1 15 10 12 16 15 10 100 12 1 1 1 1 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/reflect/Member 1 1 37 100 1 10 12 1 1 100 1 100 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass com/sun/tools/javac/file/BaseFileManager$1
+instanceKlass java/util/concurrent/ForkJoinWorkerThread
+instanceKlass jdk/internal/misc/InnocuousThread
+instanceKlass java/lang/ref/Finalizer$FinalizerThread
+instanceKlass java/lang/ref/Reference$ReferenceHandler
+instanceKlass java/lang/BaseVirtualThread
+ciInstanceKlass java/lang/Thread 1 1 872 10 7 12 1 1 1 9 12 1 1 10 100 12 1 1 10 12 1 10 100 12 1 1 8 1 10 100 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 7 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 9 12 1 1 10 12 1 7 1 10 12 1 100 1 8 1 10 12 9 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 3 8 1 7 1 5 0 10 7 12 1 1 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 7 1 8 1 10 7 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 7 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 10 7 12 1 1 9 12 1 8 1 9 7 12 1 1 9 12 1 1 5 0 100 1 10 100 1 10 100 1 10 7 1 10 8 1 10 12 1 1 10 100 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 7 1 9 12 1 1 100 1 10 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 1 10 10 12 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 9 12 1 9 12 1 1 9 12 1 1 10 100 12 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 10 12 1 10 12 1 100 1 10 10 12 9 12 1 1 10 12 1 11 100 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 10 10 12 1 10 12 1 1 9 12 1 9 12 10 12 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 8 1 10 9 12 1 10 12 1 7 1 8 1 10 10 12 1 8 1 10 12 1 1 9 12 10 12 8 1 10 10 12 1 10 12 1 8 1 10 12 1 10 8 1 10 100 12 1 1 10 12 1 1 100 1 8 1 10 9 12 1 9 12 1 1 10 12 1 1 10 10 12 1 10 12 1 100 10 7 12 1 1 1 9 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 7 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 7 1 10 12 1 100 1 10 12 1 10 12 1 1 10 12 1 1 8 1 9 12 1 10 12 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Thread NEW_THREAD_BINDINGS Ljava/lang/Object; java/lang/Class
+staticfield java/lang/Thread EMPTY_STACK_TRACE [Ljava/lang/StackTraceElement; 0 [Ljava/lang/StackTraceElement;
+ciInstanceKlass java/lang/Runnable 1 0 11 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/net/URL 1 1 771 10 7 12 1 1 1 10 12 1 10 7 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 7 1 10 10 12 1 1 8 1 10 12 1 1 9 12 1 100 1 8 1 10 12 1 10 12 1 8 1 9 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 9 12 1 8 1 9 12 1 10 12 1 1 8 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 100 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 8 1 9 12 1 8 1 10 12 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 8 1 10 10 100 1 10 10 12 1 8 1 10 7 12 1 1 1 10 12 1 9 100 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 10 100 12 1 1 1 100 1 100 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 10 12 1 10 12 1 10 12 1 1 8 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 100 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 9 12 1 1 7 1 8 1 10 10 12 1 9 12 1 1 10 7 12 1 1 8 1 10 100 12 1 1 8 1 10 12 1 1 10 12 1 8 1 8 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 10 12 1 100 1 10 9 100 12 1 1 1 10 100 12 1 1 10 12 1 1 10 12 1 8 1 100 1 10 10 7 12 1 1 1 10 12 1 8 9 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 11 7 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 8 10 100 12 1 1 100 1 10 8 8 10 12 1 8 8 8 100 1 10 12 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 100 1 8 1 10 10 10 12 1 1 10 12 1 10 12 1 1 8 1 7 1 10 10 7 1 10 12 1 9 7 12 1 1 1 9 12 1 1 7 1 10 10 7 12 1 1 1 7 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/net/URL defaultFactory Ljava/net/URLStreamHandlerFactory; java/net/URL$DefaultFactory
+staticfield java/net/URL streamHandlerLock Ljava/lang/Object; java/lang/Object
+staticfield java/net/URL serialPersistentFields [Ljava/io/ObjectStreamField; 7 [Ljava/io/ObjectStreamField;
+ciInstanceKlass java/lang/Module 1 1 1070 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 9 12 1 1 10 100 12 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 10 12 1 10 7 12 1 1 8 1 8 1 10 8 1 8 1 9 12 1 1 8 1 10 100 12 1 1 1 10 12 1 9 12 1 1 11 12 1 9 7 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 1 11 7 12 1 1 10 12 1 1 9 12 1 9 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 18 12 1 1 10 12 1 1 11 12 1 9 12 1 11 12 10 100 12 1 1 100 1 8 1 10 11 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 11 12 1 1 11 7 12 1 1 11 12 1 1 9 12 1 11 12 1 10 12 1 1 10 12 1 1 9 12 1 10 12 10 7 12 1 1 10 7 1 18 12 1 1 11 100 12 1 1 1 18 12 1 11 12 1 1 10 100 12 1 1 1 11 12 1 1 10 7 12 1 1 7 1 11 12 1 7 1 7 1 10 12 1 10 7 12 1 1 1 10 11 7 12 1 8 1 10 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 7 1 10 12 1 10 11 12 1 1 10 12 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 11 7 1 10 12 1 1 11 12 1 10 10 12 1 11 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 10 10 12 1 1 10 12 1 18 12 1 11 12 1 18 12 1 10 12 1 10 12 1 10 12 7 1 10 12 1 10 12 1 10 12 1 9 12 1 7 1 10 10 10 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 18 12 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 7 1 10 12 1 1 7 1 8 1 10 12 1 1 100 1 11 12 1 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 100 1 10 12 1 10 12 1 1 7 1 7 1 10 12 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 7 1 10 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 10 7 12 1 1 8 1 18 12 1 1 100 1 100 1 9 12 1 1 9 12 1 9 12 1 11 100 12 1 1 1 100 1 11 12 1 1 100 1 10 12 1 8 1 10 12 1 10 12 10 12 1 8 1 10 10 100 12 1 1 7 1 10 10 12 1 10 7 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 11 12 1 10 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 16 15 10 16 1 15 10 12 16 1 15 10 12 16 1 16 15 10 12 16 16 1 15 10 12 16 15 10 100 12 1 1 1 15 10 100 12 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 100 1 1
+staticfield java/lang/Module ALL_UNNAMED_MODULE Ljava/lang/Module; java/lang/Module
+staticfield java/lang/Module ALL_UNNAMED_MODULE_SET Ljava/util/Set; java/util/ImmutableCollections$Set12
+staticfield java/lang/Module EVERYONE_MODULE Ljava/lang/Module; java/lang/Module
+staticfield java/lang/Module EVERYONE_SET Ljava/util/Set; java/util/ImmutableCollections$Set12
+staticfield java/lang/Module $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Character 1 1 604 7 1 7 1 100 1 9 12 1 1 8 1 9 12 1 1 7 1 9 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 3 3 3 3 3 10 12 1 1 10 12 1 3 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 3 10 12 1 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 10 10 12 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 10 12 10 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 1 10 10 12 1 10 5 0 10 12 1 10 12 1 10 10 12 1 10 10 12 1 1 10 10 12 1 10 10 12 1 9 12 1 1 100 1 10 10 12 1 10 12 1 1 3 10 100 12 1 1 1 10 12 1 10 100 12 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 9 100 12 1 1 1 10 12 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 10 12 1 1 7 1 8 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 3 1 1 3 1 1 1 1 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1
+staticfield java/lang/Character TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Character $assertionsDisabled Z 1
+ciInstanceKlass java/lang/OutOfMemoryError 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Integer 1 1 453 7 1 7 1 7 1 7 1 10 12 1 1 9 12 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 9 12 1 1 9 12 1 100 1 8 1 10 12 1 7 1 10 12 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 8 1 10 12 1 1 3 10 12 1 1 3 10 12 1 1 10 12 1 1 10 7 12 1 1 1 11 7 1 10 12 1 1 11 10 12 1 1 8 1 10 12 1 1 8 1 7 1 10 12 1 1 10 12 1 1 5 0 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 7 1 9 12 1 1 9 12 1 1 10 12 1 10 7 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 10 12 1 1 8 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 5 0 3 3 3 3 10 12 1 10 12 1 3 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 3 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Integer TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Integer digits [C 36
+staticfield java/lang/Integer DigitTens [B 100
+staticfield java/lang/Integer DigitOnes [B 100
+instanceKlass java/util/concurrent/atomic/AtomicLong
+instanceKlass java/util/concurrent/atomic/AtomicInteger
+instanceKlass java/lang/Long
+instanceKlass java/lang/Integer
+instanceKlass java/lang/Short
+instanceKlass java/lang/Byte
+instanceKlass java/lang/Double
+instanceKlass java/lang/Float
+ciInstanceKlass java/lang/Number 1 1 37 10 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Thread$FieldHolder 1 1 48 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 100 1 1 1
+ciInstanceKlass java/lang/Thread$Constants 0 0 59 7 1 10 7 12 1 1 1 100 1 10 10 7 12 1 1 1 7 1 8 1 10 12 1 9 7 12 1 1 1 7 1 7 1 10 12 1 10 12 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ThreadGroup 1 1 411 10 7 12 1 1 1 9 7 12 1 1 1 8 1 9 12 1 1 7 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 18 12 1 1 11 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 11 12 1 1 11 7 12 1 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 11 12 1 11 12 1 1 100 1 10 10 12 1 100 1 10 18 12 1 1 11 7 12 1 1 1 11 12 1 1 9 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 11 12 10 12 1 1 10 12 1 1 11 7 1 9 12 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 7 1 8 1 10 8 1 10 12 1 10 12 1 8 1 9 12 1 1 9 12 1 10 100 12 1 1 1 100 9 12 1 1 7 1 9 12 1 10 12 10 12 1 1 100 10 12 9 12 1 10 12 1 100 1 10 11 12 1 1 7 1 10 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/ThreadGroup $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Thread$UncaughtExceptionHandler 1 0 16 100 1 100 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/security/AccessControlContext 1 1 374 9 7 12 1 1 1 9 12 1 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 7 1 10 12 1 11 7 12 1 1 1 11 12 1 11 12 1 11 12 1 1 7 1 11 12 1 1 10 12 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 11 100 12 1 1 1 10 7 1 100 1 8 1 10 12 1 10 12 1 1 7 1 10 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 10 7 12 1 1 1 9 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 10 7 12 1 1 1 10 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 8 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 100 1 10 12 1 10 12 1 1 100 1 10 12 1 8 1 10 12 1 10 12 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 11 10 12 1 10 12 1 1 10 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1
+instanceKlass java/lang/ThreadBuilders$BoundVirtualThread
+instanceKlass java/lang/VirtualThread
+ciInstanceKlass java/lang/BaseVirtualThread 0 0 36 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 1
+ciInstanceKlass java/lang/VirtualThread 0 0 906 7 1 9 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 100 1 10 12 1 9 12 1 1 18 12 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 10 12 1 10 12 1 10 12 1 11 100 12 1 1 1 100 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 100 1 10 10 12 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 10 12 1 9 12 1 1 9 12 1 100 1 10 10 12 1 10 12 1 10 100 12 1 1 10 9 10 10 12 1 1 10 12 1 1 10 100 12 1 1 10 100 1 10 9 10 10 12 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 11 7 1 10 7 12 1 1 10 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 1 10 12 1 10 12 1 9 12 1 1 10 12 1 10 12 1 11 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 10 100 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 18 10 12 1 1 10 12 1 1 7 1 5 0 100 1 10 10 12 1 7 1 9 12 1 1 10 7 12 1 1 10 9 12 1 1 9 100 12 1 1 1 11 100 12 1 1 1 11 100 1 11 12 10 12 1 10 12 1 10 12 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 11 100 12 1 1 10 12 9 100 12 1 1 1 9 12 1 10 12 1 1 9 12 1 9 12 1 7 1 10 10 12 1 1 10 12 1 10 12 10 12 1 7 1 7 1 8 1 10 10 12 1 1 10 12 1 10 7 12 1 1 8 1 10 12 1 8 1 10 12 1 9 100 12 1 1 1 10 12 1 1 10 12 1 10 10 10 10 12 9 12 1 10 12 1 1 9 12 1 10 12 1 1 9 12 1 10 12 1 1 18 12 1 1 18 12 1 10 7 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 1 18 12 1 10 100 12 1 1 1 100 1 10 12 1 8 1 10 12 1 8 1 10 12 1 1 8 1 8 1 10 100 12 1 1 8 1 10 12 1 8 1 8 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 18 12 1 1 18 12 1 1 5 0 9 12 1 10 12 1 18 12 1 100 1 10 12 10 7 12 1 1 10 12 1 1 7 1 8 1 10 10 12 1 10 12 1 1 10 12 1 9 12 1 8 10 12 1 1 8 8 9 12 1 8 10 12 1 1 3 1 3 3 1 3 1 3 1 3 1 3 1 3 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 15 16 15 10 12 16 15 10 12 16 16 15 10 12 16 15 10 12 16 15 10 12 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 7 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/ThreadBuilders$BoundVirtualThread 0 0 126 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 11 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 9 100 12 1 1 1 10 12 1 1 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/ContinuationScope 0 0 50 10 100 12 1 1 1 10 100 12 1 1 1 100 1 9 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/StackChunk 0 0 34 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Float 1 1 279 7 1 7 1 10 100 12 1 1 1 10 100 12 1 1 1 4 7 1 10 12 1 1 10 12 1 1 8 1 8 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 100 1 4 10 7 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 3 3 100 1 4 4 4 3 10 12 1 1 9 12 1 1 100 1 10 3 3 4 4 10 12 1 3 3 3 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 4 1 4 1 1 1 4 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Float TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Float $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Double 1 1 290 7 1 7 1 10 100 12 1 1 1 10 12 1 1 10 7 1 10 12 1 1 10 100 12 1 1 1 6 0 8 1 10 12 1 1 8 1 10 12 1 1 8 1 6 0 10 12 1 1 100 1 5 0 5 0 8 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 100 1 6 0 10 7 12 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 5 0 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 6 0 1 6 0 1 6 0 1 1 1 6 0 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Double TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Byte 1 1 213 7 1 100 1 10 7 12 1 1 1 9 12 1 1 8 1 9 12 1 1 7 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 100 12 1 1 1 10 12 1 1 100 1 7 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 8 1 8 1 10 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 5 0 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 1 1 3 1 3 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Byte TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Short 1 1 222 7 1 7 1 100 1 10 7 12 1 1 1 10 12 1 1 100 1 7 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 8 1 9 12 1 1 7 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 9 100 12 1 1 1 10 12 1 10 12 1 1 10 8 1 8 1 10 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 3 3 5 0 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 1 1 3 1 3 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Short TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Long 1 1 524 7 1 7 1 7 1 7 1 10 12 1 1 9 12 1 1 9 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 10 12 10 12 1 10 12 1 10 12 1 5 0 5 0 7 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 5 0 5 0 9 12 1 1 9 12 1 5 0 100 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 10 12 1 1 5 0 10 12 1 1 5 0 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 7 1 10 12 1 1 11 10 12 1 1 8 1 10 12 1 1 8 1 7 1 10 12 1 1 10 12 1 8 1 8 1 11 12 1 1 10 12 1 10 12 1 10 12 1 5 0 5 0 9 7 12 1 1 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 7 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 10 12 1 1 5 0 10 12 1 10 12 1 5 0 5 0 5 0 10 12 1 1 10 12 1 5 0 5 0 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 5 0 1 1 1 1 3 1 3 1 5 0 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Long TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport 0 0 547 100 1 10 100 12 1 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 100 1 10 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 9 12 1 1 10 100 12 1 1 11 100 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorShuffle
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorMask
+instanceKlass jdk/internal/vm/vector/VectorSupport$Vector
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorPayload 0 0 32 10 100 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$Vector 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorMask 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorShuffle 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/FillerObject 0 0 16 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1
+instanceKlass java/lang/ref/PhantomReference
+instanceKlass java/lang/ref/FinalReference
+instanceKlass java/lang/ref/WeakReference
+instanceKlass java/lang/ref/SoftReference
+ciInstanceKlass java/lang/ref/Reference 1 1 190 9 7 12 1 1 1 9 7 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 7 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 8 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 7 1 100 1 10 12 9 12 1 9 12 1 100 1 10 10 12 1 10 10 7 12 1 1 7 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 7 1 1 1
+staticfield java/lang/ref/Reference processPendingLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/ref/Reference $assertionsDisabled Z 1
+instanceKlass java/util/ResourceBundle$BundleReference
+instanceKlass sun/util/locale/LocaleObjectCache$CacheEntry
+instanceKlass java/lang/invoke/LambdaFormEditor$Transform
+ciInstanceKlass java/lang/ref/SoftReference 1 1 47 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1
+instanceKlass java/lang/ClassValue$Entry
+instanceKlass java/lang/ThreadLocal$ThreadLocalMap$Entry
+instanceKlass java/util/ResourceBundle$KeyElementReference
+instanceKlass java/lang/invoke/MethodType$ConcurrentWeakInternSet$WeakEntry
+instanceKlass java/util/WeakHashMap$Entry
+ciInstanceKlass java/lang/ref/WeakReference 1 1 31 10 7 12 1 1 1 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/ref/Finalizer
+ciInstanceKlass java/lang/ref/FinalReference 1 1 50 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 7 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1
+instanceKlass jdk/internal/ref/PhantomCleanable
+instanceKlass jdk/internal/ref/Cleaner
+ciInstanceKlass java/lang/ref/PhantomReference 1 1 39 10 100 12 1 1 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ref/Finalizer 1 1 155 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 10 12 1 7 1 8 1 10 12 1 10 12 1 1 9 12 1 100 1 10 12 1 7 1 11 100 12 1 1 10 12 1 7 1 10 12 1 100 1 10 12 1 10 7 12 1 1 1 10 100 12 1 1 1 100 1 10 10 12 1 7 1 10 12 1 7 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 10 7 1 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/ref/Finalizer lock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/ref/Finalizer ENABLED Z 1
+staticfield java/lang/ref/Finalizer $assertionsDisabled Z 1
+instanceKlass com/sun/tools/javac/comp/Flow$Liveness
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodCheckDiag
+instanceKlass com/sun/source/tree/Tree$Kind
+instanceKlass com/sun/tools/javac/code/TypeAnnotations$AnnotationType
+instanceKlass com/sun/tools/javac/comp/Resolve$InterfaceLookupPhase
+instanceKlass com/sun/tools/javac/code/TargetType
+instanceKlass com/sun/tools/javac/code/Attribute$RetentionPolicy
+instanceKlass javax/lang/model/element/NestingKind
+instanceKlass javax/lang/model/element/ElementKind
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$AttributionMode
+instanceKlass com/sun/tools/javac/code/Scope$LookupKind
+instanceKlass com/sun/tools/javac/code/Directive$OpensFlag
+instanceKlass java/util/stream/MatchOps$MatchKind
+instanceKlass com/sun/tools/javac/code/Directive$ExportsFlag
+instanceKlass com/sun/tools/javac/tree/JCTree$JCLambda$ParameterKind
+instanceKlass com/sun/tools/javac/tree/JCTree$JCPolyExpression$PolyKind
+instanceKlass com/sun/source/tree/MemberReferenceTree$ReferenceMode
+instanceKlass com/sun/tools/javac/parser/UnicodeReader$UnicodeEscapeResult
+instanceKlass com/sun/tools/javac/code/BoundKind
+instanceKlass com/sun/tools/javac/parser/JavacParser$ParensResult
+instanceKlass com/sun/tools/javac/parser/JavacParser$EnumeratorEstimate
+instanceKlass com/sun/tools/javac/parser/Tokens$Comment$CommentStyle
+instanceKlass javax/lang/model/type/TypeKind
+instanceKlass com/sun/tools/javac/util/RichDiagnosticFormatter$RichConfiguration$RichFormatterFeature
+instanceKlass com/sun/tools/javac/util/RichDiagnosticFormatter$WhereClauseKind
+instanceKlass com/sun/tools/javac/comp/CompileStates$CompileState
+instanceKlass com/sun/tools/javac/main/JavaCompiler$ImplicitSourcePolicy
+instanceKlass java/nio/file/AccessMode
+instanceKlass com/sun/tools/javac/jvm/ClassFile$Version
+instanceKlass com/sun/tools/javac/comp/Attr$CheckMode
+instanceKlass com/sun/tools/javac/comp/Analyzer$AnalyzerMode
+instanceKlass com/sun/tools/javac/jvm/Code$StackMapFormat
+instanceKlass com/sun/tools/javac/comp/Operators$OperatorType
+instanceKlass com/sun/tools/javac/tree/JCTree$Tag
+instanceKlass com/sun/tools/javac/jvm/Profile
+instanceKlass com/sun/tools/javac/comp/Resolve$VerboseResolutionMode
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$AttrMode
+instanceKlass com/sun/tools/javac/main/Option$PkgInfo
+instanceKlass com/sun/tools/javac/parser/Tokens$Token$Tag
+instanceKlass com/sun/tools/javac/parser/Tokens$TokenKind
+instanceKlass com/sun/tools/javac/util/Dependencies$CompletionCause
+instanceKlass com/sun/tools/javac/comp/Resolve$ReferenceLookupResult$StaticKind
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodResolutionPhase
+instanceKlass com/sun/tools/javac/util/Convert$Validation
+instanceKlass com/sun/tools/javac/code/Symbol$ModuleResolutionFlags
+instanceKlass com/sun/tools/javac/code/Symbol$ModuleFlags
+instanceKlass com/sun/tools/javac/code/Directive$RequiresFlag
+instanceKlass com/sun/tools/javac/code/Kinds$KindName
+instanceKlass com/sun/tools/javac/code/Kinds$Kind$Category
+instanceKlass com/sun/tools/javac/code/Kinds$Kind
+instanceKlass com/sun/tools/javac/code/TypeTag
+instanceKlass com/sun/tools/javac/jvm/ClassReader$AttributeKind
+instanceKlass com/sun/tools/javac/main/JavaCompiler$CompilePolicy
+instanceKlass com/sun/tools/javac/code/Source$Feature$DiagKind
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticType
+instanceKlass com/sun/tools/javac/code/Source$Feature
+instanceKlass javax/lang/model/SourceVersion
+instanceKlass javax/tools/StandardLocation
+instanceKlass java/nio/file/LinkOption
+instanceKlass jdk/javadoc/internal/doclint/Env$AccessKind
+instanceKlass jdk/javadoc/internal/doclint/Messages$Group
+instanceKlass com/sun/tools/javac/main/Arguments$ErrorMode
+instanceKlass com/sun/tools/javac/jvm/Target
+instanceKlass java/lang/ProcessImpl$LaunchMechanism
+instanceKlass com/sun/tools/javac/util/BasicDiagnosticFormatter$BasicConfiguration$SourcePosition
+instanceKlass com/sun/tools/javac/util/BasicDiagnosticFormatter$BasicConfiguration$BasicFormatKind
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter$Configuration$MultilineLimit
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter$Configuration$DiagnosticPart
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticFlag
+instanceKlass com/sun/tools/javac/util/Log$WriterKind
+instanceKlass java/nio/file/FileVisitOption
+instanceKlass javax/tools/JavaFileObject$Kind
+instanceKlass com/sun/tools/javac/code/Source
+instanceKlass com/sun/tools/javac/code/Lint$LintCategory
+instanceKlass com/sun/tools/javac/main/Option$ChoiceKind
+instanceKlass java/util/regex/Pattern$Qtype
+instanceKlass com/sun/tools/javac/main/Option$ArgKind
+instanceKlass com/sun/tools/javac/main/Option$OptionGroup
+instanceKlass com/sun/tools/javac/main/Option$OptionKind
+instanceKlass com/sun/tools/javac/main/Option
+instanceKlass java/io/File$PathStatus
+instanceKlass java/nio/file/StandardOpenOption
+instanceKlass java/util/stream/Collector$Characteristics
+instanceKlass java/util/concurrent/TimeUnit
+instanceKlass java/util/stream/StreamShape
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassOption
+instanceKlass java/lang/invoke/VarHandle$AccessType
+instanceKlass java/lang/invoke/VarHandle$AccessMode
+instanceKlass java/lang/invoke/MethodHandleImpl$Intrinsic
+instanceKlass java/lang/invoke/LambdaForm$BasicType
+instanceKlass java/lang/invoke/LambdaForm$Kind
+instanceKlass sun/invoke/util/Wrapper
+instanceKlass java/util/stream/StreamOpFlag$Type
+instanceKlass java/util/stream/StreamOpFlag
+instanceKlass java/lang/reflect/AccessFlag$Location
+instanceKlass java/lang/reflect/AccessFlag
+instanceKlass java/lang/module/ModuleDescriptor$Modifier
+instanceKlass java/lang/reflect/ClassFileFormatVersion
+instanceKlass java/lang/Thread$State
+instanceKlass java/lang/module/ModuleDescriptor$Requires$Modifier
+ciInstanceKlass java/lang/Enum 1 1 204 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 10 7 12 1 1 1 100 1 10 10 12 1 1 10 12 1 7 1 10 10 7 12 1 1 10 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 1 100 1 8 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 7 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 100 1 7 1 1 100 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/reflect/Method 1 1 472 9 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 8 1 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 7 1 10 7 12 1 1 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 8 1 10 12 1 10 12 1 100 1 8 1 8 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 11 7 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 11 12 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 100 12 1 1 1 100 1 100 1 100 1 10 12 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/reflect/Field 0 0 457 9 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 7 1 10 7 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 10 12 1 8 1 8 1 10 11 7 1 9 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 100 12 1 1 10 12 1 1 11 7 1 10 12 1 7 1 10 100 12 1 1 1 10 100 12 1 1 1 9 12 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 9 100 12 1 1 10 100 12 1 1 1 10 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/reflect/Parameter 0 0 243 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 11 7 12 1 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 8 1 8 1 10 7 12 1 1 1 10 12 1 10 12 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 8 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 7 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 100 1 10 11 12 1 1 11 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1
+ciInstanceKlass java/lang/reflect/RecordComponent 0 0 196 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 10 100 12 1 1 9 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 7 1 9 12 1 9 12 1 1 9 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 7 1 10 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 9 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/StringBuffer 0 0 483 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 100 12 1 1 1 10 10 12 1 1 9 12 1 1 10 100 12 1 1 10 100 1 8 10 100 12 1 1 1 8 10 12 1 8 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 100 1 10 12 100 1 8 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 9 7 12 1 1 1 9 7 1 9 12 1 1 7 1 7 1 7 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/loader/BuiltinClassLoader
+instanceKlass java/net/URLClassLoader
+ciInstanceKlass java/security/SecureClassLoader 1 1 102 10 7 12 1 1 1 7 1 10 12 1 9 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 7 1 10 12 1 7 1 10 12 1 11 7 12 1 1 1 7 1 11 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass java/net/URLClassLoader 1 1 600 10 7 12 1 1 1 7 1 10 12 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 7 1 10 12 1 9 12 1 1 10 12 1 10 10 12 1 10 100 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 100 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 11 12 1 1 7 1 11 12 1 11 7 12 1 1 10 12 1 11 12 1 11 12 1 1 11 10 12 1 1 10 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 7 1 100 1 10 12 1 1 7 1 10 10 12 1 1 10 100 12 1 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 8 1 10 12 1 1 10 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 8 1 10 12 1 1 11 100 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 7 12 1 1 1 8 1 10 12 1 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 100 1 10 100 12 1 1 9 100 12 1 1 1 10 12 1 8 1 100 1 8 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 9 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 100 1 8 1 10 100 1 10 12 1 10 100 12 1 100 1 10 12 1 10 12 1 100 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 100 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/util/jar/Manifest 0 0 339 10 7 12 1 1 1 100 1 10 9 7 12 1 1 1 100 1 10 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 1 11 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 11 100 1 10 12 1 10 12 1 1 11 12 1 1 10 12 1 11 12 1 1 11 100 12 1 1 1 11 7 12 1 1 11 12 1 1 100 1 10 12 1 8 1 11 12 1 7 1 10 12 1 1 11 12 1 10 12 1 10 12 1 10 7 12 1 1 1 8 1 10 12 1 1 10 9 100 12 1 1 1 10 12 1 1 10 100 12 1 10 12 1 10 12 1 9 100 12 1 1 1 8 1 10 12 1 8 1 8 1 100 1 10 12 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 1 8 1 10 10 12 1 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 11 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 11 10 12 1 11 10 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/io/ByteArrayInputStream 1 1 96 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/nio/CharBuffer
+instanceKlass java/nio/IntBuffer
+instanceKlass java/nio/ByteBuffer
+ciInstanceKlass java/nio/Buffer 1 1 256 100 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 100 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 8 1 10 12 1 1 10 12 1 8 1 9 12 1 1 100 1 8 1 10 12 1 8 1 8 1 9 12 10 12 1 8 1 8 1 8 1 10 12 1 8 1 8 1 8 1 100 1 10 100 1 10 100 1 10 9 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 10 12 1 10 100 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 7 1 10 10 12 1 1 7 1 10 10 7 12 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1
+staticfield java/nio/Buffer UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield java/nio/Buffer SCOPED_MEMORY_ACCESS Ljdk/internal/misc/ScopedMemoryAccess; jdk/internal/misc/ScopedMemoryAccess
+staticfield java/nio/Buffer IOOBE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+staticfield java/nio/Buffer $assertionsDisabled Z 1
+instanceKlass java/util/Collections$SingletonList
+instanceKlass java/util/AbstractSequentialList
+instanceKlass java/util/ArrayList$SubList
+instanceKlass java/util/Arrays$ArrayList
+instanceKlass java/util/Collections$EmptyList
+instanceKlass java/util/ArrayList
+ciInstanceKlass java/util/AbstractList 1 1 218 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 1 11 100 12 1 1 1 11 12 1 1 11 12 1 10 7 12 1 1 1 10 12 1 11 12 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 11 7 1 11 100 1 10 12 1 100 1 10 12 1 10 12 1 1 7 1 100 1 10 12 1 100 1 10 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 8 1 100 1 8 1 8 1 8 1 10 7 1 11 10 10 12 1 11 12 1 10 12 1 1 8 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/util/List 1 1 251 10 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 11 100 12 1 1 11 12 1 1 11 12 1 1 10 100 12 1 1 1 7 1 100 1 10 12 1 1 100 1 10 7 12 1 1 1 11 12 1 1 11 12 1 11 12 1 100 1 10 12 1 11 12 1 1 11 12 1 1 11 12 1 10 100 12 1 1 1 9 7 12 1 1 1 7 1 10 12 10 12 1 7 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1
+ciInstanceKlass java/lang/Iterable 1 1 62 10 7 12 1 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/Collection 1 1 115 11 100 12 1 1 1 100 1 11 7 12 1 1 1 10 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 10 7 12 1 1 1 11 12 1 10 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/SequencedCollection 1 1 109 100 1 10 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 8 1
+instanceKlass java/util/LinkedHashMap$LinkedValues
+instanceKlass java/util/AbstractQueue
+instanceKlass com/sun/tools/javac/util/List
+instanceKlass java/util/HashMap$Values
+instanceKlass java/util/ArrayDeque
+instanceKlass java/util/AbstractSet
+instanceKlass java/util/ImmutableCollections$AbstractImmutableCollection
+instanceKlass java/util/AbstractList
+ciInstanceKlass java/util/AbstractCollection 1 1 160 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 100 12 1 1 1 100 1 10 7 12 1 1 1 10 100 12 1 1 1 100 1 10 11 12 1 11 7 1 10 12 1 10 12 1 10 100 12 1 1 1 11 8 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/AssertionStatusDirectives 0 0 24 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/nio/file/FileSystemAlreadyExistsException
+instanceKlass com/sun/tools/javac/jvm/Gen$CodeSizeOverflow
+instanceKlass com/sun/tools/javac/code/Types$SignatureGenerator$InvalidSignatureException
+instanceKlass com/sun/tools/javac/comp/Infer$GraphStrategy$NodeNotFoundException
+instanceKlass com/sun/tools/javac/code/Types$AdaptFailure
+instanceKlass com/sun/tools/javac/comp/Attr$BreakAttr
+instanceKlass com/sun/tools/javac/code/Types$FunctionDescriptorLookupError
+instanceKlass com/sun/tools/javac/comp/Resolve$InapplicableMethodException
+instanceKlass com/sun/tools/javac/jvm/ClassWriter$StringOverflow
+instanceKlass com/sun/tools/javac/jvm/ClassWriter$PoolOverflow
+instanceKlass com/sun/tools/javac/code/Symbol$CompletionFailure
+instanceKlass java/nio/file/FileSystemNotFoundException
+instanceKlass java/util/NoSuchElementException
+instanceKlass java/lang/IndexOutOfBoundsException
+instanceKlass java/util/MissingResourceException
+instanceKlass java/lang/SecurityException
+instanceKlass java/nio/file/ProviderNotFoundException
+instanceKlass java/io/UncheckedIOException
+instanceKlass java/lang/UnsupportedOperationException
+instanceKlass java/lang/IllegalStateException
+instanceKlass com/sun/tools/javac/util/PropagatedException
+instanceKlass com/sun/tools/javac/util/ClientCodeException
+instanceKlass java/lang/IllegalArgumentException
+instanceKlass java/lang/ArithmeticException
+instanceKlass java/lang/NullPointerException
+instanceKlass java/lang/IllegalMonitorStateException
+instanceKlass java/lang/ArrayStoreException
+instanceKlass java/lang/ClassCastException
+ciInstanceKlass java/lang/RuntimeException 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass com/sun/tools/javac/code/TypeMetadata$ConstantValue
+instanceKlass java/security/SecureClassLoader$CodeSourceKey
+instanceKlass jdk/internal/module/ModuleReferenceImpl$CachedHash
+instanceKlass java/util/stream/Collectors$CollectorImpl
+instanceKlass jdk/internal/reflect/ReflectionFactory$Config
+instanceKlass jdk/internal/foreign/abi/UpcallLinker$CallRegs
+instanceKlass jdk/internal/foreign/abi/VMStorage
+ciInstanceKlass java/lang/Record 1 1 22 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/MethodType 1 1 780 7 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 7 12 1 1 8 1 10 100 12 1 1 1 9 7 1 9 7 1 10 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 7 1 8 1 10 12 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 9 12 1 11 12 1 1 7 10 12 1 1 10 12 1 1 7 1 7 1 10 7 12 1 1 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 8 1 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 10 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 11 12 1 1 10 12 1 1 7 1 10 12 10 12 1 10 12 1 100 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 10 10 12 1 11 12 1 1 11 12 1 10 100 12 1 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 9 12 1 1 7 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 11 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 100 1 10 12 1 1 11 100 12 1 1 18 12 1 1 11 12 1 1 18 12 1 11 12 1 100 1 11 100 12 1 1 10 12 1 100 1 10 12 1 10 100 12 1 1 10 12 1 1 9 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 9 12 1 10 100 12 1 1 10 12 1 100 10 12 1 1 10 12 1 10 7 1 7 1 9 12 1 1 7 1 7 1 7 1 1 1 5 0 1 1 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 7 1 1 7 1 1 100 1 100 1 1
+staticfield java/lang/invoke/MethodType internTable Ljava/lang/invoke/MethodType$ConcurrentWeakInternSet; java/lang/invoke/MethodType$ConcurrentWeakInternSet
+staticfield java/lang/invoke/MethodType NO_PTYPES [Ljava/lang/Class; 0 [Ljava/lang/Class;
+staticfield java/lang/invoke/MethodType objectOnlyTypes [Ljava/lang/invoke/MethodType; 20 [Ljava/lang/invoke/MethodType;
+staticfield java/lang/invoke/MethodType METHOD_HANDLE_ARRAY [Ljava/lang/Class; 1 [Ljava/lang/Class;
+staticfield java/lang/invoke/MethodType serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+staticfield java/lang/invoke/MethodType $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor$OfMethod 1 0 43 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+instanceKlass java/lang/NoSuchFieldException
+instanceKlass java/lang/NoSuchMethodException
+instanceKlass java/lang/ClassNotFoundException
+ciInstanceKlass java/lang/ReflectiveOperationException 1 1 34 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/invoke/DelegatingMethodHandle
+instanceKlass java/lang/invoke/BoundMethodHandle
+instanceKlass java/lang/invoke/DirectMethodHandle
+ciInstanceKlass java/lang/invoke/MethodHandle 1 1 737 100 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 7 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 10 9 7 12 1 1 1 9 7 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 11 12 1 10 12 1 10 12 1 1 10 100 12 1 1 100 1 11 12 1 10 100 1 11 12 1 7 1 10 12 1 11 12 1 9 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 10 12 1 1 9 12 1 11 12 1 9 12 1 9 12 1 9 12 1 11 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 8 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 10 7 12 1 1 10 12 1 1 100 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 10 100 12 1 1 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 8 1 8 1 10 7 12 1 1 9 12 1 9 12 1 1 9 12 1 1 10 12 1 7 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 11 7 12 1 1 9 12 1 10 12 1 1 10 12 1 9 12 1 10 12 1 8 10 12 1 1 8 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 7 1 100 1 1 100 1 1 100 1 1 1 1
+staticfield java/lang/invoke/MethodHandle FORM_OFFSET J 20
+staticfield java/lang/invoke/MethodHandle UPDATE_OFFSET J 13
+staticfield java/lang/invoke/MethodHandle $assertionsDisabled Z 1
+ciInstanceKlass java/util/concurrent/ConcurrentHashMap 1 1 1210 7 1 7 1 3 10 12 1 1 3 7 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 100 1 11 12 1 1 11 12 1 11 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 4 10 12 1 9 12 1 10 12 1 1 100 1 10 5 0 10 12 1 10 12 1 1 5 0 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 100 1 10 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 100 1 10 12 1 1 7 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 10 12 1 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 7 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 9 10 12 1 1 9 12 1 10 12 1 1 5 0 9 12 1 1 7 1 10 12 1 9 12 1 1 7 1 10 12 1 9 12 1 7 1 10 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 11 100 1 10 12 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 9 10 12 1 9 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 100 1 10 12 11 100 12 1 1 10 11 7 12 1 10 12 1 100 1 10 12 1 100 1 10 10 9 7 12 1 1 1 10 12 3 10 7 12 1 1 9 12 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 100 12 1 1 9 12 1 9 7 12 1 1 10 12 1 1 10 12 1 3 9 12 1 9 12 1 10 12 1 1 7 1 9 3 9 12 1 7 1 10 12 1 9 12 1 10 12 1 9 12 1 10 12 1 9 12 1 10 100 12 1 1 1 100 10 12 1 7 1 5 0 10 100 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 100 1 10 12 1 10 100 1 100 1 10 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 7 1 10 12 1 1 100 1 10 12 1 10 10 12 1 100 1 10 12 1 10 10 12 1 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 10 100 1 10 10 100 1 10 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 10 100 1 10 10 100 1 10 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 10 12 1 10 7 12 1 1 1 10 12 1 7 1 7 1 10 12 1 9 12 1 1 9 12 1 1 10 12 1 1 8 10 12 1 1 8 8 8 8 7 10 12 1 1 10 12 1 100 1 8 1 10 7 1 7 1 7 1 1 1 5 0 1 1 3 1 3 1 1 1 1 3 1 3 1 3 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/util/concurrent/ConcurrentHashMap NCPU I 40
+staticfield java/util/concurrent/ConcurrentHashMap serialPersistentFields [Ljava/io/ObjectStreamField; 3 [Ljava/io/ObjectStreamField;
+staticfield java/util/concurrent/ConcurrentHashMap U Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield java/util/concurrent/ConcurrentHashMap SIZECTL J 20
+staticfield java/util/concurrent/ConcurrentHashMap TRANSFERINDEX J 32
+staticfield java/util/concurrent/ConcurrentHashMap BASECOUNT J 24
+staticfield java/util/concurrent/ConcurrentHashMap CELLSBUSY J 36
+staticfield java/util/concurrent/ConcurrentHashMap CELLVALUE J 144
+staticfield java/util/concurrent/ConcurrentHashMap ABASE I 16
+staticfield java/util/concurrent/ConcurrentHashMap ASHIFT I 2
+instanceKlass java/util/Collections$SingletonMap
+instanceKlass java/util/IdentityHashMap
+instanceKlass java/lang/ProcessEnvironment$StringEnvironment
+instanceKlass java/util/EnumMap
+instanceKlass java/util/WeakHashMap
+instanceKlass java/util/Collections$EmptyMap
+instanceKlass sun/util/PreHashedMap
+instanceKlass java/util/HashMap
+instanceKlass java/util/ImmutableCollections$AbstractImmutableMap
+instanceKlass java/util/concurrent/ConcurrentHashMap
+ciInstanceKlass java/util/AbstractMap 1 1 196 10 7 12 1 1 1 10 7 12 1 1 1 11 100 12 1 1 1 10 11 12 1 1 11 7 12 1 1 1 11 12 1 1 100 1 11 12 1 10 12 1 1 11 12 1 100 1 10 11 12 1 11 7 1 10 12 1 1 11 12 1 9 12 1 1 100 1 10 12 1 9 12 1 1 100 1 10 11 11 12 1 1 11 12 1 7 1 100 1 11 12 1 8 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1
+ciInstanceKlass java/util/concurrent/ConcurrentMap 1 1 208 11 7 12 1 1 1 10 100 12 1 1 11 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 11 12 1 1 100 1 11 12 1 11 12 1 100 1 11 100 12 1 1 1 18 12 1 11 12 1 1 11 100 12 1 1 11 12 1 1 11 100 12 1 11 12 1 1 11 12 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 11 12 15 10 100 12 1 1 1 1 1 100 1 100 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders 1 1 183 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 7 1 11 100 12 1 1 1 100 1 11 12 1 1 11 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 100 1 100 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 7 1 8 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 10 12 1 10 12 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/loader/ClassLoaders JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$2
+staticfield jdk/internal/loader/ClassLoaders BOOT_LOADER Ljdk/internal/loader/ClassLoaders$BootClassLoader; jdk/internal/loader/ClassLoaders$BootClassLoader
+staticfield jdk/internal/loader/ClassLoaders PLATFORM_LOADER Ljdk/internal/loader/ClassLoaders$PlatformClassLoader; jdk/internal/loader/ClassLoaders$PlatformClassLoader
+staticfield jdk/internal/loader/ClassLoaders APP_LOADER Ljdk/internal/loader/ClassLoaders$AppClassLoader; jdk/internal/loader/ClassLoaders$AppClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$BootClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$PlatformClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$AppClassLoader
+ciInstanceKlass jdk/internal/loader/BuiltinClassLoader 1 1 737 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 7 1 10 12 1 9 12 1 10 12 1 9 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 7 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 7 1 10 12 1 10 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 7 1 8 1 8 1 10 9 12 1 1 10 7 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 10 7 12 1 1 7 1 10 7 12 1 1 1 10 12 1 100 1 8 1 10 12 1 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 11 12 1 7 1 10 11 12 1 1 11 10 12 1 1 7 1 10 12 1 10 7 12 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 100 1 10 12 1 1 11 12 1 100 1 100 1 10 12 1 10 12 1 1 100 1 100 1 10 12 1 10 12 1 18 12 1 1 10 12 1 10 12 1 1 18 100 1 10 7 12 1 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 18 12 1 7 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 100 1 10 12 1 7 1 10 12 1 10 100 12 1 1 1 10 12 1 11 12 1 7 1 10 12 1 7 1 100 1 10 12 1 10 12 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 8 1 10 10 12 1 8 1 8 1 10 100 12 1 1 1 11 100 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 7 12 1 1 1 8 1 10 12 1 7 1 10 12 1 1 10 12 1 7 1 10 11 12 1 1 10 12 10 12 1 10 12 1 100 1 10 12 1 10 12 1 10 10 12 1 10 7 12 1 1 8 1 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 16 15 10 12 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 100 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/loader/BuiltinClassLoader packageToModule Ljava/util/Map; java/util/concurrent/ConcurrentHashMap
+staticfield jdk/internal/loader/BuiltinClassLoader $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders$AppClassLoader 1 1 119 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 7 1 8 1 10 12 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders$PlatformClassLoader 1 1 42 8 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 100 1 1
+ciInstanceKlass java/lang/ArithmeticException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ArrayStoreException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ClassCastException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ClassNotFoundException 1 1 96 7 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 7 1 10 12 1 9 12 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/ClassNotFoundException serialPersistentFields [Ljava/io/ObjectStreamField; 1 [Ljava/io/ObjectStreamField;
+ciInstanceKlass java/lang/IllegalMonitorStateException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/BootstrapMethodError 0 0 45 10 100 12 1 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass java/lang/ClassFormatError
+instanceKlass java/lang/IncompatibleClassChangeError
+instanceKlass java/lang/BootstrapMethodError
+instanceKlass java/lang/NoClassDefFoundError
+ciInstanceKlass java/lang/LinkageError 1 1 31 10 7 12 1 1 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/NullPointerException 1 1 52 10 100 12 1 1 1 10 12 1 9 100 12 1 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 1 1 5 0 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass java/lang/NoClassDefFoundError 0 0 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackOverflowError 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackTraceElement 0 0 235 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 8 1 10 100 12 1 1 1 7 1 9 12 1 8 1 9 12 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 8 1 10 100 12 1 1 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 7 12 1 1 10 100 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 1 1 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer
+ciInstanceKlass java/util/concurrent/locks/AbstractOwnableSynchronizer 1 1 32 10 7 12 1 1 1 9 7 12 1 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/Continuation 0 0 549 9 100 12 1 1 1 9 12 1 9 12 1 100 1 7 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 1 11 100 12 1 1 1 10 7 1 9 12 1 1 9 12 1 1 10 8 1 10 12 1 9 12 1 1 10 11 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 9 12 1 1 10 12 1 1 18 12 1 1 10 7 12 1 1 1 100 1 10 12 1 11 100 12 1 1 1 10 12 1 9 12 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 1 9 12 1 1 11 12 1 1 9 12 1 1 8 1 10 11 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 10 10 12 1 8 1 10 12 1 8 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 9 12 1 11 12 1 7 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 11 7 12 1 1 10 7 1 10 12 1 8 1 9 12 1 10 12 1 1 9 12 1 1 10 7 12 1 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 8 1 10 7 12 1 1 1 10 12 1 8 1 100 1 8 1 10 9 12 1 1 8 1 10 7 12 1 1 10 100 12 1 1 8 1 8 1 10 12 10 100 12 1 1 1 10 7 1 10 7 12 1 1 1 18 11 100 12 1 1 1 18 12 1 11 12 1 1 7 1 10 7 12 1 1 10 12 1 1 8 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 8 1 10 12 1 7 1 7 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 1 15 10 12 16 15 11 7 12 1 1 1 16 1 16 1 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/misc/UnsafeConstants 1 1 34 10 100 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/misc/UnsafeConstants ADDRESS_SIZE0 I 8
+staticfield jdk/internal/misc/UnsafeConstants PAGE_SIZE I 4096
+staticfield jdk/internal/misc/UnsafeConstants BIG_ENDIAN Z 0
+staticfield jdk/internal/misc/UnsafeConstants UNALIGNED_ACCESS Z 1
+staticfield jdk/internal/misc/UnsafeConstants DATA_CACHE_LINE_FLUSH_SIZE I 64
+ciInstanceKlass java/lang/invoke/LambdaForm 1 1 1059 7 1 100 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 9 12 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 9 7 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 9 12 1 1 10 12 1 9 12 1 10 100 12 1 1 1 10 12 1 1 7 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 10 12 1 8 1 8 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 9 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 9 12 1 7 1 10 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 7 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 10 12 10 12 1 1 10 12 1 1 9 12 1 8 10 12 1 1 100 1 10 12 1 1 10 12 1 9 7 12 1 1 9 7 12 1 1 1 8 1 10 100 12 1 1 10 12 1 1 7 1 7 1 10 10 12 1 1 10 12 1 1 8 1 8 1 7 1 8 1 10 12 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 10 12 1 1 8 1 8 1 8 1 7 1 8 1 7 1 8 1 7 1 8 1 10 12 1 8 1 9 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 100 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 8 1 8 1 7 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 8 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 8 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 7 1 10 7 12 1 1 1 9 12 1 10 12 1 10 12 1 8 1 10 12 1 9 12 1 1 7 1 10 7 12 1 1 1 8 1 100 1 10 12 1 9 12 1 9 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 9 7 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 10 12 1 10 10 12 1 9 12 1 9 9 12 1 7 9 12 1 1 10 12 1 1 9 12 1 10 12 1 10 7 1 9 1 1 1 1 3 1 3 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 7 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/LambdaForm DEFAULT_CUSTOMIZED Ljava/lang/invoke/MethodHandle; null
+staticfield java/lang/invoke/LambdaForm DEFAULT_KIND Ljava/lang/invoke/LambdaForm$Kind; java/lang/invoke/LambdaForm$Kind
+staticfield java/lang/invoke/LambdaForm COMPILE_THRESHOLD I 0
+staticfield java/lang/invoke/LambdaForm INTERNED_ARGUMENTS [[Ljava/lang/invoke/LambdaForm$Name; 5 [[Ljava/lang/invoke/LambdaForm$Name;
+staticfield java/lang/invoke/LambdaForm IMPL_NAMES Ljava/lang/invoke/MemberName$Factory; java/lang/invoke/MemberName$Factory
+staticfield java/lang/invoke/LambdaForm LF_identity [Ljava/lang/invoke/LambdaForm; 6 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/LambdaForm LF_zero [Ljava/lang/invoke/LambdaForm; 6 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/LambdaForm NF_identity [Ljava/lang/invoke/LambdaForm$NamedFunction; 6 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/LambdaForm NF_zero [Ljava/lang/invoke/LambdaForm$NamedFunction; 6 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/LambdaForm createFormsLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/invoke/LambdaForm DEBUG_NAME_COUNTERS Ljava/util/HashMap; null
+staticfield java/lang/invoke/LambdaForm DEBUG_NAMES Ljava/util/HashMap; null
+staticfield java/lang/invoke/LambdaForm TRACE_INTERPRETER Z 0
+staticfield java/lang/invoke/LambdaForm $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MemberName 1 1 724 7 1 7 1 100 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 9 7 12 1 1 10 12 1 7 1 7 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 8 1 10 100 12 1 1 1 7 1 10 10 12 1 1 100 1 100 1 10 12 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 8 1 9 12 1 1 3 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 7 1 8 10 12 1 1 10 12 1 1 8 1 9 7 1 8 9 7 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 8 1 8 1 7 1 10 12 1 10 100 12 1 1 1 100 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 3 10 12 1 3 10 12 1 3 3 3 3 3 3 10 12 1 3 9 12 1 10 12 1 1 3 10 12 1 10 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 7 1 10 10 10 12 100 1 10 10 10 12 1 1 10 12 1 1 10 10 12 1 8 10 7 1 10 12 1 10 7 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 1 100 1 8 1 10 7 1 10 12 1 10 12 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 7 12 1 1 1 8 1 8 1 10 12 1 8 1 10 10 10 12 1 10 12 1 8 1 8 1 10 10 12 1 8 1 10 100 12 1 1 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 100 1 10 8 1 8 1 8 1 8 1 10 12 1 100 1 100 1 100 1 10 100 1 10 7 1 10 7 12 1 1 1 9 7 12 1 1 1 7 1 7 1 1 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/MemberName $assertionsDisabled Z 1
+instanceKlass java/lang/invoke/VarHandleByteArrayAsDoubles$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsLongs$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsFloats$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsInts$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsChars$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsShorts$ByteArrayViewVarHandle
+ciInstanceKlass java/lang/invoke/VarHandle 1 1 474 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 100 1 10 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 10 12 1 9 12 1 1 10 100 12 1 1 10 12 1 9 100 12 1 1 1 9 12 1 1 10 12 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 10 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 9 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 10 7 12 1 1 100 1 10 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 10 12 1 1 7 1 10 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 100 1 1 1 100 1 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1
+staticfield java/lang/invoke/VarHandle VFORM_OFFSET J 16
+staticfield java/lang/invoke/VarHandle $assertionsDisabled Z 1
+instanceKlass jdk/internal/reflect/FieldAccessorImpl
+instanceKlass jdk/internal/reflect/ConstructorAccessorImpl
+instanceKlass jdk/internal/reflect/MethodAccessorImpl
+ciInstanceKlass jdk/internal/reflect/MagicAccessorImpl 1 1 16 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/DirectMethodHandleAccessor
+ciInstanceKlass jdk/internal/reflect/MethodAccessorImpl 1 1 38 10 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/MethodAccessor 1 0 17 100 1 100 1 1 1 1 100 1 100 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/DirectConstructorHandleAccessor
+instanceKlass jdk/internal/reflect/NativeConstructorAccessorImpl
+ciInstanceKlass jdk/internal/reflect/ConstructorAccessorImpl 1 1 27 10 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass jdk/internal/reflect/ConstructorAccessor 1 0 16 100 1 100 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass jdk/internal/reflect/DelegatingClassLoader 0 0 18 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/CallerSensitive 0 0 17 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/NativeConstructorAccessorImpl 0 0 125 10 7 12 1 1 1 9 7 12 1 1 1 100 1 10 12 1 9 12 1 1 9 12 1 1 10 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 10 12 1 1 10 12 1 1 8 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/ConstantPool 1 1 142 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 8 11 7 12 1 1 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/UnsafeStaticFieldAccessorImpl 0 0 47 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 8 11 100 12 1 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/FieldAccessor 0 0 48 100 1 100 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/UnsafeFieldAccessorImpl
+ciInstanceKlass jdk/internal/reflect/FieldAccessorImpl 0 0 269 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 10 12 1 1 10 12 1 1 8 1 10 10 12 1 100 1 8 1 10 12 1 8 1 10 12 1 8 1 10 12 1 100 1 10 12 1 1 10 8 1 10 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 10 12 1 1 8 1 10 12 1 1 10 100 12 1 1 1 8 1 10 12 1 8 1 8 1 8 1 8 1 10 7 12 1 1 1 8 1 8 1 8 1 10 12 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/UnsafeStaticFieldAccessorImpl
+ciInstanceKlass jdk/internal/reflect/UnsafeFieldAccessorImpl 0 0 62 10 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 100 12 1 1 10 12 1 9 12 1 1 10 100 12 1 1 1 9 12 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/invoke/VolatileCallSite
+instanceKlass java/lang/invoke/MutableCallSite
+instanceKlass java/lang/invoke/ConstantCallSite
+ciInstanceKlass java/lang/invoke/CallSite 1 1 307 10 7 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 7 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 10 12 1 1 100 1 7 1 10 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 100 12 1 1 10 12 1 1 9 12 1 9 100 12 1 1 1 8 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 1 9 12 1 8 1 100 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 8 10 12 1 1 9 12 1 1 100 1 10 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 8 1 10 10 12 10 12 1 1 7 1 7 1 7 1 8 1 10 12 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1
+staticfield java/lang/invoke/CallSite $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/ConstantCallSite 1 1 65 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 100 1 10 12 9 12 1 1 100 1 10 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/ConstantCallSite UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+instanceKlass java/lang/invoke/DirectMethodHandle$Interface
+instanceKlass java/lang/invoke/DirectMethodHandle$Constructor
+instanceKlass java/lang/invoke/DirectMethodHandle$Accessor
+ciInstanceKlass java/lang/invoke/DirectMethodHandle 1 1 923 7 1 7 1 100 1 7 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 9 12 1 1 100 1 10 9 12 1 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 100 1 10 12 1 7 1 10 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 100 1 10 12 1 10 12 1 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 7 12 1 1 1 8 1 9 12 1 9 12 1 8 1 9 12 1 9 12 1 8 1 9 12 1 9 12 1 8 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 10 7 1 9 12 9 12 1 10 7 12 1 1 1 10 12 1 7 1 7 1 7 1 9 12 1 1 10 7 12 1 1 1 10 12 10 12 1 100 1 10 12 1 10 12 1 1 8 1 9 12 1 9 12 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 9 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 8 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 9 7 1 10 12 1 9 12 1 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 8 1 8 1 8 1 8 1 10 12 1 1 9 12 1 1 10 12 1 10 100 12 1 1 1 8 9 12 1 1 10 12 1 1 8 1 8 8 9 12 1 8 1 8 8 8 8 8 1 8 10 12 1 7 1 10 12 1 8 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 7 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/DirectMethodHandle IMPL_NAMES Ljava/lang/invoke/MemberName$Factory; java/lang/invoke/MemberName$Factory
+staticfield java/lang/invoke/DirectMethodHandle FT_UNCHECKED_REF I 8
+staticfield java/lang/invoke/DirectMethodHandle ACCESSOR_FORMS [Ljava/lang/invoke/LambdaForm; 132 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/DirectMethodHandle ALL_WRAPPERS [Lsun/invoke/util/Wrapper; 10 [Lsun/invoke/util/Wrapper;
+staticfield java/lang/invoke/DirectMethodHandle NFS [Ljava/lang/invoke/LambdaForm$NamedFunction; 12 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/DirectMethodHandle OBJ_OBJ_TYPE Ljava/lang/invoke/MethodType; java/lang/invoke/MethodType
+staticfield java/lang/invoke/DirectMethodHandle LONG_OBJ_TYPE Ljava/lang/invoke/MethodType; java/lang/invoke/MethodType
+staticfield java/lang/invoke/DirectMethodHandle $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MutableCallSite 0 0 63 10 100 12 1 1 1 10 12 1 9 100 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/lang/invoke/VolatileCallSite 0 0 37 10 100 12 1 1 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/ResolvedMethodName 1 1 16 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/MethodHandleNatives 1 1 690 100 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 1 9 7 12 1 1 1 8 1 10 100 12 1 1 1 7 1 10 12 100 1 100 1 8 1 7 1 10 10 12 1 7 1 9 7 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 7 1 10 12 1 8 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 10 10 12 1 1 10 12 1 10 100 12 1 1 1 100 1 8 1 10 100 12 1 1 1 7 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 7 1 7 1 10 12 1 10 12 1 8 1 8 1 10 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 7 1 9 12 1 1 10 7 12 1 1 1 10 10 12 1 9 12 1 10 12 1 9 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 7 1 7 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 100 1 100 1 10 10 100 1 100 1 10 100 1 10 10 12 1 1 10 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 1 1
+staticfield java/lang/invoke/MethodHandleNatives $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MethodHandleNatives$CallSiteContext 1 1 49 10 7 12 1 1 1 7 1 10 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/NativeEntryPoint 0 0 194 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 100 1 10 100 12 1 1 1 10 12 1 9 12 1 1 18 12 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 7 1 8 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 10 12 16 1 16 15 10 12 15 10 100 12 1 1 1 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/ABIDescriptor 0 0 55 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/foreign/abi/VMStorage 0 0 91 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 18 12 1 18 12 1 1 18 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 8 1 15 15 15 15 15 10 100 12 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/UpcallLinker$CallRegs 0 0 66 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 18 12 1 1 18 12 1 1 18 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 8 1 15 15 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/StackWalker 0 0 271 9 7 12 1 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 11 12 1 1 100 1 8 1 10 10 7 12 1 1 9 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 18 12 1 1 100 1 8 1 10 8 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 11 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/StackWalker$StackFrame 0 0 41 100 1 10 12 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass java/lang/LiveStackFrameInfo
+ciInstanceKlass java/lang/StackFrameInfo 0 0 142 10 7 12 1 1 1 9 7 12 1 1 1 9 7 1 9 12 1 1 11 100 12 1 1 1 9 12 1 1 11 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 11 12 1 11 12 1 1 11 12 1 10 12 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 11 12 1 1 9 12 1 1 10 7 1 10 12 1 9 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 100 12 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 7 1 1 1 1 1 1
+ciInstanceKlass java/lang/LiveStackFrameInfo 0 0 97 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 7 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 10 100 1 10 12 1 100 1 10 12 1 7 1 7 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/LiveStackFrame 0 0 135 100 1 10 100 12 1 1 1 11 7 12 1 1 1 11 12 1 10 7 12 1 1 1 100 1 8 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 12 1 10 12 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1
+ciInstanceKlass java/lang/StackStreamFactory$AbstractStackWalker 1 0 375 100 1 7 1 3 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 1 9 7 12 1 1 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 1 100 1 8 1 10 12 1 8 1 10 12 10 100 12 1 1 9 12 1 8 1 5 0 8 1 8 1 9 12 1 1 10 12 1 1 18 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 9 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 7 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 15 10 100 12 1 1 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/module/Modules 1 1 504 10 7 12 1 1 1 9 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 11 12 1 11 12 1 11 12 1 11 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 18 12 1 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 11 12 1 9 12 1 1 11 7 12 1 1 1 10 12 1 1 10 10 12 1 10 9 12 1 1 10 100 12 1 1 10 12 1 1 10 100 12 1 1 100 1 11 100 12 1 1 1 10 100 12 1 1 1 11 100 12 1 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 11 12 1 1 18 12 1 1 11 100 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 7 1 11 12 1 1 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 100 12 1 1 18 12 1 1 11 12 1 1 18 12 1 1 11 12 1 1 10 12 1 18 18 10 12 1 1 9 12 1 1 11 7 12 1 1 1 100 1 10 11 12 1 11 12 1 1 11 12 1 1 10 100 1 10 12 1 1 10 100 12 1 1 10 12 1 1 11 12 10 12 1 1 7 1 10 18 12 1 10 12 1 1 7 1 8 1 10 12 1 10 100 12 1 1 18 12 1 11 11 12 10 12 1 10 10 100 1 18 12 1 10 10 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 1 16 16 15 10 12 1 16 1 16 1 15 10 12 1 16 1 16 1 15 10 12 16 1 15 10 16 1 15 10 12 16 1 15 10 12 16 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/module/Modules JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$2
+staticfield jdk/internal/module/Modules JLMA Ljdk/internal/access/JavaLangModuleAccess; java/lang/module/ModuleDescriptor$1
+staticfield jdk/internal/module/Modules $assertionsDisabled Z 1
+ciInstanceKlass java/util/ArrayList 1 1 509 10 7 12 1 1 1 7 1 9 7 12 1 1 1 9 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 11 7 12 1 1 1 9 12 1 1 11 12 1 1 100 10 7 12 1 1 1 9 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 7 1 10 12 1 10 10 7 12 1 1 1 10 7 12 1 1 10 12 1 100 1 10 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 100 1 10 11 12 1 1 11 7 12 1 1 1 11 12 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 11 12 1 7 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 100 1 8 1 10 100 1 10 12 1 7 1 10 12 1 10 12 1 1 7 1 10 12 1 10 12 1 1 11 100 12 1 1 7 1 10 12 1 10 12 1 1 11 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 100 12 1 1 10 12 1 1 7 1 7 1 7 1 1 1 1 5 0 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1
+staticfield java/util/ArrayList EMPTY_ELEMENTDATA [Ljava/lang/Object; 0 [Ljava/lang/Object;
+staticfield java/util/ArrayList DEFAULTCAPACITY_EMPTY_ELEMENTDATA [Ljava/lang/Object; 0 [Ljava/lang/Object;
+ciInstanceKlass java/util/RandomAccess 1 0 7 100 1 100 1 1 1
+ciInstanceKlass java/lang/annotation/Annotation 0 0 17 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/org/objectweb/asm/AnnotationWriter 1 1 262 100 1 3 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 9 12 1 7 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 9 100 12 1 1 7 1 10 12 1 1 7 1 10 12 1 1 7 1 10 12 1 1 100 1 10 12 1 1 100 1 100 1 100 1 100 1 100 1 100 1 10 12 1 1 100 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 8 1 9 12 1 10 12 1 1 9 12 1 100 1 8 1 10 12 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/org/objectweb/asm/ByteVector 1 1 109 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 3 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod jdk/internal/org/objectweb/asm/ByteVector putShort (I)Ljdk/internal/org/objectweb/asm/ByteVector; 562 0 6388 0 -1
+ciMethod jdk/internal/org/objectweb/asm/ByteVector putByteArray ([BII)Ljdk/internal/org/objectweb/asm/ByteVector; 522 0 684 0 -1
+ciInstanceKlass jdk/internal/org/objectweb/asm/SymbolTable 1 1 594 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 7 1 9 12 1 1 9 12 1 1 7 1 10 9 12 1 1 9 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 100 1 10 7 1 10 12 1 1 10 12 1 100 1 8 1 10 7 12 1 1 1 9 12 1 9 12 1 10 12 1 1 10 12 1 3 10 12 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 9 12 9 12 1 1 7 1 10 12 1 10 12 1 1 7 1 10 7 1 10 12 1 1 7 1 10 7 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 10 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 10 12 10 12 1 10 12 1 1 10 12 1 10 12 1 100 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 9 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 100 12 1 1 1 10 12 1 10 7 12 1 1 1 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod jdk/internal/org/objectweb/asm/SymbolTable getMajorVersion ()I 264 0 132 0 -1
+ciMethod jdk/internal/org/objectweb/asm/SymbolTable getSource ()Ljdk/internal/org/objectweb/asm/ClassReader; 0 0 1 0 -1
+ciInstanceKlass jdk/internal/org/objectweb/asm/MethodWriter 1 1 818 100 1 3 10 7 12 1 1 1 7 1 10 12 1 9 7 12 1 1 1 9 12 1 1 8 10 7 12 1 1 1 100 1 3 9 12 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 10 12 1 1 9 7 12 1 1 9 12 1 10 7 12 1 1 9 12 1 9 12 1 7 1 10 9 12 1 1 10 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 10 12 1 1 9 12 1 7 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 100 1 10 12 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 9 12 1 10 12 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 9 12 1 9 12 1 100 1 10 10 12 1 10 12 1 1 10 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 10 100 12 1 1 1 9 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 10 12 1 1 9 12 1 7 1 10 12 1 1 10 12 1 1 100 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 1 1 9 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 3 9 12 1 9 12 1 7 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 100 12 1 1 9 12 1 9 12 1 10 12 1 10 12 1 9 12 1 8 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 10 12 1 9 12 1 9 12 1 10 12 1 9 12 1 9 12 1 10 12 1 1 9 12 1 10 12 1 1 3 10 12 1 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 1 3 10 100 12 1 1 1 9 12 1 9 12 1 3 100 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 9 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 100 12 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/org/objectweb/asm/MethodWriter STACK_SIZE_DELTA [I 202
+ciMethod jdk/internal/org/objectweb/asm/MethodWriter putMethodInfo (Ljdk/internal/org/objectweb/asm/ByteVector;)V 784 0 392 0 -1
+ciMethodData jdk/internal/org/objectweb/asm/ByteVector putShort (I)Ljdk/internal/org/objectweb/asm/ByteVector; 2 6107 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 113 127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 21 0xd0007 0x17db 0x58 0x0 0x120005 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData jdk/internal/org/objectweb/asm/ByteVector putByteArray ([BII)Ljdk/internal/org/objectweb/asm/ByteVector; 1 423 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 114 127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 29 0xb0007 0x1a7 0x58 0x0 0x100005 0x0 0x0 0x0 0x0 0x0 0x0 0x140007 0x0 0x30 0x1a7 0x220002 0x1a7 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData jdk/internal/org/objectweb/asm/MethodWriter putMethodInfo (Ljdk/internal/org/objectweb/asm/ByteVector;)V 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 113 127 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 748 0x40005 0x0 0x0 0x0 0x0 0x0 0x0 0x90007 0x0 0x38 0x0 0xd0003 0x0 0x18 0x130007 0x0 0x38 0x0 0x190003 0x0 0x18 0x270005 0x0 0x0 0x0 0x0 0x0 0x0 0x2e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x350005 0x0 0x0 0x0 0x0 0x0 0x0 0x3d0007 0x0 0x90 0x0 0x450005 0x0 0x0 0x0 0x0 0x0 0x0 0x530005 0x0 0x0 0x0 0x0 0x0 0x0 0x620007 0x0 0x20 0x0 0x6c0007 0x0 0x20 0x0 0x7a0007 0x0 0x40 0x0 0x7e0007 0x0 0x20 0x0 0x880007 0x0 0x20 0x0 0x960007 0x0 0x20 0x0 0xa00007 0x0 0x20 0x0 0xaa0007 0x0 0x20 0x0 0xb40007 0x0 0x20 0x0 0xbe0007 0x0 0x20 0x0 0xc80007 0x0 0x20 0x0 0xd20007 0x0 0x20 0x0 0xdc0007 0x0 0x20 0x0 0xe60007 0x0 0x20 0x0 0xf00007 0x0 0x58 0x0 0xf90005 0x0 0x0 0x0 0x0 0x0 0x0 0x1020005 0x0 0x0 0x0 0x0 0x0 0x0 0x10d0007 0x0 0xac0 0x0 0x11e0002 0x0 0x12b0007 0x0 0x20 0x0 0x1440007 0x0 0x20 0x0 0x15d0007 0x0 0x20 0x0 0x1760007 0x0 0x20 0x0 0x18f0007 0x0 0x58 0x0 0x19b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1a80007 0x0 0x58 0x0 0x1b40005 0x0 0x0 0x0 0x0 0x0 0x0 0x1c10007 0x0 0x90 0x0 0x1e40005 0x0 0x0 0x0 0x0 0x0 0x0 0x1f00005 0x0 0x0 0x0 0x0 0x0 0x0 0x1fe0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2010005 0x0 0x0 0x0 0x0 0x0 0x0 0x2060005 0x0 0x0 0x0 0x0 0x0 0x0 0x20d0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2140005 0x0 0x0 0x0 0x0 0x0 0x0 0x21e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2300005 0x0 0x0 0x0 0x0 0x0 0x0 0x2390002 0x0 0x23f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2470007 0x0 0x1e0 0x0 0x24e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2530007 0x0 0x38 0x0 0x2570003 0x0 0x18 0x2640007 0x0 0x38 0x0 0x26a0003 0x0 0x18 0x2700005 0x0 0x0 0x0 0x0 0x0 0x0 0x2730005 0x0 0x0 0x0 0x0 0x0 0x0 0x27f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2860005 0x0 0x0 0x0 0x0 0x0 0x0 0x2980005 0x0 0x0 0x0 0x0 0x0 0x0 0x2a00007 0x0 0x138 0x0 0x2ab0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2ae0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2ba0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2c10005 0x0 0x0 0x0 0x0 0x0 0x0 0x2d30005 0x0 0x0 0x0 0x0 0x0 0x0 0x2db0007 0x0 0x138 0x0 0x2e60005 0x0 0x0 0x0 0x0 0x0 0x0 0x2e90005 0x0 0x0 0x0 0x0 0x0 0x0 0x2f50005 0x0 0x0 0x0 0x0 0x0 0x0 0x2fc0005 0x0 0x0 0x0 0x0 0x0 0x0 0x30e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3160007 0x0 0x138 0x0 0x3210005 0x0 0x0 0x0 0x0 0x0 0x0 0x3240005 0x0 0x0 0x0 0x0 0x0 0x0 0x3300005 0x0 0x0 0x0 0x0 0x0 0x0 0x3370005 0x0 0x0 0x0 0x0 0x0 0x0 0x3490005 0x0 0x0 0x0 0x0 0x0 0x0 0x3510007 0x0 0x90 0x0 0x35f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3630005 0x0 0x0 0x0 0x0 0x0 0x0 0x36a0007 0x0 0x90 0x0 0x3780005 0x0 0x0 0x0 0x0 0x0 0x0 0x37c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3830007 0x0 0x58 0x0 0x3a50005 0x0 0x0 0x0 0x0 0x0 0x0 0x3ac0007 0x0 0x170 0x0 0x3b70005 0x0 0x0 0x0 0x0 0x0 0x0 0x3ba0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3c50005 0x0 0x0 0x0 0x0 0x0 0x0 0x3cc0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3e20007 0x0 0x70 0x0 0x3ef0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3f60003 0x0 0xffffffffffffffa8 0x4060002 0x0 0x41e0002 0x0 0x4250007 0x0 0xa0 0x0 0x42f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x43a0007 0x0 0x38 0x0 0x4420003 0x0 0x18 0x44a0002 0x0 0x4510007 0x0 0xa0 0x0 0x45b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4660007 0x0 0x38 0x0 0x46e0003 0x0 0x18 0x4760002 0x0 0x47d0007 0x0 0x100 0x0 0x4880005 0x0 0x0 0x0 0x0 0x0 0x0 0x48b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4950005 0x0 0x0 0x0 0x0 0x0 0x0 0x4a70005 0x0 0x0 0x0 0x0 0x0 0x0 0x4af0007 0x0 0x138 0x0 0x4ba0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4bd0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4c90005 0x0 0x0 0x0 0x0 0x0 0x0 0x4d00005 0x0 0x0 0x0 0x0 0x0 0x0 0x4e20005 0x0 0x0 0x0 0x0 0x0 0x0 0x4ea0007 0x0 0x58 0x0 0x4f60005 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+compile jdk/internal/org/objectweb/asm/MethodWriter putMethodInfo (Ljdk/internal/org/objectweb/asm/ByteVector;)V -1 3

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -896,6 +896,7 @@ MetaWord* Metaspace::allocate(ClassLoaderData* loader_data, size_t word_size,
   return result;
 }
 
+static int failure_threshold = 0;
 MetaWord* Metaspace::allocate(ClassLoaderData* loader_data, size_t word_size,
                               MetaspaceObj::Type type, TRAPS) {
 
@@ -904,6 +905,17 @@ MetaWord* Metaspace::allocate(ClassLoaderData* loader_data, size_t word_size,
     return nullptr;  // caller does a CHECK_NULL too
   }
 
+  MetadataType mdtype = (type == MetaspaceObj::ClassType) ? ClassType : NonClassType;
+
+  if (mdtype == ClassType && word_size == 64) {
+    FILE* f = ::fopen("/home/afshin/res_exhausted.txt","r");
+    if (f != nullptr ) {
+      fprintf(stderr,"artificial OOME. ResourceExhausted file found\n");
+      report_metadata_oome(loader_data, word_size, type, mdtype, THREAD);
+      ::fclose(f);
+      return nullptr;
+    }
+  }
   MetaWord* result = allocate(loader_data, word_size, type);
 
   if (result == nullptr) {

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -47,6 +47,7 @@ class ArrayKlass: public Klass {
   // initialization, the other is a dummy
   ArrayKlass(Symbol* name, KlassKind kind);
   ArrayKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
+  void deallocate_contents(ClassLoaderData *loader_data) { Klass::deallocate_contents(loader_data); }
 
  public:
   // Testing operation
@@ -57,6 +58,7 @@ class ArrayKlass: public Klass {
   void set_dimension(int dimension)     { _dimension = dimension; }
 
   Klass* higher_dimension() const     { return _higher_dimension; }
+  Klass* volatile* higher_dimension_addr() { return &_higher_dimension; }
   inline Klass* higher_dimension_acquire() const; // load with acquire semantics
   void set_higher_dimension(Klass* k) { _higher_dimension = k; }
   inline void release_set_higher_dimension(Klass* k); // store with release semantics

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -198,6 +198,7 @@ protected:
   Klass() : _kind(UnknownKlassKind) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
   void* operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, TRAPS) throw();
+  void deallocate_contents(ClassLoaderData *);
 
  public:
   int kind() { return _kind; }

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -76,10 +76,12 @@ class ObjArrayKlass : public ArrayKlass {
 
   // Allocation
   static ObjArrayKlass* allocate_objArray_klass(ClassLoaderData* loader_data,
-                                                int n, Klass* element_klass, TRAPS);
+                                                int n, Klass* element_klass, bool* allocated, TRAPS);
 
   objArrayOop allocate(int length, TRAPS);
   oop multi_allocate(int rank, jint* sizes, TRAPS);
+  // This is needed when calling MetadataFactory::free_metadata()
+  void deallocate_contents(ClassLoaderData* loader_data) { Klass::deallocate_contents(loader_data); }
 
   // Copying
   void  copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos, int length, TRAPS);


### PR DESCRIPTION
This PR is not completed yet. Just for sharing with reviewers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308745](https://bugs.openjdk.org/browse/JDK-8308745): ObjArrayKlass::allocate_objArray_klass may call into java while holding a lock (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14723/head:pull/14723` \
`$ git checkout pull/14723`

Update a local copy of the PR: \
`$ git checkout pull/14723` \
`$ git pull https://git.openjdk.org/jdk.git pull/14723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14723`

View PR using the GUI difftool: \
`$ git pr show -t 14723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14723.diff">https://git.openjdk.org/jdk/pull/14723.diff</a>

</details>
