### PR TITLE
8310993: Missing @since tags in jdk.attach

### DIFF
--- a/src/jdk.attach/share/classes/com/sun/tools/attach/AgentInitializationException.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/AgentInitializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ package com.sun.tools.attach;
  * {@code VirtualMachine.loadAgentPath} then the exception encapsulates
  * the error returned by the agent's {@code Agent_OnAttach} function.
  * This error code can be obtained by invoking the {@link #returnValue() returnValue} method.
+ *
+ * @since 1.6
  */
 public class AgentInitializationException extends Exception {
 

--- a/src/jdk.attach/share/classes/com/sun/tools/attach/AgentLoadException.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/AgentLoadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ package com.sun.tools.attach;
  * VirtualMachine.loadAgentLibrary}, {@link
  * com.sun.tools.attach.VirtualMachine#loadAgentPath loadAgentPath} methods
  * if the agent, or agent library, cannot be loaded.
+ *
+ * @since 1.6
  */
 public class AgentLoadException extends Exception {
 

--- a/src/jdk.attach/share/classes/com/sun/tools/attach/AttachNotSupportedException.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/AttachNotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ import com.sun.tools.attach.spi.AttachProvider;         // for javadoc
  * com.sun.tools.attach.spi.AttachProvider#attachVirtualMachine
  * AttachProvider.attachVirtualMachine} if the provider attempts to
  * attach to a Java virtual machine with which it not comptatible.
+ *
+ * @since 1.6
  */
 public class AttachNotSupportedException extends Exception {
 

--- a/src/jdk.attach/share/classes/com/sun/tools/attach/AttachPermission.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/AttachPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ package com.sun.tools.attach;
  *
  * @see com.sun.tools.attach.VirtualMachine
  * @see com.sun.tools.attach.spi.AttachProvider
+ * @since 1.6
  */
 
 public final class AttachPermission extends java.security.BasicPermission {


### PR DESCRIPTION
Simple since tag addition in selected files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310993](https://bugs.openjdk.org/browse/JDK-8310993): Missing @since tags in jdk.attach (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14724/head:pull/14724` \
`$ git checkout pull/14724`

Update a local copy of the PR: \
`$ git checkout pull/14724` \
`$ git pull https://git.openjdk.org/jdk.git pull/14724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14724`

View PR using the GUI difftool: \
`$ git pr show -t 14724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14724.diff">https://git.openjdk.org/jdk/pull/14724.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14724#issuecomment-1614343216)