### PR TITLE
8310987: Missing @since tag(s) in java/util/logging/ErrorManager.java

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/ErrorManager.java
+++ b/src/java.logging/share/classes/java/util/logging/ErrorManager.java
@@ -34,6 +34,8 @@ package java.util.logging;
  * then rather than throwing an Exception back to the issuer of
  * the logging call (who is unlikely to be interested) the Handler
  * should call its associated ErrorManager.
+ *
+ * @since 1.4
  */
 
 public class ErrorManager {


### PR DESCRIPTION
Please find here a trivial doc fix to add a missing `@since 1.4` to the java.util.logging.ErrorManager class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310987](https://bugs.openjdk.org/browse/JDK-8310987): Missing @since tag(s) in java/util/logging/ErrorManager.java (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14725/head:pull/14725` \
`$ git checkout pull/14725`

Update a local copy of the PR: \
`$ git checkout pull/14725` \
`$ git pull https://git.openjdk.org/jdk.git pull/14725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14725`

View PR using the GUI difftool: \
`$ git pr show -t 14725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14725.diff">https://git.openjdk.org/jdk/pull/14725.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14725#issuecomment-1614373292)