### PR TITLE
8311033: [macos] PrinterJob does not take into account Sides attribute

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -45,6 +45,7 @@ import javax.print.attribute.standard.MediaPrintableArea;
 import javax.print.attribute.standard.MediaSize;
 import javax.print.attribute.standard.MediaSizeName;
 import javax.print.attribute.standard.PageRanges;
+import javax.print.attribute.standard.Sides;
 import javax.print.attribute.Attribute;
 
 import sun.java2d.*;
@@ -682,6 +683,24 @@ public final class CPrinterJob extends RasterPrinterJob {
                     page.getImageableWidth(),
                     page.getImageableHeight());
         return pageFormatArea;
+    }
+
+    private int getSides() {
+        return (this.sidesAttr == null) ? -1 : this.sidesAttr.getValue();
+    }
+
+    private void setSides(int sides) {
+        if (attributes == null) {
+            return;
+        }
+
+        final Sides[] sidesTable = new Sides[] {Sides.ONE_SIDED, Sides.TWO_SIDED_LONG_EDGE, Sides.TWO_SIDED_SHORT_EDGE};
+
+        if (sides >= 0 && sides < sidesTable.length) {
+            Sides s = sidesTable[sides];
+            attributes.add(s);
+            this.sidesAttr = s;
+        }
     }
 
     private boolean cancelCheck() {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -37,6 +37,10 @@
 #import "GeomUtilities.h"
 #import "JNIUtilities.h"
 
+#define ONE_SIDED 0
+#define TWO_SIDED_LONG_EDGE 1
+#define TWO_SIDED_SHORT_EDGE 2
+
 static jclass sjc_Paper = NULL;
 static jclass sjc_PageFormat = NULL;
 static jclass sjc_CPrinterJob = NULL;
@@ -351,6 +355,24 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
     [dstPrintInfo setPrinter:printer];
 }
 
+static int duplexModeToSides(PMDuplexMode duplexMode) {
+    switch(duplexMode) {
+        case kPMDuplexNone: return ONE_SIDED;
+        case kPMDuplexTumble: return TWO_SIDED_SHORT_EDGE;
+        case kPMDuplexNoTumble: return TWO_SIDED_LONG_EDGE;
+        default: return -1;
+    }
+}
+
+static PMDuplexMode sidesToDuplexMode(int sides) {
+    switch(sides) {
+        case ONE_SIDED: return kPMDuplexNone;
+        case TWO_SIDED_SHORT_EDGE: return kPMDuplexTumble;
+        case TWO_SIDED_LONG_EDGE: return kPMDuplexNoTumble;
+        default: return kPMDuplexNone;
+    }
+}
+
 static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject dstPrinterJob, jobject dstPageable)
 {
     GET_CPRINTERJOB_CLASS();
@@ -360,6 +382,7 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
     DECLARE_METHOD(jm_setPageRangeAttribute, sjc_CPrinterJob, "setPageRangeAttribute", "(IIZ)V");
     DECLARE_METHOD(jm_setPrintToFile, sjc_CPrinterJob, "setPrintToFile", "(Z)V");
     DECLARE_METHOD(jm_setDestinationFile, sjc_CPrinterJob, "setDestinationFile", "(Ljava/lang/String;)V");
+    DECLARE_METHOD(jm_setSides, sjc_CPrinterJob, "setSides", "(I)V");
 
     // get the selected printer's name, and set the appropriate PrintService on the Java side
     NSString *name = [[src printer] name];
@@ -420,6 +443,12 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
                           jFirstPage, jLastPage, isRangeSet); // AWT_THREADING Safe (known object)
         CHECK_EXCEPTION();
 
+        PMDuplexMode duplexSetting;
+        if (PMGetDuplex(src.PMPrintSettings, &duplexSetting) == noErr) {
+            int sides = duplexModeToSides(duplexSetting);
+            (*env)->CallVoidMethod(env, dstPrinterJob, jm_setSides, sides); // AWT_THREADING Safe (known object)
+            CHECK_EXCEPTION();
+        }
     }
 }
 
@@ -438,6 +467,8 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
     DECLARE_METHOD(jm_getNumberOfPages, jc_Pageable, "getNumberOfPages", "()I");
     DECLARE_METHOD(jm_getPageFormat, sjc_CPrinterJob, "getPageFormatFromAttributes", "()Ljava/awt/print/PageFormat;");
     DECLARE_METHOD(jm_getDestinationFile, sjc_CPrinterJob, "getDestinationFile", "()Ljava/lang/String;");
+    DECLARE_METHOD(jm_getSides, sjc_CPrinterJob, "getSides", "()I");
+
 
     NSMutableDictionary* printingDictionary = [dst dictionary];
 
@@ -495,6 +526,17 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
        [printingDictionary setObject:nsURL forKey:NSPrintJobSavingURL];
     } else {
        [dst setJobDisposition:NSPrintSpoolJob];
+    }
+
+    int sides = (*env)->CallIntMethod(env, srcPrinterJob, jm_getSides);
+    CHECK_EXCEPTION();
+
+    if (sides >= 0) {
+        PMDuplexMode duplexMode = sidesToDuplexMode(sides);
+        PMPrintSettings printSettings = dst.PMPrintSettings;
+        if (PMSetDuplex(printSettings, duplexMode) == noErr) {
+            [dst updateFromPMPrintSettings];
+        }
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -355,7 +355,7 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
     [dstPrintInfo setPrinter:printer];
 }
 
-static int duplexModeToSides(PMDuplexMode duplexMode) {
+static jint duplexModeToSides(PMDuplexMode duplexMode) {
     switch(duplexMode) {
         case kPMDuplexNone: return ONE_SIDED;
         case kPMDuplexTumble: return TWO_SIDED_SHORT_EDGE;
@@ -364,7 +364,7 @@ static int duplexModeToSides(PMDuplexMode duplexMode) {
     }
 }
 
-static PMDuplexMode sidesToDuplexMode(int sides) {
+static PMDuplexMode sidesToDuplexMode(jint sides) {
     switch(sides) {
         case ONE_SIDED: return kPMDuplexNone;
         case TWO_SIDED_SHORT_EDGE: return kPMDuplexTumble;
@@ -445,7 +445,7 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
 
         PMDuplexMode duplexSetting;
         if (PMGetDuplex(src.PMPrintSettings, &duplexSetting) == noErr) {
-            int sides = duplexModeToSides(duplexSetting);
+            jint sides = duplexModeToSides(duplexSetting);
             (*env)->CallVoidMethod(env, dstPrinterJob, jm_setSides, sides); // AWT_THREADING Safe (known object)
             CHECK_EXCEPTION();
         }
@@ -528,7 +528,7 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
        [dst setJobDisposition:NSPrintSpoolJob];
     }
 
-    int sides = (*env)->CallIntMethod(env, srcPrinterJob, jm_getSides);
+    jint sides = (*env)->CallIntMethod(env, srcPrinterJob, jm_getSides);
     CHECK_EXCEPTION();
 
     if (sides >= 0) {

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -1080,6 +1080,8 @@ public abstract class RasterPrinterJob extends PrinterJob {
             return false;
         }
 
+        this.attributes = attributes;
+
         if (!service.equals(newService)) {
             try {
                 setPrintService(newService);

--- a/test/jdk/javax/print/attribute/SidesAttributeTest.java
+++ b/test/jdk/javax/print/attribute/SidesAttributeTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug JDK-8311033
+ * @summary [macos] PrinterJob does not take into account Sides attribute
+ * @run main/manual SidesAttributeTest
+ */
+
+import javax.print.attribute.Attribute;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.Sides;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+public class SidesAttributeTest {
+
+    private static final long TIMEOUT = 10 * 60_000;
+    private static volatile boolean testPassed = true;
+    private static volatile boolean testFinished = false;
+    private static volatile boolean timeout = false;
+
+    private static volatile int testCount;
+
+    public static void main(String[] args) throws Exception {
+
+        SwingUtilities.invokeLater(() -> {
+            testPrint(Sides.ONE_SIDED);
+            testPrint(Sides.DUPLEX);
+            testPrint(Sides.TUMBLE);
+            testFinished = true;
+        });
+
+        long time = System.currentTimeMillis() + TIMEOUT;
+
+        while (System.currentTimeMillis() < time) {
+            if (!testPassed || testFinished) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
+        timeout = true;
+
+        closeDialogs();
+
+        if (!testPassed) {
+            throw new Exception("Test failed!");
+        }
+
+        if (testCount < 3) {
+            throw new Exception("Timeout: less than 3 tests were running!");
+        }
+    }
+
+    private static void print(Sides sides) throws PrinterException {
+        PrintRequestAttributeSet attr = new HashPrintRequestAttributeSet();
+        attr.add(sides);
+
+        for (Attribute attribute : attr.toArray()) {
+            System.out.printf("Used print request attribute: %s%n", attribute);
+        }
+
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setPrintable(new SidesAttributePrintable(sides));
+
+        job.print(attr);
+    }
+
+    private static class SidesAttributePrintable implements Printable {
+
+        private final Sides sidesAttr;
+
+        public SidesAttributePrintable(Sides sidesAttr) {
+            this.sidesAttr = sidesAttr;
+        }
+
+        @Override
+        public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+
+            if (pageIndex >= 2) {
+                return NO_SUCH_PAGE;
+            }
+
+            int x = (int) (pageFormat.getImageableX() + pageFormat.getImageableWidth() / 10);
+            int y = (int) (pageFormat.getImageableY() + pageFormat.getImageableHeight() / 5);
+
+            Graphics2D g = (Graphics2D) graphics;
+            String text = getPageText(sidesAttr, pageIndex + 1);
+            g.drawString(text, x, y);
+            return PAGE_EXISTS;
+        }
+    }
+
+    private static String getPageText(Sides sides, int page) {
+        return String.format("Page: %d - %s", page, getSidesDescription(sides));
+    }
+
+    private static String getSidesDescription(Sides sides) {
+        if (Sides.ONE_SIDED.equals(sides)) {
+            return "ONE_SIDED";
+        } else if (Sides.TWO_SIDED_SHORT_EDGE.equals(sides)) {
+            return "TWO_SIDED_SHORT_EDGE (TUMBLE)";
+        } else if (Sides.TWO_SIDED_LONG_EDGE.equals(sides)) {
+            return "TWO_SIDED_LONG_EDGE (DUPLEX)";
+        }
+        throw new RuntimeException("Unknown sides attribute: " + sides);
+    }
+
+    private static void pass() {
+        testCount++;
+    }
+
+    private static void fail() {
+        testPassed = false;
+    }
+
+    private static void runPrint(Sides sides) {
+        try {
+            print(sides);
+        } catch (PrinterException e) {
+            fail();
+            e.printStackTrace();
+        }
+    }
+
+    private static void testPrint(Sides sides) {
+
+        if (!testPassed || timeout) {
+            return;
+        }
+
+        String[] instructions = {
+                "On-screen inspection is not possible for this printing-specific",
+                "test therefore its only output is two printed pages (one or two sided).",
+                "To be able to run this test it is required to have a default",
+                "printer configured in your user environment.",
+                "",
+                "Visual inspection of the printed pages is needed.",
+                "A passing test will print 2 pages:",
+                "  - the first page with the text: " + getPageText(sides, 1),
+                "  - the second page with the text: " + getPageText(sides, 2),
+                "The test fails only if the text on the pages is not printed",
+                "or pages are not printed according to the sides attribute",
+                getSidesDescription(sides)
+        };
+
+        String title = "Print sides test: " + getSidesDescription(sides);
+        final JDialog dialog = new JDialog((Frame) null, title, Dialog.ModalityType.DOCUMENT_MODAL);
+        JTextArea textArea = new JTextArea(String.join("\n", instructions));
+        textArea.setEditable(false);
+        final JButton testButton = new JButton("Start Test");
+        final JButton passButton = new JButton("PASS");
+        passButton.setEnabled(false);
+        passButton.addActionListener((e) -> {
+            pass();
+            dialog.dispose();
+        });
+        final JButton failButton = new JButton("FAIL");
+        failButton.setEnabled(false);
+        failButton.addActionListener((e) -> {
+            fail();
+            dialog.dispose();
+        });
+        testButton.addActionListener((e) -> {
+            testButton.setEnabled(false);
+            runPrint(sides);
+            passButton.setEnabled(true);
+            failButton.setEnabled(true);
+        });
+
+        JPanel mainPanel = new JPanel(new BorderLayout());
+        mainPanel.add(textArea, BorderLayout.CENTER);
+        JPanel buttonPanel = new JPanel(new FlowLayout());
+        buttonPanel.add(testButton);
+        buttonPanel.add(passButton);
+        buttonPanel.add(failButton);
+        mainPanel.add(buttonPanel, BorderLayout.SOUTH);
+        dialog.add(mainPanel);
+        dialog.pack();
+        dialog.setVisible(true);
+        dialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                System.out.println("Dialog closing");
+                fail();
+            }
+        });
+    }
+
+    private static void closeDialogs() {
+        for (Window w : Dialog.getWindows()) {
+            w.dispose();
+        }
+    }
+}

--- a/test/jdk/javax/print/attribute/SidesAttributeTest.java
+++ b/test/jdk/javax/print/attribute/SidesAttributeTest.java
@@ -57,8 +57,6 @@ public class SidesAttributeTest {
     private static volatile int testCount;
     private static volatile int testTotalCount;
 
-    private static Set<Attribute> supportedSides = new HashSet<>();
-
     public static void main(String[] args) throws Exception {
 
         SwingUtilities.invokeLater(() -> {


### PR DESCRIPTION
To reproduce the issue run the [JavaSidesAttributePrinting](https://bugs.openjdk.org/secure/attachment/104448/JavaSidesAttributePrinting.java) java sample with ONE_SIDED and DUPLEX arguments on macOS:
```
java JavaSidesAttributePrinting ONE_SIDED
java JavaSidesAttributePrinting DUPLEX
```

The sample calls PrinterJob print method with the given sides attribute.
The pages are printed according to the printer default settings not according to the provided Sides attributes.

The fix propagates Sides attribute
- from `PrinterJob` to `NSPrintInfo` in `CPrinterJob.javaPrinterJobToNSPrintInfo` method
- from `NSPrintInfo` to `PrinterJob` in `CPrinterJob.nsPrintInfoToJavaPrinterJob` method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311033](https://bugs.openjdk.org/browse/JDK-8311033): [macos] PrinterJob does not take into account Sides attribute (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [4480595c](https://git.openjdk.org/jdk/pull/14727/files/4480595c037197264015f16191037fbdb9d716db)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14727/head:pull/14727` \
`$ git checkout pull/14727`

Update a local copy of the PR: \
`$ git checkout pull/14727` \
`$ git pull https://git.openjdk.org/jdk.git pull/14727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14727`

View PR using the GUI difftool: \
`$ git pr show -t 14727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14727.diff">https://git.openjdk.org/jdk/pull/14727.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14727#issuecomment-1614437303)