### PR TITLE
8303086: SIGSEGV in JavaThread::is_interp_only_mode()

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -575,7 +575,7 @@ JvmtiEnv::SetEventNotificationMode(jvmtiEventMode mode, jvmtiEvent event_type, j
   if (event_type == JVMTI_EVENT_CLASS_FILE_LOAD_HOOK && enabled) {
     record_class_file_load_hook_enabled();
   }
-  JvmtiVTMSTransitionDisabler disabler(event_thread);
+  JvmtiVTMSTransitionDisabler disabler;
 
   if (event_thread == nullptr) {
     // Can be called at Agent_OnLoad() time with event_thread == nullptr


### PR DESCRIPTION
The JVMTI function `SetEventNotificationMode` can set notification mode globally (`event_thread == nullptr`) for all threads or for a specific thread (`event_thread != nullptr`). To get a stable mount/unmount vision of virtual threads a JvmtiVTMSTransitionDisabler helper object is created :
    `JvmtiVTMSTransitionDisabler disabler(event_thread);`

In a case if `event_thread == nullptr` the VTMS transitions are disabled for all virtual thread,
otherwise they are disabled for a specific thread if it is virtual.
The call to `JvmtiEventController::set_user_enabled()` makes a call to `recompute_enabled()` at the end of its work to do a required bookkeeping. As part of this work, the `recompute_thread_enabled(state)` is called for each thread from the `ThreadsListHandle`, not only for the given `event_thread`:
```
    ThreadsListHandle tlh;
    for (; state != nullptr; state = state->next()) {
      any_env_thread_enabled |= recompute_thread_enabled(state);
    }
```
This can cause crashes as VTMS transitions for other virtual threads are allowed.
Crashes are observed in this small function:
```
  bool is_interp_only_mode() {
    return _thread == nullptr ? _saved_interp_only_mode != 0 : _thread->is_interp_only_mode();
  }
```
In a case `_thread != nullptr` then the call needs to be executed: `_thread->is_interp_only_mode()`.
But the filed `_thread` can be already changed to `nullptr` by a VTMS transition.

The fix is to always disable all transitions.
Thanks to Dan and Patricio for great analysis of this crash!

Testing:
- In progress: mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303086](https://bugs.openjdk.org/browse/JDK-8303086): SIGSEGV in JavaThread::is_interp_only_mode() (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14728/head:pull/14728` \
`$ git checkout pull/14728`

Update a local copy of the PR: \
`$ git checkout pull/14728` \
`$ git pull https://git.openjdk.org/jdk.git pull/14728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14728`

View PR using the GUI difftool: \
`$ git pr show -t 14728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14728.diff">https://git.openjdk.org/jdk/pull/14728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14728#issuecomment-1614526095)