### PR TITLE
8311172: Classfile.PREVIEW_MINOR_VERSION doesn't match that read from class files

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/Classfile.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Classfile.java
@@ -690,7 +690,12 @@ public sealed interface Classfile
     int JAVA_21_VERSION = 65;
     int JAVA_22_VERSION = 66;
 
-    int PREVIEW_MINOR_VERSION = -1;
+    /**
+     * A minor version number indicating a class uses preview features
+     * of a Java SE version since 12, for major versions {@value
+     * #JAVA_12_VERSION} and above.
+     */
+    int PREVIEW_MINOR_VERSION = 65535;
 
     static int latestMajorVersion() {
         return JAVA_22_VERSION;

--- a/test/jdk/jdk/classfile/PreviewMinorVersionTest.java
+++ b/test/jdk/jdk/classfile/PreviewMinorVersionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import jdk.internal.classfile.Classfile;
+import org.junit.jupiter.api.Test;
+
+import java.lang.constant.ClassDesc;
+
+import static java.lang.constant.ConstantDescs.*;
+import static jdk.internal.classfile.Classfile.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * @test
+ * @run junit PreviewMinorVersionTest
+ * @summary Ensures Classfile.PREVIEW_MINOR_VERSION equals that of classes with
+ *          preview minor version from ClassModel::minorVersion
+ */
+public class PreviewMinorVersionTest {
+
+    @Test
+    public void testMinorVersionMatches() {
+        // compile a class with --enable-preview
+        // uses Record feature to trigger forcePreview
+        var cf = Classfile.of();
+        var cd = ClassDesc.of("Test");
+        var bytes = cf.build(cd, cb -> cb
+                .withSuperclass(CD_Object)
+                // old preview minor version,
+                // with all bits set to 1
+                .withVersion(JAVA_17_VERSION, -1)
+        );
+
+        var cm = Classfile.of().parse(bytes);
+        assertEquals(Classfile.PREVIEW_MINOR_VERSION, cm.minorVersion());
+    }
+}

--- a/test/jdk/jdk/classfile/PreviewMinorVersionTest.java
+++ b/test/jdk/jdk/classfile/PreviewMinorVersionTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * @test
+ * @bug 8311172
  * @run junit PreviewMinorVersionTest
  * @summary Ensures Classfile.PREVIEW_MINOR_VERSION equals that of classes with
  *          preview minor version from ClassModel::minorVersion


### PR DESCRIPTION
`Classfile.PREVIEW_MINOR_VERSION`, currently -1, is correct when passed to `ClassBuilder::withVersion`, but is incorrect when compared to `ClassModel::minorVersion`, which only sets the bits of 2 lowest bytes to 1 (65536). Discovered when trying to replace an asserted preview minor version with this constant in `PreviewHiddenClass` test porting in #13009, which is currently failing.

Requesting a review from @asotona.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311172](https://bugs.openjdk.org/browse/JDK-8311172): Classfile.PREVIEW_MINOR_VERSION doesn't match that read from class files (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14731/head:pull/14731` \
`$ git checkout pull/14731`

Update a local copy of the PR: \
`$ git checkout pull/14731` \
`$ git pull https://git.openjdk.org/jdk.git pull/14731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14731`

View PR using the GUI difftool: \
`$ git pr show -t 14731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14731.diff">https://git.openjdk.org/jdk/pull/14731.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14731#issuecomment-1614640927)