### PR TITLE
8311145: Remove check_with_errno duplicates

### DIFF
--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -56,15 +56,6 @@ enum membarrier_cmd {
   MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED = (1 << 4),
 };
 
-#define check_with_errno(check_type, cond, msg)                             \
-  do {                                                                      \
-    int err = errno;                                                        \
-    check_type(cond, "%s: error='%s' (errno=%s)", msg, os::strerror(err),   \
-               os::errno_name(err));                                        \
-} while (false)
-
-#define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
-
 static int membarrier(int cmd, unsigned int flags, int cpu_id) {
   return syscall(SYS_membarrier, cmd, flags, cpu_id); // cpu_id only on >= 5.10
 }

--- a/src/hotspot/os/linux/waitBarrier_linux.cpp
+++ b/src/hotspot/os/linux/waitBarrier_linux.cpp
@@ -25,18 +25,10 @@
 #include "precompiled.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/os.hpp"
+#include "utilities/debug.hpp"
 #include "waitBarrier_linux.hpp"
 #include <sys/syscall.h>
 #include <linux/futex.h>
-
-#define check_with_errno(check_type, cond, msg)                             \
-  do {                                                                      \
-    int err = errno;                                                        \
-    check_type(cond, "%s: error='%s' (errno=%s)", msg, os::strerror(err),   \
-               os::errno_name(err));                                        \
-} while (false)
-
-#define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
 
 // 32-bit RISC-V has no SYS_futex syscall.
 #ifdef RISCV32

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -42,6 +42,7 @@
 #include "runtime/park.hpp"
 #include "runtime/perfMemory.hpp"
 #include "utilities/align.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
 #include "utilities/formatBuffer.hpp"
@@ -85,16 +86,6 @@
 #ifndef MAP_ANONYMOUS
   #define MAP_ANONYMOUS MAP_ANON
 #endif
-
-#define check_with_errno(check_type, cond, msg)                             \
-  do {                                                                      \
-    int err = errno;                                                        \
-    check_type(cond, "%s; error='%s' (errno=%s)", msg, os::strerror(err),   \
-               os::errno_name(err));                                        \
-} while (false)
-
-#define assert_with_errno(cond, msg)    check_with_errno(assert, cond, msg)
-#define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
 
 static jlong initial_time_count = 0;
 

--- a/src/hotspot/os/posix/semaphore_posix.cpp
+++ b/src/hotspot/os/posix/semaphore_posix.cpp
@@ -26,19 +26,10 @@
 #ifndef __APPLE__
 #include "os_posix.hpp"
 #include "runtime/os.hpp"
+#include "utilities/debug.hpp"
 // POSIX unnamed semaphores are not supported on OS X.
 #include "semaphore_posix.hpp"
 #include <semaphore.h>
-
-#define check_with_errno(check_type, cond, msg)                             \
-  do {                                                                      \
-    int err = errno;                                                        \
-    check_type(cond, "%s; error='%s' (errno=%s)", msg, os::strerror(err),   \
-               os::errno_name(err));                                        \
-} while (false)
-
-#define assert_with_errno(cond, msg)    check_with_errno(assert, cond, msg)
-#define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
 
 PosixSemaphore::PosixSemaphore(uint value) {
   int ret = sem_init(&_semaphore, 0, value);

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -209,6 +209,16 @@ do {                                                                            
   report_vm_out_of_memory(__FILE__, __LINE__, size, vm_err_type, __VA_ARGS__);    \
 } while (0)
 
+#define check_with_errno(check_type, cond, msg)                                   \
+  do {                                                                            \
+    int err = errno;                                                              \
+    check_type(cond, "%s; error='%s' (errno=%s)", msg, os::strerror(err),         \
+               os::errno_name(err));                                              \
+} while (false)
+
+#define assert_with_errno(cond, msg)    check_with_errno(assert, cond, msg)
+#define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
+
 #define ShouldNotCallThis()                                                       \
 do {                                                                              \
   TOUCH_ASSERT_POISON;                                                            \


### PR DESCRIPTION
This trivial patch moves the same macros to a common header file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311145](https://bugs.openjdk.org/browse/JDK-8311145): Remove check_with_errno duplicates (**Enhancement** - P5)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14733/head:pull/14733` \
`$ git checkout pull/14733`

Update a local copy of the PR: \
`$ git checkout pull/14733` \
`$ git pull https://git.openjdk.org/jdk.git pull/14733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14733`

View PR using the GUI difftool: \
`$ git pr show -t 14733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14733.diff">https://git.openjdk.org/jdk/pull/14733.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14733#issuecomment-1614687406)