### PR TITLE
JDK-8310734: Add cause to Connection reset - SocketException in NioSocketImpl implRead

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -315,7 +315,7 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             throw e;
         } catch (ConnectionResetException e) {
             connectionReset = true;
-            throw new SocketException("Connection reset");
+            throw new SocketException("Connection reset", e);
         } catch (IOException ioe) {
             // throw SocketException to maintain compatibility
             throw asSocketException(ioe);


### PR DESCRIPTION
In NioSocketImpl implRead we potentially throw a SocketException("Connection reset"). We can improve this by adding the cause.
This would bring this exception also closer to the case of IOException where we use throw asSocketException(ioe);  and  preserve the stack and message of the original exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310734](https://bugs.openjdk.org/browse/JDK-8310734): Add cause to Connection reset - SocketException in NioSocketImpl implRead (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14734/head:pull/14734` \
`$ git checkout pull/14734`

Update a local copy of the PR: \
`$ git checkout pull/14734` \
`$ git pull https://git.openjdk.org/jdk.git pull/14734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14734`

View PR using the GUI difftool: \
`$ git pr show -t 14734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14734.diff">https://git.openjdk.org/jdk/pull/14734.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14734#issuecomment-1614724102)