### PR TITLE
8311180: Remove unused unneeded definitions from globalDefinitions

### DIFF
--- a/src/hotspot/cpu/ppc/icache_ppc.hpp
+++ b/src/hotspot/cpu/ppc/icache_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,7 +44,7 @@ class ICache : public AbstractICache {
   static void ppc64_flush_icache_bytes(address start, int bytes) {
     // Align start address to an icache line boundary and transform
     // nbytes to an icache line count.
-    const uint line_offset = mask_address_bits(start, line_size - 1);
+    const uint line_offset = (intptr_t)start & (line_size - 1);
     ppc64_flush_icache(start - line_offset, (bytes + line_offset + line_size - 1) >> log2_line_size, 0);
   }
 };

--- a/src/hotspot/cpu/ppc/icache_ppc.hpp
+++ b/src/hotspot/cpu/ppc/icache_ppc.hpp
@@ -44,7 +44,7 @@ class ICache : public AbstractICache {
   static void ppc64_flush_icache_bytes(address start, int bytes) {
     // Align start address to an icache line boundary and transform
     // nbytes to an icache line count.
-    const uint line_offset = (intptr_t)start & (line_size - 1);
+    const uint line_offset = (uintptr_t)start & (line_size - 1);
     ppc64_flush_icache(start - line_offset, (bytes + line_offset + line_size - 1) >> log2_line_size, 0);
   }
 };

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -125,7 +125,7 @@ class markWord {
   static const uintptr_t marked_value             = 3;
 
   static const uintptr_t no_hash                  = 0 ;  // no hash value assigned
-  static const uintptr_t no_hash_in_place         = (address_word)no_hash << hash_shift;
+  static const uintptr_t no_hash_in_place         = (uintptr_t)no_hash << hash_shift;
   static const uintptr_t no_lock_in_place         = unlocked_value;
 
   static const uint max_age                       = age_mask;

--- a/src/hotspot/share/prims/stackwalk.hpp
+++ b/src/hotspot/share/prims/stackwalk.hpp
@@ -78,7 +78,7 @@ public:
   }
 
   jlong address_value() {
-    return (jlong) castable_address(this);
+    return (jlong) this;
   }
 
   static BaseFrameStream* from_current(JavaThread* thread, jlong magic, objArrayHandle frames_array);

--- a/src/hotspot/share/runtime/icache.cpp
+++ b/src/hotspot/share/runtime/icache.cpp
@@ -96,7 +96,7 @@ void AbstractICache::invalidate_range(address start, int nbytes) {
   }
   // Align start address to an icache line boundary and transform
   // nbytes to an icache line count.
-  const uint line_offset = mask_address_bits(start, ICache::line_size-1);
+  const uint line_offset = uintptr_t(start) & (ICache::line_size-1);
   if (line_offset != 0) {
     start -= line_offset;
     nbytes += line_offset;

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -444,23 +444,6 @@ typedef unsigned int uint;   NEEDS_CLEANUP
 typedef   signed char s_char;
 typedef unsigned char u_char;
 typedef u_char*       address;
-typedef uintptr_t     address_word; // unsigned integer which will hold a pointer
-                                    // except for some implementations of a C++
-                                    // linkage pointer to function. Should never
-                                    // need one of those to be placed in this
-                                    // type anyway.
-
-//  Utility functions to "portably" (?) bit twiddle pointers
-//  Where portable means keep ANSI C++ compilers quiet
-
-inline address       set_address_bits(address x, int m)       { return address(intptr_t(x) | m); }
-inline address       clear_address_bits(address x, int m)     { return address(intptr_t(x) & ~m); }
-
-//  Utility functions to "portably" make cast to/from function pointers.
-
-inline address_word  mask_address_bits(address x, int m)      { return address_word(x) & m; }
-inline address_word  castable_address(address x)              { return address_word(x) ; }
-inline address_word  castable_address(void* x)                { return address_word(x) ; }
 
 // Pointer subtraction.
 // The idea here is to avoid ptrdiff_t, which is signed and so doesn't have
@@ -503,7 +486,7 @@ inline size_t pointer_delta(const MetaWord* left, const MetaWord* right) {
 // many C++ compilers.
 //
 #define CAST_TO_FN_PTR(func_type, value) (reinterpret_cast<func_type>(value))
-#define CAST_FROM_FN_PTR(new_type, func_ptr) ((new_type)((address_word)(func_ptr)))
+#define CAST_FROM_FN_PTR(new_type, func_ptr) ((new_type)((uintptr_t)(func_ptr)))
 
 // In many places we've added C-style casts to silence compiler
 // warnings, for example when truncating a size_t to an int when we


### PR DESCRIPTION
I noticed this cleanup in a patch that Axel shared with me that I thought should be pushed on its own as trivial.
Tested with tier1 on Oracle supported platforms and looked for these on the others.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311180](https://bugs.openjdk.org/browse/JDK-8311180): Remove unused unneeded definitions from globalDefinitions (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14737/head:pull/14737` \
`$ git checkout pull/14737`

Update a local copy of the PR: \
`$ git checkout pull/14737` \
`$ git pull https://git.openjdk.org/jdk.git pull/14737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14737`

View PR using the GUI difftool: \
`$ git pr show -t 14737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14737.diff">https://git.openjdk.org/jdk/pull/14737.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14737#issuecomment-1614787328)