### PR TITLE
8311170: Simplify and modernize equals and hashCode in security area

### DIFF
--- a/src/java.base/share/classes/java/security/CodeSigner.java
+++ b/src/java.base/share/classes/java/security/CodeSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.security;
 
 import java.io.*;
 import java.security.cert.CertPath;
+import java.util.Objects;
 
 /**
  * This class encapsulates information about a code signer.
@@ -98,12 +99,11 @@ public final class CodeSigner implements Serializable {
     }
 
     /**
-     * Returns the hash code value for this code signer.
+     * {@return the hash code value for this code signer}
      * The hash code is generated using the signer's certificate path and the
      * timestamp, if present.
-     *
-     * @return a hash code value for this code signer.
      */
+    @Override
     public int hashCode() {
         if (myhash == -1) {
             if (timestamp == null) {
@@ -126,24 +126,18 @@ public final class CodeSigner implements Serializable {
      * @return {@code true} if the objects are considered equal,
      * {@code false} otherwise.
      */
+    @Override
     public boolean equals(Object obj) {
-        if ((!(obj instanceof CodeSigner that))) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof CodeSigner that)) {
             return false;
         }
 
-        if (this == that) {
-            return true;
-        }
-        Timestamp thatTimestamp = that.getTimestamp();
-        if (timestamp == null) {
-            if (thatTimestamp != null) {
-                return false;
-            }
-        } else {
-            if ((!timestamp.equals(thatTimestamp))) {
-                return false;
-            }
-        }
+        if (!Objects.equals(timestamp, that.getTimestamp()))
+            return false;
         return signerCertPath.equals(that.getSignerCertPath());
     }
 

--- a/src/java.base/share/classes/java/security/UnresolvedPermission.java
+++ b/src/java.base/share/classes/java/security/UnresolvedPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.util.Hashtable;
 import java.lang.reflect.*;
 import java.security.cert.*;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The {@code UnresolvedPermission} class is used to hold Permissions that
@@ -349,23 +350,13 @@ implements java.io.Serializable
         }
 
         // check name
-        if (this.name == null) {
-            if (that.name != null) {
-                return false;
-            }
-        } else if (!this.name.equals(that.name)) {
+        if (!Objects.equals(this.name, that.name)) {
             return false;
         }
 
         // check actions
-        if (this.actions == null) {
-            if (that.actions != null) {
-                return false;
-            }
-        } else {
-            if (!this.actions.equals(that.actions)) {
-                return false;
-            }
+        if (!Objects.equals(this.actions, that.actions)) {
+            return false;
         }
 
         // check certs
@@ -404,18 +395,11 @@ implements java.io.Serializable
     }
 
     /**
-     * Returns the hash code value for this object.
-     *
-     * @return a hash code value for this object.
+     * {@return the hash code value for this object}
      */
     @Override
     public int hashCode() {
-        int hash = type.hashCode();
-        if (name != null)
-            hash ^= name.hashCode();
-        if (actions != null)
-            hash ^= actions.hashCode();
-        return hash;
+        return Objects.hash(type, name, actions);
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Objects;
 import java.util.Vector;
 import static java.util.Locale.ENGLISH;
 
@@ -616,20 +617,18 @@ final class CryptoPolicyParser {
          * Calculates a hash code value for the object.  Objects
          * which are equal will also have the same hashcode.
          */
+        @Override
         public int hashCode() {
             int retval = cryptoPermission.hashCode();
-            if (alg != null) retval ^= alg.hashCode();
-            if (exemptionMechanism != null) {
-                retval ^= exemptionMechanism.hashCode();
-            }
+            retval ^= Objects.hashCode(alg);
+            retval ^= Objects.hashCode(exemptionMechanism);
             retval ^= maxKeySize;
-            if (checkParam) retval ^= 100;
-            if (algParamSpec != null) {
-                retval ^= algParamSpec.hashCode();
-            }
+            retval ^= (checkParam ? 100 : 0);
+            retval ^= Objects.hashCode(algParamSpec);
             return retval;
         }
 
+        @Override
         public boolean equals(Object obj) {
             if (obj == this)
                 return true;
@@ -637,12 +636,8 @@ final class CryptoPolicyParser {
             if (!(obj instanceof CryptoPermissionEntry that))
                 return false;
 
-            if (this.cryptoPermission == null) {
-                if (that.cryptoPermission != null) return false;
-            } else {
-                if (!this.cryptoPermission.equals(
-                                                 that.cryptoPermission))
-                    return false;
+            if (Objects.equals(this.cryptoPermission, that.cryptoPermission)) {
+                return false;
             }
 
             if (this.alg == null) {
@@ -652,15 +647,11 @@ final class CryptoPolicyParser {
                     return false;
             }
 
-            if (!(this.maxKeySize == that.maxKeySize)) return false;
+            if (this.maxKeySize != that.maxKeySize) return false;
 
             if (this.checkParam != that.checkParam) return false;
 
-            if (this.algParamSpec == null) {
-                return that.algParamSpec == null;
-            } else {
-                return this.algParamSpec.equals(that.algParamSpec);
-            }
+            return Objects.equals(this.algParamSpec, that.algParamSpec);
         }
     }
 

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -907,10 +907,6 @@ public final class Subject implements java.io.Serializable {
     @Override
     public boolean equals(Object o) {
 
-        if (o == null) {
-            return false;
-        }
-
         if (this == o) {
             return true;
         }
@@ -1003,9 +999,7 @@ public final class Subject implements java.io.Serializable {
     }
 
     /**
-     * Returns a hashcode for this {@code Subject}.
-     *
-     * @return a hashcode for this {@code Subject}.
+     * {@return a hashcode for this {@code Subject}}
      *
      * @throws SecurityException if a security manager is installed and the
      *         caller does not have a {@link PrivateCredentialPermission}

--- a/src/java.base/share/classes/javax/security/cert/Certificate.java
+++ b/src/java.base/share/classes/javax/security/cert/Certificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
+import java.util.Arrays;
 
 /**
  * <p>Abstract class for managing a variety of identity certificates.
@@ -81,42 +82,30 @@ public abstract class Certificate {
      * @return true if the encoded forms of the two certificates
      *         match, false otherwise.
      */
+    @Override
     public boolean equals(Object other) {
         if (this == other)
             return true;
         if (!(other instanceof Certificate))
             return false;
         try {
-            byte[] thisCert = this.getEncoded();
-            byte[] otherCert = ((Certificate)other).getEncoded();
-
-            if (thisCert.length != otherCert.length)
-                return false;
-            for (int i = 0; i < thisCert.length; i++)
-                 if (thisCert[i] != otherCert[i])
-                     return false;
-            return true;
+            return Arrays.equals(this.getEncoded(),
+                    ((Certificate)other).getEncoded());
         } catch (CertificateException e) {
             return false;
         }
     }
 
     /**
-     * Returns a hashcode value for this certificate from its
-     * encoded form.
-     *
-     * @return the hashcode value.
+     * {@return a hashcode value for this certificate from its
+     * encoded form}
      */
+    @Override
     public int hashCode() {
-        int     retval = 0;
         try {
-            byte[] certData = this.getEncoded();
-            for (int i = 1; i < certData.length; i++) {
-                 retval += certData[i] * i;
-            }
-            return (retval);
+            return Arrays.hashCode(this.getEncoded());
         } catch (CertificateException e) {
-            return (retval);
+            return 0;
         }
     }
 

--- a/src/java.base/share/classes/sun/security/util/BitArray.java
+++ b/src/java.base/share/classes/sun/security/util/BitArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.security.util;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 
 import jdk.internal.util.Preconditions;
 
@@ -68,7 +69,7 @@ public class BitArray {
      * Creates a BitArray of the specified size, initialized from the
      * specified byte array. The most significant bit of {@code a[0]} gets
      * index zero in the BitArray. The array must be large enough to specify
-     * a value for every bit of the BitArray. i.e. {@code 8*a.length <= length}.
+     * a value for every bit of the BitArray, i.e. {@code 8*a.length >= length}.
      */
     public BitArray(int length, byte[] a) throws IllegalArgumentException {
         this(length, a, 0);
@@ -79,7 +80,7 @@ public class BitArray {
      * specified byte array starting at the specified offset.  The most
      * significant bit of {@code a[ofs]} gets index zero in the BitArray.
      * The array must be large enough to specify a value for every bit of
-     * the BitArray, i.e. {@code 8*(a.length - ofs) <= length}.
+     * the BitArray, i.e. {@code 8*(a.length - ofs) >= length}.
      */
     public BitArray(int length, byte[] a, int ofs)
             throws IllegalArgumentException {
@@ -177,16 +178,12 @@ public class BitArray {
         return repn.clone();
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
-        if (!(obj instanceof BitArray ba)) return false;
-
-        if (ba.length != length) return false;
-
-        for (int i = 0; i < repn.length; i += 1) {
-            if (repn[i] != ba.repn[i]) return false;
-        }
-        return true;
+        if (!(obj instanceof BitArray other)) return false;
+        if (length != other.length) return false;
+        return Arrays.equals(repn, other.repn);
     }
 
     /**
@@ -202,17 +199,11 @@ public class BitArray {
     }
 
     /**
-     * Returns a hash code value for this bit array.
-     *
-     * @return  a hash code value for this bit array.
+     * {@return a hash code value for this bit array}
      */
+    @Override
     public int hashCode() {
-        int hashCode = 0;
-
-        for (int i = 0; i < repn.length; i++)
-            hashCode = 31*hashCode + repn[i];
-
-        return hashCode ^ length;
+        return Arrays.hashCode(repn) ^ length;
     }
 
 


### PR DESCRIPTION
Please review this PR to use modern APIs and language features to simplify `equals` and `hashCode` in security area.

I understand that security area is sensitive and a non-expert, such as myself, should tread carefully; so below are my notes to assist the review.

* Unlike `hashCode`, non-secure `equals` implementations are typically short-circuit. But because of "timing attacks", we seem to have specialized implementations, such as `java.security.MessageDigest.isEqual(byte[], byte[])` and a more general `sun.security.util.ByteArrays.isEqual(byte[], int, int, byte[], int, int)`. So while reviewing this PR, take an opportunity to audit the affected `equals` implementations: perhaps some of them need to become secure, not modern. I have no domain knowledge to tell those cases apart, I only note that those cases exist.

* This PR sacrifices compatibility for pragmatism: it changes some `hashCode` implementations to produce different values than before to allow more utilization of methods from `Objects` and `Arrays`. To my mind, those changes are **benign**. If you disagree, I'd be happy to discuss that and/or retract the concerning part of the change.

* BitArray could be a topic of its own, but I'll do my best to be concise.

    * Truth to be told, BitArray's `equals` and `hashCode` are not used anywhere in source, and `equals` is only used in one test. For that reason, I refrained from reimplementing internals of `BitArray` using more general `java.util.BitSet`: too much effort and risk for almost nothing.
    * Speaking of `BitSet`-powered `BitArray`. Such an implementation is not for the faint of heart: there's too much impedance mismatch between data structures that those classes use to store bits. That said, for the sake of testing that it is possible and that I understand the `BitArray` correctly, I actually implemented it using `BitSet`. While that implementation is **NOT** part of this PR, you can have a look at it [here](https://cr.openjdk.org/~prappo/8311170/BitArray.java).

* One suggestion to consider is to change this somewhat arcane piece in java.security.UnresolvedPermission.equals:

          // check certs
          if (this.certs == null && that.certs != null ||
              this.certs != null && that.certs == null ||
              this.certs != null &&
                 this.certs.length != that.certs.length) {
              return false;
          }
  
          int i,j;
          boolean match;
  
          for (i = 0; this.certs != null && i < this.certs.length; i++) {
              match = false;
              for (j = 0; j < that.certs.length; j++) {
                  if (this.certs[i].equals(that.certs[j])) {
                      match = true;
                      break;
                  }
              }
              if (!match) return false;
          }
  
          for (i = 0; that.certs != null && i < that.certs.length; i++) {
              match = false;
              for (j = 0; j < this.certs.length; j++) {
                  if (that.certs[i].equals(this.certs[j])) {
                      match = true;
                      break;
                  }
              }
              if (!match) return false;
          }
          return true;

  to this:

          // check certs
          if (this.certs == null && that.certs != null ||
              this.certs != null && that.certs == null)
              return false;
          
          if (this.certs == null) {
              assert that.certs == null;
              return false;
          }
          
          return Set.of(this.certs).equals(Set.of(that.certs));
