### PR TITLE
8311186: ProblemList javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java on linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -46,3 +46,5 @@ serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 windows-x64
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_a/TestDescription.java 8308367 windows-x64
 vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 8308367 windows-x64
+
+vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64

--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -115,5 +115,3 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
-
-gc/z/TestHighUsage.java                                       8308843 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -171,3 +171,5 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64
+
+vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java 8310551 linux-all

--- a/test/hotspot/jtreg/gc/z/TestHighUsage.java
+++ b/test/hotspot/jtreg/gc/z/TestHighUsage.java
@@ -28,6 +28,7 @@ package gc.z;
  * @requires vm.gc.ZGenerational
  * @summary Test ZGC "High Usage" rule
  * @library /test/lib
+ * @ignore 8308843
  * @run main/othervm gc.z.TestHighUsage
  */
 

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -46,6 +46,8 @@ java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
 java/lang/ScopedValue/StressStackOverflow.java#default 8309646 linux-all
 
+javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
+
 ##########
 ## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -48,6 +48,8 @@ java/lang/ScopedValue/StressStackOverflow.java#default 8309646 linux-all
 
 javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
 
+javax/management/remote/mandatory/connection/ConnectionTest.java 8308352 windows-x64
+
 ##########
 ## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -520,6 +520,8 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 g
 
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8262312 linux-all
 
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java 8149084 linux-aarch64
+
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
Trivial ProblemListing/disable changes:
- [JDK-8311186](https://bugs.openjdk.org/browse/JDK-8311186) ProblemList javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java on linux-aarch64
- [JDK-8311189](https://bugs.openjdk.org/browse/JDK-8311189) disable gc/z/TestHighUsage.java
- [JDK-8311190](https://bugs.openjdk.org/browse/JDK-8311190) ProblemList javax/management/remote/mandatory/connection/DeadLockTest.java with virtual threads on windows-x64
- [JDK-8311191](https://bugs.openjdk.org/browse/JDK-8311191) ProblemList javax/management/remote/mandatory/connection/ConnectionTest.java with virtual threads on windows-x64
- [JDK-8311193](https://bugs.openjdk.org/browse/JDK-8311193) ProblemList vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java on linux-all
- [JDK-8311195](https://bugs.openjdk.org/browse/JDK-8311195) ProblemList vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java with Xcomp on macosx-x64

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8311186](https://bugs.openjdk.org/browse/JDK-8311186): ProblemList javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java on linux-aarch64 (**Sub-task** - P4)
 * [JDK-8311189](https://bugs.openjdk.org/browse/JDK-8311189): disable gc/z/TestHighUsage.java (**Sub-task** - P4)
 * [JDK-8311190](https://bugs.openjdk.org/browse/JDK-8311190): ProblemList javax/management/remote/mandatory/connection/DeadLockTest.java with virtual threads on windows-x64 (**Sub-task** - P4)
 * [JDK-8311191](https://bugs.openjdk.org/browse/JDK-8311191): ProblemList javax/management/remote/mandatory/connection/ConnectionTest.java with virtual threads on windows-x64 (**Sub-task** - P4)
 * [JDK-8311193](https://bugs.openjdk.org/browse/JDK-8311193): ProblemList vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java on linux-all (**Sub-task** - P4)
 * [JDK-8311195](https://bugs.openjdk.org/browse/JDK-8311195): ProblemList vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java with Xcomp on macosx-x64 (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14741/head:pull/14741` \
`$ git checkout pull/14741`

Update a local copy of the PR: \
`$ git checkout pull/14741` \
`$ git pull https://git.openjdk.org/jdk.git pull/14741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14741`

View PR using the GUI difftool: \
`$ git pr show -t 14741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14741.diff">https://git.openjdk.org/jdk/pull/14741.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14741#issuecomment-1615201377)