### PR TITLE
8302618: [macos] Problem typing uppercase letters with java.awt.Robot when moving mouse

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -319,7 +319,7 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
             }
 
             CGEventFlags flags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
-            flags  = (initFlags & allModifiersMask) | (flags & (~allModifiersMask));
+            flags = (initFlags & allModifiersMask) | (flags & (~allModifiersMask));
             CGEventSetFlags(event, flags);
 
             CGEventPost(kCGHIDEventTap, event);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -304,17 +304,11 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
         CGKeyCode keyCode = GetCGKeyCode(javaKeyCode);
         CGEventRef event = CGEventCreateKeyboardEvent(source, keyCode, keyPressed);
 
-        NSLog(@"JAVA KEYCODE: %d", javaKeyCode);
-        NSLog(@"CG KEYCODE: %hu", keyCode);
-
         if (event != NULL) {
-            NSLog(@"BEFORE INIT FLAG: %llu", initFlags);
             int flagMaskValue = GetCGKeyMask(keyCode);
             if (OSX_Undefined != flagMaskValue) {
-                NSLog(@"KeyCode %d and Mask Value: %d", keyCode, flagMaskValue);
                 if (keyCode == OSX_CapsLock) {
                     if (keyPressed) {
-                     NSLog(@"IF CapsLock");
                      initFlags ^= flagMaskValue;
                     }
                 } else {
@@ -334,8 +328,6 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
         if (source != NULL) {
             CFRelease(source);
         }
-        NSLog(@"AFTER INIT FLAG - Contents of Flag: %llu", initFlags);
-        NSLog(@"----------------------------------------");
     }];
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -305,12 +305,15 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
         NSLog(@"CG KEYCODE: %hu", keyCode);
 
         if (event != NULL) {
-            NSLog(@"BEFORE Contents of Flag: %llu", initFlags);
+            NSLog(@"BEFORE INIT FLAG: %llu", initFlags);
             int flagMaskValue = GetCGKeyMask(keyCode);
             if (OSX_Undefined != flagMaskValue) {
                 NSLog(@"KeyCode %d and Mask Value: %d", keyCode, flagMaskValue);
                 if (keyCode == OSX_CapsLock) {
-                    initFlags ^= flagMaskValue;
+                    if (keyPressed) {
+                     NSLog(@"IF CapsLock");
+                     initFlags ^= flagMaskValue;
+                    }
                 } else {
                     initFlags = keyPressed
                                 ? (initFlags | flagMaskValue)    // add flag bits if modifier key pressed
@@ -319,7 +322,11 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
             }
 
             CGEventFlags flags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
-            flags |= initFlags;
+            int allModifiersMask = kCGEventFlagMaskShift | kCGEventFlagMaskControl
+                                  | kCGEventFlagMaskAlternate | kCGEventFlagMaskCommand
+                                  | kCGEventFlagMaskAlphaShift;
+
+            flags  = (initFlags & allModifiersMask) | (flags & (!allModifiersMask));
             CGEventSetFlags(event, flags);
 
             CGEventPost(kCGHIDEventTap, event);
@@ -328,7 +335,7 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
         if (source != NULL) {
             CFRelease(source);
         }
-        NSLog(@"AFTER EVENT & SOURCE RELEASE - Contents of Flag: %llu", initFlags);
+        NSLog(@"AFTER INIT FLAG - Contents of Flag: %llu", initFlags);
         NSLog(@"----------------------------------------");
     }];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -66,7 +66,7 @@ static NSTimeInterval gNextKeyEventTime;
 static CGEventFlags initFlags;
 static int allModifiersMask = kCGEventFlagMaskShift | kCGEventFlagMaskControl
                               | kCGEventFlagMaskAlternate | kCGEventFlagMaskCommand
-                              | kCGEventFlagMaskAlphaShift;
+                              | kCGEventFlagMaskAlphaShift | kCGEventFlagMaskSecondaryFn;
 
 static inline CGKeyCode GetCGKeyCode(jint javaKeyCode);
 static inline int GetCGKeyMask(int cgKeyCode);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -423,7 +423,8 @@ static inline CGKeyCode GetCGKeyCode(jint javaKeyCode)
     return [keyCodeMapping getOSXKeyCodeForJavaKey:javaKeyCode];
 }
 
-static inline int GetCGKeyMask(int cgKeyCode) {
+static inline int GetCGKeyMask(int cgKeyCode)
+{
     CRobotKeyCodeMapping *keyCodeMapping = [CRobotKeyCodeMapping sharedInstance];
     return [keyCodeMapping getFlagMaskForCGKey:cgKeyCode];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -423,8 +423,7 @@ static inline CGKeyCode GetCGKeyCode(jint javaKeyCode)
     return [keyCodeMapping getOSXKeyCodeForJavaKey:javaKeyCode];
 }
 
-static inline int GetCGKeyMask(int cgKeyCode)
-{
+static inline int GetCGKeyMask(int cgKeyCode) {
     CRobotKeyCodeMapping *keyCodeMapping = [CRobotKeyCodeMapping sharedInstance];
     return [keyCodeMapping getFlagMaskForCGKey:cgKeyCode];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -64,7 +64,7 @@ static int gsEventNumber;
 static int* gsButtonEventNumber;
 static NSTimeInterval gNextKeyEventTime;
 static CGEventFlags initFlags;
-static int allModifiersMask = kCGEventFlagMaskShift | kCGEventFlagMaskControl
+static CGEventFlags allModifiersMask = kCGEventFlagMaskShift | kCGEventFlagMaskControl
                               | kCGEventFlagMaskAlternate | kCGEventFlagMaskCommand
                               | kCGEventFlagMaskAlphaShift | kCGEventFlagMaskSecondaryFn;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -309,7 +309,7 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
             if (OSX_Undefined != flagMaskValue) {
                 if (keyCode == OSX_CapsLock) {
                     if (keyPressed) {
-                     initFlags ^= flagMaskValue;
+                        initFlags ^= flagMaskValue;
                     }
                 } else {
                     initFlags = keyPressed
@@ -319,7 +319,7 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
             }
 
             CGEventFlags flags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
-            flags  = (initFlags & allModifiersMask) | (flags & (!allModifiersMask));
+            flags  = (initFlags & allModifiersMask) | (flags & (~allModifiersMask));
             CGEventSetFlags(event, flags);
 
             CGEventPost(kCGHIDEventTap, event);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -296,12 +296,12 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
 {
     autoDelay(NO);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
-       CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
-       CGKeyCode keyCode = GetCGKeyCode(javaKeyCode);
-       CGEventRef event = CGEventCreateKeyboardEvent(source, keyCode, keyPressed);
+        CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+        CGKeyCode keyCode = GetCGKeyCode(javaKeyCode);
+        CGEventRef event = CGEventCreateKeyboardEvent(source, keyCode, keyPressed);
 
-       NSLog(@"JAVA KEYCODE: %d", javaKeyCode);
-       NSLog(@"CG KEYCODE: %hu", keyCode);
+        NSLog(@"JAVA KEYCODE: %d", javaKeyCode);
+        NSLog(@"CG KEYCODE: %hu", keyCode);
 
         if (event != NULL) {
             NSLog(@"BEFORE Contents of Flag: %llu", initFlags);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -64,6 +64,9 @@ static int gsEventNumber;
 static int* gsButtonEventNumber;
 static NSTimeInterval gNextKeyEventTime;
 static CGEventFlags initFlags;
+static int allModifiersMask = kCGEventFlagMaskShift | kCGEventFlagMaskControl
+                              | kCGEventFlagMaskAlternate | kCGEventFlagMaskCommand
+                              | kCGEventFlagMaskAlphaShift;
 
 static inline CGKeyCode GetCGKeyCode(jint javaKeyCode);
 static inline int GetCGKeyMask(int cgKeyCode);
@@ -322,10 +325,6 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
             }
 
             CGEventFlags flags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
-            int allModifiersMask = kCGEventFlagMaskShift | kCGEventFlagMaskControl
-                                  | kCGEventFlagMaskAlternate | kCGEventFlagMaskCommand
-                                  | kCGEventFlagMaskAlphaShift;
-
             flags  = (initFlags & allModifiersMask) | (flags & (!allModifiersMask));
             CGEventSetFlags(event, flags);
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.h
@@ -148,9 +148,11 @@ const static int OSX_Undefined                  = 0x7F;
 }
 
 @property (readwrite, retain) NSDictionary *javaToMacKeyMap;
+@property (readwrite, retain) NSDictionary *modifierKeyToMaskMap;
 
 + (CRobotKeyCodeMapping *)sharedInstance ;
 - (int)getOSXKeyCodeForJavaKey:(int) javaKey;
+- (int)getFlagMaskForCGKey:(int) cgKeyCode;
 
 @end
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
@@ -29,6 +29,7 @@
 @implementation CRobotKeyCodeMapping
 
 @synthesize javaToMacKeyMap;
+@synthesize modifierKeyToMaskMap;
 
 +(CRobotKeyCodeMapping *) sharedInstance {
     static CRobotKeyCodeMapping *instance = nil;
@@ -161,6 +162,15 @@
             [NSNumber numberWithInt : OSX_F20], [NSNumber numberWithInt : java_awt_event_KeyEvent_VK_F20],
 
             nil];
+
+        self.modifierKeyToMaskMap = [NSDictionary dictionaryWithObjectsAndKeys:
+            [NSNumber numberWithInt : kCGEventFlagMaskShift], [NSNumber numberWithInt : OSX_Shift],
+            [NSNumber numberWithInt : kCGEventFlagMaskControl], [NSNumber numberWithInt: OSX_Control],
+            [NSNumber numberWithInt : kCGEventFlagMaskAlternate], [NSNumber numberWithInt: OSX_Option],
+            [NSNumber numberWithInt : kCGEventFlagMaskCommand], [NSNumber numberWithInt: OSX_Command],
+            [NSNumber numberWithInt : kCGEventFlagMaskAlphaShift], [NSNumber numberWithInt: OSX_CapsLock],
+
+            nil];
     }
 
     return self;
@@ -168,6 +178,16 @@
 
 -(int) getOSXKeyCodeForJavaKey : (int) javaKey {
     id val = [javaToMacKeyMap objectForKey : [NSNumber numberWithInt : javaKey]];
+
+    if (nil != val) {
+        return [val intValue];
+    } else {
+        return OSX_Undefined;
+    }
+}
+
+-(int) getFlagMaskForCGKey : (int) cgKeyCode {
+    id val = [modifierKeyToMaskMap objectForKey : [NSNumber numberWithInt : cgKeyCode]];
 
     if (nil != val) {
         return [val intValue];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
@@ -165,10 +165,10 @@
 
         self.modifierKeyToMaskMap = [NSDictionary dictionaryWithObjectsAndKeys:
             [NSNumber numberWithInt : kCGEventFlagMaskShift], [NSNumber numberWithInt : OSX_Shift],
-            [NSNumber numberWithInt : kCGEventFlagMaskControl], [NSNumber numberWithInt: OSX_Control],
-            [NSNumber numberWithInt : kCGEventFlagMaskAlternate], [NSNumber numberWithInt: OSX_Option],
-            [NSNumber numberWithInt : kCGEventFlagMaskCommand], [NSNumber numberWithInt: OSX_Command],
-            [NSNumber numberWithInt : kCGEventFlagMaskAlphaShift], [NSNumber numberWithInt: OSX_CapsLock],
+            [NSNumber numberWithInt : kCGEventFlagMaskControl], [NSNumber numberWithInt : OSX_Control],
+            [NSNumber numberWithInt : kCGEventFlagMaskAlternate], [NSNumber numberWithInt : OSX_Option],
+            [NSNumber numberWithInt : kCGEventFlagMaskCommand], [NSNumber numberWithInt : OSX_Command],
+            [NSNumber numberWithInt : kCGEventFlagMaskAlphaShift], [NSNumber numberWithInt : OSX_CapsLock],
 
             nil];
     }

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -97,8 +97,7 @@ public class RobotModifierMaskTest {
                 try {
                     countDownLatch = new CountDownLatch(1);
                     invokeAndWait(RobotModifierMaskTest::createInstructionsUI);
-                    boolean timeout = countDownLatch.await(2, TimeUnit.MINUTES);
-                    if (!timeout) {
+                    if (!countDownLatch.await(2, TimeUnit.MINUTES)) {
                         throw new RuntimeException("Test failed: Manual test timed out!!");
                     }
                 } finally {

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -74,7 +74,7 @@ public class RobotModifierMaskTest {
 
             In this mode when the Robot starts to type, the user is required to concurrently
             move the mouse (without clicking/dragging).
-            When ready click on the "Start" button to run the test.
+            When ready click on the "Start" button to run the test and start moving the mouse.
             """;
 
     public static void main(String[] args) throws Exception {
@@ -234,7 +234,7 @@ public class RobotModifierMaskTest {
         jButton.addActionListener(e -> startTest = true);
         jFrame.getContentPane().add(jButton, BorderLayout.PAGE_END);
 
-        jFrame.setSize(560,200);
+        jFrame.setSize(560, 200);
         jFrame.setLocation(200, 200);
         jFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         jFrame.setVisible(true);
@@ -247,7 +247,7 @@ public class RobotModifierMaskTest {
         JScrollPane pane = new JScrollPane(jTextArea);
         jFrame.getContentPane().add(pane, BorderLayout.CENTER);
 
-        jFrame.setSize(450,100);
+        jFrame.setSize(450, 100);
         jFrame.setLocation(200, 200);
         jFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         jFrame.setVisible(true);

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -1,0 +1,257 @@
+
+
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import java.awt.AWTException;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.KeyEvent;
+
+/*
+ * @test
+ * @bug 8302618
+ * @key headful
+ * @summary To test if modifier keys work properly,
+ *          when manual mouse move and Robot's Key Event occur simultaneously.
+ */
+public class RobotModifierMaskTest {
+
+    private static Robot robot;
+    private static JFrame jFrame;
+    private static JTextArea jTextArea;
+
+    private static StringBuffer errorLog = new StringBuffer();
+    private static final String EXPECTED_RESULT_SHIFT = "AAAAA";
+    private static final String EXPECTED_RESULT_CAPS = "AaAaAa";
+    private static final String EXPECTED_RESULT_META = "AAA";
+    private static final String EXPECTED_RESULT_ALT = "ååå";
+    private static final int EXPECTED_CARET_POS_CTRL = 0;
+
+    public static void main(String[] arguments)
+            throws Exception {
+
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(200);
+
+            SwingUtilities.invokeAndWait(() -> createTestUI());
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            testShiftKey();
+            robot.delay(200);
+            testCapsKey();
+            robot.delay(200);
+            testCmdKey();
+            testCtrlKey();
+            testAltKey();
+
+            if (!errorLog.isEmpty()) {
+                throw new RuntimeException("Test failed for following case(s): \n" + errorLog);
+            }
+
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void testShiftKey() {
+        // clear contents of JTextArea
+        jTextArea.setText("");
+
+        for (int i = 0; i < 5; ++i) {
+            // Press shift-a.
+            System.out.println("VK_SHIFT - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_SHIFT - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            System.out.println("\n");
+
+            robot.delay(200);
+        }
+
+        robot.delay(1000);
+
+        if (!jTextArea.getText().equals(EXPECTED_RESULT_SHIFT)) {
+            errorLog.append("For Shift key, Actual and Expected results differ \n"+
+                    "Expected Text : " + EXPECTED_RESULT_SHIFT + " Actual Text : " + jTextArea.getText() + "\n");
+        }
+    }
+
+    private static void testCapsKey() {
+        // clear contents of JTextArea
+        jTextArea.setText("");
+
+        for (int i = 0; i < 6; ++i) {
+            System.out.println("VK_CAPS_LOCK");
+            robot.keyPress(KeyEvent.VK_CAPS_LOCK);
+            System.out.println("\n");
+
+            System.out.println("VK_CAPS_LOCK");
+            robot.keyRelease(KeyEvent.VK_CAPS_LOCK);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            robot.delay(200);
+        }
+
+        robot.delay(1000);
+
+        if (!jTextArea.getText().equals(EXPECTED_RESULT_CAPS)) {
+            errorLog.append("For Caps key, Actual and Expected results differ. \n"+
+                    "Expected Text : " + EXPECTED_RESULT_CAPS + " Actual Text : " + jTextArea.getText() + "\n");
+        }
+    }
+
+    private static void testCmdKey() {
+        // clear contents of JTextArea
+        jTextArea.setText("");
+
+        StringSelection stringSelection = new StringSelection("AAA");
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(stringSelection, stringSelection);
+        System.out.println("VK_META - KEY PRESS");
+        robot.keyPress(KeyEvent.VK_META);
+        System.out.println("\n");
+
+        System.out.println("VK_V - KEY PRESS");
+        robot.keyPress(KeyEvent.VK_V);
+        System.out.println("\n");
+
+        System.out.println("VK_V - KEY RELEASE");
+        robot.keyRelease(KeyEvent.VK_V);
+        System.out.println("\n");
+
+        System.out.println("VK_META - KEY RELEASE");
+        robot.keyRelease(KeyEvent.VK_META);
+        System.out.println("\n");
+
+        robot.delay(1000);
+
+        if (!jTextArea.getText().equals(EXPECTED_RESULT_META)) {
+            errorLog.append("For Command key, Actual and Expected results differ \n"+
+                    "Expected Text : " + EXPECTED_RESULT_META + " Actual Text : " + jTextArea.getText() + "\n");
+        }
+    }
+
+    private static void testAltKey() throws AWTException {
+        // clear contents of JTextArea
+        jTextArea.setText("");
+
+        for (int i = 0; i < 3; ++i) {
+            // Press shift-a.
+            System.out.println("VK_ALT - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_ALT);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_ALT - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_ALT);
+            System.out.println("\n");
+
+            robot.delay(200);
+        }
+
+        robot.delay(1000);
+
+        if (!jTextArea.getText().equals(EXPECTED_RESULT_ALT)) {
+            errorLog.append("For Shift key, Actual and Expected results differ \n"+
+                    "Expected Text : " + EXPECTED_RESULT_ALT + " Actual Text : " + jTextArea.getText() + "\n");
+        }
+    }
+
+    private static void testCtrlKey() {
+        // clear contents of JTextArea
+        jTextArea.setText("");
+        for (int i = 0; i < 5; ++i) {
+            // Press shift-a.
+            System.out.println("VK_SHIFT - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY PRESS");
+            robot.keyPress(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_A - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_A);
+            System.out.println("\n");
+
+            System.out.println("VK_SHIFT - KEY RELEASE");
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            System.out.println("\n");
+
+            robot.delay(200);
+        }
+
+        robot.delay(500);
+        System.out.println("VK_CONTROL - KEY RELEASE");
+        robot.keyPress(KeyEvent.VK_CONTROL);
+        System.out.println("\n");
+
+        System.out.println("VK_V - KEY RELEASE");
+        robot.keyPress(KeyEvent.VK_A);
+        System.out.println("\n");
+
+        System.out.println("VK_V - KEY RELEASE");
+        robot.keyRelease(KeyEvent.VK_A);
+        System.out.println("\n");
+
+        System.out.println("VK_CONTROL - KEY RELEASE");
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+        System.out.println("\n");
+
+        robot.delay(1000);
+
+
+        if (jTextArea.getCaretPosition() != EXPECTED_CARET_POS_CTRL) {
+            errorLog.append("For Control key, Actual and Expected caret position differ \n"+
+                    "Expected Position : " + EXPECTED_CARET_POS_CTRL + " Actual Position : " + jTextArea.getCaretPosition() + "\n");
+        }
+    }
+
+    private static void createTestUI() {
+        jFrame = new JFrame();
+        jTextArea = new JTextArea("");
+        JScrollPane pane = new JScrollPane(jTextArea);
+        jFrame.getContentPane().add(pane);
+        jFrame.setSize(200,200);
+        jFrame.setLocation(200, 200);
+        jFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        jFrame.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -1,4 +1,25 @@
-
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -21,18 +21,19 @@
  * questions.
  */
 
-import sun.awt.OSInfo;
 
-import javax.swing.JFrame;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+import sun.awt.OSInfo;
 
 /*
  * @test
@@ -40,8 +41,8 @@ import java.awt.event.KeyEvent;
  * @key headful
  * @modules java.desktop/sun.awt
  * @requires (os.family == "mac")
- * @summary To test if modifier keys work properly,
- *          when manual mouse move and Robot's Key Event occur simultaneously.
+ * @summary To test if modifier keys work properly, during Robot's Key Event
+ *          with and without manual mouse move.
  */
 public class RobotModifierMaskTest {
 
@@ -62,9 +63,11 @@ public class RobotModifierMaskTest {
             It tests the following key modifiers - Shift, Caps, Control, Option and Command.
             It needs to be checked for following two scenarios \n
 
-            CASE 1 : Run the test as an automated test and let the Robot go through all the test cases.\n
-            CASE 2 : Run the test in semi-automated mode. While the Robot in typing,
-                     manually move the mouse (without clicking/dragging). Check if the test Passes or Fails.\n\n
+            CASE 1 : \t Run the test as an automated test and let the Robot go through
+                     \t all the test cases.\n
+            CASE 2 : \t Run the test in semi-automated mode. While the Robot in typing,
+                     \t manually move the mouse (without clicking/dragging).
+                     \t Check if the test passes or fails.\n
 
             NOTE: User doesn't need to compare the actual vs expected result in Case 2.
             The test compares it.""";
@@ -98,7 +101,8 @@ public class RobotModifierMaskTest {
             testAltKey();
 
             if (!errorLog.isEmpty()) {
-                throw new RuntimeException("Test failed for following case(s): \n" + errorLog);
+                throw new RuntimeException("Test failed for following case(s): \n"
+                                           + errorLog);
             }
 
         } finally {
@@ -124,8 +128,9 @@ public class RobotModifierMaskTest {
         robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_SHIFT)) {
-            errorLog.append("For Shift key, Actual and Expected results differ \n"+
-                    "Expected Text : " + EXPECTED_RESULT_SHIFT + " Actual Text : " + jTextArea.getText() + "\n");
+            errorLog.append("For Shift key, Actual and Expected results differ\n"
+                            + "Expected Text : " + EXPECTED_RESULT_SHIFT
+                            + " Actual Text : " + jTextArea.getText() + "\n");
         }
     }
 
@@ -146,8 +151,9 @@ public class RobotModifierMaskTest {
         robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_CAPS)) {
-            errorLog.append("For Caps key, Actual and Expected results differ. \n"+
-                    "Expected Text : " + EXPECTED_RESULT_CAPS + " Actual Text : " + jTextArea.getText() + "\n");
+            errorLog.append("For Caps key, Actual and Expected results differ. \n"
+                            + "Expected Text : " + EXPECTED_RESULT_CAPS
+                            + " Actual Text : " + jTextArea.getText() + "\n");
         }
     }
 
@@ -167,8 +173,9 @@ public class RobotModifierMaskTest {
         robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_META)) {
-            errorLog.append("For Command key, Actual and Expected results differ \n"+
-                    "Expected Text : " + EXPECTED_RESULT_META + " Actual Text : " + jTextArea.getText() + "\n");
+            errorLog.append("For Command key, Actual and Expected results differ \n"
+                            + "Expected Text : " + EXPECTED_RESULT_META
+                            + " Actual Text : " + jTextArea.getText() + "\n");
         }
     }
 
@@ -187,8 +194,9 @@ public class RobotModifierMaskTest {
         robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_ALT)) {
-            errorLog.append("For Alt key, Actual and Expected results differ \n"+
-                    "Expected Text : " + EXPECTED_RESULT_ALT + " Actual Text : " + jTextArea.getText() + "\n");
+            errorLog.append("For Alt key, Actual and Expected results differ \n"
+                            + "Expected Text : " + EXPECTED_RESULT_ALT
+                            + " Actual Text : " + jTextArea.getText() + "\n");
         }
     }
 
@@ -213,8 +221,9 @@ public class RobotModifierMaskTest {
         robot.delay(500);
 
         if (jTextArea.getCaretPosition() != EXPECTED_CARET_POS_CTRL) {
-            errorLog.append("For Control key, Actual and Expected caret position differ \n" +
-                    "Expected Position : " + EXPECTED_CARET_POS_CTRL + " Actual Position : " + jTextArea.getCaretPosition() + "\n");
+            errorLog.append("For Control key, Actual and Expected caret position differ\n"
+                            + "Expected Position : " + EXPECTED_CARET_POS_CTRL
+                            + " Actual Position : " + jTextArea.getCaretPosition() + "\n");
         }
     }
 
@@ -223,7 +232,7 @@ public class RobotModifierMaskTest {
         jTextArea = new JTextArea("");
         JScrollPane pane = new JScrollPane(jTextArea);
         jFrame.getContentPane().add(pane);
-        jFrame.setSize(600,300);
+        jFrame.setSize(600,320);
         jFrame.setLocation(200, 200);
         jFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         jFrame.setVisible(true);

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -26,7 +26,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
-import java.awt.AWTException;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -37,6 +36,7 @@ import java.awt.event.KeyEvent;
  * @test
  * @bug 8302618
  * @key headful
+ * @requires (os.family == "mac")
  * @summary To test if modifier keys work properly,
  *          when manual mouse move and Robot's Key Event occur simultaneously.
  */
@@ -50,7 +50,7 @@ public class RobotModifierMaskTest {
     private static final String EXPECTED_RESULT_SHIFT = "AAAAA";
     private static final String EXPECTED_RESULT_CAPS = "AaAaAa";
     private static final String EXPECTED_RESULT_META = "AAA";
-    private static final String EXPECTED_RESULT_ALT = "ååå";
+    private static final String EXPECTED_RESULT_ALT = "\u00e5\u00e5\u00e5";
     private static final int EXPECTED_CARET_POS_CTRL = 0;
 
     public static void main(String[] arguments)
@@ -182,7 +182,7 @@ public class RobotModifierMaskTest {
         }
     }
 
-    private static void testAltKey() throws AWTException {
+    private static void testAltKey() {
         // clear contents of JTextArea
         jTextArea.setText("");
 
@@ -210,7 +210,7 @@ public class RobotModifierMaskTest {
         robot.delay(1000);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_ALT)) {
-            errorLog.append("For Shift key, Actual and Expected results differ \n"+
+            errorLog.append("For Alt key, Actual and Expected results differ \n"+
                     "Expected Text : " + EXPECTED_RESULT_ALT + " Actual Text : " + jTextArea.getText() + "\n");
         }
     }

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import sun.awt.OSInfo;
+
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
@@ -36,6 +38,7 @@ import java.awt.event.KeyEvent;
  * @test
  * @bug 8302618
  * @key headful
+ * @modules java.desktop/sun.awt
  * @requires (os.family == "mac")
  * @summary To test if modifier keys work properly,
  *          when manual mouse move and Robot's Key Event occur simultaneously.
@@ -53,7 +56,25 @@ public class RobotModifierMaskTest {
     private static final String EXPECTED_RESULT_ALT = "\u00e5\u00e5\u00e5";
     private static final int EXPECTED_CARET_POS_CTRL = 0;
 
+    private static final String INSTRUCTIONS = """
+            This test is a semi-automatic test which checks the effect of typing modifier keys
+            through a Robot.\n
+            It tests the following key modifiers - Shift, Caps, Control, Option and Command.
+            It needs to be checked for following two scenarios \n
+
+            CASE 1 : Run the test as an automated test and let the Robot go through all the test cases.\n
+            CASE 2 : Run the test in semi-automated mode. While the Robot in typing,
+                     manually move the mouse (without clicking/dragging). Check if the test Passes or Fails.\n\n
+            
+            NOTE: User doesn't need to compare the actual vs expected result in Case 2.
+            The test compares it.""";
+
     public static void main(String[] args) throws Exception {
+        if (OSInfo.getOSType() != OSInfo.OSType.MACOSX) {
+            System.out.println("This test is for MacOS platform only");
+            return;
+        }
+
         try {
             robot = new Robot();
             robot.setAutoWaitForIdle(true);
@@ -62,6 +83,9 @@ public class RobotModifierMaskTest {
             SwingUtilities.invokeAndWait(() -> createTestUI());
             robot.waitForIdle();
             robot.delay(1000);
+
+            jTextArea.setText(INSTRUCTIONS);
+            robot.delay(8000);
 
             testShiftKey();
             robot.delay(100);
@@ -87,11 +111,7 @@ public class RobotModifierMaskTest {
     }
 
     private static void testShiftKey() {
-        jTextArea.setText("Testing Shift Key...\n"
-                + "EXPECTED STRING: "+ EXPECTED_RESULT_SHIFT);
-        robot.delay(1000);
         jTextArea.setText("");
-        robot.delay(200);
 
         for (int i = 0; i < 5; ++i) {
             robot.keyPress(KeyEvent.VK_SHIFT);
@@ -111,11 +131,7 @@ public class RobotModifierMaskTest {
 
     private static void testCapsKey() {
         // clear contents of JTextArea
-        jTextArea.setText("Testing CapsLock Key...\n"
-                + "EXPECTED STRING: "+ EXPECTED_RESULT_CAPS);
-        robot.delay(1000);
         jTextArea.setText("");
-        robot.delay(200);
 
         for (int i = 0; i < 6; ++i) {
             robot.keyPress(KeyEvent.VK_CAPS_LOCK);
@@ -137,11 +153,7 @@ public class RobotModifierMaskTest {
 
     private static void testCmdKey() {
         // clear contents of JTextArea
-        jTextArea.setText("Testing CapsLock Key...\n"
-                + " EXPECTED STRING: "+ EXPECTED_RESULT_META);
-        robot.delay(1000);
         jTextArea.setText("");
-        robot.delay(200);
 
         StringSelection stringSelection = new StringSelection("AAA");
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
@@ -161,11 +173,7 @@ public class RobotModifierMaskTest {
     }
 
     private static void testAltKey() {
-        jTextArea.setText("Testing Alt Key...\n"
-                + " EXPECTED STRING: "+ EXPECTED_RESULT_ALT);
-        robot.delay(1000);
         jTextArea.setText("");
-        robot.delay(200);
 
         for (int i = 0; i < 3; ++i) {
             robot.keyPress(KeyEvent.VK_ALT);
@@ -185,11 +193,7 @@ public class RobotModifierMaskTest {
     }
 
     private static void testCtrlKey() {
-        jTextArea.setText("Testing Alt Key...\n"
-                + "EXPECTED CARET POSITION: "+ EXPECTED_CARET_POS_CTRL);
-        robot.delay(1000);
         jTextArea.setText("");
-        robot.delay(200);
 
         for (int i = 0; i < 5; ++i) {
             robot.keyPress(KeyEvent.VK_SHIFT);
@@ -215,11 +219,11 @@ public class RobotModifierMaskTest {
     }
 
     private static void createTestUI() {
-        jFrame = new JFrame();
+        jFrame = new JFrame("RobotModifierMaskTest");
         jTextArea = new JTextArea("");
         JScrollPane pane = new JScrollPane(jTextArea);
         jFrame.getContentPane().add(pane);
-        jFrame.setSize(300,200);
+        jFrame.setSize(600,300);
         jFrame.setLocation(200, 200);
         jFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         jFrame.setVisible(true);

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -53,9 +53,7 @@ public class RobotModifierMaskTest {
     private static final String EXPECTED_RESULT_ALT = "\u00e5\u00e5\u00e5";
     private static final int EXPECTED_CARET_POS_CTRL = 0;
 
-    public static void main(String[] arguments)
-            throws Exception {
-
+    public static void main(String[] args) throws Exception {
         try {
             robot = new Robot();
             robot.setAutoWaitForIdle(true);
@@ -63,14 +61,16 @@ public class RobotModifierMaskTest {
 
             SwingUtilities.invokeAndWait(() -> createTestUI());
             robot.waitForIdle();
-            robot.delay(2000);
+            robot.delay(1000);
 
             testShiftKey();
-            robot.delay(200);
+            robot.delay(100);
             testCapsKey();
-            robot.delay(200);
+            robot.delay(100);
             testCmdKey();
+            robot.delay(100);
             testCtrlKey();
+            robot.delay(100);
             testAltKey();
 
             if (!errorLog.isEmpty()) {
@@ -87,31 +87,21 @@ public class RobotModifierMaskTest {
     }
 
     private static void testShiftKey() {
-        // clear contents of JTextArea
+        jTextArea.setText("Testing Shift Key...\n"
+                + "EXPECTED STRING: "+ EXPECTED_RESULT_SHIFT);
+        robot.delay(1000);
         jTextArea.setText("");
+        robot.delay(200);
 
         for (int i = 0; i < 5; ++i) {
-            // Press shift-a.
-            System.out.println("VK_SHIFT - KEY PRESS");
             robot.keyPress(KeyEvent.VK_SHIFT);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY PRESS");
             robot.keyPress(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_SHIFT - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_SHIFT);
-            System.out.println("\n");
-
-            robot.delay(200);
+            robot.delay(100);
         }
 
-        robot.delay(1000);
+        robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_SHIFT)) {
             errorLog.append("For Shift key, Actual and Expected results differ \n"+
@@ -121,29 +111,23 @@ public class RobotModifierMaskTest {
 
     private static void testCapsKey() {
         // clear contents of JTextArea
+        jTextArea.setText("Testing CapsLock Key...\n"
+                + "EXPECTED STRING: "+ EXPECTED_RESULT_CAPS);
+        robot.delay(1000);
         jTextArea.setText("");
+        robot.delay(200);
 
         for (int i = 0; i < 6; ++i) {
-            System.out.println("VK_CAPS_LOCK");
             robot.keyPress(KeyEvent.VK_CAPS_LOCK);
-            System.out.println("\n");
-
-            System.out.println("VK_CAPS_LOCK");
             robot.keyRelease(KeyEvent.VK_CAPS_LOCK);
-            System.out.println("\n");
 
-            System.out.println("VK_A - KEY PRESS");
             robot.keyPress(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_A);
-            System.out.println("\n");
 
-            robot.delay(200);
+            robot.delay(100);
         }
 
-        robot.delay(1000);
+        robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_CAPS)) {
             errorLog.append("For Caps key, Actual and Expected results differ. \n"+
@@ -153,28 +137,22 @@ public class RobotModifierMaskTest {
 
     private static void testCmdKey() {
         // clear contents of JTextArea
+        jTextArea.setText("Testing CapsLock Key...\n"
+                + " EXPECTED STRING: "+ EXPECTED_RESULT_META);
+        robot.delay(1000);
         jTextArea.setText("");
+        robot.delay(200);
 
         StringSelection stringSelection = new StringSelection("AAA");
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(stringSelection, stringSelection);
-        System.out.println("VK_META - KEY PRESS");
+
         robot.keyPress(KeyEvent.VK_META);
-        System.out.println("\n");
-
-        System.out.println("VK_V - KEY PRESS");
         robot.keyPress(KeyEvent.VK_V);
-        System.out.println("\n");
-
-        System.out.println("VK_V - KEY RELEASE");
         robot.keyRelease(KeyEvent.VK_V);
-        System.out.println("\n");
-
-        System.out.println("VK_META - KEY RELEASE");
         robot.keyRelease(KeyEvent.VK_META);
-        System.out.println("\n");
 
-        robot.delay(1000);
+        robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_META)) {
             errorLog.append("For Command key, Actual and Expected results differ \n"+
@@ -183,31 +161,22 @@ public class RobotModifierMaskTest {
     }
 
     private static void testAltKey() {
-        // clear contents of JTextArea
+        jTextArea.setText("Testing Alt Key...\n"
+                + " EXPECTED STRING: "+ EXPECTED_RESULT_ALT);
+        robot.delay(1000);
         jTextArea.setText("");
+        robot.delay(200);
 
         for (int i = 0; i < 3; ++i) {
-            // Press shift-a.
-            System.out.println("VK_ALT - KEY PRESS");
             robot.keyPress(KeyEvent.VK_ALT);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY PRESS");
             robot.keyPress(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_ALT - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_ALT);
-            System.out.println("\n");
 
-            robot.delay(200);
+            robot.delay(100);
         }
 
-        robot.delay(1000);
+        robot.delay(500);
 
         if (!jTextArea.getText().equals(EXPECTED_RESULT_ALT)) {
             errorLog.append("For Alt key, Actual and Expected results differ \n"+
@@ -216,51 +185,31 @@ public class RobotModifierMaskTest {
     }
 
     private static void testCtrlKey() {
-        // clear contents of JTextArea
+        jTextArea.setText("Testing Alt Key...\n"
+                + "EXPECTED CARET POSITION: "+ EXPECTED_CARET_POS_CTRL);
+        robot.delay(1000);
         jTextArea.setText("");
+        robot.delay(200);
+
         for (int i = 0; i < 5; ++i) {
-            // Press shift-a.
-            System.out.println("VK_SHIFT - KEY PRESS");
             robot.keyPress(KeyEvent.VK_SHIFT);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY PRESS");
             robot.keyPress(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_A - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_A);
-            System.out.println("\n");
-
-            System.out.println("VK_SHIFT - KEY RELEASE");
             robot.keyRelease(KeyEvent.VK_SHIFT);
-            System.out.println("\n");
 
-            robot.delay(200);
+            robot.delay(100);
         }
 
-        robot.delay(500);
-        System.out.println("VK_CONTROL - KEY RELEASE");
+        robot.delay(200);
         robot.keyPress(KeyEvent.VK_CONTROL);
-        System.out.println("\n");
-
-        System.out.println("VK_V - KEY RELEASE");
         robot.keyPress(KeyEvent.VK_A);
-        System.out.println("\n");
-
-        System.out.println("VK_V - KEY RELEASE");
         robot.keyRelease(KeyEvent.VK_A);
-        System.out.println("\n");
-
-        System.out.println("VK_CONTROL - KEY RELEASE");
         robot.keyRelease(KeyEvent.VK_CONTROL);
-        System.out.println("\n");
 
-        robot.delay(1000);
-
+        robot.delay(500);
 
         if (jTextArea.getCaretPosition() != EXPECTED_CARET_POS_CTRL) {
-            errorLog.append("For Control key, Actual and Expected caret position differ \n"+
+            errorLog.append("For Control key, Actual and Expected caret position differ \n" +
                     "Expected Position : " + EXPECTED_CARET_POS_CTRL + " Actual Position : " + jTextArea.getCaretPosition() + "\n");
         }
     }
@@ -270,7 +219,7 @@ public class RobotModifierMaskTest {
         jTextArea = new JTextArea("");
         JScrollPane pane = new JScrollPane(jTextArea);
         jFrame.getContentPane().add(pane);
-        jFrame.setSize(200,200);
+        jFrame.setSize(300,200);
         jFrame.setLocation(200, 200);
         jFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         jFrame.setVisible(true);

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -241,7 +241,7 @@ public class RobotModifierMaskTest {
     }
 
     private static void createTestUI() {
-        String mode = isManual ? "MANUAL" : "AUTOMATED" ;
+        String mode = isManual ? "MANUAL" : "AUTOMATED";
         jFrame = new JFrame("RobotModifierMaskTest - Mode: " + mode);
         jTextArea = new JTextArea("");
         JScrollPane pane = new JScrollPane(jTextArea);
@@ -253,10 +253,12 @@ public class RobotModifierMaskTest {
         jFrame.setVisible(true);
     }
 
-    private static void checkResult(String expectedResult, String s) throws Exception {
+    private static void checkResult(String expectedResult, String prefixText)
+                                                                throws Exception {
         invokeAndWait(() -> {
             boolean condition = expectedResult.equals(EXPECTED_RESULT_CTRL)
-                                ? jTextArea.getCaretPosition() != Integer.parseInt(EXPECTED_RESULT_CTRL)
+                                ? (jTextArea.getCaretPosition()
+                                     != Integer.parseInt(EXPECTED_RESULT_CTRL))
                                 : !jTextArea.getText().equals(expectedResult);
 
             String actualResult = expectedResult.equals(EXPECTED_RESULT_CTRL)
@@ -264,7 +266,7 @@ public class RobotModifierMaskTest {
                                   : jTextArea.getText();
 
             if (condition) {
-                errorLog.append(s + "Actual and Expected results differ"
+                errorLog.append(prefixText + "Actual and Expected results differ"
                         + " Expected : " + expectedResult
                         + " Actual : " + actualResult + "\n");
             }

--- a/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
+++ b/test/jdk/java/awt/Robot/RobotModifierMaskTest.java
@@ -65,7 +65,7 @@ public class RobotModifierMaskTest {
             CASE 1 : Run the test as an automated test and let the Robot go through all the test cases.\n
             CASE 2 : Run the test in semi-automated mode. While the Robot in typing,
                      manually move the mouse (without clicking/dragging). Check if the test Passes or Fails.\n\n
-            
+
             NOTE: User doesn't need to compare the actual vs expected result in Case 2.
             The test compares it.""";
 


### PR DESCRIPTION
**Problem:**

On macOS, Robot erroneously produces lowercase letter when mouse is moved (manually) in unison with Robot's keyEvents. This issue was originally logged by a developer of an on-screen accessibility keyboard  - TouchBoard. Originally reported at https://github.com/adoptium/adoptium-support/issues/710

This issue is reproducible on JDK versions 22 to 11, but works fine on JDK-8. (details below) 

This issue is not restricted to the Shift modifier key and causes problems with other modifier keys as well and in some scenarios without any external mouse movement.

- This works correctly on JDK-8 up to JDK-9+129 when Accessibility APIs (AXUIElementCreateSystemWide/ AXUIElementPostKeyboardEvent) were used. Later on it was changed to CGEvents. 

- With the present code, the issue occurs at [CRobot.m#L295](https://github.com/openjdk/jdk/blob/ac6af6a64099c182e982a0a718bc1b780cef616e/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m#L295.)  The flags gets reset or cleared when mouse is moved physically in unison with Robot's key events.

- The physical mouse movement causes the event flags to be reset. 

**Impact:**

Modifier keys don't work as expected when using Robot with any simultaneous physical mouse movement and in case of TouchBoard, this behavior breaks the usability of the on-screen a11y keyboard. There is no known workaround for this particular use case except for reverting to JDK-8. More details on this use case [here.](https://github.com/adoptium/adoptium-support/issues/710#issuecomment-1594103280)

**Proposed Fix:**

- In order to avoid resetting of the CGEventFlags here [CRobot.m#L295](https://github.com/openjdk/jdk/blob/ac6af6a64099c182e982a0a718bc1b780cef616e/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m#L295.), the CGEvent flag state is obtained in `initRobot` (stored in initFlags) which is later used within `CRobot_keyEvent`.

- The incoming keyCode is used to determine whether it is a modifier key and the corresponding modifierFlagMask is either added or cleared from the initFlags based on whether the modifier key was pressed or released.

- Finally, only the required and known flag bits from initFlag are copied over to local flag which is used in `CGEventSetFlags()`.

**Testing:**

The newly added test - RobotModifierMaskTest.java tests for Shift, Caps, Control, Option and Command keys.
The test runs in 2 modes - as automated and manual test.

CASE 1 :  As automated test. No user interaction needed.
CASE 2 :  When run in manual mode - it is semi-automatic, i.e Typing is automated via Robot and the user is required to manually move the mouse (without clicking/dragging) at the same time (concurrently when Robot is typing). Check if the test passes or fails.

CI Testing (Automated Client tests -  Swing + AWT) works as expected with the fix and does not break any existing Robot related tests in test/jdk/java/awt/Robot folder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302618](https://bugs.openjdk.org/browse/JDK-8302618): [macos] Problem typing uppercase letters with java.awt.Robot when moving mouse (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to [2b682e7b](https://git.openjdk.org/jdk/pull/14744/files/2b682e7b8fb778ff626a7ce266c368a9628ad82e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14744/head:pull/14744` \
`$ git checkout pull/14744`

Update a local copy of the PR: \
`$ git checkout pull/14744` \
`$ git pull https://git.openjdk.org/jdk.git pull/14744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14744`

View PR using the GUI difftool: \
`$ git pr show -t 14744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14744.diff">https://git.openjdk.org/jdk/pull/14744.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14744#issuecomment-1615251518)