### PR TITLE
8311178: JMH tests don't scale well when sharing output buffers

### DIFF
--- a/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(2)
 @Measurement(iterations = 6, time = 1)
 @Warmup(iterations=4, time = 2)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class DataOutputStreamTest {
 
     public enum BasicType {CHAR, SHORT, INT, STRING}

--- a/test/micro/org/openjdk/bench/java/lang/ArrayCopyObject.java
+++ b/test/micro/org/openjdk/bench/java/lang/ArrayCopyObject.java
@@ -61,7 +61,7 @@ class MyClass {
  }
 }
 
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 10, time = 1)

--- a/test/micro/org/openjdk/bench/java/lang/ArrayFiddle.java
+++ b/test/micro/org/openjdk/bench/java/lang/ArrayFiddle.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 5, time = 2)
 @Fork(3)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class ArrayFiddle {
     @Param("999")
     public int size;

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterBench.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterBench.java
@@ -53,7 +53,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(3)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class DateTimeFormatterBench {
 
     private static final TimeZone TIME_ZONE = TimeZone.getTimeZone("UTC");

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
@@ -46,7 +46,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(value = 1, jvmArgsAppend = {
     "--add-modules=jdk.incubator.vector",

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
@@ -28,7 +28,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java
@@ -52,17 +52,17 @@ public class VectorFPtoIntCastOperations {
        -0.0
     };
 
-    static float [] float_arr;
+    private float [] float_arr;
 
-    static double [] double_arr;
+    private double [] double_arr;
 
-    static long [] long_res;
+    private long [] long_res;
 
-    static int [] int_res;
+    private int [] int_res;
 
-    static short [] short_res;
+    private short [] short_res;
 
-    static byte [] byte_res;
+    private byte [] byte_res;
 
     @Setup(Level.Trial)
     public void BmSetup() {

--- a/test/micro/org/openjdk/bench/vm/compiler/ArrayFill.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ArrayFill.java
@@ -39,7 +39,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.util.concurrent.TimeUnit;
 import java.util.Arrays;
 
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)

--- a/test/micro/org/openjdk/bench/vm/compiler/IndexVector.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/IndexVector.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.*;
 
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 3)


### PR DESCRIPTION
The below benchmark files have scaling issues due to cache contention and leads to poor scaling when run on multiple threads. The patch sets the scope from benchmark level to thread level to fix the issue:
- org/openjdk/bench/java/io/DataOutputStreamTest.java
- org/openjdk/bench/java/lang/ArrayCopyObject.java
- org/openjdk/bench/java/lang/ArrayFiddle.java
- org/openjdk/bench/java/time/format/DateTimeFormatterBench.java
- org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
- org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
- org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
- org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
- org/openjdk/bench/vm/compiler/ArrayFill.java
- org/openjdk/bench/vm/compiler/IndexVector.java

Also removing the static scope for variables in org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java for better scaling.

Please review and share your feedback.

Thanks,
Swati

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311178](https://bugs.openjdk.org/browse/JDK-8311178): JMH tests don't scale well when sharing output buffers (**Enhancement** - P4)


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Contributors
 * Vladimir Ivanov `<vaivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14746/head:pull/14746` \
`$ git checkout pull/14746`

Update a local copy of the PR: \
`$ git checkout pull/14746` \
`$ git pull https://git.openjdk.org/jdk.git pull/14746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14746`

View PR using the GUI difftool: \
`$ git pr show -t 14746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14746.diff">https://git.openjdk.org/jdk/pull/14746.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14746#issuecomment-1615621299)