### PR TITLE
8311215: [BACKOUT] JDK-8047998 Abort the vm if MaxNewSize is not the same as NewSize when MaxHeapSize is the same as InitialHeapSize

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -240,13 +240,9 @@ void GenArguments::initialize_size_info() {
   size_t initial_young_size = NewSize;
 
   if (MaxHeapSize == InitialHeapSize) {
-    // The maximum and initial heap sizes are the same, so the generation's
-    // initial size must be the same as its maximum size.
-    if (FLAG_IS_CMDLINE(NewSize) && FLAG_IS_CMDLINE(MaxNewSize) && NewSize != MaxNewSize) {
-      vm_exit_during_initialization(
-          "The MaxNewSize must be the same as NewSize because the MaxHeapSize and InitialHeapSize are the same.");
-    }
-    // Use NewSize as the size if it is set on command line.
+    // The maximum and initial heap sizes are the same so the generation's
+    // initial size must be the same as it maximum size. Use NewSize as the
+    // size if set on command line.
     max_young_size = FLAG_IS_CMDLINE(NewSize) ? NewSize : max_young_size;
     initial_young_size = max_young_size;
 


### PR DESCRIPTION
This reverts commit 8abb9f590f844d098b156b719499bb0447f99759.

Two tests are failing many times in Tier2 after [JDK-8047998](https://bugs.openjdk.org/browse/JDK-8047998): 

  10 gc/arguments/TestNewSizeFlags.java 
  10 gc/arguments/TestVerifyBeforeAndAfterGCFlags.java 

so 20 failures per Tier2. 

Three tests are failing many times in Tier3 after [JDK-8047998](https://bugs.openjdk.org/browse/JDK-8047998): 

   4 compiler/runtime/Test8010927.java 
   6 jdk/jfr/event/gc/detailed/TestPromotionFailedEventWithDefNew.java 
   6 jdk/jfr/event/gc/detailed/TestPromotionFailedEventWithParallelScavenge.java 

so 16 failures per Tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311215](https://bugs.openjdk.org/browse/JDK-8311215): [BACKOUT] JDK-8047998 Abort the vm if MaxNewSize is not the same as NewSize when MaxHeapSize is the same as InitialHeapSize (**Sub-task** - P2)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14747/head:pull/14747` \
`$ git checkout pull/14747`

Update a local copy of the PR: \
`$ git checkout pull/14747` \
`$ git pull https://git.openjdk.org/jdk.git pull/14747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14747`

View PR using the GUI difftool: \
`$ git pr show -t 14747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14747.diff">https://git.openjdk.org/jdk/pull/14747.diff</a>

</details>
