### PR TITLE
8310331: JitTester: Exclude java.lang.Math.random

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/conf/exclude.methods.lst
+++ b/test/hotspot/jtreg/testlibrary/jittester/conf/exclude.methods.lst
@@ -1,4 +1,5 @@
 java/lang/EnumConstantNotPresentException::EnumConstantNotPresentException(Ljava/lang/Class;Ljava/lang/String;)
+java/lang/Math::random()
 java/lang/Object::notify()
 java/lang/Object::notifyAll()
 java/lang/Object::toString()


### PR DESCRIPTION
Test cases generated by JitTester might contain calls to `java.lang.Math.random()`. We could not set a seed for this random call. (In its implementation, `java.lang.Math` create `java.util.Random` instance statically (using the constructor `Random()`) and there is no way to set a seed for it.)

Such tests might show up different variable values/printouts on each execution (Please refer to [the issue description](https://bugs.openjdk.org/browse/JDK-8310331)).

Since it is meaningless to generate test cases with "unreproducible" results and JitTester has been able to assign random values to the generated variables (this seed could be set). Maybe we could just exclude the use of `java.lang.Math.random()` in JitTester's test case generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310331](https://bugs.openjdk.org/browse/JDK-8310331): JitTester: Exclude java.lang.Math.random (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14748/head:pull/14748` \
`$ git checkout pull/14748`

Update a local copy of the PR: \
`$ git checkout pull/14748` \
`$ git pull https://git.openjdk.org/jdk.git pull/14748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14748`

View PR using the GUI difftool: \
`$ git pr show -t 14748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14748.diff">https://git.openjdk.org/jdk/pull/14748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14748#issuecomment-1616519186)