### PR TITLE
8311092: Please disable runtime/jni/nativeStack/TestNativeStack.java on armhf

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,6 +91,7 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
+runtime/jni/nativeStack/TestNativeStack.java 8311092 linux-arm
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,7 +91,6 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
-runtime/jni/nativeStack/TestNativeStack.java 8311092 linux-arm
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64

--- a/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug  8295974
- * @requires os.family != "windows"
+ * @requires os.family != "windows" & os.arch != "arm"
  * @library /test/lib
  * @summary Generate a JNI Fatal error, or a warning, in a launched VM and check
  *          the native stack is present as expected.


### PR DESCRIPTION
Changes:
- Add test exclusion for armhf, because os::current_frame() is not implemented

Testing:

```
AMD64:

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
                                                         1     1     0     0   
==============================
TEST SUCCESS

Stopping javac server
Finished building target 'test' in configuration 'linux-x86_64-server-release

ARMHF

Running test 'jtreg:test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java'
Test results: no tests selected
Report written to /home/ubuntu/jdk/build/linux-arm-server-release/test-results/jtreg_test_hotspot_jtreg_runtime_jni_nativeStack_TestNativeStack_java/html/report.html
Results written to /home/ubuntu/jdk/build/linux-arm-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_jni_nativeStack_TestNativeStack_java
Finished running test 'jtreg:test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java'
Test report is stored in build/linux-arm-server-release/test-results/jtreg_test_hotspot_jtreg_runtime_jni_nativeStack_TestNativeStack_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
                                                         0     0     0     0   
==============================
TEST SUCCESS


```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311092](https://bugs.openjdk.org/browse/JDK-8311092): Please disable runtime/jni/nativeStack/TestNativeStack.java on armhf (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14750/head:pull/14750` \
`$ git checkout pull/14750`

Update a local copy of the PR: \
`$ git checkout pull/14750` \
`$ git pull https://git.openjdk.org/jdk.git pull/14750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14750`

View PR using the GUI difftool: \
`$ git pr show -t 14750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14750.diff">https://git.openjdk.org/jdk/pull/14750.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14750#issuecomment-1617097961)