### PR TITLE
8310997: missing @since tags in jdk.httpserver

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ package com.sun.net.httpserver;
  * of the authentication information provided in all incoming requests.
  * Note. This implies that any caching of credentials or other authentication
  * information must be done outside of this class.
+ *
+ * @since 1.6
  */
 public abstract class Authenticator {
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * authentication. It is an abstract class and must be extended
  * to provide an implementation of {@link #checkCredentials(String,String)}
  * which is called to verify each incoming request.
+ *
+ * @since 1.6
  */
 public abstract class BasicAuthenticator extends Authenticator {
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.security.Principal;
 /**
  * Represents a user authenticated by HTTP Basic or Digest
  * authentication.
+ *
+ * @since 1.6
  */
 public class HttpPrincipal implements Principal {
     private String username, realm;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import java.util.ServiceLoader;
  * Sub-classes of HttpServerProvider provide an implementation of
  * {@link HttpServer} and associated classes. Applications do not normally use
  * this class. See {@link #provider()} for how providers are found and loaded.
+ *
+ * @since 1.6
  */
 public abstract class HttpServerProvider {
 


### PR DESCRIPTION
added missing `@since` tag to 4 files in jdk.httpserver

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310997](https://bugs.openjdk.org/browse/JDK-8310997): missing @since tags in jdk.httpserver (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14755/head:pull/14755` \
`$ git checkout pull/14755`

Update a local copy of the PR: \
`$ git checkout pull/14755` \
`$ git pull https://git.openjdk.org/jdk.git pull/14755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14755`

View PR using the GUI difftool: \
`$ git pr show -t 14755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14755.diff">https://git.openjdk.org/jdk/pull/14755.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14755#issuecomment-1618770875)