### PR TITLE
8311001: missing @since info in jdk.net

### DIFF
--- a/src/jdk.net/share/classes/jdk/net/Sockets.java
+++ b/src/jdk.net/share/classes/jdk/net/Sockets.java
@@ -62,6 +62,8 @@ import java.util.Set;
  * socket's class for the equivalent method to set/get a socket option or retrieve available socket options.
  *
  * @see java.nio.channels.NetworkChannel
+ *
+ * @since 1.8
  */
 @Deprecated(since = "16")
 public class Sockets {

--- a/src/jdk.net/share/classes/jdk/net/Sockets.java
+++ b/src/jdk.net/share/classes/jdk/net/Sockets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Added missing `@since` tag to `Sockets.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311001](https://bugs.openjdk.org/browse/JDK-8311001): missing @since info in jdk.net (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14756/head:pull/14756` \
`$ git checkout pull/14756`

Update a local copy of the PR: \
`$ git checkout pull/14756` \
`$ git pull https://git.openjdk.org/jdk.git pull/14756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14756`

View PR using the GUI difftool: \
`$ git pr show -t 14756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14756.diff">https://git.openjdk.org/jdk/pull/14756.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14756#issuecomment-1618777421)