### PR TITLE
8311247: Some cpp files are compiled with -std:c11 flag

### DIFF
--- a/make/modules/java.base/gensrc/GensrcMisc.gmk
+++ b/make/modules/java.base/gensrc/GensrcMisc.gmk
@@ -105,7 +105,7 @@ define generate-preproc-src
 	$(call MakeDir, $(@D))
 	$(call ExecuteWithLog, $(SUPPORT_OUTPUTDIR)/gensrc/java.base/_$(@F), \
 	    ( $(AWK) '/@@END_COPYRIGHT@@/{exit}1' $< && \
-	      $(CPP) $(CPP_FLAGS) $(SYSROOT_CFLAGS) $(CFLAGS_JDKLIB) $(CPP_FILEPREFIX) $< \
+	      $(CPP) $(CPP_FLAGS) $(SYSROOT_CFLAGS) $(CPP_FILEPREFIX) $< \
 	          2> >($(GREP) -v '^$(<F)$$' >&2) \
 	          | $(AWK) '/@@START_HERE@@/,0' \
 	          |  $(SED) -e 's/@@START_HERE@@/\/\/ AUTOMATICALLY GENERATED FILE - DO NOT EDIT/' \

--- a/make/modules/java.base/gensrc/GensrcMisc.gmk
+++ b/make/modules/java.base/gensrc/GensrcMisc.gmk
@@ -105,7 +105,7 @@ define generate-preproc-src
 	$(call MakeDir, $(@D))
 	$(call ExecuteWithLog, $(SUPPORT_OUTPUTDIR)/gensrc/java.base/_$(@F), \
 	    ( $(AWK) '/@@END_COPYRIGHT@@/{exit}1' $< && \
-	      $(CPP) $(CPP_FLAGS) $(SYSROOT_CFLAGS) $(CPP_FILEPREFIX) $< \
+	      $(CPP) $(CPP_FLAGS) $(SYSROOT_CFLAGS) $(CFLAGS_JDKLIB) $(CPP_FILEPREFIX) $< \
 	          2> >($(GREP) -v '^$(<F)$$' >&2) \
 	          | $(AWK) '/@@START_HERE@@/,0' \
 	          |  $(SED) -e 's/@@START_HERE@@/\/\/ AUTOMATICALLY GENERATED FILE - DO NOT EDIT/' \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -132,6 +132,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
     EXCLUDE_FILES := $(LIBAWT_EXFILES), \
     OPTIMIZATION := HIGHEST, \
     CFLAGS := $(CFLAGS_JDKLIB) $(LIBAWT_CFLAGS), \
+    CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBAWT_CFLAGS), \
     EXTRA_HEADER_DIRS := $(LIBAWT_EXTRA_HEADER_DIRS), \
     DISABLED_WARNINGS_gcc_awt_LoadLibrary.c := unused-result, \
     DISABLED_WARNINGS_gcc_debug_mem.c := format-nonliteral, \
@@ -609,7 +610,9 @@ ifeq ($(call isTargetOs, windows), true)
   $(eval $(call SetupJdkLibrary, BUILD_LIBJAWT, \
       NAME := jawt, \
       OPTIMIZATION := LOW, \
-      CFLAGS := $(CXXFLAGS_JDKLIB) \
+      CFLAGS := $(CFLAGS_JDKLIB) \
+          $(LIBJAWT_CFLAGS), \
+      CXXFLAGS := $(CXXFLAGS_JDKLIB) \
           $(LIBJAWT_CFLAGS), \
       EXTRA_HEADER_DIRS := $(LIBJAWT_EXTRA_HEADER_DIRS), \
       LDFLAGS := $(LDFLAGS_JDKLIB) $(LDFLAGS_CXX_JDK), \
@@ -791,6 +794,8 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
       EXCLUDES := $(LIBSPLASHSCREEN_EXCLUDES), \
       OPTIMIZATION := LOW, \
       CFLAGS := $(CFLAGS_JDKLIB) $(LIBSPLASHSCREEN_CFLAGS) \
+          $(GIFLIB_CFLAGS) $(LIBJPEG_CFLAGS) $(PNG_CFLAGS) $(LIBZ_CFLAGS), \
+      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBSPLASHSCREEN_CFLAGS) \
           $(GIFLIB_CFLAGS) $(LIBJPEG_CFLAGS) $(PNG_CFLAGS) $(LIBZ_CFLAGS), \
       EXTRA_HEADER_DIRS := $(LIBSPLASHSCREEN_HEADER_DIRS), \
       DISABLED_WARNINGS_gcc_dgif_lib.c := sign-compare, \

--- a/make/modules/java.security.jgss/Lib.gmk
+++ b/make/modules/java.security.jgss/Lib.gmk
@@ -47,6 +47,8 @@ ifeq ($(call isTargetOs, windows), true)
       OPTIMIZATION := LOW, \
       CFLAGS := $(CFLAGS_JDKLIB) \
           -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
+      CXXFLAGS := $(CXXFLAGS_JDKLIB) \
+          -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := Secur32.lib, \

--- a/make/modules/java.security.jgss/Lib.gmk
+++ b/make/modules/java.security.jgss/Lib.gmk
@@ -45,10 +45,9 @@ ifeq ($(call isTargetOs, windows), true)
   $(eval $(call SetupJdkLibrary, BUILD_LIBSSPI_BRIDGE, \
       NAME := sspi_bridge, \
       OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB) \
-          -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) \
-          -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
+      EXTRA_HEADER_DIRS := libj2gss, \
+      CFLAGS := $(CFLAGS_JDKLIB), \
+      CXXFLAGS := $(CXXFLAGS_JDKLIB), \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := Secur32.lib, \

--- a/make/modules/jdk.accessibility/Launcher.gmk
+++ b/make/modules/jdk.accessibility/Launcher.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/jdk.accessibility/Launcher.gmk
+++ b/make/modules/jdk.accessibility/Launcher.gmk
@@ -43,6 +43,9 @@ ifeq ($(call isTargetOs, windows), true)
       CFLAGS := $(filter-out -Zc:wchar_t-, $(CFLAGS_JDKEXE)) -Zc:wchar_t \
           -analyze- -Od -Gd -D_WINDOWS \
           -D_UNICODE -DUNICODE -RTC1 -EHsc, \
+      CXXFLAGS := $(filter-out -Zc:wchar_t-, $(CXXFLAGS_JDKEXE)) -Zc:wchar_t \
+          -analyze- -Od -Gd -D_WINDOWS \
+          -D_UNICODE -DUNICODE -RTC1 -EHsc, \
       DISABLED_WARNINGS_microsoft_jabswitch.cpp := 4267 4996, \
       LDFLAGS := $(LDFLAGS_JDKEXE), \
       LIBS := advapi32.lib version.lib user32.lib, \
@@ -65,6 +68,7 @@ ifeq ($(call isTargetOs, windows), true)
       SRC := $(ACCESSIBILITY_SRCDIR)/jaccessinspector $(ACCESSIBILITY_SRCDIR)/common \
           $(ACCESSIBILITY_SRCDIR)/toolscommon $(ACCESSIBILITY_SRCDIR)/bridge, \
       CFLAGS := $$(CFLAGS_JDKEXE) $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+      CXXFLAGS := $$(CXXFLAGS_JDKEXE) $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
       LDFLAGS := $$(LDFLAGS_JDKEXE) -stack:655360, \
       LIBS := advapi32.lib user32.lib, \
       VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/jaccessinspector/jaccessinspectorWindow.rc, \
@@ -86,6 +90,7 @@ ifeq ($(call isTargetOs, windows), true)
       SRC := $(ACCESSIBILITY_SRCDIR)/jaccesswalker $(ACCESSIBILITY_SRCDIR)/common \
           $(ACCESSIBILITY_SRCDIR)/toolscommon $(ACCESSIBILITY_SRCDIR)/bridge, \
       CFLAGS := $$(CFLAGS_JDKEXE) $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+      CXXFLAGS := $$(CXXFLAGS_JDKEXE) $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
       LDFLAGS := $$(LDFLAGS_JDKEXE) -stack:655360, \
       LIBS := advapi32.lib comctl32.lib gdi32.lib user32.lib, \
       VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/jaccesswalker/jaccesswalkerWindow.rc, \

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -43,6 +43,8 @@ ifeq ($(call isTargetOs, windows), true)
         DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
         CFLAGS := $(filter-out -MD, $(CFLAGS_JDKLIB)) -MT \
             -DACCESSBRIDGE_ARCH_$2, \
+        CXXFLAGS := $(filter-out -MD, $(CXXFLAGS_JDKLIB)) -MT \
+            -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
             java.desktop:include, \
@@ -69,6 +71,8 @@ ifeq ($(call isTargetOs, windows), true)
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft_WinAccessBridge.cpp := 4302 4311, \
         CFLAGS := $(CFLAGS_JDKLIB) \
+            -DACCESSBRIDGE_ARCH_$2, \
+        CXXFLAGS := $(CXXFLAGS_JDKLIB) \
             -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge, \

--- a/make/modules/jdk.crypto.mscapi/Lib.gmk
+++ b/make/modules/jdk.crypto.mscapi/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/jdk.crypto.mscapi/Lib.gmk
+++ b/make/modules/jdk.crypto.mscapi/Lib.gmk
@@ -33,6 +33,7 @@ ifeq ($(call isTargetOs, windows), true)
       NAME := sunmscapi, \
       OPTIMIZATION := LOW, \
       CFLAGS := $(CFLAGS_JDKLIB), \
+      CXXFLAGS := $(CXXFLAGS_JDKLIB), \
       LDFLAGS := $(LDFLAGS_JDKLIB) $(LDFLAGS_CXX_JDK) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := crypt32.lib advapi32.lib ncrypt.lib, \


### PR DESCRIPTION
Please review this patch that configures C++ arguments on build jobs that involve compiling CPP files. As a result of this change, CPP files are compiled with `-std:c++14` command line argument instead of `-std:c11`, which is used when C++ arguments are not configured.
While at it, I simplified the `java.security.jgss/Lib.gmk` file by moving the additional include directory to `EXTRA_HEADER_DIRS`.

This patch fixes the following clang warning:
```
warning: argument unused during compilation: '-std:c11'
```

Microsoft states that [std:c++14 is the default](https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-170), so there shouldn't be any differences in produced code.

Testing:
- verified that after the changes, all CPP files are compiled with `std:c++14` instead of `-std:c11`
- spot-checked a few `cmdline` files that changed after this patch was applied; the `-std` change was the only difference
- tier1-5 builds, tier1-2 tests and client libs tests continue to pass on Windows, Linux & MacOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311247](https://bugs.openjdk.org/browse/JDK-8311247): Some cpp files are compiled with -std:c11 flag (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14758/head:pull/14758` \
`$ git checkout pull/14758`

Update a local copy of the PR: \
`$ git checkout pull/14758` \
`$ git pull https://git.openjdk.org/jdk.git pull/14758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14758`

View PR using the GUI difftool: \
`$ git pr show -t 14758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14758.diff">https://git.openjdk.org/jdk/pull/14758.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14758#issuecomment-1619000429)