### PR TITLE
JDK-8311109: tautological-compare warning in awt_Win32GraphicsDevice.cpp

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -899,7 +899,7 @@ BOOL AwtWin32GraphicsDevice::AreSameMonitors(HMONITOR mon1, HMONITOR mon2) {
     {
         if (::EqualRect(&mi1.rcMonitor, &mi2.rcMonitor) &&
             ::EqualRect(&mi1.rcWork, &mi2.rcWork) &&
-            (mi1.dwFlags  == mi1.dwFlags))
+            (mi1.dwFlags == mi2.dwFlags))
         {
 
             J2dTraceLn(J2D_TRACE_VERBOSE, "  the monitors are the same");


### PR DESCRIPTION
Comparison typo fix. Should be monitor2 (mi2) instead of monitor1 (mi1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311109](https://bugs.openjdk.org/browse/JDK-8311109): tautological-compare warning in awt_Win32GraphicsDevice.cpp (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14760/head:pull/14760` \
`$ git checkout pull/14760`

Update a local copy of the PR: \
`$ git checkout pull/14760` \
`$ git pull https://git.openjdk.org/jdk.git pull/14760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14760`

View PR using the GUI difftool: \
`$ git pr show -t 14760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14760.diff">https://git.openjdk.org/jdk/pull/14760.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14760#issuecomment-1618988932)