### PR TITLE
JDK-8311285: report some fontconfig related environment variables in hs_err file

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -106,8 +106,7 @@ static const char* env_list[] = {
   "JAVA_HOME", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "CLASSPATH",
   "PATH", "USERNAME",
 
-  // UNIX platforms, fontconfig related
-  "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "FC_LANG",
+  "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "FC_LANG", "FONTCONFIG_USE_MMAP",
 
   // Env variables that are defined on Linux/BSD
   "LD_LIBRARY_PATH", "LD_PRELOAD", "SHELL", "DISPLAY",

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -106,6 +106,9 @@ static const char* env_list[] = {
   "JAVA_HOME", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "CLASSPATH",
   "PATH", "USERNAME",
 
+  // UNIX platforms, fontconfig related
+  "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "FC_LANG",
+
   // Env variables that are defined on Linux/BSD
   "LD_LIBRARY_PATH", "LD_PRELOAD", "SHELL", "DISPLAY",
   "HOSTTYPE", "OSTYPE", "ARCH", "MACHTYPE",


### PR DESCRIPTION
There are a number of important environment variables influencing how fontconfig works.
See for example
https://man.archlinux.org/man/fonts-conf.5
Some of them should be added to the list of reported environment variables in hs_err file because e.g. a bad setting for some of them can even lead sometimes to crashes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311285](https://bugs.openjdk.org/browse/JDK-8311285): report some fontconfig related environment variables in hs_err file (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [76583497](https://git.openjdk.org/jdk/pull/14767/files/765834977e0c71df379c79a6287be4e22455e3b2)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [76583497](https://git.openjdk.org/jdk/pull/14767/files/765834977e0c71df379c79a6287be4e22455e3b2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14767/head:pull/14767` \
`$ git checkout pull/14767`

Update a local copy of the PR: \
`$ git checkout pull/14767` \
`$ git pull https://git.openjdk.org/jdk.git pull/14767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14767`

View PR using the GUI difftool: \
`$ git pr show -t 14767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14767.diff">https://git.openjdk.org/jdk/pull/14767.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14767#issuecomment-1620108212)