### PR TITLE
8311279: TestStressIGVNAndCCP.java failed with different IGVN traces for the same seed

### DIFF
--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
@@ -44,7 +44,7 @@ public class TestStressIGVNAndCCP {
                              int stressSeed) throws Exception {
         String className = TestStressIGVNAndCCP.class.getName();
         String[] procArgs = {
-            "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline",
+            "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline", "-XX:+CICountNative",
             "-XX:CompileOnly=" + className + "::sum", "-XX:+" + traceOption,
             "-XX:+" + stressOption, "-XX:StressSeed=" + stressSeed,
             className, "10"};


### PR DESCRIPTION
In `TestStressIGVNAndCCP`, we are executing a JVM twice and only want to compile and then run a single method `sum()`. The expectation is that we get the same output with `-XX:+TraceIterativeGVN`. However, our testing found a case where this did not match. When looking at the diff, I've noticed that with one JVM `sum()` had compile id 1, while the other JVM used compile id 2 for `sum()`. This makes a difference for the `debug_idx` which is printed for a dead node as "`compile id * 10000000000 + node index`":

Compile id 1:
```
80 Phi \=\=\= _ _ _ [[ ]] [10000000080] ...
```
Compile id 2:
```
80 Phi \=\=\= _ _ _ [[ ]] [20000000080] ...
```

I was not able to reproduce the original report but my suspicion is that one JVM additionally compiled a native method wrapper or a method handle intrinsic for some reason but the other one did not. This would explain the different compile id because we are should only compiling `sum()` with the given `CompileOnly` JVM flag. A native compilation can be triggered, for example, by passing additionally passing `-esa` with `CompileOnly`. We get compile id 3 for `sum()`:
```
     60 1 n java.lang.invoke.MethodHandle::invokeBasic()I (native)
     60 2 n java.lang.invoke.MethodHandle::linkToSpecial(LL)I (native) (static)
     69 3 b compiler.debug.TestStressIGVNAndCCP::sum (27 bytes)
```

To fix this, I suggest to use the `-XX:+CICountNative` flag which uses a separate counter for native compilations. Then, we'll always get compile id 1 for `sum()`:
```
     50 1 n java.lang.invoke.MethodHandle::invokeBasic()I (native)
     51 2 n java.lang.invoke.MethodHandle::linkToSpecial(LL)I (native) (static)
     59 1 b compiler.debug.TestStressIGVNAndCCP::sum (27 bytes)
```

This is the same approach as done in [JDK-8269342](https://bugs.openjdk.org/browse/JDK-8269342) to reliably crash with `-XX:CICrashAt=1` in the first non-native compilation.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311279](https://bugs.openjdk.org/browse/JDK-8311279): TestStressIGVNAndCCP.java failed with different IGVN traces for the same seed (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14771/head:pull/14771` \
`$ git checkout pull/14771`

Update a local copy of the PR: \
`$ git checkout pull/14771` \
`$ git pull https://git.openjdk.org/jdk.git pull/14771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14771`

View PR using the GUI difftool: \
`$ git pr show -t 14771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14771.diff">https://git.openjdk.org/jdk/pull/14771.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14771#issuecomment-1621359005)