### PR TITLE
8311500: StackWalker.getCallerClass() throws UOE if invoked reflectively

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -272,6 +272,8 @@
                                                                                                   \
   template(jdk_internal_reflect,                      "jdk/internal/reflect")                     \
   template(reflect_MethodAccessorImpl,                "jdk/internal/reflect/MethodAccessorImpl")      \
+  template(reflect_MethodAccessor,                    "jdk/internal/reflect/MethodAccessor")          \
+  template(reflect_ConstructorAccessor,               "jdk/internal/reflect/ConstructorAccessor")     \
   template(reflect_DelegatingClassLoader,             "jdk/internal/reflect/DelegatingClassLoader")   \
   template(reflect_Reflection,                        "jdk/internal/reflect/Reflection")              \
   template(reflect_CallerSensitive,                   "jdk/internal/reflect/CallerSensitive")         \

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -165,7 +165,7 @@ BaseFrameStream* BaseFrameStream::from_current(JavaThread* thread, jlong magic,
 int StackWalk::fill_in_frames(jlong mode, BaseFrameStream& stream,
                               int max_nframes, int start_index,
                               objArrayHandle  frames_array,
-                              int& end_index, bool firstBatch, TRAPS) {
+                              int& end_index, bool is_first_batch, TRAPS) {
   log_debug(stackwalk)("fill_in_frames limit=%d start=%d frames length=%d",
                        max_nframes, start_index, frames_array->length());
   assert(max_nframes > 0, "invalid max_nframes");
@@ -213,7 +213,7 @@ int StackWalk::fill_in_frames(jlong mode, BaseFrameStream& stream,
     }
 
     if (!need_method_info(mode) && get_caller_class(mode) &&
-          firstBatch && index == start_index && method->caller_sensitive()) {
+          is_first_batch && index == start_index && method->caller_sensitive()) {
       ResourceMark rm(THREAD);
       THROW_MSG_0(vmSymbols::java_lang_UnsupportedOperationException(),
         err_msg("StackWalker::getCallerClass called from @CallerSensitive '%s' method",

--- a/src/hotspot/share/prims/stackwalk.hpp
+++ b/src/hotspot/share/prims/stackwalk.hpp
@@ -88,6 +88,7 @@ class JavaFrameStream : public BaseFrameStream {
 private:
   vframeStream          _vfst;
   bool                  _need_method_info;
+  bool                  _needs_caller_sensitive_check;
 
 public:
   JavaFrameStream(JavaThread* thread, int mode, Handle cont_scope, Handle cont);
@@ -103,6 +104,13 @@ public:
 
   void fill_frame(int index, objArrayHandle  frames_array,
                   const methodHandle& method, TRAPS) override;
+
+  bool needs_caller_sensitive_check() {
+    return _needs_caller_sensitive_check;
+  }
+  void caller_sensitive_check_done() {
+    _needs_caller_sensitive_check = false;
+  }
 };
 
 class LiveFrameStream : public BaseFrameStream {
@@ -145,7 +153,7 @@ private:
   static int fill_in_frames(jlong mode, BaseFrameStream& stream,
                             int max_nframes, int start_index,
                             objArrayHandle frames_array,
-                            int& end_index, bool is_first_batch, TRAPS);
+                            int& end_index, TRAPS);
 
   static inline bool get_caller_class(int mode) {
     return (mode & JVM_STACKWALK_GET_CALLER_CLASS) != 0;

--- a/src/hotspot/share/prims/stackwalk.hpp
+++ b/src/hotspot/share/prims/stackwalk.hpp
@@ -145,7 +145,7 @@ private:
   static int fill_in_frames(jlong mode, BaseFrameStream& stream,
                             int max_nframes, int start_index,
                             objArrayHandle frames_array,
-                            int& end_index, TRAPS);
+                            int& end_index, bool firstBatch, TRAPS);
 
   static inline bool get_caller_class(int mode) {
     return (mode & JVM_STACKWALK_GET_CALLER_CLASS) != 0;

--- a/src/hotspot/share/prims/stackwalk.hpp
+++ b/src/hotspot/share/prims/stackwalk.hpp
@@ -145,7 +145,7 @@ private:
   static int fill_in_frames(jlong mode, BaseFrameStream& stream,
                             int max_nframes, int start_index,
                             objArrayHandle frames_array,
-                            int& end_index, bool firstBatch, TRAPS);
+                            int& end_index, bool is_first_batch, TRAPS);
 
   static inline bool get_caller_class(int mode) {
     return (mode & JVM_STACKWALK_GET_CALLER_CLASS) != 0;

--- a/test/jdk/java/lang/StackWalker/DumpStackTest.java
+++ b/test/jdk/java/lang/StackWalker/DumpStackTest.java
@@ -27,6 +27,7 @@
  * @summary Verify outputs of Thread.dumpStack() and Throwable.printStackTrace().
  *          This test should also been run against jdk9 successfully except of
  *          VM option MemberNameInStackFrame.
+ * @requires vm.opt.ShowHiddenFrames == false
  * @run main/othervm DumpStackTest
  */
 

--- a/test/jdk/java/lang/StackWalker/GetCallerClassTest.java
+++ b/test/jdk/java/lang/StackWalker/GetCallerClassTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8140450 8152893 8189291
  * @summary Basic test for StackWalker.getCallerClass()
+ * @requires vm.opt.ShowHiddenFrames == false
  * @run main/othervm GetCallerClassTest
  * @run main/othervm -Djava.security.manager=allow GetCallerClassTest sm
  */

--- a/test/jdk/java/lang/StackWalker/HiddenFrames.java
+++ b/test/jdk/java/lang/StackWalker/HiddenFrames.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8020968
  * @summary Basic test for hidden frames
+ * @requires vm.opt.ShowHiddenFrames == false
  * @run main HiddenFrames
  */
 

--- a/test/jdk/java/lang/StackWalker/ReflectionFrames.java
+++ b/test/jdk/java/lang/StackWalker/ReflectionFrames.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8173898
  * @summary Basic test for checking filtering of reflection frames
+ * @requires vm.opt.ShowHiddenFrames == false
  * @run testng ReflectionFrames
  */
 

--- a/test/jdk/java/lang/StackWalker/ReflectiveGetCallerClassTest.java
+++ b/test/jdk/java/lang/StackWalker/ReflectiveGetCallerClassTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8311500
+ * @summary StackWalker.getCallerClass() can throw if invoked reflectively
+ * @run main/othervm ReflectiveGetCallerClassTest
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+ShowHiddenFrames ReflectiveGetCallerClassTest
+ */
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.ArrayList;
+
+public class ReflectiveGetCallerClassTest {
+    private static StackWalker WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+    private static Method gcc, inv;
+    static {
+        try {
+            inv = Method.class.getDeclaredMethod("invoke", Object.class, Object[].class);
+            gcc = ReflectiveGetCallerClassTest.class.getDeclaredMethod("getCallerClass");
+        } catch (SecurityException se) {
+            // This test can't run if a security manager prohibits "getStackWalkerWithClassReference"
+            System.err.println(se);
+            System.exit(0);
+        } catch (Exception e) {
+            System.err.println(e);
+            System.exit(1);
+        }
+    }
+
+    public static void getCallerClass() {
+        System.out.println(WALKER.getCallerClass());
+    }
+
+    // Create a list of Object[] of the form:
+    //   { m, first }
+    //   { m, { m, first } }
+    //   { m, { m, { m, first } } }
+    static List<Object[]> prepareArgs(Object[] first, Method m, int depth) {
+        List<Object[]> l = new ArrayList<Object[]>(depth + 1);
+        l.add(first);
+        while (depth-- > 0) {
+            l.add(new Object[] { m, l.get(l.size() - 1) });
+        }
+        return l;
+    }
+
+    public static void main(String[] args) throws Throwable {
+        // gcc is ReflectiveGetCallerClassTest::getCallerClass()
+        // inv is Method::invoke()
+        for (Object[] params : prepareArgs(new Object[] { gcc, new Object[] { null, null } }, inv, 10)) {
+            inv.invoke(inv, inv, params);
+        }
+    }
+}

--- a/test/jdk/java/lang/StackWalker/StackWalkTest.java
+++ b/test/jdk/java/lang/StackWalker/StackWalkTest.java
@@ -37,6 +37,7 @@ import jdk.test.lib.RandomFactory;
  * @test
  * @bug 8140450
  * @summary Stack Walk Test (use -Dseed=X to set PRNG seed)
+ * @requires vm.opt.ShowHiddenFrames == false
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @compile StackRecorderUtil.java

--- a/test/jdk/java/lang/StackWalker/VerifyStackTrace.java
+++ b/test/jdk/java/lang/StackWalker/VerifyStackTrace.java
@@ -40,6 +40,7 @@ import static java.lang.StackWalker.Option.*;
  * @summary Verify stack trace information obtained with respect to StackWalker
  *          options, when the stack contains lambdas, method handle invoke
  *          virtual calls, and reflection.
+ * @requires vm.opt.ShowHiddenFrames == false
  * @run main/othervm VerifyStackTrace
  * @run main/othervm/java.security.policy=stackwalk.policy VerifyStackTrace
  * @author danielfuchs

--- a/test/jdk/java/lang/Thread/virtual/GetStackTrace.java
+++ b/test/jdk/java/lang/Thread/virtual/GetStackTrace.java
@@ -26,6 +26,7 @@
  * @summary Test Thread.getStackTrace to examine the stack trace of a virtual
  *     thread and its carrier
  * @requires vm.continuations
+ * @requires vm.opt.ShowHiddenFrames == false
  * @modules java.base/java.lang:+open
  * @run main GetStackTrace
  */


### PR DESCRIPTION
As the included jtreg test demonstrates, `StackWalker.getCallerClass()` can throw an `UnsupportedOperationException` if called reflectively. Currently this only happens if we invoke `StackWalker.getCallerClass()` recursively reflectively, but this issue will become more prominent once we fix [JDK-8285447](https://bugs.openjdk.org/browse/JDK-8285447). The gory details follow below:

The protocol between the Java API and the JVM for `StackWalker.getCallerClass()/walk()` is as follows:
- On the Java side, `StackWalker` calls into `StackStreamFactory` for the real work.
- For `StackWalker.getCallerClass()` `StackStreamFactory` basically creates a `Class[]` which will be passed down and filled in the JVM. For `StackWalker.walk()` it will normally be a `StackFrameInfo[]` (or a `LiveStackFrameInfo[]` if the internal `ExtendedOption.LOCALS_AND_OPERANDS` option was used).
- The default size of this arrays is currently `StackStreamFactory.SMALL_BATCH` which is 8 (but see [JDK-8285447](https://bugs.openjdk.org/browse/JDK-8285447)).
- `StackStreamFactory` than calls `AbstractStackWalker.callStackWalk()` which is a natively implemented in the VM by `JVM_CallStackWalk()`.
-  `JVM_CallStackWalk()` calls `StackWalk::walk()` which calls `StackWalk::fetchFirstBatch()` which calls `StackWalk::fill_in_frames()` which walks the stack and fills in the available class/stackframe slots in the passed in array until the array is full or there are no more stack frames,
- Once  `StackWalk::fill_in_frames()` returns, `StackWalk::fetchFirstBatch()` calls back to Java by invoking `AbstractStackWalker::doStackWalk()` to consume the result.
- `AbstractStackWalker::doStackWalk()` calls `consumeFrames()` (which is overridden depending on whether we initially called `getCallerClass()` or `walk()`) which consumes the frames until it either finishes (e.g. finds the caller class) or until there are no more frames.
- In the latter case `consumeFrames()` will call into the the VM again by calling `AbstractStackWalker.fetchStackFrames()` to fetch additional frames from the stack.
- `AbstractStackWalker.fetchStackFrames()` is implemented by `JVM_MoreStackWalk()` which calls `StackWalk::fetchNextBatch()` which calls `StackWalk::fill_in_frames()` (the same method that already fetched the initial batch of frames).

Following is a stacktrace of what I've explained so far:
```
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x143a96a]  StackWalk::fill_in_frames(long, BaseFrameStream&, int, int, objArrayHandle, int&, bool, JavaThread*)+0x4c
V  [libjvm.so+0x143c7d4]  StackWalk::fetchNextBatch(Handle, long, long, int, int, objArrayHandle, JavaThread*)+0x234
V  [libjvm.so+0xe52141]  JVM_MoreStackWalk+0x154
C  [libjava.so+0x165a5]  Java_java_lang_StackStreamFactory_00024AbstractStackWalker_fetchStackFrames+0x67
j  java.lang.StackStreamFactory$AbstractStackWalker.fetchStackFrames(JJII[Ljava/lang/Object;)I+0 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.fetchStackFrames(I)I+35 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.getNextBatch()I+107 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.peekFrame()Ljava/lang/Class;+32 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.hasNext()Z+1 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.nextFrame()Ljava/lang/Class;+1 java.base@22-internal
j  java.lang.StackStreamFactory$CallerClassFinder.consumeFrames()Ljava/lang/Integer;+21 java.base@22-internal
j  java.lang.StackStreamFactory$CallerClassFinder.consumeFrames()Ljava/lang/Object;+1 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.doStackWalk(JIIII)Ljava/lang/Object;+78 java.base@22-internal
v  ~StubRoutines::call_stub 0x00007fffdfdebd21
V  [libjvm.so+0xd2ac9d]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x607
V  [libjvm.so+0x123af32]  os::os_exception_wrapper(void (*)(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*), JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x3a
V  [libjvm.so+0xd2a692]  JavaCalls::call(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x3e
V  [libjvm.so+0x143c4e9]  StackWalk::fetchFirstBatch(BaseFrameStream&, Handle, long, int, int, int, objArrayHandle, JavaThread*)+0x551
V  [libjvm.so+0x143bf55]  StackWalk::walk(Handle, long, int, Handle, Handle, int, int, objArrayHandle, JavaThread*)+0x3ab
V  [libjvm.so+0xe51f85]  JVM_CallStackWalk+0x1e9
C  [libjava.so+0x16524]  Java_java_lang_StackStreamFactory_00024AbstractStackWalker_callStackWalk+0x74
j  java.lang.StackStreamFactory$AbstractStackWalker.callStackWalk(JILjdk/internal/vm/ContinuationScope;Ljdk/internal/vm/Continuation;II[Ljava/lang/Object;)Ljava/lang/Object;+0 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.beginStackWalk()Ljava/lang/Object;+39 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.walkHelper()Ljava/lang/Object;+1 java.base@22-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.walk()Ljava/lang/Object;+35 java.base@22-internal
j  java.lang.StackStreamFactory$CallerClassFinder.findCaller()Ljava/lang/Class;+1 java.base@22-internal
j  java.lang.StackWalker.getCallerClass()Ljava/lang/Class;+38 java.base@22-internal
j  ReflectiveGetCallerClassTest.getCallerClass()V+6

```

So far so good. But the problem is that if called from `StackWalker.getCallerClass()`, `StackWalk::fill_in_frames()` has to check if the caller of `StackWalker.getCallerClass()` is not a `@CallerSensitive` method and throw a `UnsupportedOperationException` if it is. `StackWalk::fill_in_frames()` currently does this unconditionally, no matter if called from `JVM_CallStackWalk()` for the initial batch or from `JVM_MoreStackWalk()` for a subsequent batch. As long as all the frames required to find the caller class fit into the first batch, this is not a problem. If however finding the caller class requires to fetch additional frames, the check described above might trigger due to a false positive. That's exactly what the included jtreg tests simulates. It recursively, reflectively calls   `StackWalker.getCallerClass()` to provoke a situations where:
 - the first batch doesn't include the "true" caller frame of `StackWalker.getCallerClass()` (because reflective frames are ignored)
 - a subsequent batch has a `@CallerSensitive` annotated method in the first slot.

As usually after so many words, the fix itself is pretty trivial: only do the check for a `@CallerSensitive` caller frame in the very first batch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311500](https://bugs.openjdk.org/browse/JDK-8311500): StackWalker.getCallerClass() throws UOE if invoked reflectively (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14773/head:pull/14773` \
`$ git checkout pull/14773`

Update a local copy of the PR: \
`$ git checkout pull/14773` \
`$ git pull https://git.openjdk.org/jdk.git pull/14773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14773`

View PR using the GUI difftool: \
`$ git pr show -t 14773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14773.diff">https://git.openjdk.org/jdk/pull/14773.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14773#issuecomment-1621606231)