### PR TITLE
JDK-8311511: Improve description of NativeLibrary JFR event

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -932,10 +932,11 @@
     <Field type="string" name="result" label="Thread Dump" />
   </Event>
 
-  <Event name="NativeLibrary" category="Java Virtual Machine, Runtime" label="Native Library" period="everyChunk">
+  <Event name="NativeLibrary" category="Java Virtual Machine, Runtime" label="Native Library" period="everyChunk"
+    description="Information about a dynamic library or other native image loaded by the JVM process">
     <Field type="string" name="name" label="Name" />
     <Field type="ulong" contentType="address" name="baseAddress" label="Base Address" description="Starting address of the module" />
-    <Field type="ulong" contentType="address" name="topAddress" label="Top Address" description="Ending address of the module" />
+    <Field type="ulong" contentType="address" name="topAddress" label="Top Address" description="Ending address of the module, if available" />
   </Event>
 
   <Event name="ModuleRequire" category="Java Virtual Machine, Runtime, Modules" label="Module Require" thread="false" period="everyChunk"


### PR DESCRIPTION
The JFR NativeLibrary event description should be improved.
Currently there is no description at all, but there should be one indicating that 'NativeLibrary'  can be different kinds of native images.  For example on macOS the frameworks show up.  On AIX,  java itself or some mapped files show up too in the list.

On macOS the 'Top Address'  is currently always 0 (info not available) . So give some hint in the description that this can happen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311511](https://bugs.openjdk.org/browse/JDK-8311511): Improve description of NativeLibrary JFR event (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14774/head:pull/14774` \
`$ git checkout pull/14774`

Update a local copy of the PR: \
`$ git checkout pull/14774` \
`$ git pull https://git.openjdk.org/jdk.git pull/14774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14774`

View PR using the GUI difftool: \
`$ git pr show -t 14774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14774.diff">https://git.openjdk.org/jdk/pull/14774.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14774#issuecomment-1621911874)