### PR TITLE
8309637: runtime/handshake/HandshakeTimeoutTest.java fails with "has not cleared handshake op" and SIGILL

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -471,9 +471,7 @@ void before_exit(JavaThread* thread, bool halt) {
 
   // Stop the WatcherThread. We do this before disenrolling various
   // PeriodicTasks to reduce the likelihood of races.
-  if (PeriodicTask::num_tasks() > 0) {
-    WatcherThread::stop();
-  }
+  WatcherThread::stop();
 
   // shut down the StatSampler task
   StatSampler::disengage();

--- a/src/hotspot/share/runtime/nonJavaThread.cpp
+++ b/src/hotspot/share/runtime/nonJavaThread.cpp
@@ -156,8 +156,44 @@ void NamedThread::print_on(outputStream* st) const {
 // timer interrupts exists on the platform.
 
 WatcherThread* WatcherThread::_watcher_thread   = nullptr;
-bool WatcherThread::_startable = false;
+bool WatcherThread::_run_all_tasks = false;
 volatile bool  WatcherThread::_should_terminate = false;
+
+static void check_error_reporting() {
+  if (!VMError::is_error_reported()) {
+    return;
+  }
+
+  // A fatal error has happened, the error handler(VMError::report_and_die)
+  // should abort JVM after creating an error log file. However in some
+  // rare cases, the error handler itself might deadlock. Here periodically
+  // check for error reporting timeouts, and if it happens, just proceed to
+  // abort the VM.
+
+  // This code is in WatcherThread because WatcherThread wakes up
+  // periodically so the fatal error handler doesn't need to do anything;
+  // also because the WatcherThread is less likely to crash than other
+  // threads.
+
+  for (;;) {
+    // Note: we use naked sleep in this loop because we want to avoid using
+    // any kind of VM infrastructure which may be broken at this point.
+    if (VMError::check_timeout()) {
+      // We hit error reporting timeout. Error reporting was interrupted and
+      // will be wrapping things up now (closing files etc). Give it some more
+      // time, then quit the VM.
+      os::naked_short_sleep(200);
+      // Print a message to stderr.
+      fdStream err(defaultStream::output_fd());
+      err.print_raw_cr("# [ timer expired, abort... ]");
+      // skip atexit/vm_exit/vm_abort hooks
+      os::die();
+    }
+
+    // Wait a bit, then recheck for timeout.
+    os::naked_short_sleep(250);
+  }
+}
 
 WatcherThread::WatcherThread() : NonJavaThread() {
   assert(watcher_thread() == nullptr, "we can only allocate one WatcherThread");
@@ -236,6 +272,20 @@ void WatcherThread::run() {
   assert(this == watcher_thread(), "just checking");
 
   while (true) {
+    // Just check for error reporting hangs until either VM is fully
+    // initialized or we are notified to stop running.
+    check_error_reporting();
+    MonitorLocker ml(PeriodicTask_lock, Mutex::_no_safepoint_check_flag);
+    if (_should_terminate || _run_all_tasks) break;
+    ml.wait(100);
+  }
+
+  if (_should_terminate) {
+    notify_exit();
+    return;
+  }
+
+  while (true) {
     assert(watcher_thread() == Thread::current(), "thread consistency check");
     assert(watcher_thread() == this, "thread consistency check");
 
@@ -243,68 +293,28 @@ void WatcherThread::run() {
     // should be done, and sleep that amount of time.
     int time_waited = sleep();
 
-    if (VMError::is_error_reported()) {
-      // A fatal error has happened, the error handler(VMError::report_and_die)
-      // should abort JVM after creating an error log file. However in some
-      // rare cases, the error handler itself might deadlock. Here periodically
-      // check for error reporting timeouts, and if it happens, just proceed to
-      // abort the VM.
-
-      // This code is in WatcherThread because WatcherThread wakes up
-      // periodically so the fatal error handler doesn't need to do anything;
-      // also because the WatcherThread is less likely to crash than other
-      // threads.
-
-      for (;;) {
-        // Note: we use naked sleep in this loop because we want to avoid using
-        // any kind of VM infrastructure which may be broken at this point.
-        if (VMError::check_timeout()) {
-          // We hit error reporting timeout. Error reporting was interrupted and
-          // will be wrapping things up now (closing files etc). Give it some more
-          // time, then quit the VM.
-          os::naked_short_sleep(200);
-          // Print a message to stderr.
-          fdStream err(defaultStream::output_fd());
-          err.print_raw_cr("# [ timer expired, abort... ]");
-          // skip atexit/vm_exit/vm_abort hooks
-          os::die();
-        }
-
-        // Wait a bit, then recheck for timeout.
-        os::naked_short_sleep(250);
-      }
-    }
+    check_error_reporting();
 
     if (_should_terminate) {
-      // check for termination before posting the next tick
-      break;
+      notify_exit();
+      return;
     }
 
     PeriodicTask::real_time_tick(time_waited);
   }
-
-  // Signal that it is terminated
-  {
-    MutexLocker mu(Terminator_lock, Mutex::_no_safepoint_check_flag);
-    LSAN_IGNORE_OBJECT(_watcher_thread);
-    _watcher_thread = nullptr;
-    Terminator_lock->notify_all();
-  }
 }
 
 void WatcherThread::start() {
-  assert(PeriodicTask_lock->owned_by_self(), "PeriodicTask_lock required");
-
-  if (watcher_thread() == nullptr && _startable) {
-    _should_terminate = false;
-    // Create the single instance of WatcherThread
-    new WatcherThread();
-  }
+  MonitorLocker ml(PeriodicTask_lock);
+  _should_terminate = false;
+  // Create the single instance of WatcherThread
+  new WatcherThread();
 }
 
-void WatcherThread::make_startable() {
-  assert(PeriodicTask_lock->owned_by_self(), "PeriodicTask_lock required");
-  _startable = true;
+void WatcherThread::run_all_tasks() {
+  MonitorLocker ml(PeriodicTask_lock);
+  _run_all_tasks = true;
+  ml.notify();
 }
 
 void WatcherThread::stop() {
@@ -327,6 +337,13 @@ void WatcherThread::stop() {
     // This wait should make safepoint checks and wait without a timeout.
     mu.wait(0);
   }
+}
+
+void WatcherThread::notify_exit() {
+  MonitorLocker ml(Terminator_lock, Mutex::_no_safepoint_check_flag);
+  LSAN_IGNORE_OBJECT(_watcher_thread);
+  _watcher_thread = nullptr;
+  ml.notify_all();
 }
 
 void WatcherThread::unpark() {

--- a/src/hotspot/share/runtime/nonJavaThread.hpp
+++ b/src/hotspot/share/runtime/nonJavaThread.hpp
@@ -141,7 +141,6 @@ class WatcherThread: public NonJavaThread {
   // initialized. Meanwhile only error reporting will be checked.
   static void run_all_tasks();
  private:
-  void notify_exit();
   int sleep() const;
 };
 

--- a/src/hotspot/share/runtime/nonJavaThread.hpp
+++ b/src/hotspot/share/runtime/nonJavaThread.hpp
@@ -110,7 +110,7 @@ class WatcherThread: public NonJavaThread {
  private:
   static WatcherThread* _watcher_thread;
 
-  static bool _startable;
+  static bool _run_all_tasks;
   // volatile due to at least one lock-free read
   volatile static bool _should_terminate;
  public:
@@ -137,10 +137,11 @@ class WatcherThread: public NonJavaThread {
   // Create and start the single instance of WatcherThread, or stop it on shutdown
   static void start();
   static void stop();
-  // Only allow start once the VM is sufficiently initialized
-  // Otherwise the first task to enroll will trigger the start
-  static void make_startable();
+  // Allow executing registered tasks once the VM is sufficiently
+  // initialized. Meanwhile only error reporting will be checked.
+  static void run_all_tasks();
  private:
+  void notify_exit();
   int sleep() const;
 };
 

--- a/src/hotspot/share/runtime/task.cpp
+++ b/src/hotspot/share/runtime/task.cpp
@@ -29,6 +29,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/task.hpp"
+#include "runtime/threads.hpp"
 #include "runtime/timer.hpp"
 
 int PeriodicTask::_num_tasks = 0;
@@ -95,10 +96,9 @@ void PeriodicTask::enroll() {
   }
 
   WatcherThread* thread = WatcherThread::watcher_thread();
+  assert(thread != nullptr || !Threads::is_vm_complete(), "vm created but no WatcherThread");
   if (thread != nullptr) {
     thread->unpark();
-  } else {
-    WatcherThread::start();
   }
 }
 


### PR DESCRIPTION
Please review the following fix. The test is checking the correct behavior of flag HandshakeTimeout by spawning a child VM and verifying that it crashes due to a timeout during a handshake operation. The test sometimes times out though because the child VM deadlocks during error reporting. The issue is that the JavaThread doing the error reporting deadlocks trying to acquire a lock it already owns, and the Watcher thread never kicks in to shutdown the VM because it hasn't been created yet and will never be: the "main" JavaThread is blocked in Threads::create_vm(), somewhere before creating the Watcher thread, waiting to acquire a lock that the error reporting thread owns. There are more details about the specifics resources involved in the deadlocks in the bug comments.

I moved the start of the Watcher thread further up during the initialization steps so that it is there even before creating the VMThread. Ideally it should be one of the first things we create in Threads::create_vm() but unfortunately there are dependencies. I found the earliest we can create it is at the same place the AsyncLogWriter thread is created since the barrier set needs to have been created already. I didn't move the creation there but just after that call to init_globals(). To keep the current behavior where enrolled tasks are only processed after the VM has been fully created I added a first loop in WatcherThread::run() where we only check for error reporting hangs. Most of the other changes in the patch are factoring out code.

The test timeout can be reproduced by adding a delay in ThreadCritical() (one of the locks involved in the deadlock). I verified the fix by running the test with that extra delay and verified it doesn't time out anymore. I also run tiers1-3 in mach5. I'll run the upper tiers too.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309637](https://bugs.openjdk.org/browse/JDK-8309637): runtime/handshake/HandshakeTimeoutTest.java fails with "has not cleared handshake op" and SIGILL (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14777/head:pull/14777` \
`$ git checkout pull/14777`

Update a local copy of the PR: \
`$ git checkout pull/14777` \
`$ git pull https://git.openjdk.org/jdk.git pull/14777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14777`

View PR using the GUI difftool: \
`$ git pr show -t 14777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14777.diff">https://git.openjdk.org/jdk/pull/14777.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14777#issuecomment-1622554448)