### PR TITLE
8295068: SSLEngine throws NPE parsing CertificateRequests

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
@@ -128,11 +128,8 @@ final class CertificateRequest {
             ArrayList<String> keyTypes = new ArrayList<>(3);
             for (byte id : ids) {
                 ClientCertificateType cct = ClientCertificateType.valueOf(id);
-                if(cct == null) {
-                    throw new IllegalArgumentException(id + " was " +
-                            "not a valid ClientCertificateType id");
-                }
-                if (cct.isAvailable) {
+
+                if (cct != null && cct.isAvailable) {
                     cct.keyAlgorithm.forEach(key -> {
                         if (!keyTypes.contains(key)) {
                             keyTypes.add(key);

--- a/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
@@ -128,6 +128,10 @@ final class CertificateRequest {
             ArrayList<String> keyTypes = new ArrayList<>(3);
             for (byte id : ids) {
                 ClientCertificateType cct = ClientCertificateType.valueOf(id);
+                if(cct == null) {
+                    throw new IllegalArgumentException(id + " was " +
+                            "not a valid ClientCertificateType id");
+                }
                 if (cct.isAvailable) {
                     cct.keyAlgorithm.forEach(key -> {
                         if (!keyTypes.contains(key)) {

--- a/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
@@ -128,7 +128,6 @@ final class CertificateRequest {
             ArrayList<String> keyTypes = new ArrayList<>(3);
             for (byte id : ids) {
                 ClientCertificateType cct = ClientCertificateType.valueOf(id);
-
                 if (cct != null && cct.isAvailable) {
                     cct.keyAlgorithm.forEach(key -> {
                         if (!keyTypes.contains(key)) {


### PR DESCRIPTION
JDK-8295068: an NPE is thrown when an invalid `id` is found to match up a `ClientCertificateType`; rather than throwing the `NPE`, we now ignore an `id` which does match a `ClientCertificateType`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295068](https://bugs.openjdk.org/browse/JDK-8295068): SSLEngine throws NPE parsing CertificateRequests (**Bug** - P4)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14778/head:pull/14778` \
`$ git checkout pull/14778`

Update a local copy of the PR: \
`$ git checkout pull/14778` \
`$ git pull https://git.openjdk.org/jdk.git pull/14778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14778`

View PR using the GUI difftool: \
`$ git pr show -t 14778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14778.diff">https://git.openjdk.org/jdk/pull/14778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14778#issuecomment-1622460639)