### PR TITLE
8311514: Incorrect regex in TestMetaSpaceLog.java

### DIFF
--- a/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
+++ b/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
@@ -58,7 +58,10 @@ public class TestMetaSpaceLog {
     // Do this once here.
     // Scan for Metaspace update notices as part of the GC log, e.g. in this form:
     // [gc,metaspace   ] GC(0) Metaspace: 11895K(14208K)->11895K(14208K) NonClass: 10552K(12544K)->10552K(12544K) Class: 1343K(1664K)->1343K(1664K)
-    metaSpaceRegexp = Pattern.compile(".*Metaspace: ([0-9]+)K\\([0-9]+K\\)->([0-9]+)K\\([0-9]+K\\).*");
+    // This regex has to be up-to-date with the format used in hotspot to print metaspace change.
+    metaSpaceRegexp = Pattern.compile(".* Metaspace: ([0-9]+)K\\([0-9]+K\\)->([0-9]+)K\\([0-9]+K\\) "
+                                      + "NonClass: [0-9]+K\\([0-9]+K\\)->[0-9]+K\\([0-9]+K\\) "
+                                      + "Class: [0-9]+K\\([0-9]+K\\)->[0-9]+K\\([0-9]+K\\)");
   }
 
   public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
+++ b/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
@@ -58,7 +58,7 @@ public class TestMetaSpaceLog {
     // Do this once here.
     // Scan for Metaspace update notices as part of the GC log, e.g. in this form:
     // [gc,metaspace   ] GC(0) Metaspace: 11895K(14208K)->11895K(14208K) NonClass: 10552K(12544K)->10552K(12544K) Class: 1343K(1664K)->1343K(1664K)
-    metaSpaceRegexp = Pattern.compile(".*Metaspace: ([0-9]+).*->([0-9]+).*");
+    metaSpaceRegexp = Pattern.compile(".*Metaspace: ([0-9]+)K\\([0-9]+K\\)->([0-9]+)K\\([0-9]+K\\).*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
+++ b/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
@@ -59,9 +59,12 @@ public class TestMetaSpaceLog {
     // Scan for Metaspace update notices as part of the GC log, e.g. in this form:
     // [gc,metaspace   ] GC(0) Metaspace: 11895K(14208K)->11895K(14208K) NonClass: 10552K(12544K)->10552K(12544K) Class: 1343K(1664K)->1343K(1664K)
     // This regex has to be up-to-date with the format used in hotspot to print metaspace change.
-    metaSpaceRegexp = Pattern.compile(".* Metaspace: ([0-9]+)K\\([0-9]+K\\)->([0-9]+)K\\([0-9]+K\\) "
-                                      + "NonClass: [0-9]+K\\([0-9]+K\\)->[0-9]+K\\([0-9]+K\\) "
-                                      + "Class: [0-9]+K\\([0-9]+K\\)->[0-9]+K\\([0-9]+K\\)");
+    final String NUM_K = "\\d+K";
+    final String GP_NUM_K = "(\\d+)K";
+    final String BR_NUM_K = "\\(" + NUM_K + "\\)";
+    final String SIZE_CHG = NUM_K + BR_NUM_K + "->" + NUM_K + BR_NUM_K;
+    metaSpaceRegexp = Pattern.compile(".* Metaspace: " + GP_NUM_K + BR_NUM_K + "->" + GP_NUM_K + BR_NUM_K
+                                      + "( NonClass: " + SIZE_CHG + " Class: " + SIZE_CHG + ")?$");
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The regex in jtreg test `TestMetaSpaceLog.java` is intended to capture the metaspace size before and after the reclamation. But it captures the wrong value. which might cause this test to always pass. The results of the capture can be displayed using a visualization tool.

Before this patch:
<img width="1128" alt="屏幕快照 2023-07-06 17 18 15" src="https://github.com/openjdk/jdk/assets/18374295/4e3b6606-24b3-4d7f-a70d-f312cb867fbf">

After this patch:
<img width="1125" alt="屏幕快照 2023-07-06 17 18 25" src="https://github.com/openjdk/jdk/assets/18374295/b100018e-2c39-4154-9ec7-80e5eedc212e">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311514](https://bugs.openjdk.org/browse/JDK-8311514): Incorrect regex in TestMetaSpaceLog.java (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14782/head:pull/14782` \
`$ git checkout pull/14782`

Update a local copy of the PR: \
`$ git checkout pull/14782` \
`$ git pull https://git.openjdk.org/jdk.git pull/14782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14782`

View PR using the GUI difftool: \
`$ git pr show -t 14782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14782.diff">https://git.openjdk.org/jdk/pull/14782.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14782#issuecomment-1623331969)