### PR TITLE
8311575: Fix invalid format parameters

### DIFF
--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -222,7 +222,7 @@ static bool is_directory_secure(const char* path) {
     else {
       // unexpected error, declare the path insecure
       if (PrintMiscellaneous && Verbose) {
-        warning("could not get attributes for file %s: ",
+        warning("could not get attributes for file %s: "
                 " lasterror = %d\n", path, lasterror);
       }
       return false;

--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1153,13 +1153,13 @@ char *ADLParser::parse_one_arg(const char *description) {
     }
     next_char();           // skip the close paren
     if(_curchar != ';') {  // check for semi-colon
-      parse_err(SYNERR, "missing %c in.\n", ';', description);
+      parse_err(SYNERR, "missing %c in %s.\n", ';', description);
       return nullptr;
     }
     next_char();           // skip the semi-colon
   }
   else {
-    parse_err(SYNERR, "Missing %c in.\n", '(', description);
+    parse_err(SYNERR, "Missing %c in %s.\n", '(', description);
     return nullptr;
   }
 
@@ -4191,7 +4191,7 @@ ExpandRule* ADLParser::expand_parse(InstructForm *instr) {
       if (_curchar == '%') { // Need a constructor for the operand
         c = find_cpp_block("Operand Constructor");
         if (c == nullptr) {
-          parse_err(SYNERR, "Invalid code block for operand constructor\n", _curchar);
+          parse_err(SYNERR, "Invalid code block for operand constructor\n");
           continue;
         }
         // Add constructor to _newopconst Dict

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1148,7 +1148,7 @@ bool Arguments::process_argument(const char* arg,
     JVMFlag* fuzzy_matched = JVMFlag::fuzzy_match((const char*)argname, arg_len, true);
     if (fuzzy_matched != nullptr) {
       jio_fprintf(defaultStream::error_stream(),
-                  "Did you mean '%s%s%s'? ",
+                  "Did you mean '%s%s%s'?\n",
                   (fuzzy_matched->is_bool()) ? "(+/-)" : "",
                   fuzzy_matched->name(),
                   (fuzzy_matched->is_bool()) ? "" : "=<value>");
@@ -1913,7 +1913,7 @@ bool Arguments::check_vm_args_consistency() {
   if (UseHeavyMonitors) {
     if (FLAG_IS_CMDLINE(LockingMode) && LockingMode != LM_MONITOR) {
       jio_fprintf(defaultStream::error_stream(),
-                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags", LockingMode);
+                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags\n", LockingMode);
       return false;
     }
     FLAG_SET_CMDLINE(LockingMode, LM_MONITOR);
@@ -1922,21 +1922,21 @@ bool Arguments::check_vm_args_consistency() {
 #if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64) && !defined(S390)
   if (LockingMode == LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),
-                "LockingMode == 0 (LM_MONITOR) is not fully implemented on this architecture");
+                "LockingMode == 0 (LM_MONITOR) is not fully implemented on this architecture\n");
     return false;
   }
 #endif
 #if defined(X86) && !defined(ZERO)
   if (LockingMode == LM_MONITOR && UseRTMForStackLocks) {
     jio_fprintf(defaultStream::error_stream(),
-                "LockingMode == 0 (LM_MONITOR) and -XX:+UseRTMForStackLocks are mutually exclusive");
+                "LockingMode == 0 (LM_MONITOR) and -XX:+UseRTMForStackLocks are mutually exclusive\n");
 
     return false;
   }
 #endif
   if (VerifyHeavyMonitors && LockingMode != LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),
-                "-XX:+VerifyHeavyMonitors requires LockingMode == 0 (LM_MONITOR)");
+                "-XX:+VerifyHeavyMonitors requires LockingMode == 0 (LM_MONITOR)\n");
     return false;
   }
   return status;
@@ -2838,7 +2838,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
         if (jvmci_compiler != nullptr) {
           if (strncmp(jvmci_compiler, "graal", strlen("graal")) != 0) {
             jio_fprintf(defaultStream::error_stream(),
-              "Value of jvmci.Compiler incompatible with +UseGraalJIT: %s", jvmci_compiler);
+              "Value of jvmci.Compiler incompatible with +UseGraalJIT: %s\n", jvmci_compiler);
             return JNI_ERR;
           }
         } else if (!add_property("jvmci.Compiler=graal")) {
@@ -2855,7 +2855,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       if (jvmciFlag != nullptr && jvmciFlag->is_unlocked()) {
         if (!JVMCIGlobals::enable_jvmci_product_mode(origin, use_graal_jit)) {
           jio_fprintf(defaultStream::error_stream(),
-            "Unable to enable JVMCI in product mode");
+            "Unable to enable JVMCI in product mode\n");
           return JNI_ERR;
         }
       }
@@ -3948,7 +3948,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   const NMT_TrackingLevel lvl = NMTUtil::parse_tracking_level(NativeMemoryTracking);
   if (lvl == NMT_unknown) {
     jio_fprintf(defaultStream::error_stream(),
-                "Syntax error, expecting -XX:NativeMemoryTracking=[off|summary|detail]");
+                "Syntax error, expecting -XX:NativeMemoryTracking=[off|summary|detail]\n");
     return JNI_ERR;
   }
   if (PrintNMTStatistics && lvl == NMT_off) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3948,7 +3948,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   const NMT_TrackingLevel lvl = NMTUtil::parse_tracking_level(NativeMemoryTracking);
   if (lvl == NMT_unknown) {
     jio_fprintf(defaultStream::error_stream(),
-                "Syntax error, expecting -XX:NativeMemoryTracking=[off|summary|detail]", nullptr);
+                "Syntax error, expecting -XX:NativeMemoryTracking=[off|summary|detail]");
     return JNI_ERR;
   }
   if (PrintNMTStatistics && lvl == NMT_off) {


### PR DESCRIPTION
Please review this change that fixes a few issues with printf-like function parameters.

No new tests. I'll run tier1 & tier2 before integrating, just to make sure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311575](https://bugs.openjdk.org/browse/JDK-8311575): Fix invalid format parameters (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [db287ada](https://git.openjdk.org/jdk/pull/14783/files/db287ada39141dc9aa7eddc496aded238584b0ab)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14783/head:pull/14783` \
`$ git checkout pull/14783`

Update a local copy of the PR: \
`$ git checkout pull/14783` \
`$ git pull https://git.openjdk.org/jdk.git pull/14783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14783`

View PR using the GUI difftool: \
`$ git pr show -t 14783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14783.diff">https://git.openjdk.org/jdk/pull/14783.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14783#issuecomment-1623569966)