### PR TITLE
8066869: Add Closeable::closeUnchecked that is the equivalent of close but throws UncheckedIOException

### DIFF
--- a/src/java.base/share/classes/java/io/Closeable.java
+++ b/src/java.base/share/classes/java/io/Closeable.java
@@ -43,7 +43,7 @@ public interface Closeable extends AutoCloseable {
      * with it. If the stream is already closed then invoking this
      * method has no effect.
      *
-     * <p> As noted in {@linkplain AutoCloseable#close()}, cases where the
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
      * close may fail require careful attention. It is strongly advised
      * to relinquish the underlying resources and to internally
      * <em>mark</em> the {@code Closeable} as closed, prior to throwing
@@ -67,11 +67,11 @@ public interface Closeable extends AutoCloseable {
      *     throw new UncheckedIOException(cause);
      * }
      * }
-     * Therefore if an {@linkplain UncheckedIOException} is thrown then its
-     * {@linkplain UncheckedIOException#getCause() getCause} method will return the
-     * {@linkplain IOException} thrown by {@link #close() close}.
+     * Therefore if an {@link UncheckedIOException} is thrown then its
+     * {@link UncheckedIOException#getCause() getCause} method will return the
+     * {@link IOException} thrown by {@link #close() close}.
      *
-     * @throws UncheckedIOException If invoking {@code close} throws
+     * @throws UncheckedIOException if invoking {@code close} throws
      * an {@code IOException}.
      *
      * @since 22

--- a/src/java.base/share/classes/java/io/Closeable.java
+++ b/src/java.base/share/classes/java/io/Closeable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,13 @@
 package java.io;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 /**
  * A {@code Closeable} is a source or destination of data that can be closed.
- * The close method is invoked to release resources that the object is
- * holding (such as open files).
+ * The {@code close} method is invoked to release resources that the object is
+ * holding (such as open files).  The {@code closeUnchecked} method
+ * closes the stream and may throw only an unchecked exception.
  *
  * @since 1.5
  */
@@ -41,7 +43,7 @@ public interface Closeable extends AutoCloseable {
      * with it. If the stream is already closed then invoking this
      * method has no effect.
      *
-     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * <p> As noted in {@linkplain AutoCloseable#close()}, cases where the
      * close may fail require careful attention. It is strongly advised
      * to relinquish the underlying resources and to internally
      * <em>mark</em> the {@code Closeable} as closed, prior to throwing
@@ -50,4 +52,35 @@ public interface Closeable extends AutoCloseable {
      * @throws IOException if an I/O error occurs
      */
     public void close() throws IOException;
+
+    /**
+     * Closes this stream and releases any system resources associated
+     * with it. If the stream is already closed then invoking this
+     * method has no effect.
+     *
+     * @implSpec
+     * The default implementation is equivalent for this stream to:
+     * {@snippet lang=java :
+     * try {
+     *     close();
+     * } catch (IOException cause) {
+     *     throw new UncheckedIOException(cause);
+     * }
+     * }
+     * Therefore if an {@linkplain UncheckedIOException} is thrown then its
+     * {@linkplain UncheckedIOException#getCause() getCause} method will return the
+     * {@linkplain IOException} thrown by {@link #close() close}.
+     *
+     * @throws UncheckedIOException If invoking {@code close} throws
+     * an {@code IOException}.
+     *
+     * @since 22
+     */
+    default void closeUnchecked() {
+        try {
+            close();
+        } catch (IOException cause) {
+            throw new UncheckedIOException(cause);
+        }
+    }
 }

--- a/test/jdk/java/io/Closeable/CloseUnchecked.java
+++ b/test/jdk/java/io/Closeable/CloseUnchecked.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8066869
+ * @summary Verify expected behavior of default method Closeable::closeUnchecked
+ */
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class CloseUnchecked {
+    private static final String MESSAGE = "Gratuitous exception";
+
+    private static class CloseableImpl implements Closeable {
+        private boolean closeThrows;
+
+        private CloseableImpl(boolean closeThrows) {
+            this.closeThrows = closeThrows;
+        }
+
+        public void close() throws IOException {
+            if (closeThrows)
+                throw new IOException(MESSAGE);
+        }
+    }
+
+    public static void main(String[] args) {
+        Closeable c = new CloseableImpl(false);
+        try {
+            c.closeUnchecked();
+        } catch (UncheckedIOException unexpected) {
+            throw new RuntimeException("Unexpected exception", unexpected);
+        }
+
+        c = new CloseableImpl(true);
+        try {
+            c.closeUnchecked();
+            throw new RuntimeException("UncheckedIOException not thrown");
+        } catch (UncheckedIOException expected) {
+            System.out.println("Caught expected UncheckedIOException");
+            IOException cause = expected.getCause();
+            String message = cause.getMessage();
+            if (!message.equals(MESSAGE))
+                throw new RuntimeException("Unexpected message " + message);
+        }
+    }
+}


### PR DESCRIPTION
Add a default method `java.io.Closeable::closeUnchecked` which is equivalent to `Closeable::close` except that it instead throws `java.io.UncheckedIOException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Issue
 * [JDK-8066869](https://bugs.openjdk.org/browse/JDK-8066869): Add Closeable::closeUnchecked that is the equivalent of close but throws UncheckedIOException (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14789/head:pull/14789` \
`$ git checkout pull/14789`

Update a local copy of the PR: \
`$ git checkout pull/14789` \
`$ git pull https://git.openjdk.org/jdk.git pull/14789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14789`

View PR using the GUI difftool: \
`$ git pr show -t 14789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14789.diff">https://git.openjdk.org/jdk/pull/14789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14789#issuecomment-1624255925)