### PR TITLE
8311528: Remove IDE specific SuppressWarnings

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -2701,25 +2701,25 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * @return {@code true} if this object is equal to {@code obj};
      * {@code false} otherwise.
      */
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        try {
-            Calendar that = (Calendar)obj;
-            return compareTo(getMillisOf(that)) == 0 &&
-                lenient == that.lenient &&
-                firstDayOfWeek == that.firstDayOfWeek &&
-                minimalDaysInFirstWeek == that.minimalDaysInFirstWeek &&
-                (zone instanceof ZoneInfo ?
-                    zone.equals(that.zone) :
-                    zone.equals(that.getTimeZone()));
-        } catch (Exception e) {
-            // Note: GregorianCalendar.computeTime throws
-            // IllegalArgumentException if the ERA value is invalid
-            // even it's in lenient mode.
+        if (obj instanceof Calendar that) {
+            try {
+                return compareTo(getMillisOf(that)) == 0 &&
+                    lenient == that.lenient &&
+                    firstDayOfWeek == that.firstDayOfWeek &&
+                    minimalDaysInFirstWeek == that.minimalDaysInFirstWeek &&
+                    (zone instanceof ZoneInfo ?
+                        zone.equals(that.zone) :
+                        zone.equals(that.getTimeZone()));
+            } catch (Exception e) {
+                // Note: GregorianCalendar.computeTime throws
+                // IllegalArgumentException if the ERA value is invalid
+                // even it's in lenient mode.
+            }
         }
         return false;
     }


### PR DESCRIPTION
Removing the IDE specific `@SuppressWarnings` attached to `java.util.Calendar#equals()`. `equals()` implementation now checks the type of the other instance for this.