### PR TITLE
8155902: DataOuputStream should clarify that it might write primitive types as multiple byte groups

### DIFF
--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -37,6 +37,11 @@ import jdk.internal.util.ByteArray;
  * thread then access to the data output stream should be controlled
  * by appropriate synchronization.
  *
+ * @apiNote
+ * The write methods of this class merely delegate to the methods of
+ * the underlying output stream, hence there is no guarantee as to
+ * the details of how the bytes are written.
+ *
  * @see     java.io.DataInputStream
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -32,9 +32,8 @@ import jdk.internal.util.ByteArray;
  * types to an output stream in a portable way. An application can
  * then use a data input stream to read the data back in. A data output
  * stream wraps another output stream and delegates writing bytes to the
- * write methods of that output stream. Hence writing data consisting of
- * more than a single byte may cause several writes to the underlying
- * output stream.
+ * write methods of that output stream. Writing data consisting of more than
+ * a single byte may cause several writes to the underlying output stream.
  * <p>
  * A DataOutputStream is not safe for use by multiple concurrent
  * threads. If a DataOutputStream is to be used by more than one

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -30,17 +30,16 @@ import jdk.internal.util.ByteArray;
 /**
  * A data output stream lets an application write primitive Java data
  * types to an output stream in a portable way. An application can
- * then use a data input stream to read the data back in.
+ * then use a data input stream to read the data back in. A data output
+ * stream wraps another output stream and delegates writing bytes to the
+ * write methods of that output stream. Hence writing data consisting of
+ * more than a single byte may cause several writes to the underlying
+ * output stream.
  * <p>
  * A DataOutputStream is not safe for use by multiple concurrent
  * threads. If a DataOutputStream is to be used by more than one
  * thread then access to the data output stream should be controlled
  * by appropriate synchronization.
- *
- * @apiNote
- * The write methods of this class delegate to the methods of
- * the underlying output stream, hence there is no guarantee as to
- * the details of how the bytes are written.
  *
  * @see     java.io.DataInputStream
  * @since   1.0

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -38,7 +38,7 @@ import jdk.internal.util.ByteArray;
  * by appropriate synchronization.
  *
  * @apiNote
- * The write methods of this class merely delegate to the methods of
+ * The write methods of this class delegate to the methods of
  * the underlying output stream, hence there is no guarantee as to
  * the details of how the bytes are written.
  *


### PR DESCRIPTION
Add a disclaimer to `java.io.DataOutputStream` to the effect that it makes no guarantee as to how the underlying output stream actually writes the bytes provided to it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8311882](https://bugs.openjdk.org/browse/JDK-8311882) to be approved

### Issues
 * [JDK-8155902](https://bugs.openjdk.org/browse/JDK-8155902): DataOuputStream should clarify that it might write primitive types as multiple byte groups (**Bug** - P4)
 * [JDK-8311882](https://bugs.openjdk.org/browse/JDK-8311882): DataOuputStream should clarify that it might write primitive types as multiple byte groups (**CSR**)

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14791/head:pull/14791` \
`$ git checkout pull/14791`

Update a local copy of the PR: \
`$ git checkout pull/14791` \
`$ git pull https://git.openjdk.org/jdk.git pull/14791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14791`

View PR using the GUI difftool: \
`$ git pr show -t 14791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14791.diff">https://git.openjdk.org/jdk/pull/14791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14791#issuecomment-1624351015)