### PR TITLE
8311380: Prepare java.desktop for C++17

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DTextRenderer.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DTextRenderer.cpp
@@ -23,8 +23,8 @@
  * questions.
  */
 
+#include <cmath>
 #include <malloc.h>
-#include <math.h>
 #include <jlong.h>
 
 #include "sun_java2d_d3d_D3DTextRenderer.h"

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DVertexCacher.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DVertexCacher.cpp
@@ -23,11 +23,11 @@
  * questions.
  */
 
+#include <cmath>
+
 #include "D3DPipeline.h"
 #include "D3DVertexCacher.h"
 #include "D3DPaints.h"
-
-#include "math.h"
 
 // non-texturized macros
 

--- a/src/java.desktop/windows/native/libawt/java2d/windows/GDIRenderer.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/windows/GDIRenderer.cpp
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#include <cmath>                /* for cos(), sin(), etc */
+
 #include "jni_util.h"
 #include "awt.h"
 #include "sun_java2d_windows_GDIRenderer.h"
@@ -34,8 +36,6 @@
 #include "awt_Brush.h"
 
 #include "GraphicsPrimitiveMgr.h"
-
-#include <math.h>                /* for cos(), sin(), etc */
 
 #define MAX_CLAMP_BND (1<<26)
 #define MIN_CLAMP_BND (-MAX_CLAMP_BND)

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -23,12 +23,12 @@
  * questions.
  */
 
+#include <cmath>
+
 #include "sun_awt_windows_ThemeReader.h"
 
 #include "awt.h"
 #include "awt_Toolkit.h"
-
-#include "math.h"
 
 #include <uxtheme.h>
 

--- a/src/java.desktop/windows/native/libawt/windows/alloc.h
+++ b/src/java.desktop/windows/native/libawt/windows/alloc.h
@@ -88,14 +88,14 @@ ExceptionOccurred_Instead
 // These three functions throw std::bad_alloc in an out of memory condition
 // instead of returning 0. safe_Realloc will return 0 if memblock is not
 // NULL and size is 0. safe_Malloc and safe_Calloc will never return 0.
-void *safe_Malloc(size_t size) throw (std::bad_alloc);
-void *safe_Calloc(size_t num, size_t size) throw (std::bad_alloc);
-void *safe_Realloc(void *memblock, size_t size) throw (std::bad_alloc);
+void *safe_Malloc(size_t size);
+void *safe_Calloc(size_t num, size_t size);
+void *safe_Realloc(void *memblock, size_t size);
 
 // This function should be called instead of ExceptionOccurred. It throws
 // std::bad_alloc if a java.lang.OutOfMemoryError is currently pending
 // on the calling thread.
-jthrowable safe_ExceptionOccurred(JNIEnv *env) throw (std::bad_alloc);
+jthrowable safe_ExceptionOccurred(JNIEnv *env);
 
 // This function is called at the beginning of an entry point.
 // Entry points are functions which are declared:
@@ -111,7 +111,7 @@ void entry_point(void);
 void hang_if_shutdown(void);
 
 // This function throws awt_toolkit_shutdown if the Toolkit is not active
-void throw_if_shutdown(void) throw (awt_toolkit_shutdown);
+void throw_if_shutdown(void);
 
 // This function is called when a std::bad_alloc exception is caught
 void handle_bad_alloc(void);
@@ -120,14 +120,10 @@ void handle_bad_alloc(void);
 // #define OUTOFMEM_TEST
 
 #ifdef OUTOFMEM_TEST
-    void *safe_Malloc_outofmem(size_t size, const char *, int)
-        throw (std::bad_alloc);
-    void *safe_Calloc_outofmem(size_t num, size_t size, const char *, int)
-        throw (std::bad_alloc);
-    void *safe_Realloc_outofmem(void *memblock, size_t size, const char *, int)
-        throw (std::bad_alloc);
-    void * CDECL operator new(size_t size, const char *, int)
-        throw (std::bad_alloc);
+    void *safe_Malloc_outofmem(size_t size, const char *, int);
+    void *safe_Calloc_outofmem(size_t num, size_t size, const char *, int);
+    void *safe_Realloc_outofmem(void *memblock, size_t size, const char *, int);
+    void * CDECL operator new(size_t size, const char *, int);
 
     #define safe_Malloc(size) \
         safe_Malloc_outofmem(size, __FILE__, __LINE__)

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#include <cmath>
+
 #include "awt.h"
 
 #include <windowsx.h>
@@ -47,7 +49,6 @@
 #include "awt_Win32GraphicsDevice.h"
 #include "Hashtable.h"
 #include "ComCtl32Util.h"
-#include "math.h"
 
 #include <Region.h>
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#include <cmath>
+
 #include "awt.h"
 #include "mmsystem.h"
 #include "jlong.h"
@@ -34,8 +36,6 @@
 #include "zmouse.h"
 #include <shellapi.h>
 #include <shlobj.h>
-
-#include "math.h"
 
 // WDesktopProperties fields
 jfieldID AwtDesktopProperties::pDataID = 0;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -23,8 +23,8 @@
  * questions.
  */
 
+#include <cmath>
 #include "awt.h"
-#include <math.h>
 #include <strsafe.h>
 #include "jlong.h"
 #include "awt_Font.h"

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
@@ -23,13 +23,13 @@
  * questions.
  */
 
+#include <cmath>
+#include <cfloat>
 #include "awt_Component.h"
 #include "awt_PrintControl.h"
 #include "awt.h"
 #include "awt_PrintDialog.h"
 #include <winspool.h>
-#include <float.h>
-#include <math.h>
 
 #define ROUNDTOINT(x) ((int)((x)+0.5))
 static const int DEFAULT_RES = 72;

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -23,9 +23,9 @@
  * questions.
  */
 
+#include <cmath>
 #include "awt.h"
 #include <strsafe.h>
-#include <math.h>
 #include <windef.h>
 #include <wtypes.h>
 #include <winuser.h>

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1988,7 +1988,7 @@ void AwtToolkit::SetHeapCheck(long flag) {
     }
 }
 
-void throw_if_shutdown(void) throw (awt_toolkit_shutdown)
+void throw_if_shutdown(void)
 {
     AwtToolkit::GetInstance().VerifyActive();
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -37,7 +37,7 @@
  * array index.
  */
 
-#include <cmath>
+#include <cmath> // ceil()
 #include <awt.h>
 #include "awt_Canvas.h"
 #include "awt_Win32GraphicsDevice.h"

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -37,8 +37,8 @@
  * array index.
  */
 
+#include <cmath>
 #include <awt.h>
-#include <sun_awt_Win32GraphicsDevice.h>
 #include "awt_Canvas.h"
 #include "awt_Win32GraphicsDevice.h"
 #include "awt_Window.h"
@@ -46,7 +46,6 @@
 #include "java_awt_color_ColorSpace.h"
 #include "sun_awt_Win32GraphicsDevice.h"
 #include "java_awt_image_DataBuffer.h"
-#include "dither.h"
 #include "img_util_md.h"
 #include "Devices.h"
 #include "systemScale.h"

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -23,6 +23,7 @@
  * questions.
  */
 
+#include <cmath>
 #include "awt.h"
 #include <jlong.h>
 
@@ -45,9 +46,8 @@
 #include "sun_awt_windows_WCanvasPeer.h"
 
 #include <windowsx.h>
-#include <math.h>
 #if !defined(__int3264)
-typedef __int32 LONG_PTR;
+typedef int32_t LONG_PTR;
 #endif // __int3264
 
 // Used for Swing's Menu/Tooltip animation Support

--- a/src/java.desktop/windows/native/libawt/windows/awt_new.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_new.cpp
@@ -81,37 +81,37 @@ NewHandler::handler(size_t) {
 // These three functions throw std::bad_alloc in an out of memory condition
 // instead of returning 0. safe_Realloc will return 0 if memblock is not
 // NULL and size is 0. safe_Malloc and safe_Calloc will never return 0.
-void *safe_Malloc(size_t size) throw (std::bad_alloc) {
-    register void *ret_val = malloc(size);
-    if (ret_val == NULL) {
+void *safe_Malloc(size_t size) {
+    void *ptr = malloc(size);
+    if (ptr == nullptr) {
         throw std::bad_alloc();
     }
 
-    return ret_val;
+    return ptr;
 }
 
-void *safe_Calloc(size_t num, size_t size) throw (std::bad_alloc) {
-    register void *ret_val = calloc(num, size);
-    if (ret_val == NULL) {
+void *safe_Calloc(size_t num, size_t size) {
+    void *ptr = calloc(num, size);
+    if (ptr == nullptr) {
         throw std::bad_alloc();
     }
 
-    return ret_val;
+    return nullptr;
 }
 
-void *safe_Realloc(void *memblock, size_t size) throw (std::bad_alloc) {
-    register void *ret_val = realloc(memblock, size);
+void *safe_Realloc(void *memblock, size_t size) {
+    void *ptr = realloc(memblock, size);
 
     // Special case for realloc.
-    if (memblock != NULL && size == 0) {
-        return ret_val; // even if it's NULL
+    if (memblock != nullptr && size == 0) {
+        return ptr; // even if it's NULL
     }
 
-    if (ret_val == NULL) {
+    if (ptr == nullptr) {
         throw std::bad_alloc();
     }
 
-    return ret_val;
+    return ptr;
 }
 
 #if !defined(DEBUG)
@@ -120,7 +120,7 @@ void *safe_Realloc(void *memblock, size_t size) throw (std::bad_alloc) {
 // std::bad_alloc in an out of memory situation. Instead, VC++ 5.0 returns 0.
 //
 // This function can be safely removed when the problem is corrected.
-void * CDECL operator new(size_t size) throw (std::bad_alloc) {
+void * CDECL operator new(size_t size) {
     return safe_Malloc(size);
 }
 #endif

--- a/src/java.desktop/windows/native/libawt/windows/awt_new.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_new.cpp
@@ -96,7 +96,7 @@ void *safe_Calloc(size_t num, size_t size) {
         throw std::bad_alloc();
     }
 
-    return nullptr;
+    return ptr;
 }
 
 void *safe_Realloc(void *memblock, size_t size) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_new.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_new.cpp
@@ -160,7 +160,7 @@ handle_bad_alloc(void) {
 // std::bad_alloc if a java.lang.OutOfMemoryError is currently pending
 // on the calling thread.
 jthrowable
-safe_ExceptionOccurred(JNIEnv *env) throw (std::bad_alloc) {
+safe_ExceptionOccurred(JNIEnv *env) {
     jthrowable xcp = env->ExceptionOccurred();
     if (xcp != NULL) {
         env->ExceptionClear(); // if we don't do this, isInstanceOf will fail
@@ -188,8 +188,7 @@ safe_ExceptionOccurred(JNIEnv *env) throw (std::bad_alloc) {
 #include <limits.h>
 
 static void
-rand_alloc_fail(const char *file, int line) throw (std::bad_alloc)
-{
+rand_alloc_fail(const char *file, int line) {
     if (alloc_lock == NULL) { // Not yet initialized
         return;
     }
@@ -213,31 +212,23 @@ rand_alloc_fail(const char *file, int line) throw (std::bad_alloc)
     }
 }
 
-void *safe_Malloc_outofmem(size_t size, const char *file, int line)
-    throw (std::bad_alloc)
-{
+void *safe_Malloc_outofmem(size_t size, const char *file, int line) {
     rand_alloc_fail(file, line);
     return safe_Malloc(size);
 }
 
-void *safe_Calloc_outofmem(size_t num, size_t size, const char *file, int line)
-    throw (std::bad_alloc)
-{
+void *safe_Calloc_outofmem(size_t num, size_t size, const char *file, int line) {
     rand_alloc_fail(file, line);
     return safe_Calloc(num, size);
 }
 
 void *safe_Realloc_outofmem(void *memblock, size_t size, const char *file,
-                            int line)
-    throw (std::bad_alloc)
-{
+                            int line) {
     rand_alloc_fail(file, line);
     return safe_Realloc(memblock, size);
 }
 
-void * CDECL operator new(size_t size, const char *file, int line)
-    throw (std::bad_alloc)
-{
+void * CDECL operator new(size_t size, const char *file, int line) {
     rand_alloc_fail(file, line);
     return operator new(size);
 }


### PR DESCRIPTION
Despite the fancy name, all this change does is move a few standard library headers to the top so macro definitions don't break them, remove the register specifiers from allocation methods, and remove dynamic exception specifiers from AWT code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311380](https://bugs.openjdk.org/browse/JDK-8311380): Prepare java.desktop for C++17 (**Enhancement** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14795/head:pull/14795` \
`$ git checkout pull/14795`

Update a local copy of the PR: \
`$ git checkout pull/14795` \
`$ git pull https://git.openjdk.org/jdk.git pull/14795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14795`

View PR using the GUI difftool: \
`$ git pr show -t 14795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14795.diff">https://git.openjdk.org/jdk/pull/14795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14795#issuecomment-1624555126)