### PR TITLE
8311609: [windows] Native stack printing lacks source information for dynamically loaded dlls

### DIFF
--- a/src/hotspot/os/windows/symbolengine.cpp
+++ b/src/hotspot/os/windows/symbolengine.cpp
@@ -576,6 +576,11 @@ bool SymbolEngine::recalc_search_path(bool* p_search_path_was_updated) {
 
 }
 
+bool SymbolEngine::refreshModuleList() {
+  SymbolEngineEntry entry_guard;
+  return WindowsDbgHelp::symRefreshModuleList(::GetCurrentProcess());
+}
+
 bool SymbolEngine::get_source_info(const void* addr, char* buf, size_t buflen,
                                    int* line_no)
 {

--- a/src/hotspot/os/windows/symbolengine.hpp
+++ b/src/hotspot/os/windows/symbolengine.hpp
@@ -49,6 +49,11 @@ namespace SymbolEngine {
   // Returns true for success, false for error.
   bool recalc_search_path(bool* p_search_path_was_updated = nullptr);
 
+  // Refresh the list of loaded modules e.g. pick up any newly loaded dll's
+  // since VM initialization.
+  // Returns true for success, false for error.
+  bool refreshModuleList();
+
   // Print one liner describing state (if library loaded, which functions are
   // missing - if any, and the dbhelp API version)
   void print_state_on(outputStream* st);

--- a/src/hotspot/os/windows/windbghelp.cpp
+++ b/src/hotspot/os/windows/windbghelp.cpp
@@ -35,6 +35,7 @@ typedef BOOL  (WINAPI *pfn_SymGetSymFromAddr64)(HANDLE, DWORD64, PDWORD64, PIMAG
 typedef DWORD (WINAPI *pfn_UnDecorateSymbolName)(const char*, char*, DWORD, DWORD);
 typedef BOOL  (WINAPI *pfn_SymSetSearchPath)(HANDLE, PCTSTR);
 typedef BOOL  (WINAPI *pfn_SymGetSearchPath)(HANDLE, PTSTR, int);
+typedef BOOL  (WINAPI *pfn_SymRefreshModuleList)(HANDLE);
 typedef BOOL  (WINAPI *pfn_StackWalk64)(DWORD MachineType,
                                         HANDLE hProcess,
                                         HANDLE hThread,
@@ -68,7 +69,8 @@ typedef LPAPI_VERSION (WINAPI *pfn_ImagehlpApiVersion)(void);
  DO(SymFunctionTableAccess64) \
  DO(SymGetModuleBase64) \
  DO(MiniDumpWriteDump) \
- DO(SymGetLineFromAddr64)
+ DO(SymGetLineFromAddr64) \
+ DO(SymRefreshModuleList)
 
 
 #define DECLARE_FUNCTION_POINTER(functionname) \
@@ -205,6 +207,14 @@ BOOL WindowsDbgHelp::symGetSearchPath(HANDLE hProcess, PTSTR SearchPath, int Sea
   return FALSE;
 }
 
+BOOL WindowsDbgHelp::symRefreshModuleList(HANDLE hProcess) {
+  WindowsDbgHelpEntry entry_guard;
+  if (g_pfn_SymRefreshModuleList != nullptr) {
+    return g_pfn_SymRefreshModuleList(hProcess);
+  }
+  return FALSE;
+}
+
 BOOL WindowsDbgHelp::stackWalk64(DWORD MachineType,
                                  HANDLE hProcess,
                                  HANDLE hThread,
@@ -301,4 +311,3 @@ void WindowsDbgHelp::print_state_on(outputStream* st) {
   }
   st->cr();
 }
-

--- a/src/hotspot/os/windows/windbghelp.hpp
+++ b/src/hotspot/os/windows/windbghelp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ namespace WindowsDbgHelp {
                          PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
   BOOL symGetLineFromAddr64 (HANDLE hProcess, DWORD64 dwAddr,
                              PDWORD pdwDisplacement, PIMAGEHLP_LINE64 Line);
+  BOOL symRefreshModuleList(HANDLE hProcess);
 
   // Print one liner describing state (if library loaded, which functions are
   // missing - if any, and the dbhelp API version)

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -244,6 +244,9 @@ bool os::win32::platform_print_native_stack(outputStream* st, const void* contex
   stk.AddrPC.Offset       = ctx.Rip;
   stk.AddrPC.Mode         = AddrModeFlat;
 
+  // Ensure we consider dynamically loaded dll's
+  SymbolEngine::refreshModuleList();
+
   int count = 0;
   address lastpc_internal = 0;
   while (count++ < StackPrintLimit) {
@@ -265,6 +268,8 @@ bool os::win32::platform_print_native_stack(outputStream* st, const void* contex
         int line_no;
         if (SymbolEngine::get_source_info(pc, buf, sizeof(buf), &line_no)) {
           st->print("  (%s:%d)", buf, line_no);
+        } else {
+          st->print("  (no source info available)");
         }
         st->cr();
       }


### PR DESCRIPTION
Details are in the JBS issue, but the tl;dr version is we need to call `SymRefreshModuleList` before printing the native stack to ensure we have recently loaded dll's available. You still need the pdb for those dll's to actually get source information, of course.

Testing:
- sanity testing tiers 1-3
- local testing on windows in the context of [JDK-8311541](https://bugs.openjdk.org/browse/JDK-8311541)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311609](https://bugs.openjdk.org/browse/JDK-8311609): [windows] Native stack printing lacks source information for dynamically loaded dlls (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14796/head:pull/14796` \
`$ git checkout pull/14796`

Update a local copy of the PR: \
`$ git checkout pull/14796` \
`$ git pull https://git.openjdk.org/jdk.git pull/14796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14796`

View PR using the GUI difftool: \
`$ git pr show -t 14796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14796.diff">https://git.openjdk.org/jdk/pull/14796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14796#issuecomment-1624553582)