### PR TITLE
8311545: Allow test symbol files to be kept in the test image

### DIFF
--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ define SetupTestFilesCompilationBody
         LIBS := $$($1_LIBS_$$(name)), \
         TOOLCHAIN := $(if $$(filter %.cpp, $$(file)), TOOLCHAIN_LINK_CXX, TOOLCHAIN_DEFAULT), \
         OPTIMIZATION := $$(if $$($1_OPTIMIZATION_$$(name)),$$($1_OPTIMIZATION_$$(name)),LOW), \
-        COPY_DEBUG_SYMBOLS := false, \
+        COPY_DEBUG_SYMBOLS := $$(if $$($1_COPY_DEBUG_SYMBOLS_$$(name)),$$($1_COPY_DEBUG_SYMBOLS_$$(name)),false), \
         STRIP_SYMBOLS := $$(if $$($1_STRIP_SYMBOLS_$$(name)),$$($1_STRIP_SYMBOLS_$$(name)),false), \
         BUILD_INFO_LOG_MACRO := LogInfo, \
     )) \


### PR DESCRIPTION
Please review this simple change to allow a test to request that its symbol files be copied across into the test image.

Testing:
 - sanity test - tiers 1-3
 - direct testing in the context of [JDK-8311541](https://bugs.openjdk.org/browse/JDK-8311541)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311545](https://bugs.openjdk.org/browse/JDK-8311545): Allow test symbol files to be kept in the test image (**Enhancement** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14797/head:pull/14797` \
`$ git checkout pull/14797`

Update a local copy of the PR: \
`$ git checkout pull/14797` \
`$ git pull https://git.openjdk.org/jdk.git pull/14797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14797`

View PR using the GUI difftool: \
`$ git pr show -t 14797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14797.diff">https://git.openjdk.org/jdk/pull/14797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14797#issuecomment-1624572519)