### PR TITLE
8306040:HttpResponseInputStream.available() returns 1 on empty st…

### DIFF
--- a/make/modules/java.desktop/Java.gmk
+++ b/make/modules/java.desktop/Java.gmk
@@ -141,8 +141,7 @@ endif
 # pick them up since they aren't generated when the source dirs are
 # searched and they aren't referenced by any other classes so they won't
 # be picked up by implicit compilation. On a rebuild, they are picked up
-# and compiled. Exclude them here to produce the same rt.jar as the old
-# build does when building just once.
+# and compiled.
 EXCLUDE_FILES += \
     javax/swing/plaf/nimbus/InternalFrameTitlePanePainter.java \
     javax/swing/plaf/nimbus/OptionPaneMessageAreaPainter.java \

--- a/src/demo/share/nbproject/jfc/FileChooserDemo/nbproject/project.xml
+++ b/src/demo/share/nbproject/jfc/FileChooserDemo/nbproject/project.xml
@@ -39,7 +39,6 @@
             <properties>
                 <property-file>user.build.properties</property-file>
                 <property-file>build.properties</property-file>
-                <property name="nbjdk.bootclasspath">${nbjdk.home}/jre/lib/rt.jar</property>
             </properties>
             <folders>
                 <source-folder>

--- a/src/demo/share/nbproject/jfc/Notepad/nbproject/jdk.xml
+++ b/src/demo/share/nbproject/jfc/Notepad/nbproject/jdk.xml
@@ -42,7 +42,6 @@
         <property name="nbjdk.java" value="${nbjdk.home}/bin/java${.exe}"/>
         <property name="nbjdk.javadoc" value="${nbjdk.home}/bin/javadoc${.exe}"/>
         <property name="nbjdk.appletviewer" value="${nbjdk.home}/bin/appletviewer${.exe}"/>
-        <property name="nbjdk.bootclasspath" value="${nbjdk.home}/jre/lib/rt.jar"/>
     </target>
 
     <target name="-jdk-presetdef-basic" depends="-jdk-preinit" unless="nbjdk.presetdef.basic.done">

--- a/src/demo/share/nbproject/jfc/SampleTree/nbproject/project.xml
+++ b/src/demo/share/nbproject/jfc/SampleTree/nbproject/project.xml
@@ -39,7 +39,6 @@
             <properties>
                 <property-file>user.build.properties</property-file>
                 <property-file>build.properties</property-file>
-                <property name="nbjdk.bootclasspath">${nbjdk.home}/jre/lib/rt.jar</property>
             </properties>
             <folders>
                 <source-folder>

--- a/src/demo/share/nbproject/jfc/TableExample/nbproject/project.xml
+++ b/src/demo/share/nbproject/jfc/TableExample/nbproject/project.xml
@@ -39,7 +39,6 @@
             <properties>
                 <property-file>user.build.properties</property-file>
                 <property-file>build.properties</property-file>
-                <property name="nbjdk.bootclasspath">${nbjdk.home}/jre/lib/rt.jar</property>
             </properties>
             <folders>
                 <source-folder>

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -222,7 +222,7 @@ static bool is_directory_secure(const char* path) {
     else {
       // unexpected error, declare the path insecure
       if (PrintMiscellaneous && Verbose) {
-        warning("could not get attributes for file %s: ",
+        warning("could not get attributes for file %s: "
                 " lasterror = %d\n", path, lasterror);
       }
       return false;

--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1153,13 +1153,13 @@ char *ADLParser::parse_one_arg(const char *description) {
     }
     next_char();           // skip the close paren
     if(_curchar != ';') {  // check for semi-colon
-      parse_err(SYNERR, "missing %c in.\n", ';', description);
+      parse_err(SYNERR, "missing %c in %s.\n", ';', description);
       return nullptr;
     }
     next_char();           // skip the semi-colon
   }
   else {
-    parse_err(SYNERR, "Missing %c in.\n", '(', description);
+    parse_err(SYNERR, "Missing %c in %s.\n", '(', description);
     return nullptr;
   }
 
@@ -4191,7 +4191,7 @@ ExpandRule* ADLParser::expand_parse(InstructForm *instr) {
       if (_curchar == '%') { // Need a constructor for the operand
         c = find_cpp_block("Operand Constructor");
         if (c == nullptr) {
-          parse_err(SYNERR, "Invalid code block for operand constructor\n", _curchar);
+          parse_err(SYNERR, "Invalid code block for operand constructor\n");
           continue;
         }
         // Add constructor to _newopconst Dict

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -932,10 +932,11 @@
     <Field type="string" name="result" label="Thread Dump" />
   </Event>
 
-  <Event name="NativeLibrary" category="Java Virtual Machine, Runtime" label="Native Library" period="everyChunk">
+  <Event name="NativeLibrary" category="Java Virtual Machine, Runtime" label="Native Library" period="everyChunk"
+    description="Information about a dynamic library or other native image loaded by the JVM process">
     <Field type="string" name="name" label="Name" />
     <Field type="ulong" contentType="address" name="baseAddress" label="Base Address" description="Starting address of the module" />
-    <Field type="ulong" contentType="address" name="topAddress" label="Top Address" description="Ending address of the module" />
+    <Field type="ulong" contentType="address" name="topAddress" label="Top Address" description="Ending address of the module, if available" />
   </Event>
 
   <Event name="ModuleRequire" category="Java Virtual Machine, Runtime, Modules" label="Module Require" thread="false" period="everyChunk"

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1148,7 +1148,7 @@ bool Arguments::process_argument(const char* arg,
     JVMFlag* fuzzy_matched = JVMFlag::fuzzy_match((const char*)argname, arg_len, true);
     if (fuzzy_matched != nullptr) {
       jio_fprintf(defaultStream::error_stream(),
-                  "Did you mean '%s%s%s'? ",
+                  "Did you mean '%s%s%s'?\n",
                   (fuzzy_matched->is_bool()) ? "(+/-)" : "",
                   fuzzy_matched->name(),
                   (fuzzy_matched->is_bool()) ? "" : "=<value>");
@@ -1913,7 +1913,7 @@ bool Arguments::check_vm_args_consistency() {
   if (UseHeavyMonitors) {
     if (FLAG_IS_CMDLINE(LockingMode) && LockingMode != LM_MONITOR) {
       jio_fprintf(defaultStream::error_stream(),
-                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags", LockingMode);
+                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags\n", LockingMode);
       return false;
     }
     FLAG_SET_CMDLINE(LockingMode, LM_MONITOR);
@@ -1922,21 +1922,21 @@ bool Arguments::check_vm_args_consistency() {
 #if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64) && !defined(S390)
   if (LockingMode == LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),
-                "LockingMode == 0 (LM_MONITOR) is not fully implemented on this architecture");
+                "LockingMode == 0 (LM_MONITOR) is not fully implemented on this architecture\n");
     return false;
   }
 #endif
 #if defined(X86) && !defined(ZERO)
   if (LockingMode == LM_MONITOR && UseRTMForStackLocks) {
     jio_fprintf(defaultStream::error_stream(),
-                "LockingMode == 0 (LM_MONITOR) and -XX:+UseRTMForStackLocks are mutually exclusive");
+                "LockingMode == 0 (LM_MONITOR) and -XX:+UseRTMForStackLocks are mutually exclusive\n");
 
     return false;
   }
 #endif
   if (VerifyHeavyMonitors && LockingMode != LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),
-                "-XX:+VerifyHeavyMonitors requires LockingMode == 0 (LM_MONITOR)");
+                "-XX:+VerifyHeavyMonitors requires LockingMode == 0 (LM_MONITOR)\n");
     return false;
   }
   return status;
@@ -2838,7 +2838,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
         if (jvmci_compiler != nullptr) {
           if (strncmp(jvmci_compiler, "graal", strlen("graal")) != 0) {
             jio_fprintf(defaultStream::error_stream(),
-              "Value of jvmci.Compiler incompatible with +UseGraalJIT: %s", jvmci_compiler);
+              "Value of jvmci.Compiler incompatible with +UseGraalJIT: %s\n", jvmci_compiler);
             return JNI_ERR;
           }
         } else if (!add_property("jvmci.Compiler=graal")) {
@@ -2855,7 +2855,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       if (jvmciFlag != nullptr && jvmciFlag->is_unlocked()) {
         if (!JVMCIGlobals::enable_jvmci_product_mode(origin, use_graal_jit)) {
           jio_fprintf(defaultStream::error_stream(),
-            "Unable to enable JVMCI in product mode");
+            "Unable to enable JVMCI in product mode\n");
           return JNI_ERR;
         }
       }
@@ -3948,7 +3948,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   const NMT_TrackingLevel lvl = NMTUtil::parse_tracking_level(NativeMemoryTracking);
   if (lvl == NMT_unknown) {
     jio_fprintf(defaultStream::error_stream(),
-                "Syntax error, expecting -XX:NativeMemoryTracking=[off|summary|detail]", nullptr);
+                "Syntax error, expecting -XX:NativeMemoryTracking=[off|summary|detail]\n");
     return JNI_ERR;
   }
   if (PrintNMTStatistics && lvl == NMT_off) {

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -186,18 +186,9 @@ void outputStream::put(char ch) {
   write(buf, 1);
 }
 
-#define SP_USE_TABS false
-
 void outputStream::sp(int count) {
   if (count < 0)  return;
-  if (SP_USE_TABS && count >= 8) {
-    int target = position() + count;
-    while (count >= 8) {
-      this->write("\t", 1);
-      count -= 8;
-    }
-    count = target - position();
-  }
+
   while (count > 0) {
     int nw = (count > 8) ? 8 : count;
     this->write("        ", nw);
@@ -257,7 +248,7 @@ void outputStream::date_stamp(bool guard,
 }
 
 outputStream& outputStream::indent() {
-  while (_position < _indentation) sp();
+  sp(_indentation - _position);
   return *this;
 }
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -106,6 +106,8 @@ static const char* env_list[] = {
   "JAVA_HOME", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "CLASSPATH",
   "PATH", "USERNAME",
 
+  "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "FC_LANG", "FONTCONFIG_USE_MMAP",
+
   // Env variables that are defined on Linux/BSD
   "LD_LIBRARY_PATH", "LD_PRELOAD", "SHELL", "DISPLAY",
   "HOSTTYPE", "OSTYPE", "ARCH", "MACHTYPE",

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -538,8 +538,8 @@ public class ResponseSubscribers {
             if (available != 0) return available;
             Iterator<?> iterator = currentListItr;
             if (iterator != null && iterator.hasNext()) return 1;
-            if (buffers.isEmpty()) return 0;
-            return 1;
+            if (!buffers.isEmpty() && buffers.peek() != LAST_LIST ) return 1;
+            return available;
         }
 
         @Override

--- a/src/java.sql/share/classes/java/sql/DriverManager.java
+++ b/src/java.sql/share/classes/java/sql/DriverManager.java
@@ -652,10 +652,9 @@ public class DriverManager {
     private static Connection getConnection(
         String url, java.util.Properties info, Class<?> caller) throws SQLException {
         /*
-         * When callerCl is null, we should check the application's
-         * (which is invoking this class indirectly)
-         * classloader, so that the JDBC driver class outside rt.jar
-         * can be loaded from here.
+         * If the caller is defined to the bootstrap or platform class loader then use
+         * the Thread CCL as the initiating class loader so that a JDBC on the class path,
+         * or bundled with an application, is found.
          */
         ClassLoader callerCL = caller != null ? caller.getClassLoader() : null;
         if (callerCL == null || callerCL == ClassLoader.getPlatformClassLoader()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -193,7 +193,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     }
 
     /**
-     * Set whether or not to use ct.sym as an alternate to rt.jar.
+     * Set whether or not to use ct.sym as an alternate to the current runtime.
      */
     public void setSymbolFileEnabled(boolean b) {
         symbolFileEnabled = b;

--- a/test/hotspot/jtreg/compiler/c2/Test6603011.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6603011.java
@@ -212,7 +212,6 @@ public class Test6603011 implements Runnable {
     }
 
     // Try a few divisors outside the typical range.
-    // The values below have been observed in rt.jar.
     test_divisor(101, apploader);
     test_divisor(400, apploader);
     test_divisor(1000, apploader);

--- a/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
+++ b/test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
@@ -58,7 +58,13 @@ public class TestMetaSpaceLog {
     // Do this once here.
     // Scan for Metaspace update notices as part of the GC log, e.g. in this form:
     // [gc,metaspace   ] GC(0) Metaspace: 11895K(14208K)->11895K(14208K) NonClass: 10552K(12544K)->10552K(12544K) Class: 1343K(1664K)->1343K(1664K)
-    metaSpaceRegexp = Pattern.compile(".*Metaspace: ([0-9]+).*->([0-9]+).*");
+    // This regex has to be up-to-date with the format used in hotspot to print metaspace change.
+    final String NUM_K = "\\d+K";
+    final String GP_NUM_K = "(\\d+)K";
+    final String BR_NUM_K = "\\(" + NUM_K + "\\)";
+    final String SIZE_CHG = NUM_K + BR_NUM_K + "->" + NUM_K + BR_NUM_K;
+    metaSpaceRegexp = Pattern.compile(".* Metaspace: " + GP_NUM_K + BR_NUM_K + "->" + GP_NUM_K + BR_NUM_K
+                                      + "( NonClass: " + SIZE_CHG + " Class: " + SIZE_CHG + ")?$");
   }
 
   public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
@@ -37,7 +37,7 @@
  *     Test checks that agent's JAR file is appended at the end of the system class path.
  *     Agent's JAR file contains modified class java.util.TooManyListenersException (it is assumed
  *     that this class isn't loaded before agent is loaded), agent instantiates TooManyListenersException
- *     and checks that non-modified version of this class was loaded from rt.jar (not from agent's JAR).
+ *     and checks that non-modified version of this class was loaded from the jdk image (not from agent's JAR).
  *
  * @library /vmTestbase
  *          /test/lib

--- a/test/jdk/com/sun/tools/attach/ProviderTest.java
+++ b/test/jdk/com/sun/tools/attach/ProviderTest.java
@@ -107,7 +107,7 @@ public class ProviderTest {
     public static class TestMain {
         public static void main(String args[]) throws Exception {
             // deal with internal builds where classes are loaded from the
-            // 'classes' directory rather than rt.jar
+            // 'classes' directory rather than the runtime image
             ClassLoader cl = AttachProvider.class.getClassLoader();
             if (cl != ClassLoader.getSystemClassLoader()) {
                 System.out.println("Attach API not loaded by system class loader - test skipped");

--- a/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
+++ b/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
@@ -228,8 +228,7 @@ public class FieldSetAccessibleTest {
             throw new RuntimeException("Test failed for the following classes: " + failed);
         }
         if (!classFound && startIndex == 0 && index < maxIndex) {
-            // this is just to verify that we have indeed parsed rt.jar
-            // (or the java.base module)
+            // this is just to verify that we have indeed parsed the java.base module
             throw  new RuntimeException("Test failed: Class.class not found...");
         }
         if (classCount.get() == 0 && startIndex == 0) {

--- a/test/jdk/java/net/httpclient/HttpInputStreamAvailableTest.java
+++ b/test/jdk/java/net/httpclient/HttpInputStreamAvailableTest.java
@@ -24,17 +24,16 @@
 /**
  * @test
  * @bug 8306040
- * @library /test/lib
- * @run junit HttpInputStreamAvailableTest
+ * @summary HttpResponseInputStream.available() returns 1 on empty stream
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @run testng/othervm  HttpInputStreamAvailableTest
+ * 
  */
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import jdk.test.lib.net.URIBuilder;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,10 +46,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.testng.annotations.Test;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import static org.testng.Assert.assertEquals;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class HttpInputStreamAvailableTest {
 
     private HttpServer server;
@@ -58,8 +58,8 @@ public class HttpInputStreamAvailableTest {
     static final String TEST_MESSAGE = "This is test message";
     static final int ZERO = 0;
 
-    @BeforeAll
-    void before() throws Exception {
+    @BeforeTest
+    void setup() throws Exception {
         InetAddress loopback = InetAddress.getLoopbackAddress();
         InetSocketAddress addr = new InetSocketAddress(loopback, 0);
         server = HttpServer.create(addr, 0);
@@ -71,8 +71,8 @@ public class HttpInputStreamAvailableTest {
         server.start();
     }
 
-    @AfterAll
-    void after() throws Exception {
+    @AfterTest
+    void teardown() throws Exception {
         server.stop(0);
     }
 
@@ -112,7 +112,7 @@ public class HttpInputStreamAvailableTest {
                 assertEquals(ZERO, in.available());
             }
         } catch (IOException | InterruptedException | URISyntaxException t) {
-            fail();
+            throw t;
         }
     }
 
@@ -145,7 +145,7 @@ public class HttpInputStreamAvailableTest {
                 assertEquals(ZERO, in.available());
             }
         } catch (IOException | InterruptedException | URISyntaxException t) {
-            fail();
+            throw t;
         }
     }
 

--- a/test/jdk/java/net/httpclient/HttpInputStreamAvailableTest.java
+++ b/test/jdk/java/net/httpclient/HttpInputStreamAvailableTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8306040
+ * @library /test/lib
+ * @run junit HttpInputStreamAvailableTest
+ */
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class HttpInputStreamAvailableTest {
+
+    private HttpServer server;
+    private int port;
+    static final String TEST_MESSAGE = "This is test message";
+    static final int ZERO = 0;
+
+    @BeforeAll
+    void before() throws Exception {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress addr = new InetSocketAddress(loopback, 0);
+        server = HttpServer.create(addr, 0);
+        port = server.getAddress().getPort();
+        FirstHandler fHandler = new FirstHandler();
+        server.createContext("/NonZeroResponse/", fHandler);
+        SecondHandler sHandler = new SecondHandler();
+        server.createContext("/ZeroResponse/", sHandler);
+        server.start();
+    }
+
+    @AfterAll
+    void after() throws Exception {
+        server.stop(0);
+    }
+
+    @Test
+    public void test() throws Exception {
+        try {
+            HttpClient client = HttpClient
+                    .newBuilder()
+                    .proxy(HttpClient.Builder.NO_PROXY)
+                    .build();
+
+            URI uri = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/NonZeroResponse/")
+                    .build();
+
+            HttpRequest request = HttpRequest
+                    .newBuilder(uri)
+                    .GET()
+                    .build();
+
+            // Send a httpRequest and assert the bytes available
+            HttpResponse<InputStream> response = client.send(request,
+                    HttpResponse.BodyHandlers.ofInputStream());
+            try ( InputStream in = response.body()) {
+                // This is an estimate and implementation dependent.
+                // If you use HttpURLConnection, then in.available() will return
+                // different value.
+                assertEquals(ZERO, in.available());
+                in.readNBytes(2);
+                assertEquals(TEST_MESSAGE.length() - 2, in.available());
+                //read the remaining data
+                in.readAllBytes();
+                //available should return 0
+                assertEquals(ZERO, in.available());
+            }
+        } catch (IOException | InterruptedException | URISyntaxException t) {
+            fail();
+        }
+    }
+
+    @Test
+    public void test1() throws Exception {
+        try {
+            HttpClient client = HttpClient
+                    .newBuilder()
+                    .proxy(HttpClient.Builder.NO_PROXY)
+                    .build();
+
+            URI uri = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/ZeroResponse/")
+                    .build();
+
+            HttpRequest request = HttpRequest
+                    .newBuilder(uri)
+                    .GET()
+                    .build();
+
+            // Send a httpRequest and assert the bytes available
+            HttpResponse<InputStream> response = client.send(request,
+                    HttpResponse.BodyHandlers.ofInputStream());
+            try ( InputStream in = response.body()) {
+                assertEquals(ZERO, in.available());
+                in.readAllBytes();
+                assertEquals(ZERO, in.available());
+            }
+        } catch (IOException | InterruptedException | URISyntaxException t) {
+            fail();
+        }
+    }
+
+    static class FirstHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            try ( OutputStream os = exchange.getResponseBody()) {
+                byte[] workingResponse = TEST_MESSAGE.getBytes();
+                exchange.sendResponseHeaders(200, workingResponse.length);
+                os.write(workingResponse);
+                os.flush();
+            }
+        }
+    }
+
+    static class SecondHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            exchange.sendResponseHeaders(204, -1);
+        }
+    }
+}

--- a/test/langtools/tools/javap/4798312/JavapShouldLoadClassesFromRTJarTest.java
+++ b/test/langtools/tools/javap/4798312/JavapShouldLoadClassesFromRTJarTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4798312
- * @summary In Windows, javap doesn't load classes from rt.jar
+ * @summary In Windows, javap doesn't load classes from the runtime image
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main


### PR DESCRIPTION
Please review the code change for  [JDK-8306040](https://bugs.openjdk.org/browse/JDK-8306040). In the overridden "available" method of "HttpResponseInputStream" we are returning 1 after exploring all the code path.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14798/head:pull/14798` \
`$ git checkout pull/14798`

Update a local copy of the PR: \
`$ git checkout pull/14798` \
`$ git pull https://git.openjdk.org/jdk.git pull/14798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14798`

View PR using the GUI difftool: \
`$ git pr show -t 14798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14798.diff">https://git.openjdk.org/jdk/pull/14798.diff</a>

</details>
