### PR TITLE
8311557: [JVMCI] deadlock with JVMTI thread suspension

### DIFF
--- a/src/hotspot/share/compiler/compilerThread.cpp
+++ b/src/hotspot/share/compiler/compilerThread.cpp
@@ -61,3 +61,8 @@ void CompilerThread::thread_entry(JavaThread* thread, TRAPS) {
 bool CompilerThread::can_call_java() const {
   return _compiler != nullptr && _compiler->is_jvmci();
 }
+
+// Hide native compiler threads from external view.
+bool CompilerThread::is_hidden_from_external_view() const {
+  return _compiler == nullptr || !_compiler->is_jvmci() || UseJVMCINativeLibrary;
+}

--- a/src/hotspot/share/compiler/compilerThread.hpp
+++ b/src/hotspot/share/compiler/compilerThread.hpp
@@ -72,8 +72,7 @@ class CompilerThread : public JavaThread {
 
   virtual bool can_call_java() const;
 
-  // Hide native compiler threads from external view.
-  bool is_hidden_from_external_view() const      { return !can_call_java(); }
+  virtual bool is_hidden_from_external_view() const;
 
   void set_compiler(AbstractCompiler* c)         { _compiler = c; }
   AbstractCompiler* compiler() const             { return _compiler; }


### PR DESCRIPTION
Java based JVMCI compiler threads are more like normal Java threads so they aren't `hidden_from_external_view` like the native compilers.  This can leak to deadlocks if you use JVMTI to suspend all threads since this will block the compiler queue and can block execution if background compilation is disabled.  It's reasonable to treat libgraal threads like native threads in this regard.  Making jargraal threads hidden too would interfere with using profiling and debugging tool on them so I've left that alone but it might be worth changing the JVMTI suspend and resume functions to explicitly skip compiler threads as well.