### PR TITLE
8311548: AArch64: [ZGC] Many tests fail with "assert(allocates2(pc)) failed: not in CodeBuffer memory" on some CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -39,7 +39,7 @@ enum platform_dependent_constants {
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
   _compiler_stubs_code_size     = 30000 ZGC_ONLY(+10000),
-  _final_stubs_code_size        = 20000 ZGC_ONLY(+60000)
+  _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 
 class aarch64 {


### PR DESCRIPTION
### Problem:

We got many ZGC related JTreg test failures on ThunderX2 CPU. The failure can be easily reproduced by the following command as well.

  `java -XX:+UseZGC -XX:+ZGenerational --version`

Here shows the snippet of error message:

```
 A fatal error has been detected by the Java Runtime Environment:

 Internal Error (~/jdk_build/jdk_src/src/hotspot/share/asm/codeBuffer.hpp:200), pid=108369, tid=108373
 assert(allocates2(pc)) failed: not in CodeBuffer memory: 0x0000ffff9c921100 <= 0x0000ffff9c934c04 <= 0x0000ffff9c934c00

 JRE version: (22.0) (fastdebug build )
 Java VM: OpenJDK 64-Bit Server VM (fastdebug 22-internal-git-0916e6a60, mixed mode, sharing, compressed class ptrs, z gc, linux-aarch64)
 Problematic frame:
 V [libjvm.so+0x45413c] Instruction_aarch64::~Instruction_aarch64()+0xbc
```

### Root cause:

From the backtrace (See the Description session in the JBS [1]), we can see that it's an assembler failure and the failure occurred when the VM generated "final stubs". The root cause is that the buffer size of "final stubs" is too small for ThunderX2 CPU with ZGC on.

The reason that this failure only occurred on ThunderX2 CPU but not on CPUs like Neoverse N1/N2, is that 1) VM flag "AvoidUnalignedAccesses" is enabled by default on CPUs like ThunderX2 (See the code [2]), and 2) more instructions would be generated especially with ZGC (E.g., see the code [3]).

Hence, the failure would also occur on CPUs like Neoverse N1/N2 if we pass VM option "-XX:+AvoidUnalignedAccesses", e.g.,

`java -XX:+UseZGC -XX:+ZGenerational -XX:+AvoidUnalignedAccesses --version`

### Fix:

Increasing the buffer size for "final blobs", i.e. variable `_final_stubs_code_size`, would fix the failure.

We manually computed the code size for "final stubs" on ThunderX2 CPU and the size is roughly "105568" bytes. In this patch, we increase the buffer size from "60000" to "100000" for ZGC_ONLY().

### Test:

Tier1~3 passed on Linux/ThunderX2 and Linux/Neoverse N1.

[1] https://bugs.openjdk.org/browse/JDK-8311548
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp#L154-L177
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp#L919-L1109