### PR TITLE
8311631: When multiple users run tools/jpackage/share/LicenseTest.java, Permission denied for writing /var/tmp/*.files

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -30,9 +30,9 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 #build time will substantially increase and it may require unpack200/system java to install
 %define __jar_repack %{nil}
 
-%define package_filelist %{_tmppath}/%{name}_%(%{__id_u} -n).files
-%define app_filelist %{_tmppath}/%{name}_%(%{__id_u} -n).app.files
-%define filesystem_filelist %{_tmppath}/%{name}_%(%{__id_u} -n).filesystem.files
+%define package_filelist %{_builddir}/%{name}.files
+%define app_filelist %{_builddir}/%{name}.app.files
+%define filesystem_filelist %{_builddir}/%{name}.filesystem.files
 
 %define default_filesystem / /opt /usr /usr/bin /usr/lib /usr/local /usr/local/bin /usr/local/lib
 

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -30,9 +30,9 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 #build time will substantially increase and it may require unpack200/system java to install
 %define __jar_repack %{nil}
 
-%define package_filelist %{_tmppath}/%{name}.files
-%define app_filelist %{_tmppath}/%{name}.app.files
-%define filesystem_filelist %{_tmppath}/%{name}.filesystem.files
+%define package_filelist %{_tmppath}/%{name}_%(%{__id_u} -n).files
+%define app_filelist %{_tmppath}/%{name}_%(%{__id_u} -n).app.files
+%define filesystem_filelist %{_tmppath}/%{name}_%(%{__id_u} -n).filesystem.files
 
 %define default_filesystem / /opt /usr /usr/bin /usr/lib /usr/local /usr/local/bin /usr/local/lib
 

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -30,6 +30,7 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 #build time will substantially increase and it may require unpack200/system java to install
 %define __jar_repack %{nil}
 
+
 %define package_filelist %{_builddir}/%{name}.files
 %define app_filelist %{_builddir}/%{name}.app.files
 %define filesystem_filelist %{_builddir}/%{name}.filesystem.files

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -30,7 +30,6 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 #build time will substantially increase and it may require unpack200/system java to install
 %define __jar_repack %{nil}
 
-
 %define package_filelist %{_builddir}/%{name}.files
 %define app_filelist %{_builddir}/%{name}.app.files
 %define filesystem_filelist %{_builddir}/%{name}.filesystem.files


### PR DESCRIPTION
The prerequisite is to install the rpmbuild command, when multiple users switch to write /var/tmp/*.files will have the permission forbidden.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311631](https://bugs.openjdk.org/browse/JDK-8311631): When multiple users run tools/jpackage/share/LicenseTest.java, Permission denied for writing /var/tmp/*.files (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14802/head:pull/14802` \
`$ git checkout pull/14802`

Update a local copy of the PR: \
`$ git checkout pull/14802` \
`$ git pull https://git.openjdk.org/jdk.git pull/14802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14802`

View PR using the GUI difftool: \
`$ git pr show -t 14802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14802.diff">https://git.openjdk.org/jdk/pull/14802.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14802#issuecomment-1627056134)