### PR TITLE
8262742: (fs) Add Path::resolve with varargs string

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -522,9 +522,9 @@ public interface Path
      *
      * <p> If {@code more} does not specify any {@code Path}s,
      * then the result is {@link #resolve(Path) resolve(first)}. If
-     * {@code more} specifies one or more {@code Path}s, then each non-empty
-     * {@code Path}, including {@code first}, is resolved iteratively against
-     * this {@code Path}.
+     * {@code more} specifies one or more {@code Path}s, then {@code first}
+     * is resolved against this path and then the additional paths in
+     * {@code more} are iteratively resolved.
      *
      * If {@code first} and {@code more} specify only empty paths, then this
      * method returns this path. If any of the paths in {@code first} and
@@ -551,7 +551,7 @@ public interface Path
      *          the first path to resolve against this path
      *
      * @param   more
-     *          additional paths to be iteratively resolved against this path
+     *          additional paths to be iteratively resolved
      *
      * @return  the resulting path
      *
@@ -574,10 +574,11 @@ public interface Path
      * <p> If {@code more} does not
      * specify any path strings, then the result is {@link #resolve(String)
      * resolve(first)}. If {@code more} specifies one or more path strings,
-     * then each non-empty path string, including {@code first}, is iteratively
-     * converted to a {@code Path} and resolved against this {@code Path}.
-     * Path strings which convert to empty or absolute paths are handled as
-     * specified by {@link #resolve(Path,Path...)}.
+     * then {@code first} is converted to a {@code Path}, resolved against
+     * this path, and then the additional path strings in {@code more} are
+     * iteratively converted to {@code Path}s and resolved. Path strings which
+     * convert to empty or absolute paths are handled as specified by
+     * {@link #resolve(Path,Path...)}.
      *
      * <p> The result of this method is the same as would be obtained by
      * resolving the path converted from the first path string against
@@ -600,7 +601,7 @@ public interface Path
      *
      * @param   more
      *          additional path strings to be iteratively converted to
-     *          paths and resolved against this path
+     *          paths and resolved
      *
      * @return  the resulting path
      *

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -521,7 +521,7 @@ public interface Path
      *
      * <p> The result of this method is the same as would be obtained
      * by resolving the first parameter path against this path, then
-     * resovling the second parameter path against the derived path,
+     * resolving the second parameter path against the derived path,
      * and so on until all parameters have been processed. Each single
      * resolution in the chain behaves as specified by {@linkplain
      * #resolve(Path) resolve}.

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -517,7 +517,18 @@ public interface Path
     }
 
     /**
-     * Resolves a path, or a sequence of paths against this path.
+     * Resolves one or more {@code Path}s iteratively against this
+     * {@code Path}. If {@code more} does not specify any {@code Path}s,
+     * then the result is {@link #resolve(Path) resolve(first)}. If
+     * {@code more} specifies one or more {@code Path}s, then each non-empty
+     * {@code Path}, including {@code first}, is resolved iteratively against
+     * this {@code Path}.
+     *
+     * If {@code first} and {@code more} specify only empty paths, then this
+     * method returns this path. If any of the paths in {@code first} and
+     * {@code more} is absolute, then the result will be as if the paths
+     * after the last absolute path in the sequence were resolved iteratively
+     * against that last absolute path.
      *
      * <p> The result of this method is the same as would be obtained
      * by resolving the first parameter path against this path, and then
@@ -536,7 +547,7 @@ public interface Path
      *
      * @param first the first path to resolve against this path
      *
-     * @param more additional paths to be joined to form the path
+     * @param more additional paths to be iteratively resolved against this path
      *
      * @return the resulting path
      *
@@ -553,8 +564,14 @@ public interface Path
     }
 
     /**
-     * Resolves the path or paths converted from a path string, or a
-     * sequence of path strings, against this path.
+     * Resolves one or more {@code Path}s converted from the supplied path
+     * srings iteratively against this {@code Path}. If {@code more} does not
+     * specify any path strings, then the result is {@link #resolve(String)
+     * resolve(first)}. If {@code more} specifies one or more path strings,
+     * then each non-empty path string, including {@code first}, is iteratively
+     * converted to a {@code Path} and resolved against this {@code Path}.
+     * Path strings which convert to empty or absolute paths are handled as
+     * specified by {@link #resolve(Path,Path...)}.
      *
      * <p> The result of this method is the same as would be obtained by
      * resolving the path converted from the first path string against
@@ -571,9 +588,11 @@ public interface Path
      * }
      * }
      *
-     * @param first the first path string to resolve against this path
+     * @param first the first path string to convert to a path and
+     *        resolve against this path
      *
-     * @param more additional path strings to be joined to form the path
+     * @param more additional path strings to be iteratively converted to
+     *        paths and resolved against this path
      *
      * @return the resulting path
      *

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -517,13 +517,12 @@ public interface Path
     }
 
     /**
-     * Resolves a path or a sequence of paths against this path.
+     * Resolves a path, or a sequence of paths against this path.
      *
      * <p> The result of this method is the same as would be obtained
-     * by resolving the first parameter path against this path, then
-     * resolving the second parameter path against the derived path,
-     * and so on until all parameters have been processed. Each single
-     * resolution in the chain behaves as specified by {@linkplain
+     * by resolving the first parameter path against this path, and then
+     * repeating the same procedure for each path in the sequence. Each
+     * single resolution in the chain behaves as specified by {@link
      * #resolve(Path) resolve}.
      *
      * @implSpec
@@ -554,17 +553,14 @@ public interface Path
     }
 
     /**
-     * Converts a path string or a sequence of path strings into one or more
-     * {@code Path}s and resolves them against this {@code Path} in exactly
-     * the same manner specified by the {@link #resolve(Path,Path...) resolve}
-     * method.
+     * Resolves the path or paths converted from a path string, or a
+     * sequence of path strings, against this path.
      *
-     * <p> The result of this method is the same as would be obtained
-     * by resolving the first parameter path string against this path, then
-     * resolving the second parameter path string against the derived path,
-     * and so on until all parameters have been processed. Each single
-     * resolution in the chain behaves as specified by {@linkplain
-     * #resolve(String) resolve}.
+     * <p> The result of this method is the same as would be obtained by
+     * resolving the path converted from the first path string against
+     * this path, and then repeating the same procedure for each path
+     * string in the sequence. Each single resolution in the chain
+     * behaves as specified by {@link #resolve(String) resolve}.
      *
      * @implSpec
      * The default implementation is equivalent for this path to:
@@ -582,7 +578,7 @@ public interface Path
      * @return the resulting path
      *
      * @throws  InvalidPathException
-     *          if the path string cannot be converted to a Path.
+     *          if a path string cannot be converted to a Path.
      *
      * @see #resolve(String)
      *

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -517,8 +517,10 @@ public interface Path
     }
 
     /**
-     * Resolves one or more {@code Path}s iteratively against this
-     * {@code Path}. If {@code more} does not specify any {@code Path}s,
+     * Resolves a path against this path, and then iteratively resolves any
+     * additional paths.
+     *
+     * <p> If {@code more} does not specify any {@code Path}s,
      * then the result is {@link #resolve(Path) resolve(first)}. If
      * {@code more} specifies one or more {@code Path}s, then each non-empty
      * {@code Path}, including {@code first}, is resolved iteratively against
@@ -545,11 +547,13 @@ public interface Path
      * }
      * }
      *
-     * @param first the first path to resolve against this path
+     * @param   first
+     *          the first path to resolve against this path
      *
-     * @param more additional paths to be iteratively resolved against this path
+     * @param   more
+     *          additional paths to be iteratively resolved against this path
      *
-     * @return the resulting path
+     * @return  the resulting path
      *
      * @see #resolve(Path)
      *
@@ -564,8 +568,10 @@ public interface Path
     }
 
     /**
-     * Resolves one or more {@code Path}s converted from the supplied path
-     * srings iteratively against this {@code Path}. If {@code more} does not
+     * Converts a path string to a path, resolves it against this path, and
+     * then iteratively converts and resolves any additional path strings.
+     *
+     * <p> If {@code more} does not
      * specify any path strings, then the result is {@link #resolve(String)
      * resolve(first)}. If {@code more} specifies one or more path strings,
      * then each non-empty path string, including {@code first}, is iteratively
@@ -588,17 +594,20 @@ public interface Path
      * }
      * }
      *
-     * @param first the first path string to convert to a path and
-     *        resolve against this path
+     * @param   first
+     *          the first path string to convert to a path and
+     *          resolve against this path
      *
-     * @param more additional path strings to be iteratively converted to
-     *        paths and resolved against this path
+     * @param   more
+     *          additional path strings to be iteratively converted to
+     *          paths and resolved against this path
      *
-     * @return the resulting path
+     * @return  the resulting path
      *
      * @throws  InvalidPathException
      *          if a path string cannot be converted to a Path.
      *
+     * @see #resolve(Path,Path...)
      * @see #resolve(String)
      *
      * @since 22

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -517,6 +517,89 @@ public interface Path
     }
 
     /**
+     * Resolves a path or a sequence of paths against this path.
+     *
+     * <p> The result of this method is the same as would be obtained
+     * by resolving the first parameter path against this path, then
+     * resovling the second parameter path against the derived path,
+     * and so on until all parameters have been processed. Each single
+     * resolution in the chain behaves as specified by {@linkplain
+     * #resolve(Path) resolve}.
+     *
+     * @implSpec
+     * The default implementation is equivalent for this path to:
+     * {@snippet lang=java :
+     * Path result = resolve(first);
+     * for (Path p : more) {
+     *     result = result.resolve(p);
+     * }
+     * }
+     *
+     * @param first the first path to resolve against this path
+     *
+     * @param more additional paths to be joined to form the path
+     *
+     * @return the resulting path
+     *
+     * @throws  InvalidPathException
+     *          if the path string cannot be converted to a Path.
+     *
+     * @see #resolve(Path)
+     *
+     * @since 22
+     */
+    default Path resolve(Path first, Path... more) {
+        Path result = resolve(first);
+        for (Path p : more) {
+            result = result.resolve(p);
+        }
+        return result;
+    }
+
+    /**
+     * Converts a path string or a sequence of path strings into one or more
+     * {@code Path}s and resolves them against this {@code Path} in exactly
+     * the same manner specified by the {@link #resolve(Path,Path...) resolve}
+     * method.
+     *
+     * <p> The result of this method is the same as would be obtained
+     * by resolving the first parameter path string against this path, then
+     * resovling the second parameter path string against the derived path,
+     * and so on until all parameters have been processed. Each single
+     * resolution in the chain behaves as specified by {@linkplain
+     * #resolve(String) resolve}.
+     *
+     * @implSpec
+     * The default implementation is equivalent for this path to:
+     * {@snippet lang=java :
+     * Path result = resolve(first);
+     * for (String s : more) {
+     *     result = result.resolve(s);
+     * }
+     * }
+     *
+     * @param first the first path string to resolve against this path
+     *
+     * @param more additional path strings to be joined to form the path
+     *
+     * @return the resulting path
+     *
+     * @throws  InvalidPathException
+     *          if the path string cannot be converted to a Path.
+     *
+     * @see #resolve(String)
+     *
+     * @since 22
+     */
+    default Path resolve(String first, String... more) {
+        Path result = resolve(first);
+        for (String s : more) {
+            result = result.resolve(s);
+        }
+        return result;
+    }
+
+    /**
      * Resolves the given path against this path's {@link #getParent parent}
      * path. This is useful where a file name needs to be <i>replaced</i> with
      * another file name. For example, suppose that the name separator is

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -520,43 +520,29 @@ public interface Path
      * Resolves a path against this path, and then iteratively resolves any
      * additional paths.
      *
-     * <p> If {@code more} does not specify any {@code Path}s,
-     * then the result is {@link #resolve(Path) resolve(first)}. If
-     * {@code more} specifies one or more {@code Path}s, then {@code first}
-     * is resolved against this path and then the additional paths in
-     * {@code more} are iteratively resolved.
-     *
-     * If {@code first} and {@code more} specify only empty paths, then this
-     * method returns this path. If any of the paths in {@code first} and
-     * {@code more} is absolute, then the result will be as if the paths
-     * after the last absolute path in the sequence were resolved iteratively
-     * against that last absolute path.
-     *
-     * <p> The result of this method is the same as would be obtained
-     * by resolving the first parameter path against this path, and then
-     * repeating the same procedure for each path in the sequence. Each
-     * single resolution in the chain behaves as specified by {@link
-     * #resolve(Path) resolve}.
+     * <p> This method resolves {@code first} against this {@code Path} as if
+     * by calling {@link #resolve(Path)}. If {@code more} has one or more
+     * elements then it resolves the first element against the result, then
+     * iteratively resolves all subsequent elements. This method returns the
+     * result from the final resolve.
      *
      * @implSpec
-     * The default implementation is equivalent for this path to:
+     * The default implementation is equivalent to the result obtained with:
      * {@snippet lang=java :
-     * Path result = resolve(first);
-     * for (Path p : more) {
-     *     result = result.resolve(p);
-     * }
+     *     Path result = resolve(first);
+     *     for (Path p : more) {
+     *         result = result.resolve(p);
+     *     }
      * }
      *
      * @param   first
      *          the first path to resolve against this path
-     *
      * @param   more
-     *          additional paths to be iteratively resolved
+     *          additional paths to iteratively resolve
      *
      * @return  the resulting path
      *
      * @see #resolve(Path)
-     *
      * @since 22
      */
     default Path resolve(Path first, Path... more) {
@@ -568,26 +554,19 @@ public interface Path
     }
 
     /**
-     * Converts a path string to a path, resolves it against this path, and
-     * then iteratively converts and resolves any additional path strings.
+     * Converts a path string to a path, resolves that path against this path,
+     * and then iteratively performs the same procedure for any additional
+     * path strings.
      *
-     * <p> If {@code more} does not
-     * specify any path strings, then the result is {@link #resolve(String)
-     * resolve(first)}. If {@code more} specifies one or more path strings,
-     * then {@code first} is converted to a {@code Path}, resolved against
-     * this path, and then the additional path strings in {@code more} are
-     * iteratively converted to {@code Path}s and resolved. Path strings which
-     * convert to empty or absolute paths are handled as specified by
-     * {@link #resolve(Path,Path...)}.
-     *
-     * <p> The result of this method is the same as would be obtained by
-     * resolving the path converted from the first path string against
-     * this path, and then repeating the same procedure for each path
-     * string in the sequence. Each single resolution in the chain
-     * behaves as specified by {@link #resolve(String) resolve}.
+     * <p> This method converts {@code first} to a {@code Path} and resolves
+     * that {@code Path} against this {@code Path} as if by calling
+     * {@link #resolve(String)}. If {@code more} has one or more elements
+     * then it converts the first element to a path, resolves that path against
+     * the result, then iteratively converts and resolves all subsequent
+     * elements. This method returns the result from the final resolve.
      *
      * @implSpec
-     * The default implementation is equivalent for this path to:
+     * The default implementation is equivalent to the result obtained with:
      * {@snippet lang=java :
      * Path result = resolve(first);
      * for (String s : more) {

--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -541,9 +541,6 @@ public interface Path
      *
      * @return the resulting path
      *
-     * @throws  InvalidPathException
-     *          if the path string cannot be converted to a Path.
-     *
      * @see #resolve(Path)
      *
      * @since 22
@@ -564,7 +561,7 @@ public interface Path
      *
      * <p> The result of this method is the same as would be obtained
      * by resolving the first parameter path string against this path, then
-     * resovling the second parameter path string against the derived path,
+     * resolving the second parameter path string against the derived path,
      * and so on until all parameters have been processed. Each single
      * resolution in the chain behaves as specified by {@linkplain
      * #resolve(String) resolve}.

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -395,58 +395,57 @@ class UnixPath implements Path {
         return resolve(new UnixPath(getFileSystem(), other));
     }
 
-   private static final byte[] resolve(byte[] base, byte[]... descendants) {
+   private static final byte[] resolve(byte[] base, byte[]... children) {
        // 'start' is either zero, indicating the base, or indicates which
-       // descendant is that last one which is an absolute path
+       // child is that last one which is an absolute path
        int start = 0;
-       int length = base.length;
+       int resultLength = base.length;
 
-       // Locate the last descendant which is an absolute path and calculate
+       // Locate the last child which is an absolute path and calculate
        // the total number of bytes in the resolved path
-       final int count = descendants.length;
+       final int count = children.length;
        if (count > 0) {
            for (int i = 0; i < count; i++) {
-               byte[] b = descendants[i];
+               byte[] b = children[i];
                if (b.length > 0) {
                    if (b[0] == '/') {
                        start = i + 1;
-                       length = b.length;
+                       resultLength = b.length;
                    } else {
-                       if (length > 0)
-                           length++;
-                       length += b.length;
+                       if (resultLength > 0)
+                           resultLength++;
+                       resultLength += b.length;
                    }
                }
            }
        }
 
-       // If the base is not being superseded by a descendant which is an
-       // absolute path, then if at least one descendant is non-empty and
-       // the base consists only of a '/', then decrement the length to
-       // account for an extra '/' added in the length computation.
-       if (start == 0 && length > base.length &&
-           base.length == 1 && base[0] == '/')
-           length--;
+       // If the base is not being superseded by a child which is an
+       // absolute path, then if at least one child is non-empty and
+       // the base consists only of a '/', then decrement resultLength to
+       // account for an extra '/' added in the resultLength computation.
+       if (start == 0 && resultLength > base.length && base.length == 1 && base[0] == '/')
+           resultLength--;
 
        // Allocate the result array and return if empty.
-       byte[] result = new byte[length];
+       byte[] result = new byte[resultLength];
        if (result.length == 0)
            return result;
 
        // Prepend the base if it is non-empty and would not later be
-       // overwritten by an absolute descendant
+       // overwritten by an absolute child
        int offset = 0;
        if (start == 0 && base.length > 0) {
            System.arraycopy(base, 0, result, 0, base.length);
            offset += base.length;
        }
 
-       // Append descendants starting with the last one which is an
+       // Append children starting with the last one which is an
        // absolute path
        if (count > 0) {
            int idx = Math.max(0, start - 1);
            for (int i = idx; i < count; i++) {
-               byte[] b = descendants[i];
+               byte[] b = children[i];
                if (b.length > 0) {
                    if (offset > 0 && result[offset - 1] != '/')
                        result[offset++] = '/';
@@ -464,12 +463,12 @@ class UnixPath implements Path {
         if (more.length == 0)
             return resolve(first);
 
-        byte[][] descendants = new byte[1 + more.length][];
-        descendants[0] = toUnixPath(first).path;
+        byte[][] children = new byte[1 + more.length][];
+        children[0] = toUnixPath(first).path;
         for (int i = 0; i < more.length; i++)
-            descendants[i + 1] = toUnixPath(more[i]).path;
+            children[i + 1] = toUnixPath(more[i]).path;
 
-        byte[] result = resolve(path, descendants);
+        byte[] result = resolve(path, children);
         return new UnixPath(getFileSystem(), result);
     }
 

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -22,7 +22,8 @@
  */
 
 /* @test
- * @bug 4313887 6838333 6925932 7006126 8037945 8072495 8140449 8254876 8298478
+ * @bug 4313887 6838333 6925932 7006126 8037945 8072495 8140449 8254876 8262742
+ *      8298478
  * @summary Unit test for java.nio.file.Path path operations
  */
 
@@ -179,6 +180,19 @@ public class PathOps {
         out.format("test resolve %s\n", other);
         checkPath();
         check(path.resolve(other), expected);
+        return this;
+    }
+
+    // Note: "expected" is first parameter here
+    PathOps resolve(String expected, String first, String... more) {
+        out.format("test resolve %s varargs\n", path());
+        checkPath();
+        Path[] others = new Path[more.length];
+        int i = 0;
+        for (String s : more) {
+            others[i++] = Path.of(s);
+        }
+        check(path.resolve(Path.of(first), others), expected);
         return this;
     }
 
@@ -542,6 +556,29 @@ public class PathOps {
             .resolve("C:\\", "C:\\")
             .resolve("C:foo", "C:foo")
             .resolve("\\\\server\\share\\bar", "\\\\server\\share\\bar");
+
+        // resolve - varargs
+        test("C:\\tmp")
+            .resolve("C:\\tmp\\foo\\bar\\gus", "foo", "bar", "gus")
+            .resolve("C:\\gus", "\\foo", "bar", "\\gus")
+            .resolve("C:\\tmp\\baz", "", "", "baz");
+        test("tmp")
+            .resolve("tmp\\foo\\bar\\gus", "foo", "bar", "gus")
+            .resolve("\\gus", "\\foo", "bar", "\\gus")
+            .resolve("tmp\\baz", "", "", "baz");
+        test("")
+            .resolve("", "", "")
+            .resolve("\\bar", "foo", "\\bar", "")
+            .resolve("foo\\bar\\gus", "foo", "bar", "gus")
+            .resolve("baz", "", "", "baz");
+        test("\\")
+            .resolve("\\foo", "foo", "")
+            .resolve("\\foo", "", "foo")
+            .resolve("\\bar", "foo", "", "\\bar");
+        test("C:")
+            .resolve("C:foo\\bar\\gus", "foo", "bar", "gus")
+            .resolve("C:baz", "", "baz")
+            .resolve("C:", "", "");
 
         // resolveSibling
         test("foo")
@@ -1668,6 +1705,26 @@ public class PathOps {
             .resolve("", "")
             .resolve("foo", "foo")
             .resolve("/foo", "/foo");
+
+        // resolve - varargs
+        test("/tmp")
+            .resolve("/tmp/foo/bar/gus", "foo", "bar", "gus")
+            .resolve("/gus", "/foo", "bar", "/gus")
+            .resolve("/tmp/baz", "", "", "baz");
+        test("tmp")
+            .resolve("tmp/foo/bar/gus", "foo", "bar", "gus")
+            .resolve("/gus", "/foo", "bar", "/gus")
+            .resolve("tmp/baz", "", "", "baz");
+        test("")
+            .resolve("", "", "")
+            .resolve("/bar", "foo", "/bar", "")
+            .resolve("foo/bar/gus", "foo", "bar", "gus")
+            .resolve("baz", "", "", "baz");
+        test("/")
+            .resolve("/foo", "", "", "foo", "")
+            .resolve("/foo", "foo", "")
+            .resolve("/foo", "", "foo")
+            .resolve("/bar", "foo", "", "/bar");
 
         // resolveSibling
         test("foo")

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -562,6 +562,12 @@ public class PathOps {
             .resolve("C:\\tmp\\foo\\bar\\gus", "foo", "bar", "gus")
             .resolve("C:\\gus", "\\foo", "bar", "\\gus")
             .resolve("C:\\tmp\\baz", "", "", "baz");
+        test("C:\\tmp\\foo")
+            .resolve("C:\\tmp\\foo\\bar\\gus", "", "bar\\gus", "")
+            .resolve("C:\\tmp\\foo\\bar\\gus\\foo\\baz",
+                     "", "bar\\gus", "foo\\baz")
+            .resolve("C:\\bar\\gus\\baz", "", "C::\\bar\\gus", "baz")
+            .resolve("C:\\tmp\\bar", "C:\\bar\\gus", "baz", "C:\\tmp\\bar");
         test("tmp")
             .resolve("tmp\\foo\\bar\\gus", "foo", "bar", "gus")
             .resolve("\\gus", "\\foo", "bar", "\\gus")
@@ -1711,6 +1717,11 @@ public class PathOps {
             .resolve("/tmp/foo/bar/gus", "foo", "bar", "gus")
             .resolve("/gus", "/foo", "bar", "/gus")
             .resolve("/tmp/baz", "", "", "baz");
+        test("/tmp/foo")
+            .resolve("/tmp/foo/bar/gus", "", "bar/gus", "")
+            .resolve("/tmp/foo/bar/gus/foo/baz", "", "bar/gus", "foo/baz")
+            .resolve("/bar/gus/baz", "", "/bar/gus", "baz")
+            .resolve("/tmp/bar", "/bar/gus", "baz", "/tmp/bar");
         test("tmp")
             .resolve("tmp/foo/bar/gus", "foo", "bar", "gus")
             .resolve("/gus", "/foo", "bar", "/gus")
@@ -2134,7 +2145,7 @@ public class PathOps {
         }
 
         try {
-            Path.of("foo", null);
+            Path.of("foo", (String[])null);
             throw new RuntimeException("NullPointerException not thrown");
         } catch (NullPointerException npe) {
         }

--- a/test/jdk/java/nio/file/Path/PathOps.java
+++ b/test/jdk/java/nio/file/Path/PathOps.java
@@ -185,14 +185,22 @@ public class PathOps {
 
     // Note: "expected" is first parameter here
     PathOps resolve(String expected, String first, String... more) {
-        out.format("test resolve %s varargs\n", path());
+        out.format("test resolve %s varargs (String)\n", path());
         checkPath();
+        check(path.resolve(first, more), expected);
         Path[] others = new Path[more.length];
         int i = 0;
         for (String s : more) {
             others[i++] = Path.of(s);
         }
-        check(path.resolve(Path.of(first), others), expected);
+        return resolve(expected, Path.of(first), others);
+    }
+
+    // Note: "expected" is first parameter here
+    PathOps resolve(String expected, Path first, Path... more) {
+        out.format("test resolve %s varargs (Path)\n", path());
+        checkPath();
+        check(path.resolve(first, more), expected);
         return this;
     }
 
@@ -566,7 +574,7 @@ public class PathOps {
             .resolve("C:\\tmp\\foo\\bar\\gus", "", "bar\\gus", "")
             .resolve("C:\\tmp\\foo\\bar\\gus\\foo\\baz",
                      "", "bar\\gus", "foo\\baz")
-            .resolve("C:\\bar\\gus\\baz", "", "C::\\bar\\gus", "baz")
+            .resolve("C:\\bar\\gus\\baz", "", "C:\\bar\\gus", "baz")
             .resolve("C:\\tmp\\bar", "C:\\bar\\gus", "baz", "C:\\tmp\\bar");
         test("tmp")
             .resolve("tmp\\foo\\bar\\gus", "foo", "bar", "gus")


### PR DESCRIPTION
Add to `java.nio.file.Path` methods which allow resolution of multiple descendants.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8312123](https://bugs.openjdk.org/browse/JDK-8312123) to be approved

### Issues
 * [JDK-8262742](https://bugs.openjdk.org/browse/JDK-8262742): (fs) Add Path::resolve with varargs string (**Enhancement** - P4)
 * [JDK-8312123](https://bugs.openjdk.org/browse/JDK-8312123): (fs) Add Path::resolve with varargs string (**CSR**)

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14805/head:pull/14805` \
`$ git checkout pull/14805`

Update a local copy of the PR: \
`$ git checkout pull/14805` \
`$ git pull https://git.openjdk.org/jdk.git pull/14805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14805`

View PR using the GUI difftool: \
`$ git pr show -t 14805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14805.diff">https://git.openjdk.org/jdk/pull/14805.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14805#issuecomment-1625900982)