### PR TITLE
8311081: KeytoolReaderP12Test.java fail on localized Windows platform

### DIFF
--- a/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  * @test
- * @bug 8048830 8311081
+ * @bug 8048830
  * @summary Test for PKCS12 keystore list , export commands. Refer README for
  * keystore files information
  * @library ../
@@ -117,9 +117,8 @@ public class KeytoolReaderP12Test {
             List<String> expectedValues)
             throws IOException {
         convertToPFX(name);
-        final String[] command = new String[]{
-                "-J-Duser.language=en", "-J-Duser.country=US", "-debug", "-list",
-                "-v", "-keystore", WORKING_DIRECTORY + File.separator + name,
+        final String[] command = new String[]{"-debug", "-list", "-v",
+                "-keystore", WORKING_DIRECTORY + File.separator + name,
                 "-storetype", "pkcs12", "-storepass", password
         };
         runAndValidate(command, expectedValues);
@@ -129,9 +128,8 @@ public class KeytoolReaderP12Test {
             String password, List<String> expectedValues)
             throws IOException {
         convertToPFX(name);
-        final String[] command = new String[]{
-                "-J-Duser.language=en", "-J-Duser.country=US", "-debug", "-export",
-                "-alias", alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
+        final String[] command = new String[]{"-debug", "-export", "-alias",
+                alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
                 "-storepass", password, "-storetype", "pkcs12", "-rfc"
         };
         runAndValidate(command, expectedValues);

--- a/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  * @test
- * @bug 8048830
+ * @bug 8048830 8311081
  * @summary Test for PKCS12 keystore list , export commands. Refer README for
  * keystore files information
  * @library ../
@@ -117,9 +117,11 @@ public class KeytoolReaderP12Test {
             List<String> expectedValues)
             throws IOException {
         convertToPFX(name);
-        final String[] command = new String[]{"-debug", "-list", "-v",
-            "-keystore", WORKING_DIRECTORY + File.separator + name,
-            "-storetype", "pkcs12", "-storepass", password};
+        final String[] command = new String[]{
+                "-J-Duser.language=en", "-J-Duser.country=US", "-debug", "-list",
+                "-v", "-keystore", WORKING_DIRECTORY + File.separator + name,
+                "-storetype", "pkcs12", "-storepass", password
+        };
         runAndValidate(command, expectedValues);
     }
 
@@ -127,9 +129,11 @@ public class KeytoolReaderP12Test {
             String password, List<String> expectedValues)
             throws IOException {
         convertToPFX(name);
-        final String[] command = new String[]{"-debug", "-export", "-alias",
-            alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
-            "-storepass", password, "-storetype", "pkcs12", "-rfc"};
+        final String[] command = new String[]{
+                "-J-Duser.language=en", "-J-Duser.country=US", "-debug", "-export",
+                "-alias", alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
+                "-storepass", password, "-storetype", "pkcs12", "-rfc"
+        };
         runAndValidate(command, expectedValues);
     }
 

--- a/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/KeytoolReaderP12Test.java
@@ -118,9 +118,8 @@ public class KeytoolReaderP12Test {
             throws IOException {
         convertToPFX(name);
         final String[] command = new String[]{"-debug", "-list", "-v",
-                "-keystore", WORKING_DIRECTORY + File.separator + name,
-                "-storetype", "pkcs12", "-storepass", password
-        };
+            "-keystore", WORKING_DIRECTORY + File.separator + name,
+            "-storetype", "pkcs12", "-storepass", password};
         runAndValidate(command, expectedValues);
     }
 
@@ -129,9 +128,8 @@ public class KeytoolReaderP12Test {
             throws IOException {
         convertToPFX(name);
         final String[] command = new String[]{"-debug", "-export", "-alias",
-                alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
-                "-storepass", password, "-storetype", "pkcs12", "-rfc"
-        };
+            alias, "-keystore", WORKING_DIRECTORY + File.separator + name,
+            "-storepass", password, "-storetype", "pkcs12", "-rfc"};
         runAndValidate(command, expectedValues);
     }
 

--- a/test/jdk/java/security/KeyStore/PKCS12/Utils.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,11 +59,14 @@ public class Utils {
 
     public static OutputAnalyzer executeKeytoolCommand(String[] command,
             int exitCode) {
-        String[] keytoolCmd = new String[command.length + 1];
+        String[] keytoolCmd = new String[command.length + 3];
         OutputAnalyzer output = null;
         try {
             keytoolCmd[0] = JDKToolFinder.getJDKTool(KEYTOOL);
-            System.arraycopy(command, 0, keytoolCmd, 1, command.length);
+            // Ensure the keytool process is always ran under English locale
+            keytoolCmd[1] = "-J-Duser.language=en";
+            keytoolCmd[2] = "-J-Duser.country=US";
+            System.arraycopy(command, 0, keytoolCmd, 3, command.length);
             output = ProcessTools.executeCommand(keytoolCmd);
             output.shouldHaveExitValue(exitCode);
             out.println("Executed keytool command sucessfully:"


### PR DESCRIPTION
Please review this PR which addresses `KeytoolReaderP12Test.java` failing for non-English locale users.

This test checks output from keytool, but fails on finding the value 'alias name' for non-English locale users. This is because 'alias name' is a localized value. (For example, in `ja` this is '別名'). 

To fix the failing issue, the keytool process should be ran with `-J-Duser.language=en -J-Duser.country=US`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311081](https://bugs.openjdk.org/browse/JDK-8311081): KeytoolReaderP12Test.java fail on localized Windows platform (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [57765c77](https://git.openjdk.org/jdk/pull/14806/files/57765c777dffaaa996f593f693470c20fefe7278)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14806/head:pull/14806` \
`$ git checkout pull/14806`

Update a local copy of the PR: \
`$ git checkout pull/14806` \
`$ git pull https://git.openjdk.org/jdk.git pull/14806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14806`

View PR using the GUI difftool: \
`$ git pr show -t 14806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14806.diff">https://git.openjdk.org/jdk/pull/14806.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14806#issuecomment-1625914534)