### PR TITLE
Optimization of LongAdder#add() method

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/atomic/LongAdder.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/LongAdder.java
@@ -83,14 +83,15 @@ public class LongAdder extends Striped64 implements Serializable {
      * @param x the value to add
      */
     public void add(long x) {
-        Cell[] cs; long b, v; int m; Cell c;
+        Cell[] cs; long b; int m; Cell c;
         if ((cs = cells) != null || !casBase(b = base, b + x)) {
             int index = getProbe();
-            boolean uncontended = true;
+
             if (cs == null || (m = cs.length - 1) < 0 ||
-                (c = cs[index & m]) == null ||
-                !(uncontended = c.cas(v = c.value, v + x)))
-                longAccumulate(x, null, uncontended, index);
+                    (c = cs[index & m]) == null)
+                longAccumulate(x, null, true, index);
+            else
+                c.add(x);
         }
     }
 

--- a/src/java.base/share/classes/java/util/concurrent/atomic/Striped64.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/Striped64.java
@@ -124,6 +124,10 @@ abstract class Striped64 extends Number {
     @jdk.internal.vm.annotation.Contended static final class Cell {
         volatile long value;
         Cell(long x) { value = x; }
+
+        final void add(long delta) {
+            VALUE.getAndAddRelease(this, delta);
+        }
         final boolean cas(long cmp, long val) {
             return VALUE.weakCompareAndSetRelease(this, cmp, val);
         }


### PR DESCRIPTION
added a new method to the Cell entity that atomically increases the value - add

using getAndAddRelease (better in this situation) can be faster than CAS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14811/head:pull/14811` \
`$ git checkout pull/14811`

Update a local copy of the PR: \
`$ git checkout pull/14811` \
`$ git pull https://git.openjdk.org/jdk.git pull/14811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14811`

View PR using the GUI difftool: \
`$ git pr show -t 14811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14811.diff">https://git.openjdk.org/jdk/pull/14811.diff</a>

</details>
