### PR TITLE
8311689: Wrong visible amount in Adjustable of ScrollPane

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_ScrollPane.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_ScrollPane.cpp
@@ -524,8 +524,8 @@ void AwtScrollPane::_SetSpans(void *param)
         DTRACE_PRINTLN5("%x: WScrollPanePeer.setSpans(%d, %d, %d, %d)", self,
             parentWidth, parentHeight, childWidth, childHeight);
         s->RecalcSizes(parentWidth, parentHeight, childWidth, childHeight);
-        s->VerifyState();
         s->SetInsets(env);
+        s->VerifyState();
     }
 ret:
    env->DeleteGlobalRef(self);
@@ -804,7 +804,7 @@ Java_sun_awt_windows_WScrollPanePeer_setSpans(JNIEnv *env, jobject self,
     sss->childWidth = childWidth;
     sss->childHeight = childHeight;
 
-    AwtToolkit::GetInstance().InvokeFunctionLater(AwtScrollPane::_SetSpans, sss);
+    AwtToolkit::GetInstance().InvokeFunction(AwtScrollPane::_SetSpans, sss);
     // global ref and sss are deleted in _SetSpans
 
     CATCH_BAD_ALLOC;

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneScrollEnd.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneScrollEnd.java
@@ -70,9 +70,7 @@ public final class ScrollPaneScrollEnd {
         Frame frame = new Frame("ScrollPaneScrollEnd");
         frame.add(scrollPane, "Center");
         frame.setLocation(100, 100);
-        System.out.println("frame.setSize");
         frame.pack();
-        System.out.println("frame.setVisible");
         frame.setVisible(true);
 
         Thread.sleep(DELAY);

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneScrollEnd.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneScrollEnd.java
@@ -27,6 +27,7 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Point;
+import java.awt.Robot;
 import java.awt.ScrollPane;
 
 /*
@@ -47,7 +48,7 @@ public final class ScrollPaneScrollEnd {
             new Dimension(CANVAS_SIZE.width / 3, CANVAS_SIZE.height / 3);
     private static final int SCROLL_OFFSET = 100;
 
-    private static final long DELAY = 200;
+    private static final int DELAY = 200;
 
     public static void main(String[] args) throws Exception {
         Canvas canvas = new Canvas() {
@@ -73,7 +74,9 @@ public final class ScrollPaneScrollEnd {
         frame.pack();
         frame.setVisible(true);
 
-        Thread.sleep(DELAY);
+        final Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(DELAY);
 
         final Dimension vp = scrollPane.getViewportSize();
         final Point expected = new Point(CANVAS_SIZE.width - vp.width,

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneScrollEnd.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneScrollEnd.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.ScrollPane;
+
+/*
+ * @test
+ * @bug 8311689
+ * @key headful
+ * @requires os.family=="windows"
+ * @summary Verifies ScrollPane allows viewing the whole contents of its child
+ * @run main ScrollPaneScrollEnd
+ */
+public final class ScrollPaneScrollEnd {
+    private static final Color CANVAS_BACKGROUND = new Color(255, 200, 200);
+    private static final Color CANVAS_FOREGROUND = new Color(255, 255, 200);
+    private static final int OFFSET = 12;
+
+    private static final Dimension CANVAS_SIZE = new Dimension(900, 600);
+    private static final Dimension SCROLL_PANE_SIZE =
+            new Dimension(CANVAS_SIZE.width / 3, CANVAS_SIZE.height / 3);
+    private static final int SCROLL_OFFSET = 100;
+
+    private static final long DELAY = 200;
+
+    public static void main(String[] args) throws Exception {
+        Canvas canvas = new Canvas() {
+            @Override
+            public void paint(Graphics g) {
+                g.setColor(CANVAS_BACKGROUND);
+                g.fillRect(0, 0, getWidth(), getHeight());
+
+                g.setColor(CANVAS_FOREGROUND);
+                g.fillRect(OFFSET, OFFSET,
+                           getWidth() - OFFSET * 2, getHeight() - OFFSET * 2);
+            }
+        };
+        canvas.setSize(CANVAS_SIZE);
+
+        ScrollPane scrollPane = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
+        scrollPane.add(canvas);
+        scrollPane.setSize(SCROLL_PANE_SIZE);
+
+        Frame frame = new Frame("ScrollPaneScrollEnd");
+        frame.add(scrollPane, "Center");
+        frame.setLocation(100, 100);
+        System.out.println("frame.setSize");
+        frame.pack();
+        System.out.println("frame.setVisible");
+        frame.setVisible(true);
+
+        Thread.sleep(DELAY);
+
+        final Dimension vp = scrollPane.getViewportSize();
+        final Point expected = new Point(CANVAS_SIZE.width - vp.width,
+                                         CANVAS_SIZE.height - vp.height);
+
+        scrollPane.setScrollPosition(CANVAS_SIZE.width + SCROLL_OFFSET,
+                                     CANVAS_SIZE.height + SCROLL_OFFSET);
+        try {
+            if (!expected.equals(scrollPane.getScrollPosition())) {
+                throw new Error("Can't scroll to the end of the child component");
+            }
+        } finally {
+            frame.dispose();
+        }
+    }
+}


### PR DESCRIPTION
It proved that `ScrollPane.layout` depends on the result of `WScrollPanePeer.childResized`, specifically on `setSpans` which recalculates the spans and sets the insets.

https://github.com/openjdk/jdk/blob/b285ed72aebe2d802fa9c071372cea6c09870b9a/src/java.desktop/share/classes/java/awt/ScrollPane.java#L514-L521

After the fix for [JDK-8297923](https://bugs.openjdk.org/browse/JDK-8297923), `setSpans` that is called in `childResized` is run asynchronously on the toolkit thread. Therefore `getViewportSize` uses the wrong insets which don't take into account the size of the scroll bar. Because of it, the `visibleAmount` field of adjustables is also wrong, and the scroll pane cannot display a portion of its child component.

I overlooked this dependency even when I was fixing the first regression, [JDK-8310054](https://bugs.openjdk.org/browse/JDK-8310054). Had I followed Harshitha's advice in #14478, I would've fixed this problem too. Similarly, Phil's intuition was right: `setSpans` should be synchronous. @honkar-jdk @prrace

**Fix**

The fix is to run `AwtScrollPane::_SetSpans` synchronously using `AwtToolkit::InvokeFunction`.

I also addressed [Sergey's concern](https://github.com/openjdk/jdk/pull/14478#discussion_r1239049983): `VerifyState` is now called after `SetInsets`. @mrserb

Client tests are green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311689](https://bugs.openjdk.org/browse/JDK-8311689): Wrong visible amount in Adjustable of ScrollPane (**Bug** - P2)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14815/head:pull/14815` \
`$ git checkout pull/14815`

Update a local copy of the PR: \
`$ git checkout pull/14815` \
`$ git pull https://git.openjdk.org/jdk.git pull/14815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14815`

View PR using the GUI difftool: \
`$ git pr show -t 14815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14815.diff">https://git.openjdk.org/jdk/pull/14815.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14815#issuecomment-1629413224)