### PR TITLE
8311646: ZGC: LIR_OpZStoreBarrier::_info shadows LIR_Op::_info

### DIFF
--- a/src/hotspot/share/gc/z/c1/zBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/z/c1/zBarrierSetC1.cpp
@@ -287,7 +287,6 @@ private:
   LIR_Opr       _new_zaddress;
   LIR_Opr       _new_zpointer;
   CodeStub*     _stub;
-  CodeEmitInfo* _info;
 
 public:
   LIR_OpZStoreBarrier(LIR_Opr addr,
@@ -295,12 +294,11 @@ public:
                       LIR_Opr new_zpointer,
                       CodeStub* stub,
                       CodeEmitInfo* info)
-    : LIR_Op(lir_none, new_zpointer, nullptr /* info */),
+    : LIR_Op(lir_none, new_zpointer, info),
       _addr(addr),
       _new_zaddress(new_zaddress),
       _new_zpointer(new_zpointer),
-      _stub(stub),
-      _info(info) {}
+      _stub(stub) {}
 
   virtual void visit(LIR_OpVisitState* state) {
     state->do_input(_new_zaddress);


### PR DESCRIPTION
[JDK-8311646](https://bugs.openjdk.org/browse/JDK-8311646)

In LIR_OpZStoreBarrier, SonarCloud reports:
 Field "_info" shadows a field of the same name in base class "LIR_Op".

Updates LIR_OpZStoreBarrier to use the superclass `_info` instead

Additional testing:
- [x] Linux x86_64 fastdebug `tier2`
- [x] Linux x86_64 release `tier2`
- [x] Linux x86_64 fastdebug `test/hotspot/jtreg/gc/z`
- [x] Linux x86_64 release `test/hotspot/jtreg/gc/z`
- [x] Linux x86_64 fastdebug `gtest:all`
- [x] Linux x86_64 release `gtest:all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311646](https://bugs.openjdk.org/browse/JDK-8311646): ZGC: LIR_OpZStoreBarrier::_info shadows LIR_Op::_info (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Koichi Sakata](https://openjdk.org/census#ksakata) (@jyukutyo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14816/head:pull/14816` \
`$ git checkout pull/14816`

Update a local copy of the PR: \
`$ git checkout pull/14816` \
`$ git pull https://git.openjdk.org/jdk.git pull/14816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14816`

View PR using the GUI difftool: \
`$ git pr show -t 14816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14816.diff">https://git.openjdk.org/jdk/pull/14816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14816#issuecomment-1629587240)