### PR TITLE
8310551: vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java timed out due to missing prompt

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -171,5 +171,3 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64
-
-vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java 8310551 linux-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class interrupt001 extends JdbTest {
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
     static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = DEBUGGEE_CLASS + "$" + MYTHREAD;
-    static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted.get()";
+    static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted";
 
     static int numThreads = nsk.jdb.interrupt.interrupt001.interrupt001a.numThreads;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -56,8 +56,8 @@ public class interrupt001a {
                         lock.wait();
                     }
                 } catch (InterruptedException e) {
-                    notInterrupted.decrementAndGet();
                     synchronized (waitnotify) {
+                        notInterrupted--;
                         waitnotify.notify();
                     }
                 }
@@ -83,7 +83,7 @@ public class interrupt001a {
     private JdbArgumentHandler argumentHandler;
     private Log log;
 
-    public static final AtomicInteger notInterrupted = new AtomicInteger(numThreads);
+    public static volatile int notInterrupted = numThreads;
 
     public int runIt(String args[], PrintStream out) {
 
@@ -123,7 +123,7 @@ public class interrupt001a {
         long waitTime = argumentHandler.getWaitTime() * 60 * 1000;
         long startTime = System.currentTimeMillis();
         synchronized (waitnotify) {
-            while (notInterrupted.get() > 0 && System.currentTimeMillis() - startTime <= waitTime) {
+            while (notInterrupted > 0 && System.currentTimeMillis() - startTime <= waitTime) {
                 try {
                     waitnotify.wait(waitTime);
                 } catch (InterruptedException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -120,13 +120,17 @@ public class interrupt001a {
             breakHere();  // a break to get thread ids and then to interrupt MyThreads.
         } while (!allWorkersAreWaiting);
 
-        long waitTime = argumentHandler.getWaitTime() * 60 * 1000; // max time in loop
+        long waitTime = argumentHandler.getWaitTime() * 60 * 1000;
         long startTime = System.currentTimeMillis();
         while (notInterrupted.get() > 0 && System.currentTimeMillis() - startTime <= waitTime) {
             synchronized (waitnotify) {
                 try {
-                    // Short wait to give interrupts a chance to complete
-                    waitnotify.wait(200);
+                    // Wait for a thread to be interrupted. We first need to recheck
+                    // the count inside the synchronized block because it may have gone
+                    // to 0 since last check.
+                    if (notInterrupted.get() > 0) {
+                        waitnotify.wait(waitTime);
+                    }
                 } catch (InterruptedException e) {
                     log.display("Main thread was interrupted while waiting");
                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -122,15 +122,10 @@ public class interrupt001a {
 
         long waitTime = argumentHandler.getWaitTime() * 60 * 1000;
         long startTime = System.currentTimeMillis();
-        while (notInterrupted.get() > 0 && System.currentTimeMillis() - startTime <= waitTime) {
-            synchronized (waitnotify) {
+        synchronized (waitnotify) {
+            while (notInterrupted.get() > 0 && System.currentTimeMillis() - startTime <= waitTime) {
                 try {
-                    // Wait for a thread to be interrupted. We first need to recheck
-                    // the count inside the synchronized block because it may have gone
-                    // to 0 since last check, in which case we'll never get a notify().
-                    if (notInterrupted.get() > 0) {
-                        waitnotify.wait(waitTime);
-                    }
+                    waitnotify.wait(waitTime);
                 } catch (InterruptedException e) {
                     log.display("Main thread was interrupted while waiting");
                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -127,7 +127,7 @@ public class interrupt001a {
                 try {
                     // Wait for a thread to be interrupted. We first need to recheck
                     // the count inside the synchronized block because it may have gone
-                    // to 0 since last check.
+                    // to 0 since last check, in which case we'll never get a notify().
                     if (notInterrupted.get() > 0) {
                         waitnotify.wait(waitTime);
                     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,12 +120,13 @@ public class interrupt001a {
             breakHere();  // a break to get thread ids and then to interrupt MyThreads.
         } while (!allWorkersAreWaiting);
 
-        long waitTime = argumentHandler.getWaitTime() * 60 * 1000;
+        long waitTime = argumentHandler.getWaitTime() * 60 * 1000; // max time in loop
         long startTime = System.currentTimeMillis();
         while (notInterrupted.get() > 0 && System.currentTimeMillis() - startTime <= waitTime) {
             synchronized (waitnotify) {
                 try {
-                    waitnotify.wait(waitTime);
+                    // Short wait to give interrupts a chance to complete
+                    waitnotify.wait(200);
                 } catch (InterruptedException e) {
                     log.display("Main thread was interrupted while waiting");
                 }


### PR DESCRIPTION
After [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232), both the test and the debuggee shared the same waittime of 5 minutes. The test would wait up to 5 minutes for the expected prompt, but the debuggee would also in some cases wait 5 minutes before generating the prompt, which sometimes was just a bit too late. Before [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232), the debuggee would wait at most 2 minutes before generating the prompt, so it was always generated in time.

The main issue is that after the while loop checks that there are still uninterrupted threads remaining, the last of the threads is interrupted before the wait() call is made. This means wait() won't return until it times out, and by then it is too late, and the test side has already timed out waiting for the prompt.

The fix is to widen the synchronized block so the count of not interrupted threads remains correct until `wait()` is entered. The other choice was to refetch the count after entering the synchronized block, which is what I did for the initial fix, but widening seems a better choice so no refetch is needed.

For details see https://bugs.openjdk.org/browse/JDK-8310551?focusedCommentId=14594838&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14594838

Tested with 300 runs each on linux-x64 and linux-aarch64 with -Xcomp options that reproduced the issue, and then again with no options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310551](https://bugs.openjdk.org/browse/JDK-8310551): vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java timed out due to missing prompt (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14817/head:pull/14817` \
`$ git checkout pull/14817`

Update a local copy of the PR: \
`$ git checkout pull/14817` \
`$ git pull https://git.openjdk.org/jdk.git pull/14817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14817`

View PR using the GUI difftool: \
`$ git pr show -t 14817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14817.diff">https://git.openjdk.org/jdk/pull/14817.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14817#issuecomment-1629829134)