### PR TITLE
8311656: Shenandoah: Unused ShenandoahSATBAndRemarkThreadsClosure::_claim_token

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -73,7 +73,6 @@ class ShenandoahSATBAndRemarkThreadsClosure : public ThreadClosure {
 private:
   SATBMarkQueueSet& _satb_qset;
   OopClosure* const _cl;
-  uintx _claim_token;
 
 public:
   ShenandoahSATBAndRemarkThreadsClosure(SATBMarkQueueSet& satb_qset, OopClosure* cl) :


### PR DESCRIPTION
[JDK-8311656](https://bugs.openjdk.org/browse/JDK-8311656)

Remove unused `_claim_token` field from `ShenandoahSATBAndRemarkThreadsClosure`

Additional testing:
- [x] Linux x86_64 fastdebug `tier2`
- [x] Linux x86_64 release `tier2`
- [x] Linux x86_64 fastdebug `test/hotspot/jtreg/gc/shenandoah`
- [x] Linux x86_64 release `test/hotspot/jtreg/gc/shenandoah`
- [x] Linux x86_64 fastdebug `gtest:all`
- [x] Linux x86_64 release `gtest:all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311656](https://bugs.openjdk.org/browse/JDK-8311656): Shenandoah: Unused ShenandoahSATBAndRemarkThreadsClosure::_claim_token (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14818/head:pull/14818` \
`$ git checkout pull/14818`

Update a local copy of the PR: \
`$ git checkout pull/14818` \
`$ git pull https://git.openjdk.org/jdk.git pull/14818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14818`

View PR using the GUI difftool: \
`$ git pr show -t 14818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14818.diff">https://git.openjdk.org/jdk/pull/14818.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14818#issuecomment-1631455178)