### PR TITLE
8311813: C1: Uninitialized PhiResolver::_loop field

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -78,6 +78,7 @@ void PhiResolverState::reset() {
 PhiResolver::PhiResolver(LIRGenerator* gen)
  : _gen(gen)
  , _state(gen->resolver_state())
+ , _loop(nullptr)
  , _temp(LIR_OprFact::illegalOpr)
 {
   // reinitialize the shared state arrays


### PR DESCRIPTION
[JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813)

Initialize `PhiResolver::_loop` field to `nullptr`

Additional testing:
- [x] Linux x86_64 fastdebug `tier2`
- [x] Linux x86_64 release `tier2`
- [x] Linux x86_64 fastdebug `gtest:all`
- [x] Linux x86_64 release `gtest:all`
- [x] Linux x86_64 fastdebug `test/hotspot/jtreg/compiler/c1`
- [x] Linux x86_64 release `test/hotspot/jtreg/compiler/c1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813): C1: Uninitialized PhiResolver::_loop field (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14819/head:pull/14819` \
`$ git checkout pull/14819`

Update a local copy of the PR: \
`$ git checkout pull/14819` \
`$ git pull https://git.openjdk.org/jdk.git pull/14819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14819`

View PR using the GUI difftool: \
`$ git pr show -t 14819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14819.diff">https://git.openjdk.org/jdk/pull/14819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14819#issuecomment-1631458032)