### PR TITLE
8309603: Deallocate hashtables in ClassLoaderData::unload

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -624,6 +624,13 @@ void ClassLoaderData::unload() {
   // Clean up global class iterator for compiler
   ClassLoaderDataGraph::adjust_saved_class(this);
 
+  // Release C heap allocated hashtable for all the packages.
+  if (_packages != nullptr) {
+    // Destroy the table itself
+    delete _packages;
+    _packages = nullptr;
+  }
+
   // Release C heap allocated hashtable for all the modules.
   if (_modules != nullptr) {
     // Destroy the table itself
@@ -745,13 +752,6 @@ ClassLoaderData::~ClassLoaderData() {
 
   // Release the WeakHandle
   _holder.release(Universe::vm_weak());
-
-  // Release C heap allocated hashtable for all the packages.
-  if (_packages != nullptr) {
-    // Destroy the table itself
-    delete _packages;
-    _packages = nullptr;
-  }
 
   // release the metaspace
   ClassLoaderMetaspace *m = _metaspace;

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -624,6 +624,13 @@ void ClassLoaderData::unload() {
   // Clean up global class iterator for compiler
   ClassLoaderDataGraph::adjust_saved_class(this);
 
+  // Release C heap allocated hashtable for all the packages.
+  if (_packages != nullptr) {
+    // Destroy the table itself
+    delete _packages;
+    _packages = nullptr;
+  }
+
   // Release C heap allocated hashtable for all the modules.
   if (_modules != nullptr) {
     // Destroy the table itself
@@ -636,6 +643,11 @@ void ClassLoaderData::unload() {
     // Destroy the table itself
     delete _dictionary;
     _dictionary = nullptr;
+  }
+
+  if (_unnamed_module != nullptr) {
+    delete _unnamed_module;
+    _unnamed_module = nullptr;
   }
 }
 
@@ -740,18 +752,6 @@ ClassLoaderData::~ClassLoaderData() {
 
   // Release the WeakHandle
   _holder.release(Universe::vm_weak());
-
-  // Release C heap allocated hashtable for all the packages.
-  if (_packages != nullptr) {
-    // Destroy the table itself
-    delete _packages;
-    _packages = nullptr;
-  }
-
-  if (_unnamed_module != nullptr) {
-    delete _unnamed_module;
-    _unnamed_module = nullptr;
-  }
 
   // release the metaspace
   ClassLoaderMetaspace *m = _metaspace;

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -623,6 +623,20 @@ void ClassLoaderData::unload() {
 
   // Clean up global class iterator for compiler
   ClassLoaderDataGraph::adjust_saved_class(this);
+
+  // Release C heap allocated hashtable for all the modules.
+  if (_modules != nullptr) {
+    // Destroy the table itself
+    delete _modules;
+    _modules = nullptr;
+  }
+
+  // Release C heap allocated hashtable for the dictionary
+  if (_dictionary != nullptr) {
+    // Destroy the table itself
+    delete _dictionary;
+    _dictionary = nullptr;
+  }
 }
 
 ModuleEntryTable* ClassLoaderData::modules() {
@@ -732,20 +746,6 @@ ClassLoaderData::~ClassLoaderData() {
     // Destroy the table itself
     delete _packages;
     _packages = nullptr;
-  }
-
-  // Release C heap allocated hashtable for all the modules.
-  if (_modules != nullptr) {
-    // Destroy the table itself
-    delete _modules;
-    _modules = nullptr;
-  }
-
-  // Release C heap allocated hashtable for the dictionary
-  if (_dictionary != nullptr) {
-    // Destroy the table itself
-    delete _dictionary;
-    _dictionary = nullptr;
   }
 
   if (_unnamed_module != nullptr) {

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -624,13 +624,6 @@ void ClassLoaderData::unload() {
   // Clean up global class iterator for compiler
   ClassLoaderDataGraph::adjust_saved_class(this);
 
-  // Release C heap allocated hashtable for all the packages.
-  if (_packages != nullptr) {
-    // Destroy the table itself
-    delete _packages;
-    _packages = nullptr;
-  }
-
   // Release C heap allocated hashtable for all the modules.
   if (_modules != nullptr) {
     // Destroy the table itself
@@ -752,6 +745,13 @@ ClassLoaderData::~ClassLoaderData() {
 
   // Release the WeakHandle
   _holder.release(Universe::vm_weak());
+
+  // Release C heap allocated hashtable for all the packages.
+  if (_packages != nullptr) {
+    // Destroy the table itself
+    delete _packages;
+    _packages = nullptr;
+  }
 
   // release the metaspace
   ClassLoaderMetaspace *m = _metaspace;


### PR DESCRIPTION
[JDK-8309603](https://bugs.openjdk.org/browse/JDK-8309603)

Memory is released in `ClassLoaderdata::~ClassLoaderData` for the dictionary and module hashtables but they could be deleted earlier in `ClassLoaderdata::unload`. Since we're unloading the class loader is no longer being used for lookup.

Additional testing:
- [x] Linux x86_64 fastdebug `tier2`
- [x] Linux x86_64 release `tier2`
- [x] Linux x86_64 fastdebug `gtest:all`
- [x] Linux x86_64 release `gtest:all`
- [x] Linux x86_64 fastdebug `test/hotspot/jtreg/runtime`
- [x] Linux x86_64 release `test/hotspot/jtreg/runtime`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309603](https://bugs.openjdk.org/browse/JDK-8309603): Deallocate hashtables in ClassLoaderData::unload (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14820/head:pull/14820` \
`$ git checkout pull/14820`

Update a local copy of the PR: \
`$ git checkout pull/14820` \
`$ git pull https://git.openjdk.org/jdk.git pull/14820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14820`

View PR using the GUI difftool: \
`$ git pr show -t 14820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14820.diff">https://git.openjdk.org/jdk/pull/14820.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14820#issuecomment-1631455423)