### PR TITLE
6211126: ICC_ColorSpace.toCIEXYZ(float[]): NPE is not specified

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/CMMException.java
+++ b/src/java.desktop/share/classes/java/awt/color/CMMException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class CMMException extends RuntimeException {
     /**
      * Constructs a {@code CMMException} with the specified detail message.
      *
-     * @param  s the specified detail message
+     * @param  message the specified detail message, or {@code null}
      */
-    public CMMException(String s) {
-        super(s);
+    public CMMException(String message) {
+        super(message);
     }
 }

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,6 +350,7 @@ public abstract class ColorSpace implements Serializable {
      * @return a float array of length 3
      * @throws ArrayIndexOutOfBoundsException if array length is not at least
      *         the number of components in this {@code ColorSpace}
+     * @throws NullPointerException if {@code colorvalue} is {@code null}
      */
     public abstract float[] toRGB(float[] colorvalue);
 
@@ -371,6 +372,7 @@ public abstract class ColorSpace implements Serializable {
      * @return a float array with length equal to the number of components in
      *         this {@code ColorSpace}
      * @throws ArrayIndexOutOfBoundsException if array length is not at least 3
+     * @throws NullPointerException if {@code rgbvalue} is {@code null}
      */
     public abstract float[] fromRGB(float[] rgbvalue);
 
@@ -395,7 +397,8 @@ public abstract class ColorSpace implements Serializable {
      *         components in this {@code ColorSpace}
      * @return a float array of length 3
      * @throws ArrayIndexOutOfBoundsException if array length is not at least
-     *         the number of components in this {@code ColorSpace}.
+     *         the number of components in this {@code ColorSpace}
+     * @throws NullPointerException if {@code colorvalue} is {@code null}
      */
     public abstract float[] toCIEXYZ(float[] colorvalue);
 
@@ -421,6 +424,7 @@ public abstract class ColorSpace implements Serializable {
      * @return a float array with length equal to the number of components in
      *         this {@code ColorSpace}
      * @throws ArrayIndexOutOfBoundsException if array length is not at least 3
+     * @throws NullPointerException if {@code colorvalue} is {@code null}
      */
     public abstract float[] fromCIEXYZ(float[] colorvalue);
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,7 @@ public class ICC_ColorSpace extends ColorSpace {
      * @param  profile the specified {@code ICC_Profile} object
      * @throws IllegalArgumentException if profile is inappropriate for
      *         representing a {@code ColorSpace}
+     * @throws NullPointerException if {@code profile} is {@code null}
      */
     public ICC_ColorSpace(ICC_Profile profile) {
         super(profile.getColorSpaceType(), profile.getNumComponents());
@@ -157,6 +158,7 @@ public class ICC_ColorSpace extends ColorSpace {
      * @throws ClassNotFoundException if the class of a serialized object could
      *         not be found
      * @throws IOException if an I/O error occurs
+     * @throws NullPointerException if {@code s} is {@code null}
      */
     @Serial
     private void readObject(ObjectInputStream s)
@@ -195,6 +197,7 @@ public class ICC_ColorSpace extends ColorSpace {
      * @return a float array of length 3
      * @throws ArrayIndexOutOfBoundsException if array length is not at least
      *         the number of components in this {@code ColorSpace}
+     * @throws NullPointerException if {@code colorvalue} is {@code null}
      */
     public float[] toRGB(float[] colorvalue) {
         if (this2srgb == null) {
@@ -243,6 +246,7 @@ public class ICC_ColorSpace extends ColorSpace {
      * @return a float array with length equal to the number of components in
      *         this {@code ColorSpace}
      * @throws ArrayIndexOutOfBoundsException if array length is not at least 3
+     * @throws NullPointerException if {@code rgbvalue} is {@code null}
      */
     public float[] fromRGB(float[] rgbvalue) {
         if (srgb2this == null) {
@@ -371,6 +375,7 @@ public class ICC_ColorSpace extends ColorSpace {
      * @return a float array of length 3
      * @throws ArrayIndexOutOfBoundsException if array length is not at least
      *         the number of components in this {@code ColorSpace}
+     * @throws NullPointerException if {@code colorvalue} is {@code null}
      */
     public float[] toCIEXYZ(float[] colorvalue) {
         if (this2xyz == null) {
@@ -502,6 +507,7 @@ public class ICC_ColorSpace extends ColorSpace {
      * @return a float array with length equal to the number of components in
      *         this {@code ColorSpace}
      * @throws ArrayIndexOutOfBoundsException if array length is not at least 3
+     * @throws NullPointerException if {@code colorvalue} is {@code null}
      */
     public float[] fromCIEXYZ(float[] colorvalue) {
         if (xyz2this == null) {

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1412,6 +1412,7 @@ public sealed class ICC_Profile implements Serializable
      *
      * @param  s stream used for serialization
      * @throws IOException thrown by {@code ObjectInputStream}
+     * @throws NullPointerException if {@code s} is {@code null}
      * @serialData the {@code String} is the name of one of
      *         <code>CS_<var>*</var></code> constants defined in the
      *         {@link ColorSpace} class if the profile object is a profile for a
@@ -1467,8 +1468,8 @@ public sealed class ICC_Profile implements Serializable
      *
      * @param  s stream used for deserialization
      * @throws IOException thrown by {@code ObjectInputStream}
-     * @throws ClassNotFoundException thrown by {@code
-     *         ObjectInputStream}
+     * @throws ClassNotFoundException thrown by {@code ObjectInputStream}
+     * @throws NullPointerException if {@code s} is {@code null}
      * @serialData the {@code String} is the name of one of
      *         <code>CS_<var>*</var></code> constants defined in the
      *         {@link ColorSpace} class if the profile object is a profile for a

--- a/src/java.desktop/share/classes/java/awt/color/ProfileDataException.java
+++ b/src/java.desktop/share/classes/java/awt/color/ProfileDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,9 +43,9 @@ public class ProfileDataException extends RuntimeException {
      * Constructs a {@code ProfileDataException} with the specified detail
      * message.
      *
-     * @param  s the specified detail message
+     * @param  message the specified detail message, or {@code null}
      */
-    public ProfileDataException(String s) {
-        super(s);
+    public ProfileDataException(String message) {
+        super(message);
     }
 }

--- a/test/jdk/java/awt/color/CMMExceptionMessage.java
+++ b/test/jdk/java/awt/color/CMMExceptionMessage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.CMMException;
+import java.util.Objects;
+
+/**
+ * @test
+ * @bug 6211126
+ * @summary Checks basic functionality of java.awt.color.CMMException
+ */
+public final class CMMExceptionMessage {
+
+    public static void main(String[] args) {
+        test(null);
+        test("");
+        test("CMMExceptionMessage");
+    }
+
+    private static void test(String expected) {
+        CMMException e = new CMMException(expected);
+        if (!Objects.equals(e.getMessage(), expected)) {
+            System.err.println("Expected message: " + expected);
+            System.err.println("Actual message: " + e.getMessage());
+            throw new RuntimeException();
+        }
+    }
+}

--- a/test/jdk/java/awt/color/ICC_ColorSpace/ExpectedNPEOnNull.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/ExpectedNPEOnNull.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+
+/**
+ * @test
+ * @bug 6211126 6211139
+ */
+public final class ExpectedNPEOnNull {
+
+    public static void main(String[] args) {
+        try {
+            new ICC_ColorSpace(null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        test(ICC_ColorSpace.getInstance(ColorSpace.CS_sRGB));
+        test(ICC_ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB));
+        test(ICC_ColorSpace.getInstance(ColorSpace.CS_CIEXYZ));
+        test(ICC_ColorSpace.getInstance(ColorSpace.CS_PYCC));
+        test(ICC_ColorSpace.getInstance(ColorSpace.CS_GRAY));
+    }
+
+    private static void test(ColorSpace cs) {
+        try {
+            cs.toRGB(null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        try {
+            cs.fromRGB(null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        try {
+            cs.toCIEXYZ(null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+        try {
+            cs.fromCIEXYZ(null);
+            throw new RuntimeException("NPE is expected");
+        } catch (NullPointerException ignored) {
+            // expected
+        }
+    }
+}

--- a/test/jdk/java/awt/color/ProfileDataExceptionMessage.java
+++ b/test/jdk/java/awt/color/ProfileDataExceptionMessage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ProfileDataException;
+import java.util.Objects;
+
+/**
+ * @test
+ * @bug 6211126
+ * @summary Checks basic functionality of java.awt.color.ProfileDataException
+ */
+public final class ProfileDataExceptionMessage {
+
+    public static void main(String[] args) {
+        test(null);
+        test("");
+        test("ProfileDataExceptionMessage");
+    }
+
+    private static void test(String expected) {
+        ProfileDataException e = new ProfileDataException(expected);
+        if (!Objects.equals(e.getMessage(), expected)) {
+            System.err.println("Expected message: " + expected);
+            System.err.println("Actual message: " + e.getMessage());
+            throw new RuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
The specification of some methods has been updated to include current behaviour on null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8311850](https://bugs.openjdk.org/browse/JDK-8311850) to be approved

### Issues
 * [JDK-6211126](https://bugs.openjdk.org/browse/JDK-6211126): ICC_ColorSpace.toCIEXYZ(float[]): NPE is not specified (**Bug** - P4)
 * [JDK-6211139](https://bugs.openjdk.org/browse/JDK-6211139): ICC_ColorSpace.toRGB(float[]): NPE is not specified (**Bug** - P4)
 * [JDK-8311850](https://bugs.openjdk.org/browse/JDK-8311850): ICC_ColorSpace.toCIEXYZ(float[]): NPE is not specified (**CSR**)

### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14821/head:pull/14821` \
`$ git checkout pull/14821`

Update a local copy of the PR: \
`$ git checkout pull/14821` \
`$ git pull https://git.openjdk.org/jdk.git pull/14821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14821`

View PR using the GUI difftool: \
`$ git pr show -t 14821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14821.diff">https://git.openjdk.org/jdk/pull/14821.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14821#issuecomment-1630110022)