### PR TITLE
8311847: Fix -Wconversion for assembler.hpp emit_int8,16 callers

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -186,12 +186,12 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
     gcc)
       DISABLE_WARNING_PREFIX="-Wno-"
       BUILD_CC_DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
+      CFLAGS_WARNINGS_ARE_ERRORS=""
 
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare \
           -Wunused-function -Wundef -Wunused-value -Wreturn-type \
-          -Wtrampolines"
+          -Wtrampolines -Wconversion"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -186,12 +186,12 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
     gcc)
       DISABLE_WARNING_PREFIX="-Wno-"
       BUILD_CC_DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS=""
+      CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
 
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare \
           -Wunused-function -Wundef -Wunused-value -Wreturn-type \
-          -Wtrampolines -Wconversion"
+          -Wtrampolines"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -221,7 +221,7 @@ public:
     mask <<= lsb;
     unsigned target = *(unsigned *)a;
     target &= ~mask;
-    target |= checked_cast<unsigned>(val);
+    target |= (unsigned)val;
     *(unsigned *)a = target;
   }
 
@@ -236,7 +236,7 @@ public:
     mask <<= lsb;
     unsigned target = *(unsigned *)a;
     target &= ~mask;
-    target |= checked_cast<unsigned>(uval);
+    target |= (unsigned)uval;
     *(unsigned *)a = target;
   }
 
@@ -265,7 +265,7 @@ public:
     uint64_t uval = val;
     unsigned mask = checked_cast<unsigned>(right_n_bits(nbits));
     uval &= mask;
-    f(checked_cast<unsigned>(uval), lsb + nbits - 1, lsb);
+    f((unsigned)uval, lsb + nbits - 1, lsb);
   }
 
   void rf(Register r, int lsb) {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -221,7 +221,7 @@ public:
     mask <<= lsb;
     unsigned target = *(unsigned *)a;
     target &= ~mask;
-    target |= val;
+    target |= checked_cast<unsigned>(val);
     *(unsigned *)a = target;
   }
 
@@ -229,14 +229,14 @@ public:
     int nbits = msb - lsb + 1;
     int64_t chk = val >> (nbits - 1);
     guarantee (chk == -1 || chk == 0, "Field too big for insn at " INTPTR_FORMAT, p2i(a));
-    unsigned uval = val;
+    uint64_t uval = val;
     unsigned mask = checked_cast<unsigned>(right_n_bits(nbits));
     uval &= mask;
     uval <<= lsb;
     mask <<= lsb;
     unsigned target = *(unsigned *)a;
     target &= ~mask;
-    target |= uval;
+    target |= checked_cast<unsigned>(uval);
     *(unsigned *)a = target;
   }
 
@@ -262,10 +262,10 @@ public:
     int nbits = msb - lsb + 1;
     int64_t chk = val >> (nbits - 1);
     guarantee (chk == -1 || chk == 0, "Field too big for insn");
-    unsigned uval = val;
+    uint64_t uval = val;
     unsigned mask = checked_cast<unsigned>(right_n_bits(nbits));
     uval &= mask;
-    f(uval, lsb + nbits - 1, lsb);
+    f(checked_cast<unsigned>(uval), lsb + nbits - 1, lsb);
   }
 
   void rf(Register r, int lsb) {
@@ -553,7 +553,7 @@ class Address {
           i->sf(offset(), 20, 12);
         } else {
           i->f(0b01, 25, 24);
-          i->f(offset() >> size, 21, 10);
+          i->f(checked_cast<unsigned>(offset() >> size), 21, 10);
         }
       }
       break;
@@ -653,7 +653,7 @@ class Address {
   static bool offset_ok_for_sve_immed(int64_t offset, int shift, int vl /* sve vector length */) {
     if (offset % vl == 0) {
       // Convert address offset into sve imm offset (MUL VL).
-      int sve_offset = offset / vl;
+      int64_t sve_offset = offset / vl;
       if (((-(1 << (shift - 1))) <= sve_offset) && (sve_offset < (1 << (shift - 1)))) {
         // sve_offset can be encoded
         return true;
@@ -2412,7 +2412,7 @@ public:
       ld_st(Vt, T, a.base(), op1, op2);
       break;
     case Address::post:
-      ld_st(Vt, T, a.base(), a.offset(), op1, op2, regs);
+      ld_st(Vt, T, a.base(), checked_cast<int>(a.offset()), op1, op2, regs);
       break;
     case Address::post_reg:
       ld_st(Vt, T, a.base(), a.index(), op1, op2);
@@ -3522,7 +3522,7 @@ private:
               int op1, int type, int imm_op2, int scalar_op2) {
     switch (a.getMode()) {
     case Address::base_plus_offset:
-      sve_ld_st1(Zt, a.base(), a.offset(), Pg, T, op1, type, imm_op2);
+      sve_ld_st1(Zt, a.base(), checked_cast<int>(a.offset()), Pg, T, op1, type, imm_op2);
       break;
     case Address::base_plus_offset_reg:
       sve_ld_st1(Zt, a.base(), a.index(), Pg, T, op1, type, scalar_op2);

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -26,9 +26,9 @@
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
-#include "gc/shared/collectedHeap.inline.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"
+#include "memory/universe.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/os.hpp"
@@ -2434,7 +2434,7 @@ void Assembler::jcc(Condition cc, Label& L, bool maybe_short) {
 
     const int short_size = 2;
     const int long_size = 6;
-    intptr_t offs = (intptr_t)dst - (intptr_t)pc();
+    int offs = checked_cast<int>((intptr_t)dst - (intptr_t)pc());
     if (maybe_short && is8bit(offs - short_size)) {
       // 0111 tttn #8-bit disp
       emit_int16(0x70 | cc, (offs - short_size) & 0xFF);
@@ -2461,14 +2461,14 @@ void Assembler::jccb_0(Condition cc, Label& L, const char* file, int line) {
     const int short_size = 2;
     address entry = target(L);
 #ifdef ASSERT
-    intptr_t dist = (intptr_t)entry - ((intptr_t)pc() + short_size);
-    intptr_t delta = short_branch_delta();
+    int dist = checked_cast<int>((intptr_t)entry - (intptr_t)(pc() + short_size));
+    int delta = short_branch_delta();
     if (delta != 0) {
       dist += (dist < 0 ? (-delta) :delta);
     }
-    assert(is8bit(dist), "Dispacement too large for a short jmp at %s:%d", file, line);
+    assert(is8bit(dist), "Displacement too large for a short jmp at %s:%d", file, line);
 #endif
-    intptr_t offs = (intptr_t)entry - (intptr_t)pc();
+    int offs = checked_cast<int>((intptr_t)entry - (intptr_t)pc());
     // 0111 tttn #8-bit disp
     emit_int16(0x70 | cc, (offs - short_size) & 0xFF);
   } else {
@@ -2492,7 +2492,7 @@ void Assembler::jmp(Label& L, bool maybe_short) {
     InstructionMark im(this);
     const int short_size = 2;
     const int long_size = 5;
-    intptr_t offs = entry - pc();
+    int offs = checked_cast<int>(entry - pc());
     if (maybe_short && is8bit(offs - short_size)) {
       emit_int16((unsigned char)0xEB, ((offs - short_size) & 0xFF));
     } else {
@@ -2531,12 +2531,12 @@ void Assembler::jmpb_0(Label& L, const char* file, int line) {
     address entry = target(L);
     assert(entry != nullptr, "jmp most probably wrong");
 #ifdef ASSERT
-    intptr_t dist = (intptr_t)entry - ((intptr_t)pc() + short_size);
-    intptr_t delta = short_branch_delta();
+    int dist = checked_cast<int>((intptr_t)entry - (intptr_t)(pc() + short_size));
+    int delta = short_branch_delta();
     if (delta != 0) {
       dist += (dist < 0 ? (-delta) :delta);
     }
-    assert(is8bit(dist), "Dispacement too large for a short jmp at %s:%d", file, line);
+    assert(is8bit(dist), "Displacement too large for a short jmp at %s:%d", file, line);
 #endif
     intptr_t offs = entry - pc();
     emit_int16((unsigned char)0xEB, (offs - short_size) & 0xFF);
@@ -6379,7 +6379,7 @@ void Assembler::xbegin(Label& abort, relocInfo::relocType rtype) {
   if (abort.is_bound()) {
     address entry = target(abort);
     assert(entry != nullptr, "abort entry null");
-    intptr_t offset = entry - pc();
+    int offset = checked_cast<int>(entry - pc());
     emit_int16((unsigned char)0xC7, (unsigned char)0xF8);
     emit_int32(offset - 6); // 2 opcode + 4 address
   } else {

--- a/src/hotspot/share/asm/assembler.cpp
+++ b/src/hotspot/share/asm/assembler.cpp
@@ -33,7 +33,6 @@
 #include "runtime/javaThread.hpp"
 #include "runtime/os.hpp"
 
-
 // Implementation of AbstractAssembler
 //
 // The AbstractAssembler is generating code into a CodeBuffer. To make code generation faster,

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -295,15 +295,14 @@ class AbstractAssembler : public ResourceObj  {
   // that the range is correct.
   template <typename T>
   constexpr T narrow_cast(int x) const {
-   if (x < 0) {
-    using stype = std::make_signed_t<T>;
-    assert(x >= std::numeric_limits<stype>::min(), "too negative"); // >= -128 for 8 bits
-    return static_cast<T>(x);  // cut off sign bits
-   } else {
-     return checked_cast<T>(x);
-   }
+    if (x < 0) {
+      using stype = std::make_signed_t<T>;
+      assert(x >= std::numeric_limits<stype>::min(), "too negative"); // >= -128 for 8 bits
+      return static_cast<T>(x);  // cut off sign bits
+    } else {
+      return checked_cast<T>(x);
+    }
   }
-
 
  public:
 

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -291,10 +291,13 @@ class AbstractAssembler : public ResourceObj  {
 #endif
 
   // sign-extended tolerant cast needed by callers of emit_int8 and emit_int16
+  // Some callers pass signed types that need to fit into the unsigned type so check
+  // that the range is correct.
   template <typename T>
   constexpr T narrow_cast(int x) const {
    if (x < 0) {
-    assert(x > -(std::numeric_limits<T>::max() - 1), "too negative");
+    using stype = std::make_signed_t<T>;
+    assert(x >= std::numeric_limits<stype>::min(), "too negative"); // >= -128 for 8 bits
     return static_cast<T>(x);  // cut off sign bits
    } else {
      return checked_cast<T>(x);

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -290,6 +290,18 @@ class AbstractAssembler : public ResourceObj  {
   };
 #endif
 
+  // sign-extended tolerant cast needed by callers of emit_int8 and emit_int16
+  template <typename T>
+  constexpr T narrow_cast(int x) const {
+   if (x < 0) {
+    assert(x > -(std::numeric_limits<T>::max() - 1), "too negative");
+    return static_cast<T>(x);  // cut off sign bits
+   } else {
+     return checked_cast<T>(x);
+   }
+  }
+
+
  public:
 
   // Creation
@@ -298,15 +310,22 @@ class AbstractAssembler : public ResourceObj  {
   // ensure buf contains all code (call this before using/copying the code)
   void flush();
 
-  void emit_int8(   uint8_t x1)                                     { code_section()->emit_int8(x1); }
+  void emit_int8(       int x1)                                     { code_section()->emit_int8(narrow_cast<uint8_t>(x1)); }
 
-  void emit_int16(  uint16_t x)                                     { code_section()->emit_int16(x); }
-  void emit_int16(  uint8_t x1, uint8_t x2)                         { code_section()->emit_int16(x1, x2); }
+  void emit_int16(       int x)                                     { code_section()->emit_int16(narrow_cast<uint16_t>(x)); }
 
-  void emit_int24(  uint8_t x1, uint8_t x2, uint8_t x3)             { code_section()->emit_int24(x1, x2, x3); }
+  void emit_int16(      int x1,     int x2)                         { code_section()->emit_int16(narrow_cast<uint8_t>(x1),
+                                                                                                 narrow_cast<uint8_t>(x2)); }
+
+  void emit_int24(      int x1,     int x2,     int x3)             { code_section()->emit_int24(narrow_cast<uint8_t>(x1),
+                                                                                                 narrow_cast<uint8_t>(x2),
+                                                                                                 narrow_cast<uint8_t>(x3)); }
 
   void emit_int32(  uint32_t x)                                     { code_section()->emit_int32(x); }
-  void emit_int32(  uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4) { code_section()->emit_int32(x1, x2, x3, x4); }
+  void emit_int32(      int x1,     int x2,     int x3,     int x4) { code_section()->emit_int32(narrow_cast<uint8_t>(x1),
+                                                                                                 narrow_cast<uint8_t>(x2),
+                                                                                                 narrow_cast<uint8_t>(x3),
+                                                                                                 narrow_cast<uint8_t>(x4)); }
 
   void emit_int64(  uint64_t x)                                     { code_section()->emit_int64(x); }
 

--- a/src/hotspot/share/compiler/abstractDisassembler.cpp
+++ b/src/hotspot/share/compiler/abstractDisassembler.cpp
@@ -75,8 +75,8 @@ int AbstractDisassembler::print_location(address here, address begin, address en
     if ((uintptr_t)end   < (uintptr_t)here) st->print(">>  end(" PTR_FORMAT ") < here(" PTR_FORMAT ")<<", p2i(end),   p2i(here));
     assert((uintptr_t)begin <= (uintptr_t)end, "inverted address range");
 #endif
-    const int blob_len = end - begin;
-    const int offset   = here - begin;
+    const int blob_len = pointer_delta_as_int(end, begin);
+    const int offset   = pointer_delta_as_int(here, begin);
     const int width    = (blob_len < (1<< 8)) ? 2 : (blob_len < (1<<16)) ? 4 : (blob_len < (1<<24)) ? 6 : 8;
     if (print_header) {
       st->print(" %*s", width+5, "offset");


### PR DESCRIPTION
Please review changes to fix -Wconversion warnings that come from assembler_<cpu>.cpp by adding narrow_casts to the emit_int8,16,24, and 32 functions.  And some other fixups with checked_cast.

Ran tier1 on Oracle platforms, and tier1-4 on linux-x64-debug, linux-aarch64-debug, windows-x64-debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311847](https://bugs.openjdk.org/browse/JDK-8311847): Fix -Wconversion for assembler.hpp emit_int8,16 callers (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [71c8fdec](https://git.openjdk.org/jdk/pull/14822/files/71c8fdeca5e449145806dbda6a4d58ab2ce62465)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14822/head:pull/14822` \
`$ git checkout pull/14822`

Update a local copy of the PR: \
`$ git checkout pull/14822` \
`$ git pull https://git.openjdk.org/jdk.git pull/14822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14822`

View PR using the GUI difftool: \
`$ git pr show -t 14822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14822.diff">https://git.openjdk.org/jdk/pull/14822.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14822#issuecomment-1629966377)