### PR TITLE
8280482: Window transparency bug on Linux

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -804,10 +804,10 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
         if (insLog.isLoggable(PlatformLogger.Level.FINE)) {
             insLog.fine(xe.toString());
         }
-        checkIfOnNewScreen(toGlobal(new Rectangle(scaleDown(xe.get_x()),
+        checkIfOnNewScreen(new Rectangle(scaleDown(xe.get_x()),
                 scaleDown(xe.get_y()),
                 scaleDown(xe.get_width()),
-                scaleDown(xe.get_height()))));
+                scaleDown(xe.get_height())));
 
         Rectangle oldBounds = getBounds();
 

--- a/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
@@ -53,6 +53,8 @@ public class MultiScreenCheckScreenIDTest extends MouseAdapter {
     private static GraphicsDevice[] screens;
     static List<Window> windowList = new ArrayList<>();
     static Robot robot;
+    static JWindow window;
+
 
     public static void main(final String[] args) throws Exception {
         try {
@@ -89,7 +91,7 @@ public class MultiScreenCheckScreenIDTest extends MouseAdapter {
                 try {
                     SwingUtilities.invokeAndWait(() -> {
                         try {
-                            createWindow(r);
+                            window = createWindow(r);
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -99,35 +101,34 @@ public class MultiScreenCheckScreenIDTest extends MouseAdapter {
                 }
                 robot.delay(50);
                 robot.waitForIdle();
-                if (windowList.get(windowList.size() - 1).getBounds().intersects
-                        (screen.getDefaultConfiguration().getBounds())) {
-                    if (!(windowList.get(windowList.size() - 1).
-                            getGraphicsConfiguration().getBounds().
-                            intersects(screen.getDefaultConfiguration().
-                                    getBounds()))) {
+                if (window.getBounds().intersects(screenBounds)) {
+                    if (!(window.getGraphicsConfiguration().getBounds().
+                            intersects(screenBounds))) {
                         throw new RuntimeException("Graphics configuration " +
                                 "changed for screen :" + screenNumber);
                     }
                 }
+                windowList.add(window);
             }
             screenNumber++;
         }
     }
 
-    private void createWindow(Rectangle bounds) {
+    private JWindow createWindow(Rectangle bounds) {
         JWindow window = new JWindow();
         window.setBounds(bounds);
         window.setBackground(BACKGROUND);
         window.setAlwaysOnTop(true);
         window.addMouseListener(this);
         window.setVisible(true);
-        windowList.add(window);
+        return window;
     }
 
     @Override
     public void mouseClicked(MouseEvent e) {
         ((Window) e.getSource()).dispose();
     }
+
     private static List<Rectangle> gridOfRectangles(Rectangle r, int cols, int rows) {
         List<Rectangle> l = new ArrayList<>();
         for (int row = 0; row < rows; row++) {

--- a/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
@@ -76,8 +76,9 @@ public class MultiScreenCheckScreenIDTest extends MouseAdapter {
                 .getLocalGraphicsEnvironment()
                 .getScreenDevices();
 
-        if(screens.length < 2) {
-            System.out.println("Testing aborted. Required min of 2 screens. Found : " + screens.length );
+        if (screens.length < 2) {
+            System.out.println("Testing aborted. Required min of 2 screens. " +
+                    "Found : " + screens.length );
             return;
         }
 
@@ -112,17 +113,21 @@ public class MultiScreenCheckScreenIDTest extends MouseAdapter {
         window.setVisible(true);
         windowList.add(window);
 
-        window.addPropertyChangeListener("graphicsConfiguration", new PropertyChangeListener() {
+        window.addPropertyChangeListener("graphicsConfiguration",
+                new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
                 double windowXPos = window.getBounds().getX();
-                double screen1Width = screens[0].getDefaultConfiguration().getBounds().getWidth();
-                System.out.println("window x Position : " + windowXPos + ", screen[0] width : " + screen1Width);
+                double screen1Width = screens[0].getDefaultConfiguration()
+                        .getBounds().getWidth();
+                System.out.println("window x Position : " + windowXPos + "," +
+                        " screen[0] width : " + screen1Width);
 
                 //Check if GC is changed for windows positioned in screen 0.
 
                 if (windowXPos < screen1Width) {
-                    throw new RuntimeException("Graphics configuration changed for screen 1");
+                    throw new RuntimeException("Graphics configuration changed" +
+                            " for screen 1");
                 }
             }
         });

--- a/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
@@ -48,6 +48,7 @@ import java.util.List;
 
 public class MultiScreenCheckScreenIDTest {
     private static final int COLS = 12;
+    private static final int ROWS = 8;
     private static final Color BACKGROUND = new Color(0, 0, 255, 64);
     private static GraphicsDevice[] screens;
     static List<Window> windowList = new ArrayList<>();
@@ -86,7 +87,7 @@ public class MultiScreenCheckScreenIDTest {
         for (GraphicsDevice screen : screens) {
             Rectangle screenBounds = screen.getDefaultConfiguration().getBounds();
 
-            for (Rectangle r : gridOfRectangles(screenBounds, COLS)) {
+            for (Rectangle r : gridOfRectangles(screenBounds, COLS, ROWS)) {
                 try {
                     SwingUtilities.invokeAndWait(() -> {
                         try {
@@ -132,12 +133,16 @@ public class MultiScreenCheckScreenIDTest {
         windowList.add(window);
     }
 
-    private static List<Rectangle> gridOfRectangles(Rectangle r, int cols) {
+    private static List<Rectangle> gridOfRectangles(Rectangle r, int cols, int rows) {
         List<Rectangle> l = new ArrayList<>();
-        for (int col = 0; col < cols; col++) {
-            int x1 = r.x + (int) Math.round(r.width * (double) col / cols);
-            int x2 = r.x + (int) Math.round(r.width * (double) (col + 1) / cols);
-            l.add(new Rectangle(x1, 0, x2 - x1, x2-x1));
+        for (int row = 0; row < rows; row++) {
+            int y1 = r.y + (int) Math.round(r.height * (double) row / rows);
+            int y2 = r.y + (int) Math.round(r.height * (double) (row + 1) / rows);
+            for (int col = 0; col < cols; col++) {
+                int x1 = r.x + (int) Math.round(r.width * (double) col / cols);
+                int x2 = r.x + (int) Math.round(r.width * (double) (col + 1) / cols);
+                l.add(new Rectangle(x1, y1, x2 - x1, y2 - y1));
+            }
         }
         return l;
     }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
@@ -63,6 +63,9 @@ public class MultiScreenCheckScreenIDTest extends MouseAdapter {
             for (Window win : windowList) {
                 win.dispose();
             }
+            if (window != null) {
+                window.dispose();
+            }
         }
         System.out.println("Test Pass");
     }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenCheckScreenIDTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.Rectangle;
+import java.awt.Window;
+
+import javax.swing.JWindow;
+import javax.swing.SwingUtilities;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * @test
+ * @bug 8280482
+ * @key headful
+ * @requires (os.family == "linux")
+ * @library /java/awt/regtesthelpers
+ * @summary Test to check if window GC doesn't change within same screen.
+ * @run main MultiScreenCheckScreenIDTest
+ */
+
+public class MultiScreenCheckScreenIDTest extends MouseAdapter {
+    private static final int COLS = 12;
+    private static final int ROWS = 8;
+    private static final Color BACKGROUND = new Color(0, 0, 255, 64);
+    private GraphicsDevice[] screens;
+    static List<Window> windowList = new ArrayList<>();
+
+    public static void main(final String[] args) throws Exception {
+        try {
+            createGUI();
+        } finally {
+            for (Window win : windowList) {
+                win.dispose();
+            }
+        }
+        Thread.sleep(1000);
+        System.out.println("Test Pass");
+    }
+
+    private static void createGUI() {
+        new MultiScreenCheckScreenIDTest().createWindowGrid();
+    }
+
+    private void createWindowGrid() {
+        screens = GraphicsEnvironment
+                .getLocalGraphicsEnvironment()
+                .getScreenDevices();
+
+        if(screens.length < 2) {
+            System.out.println("Testing aborted. Required min of 2 screens. Found : " + screens.length );
+            return;
+        }
+
+        for (GraphicsDevice screen : screens) {
+            Rectangle screenBounds = screen.getDefaultConfiguration().getBounds();
+
+            for (Rectangle r : gridOfRectangles(screenBounds, COLS, ROWS)) {
+                try {
+                    SwingUtilities.invokeAndWait(() -> {
+                        try {
+                            createWindow(r);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+
+                    Thread.sleep(100);
+                } catch (InterruptedException | InvocationTargetException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private void createWindow(Rectangle bounds) throws Exception {
+        Thread.sleep(50);
+        JWindow window = new JWindow();
+        window.setBounds(bounds);
+        window.setBackground(BACKGROUND);
+        window.setAlwaysOnTop(true);
+        window.addMouseListener(this);
+        window.setVisible(true);
+        windowList.add(window);
+
+        window.addPropertyChangeListener("graphicsConfiguration", new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+                double windowXPos = window.getBounds().getX();
+                double screen1Width = screens[0].getDefaultConfiguration().getBounds().getWidth();
+                System.out.println("window x Position : " + windowXPos + ", screen[0] width : " + screen1Width);
+
+                //Check if GC is changed for windows positioned in screen 0.
+
+                if (windowXPos < screen1Width) {
+                    throw new RuntimeException("Graphics configuration changed for screen 1");
+                }
+            }
+        });
+    }
+
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        ((Window) e.getSource()).dispose();
+    }
+
+    private static List<Rectangle> gridOfRectangles(Rectangle r, int cols, int rows) {
+        List<Rectangle> l = new ArrayList<>();
+        for (int row = 0; row < rows; row++) {
+            int y1 = r.y + (int) Math.round(r.height * (double) row / rows);
+            int y2 = r.y + (int) Math.round(r.height * (double) (row + 1) / rows);
+            for (int col = 0; col < cols; col++) {
+                int x1 = r.x + (int) Math.round(r.width * (double) col / cols);
+                int x2 = r.x + (int) Math.round(r.width * (double) (col + 1) / cols);
+                l.add(new Rectangle(x1, y1, x2 - x1, y2 - y1));
+            }
+        }
+        return l;
+    }
+}


### PR DESCRIPTION
The bug mentions about transparency issue on Linux which actually got resolved with [JDK-8006421](https://bugs.openjdk.org/browse/JDK-8006421) fix. Now there is another problem related to the bug, which is screen selection going wrong during checking for new screen when the test is run. The problem is that (As seen in the pictures attached in bug) the transparency is lost for windows which are in screen 0 (default screen) too, which is not supposed to happen where windows on screen 1 should have lost there transparency. The main reason being the call to `toGlobal()` when window bounds are passed to `checkIfOnNewScreen` method. I didn't get the actual reason for `toGlobal` being used here (actually not required to check monitor number), but it actually doubled the X position of the window [here]( https://github.com/openjdk/jdk/blob/4b1403d06b99b91ddd89ad6e54669b0595f1f8e5/src/java.desktop/unix/classes/sun/awt/X11/XBaseWindow.java#L776). Removing `toGlobal` solve the issue and neither didn't cause any regression (existing test + the reason `toGlobal()` was added [JDK-8143295](https://bugs.openjdk.org/browse/JDK-8143295)).

The automated test fails if GC is changed for windows within screen 0 (default screen). CI testing is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280482](https://bugs.openjdk.org/browse/JDK-8280482): Window transparency bug on Linux (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [4e47192a](https://git.openjdk.org/jdk/pull/14825/files/4e47192aca5a6fa4c25060a64f5c0d9dcf24703d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14825/head:pull/14825` \
`$ git checkout pull/14825`

Update a local copy of the PR: \
`$ git checkout pull/14825` \
`$ git pull https://git.openjdk.org/jdk.git pull/14825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14825`

View PR using the GUI difftool: \
`$ git pr show -t 14825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14825.diff">https://git.openjdk.org/jdk/pull/14825.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14825#issuecomment-1630610559)