### PR TITLE
8311805: Clean up ScrollPane: drop redundant initialiser, mark scroller final

### DIFF
--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -507,7 +507,6 @@ public class ScrollPane extends Container implements Accessible {
         Component c = getComponent(0);
         Point p = getScrollPosition();
         Dimension cs = calculateChildSize();
-        Dimension vs = getViewportSize();
 
         c.reshape(- p.x, - p.y, cs.width, cs.height);
         ScrollPanePeer peer = (ScrollPanePeer)this.peer;
@@ -518,7 +517,7 @@ public class ScrollPane extends Container implements Accessible {
         // update adjustables... the viewport size may have changed
         // with the scrollbars coming or going so the viewport size
         // is updated before the adjustables.
-        vs = getViewportSize();
+        Dimension vs = getViewportSize();
         hAdjustable.setSpan(0, cs.width, vs.width);
         vAdjustable.setSpan(0, cs.height, vs.height);
     }
@@ -776,7 +775,7 @@ public class ScrollPane extends Container implements Accessible {
             }
         }
 
-        private ScrollPane scroller;
+        private final ScrollPane scroller;
     }
 
 


### PR DESCRIPTION
A small clean-up of `awt.ScrollPane` code:

1. Remove the redundant initialiser for `vs` in `layout` and move the declaration to where it's used. (One less `Dimension` object is created.)
2. Mark the `scroller` field of the `PeerFixer` class as `final`.

Perhaps, the  `PeerFixer` class could be `final` too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311805](https://bugs.openjdk.org/browse/JDK-8311805): Clean up ScrollPane: drop redundant initialiser, mark scroller final (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14827/head:pull/14827` \
`$ git checkout pull/14827`

Update a local copy of the PR: \
`$ git checkout pull/14827` \
`$ git pull https://git.openjdk.org/jdk.git pull/14827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14827`

View PR using the GUI difftool: \
`$ git pr show -t 14827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14827.diff">https://git.openjdk.org/jdk/pull/14827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14827#issuecomment-1630682851)