### PR TITLE
8244289: fatal error: Possible safepoint reached by thread that does not allow it

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
@@ -103,7 +103,7 @@ void JfrPostBox::deposit(int new_messages) {
 void JfrPostBox::asynchronous_post(int msg) {
   assert(!is_synchronous(msg), "invariant");
   deposit(msg);
-  JfrMonitorTryLock try_msg_lock(JfrMsg_lock);
+  JfrMutexTryLock try_msg_lock(JfrMsg_lock);
   if (try_msg_lock.acquired()) {
     JfrMsg_lock->notify_all();
   }

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -38,6 +38,7 @@
 #include "jfr/utilities/jfrIterator.hpp"
 #include "jfr/utilities/jfrLinkedList.inline.hpp"
 #include "jfr/utilities/jfrTime.hpp"
+#include "jfr/utilities/jfrTryLock.hpp"
 #include "jfr/writers/jfrNativeEventWriter.hpp"
 #include "logging/log.hpp"
 #include "runtime/javaThread.hpp"
@@ -316,7 +317,8 @@ static void log_discard(size_t pre_full_count, size_t post_full_count, size_t am
 }
 
 void JfrStorage::discard_oldest(Thread* thread) {
-  if (JfrBuffer_lock->try_lock()) {
+  JfrMutexTryLock mutex(JfrBuffer_lock);
+  if (mutex.acquired()) {
     if (!control().should_discard()) {
       // another thread handled it
       return;
@@ -338,7 +340,6 @@ void JfrStorage::discard_oldest(Thread* thread) {
       oldest->release(); // publish
       break;
     }
-    JfrBuffer_lock->unlock();
     log_discard(num_full_pre_discard, control().full_count(), discarded_size);
   }
 }

--- a/src/hotspot/share/jfr/utilities/jfrTryLock.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTryLock.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,25 +50,23 @@ class JfrTryLock {
   }
 };
 
-class JfrMonitorTryLock : public StackObj {
+class JfrMutexTryLock : public StackObj {
  private:
-  Monitor* _lock;
+  Mutex* _mutex;
   bool _acquired;
 
  public:
-  JfrMonitorTryLock(Monitor* lock) : _lock(lock), _acquired(lock->try_lock()) {}
-
-  ~JfrMonitorTryLock() {
+  JfrMutexTryLock(Mutex* mutex) : _mutex(mutex), _acquired(mutex->try_lock()) {}
+  ~JfrMutexTryLock() {
     if (_acquired) {
-      assert(_lock->owned_by_self(), "invariant");
-      _lock->unlock();
+      assert(_mutex->owned_by_self(), "invariant");
+      _mutex->unlock();
     }
   }
 
   bool acquired() const {
     return _acquired;
   }
-
 };
 
 #endif // SHARE_JFR_UTILITIES_JFRTRYLOCK_HPP


### PR DESCRIPTION
Greetings,

Please help review this correction to an invalid lock acquisition when JFR is configured for not writing to disk.

Problem analysis is in the JIRA issue.

Testing: jdk_jfr, microbenchmarks

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244289](https://bugs.openjdk.org/browse/JDK-8244289): fatal error: Possible safepoint reached by thread that does not allow it (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14828/head:pull/14828` \
`$ git checkout pull/14828`

Update a local copy of the PR: \
`$ git checkout pull/14828` \
`$ git pull https://git.openjdk.org/jdk.git pull/14828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14828`

View PR using the GUI difftool: \
`$ git pr show -t 14828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14828.diff">https://git.openjdk.org/jdk/pull/14828.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14828#issuecomment-1630805112)