### PR TITLE
JDK-8311788: ClassLoadUnloadTest fails on AIX after JDK-8193513

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -123,17 +123,17 @@ public class ClassLoadUnloadTest {
         checkAbsent("[class,load,cause]");
         checkFor("class load cause logging will not produce output without LogClassLoadingCauseFor");
 
-        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringCoding
-        pb = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=java.lang.StringCoding");
-        checkFor("[class,load,cause]", "Java stack when loading java.lang.StringCoding:");
+        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper
+        pb = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper");
+        checkFor("[class,load,cause]", "Java stack when loading java.lang.StringConcatHelper:");
 
-        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringCoding
-        pb = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=java.lang.StringCoding");
-        checkFor("[class,load,cause,native]", "Native stack when loading java.lang.StringCoding:");
+        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper
+        pb = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper");
+        checkFor("[class,load,cause,native]", "Native stack when loading java.lang.StringConcatHelper:");
 
-        //  -Xlog:class+load+cause* -XX:LogClassLoadingCauseFor=java.lang.StringCoding
-        pb = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=java.lang.StringCoding");
-        checkFor("[class,load,cause] Java stack when loading java.lang.StringCoding:");
-        checkFor("[class,load,cause,native] Native stack when loading java.lang.StringCoding:");
+        //  -Xlog:class+load+cause* -XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper
+        pb = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper");
+        checkFor("[class,load,cause] Java stack when loading java.lang.StringConcatHelper:");
+        checkFor("[class,load,cause,native] Native stack when loading java.lang.StringConcatHelper:");
     }
 }

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -123,17 +123,16 @@ public class ClassLoadUnloadTest {
         checkAbsent("[class,load,cause]");
         checkFor("class load cause logging will not produce output without LogClassLoadingCauseFor");
 
-        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper
-        pb = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper");
-        checkFor("[class,load,cause]", "Java stack when loading java.lang.StringConcatHelper:");
+        String x = ClassUnloadTestMain.class.getName();
 
-        //  -Xlog:class+load+cause -XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper
-        pb = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper");
-        checkFor("[class,load,cause,native]", "Native stack when loading java.lang.StringConcatHelper:");
+        pb = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=" + x);
+        checkFor("[class,load,cause]", "Java stack when loading " + x + ":");
 
-        //  -Xlog:class+load+cause* -XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper
-        pb = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=java.lang.StringConcatHelper");
-        checkFor("[class,load,cause] Java stack when loading java.lang.StringConcatHelper:");
-        checkFor("[class,load,cause,native] Native stack when loading java.lang.StringConcatHelper:");
+        pb = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=" + x);
+        checkFor("[class,load,cause,native]", "Native stack when loading " + x + ":");
+
+        pb = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=" + x);
+        checkFor("[class,load,cause] Java stack when loading " + x + ":");
+        checkFor("[class,load,cause,native] Native stack when loading " + x + ":");
     }
 }


### PR DESCRIPTION
The change [JDK-8193513](https://bugs.openjdk.org/browse/JDK-8193513) enhanced the test runtime/logging/ClassLoadUnloadTest.java . Unfortunately the test started to fail after this on AIX :

----------System.err:(16/744)----------
 stdout: [];
 stderr: []
 exitValue = 0

java.lang.RuntimeException: '[class,load,cause]' missing from stdout/stderr
at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:221)
at ClassLoadUnloadTest.checkFor(ClassLoadUnloadTest.java:64)
at ClassLoadUnloadTest.main(ClassLoadUnloadTest.java:128)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.run(Thread.java:1570)


Reason is that we check for class java.lang.StringCoding  in the UL output; but on AIX this class is not loaded because we have a different encoding/charset  (see  ISO_8859_1.INSTANCE in the String class). This different encoding is not using StringCoding.

I suppose the same might be true for JVMs without COMPACT_STRING supported (but did not check in detail) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311788](https://bugs.openjdk.org/browse/JDK-8311788): ClassLoadUnloadTest fails on AIX after JDK-8193513 (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [35e8e6f1](https://git.openjdk.org/jdk/pull/14829/files/35e8e6f18d8990ef2fc69691c33ee26348e71586)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14829/head:pull/14829` \
`$ git checkout pull/14829`

Update a local copy of the PR: \
`$ git checkout pull/14829` \
`$ git pull https://git.openjdk.org/jdk.git pull/14829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14829`

View PR using the GUI difftool: \
`$ git pr show -t 14829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14829.diff">https://git.openjdk.org/jdk/pull/14829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14829#issuecomment-1630823958)