### PR TITLE
8311647: Memory leak in Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_ttyname_1r

### DIFF
--- a/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
@@ -188,6 +188,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
 
     if (error != 0) {
         throw_errno(env);
+        delete[] data;
         return ;
     }
 

--- a/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
@@ -187,8 +187,8 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
     int error = ttyname_r(fd, data, len);
 
     if (error != 0) {
-        throw_errno(env);
         delete[] data;
+        throw_errno(env);
         return ;
     }
 

--- a/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
@@ -192,6 +192,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_osx_CLibrar
 
     if (error != 0) {
         throw_errno(env);
+        delete[] data;
         return ;
     }
 

--- a/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
@@ -191,8 +191,8 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_osx_CLibrar
     int error = ttyname_r(fd, data, len);
 
     if (error != 0) {
-        throw_errno(env);
         delete[] data;
+        throw_errno(env);
         return ;
     }
 


### PR DESCRIPTION
Allocated data on error path is deleted before return

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311647](https://bugs.openjdk.org/browse/JDK-8311647): Memory leak in Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_ttyname_1r (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14832/head:pull/14832` \
`$ git checkout pull/14832`

Update a local copy of the PR: \
`$ git checkout pull/14832` \
`$ git pull https://git.openjdk.org/jdk.git pull/14832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14832`

View PR using the GUI difftool: \
`$ git pr show -t 14832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14832.diff">https://git.openjdk.org/jdk/pull/14832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14832#issuecomment-1631172304)