### PR TITLE
JDK-8311892: TrustManagerFactory loading an invalid keystore yield vague exception

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -386,7 +386,11 @@ final class TrustStoreManager {
             if (!"NONE".equals(descriptor.storeName)) {
                 try (@SuppressWarnings("removal") FileInputStream fis = AccessController.doPrivileged(
                         new OpenFileInputStreamAction(descriptor.storeFile))) {
-                    ks.load(fis, password);
+                    try {
+                        ks.load(fis, password);
+                    } catch (Exception e) {
+                        throw new KeyStoreException("Failed to load key store: " + descriptor.storeName, e);
+                    }
                 } catch (FileNotFoundException fnfe) {
                     // No file available, no KeyStore available.
                     if (SSLLogger.isOn && SSLLogger.isOn("trustmanager")) {


### PR DESCRIPTION
When loading the default JVM trust store, if the JVM trust store contains an invalid certificate, the exception contains insufficient information to determine which certificate is invalid, making it very difficult to fix the problem.

To reproduce the issue:
1. Modify the default JVM trust store to contain invalid information. A very easy way to do this on openjdk / red hat systems is to edit /etc/pki/ca-trust/extracted/java/cacerts and add garbage text to the file.
2. Run this code:
```
TrustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
// initializing the trust store with a null KeyStore will load the default JVM trust store
tmf.init((KeyStore) null);
```

This stack trace results:
```
Caused by: java.security.KeyStoreException: problem accessing trust store
	at java.base/sun.security.ssl.TrustManagerFactoryImpl.engineInit(TrustManagerFactoryImpl.java:73)
	at java.base/javax.net.ssl.TrustManagerFactory.init(TrustManagerFactory.java:282)
	... 81 common frames omitted
Caused by: java.io.IOException: toDerInputStream rejects tag type 97
	at java.base/sun.security.util.DerValue.toDerInputStream(DerValue.java:1155)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.engineLoad(PKCS12KeyStore.java:2013)
	at java.base/sun.security.util.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:221)
	at java.base/java.security.KeyStore.load(KeyStore.java:1473)
	at java.base/sun.security.ssl.TrustStoreManager$TrustAnchorManager.loadKeyStore(TrustStoreManager.java:390)
	at java.base/sun.security.ssl.TrustStoreManager$TrustAnchorManager.getTrustedCerts(TrustStoreManager.java:336)
	at java.base/sun.security.ssl.TrustStoreManager.getTrustedCerts(TrustStoreManager.java:57)
	at java.base/sun.security.ssl.TrustManagerFactoryImpl.engineInit(TrustManagerFactoryImpl.java:49)
	... 83 common frames omitted
```

Throwing an exception with a more detailed error message facilitates debugging and ultimately fixing such problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311892](https://bugs.openjdk.org/browse/JDK-8311892): TrustManagerFactory loading an invalid keystore yield vague exception (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14834/head:pull/14834` \
`$ git checkout pull/14834`

Update a local copy of the PR: \
`$ git checkout pull/14834` \
`$ git pull https://git.openjdk.org/jdk.git pull/14834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14834`

View PR using the GUI difftool: \
`$ git pr show -t 14834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14834.diff">https://git.openjdk.org/jdk/pull/14834.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14834#issuecomment-1631410809)