### PR TITLE
JDK-8309032: jpackage: fix ClassCastException when --module-path is not needed

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -312,13 +312,9 @@ final class LauncherData {
 
     private static List<Path> getPathListParameter(String paramName,
             Map<String, ? super Object> params) throws ConfigException {
-        return getPathParam(params, paramName, () -> {
-            String value = (String) params.get(paramName);
-            return (value == null) ? List.of() :
-                    List.of(value.split(File.pathSeparator)).stream()
-                    .map(Path::of)
-                    .collect(Collectors.toUnmodifiableList());
-        });
+        return getPathParam(params, paramName, () ->
+                params.get(paramName) instanceof String value ?
+                        Stream.of(value.split(File.pathSeparator)).map(Path::of).toList() : List.of());
     }
 
     private String qualifiedClassName;

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -105,7 +105,7 @@ final class LauncherData {
     }
 
     private void verifyIsModular(boolean isModular) {
-        if ((moduleInfo != null) != isModular) {
+        if ((moduleInfo == null) == isModular) {
             throw new IllegalStateException();
         }
     }
@@ -266,14 +266,10 @@ final class LauncherData {
     private static String getStringParam(Map<String, ? super Object> params,
             String paramName) {
         Optional<Object> value = Optional.ofNullable(params.get(paramName));
-        if (value.isPresent()) {
-            return value.get().toString();
-        }
-        return null;
+        return value.map(Object::toString).orElse(null);
     }
 
-    private static <T> T getPathParam(Map<String, ? super Object> params,
-            String paramName, Supplier<T> func) throws ConfigException {
+    private static <T> T getPathParam(String paramName, Supplier<T> func) throws ConfigException {
         try {
             return func.get();
         } catch (InvalidPathException ex) {
@@ -285,7 +281,7 @@ final class LauncherData {
 
     private static Path getPathParam(Map<String, ? super Object> params,
             String paramName) throws ConfigException {
-        return getPathParam(params, paramName, () -> {
+        return getPathParam(paramName, () -> {
             String value = getStringParam(params, paramName);
             Path result = null;
             if (value != null) {
@@ -304,7 +300,7 @@ final class LauncherData {
             runtimePath = runtimePath.resolve("lib");
             modulePath = Stream.of(modulePath, List.of(runtimePath))
                     .flatMap(List::stream)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
         }
 
         return modulePath;
@@ -312,7 +308,7 @@ final class LauncherData {
 
     private static List<Path> getPathListParameter(String paramName,
             Map<String, ? super Object> params) throws ConfigException {
-        return getPathParam(params, paramName, () ->
+        return getPathParam(paramName, () ->
                 params.get(paramName) instanceof String value ?
                         Stream.of(value.split(File.pathSeparator)).map(Path::of).toList() : List.of());
     }


### PR DESCRIPTION
[JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032), [JDK-8306488](https://bugs.openjdk.org/browse/JDK-8306488)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032)

### Issue
 * [JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032): jpackage does not work for module projects unless --module-path is specified (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14835/head:pull/14835` \
`$ git checkout pull/14835`

Update a local copy of the PR: \
`$ git checkout pull/14835` \
`$ git pull https://git.openjdk.org/jdk.git pull/14835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14835`

View PR using the GUI difftool: \
`$ git pr show -t 14835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14835.diff">https://git.openjdk.org/jdk/pull/14835.diff</a>

</details>
