### PR TITLE
8295059: test/langtools/tools/javap 12 test classes use com.sun.tools.classfile library

### DIFF
--- a/test/langtools/tools/javap/T6716452.java
+++ b/test/langtools/tools/javap/T6716452.java
@@ -24,11 +24,18 @@
 /*
  * @test 6716452
  * @summary need a method to get an index of an attribute
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import java.nio.file.Files;
+
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 public class T6716452 {
     public static void main(String[] args) throws Exception {
@@ -38,49 +45,44 @@ public class T6716452 {
     public void run() throws Exception {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
-
-        ClassFile cf = ClassFile.read(classFile);
-        for (Method m: cf.methods) {
-            test(cf, m);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         if (errors > 0)
             throw new Exception(errors + " errors found");
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.Code, Code_attribute.class);
-        test(cf, m, Attribute.Exceptions, Exceptions_attribute.class);
+    void test(MethodModel mm) {
+        test(mm, Attributes.CODE, CodeAttribute.class);
+        test(mm, Attributes.EXCEPTIONS, ExceptionsAttribute.class);
     }
 
-    // test the result of Attributes.getIndex according to expectations
+    // test the result of MethodModel.findAttribute, MethodModel.attributes().indexOf() according to expectations
     // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, Class<?> c) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        try {
-            String m_name = m.getName(cf.constant_pool);
-            System.err.println("Method " + m_name + " name:" + name + " index:" + index + " class: " + c);
-            boolean expect = (m_name.equals("<init>") && name.equals("Code"))
-                || (m_name.indexOf(name) != -1);
-            boolean found = (index != -1);
-            if (expect) {
-                if (found) {
-                    Attribute attr = m.attributes.get(index);
-                    if (!c.isAssignableFrom(attr.getClass())) {
-                        error(m + ": unexpected attribute found,"
-                              + " expected " + c.getName()
-                              + " found " + attr.getClass().getName());
-                    }
-                } else {
-                    error(m + ": expected attribute " + name + " not found");
+    <T extends Attribute<T>> void test(MethodModel mm, AttributeMapper<T> attr, Class<?> c) {
+        Attribute<T> attr_instance = mm.findAttribute(attr).orElse(null);
+        int index = mm.attributes().indexOf(attr_instance);
+        String mm_name = mm.methodName().stringValue();
+        System.err.println("Method " + mm_name + " name:" + attr.name() + " index:" + index + " class: " + c);
+        boolean expect = (mm_name.equals("<init>") && attr.name().equals("Code"))
+                || (mm_name.contains(attr.name()));
+        boolean found = (index != -1);
+        if (expect) {
+            if (found) {
+                if (!c.isAssignableFrom(mm.attributes().get(index).getClass())) {
+                    error(mm + ": unexpected attribute found,"
+                            + " expected " + c.getName()
+                            + " found " + mm.attributes().get(index).attributeName());
                 }
             } else {
-                if (found) {
-                    error(m + ": unexpected attribute " + name);
-                }
+                error(mm + ": expected attribute " + attr.name() + " not found");
             }
-        } catch (ConstantPoolException e) {
-            error(m + ": " + e);
+        } else {
+            if (found) {
+                error(mm + ": unexpected attribute " + attr.name());
+            }
         }
     }
 

--- a/test/langtools/tools/javap/typeAnnotations/NewArray.java
+++ b/test/langtools/tools/javap/typeAnnotations/NewArray.java
@@ -22,17 +22,21 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test NewArray
  * @bug 6843077
  * @summary Test type annotations on local array are in method's code attribute.
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class NewArray {
-
     public static void main(String[] args) throws Exception {
         new NewArray().run();
     }
@@ -41,51 +45,48 @@ public class NewArray {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        for (Method m: cf.methods) {
-            test(cf, m);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
-
         countAnnotations();
-
         if (errors > 0)
             throw new Exception(errors + " errors found");
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(MethodModel mm) {
+        test(mm, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(mm, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
     // test the result of Attributes.getIndex according to expectations
     // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        Attribute attr = null;
-        Code_attribute cAttr = null;
-        RuntimeTypeAnnotations_attribute tAttr = null;
+    <T extends Attribute<T>> void test(MethodModel mm, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance;
+        CodeAttribute cAttr;
 
-        int index = m.attributes.getIndex(cf.constant_pool, Attribute.Code);
-        if(index!= -1) {
-            attr = m.attributes.get(index);
-            assert attr instanceof Code_attribute;
-            cAttr = (Code_attribute)attr;
-            index = cAttr.attributes.getIndex(cf.constant_pool, name);
-            if(index!= -1) {
-                attr = cAttr.attributes.get(index);
-                assert attr instanceof RuntimeTypeAnnotations_attribute;
-                tAttr = (RuntimeTypeAnnotations_attribute)attr;
-                all += tAttr.annotations.length;
-                if (visible)
-                    visibles += tAttr.annotations.length;
-                else
-                    invisibles += tAttr.annotations.length;
-               }
+        cAttr = mm.findAttribute(Attributes.CODE).orElse(null);
+        if (cAttr != null) {
+            attr_instance = cAttr.findAttribute(attr_name).orElse(null);
+            if (attr_instance != null) {
+                switch (attr_instance) {
+                    case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                        all += tAttr.annotations().size();
+                        visibles += tAttr.annotations().size();
+                    }
+                    case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                        all += tAttr.annotations().size();
+                        invisibles += tAttr.annotations().size();
+                    }
+                    default -> throw new AssertionError();
+                }
+            }
         }
     }
 
     File writeTestFile() throws IOException {
-      File f = new File("Test.java");
+        File f = new File("Test.java");
         PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(f)));
         out.println("import java.lang.annotation.*;");
         out.println("import java.util.*;");
@@ -133,7 +134,6 @@ public class NewArray {
         }
 
     }
-
     int errors;
     int all;
     int visibles;

--- a/test/langtools/tools/javap/typeAnnotations/Presence.java
+++ b/test/langtools/tools/javap/typeAnnotations/Presence.java
@@ -23,14 +23,18 @@
 
 import java.io.*;
 import java.lang.annotation.ElementType;
-
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test Presence
  * @bug 6843077
  * @summary test that all type annotations are present in the classfile
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class Presence {
@@ -42,13 +46,13 @@ public class Presence {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        test(cf);
-        for (Field f : cf.fields) {
-            test(cf, f);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        test(cm);
+        for (FieldModel fm : cm.fields()) {
+            test(fm);
         }
-        for (Method m: cf.methods) {
-            test(cf, m);
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         countAnnotations();
@@ -58,91 +62,50 @@ public class Presence {
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf) {
-        test(cf, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(AttributedElement m) {
+        test(m, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(m, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    void test(ClassFile cf, Field m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, String name, boolean visible) {
-        int index = cf.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = cf.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    // test the result of AttributedElement.findAttribute according to expectations
+    <T extends Attribute<T>> void test(AttributedElement m, AttributeMapper<T> attr_name) {
+        Object attr_instance = m.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
+        }
+        if (m instanceof MethodModel) {
+            attr_instance = m.findAttribute(Attributes.CODE).orElse(null);
+            if(attr_instance!= null) {
+                CodeAttribute cAttr = (CodeAttribute)attr_instance;
+                attr_instance = cAttr.findAttribute(attr_name).orElse(null);
+                if(attr_instance!= null) {
+                    switch (attr_instance) {
+                        case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                            all += tAttr.annotations().size();
+                            visibles += tAttr.annotations().size();
+                        }
+                        case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                            all += tAttr.annotations().size();
+                            invisibles += tAttr.annotations().size();
+                        }
+                        default -> throw new AssertionError();
+                    }
+                }
+            }
         }
     }
 
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        Attribute attr = null;
-        Code_attribute cAttr = null;
-        RuntimeTypeAnnotations_attribute tAttr = null;
 
-        // collect annotations attributes on method
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-        // collect annotations from method's code attribute
-        index = m.attributes.getIndex(cf.constant_pool, Attribute.Code);
-        if(index!= -1) {
-            attr = m.attributes.get(index);
-            assert attr instanceof Code_attribute;
-            cAttr = (Code_attribute)attr;
-            index = cAttr.attributes.getIndex(cf.constant_pool, name);
-            if(index!= -1) {
-                attr = cAttr.attributes.get(index);
-                assert attr instanceof RuntimeTypeAnnotations_attribute;
-                tAttr = (RuntimeTypeAnnotations_attribute)attr;
-                all += tAttr.annotations.length;
-                if (visible)
-                    visibles += tAttr.annotations.length;
-                else
-                    invisibles += tAttr.annotations.length;
-               }
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Field m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
 
     File writeTestFile() throws IOException {
         File f = new File("TestPresence.java");

--- a/test/langtools/tools/javap/typeAnnotations/PresenceInner.java
+++ b/test/langtools/tools/javap/typeAnnotations/PresenceInner.java
@@ -22,13 +22,18 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test PresenceInner
  * @bug 6843077
  * @summary test that annotations in inner types count only once
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class PresenceInner {
@@ -40,13 +45,13 @@ public class PresenceInner {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        test(cf);
-        for (Field f : cf.fields) {
-            test(cf, f);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        test(cm);
+        for (FieldModel fm : cm.fields()) {
+            test(fm);
         }
-        for (Method m: cf.methods) {
-            test(cf, m);
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         // counts are zero when vising outer class
@@ -54,13 +59,13 @@ public class PresenceInner {
 
         // visit inner class
         File innerFile = new File("Test$1Inner.class");
-        ClassFile icf = ClassFile.read(innerFile);
-        test(icf);
-        for (Field f : icf.fields) {
-            test(cf, f);
+        ClassModel icm = Classfile.of().parse(innerFile.toPath());
+        test(icm);
+        for (FieldModel fm : icm.fields()) {
+            test(fm);
         }
-        for (Method m: icf.methods) {
-            test(cf, m);
+        for (MethodModel mm: icm.methods()) {
+            test(mm);
         }
 
         countAnnotations(1);
@@ -69,66 +74,26 @@ public class PresenceInner {
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf) {
-        test(cf, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(AttributedElement m) {
+        test(m, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(m, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    void test(ClassFile cf, Field m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, String name, boolean visible) {
-        int index = cf.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = cf.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Field m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    // test the result of AttributedElement.findAttribute according to expectations
+    <T extends Attribute<T>> void test(AttributedElement m, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance = m.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
         }
     }
 

--- a/test/langtools/tools/javap/typeAnnotations/Visibility.java
+++ b/test/langtools/tools/javap/typeAnnotations/Visibility.java
@@ -22,13 +22,19 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.Attributes;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test Visibility
  * @bug 6843077
  * @summary test that type annotations are recorded in the classfile
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class Visibility {
@@ -40,9 +46,9 @@ public class Visibility {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        for (Method m: cf.methods) {
-            test(cf, m);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         countAnnotations();
@@ -52,24 +58,27 @@ public class Visibility {
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(MethodModel mm) {
+        test(mm, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(mm, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
-    // test the result of Attributes.getIndex according to expectations
+    // test the result of mm.findAttribute according to expectations
     // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    <T extends Attribute<T>> void test(MethodModel mm, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance = mm.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
         }
     }
 
@@ -109,7 +118,7 @@ public class Visibility {
     }
 
     File compileTestFile(File f) {
-      int rc = com.sun.tools.javac.Main.compile(new String[] {"-g", f.getPath() });
+        int rc = com.sun.tools.javac.Main.compile(new String[] {"-g", f.getPath() });
         if (rc != 0)
             throw new Error("compilation failed. rc=" + rc);
         String path = f.getPath();

--- a/test/langtools/tools/javap/typeAnnotations/Wildcards.java
+++ b/test/langtools/tools/javap/typeAnnotations/Wildcards.java
@@ -22,13 +22,18 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test Wildcards
  * @bug 6843077
  * @summary test that annotations target wildcards get emitted to classfile
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 public class Wildcards {
     public static void main(String[] args) throws Exception {
@@ -39,13 +44,13 @@ public class Wildcards {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        test(cf);
-        for (Field f : cf.fields) {
-            test(cf, f);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        test(cm);
+        for (FieldModel fm : cm.fields()) {
+            test(fm);
         }
-        for (Method m: cf.methods) {
-            test(cf, m);
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         countAnnotations();
@@ -54,72 +59,28 @@ public class Wildcards {
             throw new Exception(errors + " errors found");
         System.out.println("PASSED");
     }
-
-    void test(ClassFile cf) {
-        test(cf, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(AttributedElement m) {
+        test(m, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(m, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
-
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    void test(ClassFile cf, Field m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, String name, boolean visible) {
-        int index = cf.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = cf.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    <T extends Attribute<T>> void test(AttributedElement m, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance = m.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
         }
     }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Field m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
     File writeTestFile() throws IOException {
-      File f = new File("Test.java");
+        File f = new File("Test.java");
         PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(f)));
         out.println("import java.lang.annotation.*;");
         out.println("import java.util.*;");


### PR DESCRIPTION
Modified 10 of 12 test/langtools/tools/javap test classes to replace com.sun.tools.classfile library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295059](https://bugs.openjdk.org/browse/JDK-8295059): test/langtools/tools/javap 12 test classes use com.sun.tools.classfile library (**Sub-task** - P5)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14837/head:pull/14837` \
`$ git checkout pull/14837`

Update a local copy of the PR: \
`$ git checkout pull/14837` \
`$ git pull https://git.openjdk.org/jdk.git pull/14837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14837`

View PR using the GUI difftool: \
`$ git pr show -t 14837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14837.diff">https://git.openjdk.org/jdk/pull/14837.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14837#issuecomment-1652789398)