### PR TITLE
8311556: GetThreadLocalStorage not working for vthreads mounted during JVMTI attach

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1602,13 +1602,8 @@ JvmtiEnvBase::is_in_thread_list(jint count, const jthread* list, oop jt_oop) {
 
 class VM_SetNotifyJvmtiEventsMode : public VM_Operation {
 private:
-  static bool _whitebox_used;
   bool _enable;
 
-  // This function is needed only for testing purposes to support multiple
-  // enable&disable notifyJvmti events. Otherwise, there can be only one call
-  // to enable_virtual_threads_notify_jvmti() for late binding agents. There
-  // have to be no JvmtiThreadState's and need to correct them in such a case.
   static void correct_jvmti_thread_state(JavaThread* jt) {
     oop  ct_oop = jt->threadObj();
     oop  vt_oop = jt->vthread();
@@ -1618,8 +1613,7 @@ private:
     bool virt = vt_oop != nullptr && java_lang_VirtualThread::is_instance(vt_oop);
 
     // Correct jt->jvmti_thread_state() and jt->jvmti_vthread().
-    // It was not maintained while notifyJvmti was disabled but there can be
-    // a leftover from previous cycle when notification were enabled.
+    // It was not maintained while notifyJvmti was disabled.
     if (virt) {
       jt->set_jvmti_thread_state(nullptr);  // reset jt->jvmti_thread_state()
       jt->set_jvmti_vthread(vt_oop);        // restore jt->jvmti_vthread()
@@ -1640,9 +1634,7 @@ private:
         count++;
         continue; // no need in JvmtiThreadState correction below if in transition
       }
-      if (_whitebox_used) {
-        correct_jvmti_thread_state(jt); // needed in testing environment only
-      }
+      correct_jvmti_thread_state(jt);
     }
     return count;
   }
@@ -1651,9 +1643,6 @@ public:
   VMOp_Type type() const { return VMOp_SetNotifyJvmtiEventsMode; }
   bool allow_nested_vm_operations() const { return false; }
   VM_SetNotifyJvmtiEventsMode(bool enable) : _enable(enable) {
-    if (!enable) {
-      _whitebox_used = true; // disabling is available via WhiteBox only
-    }
   }
 
   void doit() {
@@ -1663,8 +1652,6 @@ public:
     JvmtiVTMSTransitionDisabler::set_VTMS_notify_jvmti_events(_enable);
   }
 };
-
-bool VM_SetNotifyJvmtiEventsMode::_whitebox_used = false;
 
 // This function is to support agents loaded into running VM.
 // Must be called in thread-in-native mode.

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Verifies JVMTI GetLocalStorage/SetLocalStorage
+ * @requires vm.continuations
+ * @requires vm.jvmti
+ * @compile VThreadTLSTest.java
+ * @run main/othervm/native -agentlib:VThreadTLSTest VThreadTLSTest
+ */
+
+/**
+ * @test
+ * @bug 8311556
+ * @summary Verifies JVMTI GetLocalStorage/SetLocalStorage
+ * @requires vm.continuations
+ * @requires vm.jvmti
+ * @compile VThreadTLSTest.java
+ * @run main/othervm/native -Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading VThreadTLSTest attach
+ */
+
+import com.sun.tools.attach.VirtualMachine;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class VThreadTLSTest {
+    static final String AGENT_LIB = "VThreadTLSTest";
+
+    static volatile boolean attached;
+    static volatile boolean failed;
+
+    static void log(String msg) { System.out.println(msg); }
+
+    static native long getTLS();
+    static native void setTLS(long value);
+
+    static void test() {
+        try {
+            while (!attached) {
+                // keep mounted
+            }
+            long threadId = Thread.currentThread().threadId();
+            setTLS(threadId);
+            long mountedValue = getTLS();
+
+            if (mountedValue != threadId) {
+                log("Error: wrong TLS value while mounted: " + threadId + ", " + mountedValue);
+                failed = true;
+                return;
+            }
+            for (int repetion = 0; repetion < 10; repetion++) {
+                Thread.sleep(1);
+                long tlsValue = getTLS();
+                if (tlsValue != threadId) {
+                    log("Error: wrong TLS value after yield: expected: " + threadId + " got: " + tlsValue);
+                    failed = true;
+                    return;
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (ExecutorService execService = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int threadCount = 0; threadCount < 20; threadCount++) {
+                execService.execute(() -> test());
+            }
+            if (args.length == 1 && args[0].equals("attach")) {
+                log("loading " + AGENT_LIB + " lib");
+                VirtualMachine vm = VirtualMachine.attach(String.valueOf(ProcessHandle.current().pid()));
+                vm.loadAgentLibrary(AGENT_LIB);
+            }
+            Thread.sleep(10);
+            attached = true;
+        }
+        if (failed) {
+            throw new RuntimeException("Test FAILED: errors encountered");
+        } else {
+            log("Test passed");
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
@@ -46,12 +46,10 @@ import java.util.concurrent.Executors;
 
 public class VThreadTLSTest {
     static final String AGENT_LIB = "VThreadTLSTest";
-
     static volatile boolean attached;
     static volatile boolean failed;
 
     static void log(String msg) { System.out.println(msg); }
-
     static native long getTLS();
     static native void setTLS(long value);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
@@ -26,7 +26,6 @@
  * @summary Verifies JVMTI GetLocalStorage/SetLocalStorage
  * @requires vm.continuations
  * @requires vm.jvmti
- * @compile VThreadTLSTest.java
  * @run main/othervm/native -agentlib:VThreadTLSTest VThreadTLSTest
  */
 
@@ -36,7 +35,6 @@
  * @summary Verifies JVMTI GetLocalStorage/SetLocalStorage
  * @requires vm.continuations
  * @requires vm.jvmti
- * @compile VThreadTLSTest.java
  * @run main/othervm/native -Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading VThreadTLSTest attach
  */
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java
@@ -65,7 +65,7 @@ public class VThreadTLSTest {
                 failed = true;
                 return;
             }
-            for (int repetion = 0; repetion < 10; repetion++) {
+            for (int count = 0; count < 10; count++) {
                 Thread.sleep(1);
                 long tlsValue = getTLS();
                 if (tlsValue != threadId) {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/libVThreadTLSTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/libVThreadTLSTest.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <jvmti.h>
+#include "jvmti_common.h"
+
+extern "C" {
+
+static jvmtiEnv *jvmti;
+
+JNIEXPORT jlong JNICALL
+Java_VThreadTLSTest_getTLS(JNIEnv* jni, jclass clazz) {
+  void* data;
+  jvmtiError err = jvmti->GetThreadLocalStorage(nullptr, &data);
+  check_jvmti_status(jni, err, "getTLS: Failed in JVMTI GetThreadLocalStorage"); 
+  return (jlong)data;
+}
+
+JNIEXPORT void JNICALL
+Java_VThreadTLSTest_setTLS(JNIEnv* jni, jclass clazz, jlong value) {
+  jvmtiError err = jvmti->SetThreadLocalStorage(nullptr, (void*)value);
+  check_jvmti_status(jni, err, "setTLS: Failed in JVMTI SetThreadLocalStorage"); 
+}
+
+jint agent_init(JavaVM *jvm, char *options, void *reserved) {
+  jvmtiCapabilities caps;
+  jvmtiError err;
+
+  if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
+    LOG("agent_init: could not initialize JVMTI\n");
+    return JNI_ERR;
+  }
+  memset(&caps, 0, sizeof(caps));
+  caps.can_support_virtual_threads = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("agent_init: error in JVMTI AddCapabilities: %s (%d)\n", TranslateError(err), err);
+    return JNI_ERR;
+  }
+  return JNI_OK;
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  LOG("Agent_OnLoad\n");
+  return agent_init(jvm, options, reserved);
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  LOG("Agent_OnAttach\n");
+  return agent_init(jvm, options, reserved);
+}
+
+} // extern "C"
+

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/libVThreadTLSTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest/libVThreadTLSTest.cpp
@@ -34,14 +34,14 @@ JNIEXPORT jlong JNICALL
 Java_VThreadTLSTest_getTLS(JNIEnv* jni, jclass clazz) {
   void* data;
   jvmtiError err = jvmti->GetThreadLocalStorage(nullptr, &data);
-  check_jvmti_status(jni, err, "getTLS: Failed in JVMTI GetThreadLocalStorage"); 
+  check_jvmti_status(jni, err, "getTLS: Failed in JVMTI GetThreadLocalStorage");
   return (jlong)data;
 }
 
 JNIEXPORT void JNICALL
 Java_VThreadTLSTest_setTLS(JNIEnv* jni, jclass clazz, jlong value) {
   jvmtiError err = jvmti->SetThreadLocalStorage(nullptr, (void*)value);
-  check_jvmti_status(jni, err, "setTLS: Failed in JVMTI SetThreadLocalStorage"); 
+  check_jvmti_status(jni, err, "setTLS: Failed in JVMTI SetThreadLocalStorage");
 }
 
 jint agent_init(JavaVM *jvm, char *options, void *reserved) {


### PR DESCRIPTION
This is an issue with a dynamic load of a JVMTI agent into running VM.
The `VM_SetNotifyJvmtiEventsMode` enabling operation makes a call to the function `count_transitions_and_correct_jvmti_thread_states()`. This function in its turn make a call to the function `correct_jvmti_thread_state()`. But it does it conditionally, only if the field `_whitebox_used` is `true`.
The test provided in the bug report showed that it has to be called unconditionally as the assumption that it is only needed on the subsequent `notifyJvmti` enabling is incorrect.

Then the field `_whitebox_used` is not needed anymore and removed in this fix.
Some obsolete comments are removed or updated.

New test is added: `test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest`.
It is failed without the fix and passed with the fix. 

Testing:
  - ran new test `test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTLSTest`
  - mach5 tiers 1-5 are good

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311556](https://bugs.openjdk.org/browse/JDK-8311556): GetThreadLocalStorage not working for vthreads mounted during JVMTI attach (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [f582fbc0](https://git.openjdk.org/jdk/pull/14842/files/f582fbc01d9e0e8a4d6eaa23fba0e1c77760ffe6)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [743188b5](https://git.openjdk.org/jdk/pull/14842/files/743188b5119006dfe4e58ec9ef35128bd151e26c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14842/head:pull/14842` \
`$ git checkout pull/14842`

Update a local copy of the PR: \
`$ git checkout pull/14842` \
`$ git pull https://git.openjdk.org/jdk.git pull/14842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14842`

View PR using the GUI difftool: \
`$ git pr show -t 14842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14842.diff">https://git.openjdk.org/jdk/pull/14842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14842#issuecomment-1631873395)