### PR TITLE
JDK-8311917: MAP_FAILED definition seems to be obsolete in src/java.desktop/unix/native/common/awt/fontpath.c

### DIFF
--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -48,10 +48,6 @@
 #define AWT_UNLOCK()
 #endif /* !HEADLESS */
 
-#if defined(__linux__) && !defined(MAP_FAILED)
-#define MAP_FAILED ((caddr_t)-1)
-#endif
-
 #ifndef HEADLESS
 extern Display *awt_display;
 #endif /* !HEADLESS */


### PR DESCRIPTION
There is a MAP_FAILED definition in src/java.desktop/unix/native/common/awt/fontpath.c but it is never used in the coding and seems to be obsolete.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311917](https://bugs.openjdk.org/browse/JDK-8311917): MAP_FAILED definition seems to be obsolete in src/java.desktop/unix/native/common/awt/fontpath.c (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14843/head:pull/14843` \
`$ git checkout pull/14843`

Update a local copy of the PR: \
`$ git checkout pull/14843` \
`$ git pull https://git.openjdk.org/jdk.git pull/14843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14843`

View PR using the GUI difftool: \
`$ git pr show -t 14843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14843.diff">https://git.openjdk.org/jdk/pull/14843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14843#issuecomment-1631974513)