### PR TITLE
JDK-8311921: Inform about MaxExpectedDataSegmentSize in case of pthread_create failures on AIX

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -828,7 +828,8 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     log_warning(os, thread)("Failed to start thread \"%s\" - pthread_create failed (%d=%s) for attributes: %s.",
                             thread->name(), ret, os::errno_name(ret), os::Posix::describe_pthread_attr(buf, sizeof(buf), &attr));
     // Log some OS information which might explain why creating the thread failed.
-    log_info(os, thread)("Number of threads approx. running in the VM: %d", Threads::number_of_threads());
+    log_warning(os, thread)("Number of threads approx. running in the VM: %d", Threads::number_of_threads());
+    log_warning(os, thread)("Checking JVM parameter MaxExpectedDataSegmentSize (currently " SIZE_FORMAT "k)  might be helpful", MaxExpectedDataSegmentSize/K);
     LogStream st(Log(os, thread)::info());
     os::Posix::print_rlimit_info(&st);
     os::print_memory_info(&st);


### PR DESCRIPTION
In case pthread_create fails on AIX, MaxExpectedDataSegmentSize might be too small. We have already some UL logging when pthread_create fails, it would be helpful to mention there MaxExpectedDataSegmentSize too.

We observed the importance of the parameter MaxExpectedDataSegmentSize , when looking into failures of  https://github.com/openjdk/jdk/commits/master/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java  on AIX, this tests generates quite a few threads and might run on some machines into issues because of too low settings of MaxExpectedDataSegmentSize  .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311921](https://bugs.openjdk.org/browse/JDK-8311921): Inform about MaxExpectedDataSegmentSize in case of pthread_create failures on AIX (**Enhancement** - P4)


### Reviewers
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14845/head:pull/14845` \
`$ git checkout pull/14845`

Update a local copy of the PR: \
`$ git checkout pull/14845` \
`$ git pull https://git.openjdk.org/jdk.git pull/14845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14845`

View PR using the GUI difftool: \
`$ git pr show -t 14845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14845.diff">https://git.openjdk.org/jdk/pull/14845.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14845#issuecomment-1632032172)