### PR TITLE
8311926: java/lang/ScopedValue/StressStackOverflow.java takes 9mins in tier1

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -44,7 +44,9 @@ javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x
 
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
-java/lang/ScopedValue/StressStackOverflow.java#default 8309646 linux-all
+java/lang/ScopedValue/StressStackOverflow.java#default 8309646 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#no-TieredCompilation 8309646 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 8309646 generic-all
 
 javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
 


### PR DESCRIPTION
The test runs 3 times, each run is for 3 minutes so 9 mins in total and too long for tier1. Here's the times for test/jdk:tier1_part1 that I see locally:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk:tier1_part1                    1025  1025     0     0
==============================
TEST SUCCESS

Finished building target 'run-test' in configuration 'linux-x64'

real	10m22.414s
user	64m1.774s
sys	2m31.938s
```

The test is changed to use separate test description so that the 3 runs can execute in parallel if possible. I've also dialled down the test from 3 to 2 minutes. At some point we need to tackle the issue of stress tests in tier1, this one may be a candidate for a higher tier. The exclude list for JTREG_TEST_THREAD_FACTORY=Virtual (ProblemList-Virtual.txt) is also updated to exclude the test on all platforms rather than just Linux while JDK-8309646 is being investigated.

Here are the times with the updated test:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk:tier1_part1                    1027  1027     0     0
==============================
TEST SUCCESS

Finished building target 'run-test' in configuration 'linux-x64'

real	3m22.509s
user	60m15.551s
sys	2m32.574s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311926](https://bugs.openjdk.org/browse/JDK-8311926): java/lang/ScopedValue/StressStackOverflow.java takes 9mins in tier1 (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14849/head:pull/14849` \
`$ git checkout pull/14849`

Update a local copy of the PR: \
`$ git checkout pull/14849` \
`$ git pull https://git.openjdk.org/jdk.git pull/14849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14849`

View PR using the GUI difftool: \
`$ git pr show -t 14849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14849.diff">https://git.openjdk.org/jdk/pull/14849.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14849#issuecomment-1632140646)