### PR TITLE
8311879: SA ClassWriter generates invalid invokedynamic code

### DIFF
--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -288,9 +288,6 @@ void Rewriter::rewrite_invokedynamic(address bcp, int offset, bool reverse) {
     // Should do nothing since we are not patching this bytecode
     int cache_index = ConstantPool::decode_invokedynamic_index(
                         Bytes::get_native_u4(p));
-    // We will reverse the bytecode rewriting _after_ adjusting them.
-    // Adjust the cache index by offset to the invokedynamic entries in the
-    // cpCache plus the delta if the invokedynamic bytecodes were adjusted.
     int cp_index = _initialized_indy_entries.at(cache_index).constant_pool_index();
     assert(_pool->tag_at(cp_index).is_invoke_dynamic(), "wrong index");
     // zero out 4 bytes

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
@@ -102,7 +102,11 @@ public class ByteCodeRewriter
           // Invokedynamic require special handling
           cpCacheIndex = ~cpCacheIndex;
           cpCacheIndex = bytes.swapInt(cpCacheIndex);
-          return (short) cpCache.getEntryAt(cpCacheIndex).getConstantPoolIndex();
+          short cpIndex = (short) cpCache.getIndyEntryAt(cpCacheIndex).getConstantPoolIndex();
+          if (!cpool.getTagAt(cpIndex).isInvokeDynamic()) {
+            throw new IllegalArgumentException("CP Entry should be InvokeDynamic");
+          }
+          return cpIndex;
        } else if (fmt.contains("JJ")) {
           // change byte-ordering and go via cache
           return (short) cpCache.getEntryAt((int) (0xFFFF & bytes.swapShort((short)cpCacheIndex))).getConstantPoolIndex();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
@@ -103,9 +103,7 @@ public class ByteCodeRewriter
           cpCacheIndex = ~cpCacheIndex;
           cpCacheIndex = bytes.swapInt(cpCacheIndex);
           short cpIndex = (short) cpCache.getIndyEntryAt(cpCacheIndex).getConstantPoolIndex();
-          if (!cpool.getTagAt(cpIndex).isInvokeDynamic()) {
-            throw new IllegalArgumentException("CP Entry should be InvokeDynamic");
-          }
+          Assert.that(cpool.getTagAt(cpIndex).isInvokeDynamic(), "CP Entry should be InvokeDynamic");
           return cpIndex;
        } else if (fmt.contains("JJ")) {
           // change byte-ordering and go via cache


### PR DESCRIPTION
This patch should fix the wrong CP index for `invokedynamic` instruction generated by SA's `ClassWriter`. The buggy code in `sun.jvm.hotspot.tools.jcore.ByteCodeRewriter` should have been up-to-date with the following code snippet in `hotspot`:

https://github.com/openjdk/jdk/blob/753bd563ecca6bb5ff9b5ebc0957bc1854dce78d/src/hotspot/share/interpreter/rewriter.cpp#L291-L294

The comments above seem to be obsolete since the following change made in [JDK-8301995](https://bugs.openjdk.org/browse/JDK-8301995). So I also remove them.

```diff
+    // Should do nothing since we are not patching this bytecode
     int cache_index = ConstantPool::decode_invokedynamic_index(
                         Bytes::get_native_u4(p));
     // We will reverse the bytecode rewriting _after_ adjusting them.
     // Adjust the cache index by offset to the invokedynamic entries in the
     // cpCache plus the delta if the invokedynamic bytecodes were adjusted.
-    int adjustment = cp_cache_delta() + _first_iteration_cp_cache_limit;
-    int cp_index = invokedynamic_cp_cache_entry_pool_index(cache_index - adjustment);
+    int cp_index = _initialized_indy_entries.at(cache_index).constant_pool_index();
     assert(_pool->tag_at(cp_index).is_invoke_dynamic(), "wrong index");
```

This fix is straightforward and thank @asotona for finding this bug!

### Test Results of release build on Linux x64
* `jtreg:test/hotspot/jtreg/serviceability` and `jtreg:test/jdk/sun/tools/`: PASS
* `tier1`: PASS
* `tier2` and `tier3`: PASS (Failures of `sun/security/lib/cacerts/VerifyCACerts.java` and `sun/security/pkcs11/KeyStore/CertChainRemoval.java` seem to be unrelated to this patch)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311879](https://bugs.openjdk.org/browse/JDK-8311879): SA ClassWriter generates invalid invokedynamic code (**Bug** - P3)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [f4068028](https://git.openjdk.org/jdk/pull/14852/files/f4068028460be1aa7d451960747a7bb22b5fee36)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [f4068028](https://git.openjdk.org/jdk/pull/14852/files/f4068028460be1aa7d451960747a7bb22b5fee36)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14852/head:pull/14852` \
`$ git checkout pull/14852`

Update a local copy of the PR: \
`$ git checkout pull/14852` \
`$ git pull https://git.openjdk.org/jdk.git pull/14852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14852`

View PR using the GUI difftool: \
`$ git pr show -t 14852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14852.diff">https://git.openjdk.org/jdk/pull/14852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14852#issuecomment-1632582695)