### PR TITLE
8311536: JFR TestNativeMemoryUsageEvents fails in huge pages configuration

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeMemoryUsageEvents.java
@@ -44,8 +44,8 @@ import jdk.test.lib.jfr.Events;
  * @library /test/lib
  * @modules jdk.jfr
  *          jdk.management
- * @run main/othervm -XX:NativeMemoryTracking=summary -Xms16m -Xmx128m -Xlog:gc jdk.jfr.event.runtime.TestNativeMemoryUsageEvents true
- * @run main/othervm -XX:NativeMemoryTracking=off -Xms16m -Xmx128m -Xlog:gc jdk.jfr.event.runtime.TestNativeMemoryUsageEvents false
+ * @run main/othervm -XX:NativeMemoryTracking=summary -Xms16m -Xmx128m -XX:-UseLargePages -Xlog:gc jdk.jfr.event.runtime.TestNativeMemoryUsageEvents true
+ * @run main/othervm -XX:NativeMemoryTracking=off -Xms16m -Xmx128m -XX:-UseLargePages -Xlog:gc jdk.jfr.event.runtime.TestNativeMemoryUsageEvents false
  */
 public class TestNativeMemoryUsageEvents {
     private final static String UsageTotalEvent = EventNames.NativeMemoryUsageTotal;


### PR DESCRIPTION
Greetings,

the test is not designed to support large pages and should disallow it if someone requests it from the outside.

Testing: the test passing -XX:+UseLargePages using --jvm-args-prepend and --jvm-args-append

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311536](https://bugs.openjdk.org/browse/JDK-8311536): JFR TestNativeMemoryUsageEvents fails in huge pages configuration (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.org/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14853/head:pull/14853` \
`$ git checkout pull/14853`

Update a local copy of the PR: \
`$ git checkout pull/14853` \
`$ git pull https://git.openjdk.org/jdk.git pull/14853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14853`

View PR using the GUI difftool: \
`$ git pr show -t 14853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14853.diff">https://git.openjdk.org/jdk/pull/14853.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14853#issuecomment-1632691904)