### PR TITLE
8311971: SA's ConstantPool.java uses incorrect computation to read long value in the constant pool

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -220,11 +220,7 @@ public class ConstantPool extends Metadata implements ClassConstants {
   }
 
   public long getLongAt(long index) {
-    int oneHalf = getAddress().getJIntAt(indexOffset(index + 1));
-    int otherHalf   = getAddress().getJIntAt(indexOffset(index));
-    // buildLongFromIntsPD accepts higher address value, lower address value
-    // in that order.
-    return VM.getVM().buildLongFromIntsPD(oneHalf, otherHalf);
+    return getAddress().getJLongAt(indexOffset(index));
   }
 
   public double getDoubleAt(long index) {


### PR DESCRIPTION
Please review this fix to correctly read a long value in the runtime constant pool. Details are mentioned in the issue [0].
As an example, before this fix the long value generated by SA's dumpclass for java.lang.String.serialVersionUID was:

```
  private static final long serialVersionUID;
    descriptor: J
    flags: (0x001a) ACC_PRIVATE, ACC_STATIC, ACC_FINAL
    ConstantValue: long 2050732866l
```

After this fix value of java.lang.String.serialVersionUID is:

```
  private static final long serialVersionUID;
    descriptor: J
    flags: (0x001a) ACC_PRIVATE, ACC_STATIC, ACC_FINAL
    ConstantValue: long -6849794470754667710l
```

Correct value as obtained from original java.lang.String is `-6849794470754667710l`.

Testing: tests under `serviceability/sa` and `sun/tools/jhsdb` are passing.

[0] https://bugs.openjdk.org/browse/JDK-8311971

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311971](https://bugs.openjdk.org/browse/JDK-8311971): SA's ConstantPool.java uses incorrect computation to read long value in the constant pool (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14855/head:pull/14855` \
`$ git checkout pull/14855`

Update a local copy of the PR: \
`$ git checkout pull/14855` \
`$ git pull https://git.openjdk.org/jdk.git pull/14855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14855`

View PR using the GUI difftool: \
`$ git pr show -t 14855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14855.diff">https://git.openjdk.org/jdk/pull/14855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14855#issuecomment-1633123977)