### PR TITLE
8295058: test/langtools/tools/javac 226 test classes uses com.sun.tools.classfile library

### DIFF
--- a/test/langtools/tools/javac/8009170/RedundantByteCodeInArrayTest.java
+++ b/test/langtools/tools/javac/8009170/RedundantByteCodeInArrayTest.java
@@ -26,28 +26,26 @@
  * @bug 8009170
  * @summary Regression: javac generates redundant bytecode in assignop involving
  * arrays
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  * @run main RedundantByteCodeInArrayTest
  */
 
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.CodeAttribute;
+import jdk.internal.classfile.constantpool.ConstantPool;
 import java.io.File;
 import java.io.IOException;
 
-import com.sun.tools.classfile.Attribute;
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.Code_attribute;
-import com.sun.tools.classfile.Code_attribute.InvalidIndex;
-import com.sun.tools.classfile.ConstantPool;
-import com.sun.tools.classfile.ConstantPoolException;
-import com.sun.tools.classfile.Descriptor.InvalidDescriptor;
-import com.sun.tools.classfile.Method;
-
 public class RedundantByteCodeInArrayTest {
     public static void main(String[] args)
-            throws IOException, ConstantPoolException, InvalidDescriptor, InvalidIndex {
+            throws IOException {
         new RedundantByteCodeInArrayTest()
                 .checkClassFile(new File(System.getProperty("test.classes", "."),
-                    RedundantByteCodeInArrayTest.class.getName() + ".class"));
+                        RedundantByteCodeInArrayTest.class.getName() + ".class"));
     }
 
     void arrMethod(int[] array, int p, int inc) {
@@ -55,16 +53,16 @@ public class RedundantByteCodeInArrayTest {
     }
 
     void checkClassFile(File file)
-            throws IOException, ConstantPoolException, InvalidDescriptor, InvalidIndex {
-        ClassFile classFile = ClassFile.read(file);
-        ConstantPool constantPool = classFile.constant_pool;
+            throws IOException {
+        ClassModel classFile = Classfile.of().parse(file.toPath());
+        ConstantPool constantPool = classFile.constantPool();
 
         //lets get all the methods in the class file.
-        for (Method method : classFile.methods) {
-            if (method.getName(constantPool).equals("arrMethod")) {
-                Code_attribute code = (Code_attribute) method.attributes
-                        .get(Attribute.Code);
-                if (code.max_locals > 4)
+        for (MethodModel method : classFile.methods()) {
+            if (method.methodName().equalsString("arrMethod")) {
+                CodeAttribute code = method.findAttribute(Attributes.CODE).orElse(null);
+                assert code != null;
+                if (code.maxLocals() > 4)
                     throw new AssertionError("Too many locals for method arrMethod");
             }
         }

--- a/test/langtools/tools/javac/StringConcat/WellKnownTypes.java
+++ b/test/langtools/tools/javac/StringConcat/WellKnownTypes.java
@@ -21,14 +21,15 @@
  * questions.
  */
 
-import com.sun.tools.classfile.*;
-import com.sun.tools.classfile.ConstantPool.*;
-
 /*
  * @test
  * @bug     8273914
  * @summary Indy string concat changes order of operations
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  *
  * @compile -XDstringConcat=indy              WellKnownTypes.java
  * @run main WellKnownTypes
@@ -74,8 +75,8 @@ public class WellKnownTypes {
 
     public static void test(String actual, int index, String expected) {
         if (!actual.equals(expected)) {
-      throw new IllegalStateException(
-          index + " Unexpected: expected = " + expected + ", actual = " + actual);
+            throw new IllegalStateException(
+                    index + " Unexpected: expected = " + expected + ", actual = " + actual);
         }
     }
 }

--- a/test/langtools/tools/javac/T7165659/InnerClassAttrMustNotHaveStrictFPFlagTest.java
+++ b/test/langtools/tools/javac/T7165659/InnerClassAttrMustNotHaveStrictFPFlagTest.java
@@ -25,18 +25,22 @@
  * @test
  * @bug 7165659
  * @summary javac incorrectly sets strictfp access flag on inner-classes
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  *          jdk.compiler/com.sun.tools.javac.util
  */
 
 import java.io.File;
 
-import com.sun.tools.classfile.AccessFlags;
-import com.sun.tools.classfile.Attribute;
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.InnerClasses_attribute;
-import com.sun.tools.classfile.InnerClasses_attribute.Info;
 import com.sun.tools.javac.util.Assert;
+import jdk.internal.classfile.Attributes;
+import jdk.internal.classfile.ClassModel;
+import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.attribute.InnerClassInfo;
+import jdk.internal.classfile.attribute.InnerClassesAttribute;
 
 public class InnerClassAttrMustNotHaveStrictFPFlagTest {
 
@@ -50,11 +54,11 @@ public class InnerClassAttrMustNotHaveStrictFPFlagTest {
     }
 
     void analyzeClassFile(File path) throws Exception {
-        ClassFile classFile = ClassFile.read(path);
-        InnerClasses_attribute innerClasses =
-                (InnerClasses_attribute) classFile.attributes.get(Attribute.InnerClasses);
-        for (Info classInfo : innerClasses.classes) {
-            Assert.check(!classInfo.inner_class_access_flags.is(AccessFlags.ACC_STRICT),
+        ClassModel classFile = Classfile.of().parse(path.toPath());
+        InnerClassesAttribute innerClasses = classFile.findAttribute(Attributes.INNER_CLASSES).orElse(null);
+        assert innerClasses != null;
+        for (InnerClassInfo classInfo : innerClasses.classes()) {
+            Assert.check(!(classInfo.flagsMask() == Classfile.ACC_STRICT),
                     "Inner classes attribute must not have the ACC_STRICT flag set");
         }
     }

--- a/test/langtools/tools/javac/T8028504/DontGenerateLVTForGNoneOpTest.java
+++ b/test/langtools/tools/javac/T8028504/DontGenerateLVTForGNoneOpTest.java
@@ -25,20 +25,22 @@
  * @test
  * @bug 8028504
  * @summary javac generates LocalVariableTable even with -g:none
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  * @compile -g:none DontGenerateLVTForGNoneOpTest.java
  * @run main DontGenerateLVTForGNoneOpTest
  */
 
+
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.CodeAttribute;
 import java.io.File;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.nio.file.Paths;
-
-import com.sun.tools.classfile.Attribute;
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.Code_attribute;
-import com.sun.tools.classfile.Method;
 
 public class DontGenerateLVTForGNoneOpTest {
 
@@ -52,11 +54,11 @@ public class DontGenerateLVTForGNoneOpTest {
     }
 
     void checkClassFile(final File cfile) throws Exception {
-        ClassFile classFile = ClassFile.read(cfile);
-        for (Method method : classFile.methods) {
-            Code_attribute code = (Code_attribute)method.attributes.get(Attribute.Code);
+        ClassModel classFile = Classfile.of().parse(cfile.toPath());
+        for (MethodModel method : classFile.methods()) {
+            CodeAttribute code = method.findAttribute(Attributes.CODE).orElse(null);
             if (code != null) {
-                if (code.attributes.get(Attribute.LocalVariableTable) != null) {
+                if (code.findAttribute(Attributes.LOCAL_VARIABLE_TABLE).orElse(null) != null) {
                     throw new AssertionError("LVT shouldn't be generated for g:none");
                 }
             }

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/T8050993.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/T8050993.java
@@ -2,7 +2,11 @@
  * @test /nodynamiccopyright/
  * @bug 8050993
  * @summary Verify that the condition in the conditional lexpression gets a LineNumberTable entry
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+            java.base/jdk.internal.classfile.instruction
+            java.base/jdk.internal.classfile.components
  * @compile -g T8050993.java
  * @run main T8050993
  */
@@ -14,25 +18,28 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 public class T8050993 {
-    public static void main(String[] args) throws IOException, ConstantPoolException {
-        ClassFile someTestIn = ClassFile.read(T8050993.class.getResourceAsStream("T8050993.class"));
+    public static void main(String[] args) throws IOException {
+        ClassModel someTestIn = Classfile.of().parse(T8050993.class.getResourceAsStream("T8050993.class").readAllBytes());
         Set<Integer> expectedLineNumbers = new HashSet<>(Arrays.asList(49, 50, 47, 48));
-        for (Method m : someTestIn.methods) {
-            if ("method".equals(m.getName(someTestIn.constant_pool))) {
-                Code_attribute code_attribute = (Code_attribute) m.attributes.get(Attribute.Code);
-                for (Attribute at : code_attribute.attributes) {
-                    if (Attribute.LineNumberTable.equals(at.getName(someTestIn.constant_pool))) {
-                        LineNumberTable_attribute att = (LineNumberTable_attribute) at;
-                        Set<Integer> actualLinesNumbers = Arrays.stream(att.line_number_table)
-                                                                .map(e -> e.line_number)
-                                                                .collect(Collectors.toSet());
+        for (MethodModel m : someTestIn.methods()) {
+            if (m.methodName().equalsString("method")) {
+                CodeAttribute code_attribute = m.findAttribute(Attributes.CODE).orElse(null);
+                assert code_attribute != null;
+                for (Attribute<?> at : code_attribute.attributes()) {
+                    if (Attributes.LINE_NUMBER_TABLE.equals(at)) {
+                        assert at instanceof LineNumberTableAttribute;
+                        LineNumberTableAttribute att = (LineNumberTableAttribute) at;
+                        Set<Integer> actualLinesNumbers = Arrays.stream(att.lineNumbers().toArray(new LineNumberInfo[0]))
+                                .map(LineNumberInfo::lineNumber)
+                                .collect(Collectors.toSet());
                         if (!Objects.equals(expectedLineNumbers, actualLinesNumbers)) {
                             throw new AssertionError("Expected LineNumber entries not found;" +
-                                                     "actual=" + actualLinesNumbers + ";" +
-                                                     "expected=" + expectedLineNumbers);
+                                    "actual=" + actualLinesNumbers + ";" +
+                                    "expected=" + expectedLineNumbers);
                         }
                     }
                 }
@@ -45,8 +52,8 @@ public class T8050993 {
     public static String method() {
         String s =
                 field % 2 == 0 ?
-                "true" + field :
-                "false" + field;
+                        "true" + field :
+                        "false" + field;
         return s;
     }
 

--- a/test/langtools/tools/javac/constDebug/ConstDebugTest.java
+++ b/test/langtools/tools/javac/constDebug/ConstDebugTest.java
@@ -25,25 +25,28 @@
  * @test
  * @bug 4645152 4785453
  * @summary javac compiler incorrectly inserts <clinit> when -g is specified
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  * @run compile -g ConstDebugTest.java
  * @run main ConstDebugTest
  */
 import java.nio.file.Paths;
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.Method;
+import jdk.internal.classfile.*;
 
 public class ConstDebugTest {
 
     public static final long l = 12;
 
     public static void main(String args[]) throws Exception {
-        ClassFile classFile = ClassFile.read(Paths.get(System.getProperty("test.classes"),
+        ClassModel classModel = Classfile.of().parse(Paths.get(System.getProperty("test.classes"),
                 ConstDebugTest.class.getSimpleName() + ".class"));
-        for (Method method: classFile.methods) {
-            if (method.getName(classFile.constant_pool).equals("<clinit>")) {
+        for (MethodModel method: classModel.methods()) {
+            if (method.methodName().equalsString("<clinit>")) {
                 throw new AssertionError(
-                    "javac should not create a <clinit> method for ConstDebugTest class");
+                        "javac should not create a <clinit> method for ConstDebugTest class");
             }
         }
     }

--- a/test/langtools/tools/javac/lambda/LambdaTestStrictFPFlag.java
+++ b/test/langtools/tools/javac/lambda/LambdaTestStrictFPFlag.java
@@ -25,15 +25,18 @@
  * @test
  * @bug 8046060
  * @summary Different results of floating point multiplication for lambda code block
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  * @compile -source 16 -target 16 LambdaTestStrictFPFlag.java
  * @run main LambdaTestStrictFPFlag
  */
 
+import jdk.internal.classfile.*;
 import java.io.*;
 import java.net.URL;
-import com.sun.tools.classfile.*;
-import static com.sun.tools.classfile.AccessFlags.ACC_STRICT;
 
 public class LambdaTestStrictFPFlag {
     public static void main(String[] args) throws Exception {
@@ -41,12 +44,11 @@ public class LambdaTestStrictFPFlag {
     }
 
     void run() throws Exception {
-        ClassFile cf = getClassFile("LambdaTestStrictFPFlag$Test.class");
-        ConstantPool cp = cf.constant_pool;
+        ClassModel cm = getClassFile("LambdaTestStrictFPFlag$Test.class");
         boolean found = false;
-        for (Method meth: cf.methods) {
-            if (meth.getName(cp).startsWith("lambda$")) {
-                if ((meth.access_flags.flags & ACC_STRICT) == 0) {
+        for (MethodModel meth: cm.methods()) {
+            if (meth.methodName().stringValue().startsWith("lambda$")) {
+                if ((meth.flags().flagsMask() & Classfile.ACC_STRICT) == 0){
                     throw new Exception("strict flag missing from lambda");
                 }
                 found = true;
@@ -57,13 +59,11 @@ public class LambdaTestStrictFPFlag {
         }
     }
 
-    ClassFile getClassFile(String name) throws IOException, ConstantPoolException {
+    ClassModel getClassFile(String name) throws IOException {
         URL url = getClass().getResource(name);
-        InputStream in = url.openStream();
-        try {
-            return ClassFile.read(in);
-        } finally {
-            in.close();
+        assert url != null;
+        try (InputStream in = url.openStream()) {
+            return Classfile.of().parse(in.readAllBytes());
         }
     }
 

--- a/test/langtools/tools/javac/linenumbers/ConditionalLineNumberTest.java
+++ b/test/langtools/tools/javac/linenumbers/ConditionalLineNumberTest.java
@@ -25,43 +25,46 @@
  * @test
  * @bug 8034091
  * @summary Add LineNumberTable attributes for conditional operator (?:) split across several lines.
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.ConstantPoolException;
-import com.sun.tools.classfile.Method;
-import com.sun.tools.classfile.Attribute;
-import com.sun.tools.classfile.Code_attribute;
-import com.sun.tools.classfile.LineNumberTable_attribute;
-import com.sun.tools.classfile.LineNumberTable_attribute.Entry;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.CodeAttribute;
+import jdk.internal.classfile.attribute.LineNumberInfo;
+import jdk.internal.classfile.attribute.LineNumberTableAttribute;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 public class ConditionalLineNumberTest {
     public static void main(String[] args) throws Exception {
         // check that we have 5 consecutive entries for method()
-        Entry[] lines = findEntries();
-        if (lines == null || lines.length != 5)
+        List<LineNumberInfo> lines = findEntries();
+        if (lines == null || lines.size() != 5)
             throw new Exception("conditional line number table incorrect");
 
-        int current = lines[0].line_number;
-        for (Entry e : lines) {
-            if (e.line_number != current)
+        int current = lines.get(0).lineNumber();
+        for (LineNumberInfo e : lines) {
+            if (e.lineNumber() != current)
                 throw new Exception("conditional line number table incorrect");
             current++;
         }
-   }
+    }
 
-    static Entry[] findEntries() throws IOException, ConstantPoolException {
-        ClassFile self = ClassFile.read(ConditionalLineNumberTest.class.getResourceAsStream("ConditionalLineNumberTest.class"));
-        for (Method m : self.methods) {
-            if ("method".equals(m.getName(self.constant_pool))) {
-                Code_attribute code_attribute = (Code_attribute)m.attributes.get(Attribute.Code);
-                for (Attribute at : code_attribute.attributes) {
-                    if (Attribute.LineNumberTable.equals(at.getName(self.constant_pool))) {
-                        return ((LineNumberTable_attribute)at).line_number_table;
+    static List<LineNumberInfo> findEntries() throws IOException {
+        ClassModel self = Classfile.of().parse(ConditionalLineNumberTest.class.getResourceAsStream("ConditionalLineNumberTest.class").readAllBytes());
+        for (MethodModel m : self.methods()) {
+            if (m.methodName().equalsString("method")) {
+                CodeAttribute code_attribute = m.findAttribute(Attributes.CODE).orElse(null);
+                assert code_attribute != null;
+                for (Attribute<?> at : code_attribute.attributes()) {
+                    if (at instanceof LineNumberTableAttribute) {
+                        return ((LineNumberTableAttribute)at).lineNumbers();
                     }
                 }
             }
@@ -73,9 +76,9 @@ public class ConditionalLineNumberTest {
     // in the method body.
     public static String method(int field) {
         String s = field % 2 == 0 ?
-            (field == 0 ? "false"
-             : "true" + field) : //Breakpoint
-            "false" + field; //Breakpoint
+                (field == 0 ? "false"
+                        : "true" + field) : //Breakpoint
+                "false" + field; //Breakpoint
         return s;
     }
 }

--- a/test/langtools/tools/javac/resolve/NoObjectToString.java
+++ b/test/langtools/tools/javac/resolve/NoObjectToString.java
@@ -25,14 +25,18 @@
  * @test
  * @bug 8272564
  * @summary Correct resolution of toString() (and other similar calls) on interfaces
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  * @compile NoObjectToString.java
  * @run main NoObjectToString
  */
 
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.constantpool.*;
 import java.io.*;
-import com.sun.tools.classfile.*;
-import com.sun.tools.classfile.ConstantPool.CONSTANT_Methodref_info;
 
 public class NoObjectToString {
     public static void main(String... args) throws Exception {
@@ -41,24 +45,20 @@ public class NoObjectToString {
     }
 
     void run(String... args) throws Exception {
-         //Verify there are no references to Object.toString() in a Test:
-        InputStream in = NoObjectToString.class.getResourceAsStream("NoObjectToString$Test.class");
-        try {
-            ClassFile cf = ClassFile.read(in);
-            for (ConstantPool.CPInfo cpinfo: cf.constant_pool.entries()) {
-                if (cpinfo.getTag() == ConstantPool.CONSTANT_Methodref) {
-                    CONSTANT_Methodref_info ref = (CONSTANT_Methodref_info) cpinfo;
-                    String methodDesc = ref.getClassInfo().getName() + "." + ref.getNameAndTypeInfo().getName() + ":" + ref.getNameAndTypeInfo().getType();
+        //Verify there are no references to Object.toString() in a Test:
+        try (InputStream in = NoObjectToString.class.getResourceAsStream("NoObjectToString$Test.class")) {
+            assert in != null;
+            ClassModel cm = Classfile.of().parse(in.readAllBytes());
+            for (int i = 1; i < cm.constantPool().entryCount(); ++i) {
+                PoolEntry pe = cm.constantPool().entryByIndex(i);
+                if (pe instanceof MethodRefEntry ref) {
+                    String methodDesc = ref.owner().name() + "." + ref.nameAndType().name() + ":" + ref.nameAndType().type();
 
                     if ("java/lang/Object.toString:()Ljava/lang/String;".equals(methodDesc)) {
                         throw new AssertionError("Found call to j.l.Object.toString");
                     }
                 }
             }
-        } catch (ConstantPoolException ignore) {
-            throw new AssertionError(ignore);
-        } finally {
-            in.close();
         }
     }
 

--- a/test/langtools/tools/javap/T6716452.java
+++ b/test/langtools/tools/javap/T6716452.java
@@ -24,11 +24,18 @@
 /*
  * @test 6716452
  * @summary need a method to get an index of an attribute
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import java.nio.file.Files;
+
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 public class T6716452 {
     public static void main(String[] args) throws Exception {
@@ -38,49 +45,44 @@ public class T6716452 {
     public void run() throws Exception {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
-
-        ClassFile cf = ClassFile.read(classFile);
-        for (Method m: cf.methods) {
-            test(cf, m);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         if (errors > 0)
             throw new Exception(errors + " errors found");
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.Code, Code_attribute.class);
-        test(cf, m, Attribute.Exceptions, Exceptions_attribute.class);
+    void test(MethodModel mm) {
+        test(mm, Attributes.CODE, CodeAttribute.class);
+        test(mm, Attributes.EXCEPTIONS, ExceptionsAttribute.class);
     }
 
-    // test the result of Attributes.getIndex according to expectations
+    // test the result of MethodModel.findAttribute, MethodModel.attributes().indexOf() according to expectations
     // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, Class<?> c) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        try {
-            String m_name = m.getName(cf.constant_pool);
-            System.err.println("Method " + m_name + " name:" + name + " index:" + index + " class: " + c);
-            boolean expect = (m_name.equals("<init>") && name.equals("Code"))
-                || (m_name.indexOf(name) != -1);
-            boolean found = (index != -1);
-            if (expect) {
-                if (found) {
-                    Attribute attr = m.attributes.get(index);
-                    if (!c.isAssignableFrom(attr.getClass())) {
-                        error(m + ": unexpected attribute found,"
-                              + " expected " + c.getName()
-                              + " found " + attr.getClass().getName());
-                    }
-                } else {
-                    error(m + ": expected attribute " + name + " not found");
+    <T extends Attribute<T>> void test(MethodModel mm, AttributeMapper<T> attr, Class<?> c) {
+        Attribute<T> attr_instance = mm.findAttribute(attr).orElse(null);
+        int index = mm.attributes().indexOf(attr_instance);
+        String mm_name = mm.methodName().stringValue();
+        System.err.println("Method " + mm_name + " name:" + attr.name() + " index:" + index + " class: " + c);
+        boolean expect = (mm_name.equals("<init>") && attr.name().equals("Code"))
+                || (mm_name.contains(attr.name()));
+        boolean found = (index != -1);
+        if (expect) {
+            if (found) {
+                if (!c.isAssignableFrom(mm.attributes().get(index).getClass())) {
+                    error(mm + ": unexpected attribute found,"
+                            + " expected " + c.getName()
+                            + " found " + mm.attributes().get(index).attributeName());
                 }
             } else {
-                if (found) {
-                    error(m + ": unexpected attribute " + name);
-                }
+                error(mm + ": expected attribute " + attr.name() + " not found");
             }
-        } catch (ConstantPoolException e) {
-            error(m + ": " + e);
+        } else {
+            if (found) {
+                error(mm + ": unexpected attribute " + attr.name());
+            }
         }
     }
 

--- a/test/langtools/tools/javap/typeAnnotations/NewArray.java
+++ b/test/langtools/tools/javap/typeAnnotations/NewArray.java
@@ -22,17 +22,21 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test NewArray
  * @bug 6843077
  * @summary Test type annotations on local array are in method's code attribute.
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class NewArray {
-
     public static void main(String[] args) throws Exception {
         new NewArray().run();
     }
@@ -41,51 +45,48 @@ public class NewArray {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        for (Method m: cf.methods) {
-            test(cf, m);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
-
         countAnnotations();
-
         if (errors > 0)
             throw new Exception(errors + " errors found");
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(MethodModel mm) {
+        test(mm, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(mm, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
     // test the result of Attributes.getIndex according to expectations
     // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        Attribute attr = null;
-        Code_attribute cAttr = null;
-        RuntimeTypeAnnotations_attribute tAttr = null;
+    <T extends Attribute<T>> void test(MethodModel mm, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance;
+        CodeAttribute cAttr;
 
-        int index = m.attributes.getIndex(cf.constant_pool, Attribute.Code);
-        if(index!= -1) {
-            attr = m.attributes.get(index);
-            assert attr instanceof Code_attribute;
-            cAttr = (Code_attribute)attr;
-            index = cAttr.attributes.getIndex(cf.constant_pool, name);
-            if(index!= -1) {
-                attr = cAttr.attributes.get(index);
-                assert attr instanceof RuntimeTypeAnnotations_attribute;
-                tAttr = (RuntimeTypeAnnotations_attribute)attr;
-                all += tAttr.annotations.length;
-                if (visible)
-                    visibles += tAttr.annotations.length;
-                else
-                    invisibles += tAttr.annotations.length;
-               }
+        cAttr = mm.findAttribute(Attributes.CODE).orElse(null);
+        if (cAttr != null) {
+            attr_instance = cAttr.findAttribute(attr_name).orElse(null);
+            if (attr_instance != null) {
+                switch (attr_instance) {
+                    case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                        all += tAttr.annotations().size();
+                        visibles += tAttr.annotations().size();
+                    }
+                    case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                        all += tAttr.annotations().size();
+                        invisibles += tAttr.annotations().size();
+                    }
+                    default -> throw new AssertionError();
+                }
+            }
         }
     }
 
     File writeTestFile() throws IOException {
-      File f = new File("Test.java");
+        File f = new File("Test.java");
         PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(f)));
         out.println("import java.lang.annotation.*;");
         out.println("import java.util.*;");
@@ -133,7 +134,6 @@ public class NewArray {
         }
 
     }
-
     int errors;
     int all;
     int visibles;

--- a/test/langtools/tools/javap/typeAnnotations/Presence.java
+++ b/test/langtools/tools/javap/typeAnnotations/Presence.java
@@ -23,14 +23,18 @@
 
 import java.io.*;
 import java.lang.annotation.ElementType;
-
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test Presence
  * @bug 6843077
  * @summary test that all type annotations are present in the classfile
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class Presence {
@@ -42,13 +46,13 @@ public class Presence {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        test(cf);
-        for (Field f : cf.fields) {
-            test(cf, f);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        test(cm);
+        for (FieldModel fm : cm.fields()) {
+            test(fm);
         }
-        for (Method m: cf.methods) {
-            test(cf, m);
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         countAnnotations();
@@ -58,91 +62,50 @@ public class Presence {
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf) {
-        test(cf, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(AttributedElement m) {
+        test(m, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(m, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    void test(ClassFile cf, Field m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, String name, boolean visible) {
-        int index = cf.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = cf.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    // test the result of AttributedElement.findAttribute according to expectations
+    <T extends Attribute<T>> void test(AttributedElement m, AttributeMapper<T> attr_name) {
+        Object attr_instance = m.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
+        }
+        if (m instanceof MethodModel) {
+            attr_instance = m.findAttribute(Attributes.CODE).orElse(null);
+            if(attr_instance!= null) {
+                CodeAttribute cAttr = (CodeAttribute)attr_instance;
+                attr_instance = cAttr.findAttribute(attr_name).orElse(null);
+                if(attr_instance!= null) {
+                    switch (attr_instance) {
+                        case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                            all += tAttr.annotations().size();
+                            visibles += tAttr.annotations().size();
+                        }
+                        case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                            all += tAttr.annotations().size();
+                            invisibles += tAttr.annotations().size();
+                        }
+                        default -> throw new AssertionError();
+                    }
+                }
+            }
         }
     }
 
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        Attribute attr = null;
-        Code_attribute cAttr = null;
-        RuntimeTypeAnnotations_attribute tAttr = null;
 
-        // collect annotations attributes on method
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-        // collect annotations from method's code attribute
-        index = m.attributes.getIndex(cf.constant_pool, Attribute.Code);
-        if(index!= -1) {
-            attr = m.attributes.get(index);
-            assert attr instanceof Code_attribute;
-            cAttr = (Code_attribute)attr;
-            index = cAttr.attributes.getIndex(cf.constant_pool, name);
-            if(index!= -1) {
-                attr = cAttr.attributes.get(index);
-                assert attr instanceof RuntimeTypeAnnotations_attribute;
-                tAttr = (RuntimeTypeAnnotations_attribute)attr;
-                all += tAttr.annotations.length;
-                if (visible)
-                    visibles += tAttr.annotations.length;
-                else
-                    invisibles += tAttr.annotations.length;
-               }
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Field m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
 
     File writeTestFile() throws IOException {
         File f = new File("TestPresence.java");

--- a/test/langtools/tools/javap/typeAnnotations/PresenceInner.java
+++ b/test/langtools/tools/javap/typeAnnotations/PresenceInner.java
@@ -22,13 +22,18 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test PresenceInner
  * @bug 6843077
  * @summary test that annotations in inner types count only once
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class PresenceInner {
@@ -40,13 +45,13 @@ public class PresenceInner {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        test(cf);
-        for (Field f : cf.fields) {
-            test(cf, f);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        test(cm);
+        for (FieldModel fm : cm.fields()) {
+            test(fm);
         }
-        for (Method m: cf.methods) {
-            test(cf, m);
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         // counts are zero when vising outer class
@@ -54,13 +59,13 @@ public class PresenceInner {
 
         // visit inner class
         File innerFile = new File("Test$1Inner.class");
-        ClassFile icf = ClassFile.read(innerFile);
-        test(icf);
-        for (Field f : icf.fields) {
-            test(cf, f);
+        ClassModel icm = Classfile.of().parse(innerFile.toPath());
+        test(icm);
+        for (FieldModel fm : icm.fields()) {
+            test(fm);
         }
-        for (Method m: icf.methods) {
-            test(cf, m);
+        for (MethodModel mm: icm.methods()) {
+            test(mm);
         }
 
         countAnnotations(1);
@@ -69,66 +74,26 @@ public class PresenceInner {
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf) {
-        test(cf, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(AttributedElement m) {
+        test(m, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(m, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    void test(ClassFile cf, Field m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, String name, boolean visible) {
-        int index = cf.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = cf.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Field m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    // test the result of AttributedElement.findAttribute according to expectations
+    <T extends Attribute<T>> void test(AttributedElement m, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance = m.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
         }
     }
 

--- a/test/langtools/tools/javap/typeAnnotations/Visibility.java
+++ b/test/langtools/tools/javap/typeAnnotations/Visibility.java
@@ -22,13 +22,19 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.Attributes;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test Visibility
  * @bug 6843077
  * @summary test that type annotations are recorded in the classfile
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 
 public class Visibility {
@@ -40,9 +46,9 @@ public class Visibility {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        for (Method m: cf.methods) {
-            test(cf, m);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         countAnnotations();
@@ -52,24 +58,27 @@ public class Visibility {
         System.out.println("PASSED");
     }
 
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(MethodModel mm) {
+        test(mm, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(mm, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
 
-    // test the result of Attributes.getIndex according to expectations
+    // test the result of mm.findAttribute according to expectations
     // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    <T extends Attribute<T>> void test(MethodModel mm, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance = mm.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
         }
     }
 
@@ -109,7 +118,7 @@ public class Visibility {
     }
 
     File compileTestFile(File f) {
-      int rc = com.sun.tools.javac.Main.compile(new String[] {"-g", f.getPath() });
+        int rc = com.sun.tools.javac.Main.compile(new String[] {"-g", f.getPath() });
         if (rc != 0)
             throw new Error("compilation failed. rc=" + rc);
         String path = f.getPath();

--- a/test/langtools/tools/javap/typeAnnotations/Wildcards.java
+++ b/test/langtools/tools/javap/typeAnnotations/Wildcards.java
@@ -22,13 +22,18 @@
  */
 
 import java.io.*;
-import com.sun.tools.classfile.*;
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.*;
 
 /*
  * @test Wildcards
  * @bug 6843077
  * @summary test that annotations target wildcards get emitted to classfile
- * @modules jdk.jdeps/com.sun.tools.classfile
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
  */
 public class Wildcards {
     public static void main(String[] args) throws Exception {
@@ -39,13 +44,13 @@ public class Wildcards {
         File javaFile = writeTestFile();
         File classFile = compileTestFile(javaFile);
 
-        ClassFile cf = ClassFile.read(classFile);
-        test(cf);
-        for (Field f : cf.fields) {
-            test(cf, f);
+        ClassModel cm = Classfile.of().parse(classFile.toPath());
+        test(cm);
+        for (FieldModel fm : cm.fields()) {
+            test(fm);
         }
-        for (Method m: cf.methods) {
-            test(cf, m);
+        for (MethodModel mm: cm.methods()) {
+            test(mm);
         }
 
         countAnnotations();
@@ -54,72 +59,28 @@ public class Wildcards {
             throw new Exception(errors + " errors found");
         System.out.println("PASSED");
     }
-
-    void test(ClassFile cf) {
-        test(cf, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, Attribute.RuntimeInvisibleTypeAnnotations, false);
+    void test(AttributedElement m) {
+        test(m, Attributes.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        test(m, Attributes.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
     }
-
-    void test(ClassFile cf, Method m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    void test(ClassFile cf, Field m) {
-        test(cf, m, Attribute.RuntimeVisibleTypeAnnotations, true);
-        test(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, false);
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, String name, boolean visible) {
-        int index = cf.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = cf.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
+    <T extends Attribute<T>> void test(AttributedElement m, AttributeMapper<T> attr_name) {
+        Attribute<T> attr_instance = m.findAttribute(attr_name).orElse(null);
+        if (attr_instance != null) {
+            switch (attr_instance) {
+                case RuntimeVisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    visibles += tAttr.annotations().size();
+                }
+                case RuntimeInvisibleTypeAnnotationsAttribute tAttr -> {
+                    all += tAttr.annotations().size();
+                    invisibles += tAttr.annotations().size();
+                }
+                default -> throw new AssertionError();
+            }
         }
     }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Method m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
-    // test the result of Attributes.getIndex according to expectations
-    // encoded in the method's name
-    void test(ClassFile cf, Field m, String name, boolean visible) {
-        int index = m.attributes.getIndex(cf.constant_pool, name);
-        if (index != -1) {
-            Attribute attr = m.attributes.get(index);
-            assert attr instanceof RuntimeTypeAnnotations_attribute;
-            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
-            all += tAttr.annotations.length;
-            if (visible)
-                visibles += tAttr.annotations.length;
-            else
-                invisibles += tAttr.annotations.length;
-        }
-    }
-
     File writeTestFile() throws IOException {
-      File f = new File("Test.java");
+        File f = new File("Test.java");
         PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(f)));
         out.println("import java.lang.annotation.*;");
         out.println("import java.util.*;");


### PR DESCRIPTION
Modified 12 of 226 test/langtools/tools/javac test classes to replace com.sun.tools.classfile library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8295058](https://bugs.openjdk.org/browse/JDK-8295058): test/langtools/tools/javac 226 test classes uses com.sun.tools.classfile library (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14857/head:pull/14857` \
`$ git checkout pull/14857`

Update a local copy of the PR: \
`$ git checkout pull/14857` \
`$ git pull https://git.openjdk.org/jdk.git pull/14857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14857`

View PR using the GUI difftool: \
`$ git pr show -t 14857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14857.diff">https://git.openjdk.org/jdk/pull/14857.diff</a>

</details>
