### PR TITLE
8311986: Disable runtime/os/TestTracePageSizes.java for ShenandoahGC

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@
  * @library /test/lib
  * @build jdk.test.lib.Platform
  * @requires os.family == "linux"
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseLargePages TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes

--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -51,7 +51,7 @@
  * @library /test/lib
  * @build jdk.test.lib.Platform
  * @requires os.family == "linux"
- * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
+ * @requires vm.gc != "Shenandoah"
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseLargePages TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes

--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -51,7 +51,7 @@
  * @library /test/lib
  * @build jdk.test.lib.Platform
  * @requires os.family == "linux"
- * @requires vm.gc != "Shenandoah"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseLargePages TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes


### PR DESCRIPTION
Hi,

runtime/os/TestTracePageSizes.java fails for ShenandoahGC on linux-x86_64:

```
ACTION: main -- Failed. Execution failed: `main' threw exception: java.lang.AssertionError: Page sizes mismatch: 4 != 2048
REASON: User specified action: run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes 
TIME:   0.353 seconds
messages:
command: main -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes
reason: User specified action: run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes 
started: Thu Jul 13 09:57:18 CST 2023
Mode: othervm [/othervm specified]
finished: Thu Jul 13 09:57:19 CST 2023
elapsed time (seconds): 0.353
configuration:
STDOUT:
STDERR:
java.lang.AssertionError: Page sizes mismatch: 4 != 2048
	at TestTracePageSizes.main(TestTracePageSizes.java:294)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:1570)

JavaTest Message: Test threw exception: java.lang.AssertionError: Page sizes mismatch: 4 != 2048
JavaTest Message: shutting down test

STATUS:Failed.`main' threw exception: java.lang.AssertionError: Page sizes mismatch: 4 != 2048
rerun:
cd /mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/scratch/0 && \
HOME=/home/loongson \
LANG=zh_CN.UTF-8 \
LC_ALL=C \
PATH=/bin:/usr/bin:/usr/sbin \
TEST_IMAGE_DIR=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/test \
_JVM_DWARF_PATH=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/symbols \
CLASSPATH=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d:/mnt/repo/openjdk/jdk/test/hotspot/jtreg/runtime/os:/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/test/lib:/mnt/repo/openjdk/jdk/test/lib:/mnt/download/jtreg/lib/javatest.jar:/mnt/download/jtreg/lib/jtreg.jar \
    /mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/jdk/bin/java \
        -Dtest.vm.opts='-XX:MaxRAMPercentage=4.16667 -Dtest.boot.jdk=/mnt/download/jdk-20.0.1 -Djava.io.tmpdir=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/tmp -XX:+UseShenandoahGC' \
        -Dtest.tool.vm.opts='-J-XX:MaxRAMPercentage=4.16667 -J-Dtest.boot.jdk=/mnt/download/jdk-20.0.1 -J-Djava.io.tmpdir=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/tmp -J-XX:+UseShenandoahGC' \
        -Dtest.compiler.opts= \
        -Dtest.java.opts= \
        -Dtest.jdk=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/jdk \
        -Dcompile.jdk=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/jdk \
        -Dtest.timeout.factor=4.0 \
        -Dtest.nativepath=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/test/hotspot/jtreg/native \
        -Dtest.root=/mnt/repo/openjdk/jdk/test/hotspot/jtreg \
        -Dtest.name=runtime/os/TestTracePageSizes.java#compiler-options \
        -Dtest.file=/mnt/repo/openjdk/jdk/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java \
        -Dtest.src=/mnt/repo/openjdk/jdk/test/hotspot/jtreg/runtime/os \
        -Dtest.src.path=/mnt/repo/openjdk/jdk/test/hotspot/jtreg/runtime/os:/mnt/repo/openjdk/jdk/test/lib \
        -Dtest.classes=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d \
        -Dtest.class.path=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d:/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/test/lib \
        -Dtest.class.path.prefix=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d:/mnt/repo/openjdk/jdk/test/hotspot/jtreg/runtime/os:/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/test/lib \
        -XX:MaxRAMPercentage=4.16667 \
        -Dtest.boot.jdk=/mnt/download/jdk-20.0.1 \
        -Djava.io.tmpdir=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/tmp \
        -XX:+UseShenandoahGC \
        -Djava.library.path=/mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/images/test/hotspot/jtreg/native \
        -XX:+AlwaysPreTouch \
        -Xmx128m \
        -Xlog:pagesize:ps-%p.log \
        -XX:-SegmentedCodeCache \
        -XX:+UseTransparentHugePages \
        com.sun.javatest.regtest.agent.MainWrapper /mnt/repo/openjdk/jdk/build/linux-x86_64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/runtime/os/TestTracePageSizes_compiler-options.d/main.2.jta

TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.AssertionError: Page sizes mismatch: 4 != 2048
```

Also fails on linux-loongarch64:

```
ACTION: main -- Failed. Execution failed: `main' threw exception: java.lang.AssertionError: Page sizes mismatch: 16 != 32768
REASON: User specified action: run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes 
TIME:   1.162 seconds
messages:
command: main -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes
reason: User specified action: run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:-SegmentedCodeCache -XX:+UseTransparentHugePages TestTracePageSizes 
started: Thu Jul 13 09:15:46 CST 2023
Mode: othervm [/othervm specified]
finished: Thu Jul 13 09:15:47 CST 2023
elapsed time (seconds): 1.162
configuration:
STDOUT:
STDERR:
OpenJDK 64-Bit Server VM warning: Large pages size (32768K) is too large to afford page-sized regions, disabling uncommit
java.lang.AssertionError: Page sizes mismatch: 16 != 32768
	at TestTracePageSizes.main(TestTracePageSizes.java:300)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:1570)

JavaTest Message: Test threw exception: java.lang.AssertionError: Page sizes mismatch: 16 != 32768
JavaTest Message: shutting down test

STATUS:Failed.`main' threw exception: java.lang.AssertionError: Page sizes mismatch: 16 != 32768
rerun:
cd /mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/scratch/1 && \
HOME=/home/zhaixiang \
LANG=zh_CN.UTF-8 \
LC_ALL=C \
PATH=/bin:/usr/bin:/usr/sbin \
TEST_IMAGE_DIR=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/test \
_JVM_DWARF_PATH=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/symbols \
CLASSPATH=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d:/mnt/repo/private/jdk-ls/test/hotspot/jtreg/runtime/os:/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/test/lib:/mnt/repo/private/jdk-ls/test/lib:/mnt/jtreg/lib/javatest.jar:/mnt/jtreg/lib/jtreg.jar \
    /mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/jdk/bin/java \
        -Dtest.vm.opts='-XX:MaxRAMPercentage=12.5 -Dtest.boot.jdk=/mnt/jdk-ls-loongarch64-fx-server-release-20230526 -Djava.io.tmpdir=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/tmp -XX:+UseShenandoahGC' \
        -Dtest.tool.vm.opts='-J-XX:MaxRAMPercentage=12.5 -J-Dtest.boot.jdk=/mnt/jdk-ls-loongarch64-fx-server-release-20230526 -J-Djava.io.tmpdir=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/tmp -J-XX:+UseShenandoahGC' \
        -Dtest.compiler.opts= \
        -Dtest.java.opts= \
        -Dtest.jdk=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/jdk \
        -Dcompile.jdk=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/jdk \
        -Dtest.timeout.factor=4.0 \
        -Dtest.nativepath=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/test/hotspot/jtreg/native \
        -Dtest.root=/mnt/repo/private/jdk-ls/test/hotspot/jtreg \
        -Dtest.name=runtime/os/TestTracePageSizes.java#compiler-options \
        -Dtest.file=/mnt/repo/private/jdk-ls/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java \
        -Dtest.src=/mnt/repo/private/jdk-ls/test/hotspot/jtreg/runtime/os \
        -Dtest.src.path=/mnt/repo/private/jdk-ls/test/hotspot/jtreg/runtime/os:/mnt/repo/private/jdk-ls/test/lib \
        -Dtest.classes=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d \
        -Dtest.class.path=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d:/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/test/lib \
        -Dtest.class.path.prefix=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/runtime/os/TestTracePageSizes_compiler-options.d:/mnt/repo/private/jdk-ls/test/hotspot/jtreg/runtime/os:/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/classes/0/test/lib \
        -XX:MaxRAMPercentage=12.5 \
        -Dtest.boot.jdk=/mnt/jdk-ls-loongarch64-fx-server-release-20230526 \
        -Djava.io.tmpdir=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/tmp \
        -XX:+UseShenandoahGC \
        -Djava.library.path=/mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/images/test/hotspot/jtreg/native \
        -XX:+AlwaysPreTouch \
        -Xmx128m \
        -Xlog:pagesize:ps-%p.log \
        -XX:-SegmentedCodeCache \
        -XX:+UseTransparentHugePages \
        com.sun.javatest.regtest.agent.MainWrapper /mnt/repo/private/jdk-ls/build/linux-loongarch64-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_os_TestTracePageSizes_java/runtime/os/TestTracePageSizes_compiler-options.d/main.2.jta

TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.AssertionError: Page sizes mismatch: 16 != 32768
```

Please review my patch.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311986](https://bugs.openjdk.org/browse/JDK-8311986): Disable runtime/os/TestTracePageSizes.java for ShenandoahGC (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14858/head:pull/14858` \
`$ git checkout pull/14858`

Update a local copy of the PR: \
`$ git checkout pull/14858` \
`$ git pull https://git.openjdk.org/jdk.git pull/14858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14858`

View PR using the GUI difftool: \
`$ git pr show -t 14858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14858.diff">https://git.openjdk.org/jdk/pull/14858.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14858#issuecomment-1633444731)