### PR TITLE
8311902: Concurrency regression in the PBKDF2 key impl of SunJCE provider

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -26,6 +26,7 @@
 package com.sun.crypto.provider;
 
 import java.io.ObjectStreamException;
+import java.lang.ref.Reference;
 import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -205,7 +206,11 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     }
 
     public byte[] getEncoded() {
-        return key.clone();
+        // The key is zeroized by finalize()
+        // The reachability fence ensures finalize() isn't called early
+        byte[] result = key.clone();
+        Reference.reachabilityFence(this);
+        return result;
     }
 
     public String getAlgorithm() {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -206,11 +206,12 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     }
 
     public byte[] getEncoded() {
-        // The key is zeroized by finalize()
-        // The reachability fence ensures finalize() isn't called early
-        byte[] result = key.clone();
-        Reference.reachabilityFence(this);
-        return result;
+        try {
+            return key.clone();
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 
     public String getAlgorithm() {
@@ -226,7 +227,12 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     }
 
     public char[] getPassword() {
-        return passwd.clone();
+        try {
+            return passwd.clone();
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 
     public byte[] getSalt() {
@@ -242,30 +248,45 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
      * Objects that are equal will also have the same hashcode.
      */
     public int hashCode() {
-        int retval = 0;
-        for (int i = 1; i < this.key.length; i++) {
-            retval += this.key[i] * i;
+        try {
+            int retval = 0;
+            for (int i = 1; i < this.key.length; i++) {
+                retval += this.key[i] * i;
+            }
+            return (retval ^= getAlgorithm().toLowerCase
+                    (Locale.ENGLISH).hashCode());
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
         }
-        return(retval ^= getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode());
     }
 
     public boolean equals(Object obj) {
-        if (obj == this)
-            return true;
+        try {
+            if (obj == this) {
+                return true;
+            }
 
-        if (!(obj instanceof SecretKey))
-            return false;
+            if (!(obj instanceof SecretKey)) {
+                return false;
+            }
 
-        SecretKey that = (SecretKey) obj;
+            SecretKey that = (SecretKey) obj;
 
-        if (!(that.getAlgorithm().equalsIgnoreCase(getAlgorithm())))
-            return false;
-        if (!(that.getFormat().equalsIgnoreCase("RAW")))
-            return false;
-        byte[] thatEncoded = that.getEncoded();
-        boolean ret = MessageDigest.isEqual(key, thatEncoded);
-        Arrays.fill(thatEncoded, (byte)0x00);
-        return ret;
+            if (!(that.getAlgorithm().equalsIgnoreCase(getAlgorithm()))) {
+                return false;
+            }
+            if (!(that.getFormat().equalsIgnoreCase("RAW"))) {
+                return false;
+            }
+            byte[] thatEncoded = that.getEncoded();
+            boolean ret = MessageDigest.isEqual(key, thatEncoded);
+            Arrays.fill(thatEncoded, (byte)0x00);
+            return ret;
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 
     /**
@@ -278,7 +299,12 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
      */
     @java.io.Serial
     private Object writeReplace() throws ObjectStreamException {
-        return new KeyRep(KeyRep.Type.SECRET, getAlgorithm(),
-                getFormat(), key);
+        try {
+            return new KeyRep(KeyRep.Type.SECRET, getAlgorithm(),
+                    getFormat(), key);
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 }


### PR DESCRIPTION
This change adds back the Reference.ReachabilityFence(Object) call removed by [JDK-8301553](https://bugs.openjdk.org/browse/JDK-8301553).

Please help review.
Thanks!
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311902](https://bugs.openjdk.org/browse/JDK-8311902): Concurrency regression in the PBKDF2 key impl of SunJCE provider (**Bug** - P2)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**) ⚠️ Review applies to [9d3c15a7](https://git.openjdk.org/jdk/pull/14859/files/9d3c15a77afeac384c1b9ffbe89cd9d38595679b)
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14859/head:pull/14859` \
`$ git checkout pull/14859`

Update a local copy of the PR: \
`$ git checkout pull/14859` \
`$ git pull https://git.openjdk.org/jdk.git pull/14859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14859`

View PR using the GUI difftool: \
`$ git pr show -t 14859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14859.diff">https://git.openjdk.org/jdk/pull/14859.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14859#issuecomment-1633471813)