### PR TITLE
6211202: ColorSpace.getInstance(int): IAE is not specified

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -305,6 +305,8 @@ public abstract class ColorSpace implements Serializable {
      *         class constants (e.g. {@code CS_sRGB}, {@code CS_LINEAR_RGB},
      *         {@code CS_CIEXYZ}, {@code CS_GRAY}, or {@code CS_PYCC})
      * @return the requested {@code ColorSpace} object
+     * @throws IllegalArgumentException if {@code cspace} is not one of the
+     *         predefined color space types
      */
     // NOTE: This method may be called by privileged threads.
     //       DO NOT INVOKE CLIENT CODE ON THIS THREAD!

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -818,8 +818,7 @@ public sealed class ICC_Profile implements Serializable
     /**
      * Constructs an {@code ICC_Profile} corresponding to one of the specific
      * color spaces defined by the {@code ColorSpace} class (for example
-     * {@code CS_sRGB}). Throws an {@code IllegalArgumentException} if cspace is
-     * not one of the defined color spaces.
+     * {@code CS_sRGB}).
      *
      * @param  cspace the type of color space to create a profile for. The
      *         specified type is one of the color space constants defined in the

--- a/test/jdk/java/awt/color/GetInstanceBrokenData.java
+++ b/test/jdk/java/awt/color/GetInstanceBrokenData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,12 @@
  * questions.
  */
 
+import java.awt.color.ColorSpace;
 import java.awt.color.ICC_Profile;
 
 /**
  * @test
- * @bug 6211198
+ * @bug 6211198 6211202
  * @summary IllegalArgumentException in ICC_Profile.getInstance for broken data
  */
 public final class GetInstanceBrokenData {
@@ -34,6 +35,18 @@ public final class GetInstanceBrokenData {
         byte b[] = {-21, -22, -23};
         try {
             ICC_Profile p = ICC_Profile.getInstance(b);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignored) {
+            // expected
+        }
+        try {
+            ICC_Profile.getInstance(-5);
+            throw new RuntimeException("IllegalArgumentException is expected");
+        } catch (IllegalArgumentException ignored) {
+            // expected
+        }
+        try {
+            ColorSpace.getInstance(-5);
             throw new RuntimeException("IllegalArgumentException is expected");
         } catch (IllegalArgumentException ignored) {
             // expected


### PR DESCRIPTION
* Added @throws IllegalArgumentException to the specification of java.awt.color.ColorSpace.getInstance(int)
* Deleted duplicate text about IllegalArgumentException from the java.awt.color.ICC_Profile.getInstance(int)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8311995](https://bugs.openjdk.org/browse/JDK-8311995) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-6211202](https://bugs.openjdk.org/browse/JDK-6211202): ColorSpace.getInstance(int): IAE is not specified (**Bug** - P4)
 * [JDK-8311995](https://bugs.openjdk.org/browse/JDK-8311995): ColorSpace.getInstance(int): IAE is not specified (**CSR**)

### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14860/head:pull/14860` \
`$ git checkout pull/14860`

Update a local copy of the PR: \
`$ git checkout pull/14860` \
`$ git pull https://git.openjdk.org/jdk.git pull/14860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14860`

View PR using the GUI difftool: \
`$ git pr show -t 14860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14860.diff">https://git.openjdk.org/jdk/pull/14860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14860#issuecomment-1634744369)