### PR TITLE
8311968: Clarify Three-letter time zone IDs in java.util.TimeZone

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -130,7 +130,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * use is deprecated</strong> because the same abbreviation is often used
  * for multiple time zones (for example, "CST" could be U.S. "Central Standard
  * Time" and "China Standard Time"), and the Java platform can then only
- * recognize one of them.
+ * recognize one of them. The full list of the deprecated IDs can be viewed
+ * at {@link java.time.ZoneId#SHORT_IDS}. It should be noted that not all
+ * three-letter time zone IDs are deprecated, as some come from the TZDB.
  *
  *
  * @see          Calendar

--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -132,7 +132,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * Time" and "China Standard Time"), and the Java platform can then only
  * recognize one of them. The full list of the deprecated IDs can be viewed
  * at {@link java.time.ZoneId#SHORT_IDS}. It should be noted that not all
- * three-letter time zone IDs are deprecated, as some come from the TZDB.
+ * three-letter time zone IDs are deprecated, as some come from the IANA Time
+ * Zone Database (TZDB).
  *
  *
  * @see          Calendar


### PR DESCRIPTION
Please review this PR and associated [CSR](https://bugs.openjdk.org/browse/JDK-8311979) which links the full list of deprecated three-letter IDs in java.util.TimeZone

Although it is made apparent in TimeZone that certain 3-letter IDs are deprecated, it does not actually list them in the specification. In addition to linking the full list, it is clarified that not _all_ 3-letter IDs are deprecated, as there are quite a few that come from the tzdb.

This change links to the full list found in ZoneId.