### PR TITLE
8314129: Make fields final in java.util.Scanner

### DIFF
--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,34 @@
 
 package java.util;
 
-import java.io.*;
-import java.math.*;
-import java.nio.*;
-import java.nio.channels.*;
-import java.nio.charset.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.CharBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Path;
 import java.nio.file.Files;
-import java.text.*;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
 import java.text.spi.NumberFormatProvider;
 import java.util.function.Consumer;
-import java.util.regex.*;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import sun.util.locale.provider.LocaleProviderAdapter;
@@ -317,13 +334,13 @@ public final class Scanner implements Iterator<String>, Closeable {
     private CharBuffer buf;
 
     // Size of internal character buffer
-    private static final int BUFFER_SIZE = 1024; // change to 1024;
+    private static final int BUFFER_SIZE = 1024;
 
     // The index into the buffer currently held by the Scanner
     private int position;
 
     // Internal matcher used for finding delimiters
-    private Matcher matcher;
+    private final Matcher matcher;
 
     // Pattern used to delimit tokens
     private Pattern delimPattern;
@@ -371,7 +388,7 @@ public final class Scanner implements Iterator<String>, Closeable {
     private Locale locale = null;
 
     // A cache of the last few recently used Patterns
-    private PatternLRUCache patternCache = new PatternLRUCache(7);
+    private final PatternLRUCache patternCache = new PatternLRUCache(7);
 
     // A holder of the last IOException encountered
     private IOException lastException;
@@ -382,14 +399,14 @@ public final class Scanner implements Iterator<String>, Closeable {
     int modCount;
 
     // A pattern for java whitespace
-    private static Pattern WHITESPACE_PATTERN = Pattern.compile(
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile(
                                                 "\\p{javaWhitespace}+");
 
     // A pattern for any token
-    private static Pattern FIND_ANY_PATTERN = Pattern.compile("(?s).*");
+    private static final Pattern FIND_ANY_PATTERN = Pattern.compile("(?s).*");
 
     // A pattern for non-ASCII digits
-    private static Pattern NON_ASCII_DIGIT = Pattern.compile(
+    private static final Pattern NON_ASCII_DIGIT = Pattern.compile(
         "[\\p{javaDigit}&&[^0-9]]");
 
     // Fields and methods to support scanning primitive types
@@ -423,9 +440,9 @@ public final class Scanner implements Iterator<String>, Closeable {
      * Fields and methods to match bytes, shorts, ints, and longs
      */
     private Pattern integerPattern;
-    private String digits = "0123456789abcdefghijklmnopqrstuvwxyz";
-    private String non0Digit = "[\\p{javaDigit}&&[^0]]";
-    private int SIMPLE_GROUP_INDEX = 5;
+    private static final String digits = "0123456789abcdefghijklmnopqrstuvwxyz";
+    private static final String non0Digit = "[\\p{javaDigit}&&[^0]]";
+    private static final int SIMPLE_GROUP_INDEX = 5;
     private String buildIntegerPatternString() {
         String radixDigits = digits.substring(0, radix);
         // \\p{javaDigit} is not guaranteed to be appropriate


### PR DESCRIPTION
Made a few fields `final` in java.util.Scanner.
Also made `digits`, `non0Digit`, `SIMPLE_GROUP_INDEX` as `static.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314129](https://bugs.openjdk.org/browse/JDK-8314129): Make fields final in java.util.Scanner (**Enhancement** - P5)


### Reviewers
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14863/head:pull/14863` \
`$ git checkout pull/14863`

Update a local copy of the PR: \
`$ git checkout pull/14863` \
`$ git pull https://git.openjdk.org/jdk.git pull/14863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14863`

View PR using the GUI difftool: \
`$ git pr show -t 14863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14863.diff">https://git.openjdk.org/jdk/pull/14863.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14863#issuecomment-1673938361)