### PR TITLE
JDK-8312013: avoid UnixConstants.java.template warning: '__linux__' is not defined on AIX

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
@@ -124,7 +124,7 @@ class UnixConstants {
 // fgetxattr error codes for absent attributes depend on the OS:
 #ifdef _ALLBSD_SOURCE
     static final int PREFIX_XATTR_NOT_FOUND = ENOATTR;
-#elif __linux__
+#elif defined(__linux__)
     static final int PREFIX_XATTR_NOT_FOUND = ENODATA;
 #else
     // not supported (dummy values will not be used at runtime).


### PR DESCRIPTION
We run into this build warning on AIX :
/jdk/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template:127:7: warning: '__linux__' is not defined, evaluates to 0 [-Wundef]
#elif __linux__
1 warning generated.

Looks like the preprocessor check should be adjusted, because the macro is not present on non-Linux systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312013](https://bugs.openjdk.org/browse/JDK-8312013): avoid UnixConstants.java.template  warning: '__linux__' is not defined  on AIX (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [e53bf994](https://git.openjdk.org/jdk/pull/14864/files/e53bf994ebbc76505c4abd7188b9c83ef52fcdec)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [e53bf994](https://git.openjdk.org/jdk/pull/14864/files/e53bf994ebbc76505c4abd7188b9c83ef52fcdec)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14864/head:pull/14864` \
`$ git checkout pull/14864`

Update a local copy of the PR: \
`$ git checkout pull/14864` \
`$ git pull https://git.openjdk.org/jdk.git pull/14864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14864`

View PR using the GUI difftool: \
`$ git pr show -t 14864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14864.diff">https://git.openjdk.org/jdk/pull/14864.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14864#issuecomment-1633889125)