### PR TITLE
[PATCH] Avoid redundant ArrayList allocation in DeleteOnExitHook

### DIFF
--- a/src/java.base/share/classes/java/io/DeleteOnExitHook.java
+++ b/src/java.base/share/classes/java/io/DeleteOnExitHook.java
@@ -56,7 +56,7 @@ class DeleteOnExitHook {
     private DeleteOnExitHook() {}
 
     static synchronized void add(String file) {
-        if(files == null) {
+        if (files == null) {
             // DeleteOnExitHook is running. Too late to add a file
             throw new IllegalStateException("Shutdown in progress");
         }
@@ -72,12 +72,9 @@ class DeleteOnExitHook {
             files = null;
         }
 
-        ArrayList<String> toBeDeleted = new ArrayList<>(theFiles);
-
-        // reverse the list to maintain previous jdk deletion order.
+        // reverse the collection to maintain previous jdk deletion order.
         // Last in first deleted.
-        Collections.reverse(toBeDeleted);
-        for (String filename : toBeDeleted) {
+        for (String filename : theFiles.reversed()) {
             (new File(filename)).delete();
         }
     }


### PR DESCRIPTION
Since introduction of `SequencedSet` there are less reasons to use `Collections.reverse` when reversed() method could be used.
In `DeleteOnExitHook` we can avoid redundant `ArrayList` allocation and just use reversed iteration provided by `LinkedHashSet`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14871/head:pull/14871` \
`$ git checkout pull/14871`

Update a local copy of the PR: \
`$ git checkout pull/14871` \
`$ git pull https://git.openjdk.org/jdk.git pull/14871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14871`

View PR using the GUI difftool: \
`$ git pr show -t 14871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14871.diff">https://git.openjdk.org/jdk/pull/14871.diff</a>

</details>
