### PR TITLE
8313875: Use literals instead of static fields in java.util.Math: twoToTheDoubleScaleUp, twoToTheDoubleScaleDown

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -3421,8 +3421,8 @@ public final class Math {
     }
 
     // Constants used in scalb
-    static double twoToTheDoubleScaleUp = powerOfTwoD(512);
-    static double twoToTheDoubleScaleDown = powerOfTwoD(-512);
+    private static final double twoToTheDoubleScaleUp = powerOfTwoD(512);
+    private static final double twoToTheDoubleScaleDown = powerOfTwoD(-512);
 
     /**
      * Returns a floating-point power of two in the normal range.

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -3346,12 +3346,12 @@ public final class Math {
         if(scaleFactor < 0) {
             scaleFactor = Math.max(scaleFactor, -MAX_SCALE);
             scale_increment = -512;
-            exp_delta = twoToTheDoubleScaleDown;
+            exp_delta = 0x1p-512;
         }
         else {
             scaleFactor = Math.min(scaleFactor, MAX_SCALE);
             scale_increment = 512;
-            exp_delta = twoToTheDoubleScaleUp;
+            exp_delta = 0x1p512;
         }
 
         // Calculate (scaleFactor % +/-512), 512 = 2^9, using
@@ -3419,10 +3419,6 @@ public final class Math {
          */
         return (float)((double)f*powerOfTwoD(scaleFactor));
     }
-
-    // Constants used in scalb
-    private static final double twoToTheDoubleScaleUp = powerOfTwoD(512);
-    private static final double twoToTheDoubleScaleDown = powerOfTwoD(-512);
 
     /**
      * Returns a floating-point power of two in the normal range.


### PR DESCRIPTION
Couple of static fields in Math are used only once and can be replaced with literals `0x1p512`/`0x1p-512 `

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313875](https://bugs.openjdk.org/browse/JDK-8313875): Use literals instead of static fields in java.util.Math: twoToTheDoubleScaleUp, twoToTheDoubleScaleDown (**Enhancement** - P5)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [759180e3](https://git.openjdk.org/jdk/pull/14875/files/759180e3c9679ce63bd5e4f583a643c3d4c8853f)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [759180e3](https://git.openjdk.org/jdk/pull/14875/files/759180e3c9679ce63bd5e4f583a643c3d4c8853f)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14875/head:pull/14875` \
`$ git checkout pull/14875`

Update a local copy of the PR: \
`$ git checkout pull/14875` \
`$ git pull https://git.openjdk.org/jdk.git pull/14875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14875`

View PR using the GUI difftool: \
`$ git pr show -t 14875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14875.diff">https://git.openjdk.org/jdk/pull/14875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14875#issuecomment-1667635988)