### PR TITLE
JDK-8312049: runtime/logging/ClassLoadUnloadTest can be improved

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -46,8 +46,6 @@ import java.util.List;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class ClassLoadUnloadTest {
-    private static OutputAnalyzer out;
-    private static ProcessBuilder pb;
     private static class ClassUnloadTestMain {
         public static void main(String... args) throws Exception {
             String className = "test.Empty";
@@ -58,81 +56,78 @@ public class ClassLoadUnloadTest {
         }
     }
 
-    static void checkFor(String... outputStrings) throws Exception {
-        out = new OutputAnalyzer(pb.start());
+    static void checkFor(OutputAnalyzer output, String... outputStrings) throws Exception {
         for (String s: outputStrings) {
-            out.shouldContain(s);
+            output.shouldContain(s);
         }
-        out.shouldHaveExitValue(0);
     }
 
-    static void checkAbsent(String... outputStrings) throws Exception {
-        out = new OutputAnalyzer(pb.start());
+    static void checkAbsent(OutputAnalyzer output, String... outputStrings) throws Exception {
         for (String s: outputStrings) {
-            out.shouldNotContain(s);
+            output.shouldNotContain(s);
         }
-        out.shouldHaveExitValue(0);
     }
 
     // Use the same command-line heap size setting as ../ClassUnload/UnloadTest.java
-    static ProcessBuilder exec(String... args) throws Exception {
+    static OutputAnalyzer exec(String... args) throws Exception {
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
-        Collections.addAll(argsList, "-Xmn8m");
-        Collections.addAll(argsList, "-Xbootclasspath/a:.");
-        Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
-        Collections.addAll(argsList, "-XX:+WhiteBoxAPI");
-        Collections.addAll(argsList, "-XX:+ClassUnloading");
-        Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
-        return ProcessTools.createJavaProcessBuilder(argsList);
+        Collections.addAll(argsList, "-Xmn8m", "-Xbootclasspath/a:.", "-XX:+UnlockDiagnosticVMOptions",
+                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", ClassUnloadTestMain.class.getName());
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(argsList);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        return output;
     }
 
     public static void main(String... args) throws Exception {
 
+        OutputAnalyzer output;
+
         //  -Xlog:class+unload=info
-        pb = exec("-Xlog:class+unload=info");
-        checkFor("[class,unload]", "unloading class");
+        output = exec("-Xlog:class+unload=info");
+        checkFor(output, "[class,unload]", "unloading class");
 
         //  -Xlog:class+unload=off
-        pb = exec("-Xlog:class+unload=off");
-        checkAbsent("[class,unload]");
+        output = exec("-Xlog:class+unload=off");
+        checkAbsent(output,"[class,unload]");
 
         //  -Xlog:class+load=info
-        pb = exec("-Xlog:class+load=info");
-        checkFor("[class,load]", "java.lang.Object", "source:");
+        output = exec("-Xlog:class+load=info");
+        checkFor(output,"[class,load]", "java.lang.Object", "source:");
 
         //  -Xlog:class+load=debug
-        pb = exec("-Xlog:class+load=debug");
-        checkFor("[class,load]", "java.lang.Object", "source:", "klass:", "super:", "loader:", "bytes:");
+        output = exec("-Xlog:class+load=debug");
+        checkFor(output,"[class,load]", "java.lang.Object", "source:", "klass:", "super:", "loader:", "bytes:");
 
         //  -Xlog:class+load=off
-        pb = exec("-Xlog:class+load=off");
-        checkAbsent("[class,load]");
+        output = exec("-Xlog:class+load=off");
+        checkAbsent(output,"[class,load]");
 
         //  -verbose:class
-        pb = exec("-verbose:class");
-        checkFor("[class,load]", "java.lang.Object", "source:");
-        checkFor("[class,unload]", "unloading class");
+        output = exec("-verbose:class");
+        checkFor(output,"[class,load]", "java.lang.Object", "source:");
+        checkFor(output,"[class,unload]", "unloading class");
 
         //  -Xlog:class+loader+data=trace
-        pb = exec("-Xlog:class+loader+data=trace");
-        checkFor("[class,loader,data]", "create loader data");
+        output = exec("-Xlog:class+loader+data=trace");
+        checkFor(output, "[class,loader,data]", "create loader data");
 
         //  -Xlog:class+load+cause
-        pb = exec("-Xlog:class+load+cause");
-        checkAbsent("[class,load,cause]");
-        checkFor("class load cause logging will not produce output without LogClassLoadingCauseFor");
+        output = exec("-Xlog:class+load+cause");
+        checkAbsent(output,"[class,load,cause]");
+        checkFor(output,"class load cause logging will not produce output without LogClassLoadingCauseFor");
 
         String x = ClassUnloadTestMain.class.getName();
 
-        pb = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=" + x);
-        checkFor("[class,load,cause]", "Java stack when loading " + x + ":");
+        output = exec("-Xlog:class+load+cause", "-XX:LogClassLoadingCauseFor=" + x);
+        checkFor(output,"[class,load,cause]", "Java stack when loading " + x + ":");
 
-        pb = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=" + x);
-        checkFor("[class,load,cause,native]", "Native stack when loading " + x + ":");
+        output = exec("-Xlog:class+load+cause+native", "-XX:LogClassLoadingCauseFor=" + x);
+        checkFor(output,"[class,load,cause,native]", "Native stack when loading " + x + ":");
 
-        pb = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=" + x);
-        checkFor("[class,load,cause] Java stack when loading " + x + ":");
-        checkFor("[class,load,cause,native] Native stack when loading " + x + ":");
+        output = exec("-Xlog:class+load+cause*", "-XX:LogClassLoadingCauseFor=" + x);
+        checkFor(output,"[class,load,cause] Java stack when loading " + x + ":");
+        checkFor(output,"[class,load,cause,native] Native stack when loading " + x + ":");
     }
 }


### PR DESCRIPTION
Trivial improvements, mainly not spawning individual child processes for every call to `checkFor` and `checkAbsent`. Runtime goes down from 14s -> 10s. We could reduce the runtime a lot more by splitting up the test but I avoided that.

Checked manually on x64 Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312049](https://bugs.openjdk.org/browse/JDK-8312049): runtime/logging/ClassLoadUnloadTest can be improved (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14876/head:pull/14876` \
`$ git checkout pull/14876`

Update a local copy of the PR: \
`$ git checkout pull/14876` \
`$ git pull https://git.openjdk.org/jdk.git pull/14876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14876`

View PR using the GUI difftool: \
`$ git pr show -t 14876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14876.diff">https://git.openjdk.org/jdk/pull/14876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14876#issuecomment-1634735406)