### PR TITLE
8294979: test/jdk/tools/jlink 3 test classes use ASM library

### DIFF
--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/CompiledVersionTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/CompiledVersionTest.java
@@ -85,15 +85,15 @@ public class CompiledVersionTest {
             Path msrc = SRC_DIR.resolve(mn);
             if (version.equals("0")) {
                 assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
-                        "--add-exports", "java.base/jdk.internal.module=m1",
-                        "--add-exports", "java.base/jdk.internal.classfile=m1",
-                        "--module-source-path", SRC_DIR.toString()));
+                    "--add-exports", "java.base/jdk.internal.module=m1",
+                    "--add-exports", "java.base/jdk.internal.classfile=m1",
+                    "--module-source-path", SRC_DIR.toString()));
             } else {
                 assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
-                        "--add-exports", "java.base/jdk.internal.module=m1",
-                        "--add-exports", "java.base/jdk.internal.classfile=m1",
-                        "--module-source-path", SRC_DIR.toString(),
-                        "--module-version", version));
+                    "--add-exports", "java.base/jdk.internal.module=m1",
+                    "--add-exports", "java.base/jdk.internal.classfile=m1",
+                    "--module-source-path", SRC_DIR.toString(),
+                    "--module-version", version));
             }
         }
 
@@ -108,11 +108,11 @@ public class CompiledVersionTest {
         Path jlink = Paths.get(JAVA_HOME, "bin", "jlink");
         String mp = JMODS.toString() + File.pathSeparator + MODS_DIR.toString();
         assertTrue(executeProcess(jlink.toString(), "--output", outputDir.toString(),
-                "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
-                "--module-path", mp)
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
+                        "--module-path", mp)
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     /*
@@ -125,13 +125,13 @@ public class CompiledVersionTest {
 
         Path java = IMAGE.resolve("bin").resolve("java");
         Stream<String> options = Stream.concat(
-                Stream.of(java.toString(), "-m", MAIN_MID, String.valueOf(modules.length)),
-                Stream.concat(Arrays.stream(modules), Arrays.stream(versions))
+            Stream.of(java.toString(), "-m", MAIN_MID, String.valueOf(modules.length)),
+            Stream.concat(Arrays.stream(modules), Arrays.stream(versions))
         );
 
         assertTrue(executeProcess(options.toArray(String[]::new))
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 }

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/CompiledVersionTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/CompiledVersionTest.java
@@ -86,12 +86,10 @@ public class CompiledVersionTest {
             if (version.equals("0")) {
                 assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
                     "--add-exports", "java.base/jdk.internal.module=m1",
-                    "--add-exports", "java.base/jdk.internal.classfile=m1",
                     "--module-source-path", SRC_DIR.toString()));
             } else {
                 assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
                     "--add-exports", "java.base/jdk.internal.module=m1",
-                    "--add-exports", "java.base/jdk.internal.classfile=m1",
                     "--module-source-path", SRC_DIR.toString(),
                     "--module-version", version));
             }

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/CompiledVersionTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/CompiledVersionTest.java
@@ -85,15 +85,15 @@ public class CompiledVersionTest {
             Path msrc = SRC_DIR.resolve(mn);
             if (version.equals("0")) {
                 assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
-                    "--add-exports", "java.base/jdk.internal.module=m1",
-                    "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1",
-                    "--module-source-path", SRC_DIR.toString()));
+                        "--add-exports", "java.base/jdk.internal.module=m1",
+                        "--add-exports", "java.base/jdk.internal.classfile=m1",
+                        "--module-source-path", SRC_DIR.toString()));
             } else {
                 assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
-                    "--add-exports", "java.base/jdk.internal.module=m1",
-                    "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1",
-                    "--module-source-path", SRC_DIR.toString(),
-                    "--module-version", version));
+                        "--add-exports", "java.base/jdk.internal.module=m1",
+                        "--add-exports", "java.base/jdk.internal.classfile=m1",
+                        "--module-source-path", SRC_DIR.toString(),
+                        "--module-version", version));
             }
         }
 
@@ -108,11 +108,11 @@ public class CompiledVersionTest {
         Path jlink = Paths.get(JAVA_HOME, "bin", "jlink");
         String mp = JMODS.toString() + File.pathSeparator + MODS_DIR.toString();
         assertTrue(executeProcess(jlink.toString(), "--output", outputDir.toString(),
-                        "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
-                        "--module-path", mp)
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
+                "--module-path", mp)
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     /*
@@ -125,13 +125,13 @@ public class CompiledVersionTest {
 
         Path java = IMAGE.resolve("bin").resolve("java");
         Stream<String> options = Stream.concat(
-            Stream.of(java.toString(), "-m", MAIN_MID, String.valueOf(modules.length)),
-            Stream.concat(Arrays.stream(modules), Arrays.stream(versions))
+                Stream.of(java.toString(), "-m", MAIN_MID, String.valueOf(modules.length)),
+                Stream.concat(Arrays.stream(modules), Arrays.stream(versions))
         );
 
         assertTrue(executeProcess(options.toArray(String[]::new))
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 }

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java
@@ -44,7 +44,6 @@ import static org.testng.Assert.*;
  * @bug 8142968 8173381
  * @modules java.base/jdk.internal.access
  * @modules java.base/jdk.internal.module
- * @modules java.base/jdk.internal.classfile
  * @build ModuleTargetHelper
  * @run testng SystemModulesTest
  * @summary Verify the properties of ModuleDescriptor created

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java
@@ -53,12 +53,12 @@ import static org.testng.Assert.*;
 
 public class SystemModulesTest {
     private static final JavaLangModuleAccess JLMA =
-            SharedSecrets.getJavaLangModuleAccess();
+        SharedSecrets.getJavaLangModuleAccess();
     private static final String OS_NAME = System.getProperty("os.name");
     private static final String OS_ARCH = System.getProperty("os.arch");
     //  system modules containing no package
     private static final Set<String> EMPTY_MODULES =
-            Set.of("java.se", "jdk.jdwp.agent", "jdk.pack");
+        Set.of("java.se", "jdk.jdwp.agent", "jdk.pack");
 
     @Test
     public void testSystemModules() {
@@ -67,7 +67,7 @@ public class SystemModulesTest {
             return;
 
         ModuleFinder.ofSystem().findAll().stream()
-                .forEach(this::checkAttributes);
+                    .forEach(this::checkAttributes);
     }
 
     // JMOD files are created with OS name and arch matching the bundle name
@@ -123,16 +123,16 @@ public class SystemModulesTest {
     @Test
     public void testUnmodifableDescriptors() throws Exception {
         ModuleFinder.ofSystem().findAll()
-                .stream()
-                .map(ModuleReference::descriptor)
-                .forEach(this::testModuleDescriptor);
+                    .stream()
+                    .map(ModuleReference::descriptor)
+                    .forEach(this::testModuleDescriptor);
     }
 
     private void testModuleDescriptor(ModuleDescriptor md) {
         assertUnmodifiable(md.packages(), "package");
         assertUnmodifiable(md.requires(),
-                JLMA.newRequires(Set.of(Requires.Modifier.TRANSITIVE),
-                        "require", null));
+                           JLMA.newRequires(Set.of(Requires.Modifier.TRANSITIVE),
+                                            "require", null));
         for (Requires req : md.requires()) {
             assertUnmodifiable(req.modifiers(), Requires.Modifier.TRANSITIVE);
         }
@@ -152,7 +152,7 @@ public class SystemModulesTest {
         assertUnmodifiable(md.uses(), "use");
 
         assertUnmodifiable(md.provides(),
-                JLMA.newProvides("provide", List.of("provide")));
+                           JLMA.newProvides("provide", List.of("provide")));
         for (Provides provides : md.provides()) {
             assertUnmodifiable(provides.providers(), "provide");
         }

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/SystemModulesTest.java
@@ -44,7 +44,7 @@ import static org.testng.Assert.*;
  * @bug 8142968 8173381
  * @modules java.base/jdk.internal.access
  * @modules java.base/jdk.internal.module
- * @modules java.base/jdk.internal.org.objectweb.asm
+ * @modules java.base/jdk.internal.classfile
  * @build ModuleTargetHelper
  * @run testng SystemModulesTest
  * @summary Verify the properties of ModuleDescriptor created
@@ -53,12 +53,12 @@ import static org.testng.Assert.*;
 
 public class SystemModulesTest {
     private static final JavaLangModuleAccess JLMA =
-        SharedSecrets.getJavaLangModuleAccess();
+            SharedSecrets.getJavaLangModuleAccess();
     private static final String OS_NAME = System.getProperty("os.name");
     private static final String OS_ARCH = System.getProperty("os.arch");
     //  system modules containing no package
     private static final Set<String> EMPTY_MODULES =
-        Set.of("java.se", "jdk.jdwp.agent", "jdk.pack");
+            Set.of("java.se", "jdk.jdwp.agent", "jdk.pack");
 
     @Test
     public void testSystemModules() {
@@ -67,7 +67,7 @@ public class SystemModulesTest {
             return;
 
         ModuleFinder.ofSystem().findAll().stream()
-                    .forEach(this::checkAttributes);
+                .forEach(this::checkAttributes);
     }
 
     // JMOD files are created with OS name and arch matching the bundle name
@@ -123,16 +123,16 @@ public class SystemModulesTest {
     @Test
     public void testUnmodifableDescriptors() throws Exception {
         ModuleFinder.ofSystem().findAll()
-                    .stream()
-                    .map(ModuleReference::descriptor)
-                    .forEach(this::testModuleDescriptor);
+                .stream()
+                .map(ModuleReference::descriptor)
+                .forEach(this::testModuleDescriptor);
     }
 
     private void testModuleDescriptor(ModuleDescriptor md) {
         assertUnmodifiable(md.packages(), "package");
         assertUnmodifiable(md.requires(),
-                           JLMA.newRequires(Set.of(Requires.Modifier.TRANSITIVE),
-                                            "require", null));
+                JLMA.newRequires(Set.of(Requires.Modifier.TRANSITIVE),
+                        "require", null));
         for (Requires req : md.requires()) {
             assertUnmodifiable(req.modifiers(), Requires.Modifier.TRANSITIVE);
         }
@@ -152,7 +152,7 @@ public class SystemModulesTest {
         assertUnmodifiable(md.uses(), "use");
 
         assertUnmodifiable(md.provides(),
-                           JLMA.newProvides("provide", List.of("provide")));
+                JLMA.newProvides("provide", List.of("provide")));
         for (Provides provides : md.provides()) {
             assertUnmodifiable(provides.providers(), "provide");
         }

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/UserModuleTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/UserModuleTest.java
@@ -47,7 +47,7 @@ import static org.testng.Assert.*;
  * @library /test/lib
  * @modules jdk.compiler jdk.jlink
  * @modules java.base/jdk.internal.module
- * @modules java.base/jdk.internal.org.objectweb.asm
+ * @modules java.base/jdk.internal.classfile
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.util.FileUtils
  *        jdk.test.lib.Platform
@@ -88,9 +88,9 @@ public class UserModuleTest {
         for (String mn : modules) {
             Path msrc = SRC_DIR.resolve(mn);
             assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
-                "--module-source-path", SRC_DIR.toString(),
-                "--add-exports", "java.base/jdk.internal.module=" + mn,
-                "--add-exports", "java.base/jdk.internal.org.objectweb.asm=" + mn));
+                    "--module-source-path", SRC_DIR.toString(),
+                    "--add-exports", "java.base/jdk.internal.module=" + mn,
+                    "--add-exports", "java.base/jdk.internal.classfile=" + mn));
         }
 
         if (Files.exists(IMAGE)) {
@@ -112,26 +112,26 @@ public class UserModuleTest {
 
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                        "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                        "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1,m4",
-                        "-m", MAIN_MID)
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                "-m", MAIN_MID)
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     /*
      * Test the image created when linking with an open module
-    */
+     */
     @Test
     public void testOpenModule() throws Throwable {
         if (!hasJmods()) return;
 
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(), "-m", "m3/p3.Main")
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     /*
@@ -144,13 +144,13 @@ public class UserModuleTest {
 
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                                  "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                                  "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1,m4",
-                                  "-Djdk.system.module.finder.disabledFastPath",
-                                  "-m", MAIN_MID)
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                "-Djdk.system.module.finder.disabledFastPath",
+                "-m", MAIN_MID)
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     /*
@@ -165,12 +165,12 @@ public class UserModuleTest {
         createImage(dir, "m1", "m2", "m3", "m4");
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                         "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1,m4",
-                         "-m", MAIN_MID)
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                "-m", MAIN_MID)
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     @Test
@@ -181,18 +181,18 @@ public class UserModuleTest {
         createImage(dir, "m5");
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(), "-m", "m5/p5.Main")
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
 
         // run with m3 present
         assertTrue(executeProcess(java.toString(),
-                                  "--module-path", MODS_DIR.toString(),
-                                  "--add-modules", "m3",
-                                  "-m", "m5/p5.Main")
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                "--module-path", MODS_DIR.toString(),
+                "--add-modules", "m3",
+                "-m", "m5/p5.Main")
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     @Test
@@ -204,17 +204,17 @@ public class UserModuleTest {
 
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(), "-m", "m5/p5.Main")
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
 
         // boot layer with m3 and m5
         assertTrue(executeProcess(java.toString(),
-                                  "--add-modules", "m3",
-                                  "-m", "m5/p5.Main")
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .getExitValue() == 0);
+                "--add-modules", "m3",
+                "-m", "m5/p5.Main")
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     private void createJmods(String... modules) throws IOException {
@@ -230,11 +230,11 @@ public class UserModuleTest {
         // create JMOD files
         Files.createDirectories(JMODS_DIR);
         Stream.of(modules).forEach(mn ->
-            assertTrue(jmod("create",
-                "--class-path", MODS_DIR.resolve(mn).toString(),
-                "--target-platform", mt.targetPlatform(),
-                "--main-class", mn.replace('m', 'p') + ".Main",
-                JMODS_DIR.resolve(mn + ".jmod").toString()) == 0)
+                assertTrue(jmod("create",
+                        "--class-path", MODS_DIR.resolve(mn).toString(),
+                        "--target-platform", mt.targetPlatform(),
+                        "--main-class", mn.replace('m', 'p') + ".Main",
+                        JMODS_DIR.resolve(mn + ".jmod").toString()) == 0)
         );
     }
 
@@ -249,24 +249,24 @@ public class UserModuleTest {
         // create an image using JMOD files
         Path dir = Paths.get("packagesTest");
         String mp = Paths.get(JAVA_HOME, "jmods").toString() +
-            File.pathSeparator + JMODS_DIR.toString();
+                File.pathSeparator + JMODS_DIR.toString();
 
         Set<String> modules = Set.of("m1", "m4");
         assertTrue(JLINK_TOOL.run(System.out, System.out,
-            "--output", dir.toString(),
-            "--exclude-resources", "m4/p4/dummy/*",
-            "--add-modules", modules.stream().collect(Collectors.joining(",")),
-            "--module-path", mp) == 0);
+                "--output", dir.toString(),
+                "--exclude-resources", "m4/p4/dummy/*",
+                "--add-modules", modules.stream().collect(Collectors.joining(",")),
+                "--module-path", mp) == 0);
 
         // verify ModuleDescriptor
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                        "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                        "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1,m4",
-                        "--add-modules=m1", "-m", "m4")
-            .outputTo(System.out)
-            .errorTo(System.out)
-            .getExitValue() == 0);
+                "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                "--add-modules=m1", "-m", "m4")
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     /**
@@ -279,44 +279,44 @@ public class UserModuleTest {
         // create an image using JMOD files
         Path dir = Paths.get("retainModuleTargetTest");
         String mp = Paths.get(JAVA_HOME, "jmods").toString() +
-            File.pathSeparator + JMODS_DIR.toString();
+                File.pathSeparator + JMODS_DIR.toString();
 
         Set<String> modules = Set.of("m1", "m4");
         assertTrue(JLINK_TOOL.run(System.out, System.out,
-            "--output", dir.toString(),
-            "--exclude-resources", "m4/p4/dummy/*",
-            "--add-modules", modules.stream().collect(Collectors.joining(",")),
-            "--module-path", mp) == 0);
+                "--output", dir.toString(),
+                "--exclude-resources", "m4/p4/dummy/*",
+                "--add-modules", modules.stream().collect(Collectors.joining(",")),
+                "--module-path", mp) == 0);
 
         // verify ModuleDescriptor
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                        "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                        "--add-exports", "java.base/jdk.internal.org.objectweb.asm=m1,m4",
-                        "--add-modules=m1", "-m", "m4", "retainModuleTarget")
-            .outputTo(System.out)
-            .errorTo(System.out)
-            .getExitValue() == 0);
+                "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                "--add-modules=m1", "-m", "m4", "retainModuleTarget")
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .getExitValue() == 0);
     }
 
     static final ToolProvider JLINK_TOOL = ToolProvider.findFirst("jlink")
-        .orElseThrow(() ->
-            new RuntimeException("jlink tool not found")
-        );
+            .orElseThrow(() ->
+                    new RuntimeException("jlink tool not found")
+            );
 
     static final ToolProvider JMOD_TOOL = ToolProvider.findFirst("jmod")
-        .orElseThrow(() ->
-            new RuntimeException("jmod tool not found")
-        );
+            .orElseThrow(() ->
+                    new RuntimeException("jmod tool not found")
+            );
 
     static final String MODULE_PATH = Paths.get(JAVA_HOME, "jmods").toString()
-        + File.pathSeparator + MODS_DIR.toString();
+            + File.pathSeparator + MODS_DIR.toString();
 
     private void createImage(Path outputDir, String... modules) throws Throwable {
         assertTrue(JLINK_TOOL.run(System.out, System.out,
-            "--output", outputDir.toString(),
-            "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
-            "--module-path", MODULE_PATH) == 0);
+                "--output", outputDir.toString(),
+                "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
+                "--module-path", MODULE_PATH) == 0);
     }
 
     private static int jmod(String... options) {

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/UserModuleTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/UserModuleTest.java
@@ -47,7 +47,6 @@ import static org.testng.Assert.*;
  * @library /test/lib
  * @modules jdk.compiler jdk.jlink
  * @modules java.base/jdk.internal.module
- * @modules java.base/jdk.internal.classfile
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.util.FileUtils
  *        jdk.test.lib.Platform
@@ -89,8 +88,7 @@ public class UserModuleTest {
             Path msrc = SRC_DIR.resolve(mn);
             assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
                 "--module-source-path", SRC_DIR.toString(),
-                "--add-exports", "java.base/jdk.internal.module=" + mn,
-                "--add-exports", "java.base/jdk.internal.classfile=" + mn));
+                "--add-exports", "java.base/jdk.internal.module=" + mn));
         }
 
         if (Files.exists(IMAGE)) {
@@ -113,7 +111,6 @@ public class UserModuleTest {
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
                         "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                        "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
                         "-m", MAIN_MID)
                         .outputTo(System.out)
                         .errorTo(System.out)
@@ -145,7 +142,6 @@ public class UserModuleTest {
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
                                   "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                                  "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
                                   "-Djdk.system.module.finder.disabledFastPath",
                                   "-m", MAIN_MID)
                         .outputTo(System.out)
@@ -166,7 +162,6 @@ public class UserModuleTest {
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
                          "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                         "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
                          "-m", MAIN_MID)
                         .outputTo(System.out)
                         .errorTo(System.out)
@@ -262,7 +257,6 @@ public class UserModuleTest {
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
                         "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                        "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
                         "--add-modules=m1", "-m", "m4")
             .outputTo(System.out)
             .errorTo(System.out)
@@ -292,7 +286,6 @@ public class UserModuleTest {
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
                         "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                        "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
                         "--add-modules=m1", "-m", "m4", "retainModuleTarget")
             .outputTo(System.out)
             .errorTo(System.out)

--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/UserModuleTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/UserModuleTest.java
@@ -88,9 +88,9 @@ public class UserModuleTest {
         for (String mn : modules) {
             Path msrc = SRC_DIR.resolve(mn);
             assertTrue(CompilerUtils.compile(msrc, MODS_DIR,
-                    "--module-source-path", SRC_DIR.toString(),
-                    "--add-exports", "java.base/jdk.internal.module=" + mn,
-                    "--add-exports", "java.base/jdk.internal.classfile=" + mn));
+                "--module-source-path", SRC_DIR.toString(),
+                "--add-exports", "java.base/jdk.internal.module=" + mn,
+                "--add-exports", "java.base/jdk.internal.classfile=" + mn));
         }
 
         if (Files.exists(IMAGE)) {
@@ -112,26 +112,26 @@ public class UserModuleTest {
 
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
-                "-m", MAIN_MID)
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                        "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                        "-m", MAIN_MID)
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     /*
      * Test the image created when linking with an open module
-     */
+    */
     @Test
     public void testOpenModule() throws Throwable {
         if (!hasJmods()) return;
 
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(), "-m", "m3/p3.Main")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     /*
@@ -144,13 +144,13 @@ public class UserModuleTest {
 
         Path java = IMAGE.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
-                "-Djdk.system.module.finder.disabledFastPath",
-                "-m", MAIN_MID)
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                                  "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                                  "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                                  "-Djdk.system.module.finder.disabledFastPath",
+                                  "-m", MAIN_MID)
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     /*
@@ -165,12 +165,12 @@ public class UserModuleTest {
         createImage(dir, "m1", "m2", "m3", "m4");
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
-                "-m", MAIN_MID)
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                         "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                         "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                         "-m", MAIN_MID)
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     @Test
@@ -181,18 +181,18 @@ public class UserModuleTest {
         createImage(dir, "m5");
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(), "-m", "m5/p5.Main")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
 
         // run with m3 present
         assertTrue(executeProcess(java.toString(),
-                "--module-path", MODS_DIR.toString(),
-                "--add-modules", "m3",
-                "-m", "m5/p5.Main")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                                  "--module-path", MODS_DIR.toString(),
+                                  "--add-modules", "m3",
+                                  "-m", "m5/p5.Main")
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     @Test
@@ -204,17 +204,17 @@ public class UserModuleTest {
 
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(), "-m", "m5/p5.Main")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
 
         // boot layer with m3 and m5
         assertTrue(executeProcess(java.toString(),
-                "--add-modules", "m3",
-                "-m", "m5/p5.Main")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                                  "--add-modules", "m3",
+                                  "-m", "m5/p5.Main")
+                        .outputTo(System.out)
+                        .errorTo(System.out)
+                        .getExitValue() == 0);
     }
 
     private void createJmods(String... modules) throws IOException {
@@ -230,11 +230,11 @@ public class UserModuleTest {
         // create JMOD files
         Files.createDirectories(JMODS_DIR);
         Stream.of(modules).forEach(mn ->
-                assertTrue(jmod("create",
-                        "--class-path", MODS_DIR.resolve(mn).toString(),
-                        "--target-platform", mt.targetPlatform(),
-                        "--main-class", mn.replace('m', 'p') + ".Main",
-                        JMODS_DIR.resolve(mn + ".jmod").toString()) == 0)
+            assertTrue(jmod("create",
+                "--class-path", MODS_DIR.resolve(mn).toString(),
+                "--target-platform", mt.targetPlatform(),
+                "--main-class", mn.replace('m', 'p') + ".Main",
+                JMODS_DIR.resolve(mn + ".jmod").toString()) == 0)
         );
     }
 
@@ -249,24 +249,24 @@ public class UserModuleTest {
         // create an image using JMOD files
         Path dir = Paths.get("packagesTest");
         String mp = Paths.get(JAVA_HOME, "jmods").toString() +
-                File.pathSeparator + JMODS_DIR.toString();
+            File.pathSeparator + JMODS_DIR.toString();
 
         Set<String> modules = Set.of("m1", "m4");
         assertTrue(JLINK_TOOL.run(System.out, System.out,
-                "--output", dir.toString(),
-                "--exclude-resources", "m4/p4/dummy/*",
-                "--add-modules", modules.stream().collect(Collectors.joining(",")),
-                "--module-path", mp) == 0);
+            "--output", dir.toString(),
+            "--exclude-resources", "m4/p4/dummy/*",
+            "--add-modules", modules.stream().collect(Collectors.joining(",")),
+            "--module-path", mp) == 0);
 
         // verify ModuleDescriptor
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
-                "--add-modules=m1", "-m", "m4")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                        "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                        "--add-modules=m1", "-m", "m4")
+            .outputTo(System.out)
+            .errorTo(System.out)
+            .getExitValue() == 0);
     }
 
     /**
@@ -279,44 +279,44 @@ public class UserModuleTest {
         // create an image using JMOD files
         Path dir = Paths.get("retainModuleTargetTest");
         String mp = Paths.get(JAVA_HOME, "jmods").toString() +
-                File.pathSeparator + JMODS_DIR.toString();
+            File.pathSeparator + JMODS_DIR.toString();
 
         Set<String> modules = Set.of("m1", "m4");
         assertTrue(JLINK_TOOL.run(System.out, System.out,
-                "--output", dir.toString(),
-                "--exclude-resources", "m4/p4/dummy/*",
-                "--add-modules", modules.stream().collect(Collectors.joining(",")),
-                "--module-path", mp) == 0);
+            "--output", dir.toString(),
+            "--exclude-resources", "m4/p4/dummy/*",
+            "--add-modules", modules.stream().collect(Collectors.joining(",")),
+            "--module-path", mp) == 0);
 
         // verify ModuleDescriptor
         Path java = dir.resolve("bin").resolve("java");
         assertTrue(executeProcess(java.toString(),
-                "--add-exports", "java.base/jdk.internal.module=m1,m4",
-                "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
-                "--add-modules=m1", "-m", "m4", "retainModuleTarget")
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue() == 0);
+                        "--add-exports", "java.base/jdk.internal.module=m1,m4",
+                        "--add-exports", "java.base/jdk.internal.classfile=m1,m4",
+                        "--add-modules=m1", "-m", "m4", "retainModuleTarget")
+            .outputTo(System.out)
+            .errorTo(System.out)
+            .getExitValue() == 0);
     }
 
     static final ToolProvider JLINK_TOOL = ToolProvider.findFirst("jlink")
-            .orElseThrow(() ->
-                    new RuntimeException("jlink tool not found")
-            );
+        .orElseThrow(() ->
+            new RuntimeException("jlink tool not found")
+        );
 
     static final ToolProvider JMOD_TOOL = ToolProvider.findFirst("jmod")
-            .orElseThrow(() ->
-                    new RuntimeException("jmod tool not found")
-            );
+        .orElseThrow(() ->
+            new RuntimeException("jmod tool not found")
+        );
 
     static final String MODULE_PATH = Paths.get(JAVA_HOME, "jmods").toString()
-            + File.pathSeparator + MODS_DIR.toString();
+        + File.pathSeparator + MODS_DIR.toString();
 
     private void createImage(Path outputDir, String... modules) throws Throwable {
         assertTrue(JLINK_TOOL.run(System.out, System.out,
-                "--output", outputDir.toString(),
-                "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
-                "--module-path", MODULE_PATH) == 0);
+            "--output", outputDir.toString(),
+            "--add-modules", Arrays.stream(modules).collect(Collectors.joining(",")),
+            "--module-path", MODULE_PATH) == 0);
     }
 
     private static int jmod(String... options) {


### PR DESCRIPTION
Modified 3 of 3 test/jdk/tools/jlink test classes to replace com.sun.tools.classfile library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294979](https://bugs.openjdk.org/browse/JDK-8294979): test/jdk/tools/jlink 3 test classes use ASM library (**Sub-task** - P5)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Koichi Sakata](https://openjdk.org/census#ksakata) (@jyukutyo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14877/head:pull/14877` \
`$ git checkout pull/14877`

Update a local copy of the PR: \
`$ git checkout pull/14877` \
`$ git pull https://git.openjdk.org/jdk.git pull/14877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14877`

View PR using the GUI difftool: \
`$ git pr show -t 14877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14877.diff">https://git.openjdk.org/jdk/pull/14877.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14877#issuecomment-1654076109)