### PR TITLE
JDK-8310584: GetThreadState reports blocked and runnable for pinned suspended virtual threads

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -799,11 +799,14 @@ JvmtiEnvBase::get_vthread_state(oop thread_oop, JavaThread* java_thread) {
     int vt_state = java_lang_VirtualThread::state(thread_oop);
     state = (jint)java_lang_VirtualThread::map_state_to_thread_status(vt_state);
   }
-  if (ext_suspended && ((state & JVMTI_THREAD_STATE_ALIVE) != 0)) {
-    state |= JVMTI_THREAD_STATE_SUSPENDED;
-  }
-  if (interrupted) {
-    state |= JVMTI_THREAD_STATE_INTERRUPTED;
+  // Ensure the thread has not exited after retrieving suspended/interrupted values.
+  if ((state & JVMTI_THREAD_STATE_ALIVE) != 0) {
+    if (ext_suspended) {
+      state |= JVMTI_THREAD_STATE_SUSPENDED;
+    }
+    if (interrupted) {
+      state |= JVMTI_THREAD_STATE_INTERRUPTED;
+    }
   }
   return state;
 }

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -800,8 +800,7 @@ JvmtiEnvBase::get_vthread_state(oop thread_oop, JavaThread* java_thread) {
     state = (jint)java_lang_VirtualThread::map_state_to_thread_status(vt_state);
   }
   if (ext_suspended && ((state & JVMTI_THREAD_STATE_ALIVE) != 0)) {
-    state &= ~java_lang_VirtualThread::RUNNING;
-    state |= JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_RUNNABLE | JVMTI_THREAD_STATE_SUSPENDED;
+    state |= JVMTI_THREAD_STATE_SUSPENDED;
   }
   if (interrupted) {
     state |= JVMTI_THREAD_STATE_INTERRUPTED;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java
@@ -238,13 +238,11 @@ public class GetThreadStateMountedTest {
 
     public static void main(String[] args) throws Exception {
         runnable();
-        /* "waiting" test cases fail due JDK-8310584
         blockedOnMonitorEnter();
         waiting(false);
         waiting(true);
         sleeping();
         parked();
-        */
         inNative();
 
         int errCount = getErrorCount();


### PR DESCRIPTION
The change fixes handling of "suspended" bit in VT state.
The code looks very strange.
java_lang_VirtualThread::RUNNING == 3, so line 803 clears JVMTI_THREAD_STATE_ALIVE(1) and JVMTI_THREAD_STATE_TERMINATED(2)
Per log this code came from loom repo with VT integration.

Testing: tier1-4, updated GetThreadStateMountedTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310584](https://bugs.openjdk.org/browse/JDK-8310584): GetThreadState reports blocked and runnable for pinned suspended virtual threads (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14878/head:pull/14878` \
`$ git checkout pull/14878`

Update a local copy of the PR: \
`$ git checkout pull/14878` \
`$ git pull https://git.openjdk.org/jdk.git pull/14878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14878`

View PR using the GUI difftool: \
`$ git pr show -t 14878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14878.diff">https://git.openjdk.org/jdk/pull/14878.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14878#issuecomment-1634781767)