### PR TITLE
8311663: Additional refactoring of Locale tests to JUnit

### DIFF
--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8135061
  * @summary Checks that the Locale.lookup executes properly without throwing
  *          any exception for some specific language ranges
- * @run main Bug8135061
+ * @run junit Bug8135061
  */
 
 import java.util.Collection;
@@ -35,47 +35,46 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 public class Bug8135061 {
 
-    public static void main(String[] args) {
-
-        /* lookup should run without throwing any exception and
-         * return null as the language range does not match with the language
-         * tag
-         */
+    /**
+     * Lookup should run without throwing any exception and return null as
+     * the language range does not match with the language tag.
+     */
+    @Test
+    public void lookupReturnNullTest() {
         List<LanguageRange> ranges = LanguageRange.parse("nv");
         Collection<Locale> locales = Collections.singleton(Locale.ENGLISH);
-
         try {
             Locale match = Locale.lookup(ranges, locales);
-            if (match != null) {
-                throw new RuntimeException("Locale.lookup returned non-null: "
-                        + match);
-            }
+            assertNull(match);
         } catch (Exception ex) {
             throw new RuntimeException("[Locale.lookup failed on language"
                     + " range: " + ranges + " and language tags "
                     + locales + "]", ex);
         }
-
-        /* lookup should run without throwing any exception and
-         * return "nv" as the matching tag
-         */
-        ranges = LanguageRange.parse("i-navajo");
-        locales = Collections.singleton(Locale.of("nv"));
-
-        try {
-            Locale match = Locale.lookup(ranges, locales);
-            if (!match.toLanguageTag().equals("nv")) {
-                throw new RuntimeException("Locale.lookup returned unexpected"
-                        + " result: " + match);
-            }
-        } catch (Exception ex) {
-            throw new RuntimeException("[Locale.lookup failed on language"
-                    + " range: " + ranges + " and language tags "
-                    + locales + "]", ex);
-        }
-
     }
 
+    /**
+     * Lookup should run without throwing any exception and return "nv"
+     * as the matching tag.
+     */
+    @Test
+    public void lookupReturnValueTest() {
+        List<LanguageRange> ranges = LanguageRange.parse("i-navajo");
+        Collection<Locale> locales = Collections.singleton(Locale.of("nv"));
+        try {
+            Locale match = Locale.lookup(ranges, locales);
+            assertEquals(match.toLanguageTag(), "nv");
+        } catch (Exception ex) {
+            throw new RuntimeException("[Locale.lookup failed on language"
+                    + " range: " + ranges + " and language tags "
+                    + locales + "]", ex);
+        }
+    }
 }

--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -50,14 +50,10 @@ public class Bug8135061 {
     public void lookupReturnNullTest() {
         List<LanguageRange> ranges = LanguageRange.parse("nv");
         Collection<Locale> locales = Collections.singleton(Locale.ENGLISH);
-        try {
-            Locale match = Locale.lookup(ranges, locales);
-            assertNull(match);
-        } catch (Exception ex) {
-            throw new RuntimeException("[Locale.lookup failed on language"
-                    + " range: " + ranges + " and language tags "
-                    + locales + "]", ex);
-        }
+        Locale match = Locale.lookup(ranges, locales);
+        assertNull(match, "[Locale.lookup failed on language"
+                + " range: " + ranges + " and language tags "
+                + locales + "]");
     }
 
     /**

--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -64,13 +64,9 @@ public class Bug8135061 {
     public void lookupReturnValueTest() {
         List<LanguageRange> ranges = LanguageRange.parse("i-navajo");
         Collection<Locale> locales = Collections.singleton(Locale.of("nv"));
-        try {
-            Locale match = Locale.lookup(ranges, locales);
-            assertEquals(match.toLanguageTag(), "nv");
-        } catch (Exception ex) {
-            throw new RuntimeException("[Locale.lookup failed on language"
-                    + " range: " + ranges + " and language tags "
-                    + locales + "]", ex);
-        }
+        Locale match = Locale.lookup(ranges, locales);
+        assertEquals(match.toLanguageTag(), "nv", "[Locale.lookup failed on language"
+                + " range: " + ranges + " and language tags "
+                + locales + "]");
     }
 }

--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -68,9 +68,13 @@ public class Bug8135061 {
     public void lookupReturnValueTest() {
         List<LanguageRange> ranges = LanguageRange.parse("i-navajo");
         Collection<Locale> locales = Collections.singleton(Locale.of("nv"));
-        Locale match = Locale.lookup(ranges, locales);
-        assertEquals(match.toLanguageTag(), "nv", "[Locale.lookup failed on language"
-                + " range: " + ranges + " and language tags "
-                + locales + "]");
+        try {
+            Locale match = Locale.lookup(ranges, locales);
+            assertEquals(match.toLanguageTag(), "nv");
+        } catch (Exception ex) {
+            throw new RuntimeException("[Locale.lookup failed on language"
+                    + " range: " + ranges + " and language tags "
+                    + locales + "]", ex);
+        }
     }
 }

--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -50,10 +50,14 @@ public class Bug8135061 {
     public void lookupReturnNullTest() {
         List<LanguageRange> ranges = LanguageRange.parse("nv");
         Collection<Locale> locales = Collections.singleton(Locale.ENGLISH);
-        Locale match = Locale.lookup(ranges, locales);
-        assertNull(match, "[Locale.lookup failed on language"
-                + " range: " + ranges + " and language tags "
-                + locales + "]");
+        try {
+            Locale match = Locale.lookup(ranges, locales);
+            assertNull(match);
+        } catch (Exception ex) {
+            throw new RuntimeException("[Locale.lookup failed on language"
+                    + " range: " + ranges + " and language tags "
+                    + locales + "]", ex);
+        }
     }
 
     /**

--- a/test/jdk/java/util/Locale/Bug8159420.java
+++ b/test/jdk/java/util/Locale/Bug8159420.java
@@ -32,7 +32,7 @@
  *          "hı-deva", where 'ı' is the LATIN SMALL LETTER DOTLESS I character
  *          which is not allowed in the language ranges/tags.
  * @compile -encoding utf-8 Bug8159420.java
- * @run junit Bug8159420
+ * @run junit/othervm -Duser.language=tr -Duser.country=TR Bug8159420
  */
 
 import java.util.ArrayList;
@@ -48,7 +48,6 @@ import java.util.stream.Stream;
 import static java.util.Locale.FilteringMode.EXTENDED_FILTERING;
 import static java.util.Locale.FilteringMode.AUTOSELECT_FILTERING;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -60,12 +59,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Bug8159420 {
-
-    // Ensure all tests run with a Turkish Locale
-    @BeforeAll
-    static void setTurkishLocale() {
-        Locale.setDefault(Locale.of("tr", "TR"));
-    }
 
     /*
      * Ensure parse() does not throw IllegalArgumentException for the Turkish Locale

--- a/test/jdk/java/util/Locale/Bug8159420.java
+++ b/test/jdk/java/util/Locale/Bug8159420.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,119 +32,97 @@
  *          "hı-deva", where 'ı' is the LATIN SMALL LETTER DOTLESS I character
  *          which is not allowed in the language ranges/tags.
  * @compile -encoding utf-8 Bug8159420.java
- * @run main Bug8159420
+ * @run junit Bug8159420
  */
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
 import java.util.Locale.FilteringMode;
 import java.util.LinkedHashMap;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.ArrayList;
+import java.util.stream.Stream;
+
 import static java.util.Locale.FilteringMode.EXTENDED_FILTERING;
 import static java.util.Locale.FilteringMode.AUTOSELECT_FILTERING;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class Bug8159420 {
 
-    static boolean err = false;
-
-    public static void main(String[] args) {
-
-        Locale origLocale = null;
-        try {
-
-            origLocale = Locale.getDefault();
-            Locale.setDefault(Locale.of("tr", "TR"));
-            testParse();
-            testFilter(EXTENDED_FILTERING);
-            testFilter(AUTOSELECT_FILTERING);
-            testLookup();
-            testMapEquivalents();
-
-            if (err) {
-                throw new RuntimeException("[LocaleMatcher method(s) in turkish"
-                        + " locale failed]");
-            }
-
-        } finally {
-            Locale.setDefault(origLocale);
-        }
-
+    // Ensure all tests run with a Turkish Locale
+    @BeforeAll
+    static void setTurkishLocale() {
+        Locale.setDefault(Locale.of("tr", "TR"));
     }
 
-    /* Before the fix, the testParse() method was throwing
-     * IllegalArgumentException in Turkish Locale
+    /*
+     * Ensure parse() does not throw IllegalArgumentException for the Turkish Locale
+     * with the given input.
      */
-    private static void testParse() {
+    @Test
+    public void parseTest() {
         String ranges = "HI-Deva, ja-hIrA-JP, RKI";
-        try {
-            LanguageRange.parse(ranges);
-        } catch (Exception ex) {
-            System.err.println("[testParse() failed on range string: "
-                    + ranges + "] due to "+ex);
-            err = true;
-        }
+        assertDoesNotThrow(() -> LanguageRange.parse(ranges));
     }
 
-    /* Before the fix, the testFilter() method was returning empty list in
-     * Turkish Locale
+    /*
+     * Ensure filter() does not return empty list for the Turkish Locale
+     * with the given input.
      */
-    private static void testFilter(FilteringMode mode) {
-
+    @ParameterizedTest
+    @MethodSource("modes")
+    public void filterTest(FilteringMode mode) {
         String ranges = "hi-IN, itc-Ital";
         String tags = "hi-IN, itc-Ital";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> tagList = generateLocales(tags);
         String actualLocales = showLocales(Locale.filter(priorityList, tagList, mode));
         String expectedLocales = "hi-IN, itc-Ital";
-
-        if (!expectedLocales.equals(actualLocales)) {
-            System.err.println("testFilter(" + mode + ") failed on language ranges:"
-                    + " [" + ranges + "] and language tags: [" + tags + "]");
-            err = true;
-        }
+        assertEquals(expectedLocales, actualLocales);
     }
 
-    /* Before the fix, the testLookup() method was returning null in Turkish
-     * Locale
+    private static Stream<FilteringMode> modes() {
+        return Stream.of(
+                EXTENDED_FILTERING,
+                AUTOSELECT_FILTERING
+        );
+    }
+
+    /*
+     * Ensure lookup() does not return null for the Turkish Locale with
+     * the given input.
      */
-    private static void testLookup() {
-        boolean error = false;
+    @Test
+    public void lookupTest() {
         String ranges = "hi-IN, itc-Ital";
         String tags = "hi-IN, itc-Ital";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> localeList = generateLocales(tags);
-        Locale actualLocale
-                = Locale.lookup(priorityList, localeList);
-        String actualLocaleString = "";
-
-        if (actualLocale != null) {
-            actualLocaleString = actualLocale.toLanguageTag();
-        } else {
-            error = true;
-        }
-
+        Locale actualLocale = Locale.lookup(priorityList, localeList);
+        assertNotNull(actualLocale);
+        String actualLocaleString = actualLocale.toLanguageTag();
         String expectedLocale = "hi-IN";
-
-        if (!expectedLocale.equals(actualLocaleString)) {
-            error = true;
-        }
-
-        if (error) {
-            System.err.println("testLookup() failed on language ranges:"
-                    + " [" + ranges + "] and language tags: [" + tags + "]");
-            err = true;
-        }
-
+        assertEquals(expectedLocale, actualLocaleString);
     }
 
-    /* Before the fix, testMapEquivalents() method was returning only "hi-in"
-     * in Turkish Locale
+    /*
+     * Ensure mapEquivalents() does not only return "hi-in" for the Turkish
+     * Locale with the given input.
      */
-    private static void testMapEquivalents() {
-
+    @Test
+    public void mapEquivalentsTest() {
         String ranges = "HI-IN";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         HashMap<String, List<String>> map = new LinkedHashMap<>();
@@ -156,38 +134,29 @@ public class Bug8159420 {
         List<LanguageRange> expected = new ArrayList<>();
         expected.add(new LanguageRange("hi-in"));
         expected.add(new LanguageRange("hi-deva-in"));
-        List<LanguageRange> got
-                = LanguageRange.mapEquivalents(priorityList, map);
-
-        if (!areEqual(expected, got)) {
-            System.err.println("testMapEquivalents() failed");
-            err = true;
-        }
-
+        List<LanguageRange> got =
+                LanguageRange.mapEquivalents(priorityList, map);
+        assertEquals(expected, got, getDifferences(expected, got));
     }
 
-    private static boolean areEqual(List<LanguageRange> expected,
+    private static String getDifferences(List<LanguageRange> expected,
             List<LanguageRange> got) {
-
-        boolean error = false;
-        if (expected.equals(got)) {
-            return !error;
-        }
-
+        StringBuilder diffs = new StringBuilder();
         List<LanguageRange> cloneExpected = new ArrayList<>(expected);
         cloneExpected.removeAll(got);
         if (!cloneExpected.isEmpty()) {
-            error = true;
-            System.err.println("Found missing range(s): " + cloneExpected);
+            diffs.append("Found missing range(s): ")
+                    .append(cloneExpected)
+                    .append(System.lineSeparator());
         }
-
-        // not creating the 'got' clone as the list will not be used after this
-        got.removeAll(expected);
+        List<LanguageRange> cloneGot = new ArrayList<>(got);
+        cloneGot.removeAll(expected);
         if (!got.isEmpty()) {
-            error = true;
-            System.err.println("Found extra range(s): " + got);
+            diffs.append("Got extra range(s): ")
+                    .append(cloneGot)
+                    .append(System.lineSeparator());
         }
-        return !error;
+        return diffs.toString();
     }
 
     private static List<Locale> generateLocales(String tags) {
@@ -220,5 +189,4 @@ public class Bug8159420 {
 
         return sb.toString().trim();
     }
-
 }

--- a/test/jdk/java/util/Locale/Bug8166994.java
+++ b/test/jdk/java/util/Locale/Bug8166994.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class Bug8166994 {
 
     /*

--- a/test/jdk/java/util/Locale/Bug8166994.java
+++ b/test/jdk/java/util/Locale/Bug8166994.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8166884
@@ -27,41 +28,37 @@
  *          which must generate the same list of language ranges
  *          i.e. the priority list containing equivalents, as in the
  *          first call
+ * @run junit Bug8166994
  */
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class Bug8166994 {
 
-    public static void main(String[] args) {
-        List<String> list = Arrays.asList("ccq-aa", "ybd-aa", "rki-aa");
-        String ranges = "ccq-aa";
-        testParseConsistency(list, ranges);
-
+    /*
+     * Checks that consecutive calls to parse the same language ranges
+     * generate the same list of language ranges.
+     */
+    @ParameterizedTest
+    @MethodSource("ranges")
+    public void parseConsistencyTest(List<String> list, String ranges) {
         // consecutive call to check the language range parse consistency
         testParseConsistency(list, ranges);
-
-        // another case with ranges consisting of multiple equivalents and
-        // single equivalents
-        list = Arrays.asList("gfx-xz", "oun-xz", "mwj-xz", "vaj-xz",
-                "taj-xy", "tsf-xy");
-        ranges = "gfx-xz, taj-xy";
         testParseConsistency(list, ranges);
-        // consecutive call to check the language range parse consistency
-        testParseConsistency(list, ranges);
-
     }
 
+    // Ensure that parsing the ranges returns the expected list.
     private static void testParseConsistency(List<String> list, String ranges) {
         List<String> priorityList = parseRanges(ranges);
-        if (!list.equals(priorityList)) {
-            throw new RuntimeException("Failed to parse the language range ["
-                    + ranges + "], Expected: " + list + " Found: "
-                    + priorityList);
-        }
+        assertEquals(list, priorityList, "Failed to parse the language range:");
     }
 
     private static List<String> parseRanges(String s) {
@@ -70,5 +67,13 @@ public class Bug8166994 {
                 .collect(Collectors.toList());
     }
 
+    // Ranges that have multiple equivalents and single equivalents.
+    private static Stream<Arguments> ranges() {
+        return Stream.of(
+                Arguments.of(Arrays.asList("ccq-aa", "ybd-aa", "rki-aa"),
+                        "ccq-aa"),
+                Arguments.of(Arrays.asList("gfx-xz", "oun-xz", "mwj-xz",
+                        "vaj-xz", "taj-xy", "tsf-xy"), "gfx-xz, taj-xy")
+        );
+    }
 }
-

--- a/test/jdk/java/util/Locale/Bug8179071.java
+++ b/test/jdk/java/util/Locale/Bug8179071.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,10 @@
  * @bug 8179071 8202537 8231273 8251317
  * @summary Test that language aliases of CLDR supplemental metadata are handled correctly.
  * @modules jdk.localedata
- * @run main/othervm -Djava.locale.providers=CLDR Bug8179071
+ * @run junit/othervm -Djava.locale.providers=CLDR Bug8179071
  */
 
-/**
+/*
  * This fix is dependent on a particular version of CLDR data.
  */
 
@@ -38,53 +38,60 @@ import java.time.format.TextStyle;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Bug8179071 {
 
-    // Deprecated and Legacy tags.
-    // As of CLDR 38, language aliases for some of the legacy tags have been removed.
+    /*
+     * Deprecated and Legacy tags.
+     * As of CLDR 38, language aliases for some legacy tags have been removed.
+     */
     private static final Set<String> LegacyAliases = Set.of(
             "zh-guoyu", "zh-min-nan", "i-klingon", "i-tsu",
             "sgn-CH-DE", "mo", "i-tay", "scc",
             "i-hak", "sgn-BE-FR", "i-lux", "tl", "zh-hakka", "i-ami", "aa-SAAHO",
             "zh-xiang", "i-pwn", "sgn-BE-NL", "jw", "sh", "i-bnn");
-    // expected month format data for  locales after language aliases replacement.
-    private static final Map<String, String> shortJanuaryNames = Map.of( "pa-PK", "\u0a1c\u0a28",
-                                                          "uz-AF" , "yan",
-                                                          "sr-ME", "\u0458\u0430\u043d",
-                                                          "scc", "\u0458\u0430\u043d",
-                                                          "sh", "jan",
-                                                          "ha-Latn-NE", "Jan",
-                                                          "i-lux", "Jan.");
 
-
-    private static void test(String tag, String expected) {
+    // Ensure the display name for the given tag's January is correct
+    @ParameterizedTest
+    @MethodSource("shortJanuaryNames")
+    public void janDisplayNameTest(String tag, String expected) {
         Locale target = Locale.forLanguageTag(tag);
         Month day = Month.JANUARY;
         TextStyle style = TextStyle.SHORT;
         String actual = day.getDisplayName(style, target);
-        if (!actual.equals(expected)) {
-            throw new RuntimeException("failed for locale  " + tag + " actual output " + actual +"  does not match with  " + expected);
-        }
+        assertEquals(expected, actual);
     }
 
-    /**
-     * getAvailableLocales() should not contain any deprecated or Legacy language tags
-     */
-    private static void checkInvalidTags() {
+    // Expected month format data for locales after language aliases replacement.
+    private static Stream<Arguments> shortJanuaryNames() {
+        return Stream.of(
+                Arguments.of("pa-PK", "\u0a1c\u0a28"),
+                Arguments.of("uz-AF" , "yan"),
+                Arguments.of("sr-ME", "\u0458\u0430\u043d"),
+                Arguments.of("scc", "\u0458\u0430\u043d"),
+                Arguments.of("sh", "jan"),
+                Arguments.of("ha-Latn-NE", "Jan"),
+                Arguments.of("i-lux", "Jan.")
+        );
+    }
+
+    // getAvailableLocales() should not contain any deprecated or Legacy language tags
+    @Test
+    public void invalidTagsTest() {
         Set<String> invalidTags = new HashSet<>();
-        Arrays.asList(Locale.getAvailableLocales()).stream()
-                .map(loc -> loc.toLanguageTag())
-                .forEach( tag -> {if(LegacyAliases.contains(tag)) {invalidTags.add(tag);}});
-        if (!invalidTags.isEmpty()) {
-          throw new RuntimeException("failed: Deprecated and Legacy tags found  " + invalidTags  + " in AvailableLocales ");
-        }
-    }
-
-    public static void main(String[] args) {
-        shortJanuaryNames.forEach(Bug8179071::test);
-        checkInvalidTags();
+        Arrays.stream(Locale.getAvailableLocales())
+                .map(Locale::toLanguageTag)
+                .forEach(tag -> {if(LegacyAliases.contains(tag)) {invalidTags.add(tag);}});
+        assertEquals(true, invalidTags.isEmpty(),
+                "Deprecated and Legacy tags found  " + invalidTags  + " in AvailableLocales ");
     }
 }

--- a/test/jdk/java/util/Locale/Bug8179071.java
+++ b/test/jdk/java/util/Locale/Bug8179071.java
@@ -76,7 +76,7 @@ public class Bug8179071 {
     private static Stream<Arguments> shortJanuaryNames() {
         return Stream.of(
                 Arguments.of("pa-PK", "\u0a1c\u0a28"),
-                Arguments.of("uz-AF" , "yan"),
+                Arguments.of("uz-AF", "yan"),
                 Arguments.of("sr-ME", "\u0458\u0430\u043d"),
                 Arguments.of("scc", "\u0458\u0430\u043d"),
                 Arguments.of("sh", "jan"),
@@ -93,6 +93,6 @@ public class Bug8179071 {
                 .map(Locale::toLanguageTag)
                 .forEach(tag -> {if(LegacyAliases.contains(tag)) {invalidTags.add(tag);}});
         assertTrue(invalidTags.isEmpty(),
-                "Deprecated and Legacy tags found  " + invalidTags  + " in AvailableLocales ");
+                "Deprecated and Legacy tags found  " + invalidTags + " in AvailableLocales ");
     }
 }

--- a/test/jdk/java/util/Locale/Bug8179071.java
+++ b/test/jdk/java/util/Locale/Bug8179071.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Bug8179071 {
 
@@ -91,7 +92,7 @@ public class Bug8179071 {
         Arrays.stream(Locale.getAvailableLocales())
                 .map(Locale::toLanguageTag)
                 .forEach(tag -> {if(LegacyAliases.contains(tag)) {invalidTags.add(tag);}});
-        assertEquals(true, invalidTags.isEmpty(),
+        assertTrue(invalidTags.isEmpty(),
                 "Deprecated and Legacy tags found  " + invalidTags  + " in AvailableLocales ");
     }
 }

--- a/test/jdk/java/util/Locale/FilteringModeTest.java
+++ b/test/jdk/java/util/Locale/FilteringModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,67 +25,61 @@
  * @test
  * @bug 8210443
  * @summary Check values() and valueOf(String name) of Locale.FilteringMode.
- * @run main FilteringModeTest
+ * @run junit FilteringModeTest
  */
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale.FilteringMode;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FilteringModeTest {
-    private static boolean err = false;
-    private static List<String> modeNames = List.of("AUTOSELECT_FILTERING",
-                                                    "EXTENDED_FILTERING",
-                                                    "IGNORE_EXTENDED_RANGES",
-                                                    "MAP_EXTENDED_RANGES",
-                                                    "REJECT_EXTENDED_RANGES");
 
-    public static void main(String[] args) throws Exception {
-        testValues();
-        testValueOf();
+    private static final List<String> expectedModeNames = List.of(
+            "AUTOSELECT_FILTERING",
+            "EXTENDED_FILTERING",
+            "IGNORE_EXTENDED_RANGES",
+            "MAP_EXTENDED_RANGES",
+            "REJECT_EXTENDED_RANGES"
+    );
 
-        if (err) {
-            throw new RuntimeException("Failed.");
-        }
+    // Ensure valueOf() exceptions are thrown
+    @Test
+    public void valueOfExceptionsTest() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FilteringMode.valueOf("").name());
+        assertThrows(NullPointerException.class,
+                () -> FilteringMode.valueOf(null).name());
     }
 
-    private static void testValueOf() {
-        try {
-            FilteringMode.valueOf("").name();
-            err = true;
-            System.err.println("IAE should be thrown for valueOf(\"\").");
-        } catch (IllegalArgumentException ex) {
-        }
-
-        try {
-            FilteringMode.valueOf(null).name();
-            err = true;
-            System.err.println("NPE should be thrown for valueOf(null).");
-        } catch (NullPointerException ex) {
-        }
-
-        modeNames.forEach((expectedName) -> {
-            String name = FilteringMode.valueOf(expectedName).name();
-            if (!expectedName.equals(name)) {
-                err = true;
-                System.err.println("FilteringMode.valueOf(" + expectedName
-                        + ") returned unexpected value. Expected: "
-                        + expectedName + ", got: " + name);
-            }
-        });
+    // Ensure valueOf() returns expected results
+    @ParameterizedTest
+    @MethodSource("modes")
+    public void valueOfTest(String expectedName) {
+        String name = FilteringMode.valueOf(expectedName).name();
+        assertEquals(expectedName, name);
     }
 
-    private static void testValues() {
+    private static Stream<String> modes() {
+        return expectedModeNames.stream();
+    }
+
+    // Ensure values() returns expected results
+    @Test
+    public void valuesTest() {
         FilteringMode[] modeArray = FilteringMode.values();
-        List<String> modeNames2 = Arrays.stream(modeArray)
+        List<String> actualNames = Arrays.stream(modeArray)
                 .map(mode -> mode.name())
                 .collect(Collectors.toList());
-
-        if (!modeNames.equals(modeNames2)) {
-            err = true;
-            System.err.println("FilteringMode.values() returned unexpected value. Expected:"
-                    + modeNames + " Got:" + modeNames2);
-        }
+        assertEquals(expectedModeNames, actualNames);
     }
 }

--- a/test/jdk/java/util/Locale/HashCodeTest.java
+++ b/test/jdk/java/util/Locale/HashCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,28 +20,35 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 4944561
  * @summary Test hashCode() to have less than 10% of hash code conflicts.
  * @modules jdk.localedata
+ * @run junit HashCodeTest
  */
 
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 public class HashCodeTest {
 
-    public static void main(String[] args) {
+    // Ensure Locale.hashCode() has less than 10% conflicts
+    @Test
+    public void hashConflictsTest() {
         Locale[] locales = Locale.getAvailableLocales();
         int min = Integer.MAX_VALUE;
         int max = Integer.MIN_VALUE;
         Map<Integer, Locale> map = new HashMap<>(locales.length);
         int conflicts = 0;
 
-        for (int i = 0; i < locales.length; i++) {
-            Locale loc = locales[i];
+        for (Locale loc : locales) {
             int hc = loc.hashCode();
             min = Math.min(hc, min);
             max = Math.max(hc, max);
@@ -55,9 +62,7 @@ public class HashCodeTest {
         }
         System.out.println(locales.length + " locales: conflicts=" + conflicts
                 + ", min=" + min + ", max=" + max + ", diff=" + (max - min));
-        if (conflicts >= (locales.length / 10)) {
-            throw new RuntimeException("too many conflicts: " + conflicts
-                    + " per " + locales.length + " locales");
-        }
+        assertFalse(conflicts >= (locales.length / 10),
+                String.format("%s conflicts per %s locales", conflicts, locales.length));
     }
 }

--- a/test/jdk/java/util/Locale/ThaiGov.java
+++ b/test/jdk/java/util/Locale/ThaiGov.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,98 +20,70 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/**
+
+/*
  * @test
  * @bug 4474409
+ * @summary Tests some localized methods with Thai locale
  * @author John O'Conner
  * @modules jdk.localedata
- * @run main/othervm -Djava.locale.providers=COMPAT ThaiGov
+ * @run junit/othervm -Djava.locale.providers=COMPAT ThaiGov
  */
 
-import java.util.*;
-import java.text.*;
+import java.text.DateFormat;
+import java.text.NumberFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ThaiGov {
 
-    ThaiGov() {
-        System.out.println("ThaiGov locale test...");
+    private static final double VALUE = 12345678.234;
+    private static final Locale TH = Locale.of("th", "TH", "TH");
 
-    }
-
-    void numberTest() throws RuntimeException {
+    // Test number formatting for thai
+    @Test
+    public void numberTest() throws RuntimeException {
         final String strExpected = "\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53\u0E54";
-        final double value =  12345678.234;
-
-        Locale locTH = Locale.of("th", "TH", "TH");
-
-        // th_TH_TH test
-        NumberFormat nf = NumberFormat.getInstance(locTH);
-        String str = nf.format(value);
-
-        if (!strExpected.equals(str)) {
-            throw new RuntimeException();
-        }
-
+        NumberFormat nf = NumberFormat.getInstance(TH);
+        String str = nf.format(VALUE);
+        assertEquals(strExpected, str);
     }
 
-    void currencyTest() throws RuntimeException {
+    // Test currency formatting for Thai
+    @Test
+    public void currencyTest() throws RuntimeException {
         final String strExpected = "\u0E3F\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53";
-        final double value =  12345678.234;
-
-        Locale locTH = Locale.of("th", "TH", "TH");
-
-        // th_TH_TH test
-        NumberFormat nf = NumberFormat.getCurrencyInstance(locTH);
-        String str = nf.format(value);
-
-        if (!strExpected.equals(str)) {
-            throw new RuntimeException();
-        }
-
+        NumberFormat nf = NumberFormat.getCurrencyInstance(TH);
+        String str = nf.format(VALUE);
+        assertEquals(strExpected, str);
     }
 
-    void dateTest() throws RuntimeException {
-        Locale locTH = Locale.of("th", "TH", "TH");
-        TimeZone tz = TimeZone.getTimeZone("PST");
-
+    // Test date formatting for Thai
+    @Test
+    public void dateTest() throws RuntimeException {
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         Calendar calGregorian = Calendar.getInstance(tz, Locale.US);
         calGregorian.clear();
         calGregorian.set(2002, 4, 1, 8, 30);
         final Date date = calGregorian.getTime();
-        Calendar cal = Calendar.getInstance(tz, locTH);
+        Calendar cal = Calendar.getInstance(tz, TH);
         cal.clear();
         cal.setTime(date);
 
 
         final String strExpected = "\u0E27\u0E31\u0E19\u0E1E\u0E38\u0E18\u0E17\u0E35\u0E48\u0020\u0E51\u0020\u0E1E\u0E24\u0E29\u0E20\u0E32\u0E04\u0E21\u0020\u0E1E\u002E\u0E28\u002E\u0020\u0E52\u0E55\u0E54\u0E55\u002C\u0020\u0E58\u0020\u0E19\u0E32\u0E2C\u0E34\u0E01\u0E32\u0020\u0E53\u0E50\u0020\u0E19\u0E32\u0E17\u0E35\u0020\u0E50\u0E50\u0020\u0E27\u0E34\u0E19\u0E32\u0E17\u0E35";
-        Date value =  cal.getTime();
+        Date value = cal.getTime();
 
         // th_TH_TH test
-        DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, locTH);
+        DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, TH);
         df.setTimeZone(tz);
         String str = df.format(value);
-
-        if (!strExpected.equals(str)) {
-            throw new RuntimeException();
-        }
-
+        assertEquals(strExpected, str);
     }
-
-    public static void main(String[] args) {
-
-        ThaiGov app = new ThaiGov();
-        System.out.print("Running numberTest...");
-        app.numberTest();
-        System.out.print("Finished\n");
-        System.out.print("Running currencyTest...");
-        app.currencyTest();
-        System.out.print("Finished\n");
-        System.out.print("Running dateTest...");
-        app.dateTest();
-        System.out.print("Finished\n");
-
-        System.out.println("PASSED");
-    }
-
-
 }

--- a/test/jdk/java/util/Locale/ThaiGov.java
+++ b/test/jdk/java/util/Locale/ThaiGov.java
@@ -48,7 +48,7 @@ public class ThaiGov {
 
     // Test number formatting for thai
     @Test
-    public void numberTest() throws RuntimeException {
+    public void numberTest() {
         final String strExpected = "\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53\u0E54";
         NumberFormat nf = NumberFormat.getInstance(TH);
         String str = nf.format(VALUE);
@@ -57,7 +57,7 @@ public class ThaiGov {
 
     // Test currency formatting for Thai
     @Test
-    public void currencyTest() throws RuntimeException {
+    public void currencyTest() {
         final String strExpected = "\u0E3F\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53";
         NumberFormat nf = NumberFormat.getCurrencyInstance(TH);
         String str = nf.format(VALUE);
@@ -66,7 +66,7 @@ public class ThaiGov {
 
     // Test date formatting for Thai
     @Test
-    public void dateTest() throws RuntimeException {
+    public void dateTest() {
         TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         Calendar calGregorian = Calendar.getInstance(tz, Locale.US);
         calGregorian.clear();

--- a/test/jdk/java/util/Locale/UseOldISOCodesTest.java
+++ b/test/jdk/java/util/Locale/UseOldISOCodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,18 +20,27 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/**
+
+/*
  * @test
  * @bug 8295232
  * @summary Ensures java.locale.useOldISOCodes is statically initialized
  * @library /test/lib
- * @run main UseOldISOCodesTest
+ * @run junit UseOldISOCodesTest
  */
+
 import java.util.Locale;
 import jdk.test.lib.process.ProcessTools;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class UseOldISOCodesTest {
-    public static void main(String[] args) throws Exception {
+
+    // Ensure java.locale.useOldISOCodes is only interpreted at runtime startup
+    @Test
+    public void staticInitializationTest() throws Exception {
         ProcessTools.executeTestJvm("-Djava.locale.useOldISOCodes=true", "UseOldISOCodesTest$Runner")
                 .outputTo(System.out)
                 .errorTo(System.err)
@@ -43,11 +52,11 @@ public class UseOldISOCodesTest {
         private static final String newCode = "he";
 
         public static void main(String[] args) {
+            // Should have no effect
             System.setProperty("java.locale.useOldISOCodes", "false");
             Locale locale = Locale.of(newCode);
-            if(!obsoleteCode.equals(locale.getLanguage())){
-                throw new RuntimeException("Expected that newcode mapped to old ");
-            }
+            assertEquals(obsoleteCode, locale.getLanguage(),
+                    "newCode 'he' was not mapped to 'iw' with useOldISOCodes=true");
         }
     }
 }


### PR DESCRIPTION
Please review this PR which refactors more java.util.Locale tests to JUnit with some minor cleanup as well.

Although some of the files could benefit from being renamed bugNNNNNNN to something more descriptive, this makes reviewing harder, and will be handled separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311663](https://bugs.openjdk.org/browse/JDK-8311663): Additional refactoring of Locale tests to JUnit (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14881/head:pull/14881` \
`$ git checkout pull/14881`

Update a local copy of the PR: \
`$ git checkout pull/14881` \
`$ git pull https://git.openjdk.org/jdk.git pull/14881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14881`

View PR using the GUI difftool: \
`$ git pr show -t 14881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14881.diff">https://git.openjdk.org/jdk/pull/14881.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14881#issuecomment-1635054361)