### PR TITLE
8312072: Deprecate for removal the -Xnoagent option

### DIFF
--- a/make/ide/netbeans/langtools/build.xml
+++ b/make/ide/netbeans/langtools/build.xml
@@ -242,7 +242,7 @@
                 </nbjpdastart>
                 <property
                     name="@{jpda.jvmargs.property}"
-                    value="-Xdebug -Djava.compiler=none -Xrunjdwp:transport=dt_socket,address=${jpda.address}"
+                    value="-Xdebug -Xrunjdwp:transport=dt_socket,address=${jpda.address}"
                 />
             </sequential>
         </macrodef>

--- a/make/ide/netbeans/langtools/build.xml
+++ b/make/ide/netbeans/langtools/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/make/ide/netbeans/langtools/build.xml
+++ b/make/ide/netbeans/langtools/build.xml
@@ -242,7 +242,7 @@
                 </nbjpdastart>
                 <property
                     name="@{jpda.jvmargs.property}"
-                    value="-Xdebug -Xnoagent -Djava.compiler=none -Xrunjdwp:transport=dt_socket,address=${jpda.address}"
+                    value="-Xdebug -Djava.compiler=none -Xrunjdwp:transport=dt_socket,address=${jpda.address}"
                 />
             </sequential>
         </macrodef>

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2659,7 +2659,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       set_xdebug_mode(true);
     // -Xnoagent
     } else if (match_option(option, "-Xnoagent")) {
-      // For compatibility with classic. HotSpot refuses to load the old style agent.dll.
+      warning("Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release.");
     } else if (match_option(option, "-Xloggc:", &tail)) {
       // Deprecated flag to redirect GC output to a file. -Xloggc:<filename>
       log_warning(gc)("-Xloggc is deprecated. Will use -Xlog:gc:%s instead.", tail);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ public class attach001 {
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
         String cmd = java
-                + " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,address=0"
+                + " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=0"
                 + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ public class attach002 extends Log {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_shmem,server=y,address=" +
+            " -Xdebug -Xrunjdwp:transport=dt_shmem,server=y,address=" +
             name + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ public class attachnosuspend001 {
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
         String cmd = java
-                + " -Xdebug -Xnoagent -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"
+                + " -Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"
                 + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public class launch003 {
             Connector.Argument a = (Connector.Argument) cava[i];
             if (a.name().equals("command"))
                 a.setValue(java +
-                " -Xdebug -Xnoagent -Xrunjdwp:suspend=y,transport=" +
+                " -Xdebug -Xrunjdwp:suspend=y,transport=" +
                 TRANSPORT_NAME +
                 ",address=" + host + ":" + port +
                 " " + DEBUGEE_CLASS);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ public class launch004 {
             Connector.Argument a = (Connector.Argument) cava[i];
             if (a.name().equals("command"))
                 a.setValue(java +
-                " -Xdebug -Xnoagent -Xrunjdwp:suspend=y,transport=" +
+                " -Xdebug -Xrunjdwp:suspend=y,transport=" +
                 TRANSPORT_NAME +
                 ",address=" + name +
                 " " + DEBUGEE_CLASS);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class accept001 {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=n,address=" +
+            " -Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=" +
             connAddr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class accept002 {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_shmem,server=n,address=" +
+            " -Xdebug -Xrunjdwp:transport=dt_shmem,server=n,address=" +
             connAddr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/listennosuspend/listennosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/listennosuspend/listennosuspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class listennosuspend001 {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=n,suspend=n,address=" +
+            " -Xdebug -Xrunjdwp:transport=dt_socket,server=n,suspend=n,address=" +
             connAddr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ public class startlis001 {
                           + " " + argHandler.getLaunchOptions();
 
         String cmd = java +
-            " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=n,address=" +
+            " -Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=" +
             addr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,7 @@ public class startlis002 {
                           + " " + argHandler.getLaunchOptions();
 
         String cmd = java +
-            " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_shmem,server=n,address=" +
+            " -Xdebug -Xrunjdwp:transport=dt_shmem,server=n,address=" +
             addr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);


### PR DESCRIPTION
Can I please get a review of this change which proposes to deprecate `-Xnoagent` option of the `java` command? This addresses https://bugs.openjdk.org/browse/JDK-8312072.

As noted in the JBS issue, this option currently is a no-op and provides no functionality. The commit in this PR logs a deprecation warning if this option is used when launching `java`.

Additionally, this PR also cleans up one such usage that I found in the JDK code.

`tier1`, `tier2` and `tier3` tests passed with this change. A CSR has been proposed for this deprecation https://bugs.openjdk.org/browse/JDK-8312073.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8312073](https://bugs.openjdk.org/browse/JDK-8312073) to be approved

### Issues
 * [JDK-8312072](https://bugs.openjdk.org/browse/JDK-8312072): Deprecate for removal the -Xnoagent option (**Bug** - P4)
 * [JDK-8312073](https://bugs.openjdk.org/browse/JDK-8312073): Deprecate for removal the -Xnoagent option (**CSR**)

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [71df3079](https://git.openjdk.org/jdk/pull/14882/files/71df30790eaf6ddff184d32e7be2d1864dcb1b4e)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14882/head:pull/14882` \
`$ git checkout pull/14882`

Update a local copy of the PR: \
`$ git checkout pull/14882` \
`$ git pull https://git.openjdk.org/jdk.git pull/14882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14882`

View PR using the GUI difftool: \
`$ git pr show -t 14882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14882.diff">https://git.openjdk.org/jdk/pull/14882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14882#issuecomment-1635440073)