### PR TITLE
8310201: Reduce verbose locale output in -XshowSettings launcher option

### DIFF
--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -286,7 +286,7 @@ public final class LauncherHelper {
             ostream.println(LOCALE_SETTINGS);
         } else {
             ostream.println("Locale settings summary:");
-            ostream.println(INDENT + "Use \":locale\" " +
+            ostream.println(INDENT + "Use \"-XshowSettings:locale\" " +
                     "option for verbose locale settings options");
         }
         ostream.println(INDENT + "default locale = " +

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -170,7 +170,7 @@ public final class LauncherHelper {
                 printProperties();
                 break;
             case "locale":
-                printLocale();
+                printLocale(false);
                 break;
             case "security":
                 var opt = opts.length > 2 ? opts[2].trim() : "all";
@@ -184,7 +184,7 @@ public final class LauncherHelper {
             default:
                 printVmSettings(initialHeapSize, maxHeapSize, stackSize);
                 printProperties();
-                printLocale();
+                printLocale(true);
                 SecuritySettings.printSecuritySummarySettings(ostream);
                 if (OperatingSystem.isLinux()) {
                     printSystemMetrics();
@@ -280,9 +280,15 @@ public final class LauncherHelper {
     /*
      * prints the locale subopt/section
      */
-    private static void printLocale() {
+    private static void printLocale(boolean summaryMode) {
         Locale locale = Locale.getDefault();
-        ostream.println(LOCALE_SETTINGS);
+        if (!summaryMode) {
+            ostream.println(LOCALE_SETTINGS);
+        } else {
+            ostream.println("Locale settings summary:");
+            ostream.println(INDENT + "Use \":locale\" " +
+                    "option for verbose locale settings options");
+        }
         ostream.println(INDENT + "default locale = " +
                 locale.getDisplayName());
         ostream.println(INDENT + "default display locale = " +
@@ -291,7 +297,9 @@ public final class LauncherHelper {
                 Locale.getDefault(Category.FORMAT).getDisplayName());
         ostream.println(INDENT + "tzdata version = " +
                 ZoneInfoFile.getVersion());
-        printLocales();
+        if (!summaryMode) {
+            printLocales();
+        }
         ostream.println();
     }
 

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -67,6 +67,9 @@ public class Settings extends TestHelper {
     private static final String VM_SETTINGS = "VM settings:";
     private static final String PROP_SETTINGS = "Property settings:";
     private static final String LOCALE_SETTINGS = "Locale settings:";
+    private static final String LOCALE_SUMMARY_SETTINGS =
+                "Locale settings summary:";
+    private static final String AVAILABLE_LOCALES = "available locales";
     private static final String SEC_PROPS_SETTINGS = "Security properties:";
     private static final String SEC_SUMMARY_PROPS_SETTINGS =
                 "Security settings summary:";
@@ -81,7 +84,9 @@ public class Settings extends TestHelper {
     static void containsAllOptions(TestResult tr) {
         checkContains(tr, VM_SETTINGS);
         checkContains(tr, PROP_SETTINGS);
-        checkContains(tr, LOCALE_SETTINGS);
+        checkNotContains(tr, LOCALE_SETTINGS);
+        checkNotContains(tr, AVAILABLE_LOCALES);
+        checkContains(tr, LOCALE_SUMMARY_SETTINGS);
         // no verbose security settings unless "security" used
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkContains(tr, SEC_SUMMARY_PROPS_SETTINGS);
@@ -153,6 +158,8 @@ public class Settings extends TestHelper {
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
         checkContains(tr, LOCALE_SETTINGS);
+        checkContains(tr, AVAILABLE_LOCALES);
+        checkNotContains(tr, LOCALE_SUMMARY_SETTINGS);
         checkContains(tr, TZDATA_SETTINGS);
     }
 

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 /*
  * @test
- * @bug 6994753 7123582 8305950 8281658
+ * @bug 6994753 7123582 8305950 8281658 8310201
  * @summary tests -XshowSettings options
  * @modules jdk.compiler
  *          jdk.zipfs


### PR DESCRIPTION
Simple tweak to remove the "available locales" section from default `-XshowSettings` output.

Instead, it remains available with the `-XshowSettings:locale` option

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8311826](https://bugs.openjdk.org/browse/JDK-8311826) to be approved

### Issues
 * [JDK-8310201](https://bugs.openjdk.org/browse/JDK-8310201): Reduce verbose locale output in -XshowSettings launcher option (**Bug** - P3)
 * [JDK-8311826](https://bugs.openjdk.org/browse/JDK-8311826): Reduce verbose locale output in -XshowSettings launcher option (**CSR**)

### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14885/head:pull/14885` \
`$ git checkout pull/14885`

Update a local copy of the PR: \
`$ git checkout pull/14885` \
`$ git pull https://git.openjdk.org/jdk.git pull/14885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14885`

View PR using the GUI difftool: \
`$ git pr show -t 14885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14885.diff">https://git.openjdk.org/jdk/pull/14885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14885#issuecomment-1635632159)