### PR TITLE
8310874: Runthese30m crashes with klass should be in the placeholders during verification

### DIFF
--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -468,15 +468,6 @@ void LoaderConstraintTable::verify() {
           // We found the class in the dictionary, so we should
           // make sure that the Klass* matches what we already have.
           guarantee(k == probe->klass(), "klass should be in dictionary");
-        } else {
-          // If we don't find the class in the dictionary, it
-          // has to be in the placeholders table.
-          PlaceholderEntry* entry = PlaceholderTable::get_entry(name, loader_data);
-
-          // The InstanceKlass might not be on the entry, so the only
-          // thing we can check here is whether we were successful in
-          // finding the class in the placeholders table.
-          guarantee(entry != nullptr, "klass should be in the placeholders");
         }
       }
       for (int n = 0; n< probe->num_loaders(); n++) {

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -453,7 +453,8 @@ void LoaderConstraintTable::merge_loader_constraints(Symbol* class_name,
 void LoaderConstraintTable::verify() {
   Thread* thread = Thread::current();
   auto check = [&] (SymbolHandle& key, ConstraintSet& set) {
-    // foreach constraint in the set, check the klass is in the dictionary or placeholder table.
+    // foreach constraint in the set, check the klass is the same as what is in the dictionary.
+    // If the class is in defineClass, it may not be in the dictionary yet.
     int len = set.num_constraints();
     for (int i = 0; i < len; i++) {
       LoaderConstraint* probe = set.constraint_at(i);


### PR DESCRIPTION
For non-parallel capable class loaders, the class is not put in the placeholders table, so a verification at the wrong time will hit this assert.  This trivial change removes the invalid assert.
Tested with inserting a LoaderConstraintTable::verify while running jck tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310874](https://bugs.openjdk.org/browse/JDK-8310874): Runthese30m crashes with klass should be in the placeholders during verification (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14887/head:pull/14887` \
`$ git checkout pull/14887`

Update a local copy of the PR: \
`$ git checkout pull/14887` \
`$ git pull https://git.openjdk.org/jdk.git pull/14887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14887`

View PR using the GUI difftool: \
`$ git pr show -t 14887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14887.diff">https://git.openjdk.org/jdk/pull/14887.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14887#issuecomment-1635816775)