### PR TITLE
8312014: [s390x] TestSigInfoInHsErrFile.java Failure

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -27,7 +27,7 @@
 #define CPU_AARCH64_GLOBALDEFINITIONS_AARCH64_HPP
 
 const int StackAlignmentInBytes  = 16;
-const size_t Pdsegfault_address = 1024;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -27,6 +27,7 @@
 #define CPU_AARCH64_GLOBALDEFINITIONS_AARCH64_HPP
 
 const int StackAlignmentInBytes  = 16;
+const size_t Pdsegfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
+++ b/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
@@ -26,7 +26,7 @@
 #define CPU_ARM_GLOBALDEFINITIONS_ARM_HPP
 
 const int StackAlignmentInBytes = 8;
-const size_t Pdsegfault_address = 1024;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
+++ b/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
@@ -26,6 +26,7 @@
 #define CPU_ARM_GLOBALDEFINITIONS_ARM_HPP
 
 const int StackAlignmentInBytes = 8;
+const size_t Pdsegfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
@@ -30,10 +30,11 @@
 const int BytesPerInstWord = 4;
 
 const int StackAlignmentInBytes = 16;
-#if define(AIX)
-const size_t Pdsegfault_address = -1;
+
+#ifdef defined(AIX)
+const size_t pd_segfault_address = -1;
 #else
-const size_t Pdsegfault_address = 1024;
+const size_t pd_segfault_address = 1024;
 #endif
 
 // Indicates whether the C calling conventions require that

--- a/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
@@ -30,6 +30,11 @@
 const int BytesPerInstWord = 4;
 
 const int StackAlignmentInBytes = 16;
+#if define(AIX)
+const size_t Pdsegfault_address = -1;
+#else
+const size_t Pdsegfault_address = 1024;
+#endif
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
@@ -31,7 +31,7 @@ const int BytesPerInstWord = 4;
 
 const int StackAlignmentInBytes = 16;
 
-#ifdef defined(AIX)
+#ifdef AIX
 const size_t pd_segfault_address = -1;
 #else
 const size_t pd_segfault_address = 1024;

--- a/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
@@ -28,6 +28,7 @@
 #define CPU_RISCV_GLOBALDEFINITIONS_RISCV_HPP
 
 const int StackAlignmentInBytes = 16;
+const size_t Pdsegfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
@@ -28,7 +28,7 @@
 #define CPU_RISCV_GLOBALDEFINITIONS_RISCV_HPP
 
 const int StackAlignmentInBytes = 16;
-const size_t Pdsegfault_address = 1024;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
+++ b/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
@@ -31,7 +31,7 @@
 const int StackAlignmentInBytes = 16;
 
 //All faults on s390x give the address only on page granularity.
-//Set Pdsegfault_address to minumum one page address.
+//Set Pdsegfault_address to miniumum one page address.
 const size_t pd_segfault_address = 4096;
 
 #define SUPPORTS_NATIVE_CX8

--- a/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
+++ b/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
@@ -30,8 +30,8 @@
 
 const int StackAlignmentInBytes = 16;
 
-//All faults on s390x give the address only on page granularity.
-//Set Pdsegfault_address to miniumum one page address.
+// All faults on s390x give the address only on page granularity.
+// Set Pdsegfault_address to miniumum one page address.
 const size_t pd_segfault_address = 4096;
 
 #define SUPPORTS_NATIVE_CX8

--- a/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
+++ b/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
@@ -32,7 +32,7 @@ const int StackAlignmentInBytes = 16;
 
 //All faults on s390x give the address only on page granularity.
 //Set Pdsegfault_address to minumum one page address.
-const size_t Pdsegfault_address = 4096;
+const size_t pd_segfault_address = 4096;
 
 #define SUPPORTS_NATIVE_CX8
 

--- a/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
+++ b/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
@@ -30,6 +30,10 @@
 
 const int StackAlignmentInBytes = 16;
 
+//All faults on s390x give the address only on page granularity.
+//Set Pdsegfault_address to minumum one page address.
+const size_t Pdsegfault_address = 4096;
+
 #define SUPPORTS_NATIVE_CX8
 
 #define CPU_MULTI_COPY_ATOMIC

--- a/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
+++ b/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
@@ -31,7 +31,7 @@
 const int StackAlignmentInBytes = 16;
 
 // All faults on s390x give the address only on page granularity.
-// Set Pdsegfault_address to miniumum one page address.
+// Set Pdsegfault_address to minimum one page address.
 const size_t pd_segfault_address = 4096;
 
 #define SUPPORTS_NATIVE_CX8

--- a/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
+++ b/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
@@ -26,6 +26,7 @@
 #define CPU_X86_GLOBALDEFINITIONS_X86_HPP
 
 const int StackAlignmentInBytes  = 16;
+const size_t Pdsegfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
+++ b/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
@@ -26,7 +26,7 @@
 #define CPU_X86_GLOBALDEFINITIONS_X86_HPP
 
 const int StackAlignmentInBytes  = 16;
-const size_t Pdsegfault_address = 1024;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -37,6 +37,6 @@
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = false;
-const size_t pd_segfault_address = 4096;
+const size_t pd_segfault_address = S390_ONLY(4096) NOT_S390(1024);
 
 #endif // CPU_ZERO_GLOBALDEFINITIONS_ZERO_HPP

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -37,6 +37,12 @@
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = false;
-const size_t pd_segfault_address = S390_ONLY(4096) NOT_S390(1024);
+#if defined(AIX)
+const size_t pd_segfault_address = -1;
+#elif defined(S390)
+const size_t pd_segfault_address = 4096;
+#else
+const size_t pd_segfault_address = 1024;
+#endif
 
 #endif // CPU_ZERO_GLOBALDEFINITIONS_ZERO_HPP

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -37,5 +37,6 @@
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = false;
+const size_t pd_segfault_address = 4096;
 
 #endif // CPU_ZERO_GLOBALDEFINITIONS_ZERO_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -99,6 +99,7 @@ const char*       VMError::_filename;
 int               VMError::_lineno;
 size_t            VMError::_size;
 const size_t      VMError::_reattempt_required_stack_headroom = 64 * K;
+const intptr_t    VMError::segfault_address = Pdsegfault_address;
 
 // List of environment variables that should be reported in error log file.
 static const char* env_list[] = {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -99,7 +99,7 @@ const char*       VMError::_filename;
 int               VMError::_lineno;
 size_t            VMError::_size;
 const size_t      VMError::_reattempt_required_stack_headroom = 64 * K;
-const intptr_t    VMError::segfault_address = Pdsegfault_address;
+const intptr_t    VMError::segfault_address = pd_segfault_address;
 
 // List of environment variables that should be reported in error log file.
 static const char* env_list[] = {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -207,7 +207,7 @@ public:
   DEBUG_ONLY(static void controlled_crash(int how);)
 
   // Non-null address guaranteed to generate a SEGV mapping error on read, for test purposes.
-  static constexpr intptr_t segfault_address = AIX_ONLY(-1) NOT_AIX(4 * K);
+  static const intptr_t segfault_address;
 
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -207,7 +207,7 @@ public:
   DEBUG_ONLY(static void controlled_crash(int how);)
 
   // Non-null address guaranteed to generate a SEGV mapping error on read, for test purposes.
-  static constexpr intptr_t segfault_address = AIX_ONLY(-1) NOT_AIX(1 * K);
+  static constexpr intptr_t segfault_address = AIX_ONLY(-1) NOT_AIX(4 * K);
 
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -68,7 +68,7 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
     // Crash address: see VMError::_segfault_address
-    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : "0x0*400";
+    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : "0x0*1000";
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -71,7 +71,7 @@ public class TestSigInfoInHsErrFile {
     String crashAddress = "0x0*400";
     if (Platform.isAix()) {
         crashAddress = "0xffffffffffffffff";
-    } else if  (Platform.isS390x()) {
+    } else if (Platform.isS390x()) {
         // All faults on s390x give the address only on page granularity.
         // Hence fault address is first page address.
         crashAddress = "0x0*1000";

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -68,9 +68,14 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
     // Crash address: see VMError::_segfault_address
-    //All faults on s390x give the address only on page granularity.
-    //Hence fault address is first page address.
-    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : Platform.isS390x() ? "0x0*1000" : "0x0*400";
+    String crashAddress = "0x0*400";
+    if (Platform.isAix()) {
+        crashAddress = "0xffffffffffffffff";
+    } else if  (Platform.isS390x()) {
+        // All faults on s390x give the address only on page granularity.
+        // Hence fault address is first page address.
+        crashAddress = "0x0*1000";
+    }
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -68,7 +68,9 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
     // Crash address: see VMError::_segfault_address
-    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : "0x0*1000";
+    //All faults on s390x give the address only on page granularity.
+    //Hence fault address is first page address.
+    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : Platform.isS390x() ? "0x0*1000" : "0x0*400";
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);


### PR DESCRIPTION
All faults on s390x give the address only on page granularity.
e.g. if you use 0x123456 as fail address you get si_addr = 0x123000

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312014](https://bugs.openjdk.org/browse/JDK-8312014): [s390x] TestSigInfoInHsErrFile.java Failure (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [fa8ea22b](https://git.openjdk.org/jdk/pull/14888/files/fa8ea22b06100a03b5292905c6fefd2bbe533557)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer) ⚠️ Review applies to [29d254a1](https://git.openjdk.org/jdk/pull/14888/files/29d254a1fc674b0b8a7ccdf2c18cb0a7b34fa74d)
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14888/head:pull/14888` \
`$ git checkout pull/14888`

Update a local copy of the PR: \
`$ git checkout pull/14888` \
`$ git pull https://git.openjdk.org/jdk.git pull/14888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14888`

View PR using the GUI difftool: \
`$ git pr show -t 14888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14888.diff">https://git.openjdk.org/jdk/pull/14888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14888#issuecomment-1635818875)