### PR TITLE
8312093: Incorrect javadoc comment text

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1546,7 +1546,10 @@ public class JavaTokenizer extends UnicodeReader {
                     return;
                 }
 
-                skip('*');
+                if (skip('*') != 0 && is('/')) {
+                    return ;
+                }
+
                 skipWhitespace();
 
                 if (isEOLN()) {

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2416,6 +2416,34 @@ public class JavacParserTest extends TestCase {
                 assertEquals("Wrong modifiers start position", -1, sp.getStartPosition(cut, node.getModifiers()));
                 assertEquals("Wrong modifiers end position", -1, sp.getEndPosition(cut, node.getModifiers()));
                 return super.visitClass(node, p);
+            }
+        }.scan(cut, null);
+    }
+
+    @Test //JDK-8312093
+    void testJavadoc() throws IOException {
+        String code = """
+                      public class Test {
+                          /***/
+                          void main() {
+                          }
+                      }
+                      """;
+        DiagnosticCollector<JavaFileObject> coll =
+                new DiagnosticCollector<>();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll, null,
+                null, Arrays.asList(new MyFileObject(code)));
+        Trees trees = Trees.instance(ct);
+        CompilationUnitTree cut = ct.parse().iterator().next();
+        new TreePathScanner<Void, Void>() {
+            @Override
+            public Void visitMethod(MethodTree node, Void p) {
+                if (!node.getName().contentEquals("main")) {
+                    return null;
+                }
+                String comment = trees.getDocComment(getCurrentPath());
+                assertEquals("Expecting empty comment", "", comment);
+                return null;
             }
         }.scan(cut, null);
     }


### PR DESCRIPTION
Consider a javadoc comment like:
```
public class Test {
    /***/
    void main() {
    }
}
```

The doc comment's String for the javadoc comment will be "`/`", which is wrong. The reason is that the third '*' is ignored, and the closing '/' is used as the content of the comment.

The proposed solution is to tweak the parser to properly handle the closing '*/' in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312093](https://bugs.openjdk.org/browse/JDK-8312093): Incorrect javadoc comment text (**Bug** - P3)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14890/head:pull/14890` \
`$ git checkout pull/14890`

Update a local copy of the PR: \
`$ git checkout pull/14890` \
`$ git pull https://git.openjdk.org/jdk.git pull/14890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14890`

View PR using the GUI difftool: \
`$ git pr show -t 14890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14890.diff">https://git.openjdk.org/jdk/pull/14890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14890#issuecomment-1636000503)