### PR TITLE
8312106: Update man page for javadoc

### DIFF
--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -84,9 +84,9 @@ options, package names, and source file names in any order.
 The \f[V]javadoc\f[R] tool parses the declarations and documentation
 comments in a set of Java source files and produces corresponding HTML
 pages that describe (by default) the public and protected classes,
-nested classes (but not anonymous inner classes), interfaces,
-constructors, methods, and fields.
-You can use the \f[V]javadoc\f[R] tool to generate the API documentation
+nested and unnamed classes (but not anonymous inner classes),
+interfaces, constructors, methods, and fields.
+You can use the\f[V]javadoc\f[R] tool to generate the API documentation
 or the implementation documentation for a set of source files.
 .PP
 You can run the \f[V]javadoc\f[R] tool on entire packages, individual


### PR DESCRIPTION
Update javadoc man page to indicate unnamed classes are supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312106](https://bugs.openjdk.org/browse/JDK-8312106): Update man page for javadoc (**Task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14891/head:pull/14891` \
`$ git checkout pull/14891`

Update a local copy of the PR: \
`$ git checkout pull/14891` \
`$ git pull https://git.openjdk.org/jdk.git pull/14891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14891`

View PR using the GUI difftool: \
`$ git pr show -t 14891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14891.diff">https://git.openjdk.org/jdk/pull/14891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14891#issuecomment-1636068047)