### PR TITLE
8312121: Fix -Wconversion warnings in tribool.hpp

### DIFF
--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -32,6 +32,7 @@
 #include "c1/c1_Runtime1.hpp"
 #include "c1/c1_ValueType.hpp"
 #include "compiler/compileBroker.hpp"
+#include "compiler/compilerDirectives.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "jfr/support/jfrIntrinsics.hpp"
 #include "memory/allocation.hpp"

--- a/src/hotspot/share/c1/c1_Compiler.hpp
+++ b/src/hotspot/share/c1/c1_Compiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,8 @@
 #define SHARE_C1_C1_COMPILER_HPP
 
 #include "compiler/abstractCompiler.hpp"
-#include "compiler/compilerDirectives.hpp"
+
+class DirectiveSet;
 
 // There is one instance of the Compiler per CompilerThread.
 

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -29,6 +29,7 @@
 #include "jvm_constants.h"
 #include "jvm_io.h"
 #include "runtime/vm_version.hpp"
+#include "utilities/tribool.hpp"
 #include "utilities/xmlstream.hpp"
 
 // These are flag-matching functions:

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -34,7 +34,6 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/signature.hpp"
-#include "utilities/tribool.hpp"
 #include "utilities/xmlstream.hpp"
 
 

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -41,8 +41,8 @@ class TriBool{
  public:
   TriBool() : _value(0) {}
   TriBool(bool value) : _value(value) {
-    // set to not-default in separate step to avoid -Wconversion warnings
-    _value |= _value;
+    // set to not-default in separate step to avoid conversion warnings
+    _value |= 2;
   }
   TriBool(const TriBool& o): _value(o._value) {}
 

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -40,11 +40,11 @@ class TriBool{
 
  public:
   TriBool() : _value(0) {}
-  TriBool(bool value) : _value((u1)(value | 2) & 3) { }
+  TriBool(bool value) : _value((u1)((u1)value | 2) & 3) {}
   TriBool(const TriBool& o): _value(o._value) {}
 
   TriBool& operator=(bool value) {
-    _value = (u1)(value | 2) & 3;
+    _value = (u1)((u1)value | 2) & 3;
     return *this;
   }
 
@@ -73,7 +73,7 @@ class TriBoolArray {
 
     TriBoolAssigner& operator=(bool newval) {
       _slot ^= ((u1)_value) << _offset;  // reset the tribool
-      _value = (u1)(newval | 2) & 3;
+      _value = (u1)((u1)newval | 2) & 3;
       _slot |= ((u1)_value) << _offset;
       return *this;
     };

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -40,11 +40,14 @@ class TriBool{
 
  public:
   TriBool() : _value(0) {}
-  TriBool(bool value) : _value(((u1)value) | 2) {}
+  TriBool(bool value) : _value(value) {
+    _value = _value | 2;
+  }
   TriBool(const TriBool& o): _value(o._value) {}
 
   TriBool& operator=(bool value) {
-    _value = ((u1)value) | 2;
+    _value = (u1)value;
+    _value = _value | 2;
     return *this;
   }
 
@@ -73,7 +76,8 @@ class TriBoolArray {
 
     TriBoolAssigner& operator=(bool newval) {
       _slot ^= ((u1)_value) << _offset;  // reset the tribool
-      _value = (u1)newval| 2;
+      _value = (u1)newval;
+      _value = _value | 2;
       _slot |= ((u1)_value) << _offset;
       return *this;
     };

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -73,8 +73,7 @@ class TriBoolArray {
 
     TriBoolAssigner& operator=(bool newval) {
       _slot ^= ((u1)_value) << _offset;  // reset the tribool
-      _value = (u1)newval;
-      _value = _value | 2;
+      _value = (u1)(newval | 2) & 3;
       _slot |= ((u1)_value) << _offset;
       return *this;
     };

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -40,14 +40,11 @@ class TriBool{
 
  public:
   TriBool() : _value(0) {}
-  TriBool(bool value) : _value(value) {
-    _value = _value | 2;
-  }
+  TriBool(bool value) : _value((u1)(value | 2) & 3) { }
   TriBool(const TriBool& o): _value(o._value) {}
 
   TriBool& operator=(bool value) {
-    _value = (u1)value;
-    _value = _value | 2;
+    _value = (u1)(value | 2) & 3;
     return *this;
   }
 

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -41,7 +41,8 @@ class TriBool{
  public:
   TriBool() : _value(0) {}
   TriBool(bool value) : _value(value) {
-    _value = _value | 2; // set to not-default
+    // set to not-default in separate step to avoid -Wconversion warnings
+    _value |= _value;
   }
   TriBool(const TriBool& o): _value(o._value) {}
 

--- a/src/hotspot/share/utilities/tribool.hpp
+++ b/src/hotspot/share/utilities/tribool.hpp
@@ -40,11 +40,14 @@ class TriBool{
 
  public:
   TriBool() : _value(0) {}
-  TriBool(bool value) : _value((u1)((u1)value | 2) & 3) {}
+  TriBool(bool value) : _value(value) {
+    _value = _value | 2; // set to not-default
+  }
   TriBool(const TriBool& o): _value(o._value) {}
 
   TriBool& operator=(bool value) {
-    _value = (u1)((u1)value | 2) & 3;
+    _value = value;
+    _value |= 2; // set to not-default
     return *this;
   }
 
@@ -73,7 +76,8 @@ class TriBoolArray {
 
     TriBoolAssigner& operator=(bool newval) {
       _slot ^= ((u1)_value) << _offset;  // reset the tribool
-      _value = (u1)((u1)newval | 2) & 3;
+      _value = newval;
+      _value |= 2; // set to not-default
       _slot |= ((u1)_value) << _offset;
       return *this;
     };


### PR DESCRIPTION
Assigning _value first, and then doing _value | 2 doesn't get -Wconversion warnings.  Also, reduced include file inclusion a little.
Tested with tier1 on linux-x64-debug, windows-x64-debug, macos-aarch64-debug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312121](https://bugs.openjdk.org/browse/JDK-8312121): Fix -Wconversion warnings in tribool.hpp (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [73c2075a](https://git.openjdk.org/jdk/pull/14892/files/73c2075a1995b190348822ca61f733da6572ce42)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14892/head:pull/14892` \
`$ git checkout pull/14892`

Update a local copy of the PR: \
`$ git checkout pull/14892` \
`$ git pull https://git.openjdk.org/jdk.git pull/14892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14892`

View PR using the GUI difftool: \
`$ git pr show -t 14892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14892.diff">https://git.openjdk.org/jdk/pull/14892.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14892#issuecomment-1636464052)