### PR TITLE
8312127: FileDescriptor.sync should temporarily increase parallelism

### DIFF
--- a/src/java.base/share/classes/java/io/FileDescriptor.java
+++ b/src/java.base/share/classes/java/io/FileDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.Blocker;
 import jdk.internal.ref.PhantomCleanable;
 
 /**
@@ -205,7 +206,17 @@ public final class FileDescriptor {
      *        buffers have been synchronized with physical media.
      * @since     1.1
      */
-    public native void sync() throws SyncFailedException;
+    public void sync() throws SyncFailedException {
+        long comp = Blocker.begin();
+        try {
+            sync0();
+        } finally {
+            Blocker.end(comp);
+        }
+    }
+
+    /* fsync/equivalent this file descriptor */
+    private native void sync0() throws SyncFailedException;
 
     /* This routine initializes JNI field offsets for the class */
     private static native void initIDs();

--- a/src/java.base/unix/native/libjava/FileDescriptor_md.c
+++ b/src/java.base/unix/native/libjava/FileDescriptor_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ Java_java_io_FileDescriptor_initIDs(JNIEnv *env, jclass fdClass) {
  */
 
 JNIEXPORT void JNICALL
-Java_java_io_FileDescriptor_sync(JNIEnv *env, jobject this) {
+Java_java_io_FileDescriptor_sync0(JNIEnv *env, jobject this) {
     FD fd = THIS_FD(this);
     if (IO_Sync(fd) == -1) {
         JNU_ThrowByName(env, "java/io/SyncFailedException", "sync failed");

--- a/src/java.base/windows/native/libjava/FileDescriptor_md.c
+++ b/src/java.base/windows/native/libjava/FileDescriptor_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ Java_java_io_FileDescriptor_initIDs(JNIEnv *env, jclass fdClass) {
  */
 
 JNIEXPORT void JNICALL
-Java_java_io_FileDescriptor_sync(JNIEnv *env, jobject this) {
+Java_java_io_FileDescriptor_sync0(JNIEnv *env, jobject this) {
     FD fd = THIS_FD(this);
     if (IO_Sync(fd) == -1) {
         JNU_ThrowByName(env, "java/io/SyncFailedException", "sync failed");


### PR DESCRIPTION
If FileDescriptor::sync is invoked by a virtual thread then it doesn't release its carrier to do other work while modifications are written to the file system. For cases like this, parallelism should be temporarily increased for the duration of the operation. This one is somewhat legacy as it's only JDK 1.0/1.1 era APIs that provide access to the FileDescriptor so it wasn't done with the other methods in JDK 19. It's updated here, as it has been noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312127](https://bugs.openjdk.org/browse/JDK-8312127): FileDescriptor.sync should temporarily increase parallelism (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14893/head:pull/14893` \
`$ git checkout pull/14893`

Update a local copy of the PR: \
`$ git checkout pull/14893` \
`$ git pull https://git.openjdk.org/jdk.git pull/14893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14893`

View PR using the GUI difftool: \
`$ git pr show -t 14893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14893.diff">https://git.openjdk.org/jdk/pull/14893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14893#issuecomment-1638347919)