### PR TITLE
8263476: NMT: Stack guard pages should not marked as committed

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1642,7 +1642,8 @@ bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::commit_memory(addr, size, !ExecMem);
+  char* res = os::reserve_memory_at(addr, size, !ExecMem);
+  return res != nullptr;
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1642,7 +1642,7 @@ bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  char* res = os::reserve_memory_at(addr, size, !ExecMem);
+  char* res = os::attempt_reserve_memory_at(addr, size, !ExecMem);
   return res != nullptr;
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3402,7 +3402,8 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
     }
   }
 
-  return os::commit_memory(addr, size, !ExecMem);
+  char* res = os::attempt_reserve_memory_at(addr, size, !ExecMem);
+  return res != nullptr;
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3673,7 +3673,8 @@ bool os::pd_release_memory(char* addr, size_t bytes) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::commit_memory(addr, size, !ExecMem);
+  char* res = os::attempt_reserve_memory_at(addr, size, !ExecMem);
+  return res != nullptr;
 }
 
 bool os::remove_stack_guard_pages(char* addr, size_t size) {


### PR DESCRIPTION
Hi,

Previously the stack guard pages were allocated through the use of `os::commit_memory`. The effect of this is that:

1. The pages are considered read+write:able on Linux and BSD
2. NMT considers this memory to be committed (approx: considered to be backed by RAM)

Neither of these properties are desirable. We can instead reserve the memory and be done with it. On Linux and BSD this has the effect that the stack guard pages are active slightly earlier than before as memory is reserved with `PROT_NONE`:

```c++
void StackOverflow::create_stack_guard_pages() {
  if (!os::uses_stack_guard_pages() ||
      _stack_guard_state != stack_guard_unused ||
      (DisablePrimordialThreadGuardPages && os::is_primordial_thread())) {
      log_info(os, thread)("Stack guard page creation for thread "
                           UINTX_FORMAT " disabled", os::current_thread_id());
    return;
  }
  address low_addr = stack_end();
  size_t len = stack_guard_zone_size();

  assert(is_aligned(low_addr, os::vm_page_size()), "Stack base should be the start of a page");
  assert(is_aligned(len, os::vm_page_size()), "Stack size should be a multiple of page size");

  int must_commit = os::must_commit_stack_guard_pages(); // (1) Now active at this call
  // warning("Guarding at " PTR_FORMAT " for len " SIZE_FORMAT "\n", low_addr, len);

  if (must_commit && !os::create_stack_guard_pages((char *) low_addr, len)) {
    log_warning(os, thread)("Attempt to allocate stack guard pages failed.");
    return;
  }

  if (os::guard_memory((char *) low_addr, len)) { // (2) Previously active after this call
    _stack_guard_state = stack_guard_enabled;
  } else {
    log_warning(os, thread)("Attempt to protect stack guard pages failed ("
      PTR_FORMAT "-" PTR_FORMAT ").", p2i(low_addr), p2i(low_addr + len));
    vm_exit_out_of_memory(len, OOM_MPROTECT_ERROR, "memory to guard stack pages");
  }

  log_debug(os, thread)("Thread " UINTX_FORMAT " stack guard pages activated: "
    PTR_FORMAT "-" PTR_FORMAT ".",
    os::current_thread_id(), p2i(low_addr), p2i(low_addr + len));
}
```

On Windows `os::reserve_memory` seems to reserve the pages with read+write privileges, so only the NMT accounting is different here.

I'm opening the PR now, but this change hasn't gone through testing yet. I will update this PR with a comment and edit here when CI is done.

Thank you for considering this change.

Regards,
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263476](https://bugs.openjdk.org/browse/JDK-8263476): NMT: Stack guard pages should not marked as committed (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14896/head:pull/14896` \
`$ git checkout pull/14896`

Update a local copy of the PR: \
`$ git checkout pull/14896` \
`$ git pull https://git.openjdk.org/jdk.git pull/14896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14896`

View PR using the GUI difftool: \
`$ git pr show -t 14896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14896.diff">https://git.openjdk.org/jdk/pull/14896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14896#issuecomment-1637145631)