### PR TITLE
8312147: Dynamic Exception Specification warnings are no longer required after JDK-8311380

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/alloc.h
+++ b/src/java.desktop/windows/native/libawt/windows/alloc.h
@@ -40,12 +40,6 @@ namespace std {
 
 class awt_toolkit_shutdown {};
 
-// Disable "C++ Exception Specification ignored" warnings.
-// These warnings are generated because VC++ 5.0 allows, but does not enforce,
-// exception specifications. This #pragma can be safely removed when VC++
-// is updated to enforce exception specifications.
-#pragma warning(disable : 4290)
-
 #ifdef TRY
 #error Multiple definitions of TRY
 #endif

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.h
@@ -254,7 +254,7 @@ public:
     INLINE void SetModuleHandle(HMODULE h) { m_dllHandle = h; }
 
     INLINE static DWORD MainThread() { return GetInstance().m_mainThreadId; }
-    INLINE void VerifyActive() throw (awt_toolkit_shutdown) {
+    INLINE void VerifyActive() {
         if (!m_isActive && m_mainThreadId != ::GetCurrentThreadId()) {
             throw awt_toolkit_shutdown();
         }


### PR DESCRIPTION
After [JDK-8311380](https://bugs.openjdk.org/browse/JDK-8311380), the dynamic exception specification warning pragma can be removed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8312147](https://bugs.openjdk.org/browse/JDK-8312147): Dynamic Exception Specification warnings are no longer required after JDK-8311380 (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14899/head:pull/14899` \
`$ git checkout pull/14899`

Update a local copy of the PR: \
`$ git checkout pull/14899` \
`$ git pull https://git.openjdk.org/jdk.git pull/14899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14899`

View PR using the GUI difftool: \
`$ git pr show -t 14899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14899.diff">https://git.openjdk.org/jdk/pull/14899.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14899#issuecomment-1637474966)