### PR TITLE
JDK-8304954: SegmentedCodeCache fails when using large pages

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -336,8 +336,8 @@ void CodeCache::initialize_heaps() {
       jio_snprintf(msg, sizeof(msg),
                    "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
                    "Reverting to smaller page size (" SIZE_FORMAT "%s).",
-                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps),
-                   byte_size_in_exact_unit(temp_ps), exact_unit_for_byte_size(temp_ps));
+                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
+                   byte_size_in_exact_unit(temp_ps), exact_unit_for_byte_size(temp_ps),
       log_warning(codecache)("%s", msg);
       warning("%s", msg);
       ps = temp_ps;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -315,7 +315,7 @@ void CodeCache::initialize_heaps() {
   if (UseLargePages) {
     const size_t lg_ps = page_size(false, 1);
     if (ps < lg_ps) {
-      log_warning(codecache)("Failed to reserve large page memory for code cache (" PROPERFMT "). "
+      log_warning(codecache)("Failed to use large page memory for code cache (" PROPERFMT "). "
                              "Reverting to smaller page size (" PROPERFMT ").",
                              PROPERFMTARGS(lg_ps), PROPERFMTARGS(ps));
     }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -312,8 +312,7 @@ void CodeCache::initialize_heaps() {
 
   const size_t ps = page_size(false, 8);
   // Print warning if using large pages but not able to use the size given
-  if (UseLargePages) {
-    if (ps < LargePageSizeInBytes) {
+  if (UseLargePages && ps < LargePageSizeInBytes) {
       char msg[256];
       jio_snprintf(msg, sizeof(msg),
                    "Failed to reserve large page memory for code cache (" SIZE_FORMAT "%s). "
@@ -322,7 +321,6 @@ void CodeCache::initialize_heaps() {
                    byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
       log_warning(codecache)("%s", msg);
       warning("%s", msg);
-    };
   }
 
   // If large page support is enabled, align code heaps according to large

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -312,15 +312,13 @@ void CodeCache::initialize_heaps() {
 
   const size_t ps = page_size(false, 8);
   // Print warning if using large pages but not able to use the size given
-  if (UseLargePages && ps < LargePageSizeInBytes) {
-      char msg[256];
-      jio_snprintf(msg, sizeof(msg),
-                   "Failed to reserve large page memory for code cache (" SIZE_FORMAT "%s). "
-                   "Reverting to smaller page size (" SIZE_FORMAT "%s).",
-                   byte_size_in_exact_unit(LargePageSizeInBytes), exact_unit_for_byte_size(LargePageSizeInBytes),
-                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
-      log_warning(codecache)("%s", msg);
-      warning("%s", msg);
+  if (UseLargePages) {
+    const size_t lg_ps = page_size(false, 1);
+    if (ps < lg_ps) {
+      log_warning(codecache)("Failed to reserve large page memory for code cache (" PROPERFMT "). "
+                             "Reverting to smaller page size (" PROPERFMT ").",
+                             PROPERFMTARGS(lg_ps), PROPERFMTARGS(ps));
+    }
   }
 
   // If large page support is enabled, align code heaps according to large

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -320,27 +320,25 @@ void CodeCache::initialize_heaps() {
   // Check that code heap segments fit in cache when using large pages
   size_t ps = page_size();
   if (UseLargePages) {
-    size_t temp_ps = ps;
-    while (temp_ps > 0 &&
-           align_up(non_nmethod_size, temp_ps) +
-           align_up(profiled_size, temp_ps) +
-           align_up(non_profiled_size, temp_ps) > cache_size) {
-      temp_ps = os::page_sizes().next_smaller(temp_ps);
+    while (ps > 0 &&
+           align_up(non_nmethod_size, ps) +
+           align_up(profiled_size, ps) +
+           align_up(non_profiled_size, ps) > cache_size) {
+      ps = os::page_sizes().next_smaller(ps);
     }
-    if (temp_ps <= 0) {
+    if (ps <= 0) {
       // No small enough page found
       vm_exit_during_initialization(err_msg("Could not reserve enough space for code cache with any page size"));
-    } else if (temp_ps != ps){
+    } else {
       // Smaller page found
       char msg[256];
       jio_snprintf(msg, sizeof(msg),
                    "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
                    "Reverting to smaller page size (" SIZE_FORMAT "%s).",
+                   byte_size_in_exact_unit(page_size()), exact_unit_for_byte_size(page_size()),
                    byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
-                   byte_size_in_exact_unit(temp_ps), exact_unit_for_byte_size(temp_ps),
       log_warning(codecache)("%s", msg);
       warning("%s", msg);
-      ps = temp_ps;
     }
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -324,7 +324,13 @@ void CodeCache::initialize_heaps() {
         align_up(profiled_size, ps) +
         align_up(non_profiled_size, ps) > cache_size) {
       ps = os::page_sizes().next_smaller(ps);
-      log_warning(codecache)("Failed to reserve large page memory for segmented code cache");
+      char msg[256];
+      jio_snprintf(msg, sizeof(msg), "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
+                                     "Reverting to smaller page size (" SIZE_FORMAT "%s).",
+                   byte_size_in_exact_unit(page_size()), exact_unit_for_byte_size(page_size()),
+                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
+      log_warning(codecache)("%s", msg);
+      warning("%s", msg);
     }
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -336,8 +336,8 @@ void CodeCache::initialize_heaps() {
       jio_snprintf(msg, sizeof(msg),
                    "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
                    "Reverting to smaller page size (" SIZE_FORMAT "%s).",
-                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
-                   byte_size_in_exact_unit(temp_ps), exact_unit_for_byte_size(temp_ps),
+                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps),
+                   byte_size_in_exact_unit(temp_ps), exact_unit_for_byte_size(temp_ps));
       log_warning(codecache)("%s", msg);
       warning("%s", msg);
       ps = temp_ps;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -315,7 +315,7 @@ void CodeCache::initialize_heaps() {
   if (UseLargePages) {
     const size_t lg_ps = page_size(false, 1);
     if (ps < lg_ps) {
-      log_warning(codecache)("Failed to use large page memory for code cache (" PROPERFMT "). "
+      log_warning(codecache)("Code cache size too small for " PROPERFMT " pages. "
                              "Reverting to smaller page size (" PROPERFMT ").",
                              PROPERFMTARGS(lg_ps), PROPERFMTARGS(ps));
     }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -320,21 +320,13 @@ void CodeCache::initialize_heaps() {
   // Check that code heap segments fit in cache when using large pages
   size_t ps = page_size();
   if (UseLargePages) {
-    while (ps > 0 &&
-           align_up(non_nmethod_size, ps) +
-           align_up(profiled_size, ps) +
-           align_up(non_profiled_size, ps) > cache_size) {
+    if (align_up(non_nmethod_size, ps) +
+        align_up(profiled_size, ps) +
+        align_up(non_profiled_size, ps) > cache_size) {
       ps = os::page_sizes().next_smaller(ps);
-    }
-    if (ps <= 0) {
-      // No small enough page found
-      vm_exit_during_initialization(err_msg("Could not reserve enough space for code cache with any page size"));
-    } else {
-      // Smaller page found
       char msg[256];
-      jio_snprintf(msg, sizeof(msg),
-                   "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
-                   "Reverting to smaller page size (" SIZE_FORMAT "%s).",
+      jio_snprintf(msg, sizeof(msg), "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
+                                     "Reverting to smaller page size (" SIZE_FORMAT "%s).",
                    byte_size_in_exact_unit(page_size()), exact_unit_for_byte_size(page_size()),
                    byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
       log_warning(codecache)("%s", msg);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -320,25 +320,27 @@ void CodeCache::initialize_heaps() {
   // Check that code heap segments fit in cache when using large pages
   size_t ps = page_size();
   if (UseLargePages) {
-    while (ps > 0 &&
-           align_up(non_nmethod_size, ps) +
-           align_up(profiled_size, ps) +
-           align_up(non_profiled_size, ps) > cache_size) {
-      ps = os::page_sizes().next_smaller(ps);
+    size_t temp_ps = ps;
+    while (temp_ps > 0 &&
+           align_up(non_nmethod_size, temp_ps) +
+           align_up(profiled_size, temp_ps) +
+           align_up(non_profiled_size, temp_ps) > cache_size) {
+      temp_ps = os::page_sizes().next_smaller(temp_ps);
     }
-    if (ps <= 0) {
+    if (temp_ps <= 0) {
       // No small enough page found
       vm_exit_during_initialization(err_msg("Could not reserve enough space for code cache with any page size"));
-    } else {
+    } else if (temp_ps != ps){
       // Smaller page found
       char msg[256];
       jio_snprintf(msg, sizeof(msg),
                    "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
                    "Reverting to smaller page size (" SIZE_FORMAT "%s).",
-                   byte_size_in_exact_unit(page_size()), exact_unit_for_byte_size(page_size()),
                    byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
+                   byte_size_in_exact_unit(temp_ps), exact_unit_for_byte_size(temp_ps),
       log_warning(codecache)("%s", msg);
       warning("%s", msg);
+      ps = temp_ps;
     }
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -324,13 +324,7 @@ void CodeCache::initialize_heaps() {
         align_up(profiled_size, ps) +
         align_up(non_profiled_size, ps) > cache_size) {
       ps = os::page_sizes().next_smaller(ps);
-      char msg[256];
-      jio_snprintf(msg, sizeof(msg), "Failed to reserve large page memory for segmented code cache (" SIZE_FORMAT "%s). "
-                                     "Reverting to smaller page size (" SIZE_FORMAT "%s).",
-                   byte_size_in_exact_unit(page_size()), exact_unit_for_byte_size(page_size()),
-                   byte_size_in_exact_unit(ps), exact_unit_for_byte_size(ps));
-      log_warning(codecache)("%s", msg);
-      warning("%s", msg);
+      log_warning(codecache)("Failed to reserve large page memory for segmented code cache");
     }
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -312,7 +312,8 @@ void CodeCache::initialize_heaps() {
 
   // If large page support is enabled, align code heaps according to large
   // page size to make sure that code cache is covered by large pages.
-  const size_t alignment = MAX2(page_size(false, 8), os::vm_allocation_granularity());
+  const size_t ps = page_size(false, 8);
+  const size_t alignment = MAX2(ps, os::vm_allocation_granularity());
   non_nmethod_size = align_up(non_nmethod_size, alignment);
   profiled_size    = align_down(profiled_size, alignment);
   non_profiled_size = align_down(non_profiled_size, alignment);
@@ -324,7 +325,7 @@ void CodeCache::initialize_heaps() {
   //         Non-nmethods
   //      Profiled nmethods
   // ---------- low ------------
-  ReservedCodeSpace rs = reserve_heap_memory(cache_size);
+  ReservedCodeSpace rs = reserve_heap_memory(cache_size, ps);
   ReservedSpace profiled_space      = rs.first_part(profiled_size);
   ReservedSpace rest                = rs.last_part(profiled_size);
   ReservedSpace non_method_space    = rest.first_part(non_nmethod_size);
@@ -354,9 +355,8 @@ size_t CodeCache::page_size(bool aligned, size_t min_pages) {
   }
 }
 
-ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size) {
+ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size, size_t rs_ps) {
   // Align and reserve space for code cache
-  const size_t rs_ps = page_size(false, 8);
   if (UseLargePages) {
     const size_t ps = page_size();
     if (rs_ps < ps) {
@@ -1207,7 +1207,7 @@ void CodeCache::initialize() {
     FLAG_SET_ERGO(NonNMethodCodeHeapSize, (uintx)os::vm_page_size());
     FLAG_SET_ERGO(ProfiledCodeHeapSize, 0);
     FLAG_SET_ERGO(NonProfiledCodeHeapSize, 0);
-    ReservedCodeSpace rs = reserve_heap_memory(ReservedCodeCacheSize);
+    ReservedCodeSpace rs = reserve_heap_memory(ReservedCodeCacheSize, page_size(false, 8));
     // Register CodeHeaps with LSan as we sometimes embed pointers to malloc memory.
     LSAN_REGISTER_ROOT_REGION(rs.base(), rs.size());
     add_heap(rs, "CodeCache", CodeBlobType::All);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -317,17 +317,6 @@ void CodeCache::initialize_heaps() {
   profiled_size    = align_down(profiled_size, alignment);
   non_profiled_size = align_down(non_profiled_size, alignment);
 
-  // Check that code heap segments fit in cache when using large pages
-  size_t ps = page_size();
-  if (UseLargePages) {
-    if (align_up(non_nmethod_size, ps) +
-        align_up(profiled_size, ps) +
-        align_up(non_profiled_size, ps) > cache_size) {
-      ps = os::page_sizes().next_smaller(ps);
-      log_warning(codecache)("Failed to reserve large page memory for segmented code cache");
-    }
-  }
-
   // Reserve one continuous chunk of memory for CodeHeaps and split it into
   // parts for the individual heaps. The memory layout looks like this:
   // ---------- high -----------
@@ -335,7 +324,7 @@ void CodeCache::initialize_heaps() {
   //         Non-nmethods
   //      Profiled nmethods
   // ---------- low ------------
-  ReservedCodeSpace rs = reserve_heap_memory(cache_size, ps);
+  ReservedCodeSpace rs = reserve_heap_memory(cache_size);
   ReservedSpace profiled_space      = rs.first_part(profiled_size);
   ReservedSpace rest                = rs.last_part(profiled_size);
   ReservedSpace non_method_space    = rest.first_part(non_nmethod_size);
@@ -365,11 +354,12 @@ size_t CodeCache::page_size(bool aligned, size_t min_pages) {
   }
 }
 
-ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size, size_t page_size) {
+ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size) {
   // Align and reserve space for code cache
-  const size_t rs_align = MAX2(page_size, os::vm_allocation_granularity());
+  const size_t rs_ps = page_size();
+  const size_t rs_align = MAX2(rs_ps, os::vm_allocation_granularity());
   const size_t rs_size = align_up(size, rs_align);
-  ReservedCodeSpace rs(rs_size, rs_align, page_size);
+  ReservedCodeSpace rs(rs_size, rs_align, rs_ps);
   if (!rs.is_reserved()) {
     vm_exit_during_initialization(err_msg("Could not reserve enough space for code cache (" SIZE_FORMAT "K)",
                                           rs_size/K));

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -121,7 +121,7 @@ class CodeCache : AllStatic {
   static CodeHeap* get_code_heap(CodeBlobType code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
   // Returns the name of the VM option to set the size of the corresponding CodeHeap
   static const char* get_code_heap_flag_name(CodeBlobType code_blob_type);
-  static ReservedCodeSpace reserve_heap_memory(size_t size);  // Reserves one continuous chunk of memory for the CodeHeaps
+  static ReservedCodeSpace reserve_heap_memory(size_t size, size_t rs_ps); // Reserves one continuous chunk of memory for the CodeHeaps
 
   // Iteration
   static CodeBlob* first_blob(CodeHeap* heap);                // Returns the first CodeBlob on the given CodeHeap

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -121,7 +121,10 @@ class CodeCache : AllStatic {
   static CodeHeap* get_code_heap(CodeBlobType code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
   // Returns the name of the VM option to set the size of the corresponding CodeHeap
   static const char* get_code_heap_flag_name(CodeBlobType code_blob_type);
-  static ReservedCodeSpace reserve_heap_memory(size_t size);  // Reserves one continuous chunk of memory for the CodeHeaps
+  static ReservedCodeSpace reserve_heap_memory(size_t size, size_t page_size);  // Reserves one continuous chunk of memory for the CodeHeaps
+  static ReservedCodeSpace reserve_heap_memory(size_t size) { // Calls the above with current page size
+    return reserve_heap_memory(size, page_size());
+  };
 
   // Iteration
   static CodeBlob* first_blob(CodeHeap* heap);                // Returns the first CodeBlob on the given CodeHeap

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -121,10 +121,7 @@ class CodeCache : AllStatic {
   static CodeHeap* get_code_heap(CodeBlobType code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
   // Returns the name of the VM option to set the size of the corresponding CodeHeap
   static const char* get_code_heap_flag_name(CodeBlobType code_blob_type);
-  static ReservedCodeSpace reserve_heap_memory(size_t size, size_t page_size);  // Reserves one continuous chunk of memory for the CodeHeaps
-  static ReservedCodeSpace reserve_heap_memory(size_t size) { // Calls the above with current page size
-    return reserve_heap_memory(size, page_size());
-  };
+  static ReservedCodeSpace reserve_heap_memory(size_t size);  // Reserves one continuous chunk of memory for the CodeHeaps
 
   // Iteration
   static CodeBlob* first_blob(CodeHeap* heap);                // Returns the first CodeBlob on the given CodeHeap

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8304954
- * @summary Test checks that if using large pages and code cache gets above the limit it tries to revert to smaller pages instead of failing
+ * @summary Code cache reservation should gracefully downgrade to using smaller pages if the code cache size is too small to host the requested page size.
+ * @requires os.family == "linux"
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
@@ -51,10 +52,9 @@ public class CheckLargePages {
                     "-XX:InitialCodeCacheSize=2g",
                     "-XX:ReservedCodeCacheSize=2g",
                     "-XX:LargePageSizeInBytes=1g",
-                    "-Xlog:pagesize*=debug",
                     "-version");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
-            out.shouldContain("Failed to reserve large page memory for code cache");
+            out.shouldContain("Failed to use large page memory for code cache");
             out.shouldHaveExitValue(0);
         } else {
             System.out.println("1GB large pages not supported: UseLargePages=" + largePages +

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8304954
  * @summary Test checks that if using large pages and code cache gets above the limit it tries to revert to smaller pages instead of failing
+ * @requires vm.gc != "Z"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -54,7 +54,7 @@ public class CheckLargePages {
                     "-Xlog:pagesize*=debug",
                     "-version");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
-            out.shouldContain("Failed to reserve large page memory for segmented code cache");
+            out.shouldContain("Failed to reserve large page memory for code cache");
             out.shouldHaveExitValue(0);
         } else {
             System.out.println("1GB large pages not supported: UseLargePages=" + largePages +

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -35,9 +35,13 @@
 
 package compiler.codecache;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.whitebox.WhiteBox;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class CheckLargePages {
     private final static WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
@@ -52,13 +56,43 @@ public class CheckLargePages {
                     "-XX:InitialCodeCacheSize=2g",
                     "-XX:ReservedCodeCacheSize=2g",
                     "-XX:LargePageSizeInBytes=1g",
+                    "-Xlog:pagesize=info",
                     "-version");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
             out.shouldContain("Failed to use large page memory for code cache");
             out.shouldHaveExitValue(0);
+            // Parse page sizes to find next smaller page
+            String sizes = out.firstMatch("Usable page sizes:(.*)", 1);
+            List<Long> sizeList = Arrays.stream(sizes.trim().split("\\s*,\\s*")).map(CheckLargePages::parseMemoryString).sorted().toList();
+            final int smallerPageSizeIndex = sizeList.indexOf(largePageSize) - 1;
+            Asserts.assertGreaterThanOrEqual(smallerPageSizeIndex, 0);
+            final long smallerPageSize = sizeList.get(smallerPageSizeIndex);
+            // Retrieve reverted page size from code cache warning
+            String revertedSizeString = out.firstMatch("Failed to use large page memory for code cache \\((.*)\\)\\. Reverting to smaller page size \\((.*)\\)\\.", 2);
+            Asserts.assertEquals(parseMemoryString(revertedSizeString), smallerPageSize);
         } else {
             System.out.println("1GB large pages not supported: UseLargePages=" + largePages +
                     (largePages ? ", largePageSize=" + largePageSize : "") + ". Skipping");
         }
+    }
+
+    public static long parseMemoryString(String value) {
+        value = value.toUpperCase();
+        long multiplier = 1;
+        if (value.endsWith("B")) {
+            multiplier = 1;
+        } else if (value.endsWith("K")) {
+            multiplier = 1024;
+        } else if (value.endsWith("M")) {
+            multiplier = 1024 * 1024;
+        } else if (value.endsWith("G")) {
+            multiplier = 1024 * 1024 * 1024;
+        } else {
+            throw new IllegalArgumentException("Expected memory string '" + value + "'to end with either of: B, K, M, G");
+        }
+
+        long longValue = Long.parseUnsignedLong(value.substring(0, value.length() - 1));
+
+        return longValue * multiplier;
     }
 }

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -59,7 +59,7 @@ public class CheckLargePages {
                     "-Xlog:pagesize=info",
                     "-version");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
-            out.shouldContain("Failed to use large page memory for code cache");
+            out.shouldMatch("Code cache size too small for \\S* pages\\. Reverting to smaller page size \\((\\S*)\\)\\.");
             out.shouldHaveExitValue(0);
             // Parse page sizes to find next biggest page
             String sizes = out.firstMatch("Usable page sizes:(.*)", 1);
@@ -68,7 +68,7 @@ public class CheckLargePages {
             Asserts.assertGreaterThanOrEqual(smallerPageSizeIndex, 0);
             final long smallerPageSize = sizeList.get(smallerPageSizeIndex);
             // Retrieve reverted page size from code cache warning
-            String revertedSizeString = out.firstMatch("Failed to use large page memory for code cache \\((.*)\\)\\. Reverting to smaller page size \\((.*)\\)\\.", 2);
+            String revertedSizeString = out.firstMatch("Code cache size too small for (\\S*) pages. Reverting to smaller page size \\((\\S*)\\)\\.", 2);
             Asserts.assertEquals(parseMemoryString(revertedSizeString), smallerPageSize);
         } else {
             System.out.println("1GB large pages not supported: UseLargePages=" + largePages +

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8304954
+ * @summary Test checks that if using large pages and code cache gets above the limit it tries to revert to smaller pages instead of failing
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseLargePages -XX:LargePageSizeInBytes=1g compiler.codecache.CheckLargePages
+ */
+
+package compiler.codecache;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.whitebox.WhiteBox;
+
+public class CheckLargePages {
+    private final static WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        final boolean largePages = WHITE_BOX.getBooleanVMFlag("UseLargePages");
+        final long largePageSize = WHITE_BOX.getVMLargePageSize();
+        if (largePages && (largePageSize == 1024 * 1024 * 1024)) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    "-XX:+UseLargePages",
+                    "-XX:+SegmentedCodeCache",
+                    "-XX:InitialCodeCacheSize=2g",
+                    "-XX:ReservedCodeCacheSize=2g",
+                    "-XX:LargePageSizeInBytes=1g",
+                    "-Xlog:pagesize*=debug",
+                    "-version");
+            OutputAnalyzer out = new OutputAnalyzer(pb.start());
+            out.shouldContain("Failed to reserve large page memory for segmented code cache");
+            out.shouldHaveExitValue(0);
+        } else {
+            System.out.println("1GB large pages not supported: UseLargePages=" + largePages +
+                    (largePages ? ", largePageSize=" + largePageSize : "") + ". Skipping");
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -61,7 +61,7 @@ public class CheckLargePages {
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
             out.shouldContain("Failed to use large page memory for code cache");
             out.shouldHaveExitValue(0);
-            // Parse page sizes to find next smaller page
+            // Parse page sizes to find next biggest page
             String sizes = out.firstMatch("Usable page sizes:(.*)", 1);
             List<Long> sizeList = Arrays.stream(sizes.trim().split("\\s*,\\s*")).map(CheckLargePages::parseMemoryString).sorted().toList();
             final int smallerPageSizeIndex = sizeList.indexOf(largePageSize) - 1;


### PR DESCRIPTION
# Issue

When large pages are enabled and segmented code cache is used, the VM tries to use one page for each segment. If the amount of reserved code cache is limited, this can make the total size of the code cache bigger than the reserved size, which in turn makes the VM fail, claiming that there is not enough space (e.g. this happens when running `java -XX:+UseLargePages -XX:+SegmentedCodeCache -XX:InitialCodeCacheSize=2g -XX:ReservedCodeCacheSize=2g -XX:LargePageSizeInBytes=1g -Xlog:pagesize*=debug -version`).
This behaviour is not correct as the VM should fall back and try with a smaller page size (and print a warning).

# Solution

When reserving heap space for code cache we give a minimum of 8 pages. Since the page size is already calculated right before for segment sizes, it is saved and passed as an argument instead.

https://github.com/openjdk/jdk/blob/67fbd87378a9b3861f1676977f9f2b36052add29/src/hotspot/share/code/codeCache.cpp#L315

Additionally a warning is printed if large pages are enabled and we end up using a smaller page sizes for code caching.

# Test

The regression test runs a new VM with `-XX:+UseLargePages -XX:LargePageSizeInBytes=1g`. The `main` method then checks if the two flags have been "taken". If so, another process is started that checks for a specific output, otherwise the test passes (i.e. the current system doesn't allow 1GB large pages)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304954](https://bugs.openjdk.org/browse/JDK-8304954): SegmentedCodeCache fails when using large pages (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [eea06dd6](https://git.openjdk.org/jdk/pull/14903/files/eea06dd63671e47752de747ac452e94b9ba25433)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [e1b09a9f](https://git.openjdk.org/jdk/pull/14903/files/e1b09a9fe267d6aa48f4656652411000a4f4d2ee)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14903/head:pull/14903` \
`$ git checkout pull/14903`

Update a local copy of the PR: \
`$ git checkout pull/14903` \
`$ git pull https://git.openjdk.org/jdk.git pull/14903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14903`

View PR using the GUI difftool: \
`$ git pr show -t 14903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14903.diff">https://git.openjdk.org/jdk/pull/14903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14903#issuecomment-1643833785)