### PR TITLE
8312180: (bf) MappedMemoryUtils passes incorrect arguments to msync (aix)

### DIFF
--- a/src/java.base/aix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/aix/native/libnio/MappedMemoryUtils.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "jni_util.h"
+#include "java_nio_MappedMemoryUtils.h"
+
+JNIEXPORT jint JNICALL
+Java_java_nio_MappedMemoryUtils_pageSize0()
+{
+    return (jint)sysconf(_SC_PAGESIZE);
+}

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -176,5 +176,5 @@ import jdk.internal.misc.Unsafe;
         }
     }
 
-    private static native int pageSize0();
+    private static native int pageSize0(Object changeToReGenerateHeaderfile);
 }

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -167,7 +167,7 @@ import jdk.internal.misc.Unsafe;
 
     // Returns the platform defined page size, which could be different from the one Bits.pageSize
     // is aware of. If no implementation is provided, return Bits.pageSize instead.
-    private static ing pageSize() {
+    private static int pageSize() {
         int ps = pageSize0();
         if (ps > 0) {
             return ps;

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -130,7 +130,7 @@ import jdk.internal.misc.Unsafe;
     // the mapping less than or equal to the element address. Computed
     // each time to avoid storing in every direct buffer.
     private static long mappingOffset(long address, long index) {
-        int ps = Bits.pageSize();
+        int ps = pageSize();
         long indexAddress = address + index;
         long baseAddress = alignDown(indexAddress, ps);
         return indexAddress - baseAddress;
@@ -164,4 +164,17 @@ import jdk.internal.misc.Unsafe;
         // pageSize must be a power of 2
         return address & ~(pageSize - 1);
     }
+
+    // Returns the platform defined page size, which could be different from the one Bits.pageSize
+    // is aware of. If no implementation is provided, return Bits.pageSize instead.
+    private static ing pageSize() {
+        int ps = pageSize0();
+        if (ps > 0) {
+            return ps;
+        } else {
+            return Bits.pageSize();
+        }
+    }
+
+    private static native int pageSize0();
 }

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -176,5 +176,5 @@ import jdk.internal.misc.Unsafe;
         }
     }
 
-    private static native int pageSize0(Object changeToReGenerateHeaderfile);
+    private static native int pageSize0();
 }

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -135,3 +135,9 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
         JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed");
     }
 }
+
+JNIEXPORT jint JNICALL
+Java_java_nio_MappedMemoryUtils_pageSize0()
+{
+    return (jint)sysconf(_SC_PAGESIZE);
+}

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -139,5 +139,6 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
 JNIEXPORT jint JNICALL
 Java_java_nio_MappedMemoryUtils_pageSize0()
 {
-    return (jint)sysconf(_SC_PAGESIZE);
+    // not required on AIX
+    return -1;
 }

--- a/src/java.base/windows/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/windows/native/libnio/MappedMemoryUtils.c
@@ -106,3 +106,10 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
         JNU_ThrowIOExceptionWithLastError(env, "Flush failed");
     }
 }
+
+JNIEXPORT jint JNICALL
+Java_java_nio_MappedMemoryUtils_pageSize0()
+{
+    // Not required on Windows.
+    return -1;
+}


### PR DESCRIPTION
Calls to `msync` on AIX require the length to be a multiple of a specific pagesize which may not be the same as the one returned by `Bits.pageSize()`, as explained in the JBS issue description.

> EINVAL The addr argument is not a multiple of the page size as **returned by the sysconf subroutine using the _SC_PAGE_SIZE value for the Name parameter**, ...
[emphasis added by me]

By adding this as platform dependant code, the correct value of page size is used on AIX. Other Unix platforms should see no change by calling sysconf instead of Bits.pagesize. Windows is unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312180](https://bugs.openjdk.org/browse/JDK-8312180): (bf) MappedMemoryUtils passes incorrect arguments to msync (aix) (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14904/head:pull/14904` \
`$ git checkout pull/14904`

Update a local copy of the PR: \
`$ git checkout pull/14904` \
`$ git pull https://git.openjdk.org/jdk.git pull/14904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14904`

View PR using the GUI difftool: \
`$ git pr show -t 14904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14904.diff">https://git.openjdk.org/jdk/pull/14904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14904#issuecomment-1639000495)