### PR TITLE
8310629: java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java fails with RuntimeException Server not ready

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -189,7 +189,7 @@ public class OCSPTimeout {
         rootOcsp.start();
 
         // Wait 5 seconds for server ready
-        boolean readyStatus = rootOcsp.awaitServerReady(5, TimeUnit.SECONDS);
+        boolean readyStatus = rootOcsp.awaitServerReady(60, TimeUnit.SECONDS);
         if (!readyStatus) {
             throw new RuntimeException("Server not ready");
         }


### PR DESCRIPTION
In this PR, i raised the client timeout from 5 to 60 seconds. I considered refactoring the SimpleOSCPServer class a little but ultimately, the client needs to just wait until the server is ready or a time-out is reached. Alternately, we can wait indefinitely and let the test time out but that results in holding onto resources for too long.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310629](https://bugs.openjdk.org/browse/JDK-8310629): java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java fails with RuntimeException  Server not ready (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14905/head:pull/14905` \
`$ git checkout pull/14905`

Update a local copy of the PR: \
`$ git checkout pull/14905` \
`$ git pull https://git.openjdk.org/jdk.git pull/14905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14905`

View PR using the GUI difftool: \
`$ git pr show -t 14905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14905.diff">https://git.openjdk.org/jdk/pull/14905.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14905#issuecomment-1638608345)