### PR TITLE
8312189: ProblemList serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -117,6 +117,7 @@ serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
+serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1 8300051 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
 serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64


### PR DESCRIPTION
A trivial fix to problem list the test:
`  serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1`

This recently added test is frequently failing on Windows but has a potential to fail on other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312189](https://bugs.openjdk.org/browse/JDK-8312189): ProblemList serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1 (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14906/head:pull/14906` \
`$ git checkout pull/14906`

Update a local copy of the PR: \
`$ git checkout pull/14906` \
`$ git pull https://git.openjdk.org/jdk.git pull/14906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14906`

View PR using the GUI difftool: \
`$ git pr show -t 14906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14906.diff">https://git.openjdk.org/jdk/pull/14906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14906#issuecomment-1638659308)