### PR TITLE
8312190: Fix c++11-narrowing warnings in hotspot code

### DIFF
--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -31,7 +31,7 @@
 #include "runtime/handles.hpp"
 #include "runtime/signature.hpp"
 
-enum {
+enum : uint {
   // As specified in the JVM spec
   ITEM_Top = 0,
   ITEM_Integer = 1,
@@ -67,7 +67,7 @@ class VerificationType {
     };
 
     // Enum for the _data field
-    enum {
+    enum : uint {
       // Bottom two bits determine if the type is a reference, primitive,
       // uninitialized or a query-type.
       TypeMask           = 0x00000003,

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -245,7 +245,7 @@ do {                                                                            
 
 
 // types of VM error - originally in vmError.hpp
-enum VMErrorType {
+enum VMErrorType : unsigned int {
   INTERNAL_ERROR   = 0xe0000000,
   OOM_MALLOC_ERROR = 0xe0000001,
   OOM_MMAP_ERROR   = 0xe0000002,


### PR DESCRIPTION
This patch fixes compilation warnings produced by Clang when compiling on Windows.

Clang emulates MSVC behavior and uses `int` for enumeration types that do not explicitly specify the underlying type. This patch sets an explicit underlying type for 3 enumerations to fix the warnings.

See Microsoft's documentation of [Zc:enumTypes](https://learn.microsoft.com/en-us/cpp/build/reference/zc-enumtypes?view=msvc-170) for more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312190](https://bugs.openjdk.org/browse/JDK-8312190): Fix c++11-narrowing warnings in hotspot code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14907/head:pull/14907` \
`$ git checkout pull/14907`

Update a local copy of the PR: \
`$ git checkout pull/14907` \
`$ git pull https://git.openjdk.org/jdk.git pull/14907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14907`

View PR using the GUI difftool: \
`$ git pr show -t 14907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14907.diff">https://git.openjdk.org/jdk/pull/14907.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14907#issuecomment-1639427545)