### PR TITLE
JDK-8312195: Changes in JDK-8284493 use wrong copyright syntax

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/random/RandomGeneratorNext.java
+++ b/test/micro/org/openjdk/bench/java/util/random/RandomGeneratorNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/random/RandomNext.java
+++ b/test/micro/org/openjdk/bench/java/util/random/RandomNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Update to conform to accepted syntax.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312195](https://bugs.openjdk.org/browse/JDK-8312195): Changes in JDK-8284493 use wrong copyright syntax (**Bug** - P2)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14908/head:pull/14908` \
`$ git checkout pull/14908`

Update a local copy of the PR: \
`$ git checkout pull/14908` \
`$ git pull https://git.openjdk.org/jdk.git pull/14908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14908`

View PR using the GUI difftool: \
`$ git pr show -t 14908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14908.diff">https://git.openjdk.org/jdk/pull/14908.diff</a>

</details>
