### PR TITLE
JDK-8312196 ProblemList test/hotspot/jtreg/applications/ctw/modules/jdk_crypto_ec.java 

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,6 +104,7 @@ runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java 8305489 linux-all
 
 applications/jcstress/copy.java 8229852 linux-all
+applications/ctw/modules/jdk_crypto_ec.java 8312194 generic-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-x64


### PR DESCRIPTION
I need a review to add the jdk_crypto_ec.java test.  The test will need to be evaluated for removal or change.  jdk.crypto.ec is now a deprecated module that is empty module, which this test doesn't appear to handle well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312196](https://bugs.openjdk.org/browse/JDK-8312196): ProblemList test/hotspot/jtreg/applications/ctw/modules/jdk_crypto_ec.java (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14909/head:pull/14909` \
`$ git checkout pull/14909`

Update a local copy of the PR: \
`$ git checkout pull/14909` \
`$ git pull https://git.openjdk.org/jdk.git pull/14909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14909`

View PR using the GUI difftool: \
`$ git pr show -t 14909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14909.diff">https://git.openjdk.org/jdk/pull/14909.diff</a>

</details>
