### PR TITLE
8312163: Crash in dominance check when compiling unnamed patterns

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4734,7 +4734,7 @@ public class Check {
                 }
             }
             if (currentPattern instanceof JCBindingPattern) {
-                return existingPattern instanceof JCBindingPattern;
+                return existingPattern instanceof JCBindingPattern || existingPattern instanceof JCAnyPattern;
             } else if (currentPattern instanceof JCRecordPattern currentRecordPattern) {
                 if (existingPattern instanceof JCBindingPattern) {
                     return true;
@@ -4752,10 +4752,19 @@ public class Check {
                         currentNested = currentNested.tail;
                     }
                     return true;
-                } else {
+                } else if (existingPattern instanceof JCAnyPattern) {
+                    return true;
+                }
+                else {
                     Assert.error("Unknown pattern: " + existingPattern.getTag());
                 }
-            } else {
+            } else if (currentPattern instanceof JCAnyPattern) {
+                if(existingPattern instanceof JCAnyPattern) {
+                    return true;
+                } else {
+                    return existingPattern instanceof JCBindingPattern;
+                }
+            } {
                 Assert.error("Unknown pattern: " + currentPattern.getTag());
             }
             return false;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4733,10 +4733,13 @@ public class Check {
                     return false;
                 }
             }
-            if (currentPattern instanceof JCBindingPattern) {
-                return existingPattern instanceof JCBindingPattern || existingPattern instanceof JCAnyPattern;
+            if (currentPattern instanceof JCBindingPattern ||
+                currentPattern instanceof JCAnyPattern) {
+                return existingPattern instanceof JCBindingPattern ||
+                       existingPattern instanceof JCAnyPattern;
             } else if (currentPattern instanceof JCRecordPattern currentRecordPattern) {
-                if (existingPattern instanceof JCBindingPattern) {
+                if (existingPattern instanceof JCBindingPattern ||
+                    existingPattern instanceof JCAnyPattern) {
                     return true;
                 } else if (existingPattern instanceof JCRecordPattern existingRecordPattern) {
                     List<JCPattern> existingNested = existingRecordPattern.nested;
@@ -4752,19 +4755,10 @@ public class Check {
                         currentNested = currentNested.tail;
                     }
                     return true;
-                } else if (existingPattern instanceof JCAnyPattern) {
-                    return true;
-                }
-                else {
+                } else {
                     Assert.error("Unknown pattern: " + existingPattern.getTag());
                 }
-            } else if (currentPattern instanceof JCAnyPattern) {
-                if(existingPattern instanceof JCAnyPattern) {
-                    return true;
-                } else {
-                    return existingPattern instanceof JCBindingPattern;
-                }
-            } {
+            } else {
                 Assert.error("Unknown pattern: " + currentPattern.getTag());
             }
             return false;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -879,6 +879,7 @@ public class JavacParser implements Parser {
         JCExpression e;
         if (token.kind == UNDERSCORE && parsedType == null) {
             nextToken();
+            checkSourceLevel(Feature.UNNAMED_VARIABLES);
             pattern = toP(F.at(token.pos).AnyPattern());
         }
         else {

--- a/test/langtools/tools/javac/T8312163.java
+++ b/test/langtools/tools/javac/T8312163.java
@@ -1,0 +1,57 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8312163
+ * @summary Crash in dominance check when compiling unnamed patterns
+ * @enablePreview
+ * @compile/fail/ref=T8312163.out -XDrawDiagnostics T8312163.java
+ */
+public class T8312163 {
+    sealed interface A permits B {}
+    record B() implements A {}
+
+    record Rec(A a, A b) {}
+
+    public void test(Rec r)
+    {
+        switch (r) {
+            case Rec(_, _): break;
+            case Rec(_, B()):   // dominated
+        }
+
+        switch (r) {
+            case Rec(_, B()): break;
+            case Rec(_, _):
+        }
+
+        switch (r) {
+            case Rec(_, _): break;
+            case Rec(_, A a):   // dominated
+        }
+
+        switch (r) {
+            case Rec(_, A a): break;
+            case Rec(_, _): // dominated
+        }
+
+        // duplicated unnamed patterns with unnamed pattern variables for reference
+        switch (r) {
+            case Rec(var _, var _): break;
+            case Rec(var _, B()):   // dominated
+        }
+
+        switch (r) {
+            case Rec(var _, B()): break;
+            case Rec(var _, var _):
+        }
+
+        switch (r) {
+            case Rec(var _, var _): break;
+            case Rec(var _, A a):   // dominated
+        }
+
+        switch (r) {
+            case Rec(var _, A a): break;
+            case Rec(var _, var _): // dominated
+        }
+    }
+}

--- a/test/langtools/tools/javac/T8312163.out
+++ b/test/langtools/tools/javac/T8312163.out
@@ -1,0 +1,9 @@
+T8312163.java:18:18: compiler.err.pattern.dominated
+T8312163.java:28:18: compiler.err.pattern.dominated
+T8312163.java:33:18: compiler.err.pattern.dominated
+T8312163.java:39:18: compiler.err.pattern.dominated
+T8312163.java:49:18: compiler.err.pattern.dominated
+T8312163.java:54:18: compiler.err.pattern.dominated
+- compiler.note.preview.filename: T8312163.java, DEFAULT
+- compiler.note.preview.recompile
+6 errors


### PR DESCRIPTION
The following fixes a crash in dominance checking involving unnamed patterns by teaching the method `patternDominated` how to handle `AnyPattern` nodes. The test file includes snippets with `_` that need to expose the same behavior as if `var _` was used in all nested positions in place of just `_`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312163](https://bugs.openjdk.org/browse/JDK-8312163): Crash in dominance check when compiling unnamed patterns (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [c8b6c196](https://git.openjdk.org/jdk/pull/14912/files/c8b6c196bbbe48de3bc7d23f9ed36be97fc3839c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14912/head:pull/14912` \
`$ git checkout pull/14912`

Update a local copy of the PR: \
`$ git checkout pull/14912` \
`$ git pull https://git.openjdk.org/jdk.git pull/14912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14912`

View PR using the GUI difftool: \
`$ git pr show -t 14912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14912.diff">https://git.openjdk.org/jdk/pull/14912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14912#issuecomment-1638949040)