### PR TITLE
8309475: Test java/foreign/TestByteBuffer.java fails: a problem with msync (aix)

### DIFF
--- a/src/java.base/aix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/aix/native/libnio/MappedMemoryUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/aix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/aix/native/libnio/MappedMemoryUtils.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "jni_util.h"
+#include "jvm.h"
+#include "jlong.h"
+#include "java_nio_MappedMemoryUtils.h"
+#include <assert.h>
+#include <sys/mman.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/procfs.h>
+#include <unistd.h>
+
+void set_error_if_shared(JNIEnv* env, prmap_t* map_entry)
+{
+    if (map_entry->pr_mflags & MA_SHARED) {
+        // MA_SHARED => MAP_SHARED => !MAP_PRIVATE. This error is valid and should be thrown.
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed (MAP_SHARED)");
+        return;
+    } else {
+        // O.W. MAP_PRIVATE or no flag was specified and EINVAL is the expected behaviour.
+        return;
+    }
+}
+
+void check_proc_map_array(JNIEnv* env, FILE* proc_file, prmap_t* map_entry, void* end_address)
+{
+    while (!feof(proc_file)) {
+        memset(map_entry, '\0', sizeof(prmap_t));
+        fread((char*)map_entry, sizeof(prmap_t), 1, proc_file);
+        if (ferror(proc_file)) {
+            JNU_ThrowIOExceptionWithMessageAndLastError(env,
+                        "msync with parameter MS_SYNC failed (could not read /proc/<pid>/map)");
+            return;
+        } else if (map_entry->pr_vaddr <= end_address &&
+                   end_address <= map_entry->pr_vaddr + map_entry->pr_size) {
+            set_error_if_shared(env, map_entry);
+            return;
+        }
+    }
+    JNU_ThrowIOExceptionWithMessageAndLastError(env,
+                                    "msync with parameter MS_SYNC failed (address not found)");
+}
+
+// '/proc/' + <pid> + '/map' + '\0'
+#define PFNAME_LEN 32
+void check_aix_einval(JNIEnv* env, void* end_address)
+{
+    // If EINVAL is set for a mmap address on AIX, additional validation is required.
+    // AIX will set EINVAL when msync is called on a mmap address that didn't receive MAP_SHARED
+    // as a flag (since MAP_PRIVATE is the default).
+    // https://www.ibm.com/docs/en/aix/7.2?topic=m-msync-subroutine
+
+    FILE* proc_file;
+    {
+        char* fname = (char*) malloc(sizeof(char) * PFNAME_LEN);
+        pid_t the_pid = getpid();
+        jio_snprintf(fname, PFNAME_LEN, "/proc/%d/map", the_pid);
+        proc_file = fopen(fname, "r");
+        free(fname);
+    }
+    if (!proc_file) {
+        JNU_ThrowIOExceptionWithMessageAndLastError(env,
+                        "msync with parameter MS_SYNC failed (could not open /proc/<pid>/map)");
+        return;
+    }
+    {
+        prmap_t* map_entry = (prmap_t*) malloc(sizeof(prmap_t));
+        check_proc_map_array(env, proc_file, map_entry, end_address);
+        free(map_entry);
+    }
+    fclose(proc_file);
+}
+
+// Normally we would just let msync handle this, but since we'll be (potentially) ignoring
+// the error code returned by msync, we check the args before the call instead.
+int validate_msync_address(size_t addresss) {
+    size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
+    if (address % pagesize != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+JNIEXPORT void JNICALL
+Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
+                                      jlong address, jlong len)
+{
+    void* a = (void *)jlong_to_ptr(address);
+    if (validate_msync_address((size_t)a) > 0) {
+        JNU_ThrowIOExceptionWithMessageAndLastError(env,
+            "msync with parameter MS_SYNC failed (arguments invalid)");
+        return;
+    }
+    int result = msync(a, (size_t)len, MS_SYNC);
+    if (result == -1) {
+        void* end_address = (void*)jlong_to_ptr(address + len);
+        if (errno == EINVAL) {
+            check_aix_einval(env, end_address);
+            return;
+        }
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed");
+    }
+}

--- a/src/java.base/aix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/aix/native/libnio/MappedMemoryUtils.c
@@ -99,7 +99,7 @@ void check_aix_einval(JNIEnv* env, void* end_address)
 
 // Normally we would just let msync handle this, but since we'll be (potentially) ignoring
 // the error code returned by msync, we check the args before the call instead.
-int validate_msync_address(size_t addresss) {
+int validate_msync_address(size_t address) {
     size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
     if (address % pagesize != 0) {
         errno = EINVAL;

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -167,7 +167,7 @@ import jdk.internal.misc.Unsafe;
 
     // Returns the platform defined page size, which could be different from the one Bits.pageSize
     // is aware of. If no implementation is provided, return Bits.pageSize instead.
-    private static ing pageSize() {
+    private static int pageSize() {
         int ps = pageSize0();
         if (ps > 0) {
             return ps;

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -130,7 +130,7 @@ import jdk.internal.misc.Unsafe;
     // the mapping less than or equal to the element address. Computed
     // each time to avoid storing in every direct buffer.
     private static long mappingOffset(long address, long index) {
-        int ps = Bits.pageSize();
+        int ps = pageSize();
         long indexAddress = address + index;
         long baseAddress = alignDown(indexAddress, ps);
         return indexAddress - baseAddress;
@@ -164,4 +164,17 @@ import jdk.internal.misc.Unsafe;
         // pageSize must be a power of 2
         return address & ~(pageSize - 1);
     }
+
+    // Returns the platform defined page size, which could be different from the one Bits.pageSize
+    // is aware of. If no implementation is provided, return Bits.pageSize instead.
+    private static ing pageSize() {
+        int ps = pageSize0();
+        if (ps > 0) {
+            return ps;
+        } else {
+            return Bits.pageSize();
+        }
+    }
+
+    private static native int pageSize0();
 }

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -34,6 +34,8 @@
 #include <stdlib.h>
 
 #ifdef _AIX
+#include <string.h>
+#include <sys/procfs.h>
 #include <unistd.h>
 #endif
 
@@ -124,14 +126,99 @@ Java_java_nio_MappedMemoryUtils_unload0(JNIEnv *env, jobject obj, jlong address,
         JNU_ThrowIOExceptionWithMessageAndLastError(env, "madvise with advise MADV_DONTNEED failed");
     }
 }
+#ifdef AIX
+    void set_error_if_shared(JNIEnv* env, prmap_t* map_entry)
+    {
+        if (map_entry->pr_mflags & MA_SHARED) {
+            // MA_SHARED => MAP_SHARED => !MAP_PRIVATE. This error is valid and should be thrown.
+            JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed");
+            return;
+        } else {
+            // O.W. MAP_PRIVATE or no flag was specified and EINVAL is the expected behaviour.
+            return;
+        }
+    }
+
+    void check_proc_map_array(JNIEnv* env, FILE* proc_file, prmap_t* map_entry, void* end_address)
+    {
+        while (!feof(proc_file)) {
+            memset(map_entry, '\0', sizeof(prmap_t));
+            fread((char*)map_entry, sizeof(prmap_t), 1, proc_file);
+            if (ferror(proc_file)) {
+                JNU_ThrowIOExceptionWithMessageAndLastError(env,
+                            "msync with parameter MS_SYNC failed (could not read /proc/<pid>/map)");
+                return;
+            } else if (map_entry->pr_vaddr <= end_address && end_address <= map_entry->pr_vaddr + map_entry->pr_size) {
+                set_error_if_shared(env, map_entry);
+                return;
+            }
+        }
+        JNU_ThrowIOExceptionWithMessageAndLastError(env,
+                                        "msync with parameter MS_SYNC failed (end_address not found)");
+    }
+
+    // '/proc/' + <pid> + '/map' + '\0'
+    #define PFNAME_LEN 32
+    void check_aix_einval(JNIEnv* env, void* end_address)
+    {
+        // If EINVAL is set for a mmap address on AIX, additional validation is required.
+        // AIX will set EINVAL when msync is called on a mmap address that didn't receive MAP_SHARED
+        // as a flag (since MAP_PRIVATE is the default).
+        // https://www.ibm.com/docs/en/aix/7.2?topic=m-msync-subroutine
+
+        FILE* proc_file;
+        {
+            char* fname = (char*) malloc(sizeof(char) * PFNAME_LEN);
+            pid_t the_pid = getpid();
+            jio_snprintf(fname, PFNAME_LEN, "/proc/%d/map", the_pid);
+            proc_file = fopen(fname, "r");
+            free(fname);
+        }
+        if (!proc_file) {
+            JNU_ThrowIOExceptionWithMessageAndLastError(env,
+                            "msync with parameter MS_SYNC failed (could not open /proc/<pid>/map)");
+            return;
+        }
+        {
+            prmap_t* map_entry = (prmap_t*) malloc(sizeof(prmap_t));
+            check_proc_map_array(env, proc_file, map_entry, end_address);
+            free(map_entry);
+        }
+        fclose(proc_file);
+    }
+
+    // AIX P6+ supports Dynamic Variable Page Sizes as an optimization
+    // A larger page size is used as an allocation size, and a smaller page size is used when fine-
+    // grained control is needed. However, this presents some complexity. The vm Bits.pageSize method
+    // does not necessarily return the size required by the call to msync, which specifically requires
+    // the one returned by sysconf(_SC_PAGE[_]SIZE).
+    //
+    // More info at:
+    // - https://www.ibm.com/docs/en/aix/7.2?topic=support-dynamic-variable-page-size
+    // - https://www.ibm.com/docs/en/aix/7.2?topic=m-msync-subroutine (see the note in the 'len' parameter)
+    int fix_address_aix(void* end_address)
+    {
+        prmap_t* map_entry = (prmap_t*) malloc(sizeof(prmap_t));
+        free(map_entry);
+        return -1;
+    }
+#endif // AIX
 
 JNIEXPORT void JNICALL
 Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
                                       jlong address, jlong len)
 {
     void* a = (void *)jlong_to_ptr(address);
-    int result = msync(a, (size_t)len, MS_SYNC);
+    int result = msync(a, len, MS_SYNC);
     if (result == -1) {
+        #ifdef AIX
+            void* end_address = (void*)jlong_to_ptr(address + len);
+            size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
+            if (errno == EINVAL) {
+                check_aix_einval(env, end_address);
+                return;
+            }
+        #endif
         JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed");
     }
 }

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -135,3 +135,9 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
         JNU_ThrowIOExceptionWithMessageAndLastError(env, "msync with parameter MS_SYNC failed");
     }
 }
+
+JNIEXPORT jint JNICALL
+Java_java_nio_MappedMemoryUtils_pageSize0()
+{
+    return (jint)sysconf(_SC_PAGESIZE);
+}

--- a/src/java.base/windows/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/windows/native/libnio/MappedMemoryUtils.c
@@ -106,3 +106,10 @@ Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
         JNU_ThrowIOExceptionWithLastError(env, "Flush failed");
     }
 }
+
+JNIEXPORT jint JNICALL
+Java_java_nio_MappedMemoryUtils_pageSize0()
+{
+    // Not required on Windows.
+    return -1;
+}


### PR DESCRIPTION
Solves the issue by searching `/proc/<pid>/map` for the map after an EINVAL. If the map is marked `MAP_PRIVATE` then EINVAL is ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #14904 must be integrated first

### Issue
 * [JDK-8309475](https://bugs.openjdk.org/browse/JDK-8309475): Test java/foreign/TestByteBuffer.java fails: a problem with msync (aix) (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14914/head:pull/14914` \
`$ git checkout pull/14914`

Update a local copy of the PR: \
`$ git checkout pull/14914` \
`$ git pull https://git.openjdk.org/jdk.git pull/14914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14914`

View PR using the GUI difftool: \
`$ git pr show -t 14914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14914.diff">https://git.openjdk.org/jdk/pull/14914.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14914#issuecomment-1639029392)