### PR TITLE
8227229: Deprecate the launcher -Xdebug/-debug flags that have not done anything since Java 6

### DIFF
--- a/make/ide/netbeans/langtools/build.xml
+++ b/make/ide/netbeans/langtools/build.xml
@@ -242,7 +242,7 @@
                 </nbjpdastart>
                 <property
                     name="@{jpda.jvmargs.property}"
-                    value="-Xdebug -Xrunjdwp:transport=dt_socket,address=${jpda.address}"
+                    value="-Xrunjdwp:transport=dt_socket,address=${jpda.address}"
                 />
             </sequential>
         </macrodef>

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -86,7 +86,6 @@ char*  Arguments::_java_command                 = nullptr;
 SystemProperty* Arguments::_system_properties   = nullptr;
 size_t Arguments::_conservative_max_heap_alignment = 0;
 Arguments::Mode Arguments::_mode                = _mixed;
-bool   Arguments::_xdebug_mode                  = false;
 const char*  Arguments::_java_vendor_url_bug    = nullptr;
 const char*  Arguments::_sun_java_launcher      = DEFAULT_JAVA_LAUNCHER;
 bool   Arguments::_sun_java_launcher_is_altjvm  = false;
@@ -2655,8 +2654,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       }
     // -Xdebug
     } else if (match_option(option, "-Xdebug")) {
-      // note this flag has been used, then ignore
-      set_xdebug_mode(true);
+      warning("Option -Xdebug was deprecated in JDK 22 and will likely be removed in a future release.");
     // -Xnoagent
     } else if (match_option(option, "-Xnoagent")) {
       warning("Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release.");

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2654,7 +2654,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       }
     // -Xdebug
     } else if (match_option(option, "-Xdebug")) {
-      warning("Options -Xdebug and -debug were deprecated in JDK 22 and will likely be removed in a future release.");
+      warning("Option -Xdebug was deprecated in JDK 22 and will likely be removed in a future release.");
     // -Xnoagent
     } else if (match_option(option, "-Xnoagent")) {
       warning("Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release.");

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2654,7 +2654,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       }
     // -Xdebug
     } else if (match_option(option, "-Xdebug")) {
-      warning("Option -Xdebug was deprecated in JDK 22 and will likely be removed in a future release.");
+      warning("Options -Xdebug and -debug were deprecated in JDK 22 and will likely be removed in a future release.");
     // -Xnoagent
     } else if (match_option(option, "-Xnoagent")) {
       warning("Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release.");

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -250,11 +250,6 @@ class Arguments : AllStatic {
   static Mode _mode;
   static void set_mode_flags(Mode mode);
 
-  // -Xdebug flag
-  static bool _xdebug_mode;
-  static void set_xdebug_mode(bool arg) { _xdebug_mode = arg; }
-  static bool xdebug_mode()             { return _xdebug_mode; }
-
   // preview features
   static bool _enable_preview;
 

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -134,7 +134,7 @@ java.launcher.X.usage=\n\
 \                      append to end of bootstrap class path\n\
 \    -Xcheck:jni       perform additional checks for JNI functions\n\
 \    -Xcomp            forces compilation of methods on first invocation\n\
-\    -Xdebug           does nothing. Provided for backward compatibility.\n\
+\    -Xdebug           deprecated and may be removed in a future release.\n\
 \    -Xdiag            show additional diagnostic messages\n\
 \    -Xfuture          enable strictest checks, anticipating future default.\n\
 \                      This option is deprecated and may be removed in a\n\

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -134,7 +134,7 @@ java.launcher.X.usage=\n\
 \                      append to end of bootstrap class path\n\
 \    -Xcheck:jni       perform additional checks for JNI functions\n\
 \    -Xcomp            forces compilation of methods on first invocation\n\
-\    -Xdebug           deprecated and may be removed in a future release.\n\
+\    -Xdebug           does nothing; deprecated for removal in a future release.\n\
 \    -Xdiag            show additional diagnostic messages\n\
 \    -Xfuture          enable strictest checks, anticipating future default.\n\
 \                      This option is deprecated and may be removed in a\n\

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -838,7 +838,7 @@ Testing mode to exercise JIT compilers.
 This option should not be used in production environments.
 .TP
 \f[V]-Xdebug\f[R]
-Deprecated and may be removed in a future release.
+Does nothing; deprecated for removal in a future release.
 .TP
 \f[V]-Xdiag\f[R]
 Shows additional diagnostic messages.

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -838,8 +838,7 @@ Testing mode to exercise JIT compilers.
 This option should not be used in production environments.
 .TP
 \f[V]-Xdebug\f[R]
-Does nothing.
-Provided for backward compatibility.
+Deprecated and may be removed in a future release.
 .TP
 \f[V]-Xdiag\f[R]
 Shows additional diagnostic messages.

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1390,7 +1390,7 @@ ParseArguments(int *pargc, char ***pargv,
         } else if (JLI_StrCmp(arg, "-tm") == 0) {
             AddOption("-Xtm", NULL);
         } else if (JLI_StrCmp(arg, "-debug") == 0) {
-            AddOption("-Xdebug", NULL);
+            JLI_ReportErrorMessage(ARG_DEPRECATED, "-debug");
         } else if (JLI_StrCmp(arg, "-noclassgc") == 0) {
             AddOption("-Xnoclassgc", NULL);
         } else if (JLI_StrCmp(arg, "-Xfuture") == 0) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java
@@ -225,7 +225,6 @@ public class SunCommandLineLauncher extends AbstractLauncher {
 
             String command = exePath + ' ' +
                              options + ' ' +
-                             "-Xdebug " +
                              "-Xrunjdwp:" + xrun + ' ' +
                              mainClassAndArgs;
 

--- a/test/hotspot/jtreg/runtime/6294277/SourceDebugExtension.java
+++ b/test/hotspot/jtreg/runtime/6294277/SourceDebugExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 6294277
  * @requires vm.jvmti
- * @summary java -Xdebug crashes on SourceDebugExtension attribute larger than 64K
- * @run main/othervm -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n SourceDebugExtension
+ * @summary verify that the JVM doesn't crash when SourceDebugExtension attribute is larger than 64K
+ * @run main/othervm -Xrunjdwp:transport=dt_socket,server=y,suspend=n SourceDebugExtension
  */
 import java.io.*;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
@@ -97,7 +97,7 @@ public class attach001 {
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
         String cmd = java
-                + " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=0"
+                + " -Xrunjdwp:transport=dt_socket,server=y,address=0"
                 + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach002.java
@@ -102,7 +102,7 @@ public class attach002 extends Log {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xrunjdwp:transport=dt_shmem,server=y,address=" +
+            " -Xrunjdwp:transport=dt_shmem,server=y,address=" +
             name + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
@@ -97,7 +97,7 @@ public class attachnosuspend001 {
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
         String cmd = java
-                + " -Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"
+                + " -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"
                 + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch003.java
@@ -134,7 +134,7 @@ public class launch003 {
             Connector.Argument a = (Connector.Argument) cava[i];
             if (a.name().equals("command"))
                 a.setValue(java +
-                " -Xdebug -Xrunjdwp:suspend=y,transport=" +
+                " -Xrunjdwp:suspend=y,transport=" +
                 TRANSPORT_NAME +
                 ",address=" + host + ":" + port +
                 " " + DEBUGEE_CLASS);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launch/launch004.java
@@ -133,7 +133,7 @@ public class launch004 {
             Connector.Argument a = (Connector.Argument) cava[i];
             if (a.name().equals("command"))
                 a.setValue(java +
-                " -Xdebug -Xrunjdwp:suspend=y,transport=" +
+                " -Xrunjdwp:suspend=y,transport=" +
                 TRANSPORT_NAME +
                 ",address=" + name +
                 " " + DEBUGEE_CLASS);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept001.java
@@ -81,7 +81,7 @@ public class accept001 {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=" +
+            " -Xrunjdwp:transport=dt_socket,server=n,address=" +
             connAddr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/accept/accept002.java
@@ -82,7 +82,7 @@ public class accept002 {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xrunjdwp:transport=dt_shmem,server=n,address=" +
+            " -Xrunjdwp:transport=dt_shmem,server=n,address=" +
             connAddr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/listennosuspend/listennosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/listennosuspend/listennosuspend001.java
@@ -81,7 +81,7 @@ public class listennosuspend001 {
         String java = argHandler.getLaunchExecPath()
                           + " " + argHandler.getLaunchOptions();
         String cmd = java +
-            " -Xdebug -Xrunjdwp:transport=dt_socket,server=n,suspend=n,address=" +
+            " -Xrunjdwp:transport=dt_socket,server=n,suspend=n,address=" +
             connAddr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis001.java
@@ -157,7 +157,7 @@ public class startlis001 {
                           + " " + argHandler.getLaunchOptions();
 
         String cmd = java +
-            " -Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=" +
+            " -Xrunjdwp:transport=dt_socket,server=n,address=" +
             addr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis002.java
@@ -132,7 +132,7 @@ public class startlis002 {
                           + " " + argHandler.getLaunchOptions();
 
         String cmd = java +
-            " -Xdebug -Xrunjdwp:transport=dt_shmem,server=n,address=" +
+            " -Xrunjdwp:transport=dt_shmem,server=n,address=" +
             addr + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,7 @@ public class createVM002 {
 
         String targetJava = argsHandler.getLaunchExecPath()
                                     + " " + argsHandler.getLaunchOptions();
-        String commandToRun = targetJava + " -Xdebug -Xrunjdwp:transport=dt_socket,address=" +
+        String commandToRun = targetJava + " -Xrunjdwp:transport=dt_socket,address=" +
                 testTransportServiceListenKey.address() +
                 // Addind "suspend=n' option helps avoid debugee hang. See 6803636.
                 ",suspend=n" +

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,7 @@ public class createVM003 {
 
         String targetJava = argsHandler.getLaunchExecPath()
                                     + " " + argsHandler.getLaunchOptions();
-        String commandToRun = targetJava + " -Xdebug -Xrunjdwp:transport=dt_socket,address=" +
+        String commandToRun = targetJava + " -Xrunjdwp:transport=dt_socket,address=" +
             testTransportServiceListenKey.address() + " " + targetVMClassName;
 
         Binder binder = new Binder(argsHandler, logHandler);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ public class createVM004 {
 
         String targetJava = argsHandler.getLaunchExecPath()
                                     + " " + argsHandler.getLaunchOptions();
-        String commandToRun = targetJava + " -Xdebug -Xrunjdwp:transport=dt_socket,address=" +
+        String commandToRun = targetJava + " -Xrunjdwp:transport=dt_socket,address=" +
             testTransportServiceListenKey.address() + " " + targetVMClassName;
 
         Binder binder = new Binder(argsHandler, logHandler);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@ public class createVM005 {
 
         String targetJava = argsHandler.getLaunchExecPath()
                                     + " " + argsHandler.getLaunchOptions();
-        String commandToRun = targetJava + " -Xdebug -Xrunjdwp:transport=dt_socket,address=" +
+        String commandToRun = targetJava + " -Xrunjdwp:transport=dt_socket,address=" +
             testTransportServiceListenKey.address() + " " + targetVMClassName;
 
         Binder binder = new Binder(argsHandler, logHandler);

--- a/test/jdk/com/sun/jdi/connect/spi/SimpleLaunchingConnector.java
+++ b/test/jdk/com/sun/jdi/connect/spi/SimpleLaunchingConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,7 +144,7 @@ public class SimpleLaunchingConnector implements LaunchingConnector {
 
         String exe = System.getProperty("java.home") + File.separator + "bin" +
             File.separator + "java";
-        String cmd = exe + " -Xdebug -Xrunjdwp:transport=dt_socket,timeout=15000,address=" +
+        String cmd = exe + " -Xrunjdwp:transport=dt_socket,timeout=15000,address=" +
             key.address() +
             " -classpath " + System.getProperty("test.classes") +
             " " + className;

--- a/test/jdk/java/awt/Clipboard/HTMLTransferTest/HTMLTransferTest.java
+++ b/test/jdk/java/awt/Clipboard/HTMLTransferTest/HTMLTransferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ public class HTMLTransferTest {
             String javaPath = System.getProperty("java.home", "");
             String cmd = javaPath + File.separator + "bin" + File.separator
                 + "java -cp " + System.getProperty("test.classes", ".") +
-                //+ "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 "
+                //+ "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 "
                 " THTMLConsumer"
                 //+ stFormats
                 ;

--- a/test/jdk/java/awt/datatransfer/DragUnicodeBetweenJVMTest/DragUnicodeBetweenJVMTest.java
+++ b/test/jdk/java/awt/datatransfer/DragUnicodeBetweenJVMTest/DragUnicodeBetweenJVMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public class DragUnicodeBetweenJVMTest {
 
 
        ProcessResults processResults =
-                // ProcessCommunicator.executeChildProcess(this.getClass()," -cp \"C:\\Documents and Settings\\df153228\\IdeaProjects\\UnicodeTestDebug\\out\\production\\UnicodeTestDebug\" -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 ", args);
+                // ProcessCommunicator.executeChildProcess(this.getClass()," -cp \"C:\\Documents and Settings\\df153228\\IdeaProjects\\UnicodeTestDebug\\out\\production\\UnicodeTestDebug\" -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 ", args);
                 ProcessCommunicator.executeChildProcess(this.getClass(), args);
 
         verifyTestResults(processResults);


### PR DESCRIPTION
Can I please get a review of this change which proposes to deprecate for removal the  `-Xdebug` option and `-debug` option of the `java` command? This addresses https://bugs.openjdk.org/browse/JDK-8227229.

As noted in the JBS issue this option is currently a no-op and has been there only for backward compatible since even Java 8 days.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8312220](https://bugs.openjdk.org/browse/JDK-8312220) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8227229](https://bugs.openjdk.org/browse/JDK-8227229): Deprecate the launcher -Xdebug/-debug flags that have not done anything since Java 6 (**Enhancement** - P4)
 * [JDK-8312220](https://bugs.openjdk.org/browse/JDK-8312220): Deprecate the launcher -Xdebug/-debug flags that have not done anything since Java 6 (**CSR**)

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [b6c867b0](https://git.openjdk.org/jdk/pull/14918/files/b6c867b0f8344068a0e8c6a563bb17c35e88fd42)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14918/head:pull/14918` \
`$ git checkout pull/14918`

Update a local copy of the PR: \
`$ git checkout pull/14918` \
`$ git pull https://git.openjdk.org/jdk.git pull/14918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14918`

View PR using the GUI difftool: \
`$ git pr show -t 14918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14918.diff">https://git.openjdk.org/jdk/pull/14918.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14918#issuecomment-1639623569)