### PR TITLE
JDK-8312182: THPs cause huge RSS due to thread start timing issue

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -89,9 +89,11 @@
           "to disable both the override and the printouts."             \
           "See prctl(PR_SET_TIMERSLACK) for more info.")                \
                                                                         \
-  product(bool, PreventTHPsForThreadStacks, true, EXPERIMENTAL,         \
-          "If true, the JVM will attempt to prevent formation of "      \
-          "transparent huge pages in thread stacks.")                   \
+  product(bool, DisableTHPStackMitigation, false, DIAGNOSTIC,           \
+          "If THPs are unconditionally enabled on the system (mode "    \
+          "\"always\"), the JVM will prevent THP from forming in "      \
+          "thread stacks. This switch disables that mitigation and "    \
+          "allows THPs to form in thread stacks.")                      \
                                                                         \
   develop(bool, DelayThreadStartALot, false,                            \
           "Artificially delay thread starts randomly for testing.")     \

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -89,6 +89,13 @@
           "to disable both the override and the printouts."             \
           "See prctl(PR_SET_TIMERSLACK) for more info.")                \
                                                                         \
+  product(bool, PreventTHPsForThreadStacks, true, EXPERIMENTAL,         \
+          "If true, the JVM will attempt to prevent formation of "      \
+          "transparent huge pages in thread stacks.")                   \
+                                                                        \
+  develop(bool, DelayThreadStartALot, false,                            \
+          "Artificially delay thread starts randomly for testing.")     \
+                                                                        \
 
 
 // end of RUNTIME_OS_FLAGS

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -916,22 +916,12 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   size_t stack_size = os::Posix::get_initial_stack_size(thr_type, req_stack_size);
   size_t guard_size = os::Linux::default_guard_size(thr_type);
 
-  // If THPs are unconditionally enabled, the following scenario can lead to huge RSS:
-  // - parent thread spawns, in quick succession, multiple child threads
-  // - child threads are slow to start
-  // - thread stacks of future child threads are adjacent and get merged into one large VMA
-  //   by the kernel, and subsequently transformed into huge pages by khugepaged
-  // - child threads come up, place JVM guard pages, thus splinter the large VMA, splinter
-  //   the huge pages into many (still paged-in) small pages.
-  // The result of that sequence are thread stacks that are fully paged-in even though the
-  // threads did not even start yet.
-  // We prevent that by letting the glibc allocate a guard page, which causes a VMA with different
-  // permission bits to separate two ajacent thread stacks and therefore prevent merging stacks
-  // into one VMA.
   if (PreventTHPsForThreadStacks) {
-    guard_size = MAX2(guard_size, os::vm_page_size());
-    // Add an additional page to the stack size to reduce its chances of getting huge page aligned
-    // so that the stack does not get backed by a transparent huge page.
+    // In addition to the glibc guard page that prevents inter-thread-stack hugepage
+    // coalescation (see comment in os::Linux::default_guard_size()), we also make
+    // sure the stack size itself is not huge-page-size aligned; that makes it much
+    // more likely for thread stack boundaries to be unaligned as well and hence
+    // protects thread stacks from being targeted by khugepaged.
     if (HugePages::thp_pagesize() > 0 &&
         is_aligned(stack_size, HugePages::thp_pagesize())) {
       stack_size += os::vm_page_size();
@@ -3095,6 +3085,27 @@ bool os::Linux::libnuma_init() {
 }
 
 size_t os::Linux::default_guard_size(os::ThreadType thr_type) {
+
+  if (PreventTHPsForThreadStacks) {
+    // If THPs are unconditionally enabled, the following scenario can lead to huge RSS
+    // - parent thread spawns, in quick succession, multiple child threads
+    // - child threads are slow to start
+    // - thread stacks of future child threads are adjacent and get merged into one large VMA
+    //   by the kernel, and subsequently transformed into huge pages by khugepaged
+    // - child threads come up, place JVM guard pages, thus splinter the large VMA, splinter
+    //   the huge pages into many (still paged-in) small pages.
+    // The result of that sequence are thread stacks that are fully paged-in even though the
+    // threads did not even start yet.
+    // We prevent that by letting the glibc allocate a guard page, which causes a VMA with different
+    // permission bits to separate two ajacent thread stacks and therefore prevent merging stacks
+    // into one VMA.
+    //
+    // Yes, this means we have two guard sections - the glibc and the JVM one - per thread. But the
+    // cost for that one extra protected page is dwarfed a large win in performance and memory that
+    // avoiding interference by khugepaged buys us.
+    return os::vm_page_size();
+  }
+
   // Creating guard page is very expensive. Java thread has HotSpot
   // guard pages, only enable glibc guard page for non-Java threads.
   // (Remember: compiler thread is a Java thread, too!)

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -36,7 +36,6 @@
  */
 
 /*
- * Note: only run manually, since this test is very costly (>2 GB)! Remove this line to run test.
  * @test id=DISABLED
  * @bug 8303215 8312182
  * @summary On THP=always systems, we prevent THPs from forming within thread stacks (negative test)
@@ -46,7 +45,7 @@
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver THPsInThreadStackPreventionTest  PATCH-DISABLED
+ * @run main/manual THPsInThreadStackPreventionTest  PATCH-DISABLED
  */
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -208,8 +207,8 @@ public class THPsInThreadStackPreventionTest {
                 // Only execute manually! this will allocate ~2gb of memory!
 
                 // explicitly disable the no-THP-workaround:
-                finalargs.add("-XX:+UnlockExperimentalVMOptions");
-                finalargs.add("-XX:-PreventTHPsForThreadStacks");
+                finalargs.add("-XX:+UnlockDiagnosticVMOptions");
+                finalargs.add("-XX:+DisableTHPStackMitigation");
 
                 finalargs.add(TestMain.class.getName());
                 ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=ENABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver THPsInThreadStackPreventionTest PATCH-ENABLED
+ */
+
+/*
+ * Note: only run manually, since this test is very costly (>2 GB)! Remove this line to run test.
+ * @test id=DISABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks (negative test)
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver THPsInThreadStackPreventionTest  PATCH-DISABLED
+ */
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+public class THPsInThreadStackPreventionTest {
+
+    // We test the mitigation for "huge rss for THP=always" introduced with JDK-8312182 and JDK-8302015:
+    //
+    // We start a program that spawns a ton of threads with a stack size close to THP page size. The threads
+    // are idle and should not build up a lot of stack. The threads are started with an artificial delay
+    // between thread start and stack guardpage creation, which exacerbates the RSS bloat (for explanation
+    // please see 8312182).
+    //
+    // We then observe RSS of that program. We expect it to stay below a reasonable maximum. The unpatched
+    // version should show an RSS of ~2 GB (paying for the fully paged in thread stacks). The fixed variant should
+    // cost only ~200-400 MB.
+
+    static final int numThreads = 1000;
+    static final long threadStackSizeMB = 2; // must be 2M
+    static final long heapSizeMB = 64;
+    static final long basicRSSOverheadMB = heapSizeMB + 150;
+    // A successful completion of this test would show not more than X KB per thread stack.
+    static final long acceptableRSSPerThreadStack = 128 * 1024;
+    static final long acceptableRSSForAllThreadStacks = numThreads * acceptableRSSPerThreadStack;
+    static final long acceptableRSSLimitMB = (acceptableRSSForAllThreadStacks / (1024 * 1024)) + basicRSSOverheadMB;
+
+    private static class TestMain {
+
+        static class Sleeper extends Thread {
+            CyclicBarrier barrier;
+            public Sleeper(CyclicBarrier barrier) {
+                this.barrier = barrier;
+            }
+            @Override
+            public void run() {
+                try {
+                    barrier.await(); // wait for all siblings
+                    barrier.await(); // wait main thread to print status
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static void main(String[] args) throws BrokenBarrierException, InterruptedException {
+
+            // Fire up 1000 threads with 2M stack size each.
+            Sleeper[] threads = new Sleeper[numThreads];
+            CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);
+
+            for (int i = 0; i < numThreads; i++) {
+                threads[i] = new Sleeper(barrier);
+                threads[i].start();
+            }
+
+            // Wait for all threads to come up
+            barrier.await();
+
+            // print status
+            String file = "/proc/self/status";
+            try (FileReader fr = new FileReader(file);
+                 BufferedReader reader = new BufferedReader(fr)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+            } catch (IOException | NumberFormatException e) { /* ignored */ }
+
+            // Signal threads to stop
+            barrier.await();
+
+        }
+    }
+
+    static class ProcSelfStatus {
+
+        public long rssMB;
+        public long swapMB;
+        public int numLifeThreads;
+
+        // Parse output from /proc/self/status
+        public static ProcSelfStatus parse(OutputAnalyzer o) {
+            ProcSelfStatus status = new ProcSelfStatus();
+            String s = o.firstMatch("Threads:\\s*(\\d+)", 1);
+            Objects.requireNonNull(s);
+            status.numLifeThreads = Integer.parseInt(s);
+            s = o.firstMatch("VmRSS:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.rssMB = Long.parseLong(s) / 1024;
+            s = o.firstMatch("VmSwap:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.swapMB = Long.parseLong(s) / 1024;
+            return status;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        HugePageConfiguration config = HugePageConfiguration.readFromOS();
+        // This issue is bound to THP=always
+        if (config.getThpMode() != HugePageConfiguration.THPMode.always) {
+            throw new SkippedException("Test only makes sense in THP \"always\" mode");
+        }
+
+        String[] defaultArgs = {
+            "-Xlog:pagesize",
+            "-Xmx" + heapSizeMB + "m", "-Xms" + heapSizeMB + "m", "-XX:+AlwaysPreTouch", // stabilize RSS
+            "-Xss" + threadStackSizeMB + "m",
+            "-XX:-CreateCoredumpOnCrash",
+            // This will delay the child threads before they create guard pages, thereby greatly increasing the
+            // chance of large VMA formation + hugepage coalescation; see JDK-8312182
+            "-XX:+DelayThreadStartALot"
+        };
+        ArrayList<String> finalargs = new ArrayList<>(Arrays.asList(defaultArgs));
+
+        switch (args[0]) {
+            case "PATCH-ENABLED": {
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.shouldHaveExitValue(0);
+
+                // this line indicates the mitigation is active:
+                output.shouldContain("[pagesize] JVM will attempt to prevent THPs in thread stacks.");
+
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected: " + status.numLifeThreads + ", expected " + numThreads);
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB > acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap larger than expected: " + rssPlusSwapMB + "m, expected at most " + acceptableRSSLimitMB + "m");
+                } else {
+                    if (rssPlusSwapMB < heapSizeMB) { // we pretouch the java heap, so we expect to see at least that:
+                        throw new RuntimeException("RSS+Swap suspiciously low: " + rssPlusSwapMB + "m, expected at least " + heapSizeMB + "m");
+                    }
+                    System.out.println("Okay: RSS+Swap=" + rssPlusSwapMB + ", within acceptable limit of " + acceptableRSSLimitMB);
+                }
+            }
+            break;
+
+            case "PATCH-DISABLED": {
+
+                // Only execute manually! this will allocate ~2gb of memory!
+
+                // explicitly disable the no-THP-workaround:
+                finalargs.add("-XX:+UnlockExperimentalVMOptions");
+                finalargs.add("-XX:-PreventTHPsForThreadStacks");
+
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+                output.shouldHaveExitValue(0);
+
+                // We deliberately switched off mitigation, VM should tell us:
+                output.shouldContain("[pagesize] JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+
+                // Parse output from self/status
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected (" + status.numLifeThreads + ", expected " + numThreads +")");
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB < acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap lower than expected: " + rssPlusSwapMB + "m, expected more than " + acceptableRSSLimitMB + "m");
+                }
+                break;
+            }
+
+            default: throw new RuntimeException("Bad argument: " + args[0]);
+        }
+    }
+}


### PR DESCRIPTION
If Transparent Huge Pages are unconditionally enabled (`/sys/kernel/mm/transparent_hugepage/enabled` contains `[always]`), Java applications that use many threads may see a huge Resident Set Size. That RSS is caused by thread stacks being mostly paged in. This page-in is caused by thread stack memory being transformed into huge pages by `khugepaged`; later, those huge pages usually shatter into small pages when Java guard pages are established at thread start, but the remaining splinter small pages remain paged in.

[JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215) attempted to fix this problem by making it unlikely that thread stack boundaries are aligned to THP page size. Unfortunately, that was not sufficient. We still see JVMs with huge footprints, especially if they did create many Java threads in rapid succession.

Note that this effect is independent of any JVM switches; in particular, it happens regardless of `-XX:+UseTransparentHugePages` or `-XX:+UseLargePages`.

Update: tests show that the interference of `khugepaged` also costs performance when starting threads, and this patch addresses both footprint and performance problems.

##### Demonstration:

Linux 5.15 on x64, glibc 2.31: 10000 idle threads with 100 MB pre-touched java heap, `-Xss2M`, on x64, will consume:

A) Baseline (THP disabled on system):  *369 MB*
B) THP="always", JDK-8303215 present: *1.5 GB .. >2 GB* (very wobbly)
C) THP="always", JDK-8303215 present, artificial delay after thread start: **20,6 GB** (!).


#### Cause:

The problem is caused by timing. When we create multiple Java threads, the following sequence of actions happens:

In the parent thread:
- the parent thread calls `pthread_create(3)`
- `pthread_create(3)` creates the thread stack by calling `mmap(2)`
- `pthread_create(3)` calls `clone(2)` to start the child thread
- repeat to start more threads

Each child thread:
- queries its stack dimensions
- handshakes with the parent to signal lifeness
- establishes guard pages at the low end of the stack

The thread stack mapping is established in the parent thread; the guard pages are placed by the child threads. There is a time window in which the thread stack is already mapped into address space, but guard pages still need to be placed.

If the parent is faster than the children, it will have created mappings faster than the children can place guard pages on them.

For the kernel, these thread stacks are just anonymous mappings. It places them adjacent to each other to reduce address space fragmentation. As long as no guard pages are placed yet, all these thread stack mappings (VMAs) have the same attributes - same permission bits, all anonymous. Hence, the kernel will fold them into a single large VMA. 

That VMA may be large enough to be eligible for huge pages. Now the JVM races with the `khugepaged`: If `khugepaged` is faster than the JVM, it will have converted that larger VMA partly or fully into hugepages before the child threads start creating guard pages:


```
glibc does              Kernel folds them        khugepaged creates
1 mmap/stack:           into one VMA (still      huge pages (paged in):
                        not paged in):
+---------+             +---------+              +---------+ 
|         |             |         |              |         | 
| stack A |             |         |              | hugepage|
|         |             |         |              | ------- | 
+---------+             |         |              |         | 
|         |             |         |              | hugepage| 
| stack B |    ====>    |  VMA    |    ====>     | ------- | 
|         |             |         |              |         | 
+---------+             |         |              | hugepage| 
|         |             |         |              | ------- | 
| stack C |             |         |              |         | 
|         |             |         |              | hugepage| 
+---------+             +---------+              +---------+
```

The child threads will catch up and create guard pages. That will splinter the large VMA into several smaller VMAs (two for each thread, one for the usable thread section, and one protected for the guards). Each of these VMAs will typically be smaller than a huge page, and typically not huge-page-aligned. The huge pages created by `khugepaged` will mostly shatter into small pages, but these small pages remain paged-in. Effect: we pay memory for the whole thread stacks even though the threads did not start yet.

This is a similar effect as described in [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215); but we assumed it only affects individual threads when it affects whole regions of adjacent thread stacks.

#### Example:

Let's create three threads. Each thread stack, including guard pages, is 2M + 4K sized (+4K because of JDK-8303215).

Their thread stacks will be located at: ( `[base .. end .. guard]`:

```
T1: [7feea53ff000 .. 7feea5202000 .. 7feea51fe000] 
T2: [7feea5600000 .. 7feea5403000 .. 7feea53ff000] 
T3: [7feea5801000 .. 7feea5604000 .. 7feea5600000]
```

After `pthread_create(3)`, their thread stacks exist without JVM guard pages. Kernel merges the VMAs of their thread stacks into a single mapping > 6MB. `khugepaged` then coalesces their small pages into 3 huge pages:

```
7feea51fe000-7feea5801000 rw-p 00000000 00:00 0    <<<------- all three stacks as one VMA
Size:               6156 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                6148 kB
Pss:                6148 kB
Shared_Clean:          0 kB
Shared_Dirty:          0 kB
Private_Clean:         0 kB
Private_Dirty:      6148 kB
Referenced:         6148 kB
Anonymous:          6148 kB
LazyFree:              0 kB
AnonHugePages:      6144 kB      <<<---------- 3x2MB huge pages
ShmemPmdMapped:        0 kB
FilePmdMapped:         0 kB
Shared_Hugetlb:        0 kB
Private_Hugetlb:       0 kB
Swap:                  0 kB
SwapPss:               0 kB
Locked:                0 kB
THPeligible:    1    
VmFlags: rd wr mr mw me ac sd 
```

Threads start and create their respective guard pages. The single VMA splinters into 6 smaller VMAs. The huge pages shatter into small pages that remain paged-in:

```
7feea51fe000-7feea5202000 ---p 00000000 00:00 0   <<----- guard pages for T1
Size:                 16 kB
...
7feea5202000-7feea53ff000 rw-p 00000000 00:00 0   <<------ thread stack for T1
Size:               2036 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                2036 kB
Pss:                2036 kB
Private_Dirty:      2036 kB   <<<--------  all pages resident
...
7feea53ff000-7feea5403000 ---p 00000000 00:00 0   <<----- guard pages for T2
Size:                 16 kB
...
7feea5403000-7feea5600000 rw-p 00000000 00:00 0   <<------ thread stack for T2
Size:               2036 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                2036 kB
Pss:                2036 kB
Private_Dirty:      2036 kB   <<<--------  all pages resident
...
7feea5600000-7feea5604000 ---p 00000000 00:00 0    <<----- guard pages for T3 
Size:                 16 kB
...
7feea5604000-7feea5801000 rw-p 00000000 00:00 0    <<------ thread stack for T3
Size:               2036 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                2036 kB
Pss:                2036 kB
Private_Dirty:      2036 kB   <<<--------  all pages resident
...
```

#### Fix

The mitigation for the huge RSS buildup involves letting the glibc allocate guards for Java thread stacks. We usually avoid that since Java thread stacks are already guarded by JVM guard pages. However, here we use the fact that the glibc guard page is established by `pthread_create(3)` **before** starting the child thread. Therefore adjacent thread stack VMAs will be separated by a guard page - we close the time window within which the kernel sees a large VMA. 

The fix works: the aforementioned 20.6 GB RSS example, with the fix applied, drops back to ~400 MB RSS.

As a byproduct, this patch fixes [JDK-8310687](https://bugs.openjdk.org/browse/JDK-8310687): the mitigation will only be activated if THPs are enabled unconditionally on the system (THP mode = "always"). And we use the correct page size for THPs.

Finally, note that this solution has a slight disadvantage: threads now have two guards, the JVM guard pages and the glibc guard page. Currently, the kernel cannot merge these VMAs because their attributes differ. This problem may be solvable; I opened [JDK-8312211](https://bugs.openjdk.org/browse/JDK-8312211)  to track this problem.

/issue JDK-8310687

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182): THPs cause huge RSS due to thread start timing issue (**Bug** - P3)
 * [JDK-8310687](https://bugs.openjdk.org/browse/JDK-8310687): JDK-8303215 is incomplete (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Poonam Bajaj](https://openjdk.org/census#poonam) (@poonamparhar - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14919/head:pull/14919` \
`$ git checkout pull/14919`

Update a local copy of the PR: \
`$ git checkout pull/14919` \
`$ git pull https://git.openjdk.org/jdk.git pull/14919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14919`

View PR using the GUI difftool: \
`$ git pr show -t 14919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14919.diff">https://git.openjdk.org/jdk/pull/14919.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14919#issuecomment-1640486548)