### PR TITLE
8312246: NPE when HSDB visits bad oop

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1096,7 +1096,9 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
                           G1CollectedHeap heap = (G1CollectedHeap)collHeap;
                           HeapRegion region = heap.hrm().getByAddress(handle);
 
-                          if (region.isFree()) {
+                          if (region == null) {
+                            // intentionally skip
+                          } else if (region.isFree()) {
                             anno = "Free ";
                             bad = false;
                           } else if (region.isYoung()) {


### PR DESCRIPTION
Hi!

This is a minor HSDB fix. It prints "bad oop" instead of throwing an NPE message to the console when a corrupted object is found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312246](https://bugs.openjdk.org/browse/JDK-8312246): NPE when HSDB visits bad oop (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14922/head:pull/14922` \
`$ git checkout pull/14922`

Update a local copy of the PR: \
`$ git checkout pull/14922` \
`$ git pull https://git.openjdk.org/jdk.git pull/14922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14922`

View PR using the GUI difftool: \
`$ git pr show -t 14922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14922.diff">https://git.openjdk.org/jdk/pull/14922.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14922#issuecomment-1640596207)