### PR TITLE
JDK-8311261: [AIX] TestAlwaysPreTouchStacks.java fails due to java.lang.RuntimeException: Did not find expected NMT output

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CyclicBarrier;
 /*
  * @test
  * @summary Test AlwaysPreTouchThreadStacks
+ * @requires os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
On AIX we are getting the pattern “Stack: “, but the test is expecting the pattern : ".*stack: reserved=(\\d+), committed=(\\d+).*”. This is due to track_as_vm() is returning false on AIX. The function should return false because on AIX by [default page is not aligned](https://github.com/openjdk/jdk/blob/354c6605e32790ca421869636d8bf5456fc51717/src/hotspot/share/services/threadStackTracker.hpp#L57). Thus disabling the test on AIX.

JBS Issue : [JDK-8311261](https://bugs.openjdk.org/browse/JDK-8311261)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311261](https://bugs.openjdk.org/browse/JDK-8311261): [AIX] TestAlwaysPreTouchStacks.java fails due to java.lang.RuntimeException: Did not find expected NMT output (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14923/head:pull/14923` \
`$ git checkout pull/14923`

Update a local copy of the PR: \
`$ git checkout pull/14923` \
`$ git pull https://git.openjdk.org/jdk.git pull/14923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14923`

View PR using the GUI difftool: \
`$ git pr show -t 14923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14923.diff">https://git.openjdk.org/jdk/pull/14923.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14923#issuecomment-1640670065)