### PR TITLE
8312414: Make java.util.ServiceLoader.LANG_ACCESS final

### DIFF
--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -422,8 +422,7 @@ public final class ServiceLoader<S>
     // Incremented when reload is called
     private int reloadCount;
 
-    private static final JavaLangAccess LANG_ACCESS =
-            SharedSecrets.getJavaLangAccess();
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
 
     /**
      * Represents a service provider located by {@code ServiceLoader}.

--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -422,10 +422,8 @@ public final class ServiceLoader<S>
     // Incremented when reload is called
     private int reloadCount;
 
-    private static JavaLangAccess LANG_ACCESS;
-    static {
-        LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-    }
+    private static final JavaLangAccess LANG_ACCESS =
+            SharedSecrets.getJavaLangAccess();
 
     /**
      * Represents a service provider located by {@code ServiceLoader}.


### PR DESCRIPTION
Found opportunity to make static `ServiceLoader.LANG_ACCESS` field `final`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312414](https://bugs.openjdk.org/browse/JDK-8312414): Make java.util.ServiceLoader.LANG_ACCESS final (**Enhancement** - P5)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14926/head:pull/14926` \
`$ git checkout pull/14926`

Update a local copy of the PR: \
`$ git checkout pull/14926` \
`$ git pull https://git.openjdk.org/jdk.git pull/14926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14926`

View PR using the GUI difftool: \
`$ git pr show -t 14926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14926.diff">https://git.openjdk.org/jdk/pull/14926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14926#issuecomment-1642649164)