### PR TITLE
8199149: Improve the exception message thrown by VarHandle of unsupported operation

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -103,6 +103,6 @@ import java.util.function.BiFunction;
     @Override
     MethodHandle getMethodHandleUncached(int mode) {
         MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
-        return handleFactory.apply(AccessMode.values()[mode], targetHandle);
+        return handleFactory.apply(AccessMode.valueFromOrdinal(mode), targetHandle);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -90,7 +90,9 @@ import java.util.function.BiFunction;
     @Override
     @ForceInline
     boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
-        super.checkAccessModeThenIsDirect(ad);
+        if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
+            throwWrongMethodTypeException(ad);
+        }
         // return false to indicate this is an IndirectVarHandle
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -90,9 +90,7 @@ import java.util.function.BiFunction;
     @Override
     @ForceInline
     boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
-        if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throwWrongMethodTypeException(ad);
-        }
+        super.checkAccessModeThenIsDirect(ad);
         // return false to indicate this is an IndirectVarHandle
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -134,7 +134,7 @@ final class VarForm {
 
     @DontInline
     MemberName resolveMemberName(int mode) {
-        AccessMode value = AccessMode.values()[mode];
+        AccessMode value = AccessMode.valueFromOrdinal(mode);
         String methodName = value.methodName();
         MethodType type = methodType_table[value.at.ordinal()].insertParameterTypes(0, VarHandle.class);
         return memberName_table[mode] = MethodHandles.Lookup.IMPL_LOOKUP

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -26,6 +26,7 @@ package java.lang.invoke;
 
 import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.Hidden;
 import jdk.internal.vm.annotation.Stable;
 
 import java.lang.invoke.VarHandle.AccessMode;
@@ -108,6 +109,7 @@ final class VarForm {
     }
 
     @ForceInline
+    @Hidden
     final MemberName getMemberName(int mode) {
         // Can be simplified by calling getMemberNameOrNull, but written in this
         // form to improve interpreter/coldpath performance.

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -115,7 +115,7 @@ final class VarForm {
         if (mn == null) {
             mn = resolveMemberName(mode);
             if (mn == null) {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException(AccessMode.valueFromOrdinal(mode).methodName());
             }
         }
         return mn;

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -2220,7 +2220,7 @@ public abstract sealed class VarHandle implements Constable
      * @throws UnsupportedOperationException if the access mode is not supported
      */
     MethodHandle getMethodHandleUncached(int mode) {
-        MethodType mt = accessModeType(AccessMode.values()[mode]).
+        MethodType mt = accessModeType(AccessMode.valueFromOrdinal(mode)).
                 insertParameterTypes(0, VarHandle.class);
         MemberName mn = vform.getMemberName(mode);
         DirectMethodHandle dmh = DirectMethodHandle.make(mn);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -2006,18 +2006,9 @@ public abstract sealed class VarHandle implements Constable
             };
         }
 
-        // Mapping from the ordinal to AccessMode
-        private static final Map<Integer, AccessMode> modeToAccessMode = initOrdinalToAccessModeMap();
-        private static Map<Integer, AccessMode> initOrdinalToAccessModeMap() {
-            Map<Integer, AccessMode> map = new HashMap<>();
-            for (AccessMode am : AccessMode.values()) {
-                map.put(am.ordinal(), am);
-            }
-            return map;
-        }
-
+        private static final @Stable AccessMode[] VALUES = values();
         static AccessMode valueFromOrdinal(int mode) {
-            return modeToAccessMode.get(mode);
+            return VALUES[mode];
         }
     }
 
@@ -2110,7 +2101,7 @@ public abstract sealed class VarHandle implements Constable
      */
     @ForceInline
     boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
-        if (vform.getMemberNameOrNull(ad.mode) == null) {
+        if (!isAccessModeSupported(AccessMode.valueFromOrdinal(ad.mode))) {
             throwUnsupportedOperationException(ad.mode);
         }
         if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -31,9 +31,7 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -2094,16 +2092,11 @@ public abstract sealed class VarHandle implements Constable
      *
      * @return true if this is a direct VarHandle, false if it's an indirect
      *         VarHandle.
-     * @throws UnsupportedOperationException if this VarHandle does not support
-     *         the given access mode
      * @throws WrongMethodTypeException if there's an access type mismatch
      * @see #asDirect()
      */
     @ForceInline
     boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
-        if (!isAccessModeSupported(AccessMode.valueFromOrdinal(ad.mode))) {
-            throwUnsupportedOperationException(ad.mode);
-        }
         if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throwWrongMethodTypeException(ad);
         }
@@ -2112,15 +2105,9 @@ public abstract sealed class VarHandle implements Constable
     }
 
     @DontInline
-    final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
+    private final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
         throw new WrongMethodTypeException("handle's method type " + accessModeType(ad.type)
                 + " but found " + ad.symbolicMethodTypeExact);
-    }
-
-    @DontInline
-    final void throwUnsupportedOperationException(int mode) {
-        throw new UnsupportedOperationException(AccessMode.valueFromOrdinal(mode).methodName()
-                + " is not supported for " + this);
     }
 
     @ForceInline
@@ -2235,9 +2222,7 @@ public abstract sealed class VarHandle implements Constable
     MethodHandle getMethodHandleUncached(int mode) {
         MethodType mt = accessModeType(AccessMode.values()[mode]).
                 insertParameterTypes(0, VarHandle.class);
-        MemberName mn = vform.getMemberNameOrNull(mode);
-        if (mn == null)
-            throwUnsupportedOperationException(mode);
+        MemberName mn = vform.getMemberName(mode);
         DirectMethodHandle dmh = DirectMethodHandle.make(mn);
         // Such a method handle must not be publicly exposed directly
         // otherwise it can be cracked, it must be transformed or rebound

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
`VarForm::getMemberName` currently throws UOE with no information if the requested access mode is unsupported.   To provide the var handle information, move the access mode check to `VarHandle` so that the exception message can include the var handle information.  Changes include:

1. change `VarHandle::checkAccessModeThenIsDirect` to check if the access mode is unsupported.  This check is only needed for direct var handle.
2. change `VarHandle::getMethodHandleUncached` to call `getMemberNameOrNull` and throw UOE with an informative exception message if the access mode is unsupported

The error message looks like:
```
java.lang.UnsupportedOperationException: compareAndSet is not supported for VarHandle[varType=java.lang.String, coord=[class Foo$Goo]]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8199149](https://bugs.openjdk.org/browse/JDK-8199149): Improve the exception message thrown by VarHandle of unsupported operation (**Enhancement** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [9196ccb4](https://git.openjdk.org/jdk/pull/14928/files/9196ccb4d2feae0dd3907463d485c967c295b9db)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14928/head:pull/14928` \
`$ git checkout pull/14928`

Update a local copy of the PR: \
`$ git checkout pull/14928` \
`$ git pull https://git.openjdk.org/jdk.git pull/14928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14928`

View PR using the GUI difftool: \
`$ git pr show -t 14928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14928.diff">https://git.openjdk.org/jdk/pull/14928.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14928#issuecomment-1641191410)