### PR TITLE
8312229: Crash involving yield, switch and anonymous classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1569,8 +1569,15 @@ public class LambdaToMethod extends TreeTranslator {
         public void visitVarDef(JCVariableDecl tree) {
             TranslationContext<?> context = context();
             if (context != null && context instanceof LambdaTranslationContext lambdaContext) {
-                if (frameStack.head.tree.hasTag(LAMBDA)) {
-                    lambdaContext.addSymbol(tree.sym, LOCAL_VAR);
+                for (Frame frame : frameStack) {
+                    if (frame.tree.hasTag(VARDEF)) {
+                        //skip variable frames inside a lambda:
+                        continue;
+                    } else if (frame.tree.hasTag(LAMBDA)) {
+                        lambdaContext.addSymbol(tree.sym, LOCAL_VAR);
+                    } else {
+                        break;
+                    }
                 }
                 // Check for type variables (including as type arguments).
                 // If they occur within class nested in a lambda, mark for erasure

--- a/test/langtools/tools/javac/patterns/T8312229.java
+++ b/test/langtools/tools/javac/patterns/T8312229.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+ /*
+ * @test
+ * @bug 8312229
+ * @summary Ensure javac does not crash when a variable is used from an anonymous class
+ * @compile T8312229.java
+ */
+public class T8312229 {
+    void test(Object o) {
+        Runnable r = () -> {
+            var l = switch (o) {
+                default -> {
+                    Integer i = 42;
+                    yield new Runnable() {
+                        public void run() {
+                            i.toString(); // should not crash here
+                        }
+                    };
+                }
+            };
+        };
+    }
+}


### PR DESCRIPTION
Consider code like:
```
    void test(Object o) {
        Runnable r = () -> {
            switch (o) {
                default -> {
                    Integer i = 42;
                    new Runnable() {
                        public void run() {
                            i.toString();
                        }
                    };
                }
            };
        };
    }
```

During `LambdaToMethod`, the `i` variable is seen as a local variable in the lambda, and re-written to a different variable inside the new lambda method. This is due to:
https://github.com/openjdk/jdk/blob/d33e8e6f93d7b0806e1d0087c3c0a11fe1bc8e21/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java#L1573

note the lambda frame is the topmost frame in this case.

But, if the code is altered to:
```
    void test(Object o) {
        Runnable r = () -> {
            var l = switch (o) {
                default -> {
                    Integer i = 42;
                    yield new Runnable() {
                        public void run() {
                            i.toString();
                        }
                    };
                }
            };
        };
    }
```

the topmost frame will not be the lambda frame, but rather a variable frame, so that the `i` variable is not seem as a lambda-local variable, and the translations eventually fail.

The proposed solution is to search for the lambda frame, ignoring intervening variable frames.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312229](https://bugs.openjdk.org/browse/JDK-8312229): Crash involving yield, switch and anonymous classes (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14930/head:pull/14930` \
`$ git checkout pull/14930`

Update a local copy of the PR: \
`$ git checkout pull/14930` \
`$ git pull https://git.openjdk.org/jdk.git pull/14930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14930`

View PR using the GUI difftool: \
`$ git pr show -t 14930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14930.diff">https://git.openjdk.org/jdk/pull/14930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14930#issuecomment-1641861458)