### PR TITLE
8312320: Remove javax/rmi/ssl/SSLSocketParametersTest.sh from ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -733,8 +733,6 @@ sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aa
 
 # jdk_other
 
-javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-all
-
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
 jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
 


### PR DESCRIPTION
This PR removes javax/rmi/ssl/SSLSocketParametersTest.sh from the ProblemList. The script was removed in JDK-8298939 and the Java code refactored to be a jtreg test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312320](https://bugs.openjdk.org/browse/JDK-8312320): Remove javax/rmi/ssl/SSLSocketParametersTest.sh from ProblemList (**Task** - P4)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14933/head:pull/14933` \
`$ git checkout pull/14933`

Update a local copy of the PR: \
`$ git checkout pull/14933` \
`$ git pull https://git.openjdk.org/jdk.git pull/14933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14933`

View PR using the GUI difftool: \
`$ git pr show -t 14933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14933.diff">https://git.openjdk.org/jdk/pull/14933.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14933#issuecomment-1642478360)