### PR TITLE
JDK-8312392: ARM32 build broken since 8311035

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1252,10 +1252,12 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
   if (base_address != nullptr) {
     assert(is_aligned(base_address, archive_space_alignment),
            "Archive base address invalid: " PTR_FORMAT ".", p2i(base_address));
+#ifdef _LP64
     if (Metaspace::using_class_space()) {
       assert(CompressedKlassPointers::is_valid_base(base_address),
              "Archive base address invalid: " PTR_FORMAT ".", p2i(base_address));
     }
+#endif
   }
 
   if (!Metaspace::using_class_space()) {


### PR DESCRIPTION
Trivial fix.

```
/shared/projects/openjdk/jdk-jdk/source/src/hotspot/share/cds/metaspaceShared.cpp:1256: error: undefined reference to 'CompressedKlassPointers::is_valid_base(unsigned char*)'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312392](https://bugs.openjdk.org/browse/JDK-8312392): ARM32 build broken since 8311035 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14934/head:pull/14934` \
`$ git checkout pull/14934`

Update a local copy of the PR: \
`$ git checkout pull/14934` \
`$ git pull https://git.openjdk.org/jdk.git pull/14934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14934`

View PR using the GUI difftool: \
`$ git pr show -t 14934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14934.diff">https://git.openjdk.org/jdk/pull/14934.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14934#issuecomment-1642114039)