### PR TITLE
8312401: SymbolTable::do_add_if_needed hangs when called in InstanceKlass::add_initialization_error path with requesting length exceeds max_symbol_length

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -569,16 +569,9 @@ char* java_lang_String::as_quoted_ascii(oop java_string) {
   return result;
 }
 
-// Return a Symbol for the input Java string. A new Symbol is created if one
-// does not exist. If the length of the input string exceeds Symbol::max_length,
-// the string is truncated to Symbol::max_length.
 Symbol* java_lang_String::as_symbol(oop java_string) {
   typeArrayOop value  = java_lang_String::value(java_string);
   int          length = java_lang_String::length(java_string, value);
-  if (length > Symbol::max_length()) {
-    length = Symbol::max_length();
-  }
-
   bool      is_latin1 = java_lang_String::is_latin1(java_string);
   if (!is_latin1) {
     jchar* base = (length == 0) ? nullptr : value->char_at_addr(0);
@@ -593,15 +586,9 @@ Symbol* java_lang_String::as_symbol(oop java_string) {
   }
 }
 
-// Find the Symbol for the input Java string. If the length of the input string
-// exceeds Symbol::max_length, the string is truncated to Symbol::max_length.
 Symbol* java_lang_String::as_symbol_or_null(oop java_string) {
   typeArrayOop value  = java_lang_String::value(java_string);
   int          length = java_lang_String::length(java_string, value);
-  if (length > Symbol::max_length()) {
-    length = Symbol::max_length();
-  }
-
   bool      is_latin1 = java_lang_String::is_latin1(java_string);
   if (!is_latin1) {
     jchar* base = (length == 0) ? nullptr : value->char_at_addr(0);

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2768,7 +2768,6 @@ Handle java_lang_Throwable::create_initialization_error(JavaThread* current, Han
   // Now create the message from the original exception and thread name.
   Symbol* message = java_lang_Throwable::detail_message(throwable());
   ResourceMark rm(current);
-
   stringStream st;
   st.print("Exception %s%s ", throwable()->klass()->name()->as_klass_external_name(),
              message == nullptr ? "" : ":");

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -188,8 +188,6 @@ class java_lang_String : AllStatic {
   static Handle externalize_classname(Symbol* java_name, TRAPS);
 
   // Conversion
-  // If the length of the input string exceeds Symbol::max_length, the string
-  // is truncated to Symbol::max_length.
   static Symbol* as_symbol(oop java_string);
   static Symbol* as_symbol_or_null(oop java_string);
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -188,6 +188,8 @@ class java_lang_String : AllStatic {
   static Handle externalize_classname(Symbol* java_name, TRAPS);
 
   // Conversion
+  // If the length of the input string exceeds Symbol::max_length, the string
+  // is truncated to Symbol::max_length.
   static Symbol* as_symbol(oop java_string);
   static Symbol* as_symbol_or_null(oop java_string);
 

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -337,6 +337,7 @@ Symbol* SymbolTable::lookup_common(const char* name,
 }
 
 Symbol* SymbolTable::new_symbol(const char* name, int len) {
+  assert(len <= Symbol::max_length(), "sanity");
   unsigned int hash = hash_symbol(name, len, _alt_hash);
   Symbol* sym = lookup_common(name, len, hash);
   if (sym == nullptr) {
@@ -352,6 +353,7 @@ Symbol* SymbolTable::new_symbol(const Symbol* sym, int begin, int end) {
   assert(sym->refcount() != 0, "require a valid symbol");
   const char* name = (const char*)sym->base() + begin;
   int len = end - begin;
+  assert(len <= Symbol::max_length(), "sanity");
   unsigned int hash = hash_symbol(name, len, _alt_hash);
   Symbol* found = lookup_common(name, len, hash);
   if (found == nullptr) {

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/LongExceptionMessageTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/LongExceptionMessageTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Google and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test to verify throwing an exception with extra long message does
+ *          not cause hang.
+ * @bug 8312401
+ * @run main/othervm LongExceptionMessageTest
+ */
+
+class ClassWithLongExceptionMessage {
+  static {
+    if (true) throw new AssertionError("lorem ipsum ".repeat(16000));
+  }
+}
+
+public class LongExceptionMessageTest {
+  public static void main(String[] args) {
+    try {
+      new ClassWithLongExceptionMessage();
+    } catch(Throwable t) {}
+  }
+}
+


### PR DESCRIPTION
Please review the simple fix to resolve infinite loop in SymbolTable::do_add_if_needed caused by extra long symbol string that exceeds Symbol::max_length(). See JDK-8312401 for details.

The jtreg test is converted from a test case constructed by @cushon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312401](https://bugs.openjdk.org/browse/JDK-8312401): SymbolTable::do_add_if_needed hangs when called in InstanceKlass::add_initialization_error path with requesting length exceeds max_symbol_length (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14938/head:pull/14938` \
`$ git checkout pull/14938`

Update a local copy of the PR: \
`$ git checkout pull/14938` \
`$ git pull https://git.openjdk.org/jdk.git pull/14938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14938`

View PR using the GUI difftool: \
`$ git pr show -t 14938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14938.diff">https://git.openjdk.org/jdk/pull/14938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14938#issuecomment-1642707549)