### PR TITLE
Fix failing jtreg tests due to missing c2 flags on x86

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestBackedgeLoadArrayFillMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBackedgeLoadArrayFillMain.java
@@ -28,6 +28,7 @@
  * @summary ArrayFill: if store is on backedge, last iteration is not to be executed.
  * @library /test/lib
  * @compile TestBackedgeLoadArrayFill.jasm
+ * @requires vm.compiler2.enabled
  * @run main/othervm
  *      -XX:CompileCommand=compileonly,TestBackedgeLoadArrayFill*::test*
  *      -XX:-TieredCompilation -Xcomp -XX:+OptimizeFill

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
@@ -26,6 +26,7 @@
  * @bug 8296412
  * @compile TestInfiniteLoopWithUnmergedBackedges.jasm
  * @summary Infinite loops may not have the backedges merged, before we call IdealLoopTree::check_safepts
+ * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-LoopUnswitching
  *      -XX:CompileCommand=compileonly,TestInfiniteLoopWithUnmergedBackedges::test*
  *      TestInfiniteLoopWithUnmergedBackedgesMain

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8299959
  * @summary In CmpU::Value, the sub computation may be narrower than the overflow computation.
+ * @requires vm.compiler2.enabled
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressCCP -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUOverflowVsSub::test


### PR DESCRIPTION
This commit addresses the issue of failing jtreg tests on the x86 platform. The tests were failing due to unrecognized VM options 'LoopUnswitching', 'OptimizeFill' and 'StressCCP' which are not available in x86 binary. 

Following tests were affected: 

1. TestInfiniteLoopWithUnmergedBackedgesMain.java - Affected by 'LoopUnswitching'
2. TestBackedgeLoadArrayFillMain.java - Affected by 'OptimizeFill'
3. TestRangeCheckCmpUOverflowVsSub.java - Affected by 'StressCCP'

Changes have been made to these tests to avoid the use of these flags when testing on x86. 

These changes maintain the integrity of the tests while ensuring compatibility across different platforms.

Related commits: 

- [ee63f83ed705c9cd3c49316fc4936668744f415d](https://github.com/microsoft/openjdk-jdk17u/commit/ee63f83ed705c9cd3c49316fc4936668744f415d#diff-ac9e408e8f32ed8c6260b005b8c386bc7a0a8738a8b8d2fe91c82b66f9f6ab7e)
- [d21597aec91bbd41960923385f6a1feb31f14a0c](https://github.com/microsoft/openjdk-jdk17u/commit/d21597aec91bbd41960923385f6a1feb31f14a0c)
- [e6c27925d23fe283a23c6adbe263658909c3739d](https://github.com/microsoft/openjdk-jdk17u/commit/e6c27925d23fe283a23c6adbe263658909c3739d#diff-36a07bd10ab86c032882232a1d18b96fb6a399c01dc05739c24ea12e9abc2d55)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14940/head:pull/14940` \
`$ git checkout pull/14940`

Update a local copy of the PR: \
`$ git checkout pull/14940` \
`$ git pull https://git.openjdk.org/jdk.git pull/14940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14940`

View PR using the GUI difftool: \
`$ git pr show -t 14940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14940.diff">https://git.openjdk.org/jdk/pull/14940.diff</a>

</details>
