### PR TITLE
8312420: Integrate Graal's blender micro benchmark

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/pea/Blender.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/pea/Blender.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler.pea;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 3)
+public class Blender {
+    @Param({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"})
+    int iteration;
+
+    private static class Color {
+        double r, g, b;
+
+        private Color(double r, double g, double b) {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+        }
+
+        public static Color color() {
+            return new Color(0, 0, 0);
+        }
+
+        public void add(Color other) {
+            r += other.r;
+            g += other.g;
+            b += other.b;
+        }
+
+        public void add(double nr, double ng, double nb) {
+            r += nr;
+            g += ng;
+            b += nb;
+        }
+
+        public void multiply(double factor) {
+            r *= factor;
+            g *= factor;
+            b *= factor;
+        }
+    }
+
+    private static final Color[][][] colors = new Color[100][100][100];
+
+    @Benchmark
+    public void initialize() {
+        Color id = new Color(iteration / 20, 0, 1);
+        for (int x = 0; x < colors.length; x++) {
+            Color[][] plane = colors[x];
+            for (int y = 0; y < plane.length; y++) {
+                Color[] row = plane[y];
+                for (int z = 0; z < row.length; z++) {
+                    Color color = new Color(x, y, z);
+                    color.add(id);
+                    if ((color.r + color.g + color.b) % 42 == 0) {
+                         // PEA only allocates a color object here
+                         row[z] = color;
+                    } else {
+                         // Here the color object is not allocated at all
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/test/micro/org/openjdk/bench/vm/compiler/pea/Blender.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/pea/Blender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package org.openjdk.bench.vm.compiler.pea;
 
 import org.openjdk.jmh.annotations.Benchmark;


### PR DESCRIPTION
We would like to integrate Graal's blender micro benchmark from https://www.graalvm.org/22.1/examples/java-performance-examples/. We have been using this benchmark to test our partial escape analysis work (https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2023-July/066670.html). This test can exist independently of the project.


example command to run test:

```
make run-test TEST=micro:org.openjdk.bench.vm.compiler.pea.Blender MICRO="FORK=1;OPTIONS=-prof gc -gc true"
```

example output (not complete):

```
Benchmark                               (iteration)  Mode  Cnt          Score   Error   Units                                                                       [29/1913]
Blender.initialize                                1  avgt       227997775.000           ns/op
Blender.initialize:·gc.alloc.rate                 1  avgt             167.192          MB/sec
Blender.initialize:·gc.alloc.rate.norm            1  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      1  avgt               4.000          counts
Blender.initialize:·gc.time                       1  avgt              65.000              ms
Blender.initialize                                2  avgt       226255767.800           ns/op
Blender.initialize:·gc.alloc.rate                 2  avgt             168.466          MB/sec
Blender.initialize:·gc.alloc.rate.norm            2  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      2  avgt               4.000          counts
Blender.initialize:·gc.time                       2  avgt              58.000              ms
Blender.initialize                                3  avgt       225596324.600           ns/op
Blender.initialize:·gc.alloc.rate                 3  avgt             168.960          MB/sec
Blender.initialize:·gc.alloc.rate.norm            3  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      3  avgt               4.000          counts
Blender.initialize:·gc.time                       3  avgt              55.000              ms
Blender.initialize                                4  avgt       224856811.000           ns/op
Blender.initialize:·gc.alloc.rate                 4  avgt             169.520          MB/sec
Blender.initialize:·gc.alloc.rate.norm            4  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      4  avgt               4.000          counts
Blender.initialize:·gc.time                       4  avgt              55.000              ms
Blender.initialize                                5  avgt       225413704.400           ns/op
Blender.initialize:·gc.alloc.rate                 5  avgt             169.126          MB/sec
Blender.initialize:·gc.alloc.rate.norm            5  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      5  avgt               4.000          counts
Blender.initialize:·gc.time                       5  avgt              58.000              ms
Blender.initialize                                6  avgt       224426973.800           ns/op
Blender.initialize:·gc.alloc.rate                 6  avgt             169.867          MB/sec
Blender.initialize:·gc.alloc.rate.norm            6  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      6  avgt               4.000          counts
Blender.initialize:·gc.time                       6  avgt              58.000              ms
Blender.initialize                                7  avgt       225148411.800           ns/op
Blender.initialize:·gc.alloc.rate                 7  avgt             169.308          MB/sec
Blender.initialize:·gc.alloc.rate.norm            7  avgt        40000081.600            B/op
Blender.initialize:·gc.count                      7  avgt               4.000          counts
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312420](https://bugs.openjdk.org/browse/JDK-8312420): Integrate Graal's blender micro benchmark (**Enhancement** - P5)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Koichi Sakata](https://openjdk.org/census#ksakata) (@jyukutyo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14941/head:pull/14941` \
`$ git checkout pull/14941`

Update a local copy of the PR: \
`$ git checkout pull/14941` \
`$ git pull https://git.openjdk.org/jdk.git pull/14941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14941`

View PR using the GUI difftool: \
`$ git pr show -t 14941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14941.diff">https://git.openjdk.org/jdk/pull/14941.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14941#issuecomment-1642856545)