### PR TITLE
8312423: Cache the enum values for VarHandle.AccessType

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -103,6 +103,6 @@ import java.util.function.BiFunction;
     @Override
     MethodHandle getMethodHandleUncached(int mode) {
         MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
-        return handleFactory.apply(AccessMode.values()[mode], targetHandle);
+        return handleFactory.apply(AccessMode.valueFromOrdinal(mode), targetHandle);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -132,7 +132,7 @@ final class VarForm {
 
     @DontInline
     MemberName resolveMemberName(int mode) {
-        AccessMode value = AccessMode.values()[mode];
+        AccessMode value = AccessMode.valueFromOrdinal(mode);
         String methodName = value.methodName();
         MethodType type = methodType_table[value.at.ordinal()].insertParameterTypes(0, VarHandle.class);
         return memberName_table[mode] = MethodHandles.Lookup.IMPL_LOOKUP
@@ -144,7 +144,7 @@ final class VarForm {
 
     @ForceInline
     final MethodType[] getMethodType_V_init() {
-        MethodType[] table = new MethodType[VarHandle.AccessType.values().length];
+        MethodType[] table = new MethodType[VarHandle.AccessType.COUNT];
         for (int i = 0; i < methodType_table.length; i++) {
             MethodType mt = methodType_table[i];
             // TODO only adjust for sig-poly methods returning Object

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1737,6 +1737,11 @@ public abstract sealed class VarHandle implements Constable
                 ps[i++] = intermediate[j];
             return i;
         }
+
+        private static final @Stable AccessType[] VALUES = values();
+        static AccessType valueFromOrdinal(int mode) {
+            return VALUES[mode];
+        }
     }
 
     /**
@@ -2003,6 +2008,11 @@ public abstract sealed class VarHandle implements Constable
                 default -> throw new IllegalArgumentException("No AccessMode value for method name " + methodName);
             };
         }
+
+        private static final @Stable AccessMode[] VALUES = values();
+        static AccessMode valueFromOrdinal(int mode) {
+            return VALUES[mode];
+        }
     }
 
     static final class AccessDescriptor {
@@ -2120,7 +2130,7 @@ public abstract sealed class VarHandle implements Constable
     }
 
     final MethodType accessModeTypeUncached(int accessTypeOrdinal) {
-        return accessModeTypeUncached(AccessType.values()[accessTypeOrdinal]);
+        return accessModeTypeUncached(AccessType.valueFromOrdinal(accessTypeOrdinal));
     }
 
     abstract MethodType accessModeTypeUncached(AccessType accessMode);
@@ -2215,7 +2225,7 @@ public abstract sealed class VarHandle implements Constable
      * @throws UnsupportedOperationException if the access mode is not supported
      */
     MethodHandle getMethodHandleUncached(int mode) {
-        MethodType mt = accessModeType(AccessMode.values()[mode]).
+        MethodType mt = accessModeType(AccessMode.valueFromOrdinal(mode)).
                 insertParameterTypes(0, VarHandle.class);
         MemberName mn = vform.getMemberName(mode);
         DirectMethodHandle dmh = DirectMethodHandle.make(mn);


### PR DESCRIPTION
Removed redundant calls to `values()` for `VarHandle.AccessType` and `VarHandle.AccessMode`, migrating calls to a cached accessor instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312423](https://bugs.openjdk.org/browse/JDK-8312423): Cache the enum values for VarHandle.AccessType (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14943/head:pull/14943` \
`$ git checkout pull/14943`

Update a local copy of the PR: \
`$ git checkout pull/14943` \
`$ git pull https://git.openjdk.org/jdk.git pull/14943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14943`

View PR using the GUI difftool: \
`$ git pr show -t 14943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14943.diff">https://git.openjdk.org/jdk/pull/14943.diff</a>

</details>
