### PR TITLE
8312424: 80% throughput decrease in Arrays.hashCode(Object[]) after JDK-8312164

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4555,7 +4555,7 @@ public final class Arrays {
         int result = 1;
 
         for (Object element : a)
-            result = 31 * result + Objects.hashCode(element);
+            result = 31 * result + (element == null ? 0 : element.hashCode());
 
         return result;
     }

--- a/test/micro/org/openjdk/bench/java/util/ArraysHashCode.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysHashCode.java
@@ -62,6 +62,7 @@ public class ArraysHashCode {
     private char[] chars;
     private short[] shorts;
     private int[] ints;
+    private Object[] objects;
     private byte[][] multibytes;
     private char[][] multichars;
     private short[][] multishorts;
@@ -75,12 +76,14 @@ public class ArraysHashCode {
         chars = new char[size];
         shorts = new short[size];
         ints = new int[size];
+        objects = new Object[size];
         for (int i = 0; i < size; i++) {
             int next = rnd.nextInt();
             bytes[i] = (byte)next;
             chars[i] = (char)next;
             shorts[i] = (short)next;
             ints[i] = next;
+            objects[i] = next;
         }
 
         multibytes = new byte[100][];
@@ -121,6 +124,11 @@ public class ArraysHashCode {
     @Benchmark
     public int ints() throws Throwable {
         return Arrays.hashCode(ints);
+    }
+
+    @Benchmark
+    public int objects() throws Throwable {
+        return Arrays.hashCode(objects);
     }
 
     @Benchmark


### PR DESCRIPTION
The changes to `Arrays.hashCode(Object[])` in JDK-8312164 caused its performance  is reduced by about 80%.

This PR reverts this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312424](https://bugs.openjdk.org/browse/JDK-8312424): 80% throughput decrease in Arrays.hashCode(Object[]) after JDK-8312164 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14944/head:pull/14944` \
`$ git checkout pull/14944`

Update a local copy of the PR: \
`$ git checkout pull/14944` \
`$ git pull https://git.openjdk.org/jdk.git pull/14944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14944`

View PR using the GUI difftool: \
`$ git pr show -t 14944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14944.diff">https://git.openjdk.org/jdk/pull/14944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14944#issuecomment-1642976052)