### PR TITLE
JDK-8312395: Improve assertions in growableArray

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -142,17 +142,17 @@ public:
   }
 
   E& at(int i) {
-    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
+    assert(0 <= i && i < _len, "illegal index %d for length %d", i, _len);
     return _data[i];
   }
 
   E const& at(int i) const {
-    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
+    assert(0 <= i && i < _len, "illegal index %d for length %d", i, _len);
     return _data[i];
   }
 
   E* adr_at(int i) const {
-    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
+    assert(0 <= i && i < _len, "illegal index %d for length %d", i, _len);
     return &_data[i];
   }
 
@@ -184,7 +184,7 @@ public:
   }
 
   void at_put(int i, const E& elem) {
-    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
+    assert(0 <= i && i < _len, "illegal index %d for length %d", i, _len);
     _data[i] = elem;
   }
 
@@ -245,7 +245,7 @@ public:
   }
 
   void remove_at(int index) {
-    assert(0 <= index && index < _len, "illegal index %d, %d accessible elements", index, _len);
+    assert(0 <= index && index < _len, "illegal index %d for length %d", index, _len);
     for (int j = index + 1; j < _len; j++) {
       _data[j-1] = _data[j];
     }
@@ -270,7 +270,7 @@ public:
 
   // The order is changed.
   void delete_at(int index) {
-    assert(0 <= index && index < _len, "illegal index %d", index);
+    assert(0 <= index && index < _len, "illegal index %d for length %d", index, _len);
     if (index < --_len) {
       // Replace removed element with last one.
       _data[index] = _data[_len];
@@ -426,7 +426,7 @@ public:
 
   // inserts the given element before the element at index i
   void insert_before(const int idx, const E& elem) {
-    assert(0 <= idx && idx <= this->_len, "illegal index");
+    assert(0 <= idx && idx <= this->_len, "illegal index %d for length %d", idx, this->_len);
     if (this->_len == this->_capacity) grow(this->_len);
     for (int j = this->_len - 1; j >= idx; j--) {
       this->_data[j + 1] = this->_data[j];
@@ -436,7 +436,7 @@ public:
   }
 
   void insert_before(const int idx, const GrowableArrayView<E>* array) {
-    assert(0 <= idx && idx <= this->_len, "illegal index");
+    assert(0 <= idx && idx <= this->_len, "illegal index %d for length %d", idx, this->_len);
     int array_len = array->length();
     int new_len = this->_len + array_len;
     if (new_len >= this->_capacity) grow(new_len);

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -260,7 +260,7 @@ public:
   // Remove all elements in the range [start - end). The order is preserved.
   void remove_range(int start, int end) {
     assert(0 <= start, "illegal start index %d", start);
-    assert(start < end && end <= _len, "erase called with invalid range %d, %d", start, end);
+    assert(start < end && end <= _len, "erase called with invalid range (%d, %d) for length %d", start, end, _len);
 
     for (int i = start, j = end; j < length(); i++, j++) {
       at_put(i, at(j));

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -142,17 +142,17 @@ public:
   }
 
   E& at(int i) {
-    assert(0 <= i && i < _len, "illegal index");
+    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
     return _data[i];
   }
 
   E const& at(int i) const {
-    assert(0 <= i && i < _len, "illegal index");
+    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
     return _data[i];
   }
 
   E* adr_at(int i) const {
-    assert(0 <= i && i < _len, "illegal index");
+    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
     return &_data[i];
   }
 
@@ -184,7 +184,7 @@ public:
   }
 
   void at_put(int i, const E& elem) {
-    assert(0 <= i && i < _len, "illegal index");
+    assert(0 <= i && i < _len, "illegal index %d, %d accessible elements", i, _len);
     _data[i] = elem;
   }
 
@@ -245,7 +245,7 @@ public:
   }
 
   void remove_at(int index) {
-    assert(0 <= index && index < _len, "illegal index");
+    assert(0 <= index && index < _len, "illegal index %d, %d accessible elements", index, _len);
     for (int j = index + 1; j < _len; j++) {
       _data[j-1] = _data[j];
     }
@@ -259,8 +259,8 @@ public:
 
   // Remove all elements in the range [start - end). The order is preserved.
   void remove_range(int start, int end) {
-    assert(0 <= start, "illegal index");
-    assert(start < end && end <= _len, "erase called with invalid range");
+    assert(0 <= start, "illegal start index %d", start);
+    assert(start < end && end <= _len, "erase called with invalid range %d, %d", start, end);
 
     for (int i = start, j = end; j < length(); i++, j++) {
       at_put(i, at(j));
@@ -270,7 +270,7 @@ public:
 
   // The order is changed.
   void delete_at(int index) {
-    assert(0 <= index && index < _len, "illegal index");
+    assert(0 <= index && index < _len, "illegal index %d", index);
     if (index < --_len) {
       // Replace removed element with last one.
       _data[index] = _data[_len];
@@ -403,7 +403,7 @@ public:
   void push(const E& elem) { append(elem); }
 
   E at_grow(int i, const E& fill = E()) {
-    assert(0 <= i, "negative index");
+    assert(0 <= i, "negative index %d", i);
     if (i >= this->_len) {
       if (i >= this->_capacity) grow(i);
       for (int j = this->_len; j <= i; j++)
@@ -414,7 +414,7 @@ public:
   }
 
   void at_put_grow(int i, const E& elem, const E& fill = E()) {
-    assert(0 <= i, "negative index");
+    assert(0 <= i, "negative index %d", i);
     if (i >= this->_len) {
       if (i >= this->_capacity) grow(i);
       for (int j = this->_len; j < i; j++)


### PR DESCRIPTION
There are a number of assertions in growableArray , for example to check for a valid index to access/remove elements.
Those assertions can be improved, e.g. by showing the bad index value used in case of failure.

Example for an assertion in the 'at(index i)' access method 
old assertion looks like
assert(0 <= i && i < _len) failed: illegal index

new assertion looks like
assert(0 <= i && i < _len) failed: illegal index -559030609, 1 accessible elements

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312395](https://bugs.openjdk.org/browse/JDK-8312395): Improve assertions in growableArray (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d4e3ba68](https://git.openjdk.org/jdk/pull/14946/files/d4e3ba687413ec1dd93535eab55bd042b288d634)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [d4e3ba68](https://git.openjdk.org/jdk/pull/14946/files/d4e3ba687413ec1dd93535eab55bd042b288d634)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14946/head:pull/14946` \
`$ git checkout pull/14946`

Update a local copy of the PR: \
`$ git checkout pull/14946` \
`$ git pull https://git.openjdk.org/jdk.git pull/14946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14946`

View PR using the GUI difftool: \
`$ git pr show -t 14946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14946.diff">https://git.openjdk.org/jdk/pull/14946.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14946#issuecomment-1643446540)