### PR TITLE
[PATCH] Make default timeouts and encoding final in sun.net.NetworkClient

### DIFF
--- a/src/java.base/share/classes/sun/net/NetworkClient.java
+++ b/src/java.base/share/classes/sun/net/NetworkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,17 +57,17 @@ public class NetworkClient {
     /** Buffered stream for reading replies from server. */
     public InputStream  serverInput;
 
-    protected static int defaultSoTimeout;
-    protected static int defaultConnectTimeout;
+    protected static final int defaultSoTimeout;
+    protected static final int defaultConnectTimeout;
 
     protected int readTimeout = DEFAULT_READ_TIMEOUT;
     protected int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     /* Name of encoding to use for output */
-    protected static String encoding;
+    protected static final String encoding;
 
     static {
-        final int vals[] = {0, 0};
-        final String encs[] = { null };
+        final int[] vals = {0, 0};
+        final String[] encs = { null };
 
         AccessController.doPrivileged(
                 new PrivilegedAction<>() {
@@ -78,21 +78,18 @@ public class NetworkClient {
                         return null;
             }
         });
-        if (vals[0] != 0) {
-            defaultSoTimeout = vals[0];
-        }
-        if (vals[1] != 0) {
-            defaultConnectTimeout = vals[1];
-        }
+        defaultSoTimeout = vals[0];
+        defaultConnectTimeout = vals[1];
 
-        encoding = encs[0];
+        String enc = encs[0];
         try {
-            if (!isASCIISuperset (encoding)) {
-                encoding = "ISO8859_1";
+            if (!isASCIISuperset(enc)) {
+                enc = "ISO8859_1";
             }
         } catch (Exception e) {
-            encoding = "ISO8859_1";
+            enc = "ISO8859_1";
         }
+        encoding = enc;
     }
 
 


### PR DESCRIPTION
There is opportunity to make 3 static fields `final` in `sun.net.NetworkClient`:
1. defaultSoTimeout
2. defaultConnectTimeout
3. encoding

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14947/head:pull/14947` \
`$ git checkout pull/14947`

Update a local copy of the PR: \
`$ git checkout pull/14947` \
`$ git pull https://git.openjdk.org/jdk.git pull/14947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14947`

View PR using the GUI difftool: \
`$ git pr show -t 14947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14947.diff">https://git.openjdk.org/jdk/pull/14947.diff</a>

</details>
