### PR TITLE
8312443: sun.security should use toLowerCase(Locale.ROOT)

### DIFF
--- a/src/java.base/share/classes/sun/security/action/GetPropertyAction.java
+++ b/src/java.base/share/classes/sun/security/action/GetPropertyAction.java
@@ -27,6 +27,7 @@ package sun.security.action;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 import java.util.Properties;
 import sun.security.util.Debug;
 
@@ -194,10 +195,10 @@ public class GetPropertyAction implements PrivilegedAction<String> {
         // the original value in rawPropVal for debug messages.
         boolean isMillis = false;
         String propVal = rawPropVal;
-        if (rawPropVal.toLowerCase().endsWith("ms")) {
+        if (rawPropVal.toLowerCase(Locale.ROOT).endsWith("ms")) {
             propVal = rawPropVal.substring(0, rawPropVal.length() - 2);
             isMillis = true;
-        } else if (rawPropVal.toLowerCase().endsWith("s")) {
+        } else if (rawPropVal.toLowerCase(Locale.ROOT).endsWith("s")) {
             propVal = rawPropVal.substring(0, rawPropVal.length() - 1);
         }
 

--- a/src/java.base/share/classes/sun/security/ec/ParametersMap.java
+++ b/src/java.base/share/classes/sun/security/ec/ParametersMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import sun.security.x509.AlgorithmId;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.NamedParameterSpec;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Optional;
@@ -53,7 +54,7 @@ public class ParametersMap<T> {
     }
 
     public void put(String name, ObjectIdentifier oid, int size, T params) {
-        nameMap.put(name.toLowerCase(), params);
+        nameMap.put(name.toLowerCase(Locale.ROOT), params);
         oidMap.put(oid, params);
         sizeMap.put(size, params);
     }
@@ -65,7 +66,7 @@ public class ParametersMap<T> {
         return Optional.ofNullable(sizeMap.get(size));
     }
     public Optional<T> getByName(String name) {
-        return Optional.ofNullable(nameMap.get(name.toLowerCase()));
+        return Optional.ofNullable(nameMap.get(name.toLowerCase(Locale.ROOT)));
     }
 
     // Utility method that is used by the methods below to handle exception

--- a/src/java.base/share/classes/sun/security/ec/XECParameters.java
+++ b/src/java.base/share/classes/sun/security/ec/XECParameters.java
@@ -137,7 +137,7 @@ public class XECParameters {
         ObjectIdentifier oid = ObjectIdentifier.of(koid);
         XECParameters params =
             new XECParameters(bits, p, a24, basePoint, logCofactor, oid, name);
-        namedParams.put(name.toLowerCase(), oid, bits, params);
+        namedParams.put(name, oid, bits, params);
         return params;
     }
 
@@ -170,4 +170,3 @@ public class XECParameters {
         return namedParams.get(exception, params);
     }
 }
-


### PR DESCRIPTION
sun.security codes should use `toLowerCase(Locale.ROOT)` instead of `toLowerCase()`.
In addition, no `toUpperCase()` was found in this code scope.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312443](https://bugs.openjdk.org/browse/JDK-8312443): sun.security should use toLowerCase(Locale.ROOT) (**Bug** - P4)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14948/head:pull/14948` \
`$ git checkout pull/14948`

Update a local copy of the PR: \
`$ git checkout pull/14948` \
`$ git pull https://git.openjdk.org/jdk.git pull/14948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14948`

View PR using the GUI difftool: \
`$ git pr show -t 14948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14948.diff">https://git.openjdk.org/jdk/pull/14948.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14948#issuecomment-1643599931)