### PR TITLE
6442919: JFilechooser popup still left-to-right when JFilechooser is set to right-to-left

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1932,6 +1932,8 @@ public class FilePane extends JPanel implements PropertyChangeListener {
         if (viewMenu != null) {
             viewMenu.getPopupMenu().setInvoker(viewMenu);
         }
+
+        contextMenu.applyComponentOrientation(getFileChooser().getComponentOrientation());
         return contextMenu;
     }
 

--- a/test/jdk/javax/swing/JFileChooser/FCPopupMenuOrientationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FCPopupMenuOrientationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.ComponentOrientation;
+
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+/*
+ * @test
+ * @bug 6442919
+ * @library ../regtesthelpers
+ * @build Util
+ * @summary Test to check the orientation of Popup menu is set
+ * as per FileChooser orientation.
+ * @run main FCPopupMenuOrientationTest
+ */
+
+public class FCPopupMenuOrientationTest {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                for (UIManager.LookAndFeelInfo laf :
+                        UIManager.getInstalledLookAndFeels()) {
+                    String className = laf.getName().toLowerCase();
+                    if (className.contains("motif") || className.contains("mac")) {
+                        continue;
+                    }
+                    setLookAndFeel(laf);
+                    JFileChooser fc = new JFileChooser();
+                    fc.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+
+                    JComponent comp = (JComponent) Util.findSubComponent(
+                            fc, "FilePane");
+                    JPopupMenu popupMenu = comp.getComponentPopupMenu();
+                    if (popupMenu.getComponentOrientation() !=
+                            fc.getComponentOrientation()) {
+                        throw new RuntimeException("File Chooser component " +
+                                "orientation doesn't match with PopupMenu");
+                    }
+                }
+            }
+        });
+        System.out.println("Test Pass");
+    }
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+            System.out.println("Set L&F : "+laf.getName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException |
+                 IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+

--- a/test/jdk/javax/swing/JFileChooser/FCPopupMenuOrientationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FCPopupMenuOrientationTest.java
@@ -73,7 +73,7 @@ public class FCPopupMenuOrientationTest {
     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
             UIManager.setLookAndFeel(laf.getClassName());
-            System.out.println("Set L&F : "+laf.getName());
+            System.out.println("Set L&F : " + laf.getName());
         } catch (UnsupportedLookAndFeelException ignored) {
             System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
         } catch (ClassNotFoundException | InstantiationException |

--- a/test/jdk/javax/swing/JFileChooser/FCPopupMenuOrientationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FCPopupMenuOrientationTest.java
@@ -48,7 +48,9 @@ public class FCPopupMenuOrientationTest {
                 for (UIManager.LookAndFeelInfo laf :
                         UIManager.getInstalledLookAndFeels()) {
                     String className = laf.getName().toLowerCase();
-                    if (className.contains("motif") || className.contains("mac")) {
+                    if (className.contains("motif")
+                            || className.contains("mac")
+                            || className.contains("gtk")) {
                         continue;
                     }
                     setLookAndFeel(laf);


### PR DESCRIPTION
Popup menu is created on mouse click, hence the orientation for FileChooser won't apply to the popup menu created. Hence the fix address the issue by applying the FileChooser orientation when it is created on mouse operation (Right Click). 
The test does not apply to Motif and Aqua Look And Feel since right click is not supported on filePane of FileChooser, hence it is skipped. The fix is tested in CI and it is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6442919](https://bugs.openjdk.org/browse/JDK-6442919): JFilechooser popup still left-to-right when JFilechooser is set to right-to-left (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14949/head:pull/14949` \
`$ git checkout pull/14949`

Update a local copy of the PR: \
`$ git checkout pull/14949` \
`$ git pull https://git.openjdk.org/jdk.git pull/14949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14949`

View PR using the GUI difftool: \
`$ git pr show -t 14949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14949.diff">https://git.openjdk.org/jdk/pull/14949.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14949#issuecomment-1643616228)