### PR TITLE
8313948: Remove unnecessary static fields defaultUpper/defaultLower in sun.net.PortConfig

### DIFF
--- a/src/java.base/unix/classes/sun/net/PortConfig.java
+++ b/src/java.base/unix/classes/sun/net/PortConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import jdk.internal.util.OperatingSystem;
 
 public final class PortConfig {
 
-    private static int defaultUpper, defaultLower;
     private static final int upper, lower;
 
     private PortConfig() {}
 
     static {
         jdk.internal.loader.BootLoader.loadLibrary("net");
+        int defaultUpper;
+        int defaultLower;
         switch (OperatingSystem.current()) {
             case LINUX:
                 defaultLower = 32768;


### PR DESCRIPTION
Static fields `defaultUpper`/`defaultLower` can be converted to local variables in `<clinit>`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313948](https://bugs.openjdk.org/browse/JDK-8313948): Remove unnecessary static fields defaultUpper/defaultLower in sun.net.PortConfig (**Enhancement** - P5)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14950/head:pull/14950` \
`$ git checkout pull/14950`

Update a local copy of the PR: \
`$ git checkout pull/14950` \
`$ git pull https://git.openjdk.org/jdk.git pull/14950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14950`

View PR using the GUI difftool: \
`$ git pr show -t 14950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14950.diff">https://git.openjdk.org/jdk/pull/14950.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14950#issuecomment-1669463406)