### PR TITLE
JDK-8312453: GrowableArray should assert for length overflow on append

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -387,6 +387,7 @@ protected:
 
 public:
   int append(const E& elem) {
+    assert(this->_len != INT_MAX, "Overflow");
     if (this->_len == this->_capacity) grow(this->_len);
     int idx = this->_len++;
     this->_data[idx] = elem;
@@ -514,8 +515,9 @@ void GrowableArrayWithAllocator<E, Derived>::expand_to(int new_capacity) {
 
 template <typename E, typename Derived>
 void GrowableArrayWithAllocator<E, Derived>::grow(int j) {
-  // grow the array by increasing _capacity to the first power of two larger than the size we need
-  expand_to(next_power_of_2(j));
+  const size_t next_p2 = next_power_of_2((size_t)j);
+  assert(next_p2 < INT_MAX, "GrowableArray overflow (current capacity: %d)", this->_capacity);
+  expand_to((int) next_p2);
 }
 
 template <typename E, typename Derived>


### PR DESCRIPTION
Trivial change to assert that we don't overflow on append.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312453](https://bugs.openjdk.org/browse/JDK-8312453): GrowableArray should assert for length overflow on append (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14951/head:pull/14951` \
`$ git checkout pull/14951`

Update a local copy of the PR: \
`$ git checkout pull/14951` \
`$ git pull https://git.openjdk.org/jdk.git pull/14951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14951`

View PR using the GUI difftool: \
`$ git pr show -t 14951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14951.diff">https://git.openjdk.org/jdk/pull/14951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14951#issuecomment-1644109670)