### PR TITLE
[PATCH] Duplicate condition in ResolverConfigurationImpl

### DIFF
--- a/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-/*
+/**
  * An implementation of sun.net.ResolverConfiguration for Windows.
  */
 
@@ -95,7 +95,7 @@ public final class ResolverConfigurationImpl
                     // Not BSD style
                     s = '[' + s + ']';
                 }
-                if (!s.isEmpty() && !l.contains(s)) {
+                if (!l.contains(s)) {
                     l.add(s);
                 }
             }


### PR DESCRIPTION
`s` is already checked before to emptiness.
https://github.com/openjdk/jdk/blob/8d29329138d44800ee4c0c02dacc01a06097de66/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java#L93-L100

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14954/head:pull/14954` \
`$ git checkout pull/14954`

Update a local copy of the PR: \
`$ git checkout pull/14954` \
`$ git pull https://git.openjdk.org/jdk.git pull/14954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14954`

View PR using the GUI difftool: \
`$ git pr show -t 14954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14954.diff">https://git.openjdk.org/jdk/pull/14954.diff</a>

</details>
