### PR TITLE
8354826: Make ResolverConfigurationImpl.lock field final

### DIFF
--- a/src/java.base/unix/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/unix/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public final class ResolverConfigurationImpl
     extends ResolverConfiguration
 {
     // Lock helds whilst loading configuration or checking
-    private static Object lock = new Object();
+    private static final Object lock = new Object();
 
     // Time of last refresh.
     private static long lastRefresh = -1;


### PR DESCRIPTION
It was made `final` in Windows version of `ResolverConfigurationImpl` under [JDK-8287104](https://bugs.openjdk.java.net/browse/JDK-8287104).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354826](https://bugs.openjdk.org/browse/JDK-8354826): Make ResolverConfigurationImpl.lock field final (**Enhancement** - P5)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14955/head:pull/14955` \
`$ git checkout pull/14955`

Update a local copy of the PR: \
`$ git checkout pull/14955` \
`$ git pull https://git.openjdk.org/jdk.git pull/14955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14955`

View PR using the GUI difftool: \
`$ git pr show -t 14955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14955.diff">https://git.openjdk.org/jdk/pull/14955.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14955#issuecomment-2809378710)
</details>
