### PR TITLE
JDK-8310316: Failing HotSpot Compiler directives are too verbose

### DIFF
--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -57,8 +57,8 @@ void DirectivesParser::clean_tmp() {
   assert(_tmp_depth == 0, "Consistency");
 }
 
-int DirectivesParser::parse_string(const char* text, outputStream* st) {
-  DirectivesParser cd(text, st, false);
+int DirectivesParser::parse_string(const char* text, outputStream* st, bool silent) {
+  DirectivesParser cd(text, st, silent);
   if (cd.valid()) {
     return cd.install_directives();
   } else {
@@ -77,16 +77,16 @@ bool DirectivesParser::parse_from_flag() {
   return parse_from_file(CompilerDirectivesFile, tty);
 }
 
-bool DirectivesParser::parse_from_file(const char* filename, outputStream* st) {
+bool DirectivesParser::parse_from_file(const char* filename, outputStream* st, bool silent) {
   assert(filename != nullptr, "Test before calling this");
-  if (!parse_from_file_inner(filename, st)) {
+  if (!parse_from_file_inner(filename, st, silent)) {
     st->print_cr("Could not load file: %s", filename);
     return false;
   }
   return true;
 }
 
-bool DirectivesParser::parse_from_file_inner(const char* filename, outputStream* stream) {
+bool DirectivesParser::parse_from_file_inner(const char* filename, outputStream* stream, bool silent) {
   struct stat st;
   ResourceMark rm;
   if (os::stat(filename, &st) == 0) {
@@ -99,7 +99,7 @@ bool DirectivesParser::parse_from_file_inner(const char* filename, outputStream*
       ::close(file_handle);
       if (num_read >= 0) {
         buffer[num_read] = '\0';
-        return parse_string(buffer, stream) > 0;
+        return parse_string(buffer, stream, silent) > 0;
       }
     }
   }

--- a/src/hotspot/share/compiler/directivesParser.hpp
+++ b/src/hotspot/share/compiler/directivesParser.hpp
@@ -55,8 +55,8 @@ class DirectivesParser : public JSON {
  public:
   static bool has_file();
   static bool parse_from_flag();
-  static bool parse_from_file(const char* filename, outputStream* st);
-  static int  parse_string(const char* string, outputStream* st);
+  static bool parse_from_file(const char* filename, outputStream* st, bool silent = false);
+  static int  parse_string(const char* string, outputStream* st, bool silent = false);
   int install_directives();
 
  private:
@@ -64,7 +64,7 @@ class DirectivesParser : public JSON {
   ~DirectivesParser();
 
   bool callback(JSON_TYPE t, JSON_VAL* v, uint level);
-  static bool parse_from_file_inner(const char* filename, outputStream* st);
+  static bool parse_from_file_inner(const char* filename, outputStream* st, bool silent = false);
 
   // types of "keys". i.e recognized <key>:<value> pairs in our JSON syntax
   typedef enum {

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -889,7 +889,7 @@ CompilerDirectivesAddDCmd::CompilerDirectivesAddDCmd(outputStream* output, bool 
 }
 
 void CompilerDirectivesAddDCmd::execute(DCmdSource source, TRAPS) {
-  DirectivesParser::parse_from_file(_filename.value(), output());
+  DirectivesParser::parse_from_file(_filename.value(), output(), true);
 }
 
 void CompilerDirectivesRemoveDCmd::execute(DCmdSource source, TRAPS) {


### PR DESCRIPTION
Previously jcmd printed the whole file if a compiler directive was added that was not in json format. This example illustrates the issue:

```
./jcmd 331311 Compiler.directives_add ./example.txt
331311:
Syntax error on line 1 byte 1: Json must start with an object or an array.
  At 'This'.
This is my very interesting text,
followed by some more exciting text.

Parsing of compiler directives failed
Could not load file: ./example.txt
```
The json error message is not printed if the silent field is set in the `DirectivesParser` object.
The proposed change adds a boolean parameter silent that is propagated from `CompilerDirectivesAddDCmd::execute` to the `DirectivesParser` constructor. The default value for the new parameter is set to false, which represents the original behavior. In case where a compiler directive is added, the parameter is set to true and the error message will be reduced.

The proposed change reduces the error message to:

```
./jcmd 335703 Compiler.directives_add ./example.txt
335703:
Parsing of compiler directives failed
Could not load file: ./example.txt
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310316](https://bugs.openjdk.org/browse/JDK-8310316): Failing HotSpot Compiler directives are too verbose (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14957/head:pull/14957` \
`$ git checkout pull/14957`

Update a local copy of the PR: \
`$ git checkout pull/14957` \
`$ git pull https://git.openjdk.org/jdk.git pull/14957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14957`

View PR using the GUI difftool: \
`$ git pr show -t 14957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14957.diff">https://git.openjdk.org/jdk/pull/14957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14957#issuecomment-1645523068)