### PR TITLE
8312474: JFR: Improve logging to diagnose event stream timeout

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -38,6 +38,9 @@ import java.util.function.Consumer;
 import jdk.jfr.Configuration;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.PlatformRecording;
 import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.util.Utils;
@@ -196,6 +199,9 @@ public final class EventDirectoryStream extends AbstractEventStream {
                     // Avoid reading the same chunk again and again if
                     // duration is 0 ns
                     durationNanos++;
+                    if (Logger.shouldLog(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO)) {
+                        Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Unexpected chunk with 0 ns duration");
+                    }
                 }
                 path = repositoryFiles.nextPath(currentChunkStartNanos + durationNanos, true);
                 if (path == null) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdView.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdView.java
@@ -29,6 +29,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.OldObjectSample;
 import jdk.jfr.internal.util.Utils;
 import jdk.jfr.internal.query.Configuration;
@@ -61,6 +64,10 @@ public class DCmdView extends AbstractDCmd {
             OldObjectSample.emit(0);
             Utils.waitFlush(10_000);
             configuration.endTime = Instant.now();
+        }
+
+        if (Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG)) {
+            Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG, "JFR.view time range: " + configuration.startTime + " - " + configuration.endTime);
         }
         try (QueryRecording recording = new QueryRecording(configuration, parser)) {
             ViewPrinter printer = new ViewPrinter(configuration, recording.getStream());


### PR DESCRIPTION
Could I have review of a PR that adds logging to diagnose a test timeout. 

It also fixes a bug where the test didn't wait for the Old Collection event to arrive.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312474](https://bugs.openjdk.org/browse/JDK-8312474): JFR: Improve logging to diagnose event stream timeout (**Sub-task** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14960/head:pull/14960` \
`$ git checkout pull/14960`

Update a local copy of the PR: \
`$ git checkout pull/14960` \
`$ git pull https://git.openjdk.org/jdk.git pull/14960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14960`

View PR using the GUI difftool: \
`$ git pr show -t 14960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14960.diff">https://git.openjdk.org/jdk/pull/14960.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14960#issuecomment-1644399992)