### PR TITLE
4800398: (ch spec) Clarify Channels.newChannel(InputStream) spec

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -259,14 +259,15 @@ public final class Channels {
     /**
      * Constructs a channel that reads bytes from the given stream.
      *
-     * <p> The resulting channel will be in blocking mode and will not be
-     * buffered; it will simply redirect its I/O operations to the given stream.
-     * Closing the channel will in turn cause the stream to be closed.  </p>
+     * <p> The resulting channel will not be buffered; it will simply redirect
+     * its I/O operations to the given stream. Reading from the resulting
+     * channel will read from the input stream hence might block. Closing the
+     * channel will in turn cause the stream to be closed.  </p>
      *
      * @param  in
      *         The stream from which bytes are to be read
      *
-     * @return  A new readable byte channel in blocking mode
+     * @return  A new readable byte channel
      */
     public static ReadableByteChannel newChannel(InputStream in) {
         Objects.requireNonNull(in, "in");

--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -261,8 +261,9 @@ public final class Channels {
      *
      * <p> The resulting channel will not be buffered; it will simply redirect
      * its I/O operations to the given stream. Reading from the resulting
-     * channel will read from the input stream hence might block. Closing the
-     * channel will in turn cause the stream to be closed.  </p>
+     * channel will read from the input stream and thus block until input is
+     * available or end of file is reached. Closing the channel will in turn
+     * cause the stream to be closed.  </p>
      *
      * @param  in
      *         The stream from which bytes are to be read

--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -259,14 +259,14 @@ public final class Channels {
     /**
      * Constructs a channel that reads bytes from the given stream.
      *
-     * <p> The resulting channel will not be buffered; it will simply redirect
-     * its I/O operations to the given stream.  Closing the channel will in
-     * turn cause the stream to be closed.  </p>
+     * <p> The resulting channel will be in blocking mode and will not be
+     * buffered; it will simply redirect its I/O operations to the given stream.
+     * Closing the channel will in turn cause the stream to be closed.  </p>
      *
      * @param  in
      *         The stream from which bytes are to be read
      *
-     * @return  A new readable byte channel
+     * @return  A new readable byte channel in blocking mode
      */
     public static ReadableByteChannel newChannel(InputStream in) {
         Objects.requireNonNull(in, "in");


### PR DESCRIPTION
Clarify that the `ReadableByteChannel` returned by `Channels::newChannel` is in blocking mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8312516](https://bugs.openjdk.org/browse/JDK-8312516) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-4800398](https://bugs.openjdk.org/browse/JDK-4800398): (ch spec) Clarify Channels.newChannel(InputStream) spec (**Bug** - P4)
 * [JDK-8312516](https://bugs.openjdk.org/browse/JDK-8312516): (ch spec) Clarify Channels.newChannel(InputStream) spec (**CSR**)

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14961/head:pull/14961` \
`$ git checkout pull/14961`

Update a local copy of the PR: \
`$ git checkout pull/14961` \
`$ git pull https://git.openjdk.org/jdk.git pull/14961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14961`

View PR using the GUI difftool: \
`$ git pr show -t 14961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14961.diff">https://git.openjdk.org/jdk/pull/14961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14961#issuecomment-1644383059)