### PR TITLE
8312293: SIGSEGV in jfr.internal.event.EventWriter.putUncheckedByte after JDK-8312086

### DIFF
--- a/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
@@ -71,7 +71,7 @@ void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
   return JfrJavaEventWriter::event_writer(jt);
 }
 
-void JfrIntrinsicSupport::return_lease(JavaThread* jt) {
+void* JfrIntrinsicSupport::return_lease(JavaThread* jt) {
   DEBUG_ONLY(assert_precondition(jt);)
   ThreadStateTransition::transition_from_java(jt, _thread_in_native);
   assert(jt->jfr_thread_local()->has_java_event_writer(), "invariant");
@@ -79,6 +79,7 @@ void JfrIntrinsicSupport::return_lease(JavaThread* jt) {
   JfrJavaEventWriter::flush(jt->jfr_thread_local()->java_event_writer(), 0, 0, jt);
   assert(jt->jfr_thread_local()->shelved_buffer() == nullptr, "invariant");
   ThreadStateTransition::transition_from_native(jt, _thread_in_Java);
+  return nullptr;
 }
 
 void JfrIntrinsicSupport::load_barrier(const Klass* klass) {

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
@@ -37,7 +37,7 @@
 class JfrIntrinsicSupport : AllStatic {
  public:
   static void* write_checkpoint(JavaThread* jt);
-  static void return_lease(JavaThread* jt);
+  static void* return_lease(JavaThread* jt);
   static void load_barrier(const Klass* klass);
   static address epoch_address();
   static address signal_address();


### PR DESCRIPTION
Greetings,

please help review this fix. The problem description and fix are described in detail in the JIRA issue.

Testing: jdk_jfr, microbenchmarks

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312293](https://bugs.openjdk.org/browse/JDK-8312293): SIGSEGV in jfr.internal.event.EventWriter.putUncheckedByte after JDK-8312086 (**Bug** - P2)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14962/head:pull/14962` \
`$ git checkout pull/14962`

Update a local copy of the PR: \
`$ git checkout pull/14962` \
`$ git pull https://git.openjdk.org/jdk.git pull/14962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14962`

View PR using the GUI difftool: \
`$ git pr show -t 14962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14962.diff">https://git.openjdk.org/jdk/pull/14962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14962#issuecomment-1644528850)