### PR TITLE
8312180: (bf) MappedMemoryUtils passes incorrect arguments to msync (aix)

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -93,6 +93,10 @@
 #include "jvmci/jvmciJavaClasses.hpp"
 #endif
 
+#ifdef AIX
+#include <unistd.h>
+#endif
+
 #define DECLARE_INJECTED_FIELD(klass, name, signature, may_be_java)           \
   { VM_CLASS_ID(klass), VM_SYMBOL_ENUM_NAME(name##_name), VM_SYMBOL_ENUM_NAME(signature), may_be_java },
 
@@ -4711,7 +4715,7 @@ public:
   UnsafeConstantsFixup() {
     // round up values for all static final fields
     _address_size = sizeof(void*);
-    _page_size = (int)os::vm_page_size();
+    _page_size = AIX_ONLY(sysconf(_SC_PAGESIZE)) NOT_AIX((int)os::vm_page_size());
     _big_endian = LITTLE_ENDIAN_ONLY(false) BIG_ENDIAN_ONLY(true);
     _use_unaligned_access = UseUnalignedAccesses;
     _data_cache_line_flush_size = (int)VM_Version::data_cache_line_flush_size();

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -86,15 +86,12 @@
 #include "runtime/vframe.inline.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/align.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/preserveException.hpp"
 #include "utilities/utf8.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciJavaClasses.hpp"
-#endif
-
-#ifdef AIX
-#include <unistd.h>
 #endif
 
 #define DECLARE_INJECTED_FIELD(klass, name, signature, may_be_java)           \


### PR DESCRIPTION
This change is as an alternate solution to my original proposal for [JDK-8312180](https://bugs.openjdk.org/browse/JDK-8312180).

Suggested by @tstuefe.

This change matches the return value of Bits.pageSize with the system page size (which is not currently true on AIX).

These tests are upstream of my target test (TestByteBuffer) and results are encouraging. Tier1 testing ~in ongoing for this change~ passes with flying colours.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312180](https://bugs.openjdk.org/browse/JDK-8312180): (bf) MappedMemoryUtils passes incorrect arguments to msync (aix) (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14963/head:pull/14963` \
`$ git checkout pull/14963`

Update a local copy of the PR: \
`$ git checkout pull/14963` \
`$ git pull https://git.openjdk.org/jdk.git pull/14963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14963`

View PR using the GUI difftool: \
`$ git pr show -t 14963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14963.diff">https://git.openjdk.org/jdk/pull/14963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14963#issuecomment-1644555441)