### PR TITLE
8312486: Allow abstract classes for MethodHandleProxies::asInterfaceInstance

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/MethodInheritance.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodInheritance.java
@@ -22,23 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang;
-
-import jdk.internal.reflect.ReflectionFactory;
+package jdk.internal.reflect;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.security.AccessController;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * A collection of most specific public methods. Methods are added to it using
- * {@link #merge(Method)} method. Only the most specific methods for a
+ * A collection of most specific methods in inheritance. Methods are added to
+ * it using {@link #merge(Method)} method. Only the most specific methods for a
  * particular signature are kept.
  */
-final class PublicMethods {
+public final class MethodInheritance {
 
     /**
      * a map of (method name, parameter types) -> linked list of Method(s)
@@ -58,7 +55,7 @@ final class PublicMethods {
      * than added method.
      * See comments in code...
      */
-    void merge(Method method) {
+    public void merge(Method method) {
         Key key = new Key(method);
         MethodList existing = map.get(key);
         int xLen = existing == null ? 0 : existing.length();
@@ -73,7 +70,7 @@ final class PublicMethods {
     /**
      * Dumps methods to array.
      */
-    Method[] toArray() {
+    public Method[] toArray() {
         Method[] array = new Method[methodCount];
         int i = 0;
         for (MethodList ml : map.values()) {
@@ -88,10 +85,8 @@ final class PublicMethods {
      * Method (name, parameter types) tuple.
      */
     private static final class Key {
-        @SuppressWarnings("removal")
         private static final ReflectionFactory reflectionFactory =
-            AccessController.doPrivileged(
-                new ReflectionFactory.GetReflectionFactoryAction());
+            ReflectionFactory.getReflectionFactory();
 
         private final String name; // must be interned (as from Method.getName())
         private final Class<?>[] ptypes;
@@ -128,12 +123,12 @@ final class PublicMethods {
     }
 
     /**
-     * Node of a inked list containing Method(s) sharing the same
+     * Node of a linked list containing Method(s) sharing the same
      * (name, parameter types) tuple.
      */
-    static final class MethodList {
-        Method method;
-        MethodList next;
+    public static final class MethodList {
+        private final Method method;
+        private MethodList next;
 
         private MethodList(Method method) {
             this.method = method;
@@ -145,7 +140,7 @@ final class PublicMethods {
          *         {@code ptypes} and including or excluding static methods as
          *         requested by {@code includeStatic} flag.
          */
-        static MethodList filter(Method[] methods, String name,
+        public static MethodList filter(Method[] methods, String name,
                                  Class<?>[] ptypes, boolean includeStatic) {
             MethodList head = null, tail = null;
             for (Method method : methods) {
@@ -172,7 +167,7 @@ final class PublicMethods {
          * may not be the same as the {@code head} of the given list.
          * The given {@code methodList} is not modified.
          */
-        static MethodList merge(MethodList head, MethodList methodList) {
+        public static MethodList merge(MethodList head, MethodList methodList) {
             for (MethodList ml = methodList; ml != null; ml = ml.next) {
                 head = merge(head, ml.method);
             }
@@ -256,7 +251,7 @@ final class PublicMethods {
         /**
          * @return 1st method in list with most specific return type
          */
-        Method getMostSpecific() {
+        public Method getMostSpecific() {
             Method m = method;
             Class<?> rt = m.getReturnType();
             for (MethodList ml = next; ml != null; ml = ml.next) {

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/BasicTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/BasicTest.java
@@ -142,6 +142,10 @@ public class BasicTest {
     @Test
     public void testRejects() {
         var mh = MethodHandles.constant(String.class, "42");
+        assertThrows(IllegalArgumentException.class, () -> asInterfaceInstance(int.class, mh),
+                "primitive type");
+        assertThrows(IllegalArgumentException.class, () -> asInterfaceInstance(Object[].class, mh),
+                "array class");
         assertThrows(IllegalArgumentException.class, () -> asInterfaceInstance(PackagePrivate.class, mh),
                 "non-public interface");
         assertThrows(IllegalArgumentException.class, () -> asInterfaceInstance(loadHidden(), mh),

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/BasicTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/BasicTest.java
@@ -36,7 +36,6 @@ import java.lang.invoke.WrongMethodTypeException;
 import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Method;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/WithSecurityManagerTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/WithSecurityManagerTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
 import java.lang.invoke.MethodHandles;
@@ -37,6 +38,10 @@ import static jdk.test.lib.Asserts.assertSame;
  * @summary Checks MethodHandleProxies behavior with security manager present
  */
 public class WithSecurityManagerTest {
+    public abstract static class NestedAbstractClass {
+        protected abstract void task();
+    }
+
     public interface NestedInterface {
         void task();
     }
@@ -45,7 +50,8 @@ public class WithSecurityManagerTest {
         var originalMh = MethodHandles.zero(void.class);
 
         // Test system and user interfaces
-        for (Class<?> cl : List.of(Runnable.class, Client.class, NestedInterface.class)) {
+        for (Class<?> cl : List.of(Runnable.class, Client.class, NestedInterface.class,
+                InputStream.class, NestedAbstractClass.class)) {
             try {
                 Object o = MethodHandleProxies.asInterfaceInstance(cl, originalMh);
                 testWrapperInstanceTarget(o, originalMh);

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java
@@ -34,6 +34,7 @@ import java.lang.invoke.MethodHandleProxies;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Modifier;
 import java.util.Comparator;
 import java.util.function.BooleanSupplier;
 
@@ -244,4 +245,27 @@ public class WrapperHiddenClassTest {
 
         public abstract String produce();
     }
+
+    /**
+     * Ensures that in abstract classes, abstract methods keep their
+     * existing access level (public, protected).
+     */
+    @Test
+    public void testMethodAccess() throws Throwable {
+        var value = new String(new char[] {'4', '2'});
+        var mh = MethodHandles.constant(String.class, value);
+        mh = MethodHandles.dropArguments(mh, 0, int.class);
+        var inst = asInterfaceInstance(Accesses.class, mh);
+        var implClass = inst.getClass();
+        assertTrue(Modifier.isPublic(implClass.getDeclaredMethod("work", Integer.class).getModifiers()),
+                "public method not public in implementation wrapper");
+        assertTrue(Modifier.isProtected(implClass.getDeclaredMethod("work", int.class).getModifiers()),
+                "protected method not protected in implementation wrapper");
+    }
+
+    public abstract static class Accesses {
+        public abstract String work(Integer a);
+        protected abstract String work(int a);
+    }
+
 }


### PR DESCRIPTION
With the reimplementation of MHP.asIFInstance, now it can easily adapt to abstract classes as well. Repurposed PublicMethods from java.lang to track method inheritance for MHP to reduce redundancies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312486](https://bugs.openjdk.org/browse/JDK-8312486): Allow abstract classes for MethodHandleProxies::asInterfaceInstance (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14966/head:pull/14966` \
`$ git checkout pull/14966`

Update a local copy of the PR: \
`$ git checkout pull/14966` \
`$ git pull https://git.openjdk.org/jdk.git pull/14966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14966`

View PR using the GUI difftool: \
`$ git pr show -t 14966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14966.diff">https://git.openjdk.org/jdk/pull/14966.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14966#issuecomment-1644799579)