### PR TITLE
8312488: tools/jpackage/share/AppLauncherEnvTest.java fails with dynamically linked libstdc++

### DIFF
--- a/src/jdk.jpackage/share/native/common/app.cpp
+++ b/src/jdk.jpackage/share/native/common/app.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 namespace {
 const std::string* theLastErrorMsg = 0;
 
-NopLogAppender nopLogAppender;
+char nopLogAppenderMemory[sizeof(NopLogAppender)] = {};
 
 class StandardLogAppender : public LogAppender {
 public:
@@ -46,7 +46,9 @@ public:
             << ": " << v.message
             << std::endl;
     }
-} standardLogAppender;
+};
+
+char standardLogAppenderMemory[sizeof(StandardLogAppender)] = {};
 
 class LastErrorLogAppender : public LogAppender {
 public:
@@ -114,10 +116,13 @@ bool isWithLogging() {
 
 int launch(const std::nothrow_t&,
         LauncherFunc func, LogAppender* lastErrorLogAppender) {
+    // The log appender is set for the lifetime of the application.
+    // Use in-place new to avoid accessing destroyed instance
+    // when the shared object destructor logs something.
     if (isWithLogging()) {
-        Logger::defaultLogger().setAppender(standardLogAppender);
+        Logger::defaultLogger().setAppender(*new (standardLogAppenderMemory) StandardLogAppender());
     } else {
-        Logger::defaultLogger().setAppender(nopLogAppender);
+        Logger::defaultLogger().setAppender(*new (nopLogAppenderMemory) NopLogAppender());
     }
 
     LOG_TRACE_FUNCTION();

--- a/src/jdk.jpackage/share/native/common/app.cpp
+++ b/src/jdk.jpackage/share/native/common/app.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Use the  same approach as Logger::defaultLogger() to ensure that the appender is not destroyed before shared object destructor function is executed.

The alternative is to delete dcon() function, but we might run into a similiar tear-down issue later (e.g. logging from some object's destructor).

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/tools                                215   215     0     0   
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312488](https://bugs.openjdk.org/browse/JDK-8312488): tools/jpackage/share/AppLauncherEnvTest.java fails with dynamically linked libstdc++ (**Bug** - P3)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14971/head:pull/14971` \
`$ git checkout pull/14971`

Update a local copy of the PR: \
`$ git checkout pull/14971` \
`$ git pull https://git.openjdk.org/jdk.git pull/14971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14971`

View PR using the GUI difftool: \
`$ git pr show -t 14971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14971.diff">https://git.openjdk.org/jdk/pull/14971.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14971#issuecomment-1645401710)