### PR TITLE
JDK-8311955: c++filt is now ibm-llvm-cxxfilt when using xlc17 / clang on AIX

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -804,7 +804,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_EXTRA],
 
   case $TOOLCHAIN_TYPE in
     gcc|clang)
-      UTIL_REQUIRE_TOOLCHAIN_PROGS(CXXFILT, c++filt)
+      if test "x$OPENJDK_TARGET_OS" = xaix; then
+        UTIL_REQUIRE_TOOLCHAIN_PROGS(CXXFILT, ibm-llvm-cxxfilt)
+      else
+        UTIL_REQUIRE_TOOLCHAIN_PROGS(CXXFILT, c++filt)
+      fi
       ;;
   esac
 ])


### PR DESCRIPTION
When using xlc17 to build on AIX , the mentioned tool is /opt/IBM/openxlC/17.1.1/tools/ibm-llvm-cxxfilt instead of c++filt to check that global operators new and delete are not present in hotspot objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311955](https://bugs.openjdk.org/browse/JDK-8311955): c++filt is now ibm-llvm-cxxfilt when using xlc17 / clang on AIX (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14972/head:pull/14972` \
`$ git checkout pull/14972`

Update a local copy of the PR: \
`$ git checkout pull/14972` \
`$ git pull https://git.openjdk.org/jdk.git pull/14972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14972`

View PR using the GUI difftool: \
`$ git pr show -t 14972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14972.diff">https://git.openjdk.org/jdk/pull/14972.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14972#issuecomment-1645493997)