### PR TITLE
8308504: C2: "malformed control flow" after JDK-8303466

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1515,7 +1515,7 @@ IfProjNode* PhaseIdealLoop::add_template_assertion_predicate(IfNode* iff, IdealL
   // unrolling proceeds current stride is updated.
   if (max_value == nullptr) {
     // init + (current stride - initial stride) is within the loop so narrow its type by leveraging the type of the iv Phi
-    iv_phi_assertion_predicate_condition(loop->_head->as_CountedLoop(), new_proj, opaque_init, max_value);
+    bol = iv_phi_assertion_predicate_condition(loop->_head->as_CountedLoop(), new_proj, opaque_init, max_value);
     new_proj = add_template_assertion_predicate_helper(predicate_proj, reason, new_proj, bol, Op_If);
   }
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1342,7 +1342,7 @@ void PhaseIdealLoop::copy_assertion_predicates_to_main_loop_helper(Node* predica
       predicates.push(predicate);
       predicate = predicate->in(0)->in(0);
     }
-    while(predicates.size() > 0) {
+    while (predicates.size() > 0) {
       predicate = predicates.pop();
       iff = predicate->in(0)->as_If();
       uncommon_proj = iff->proj_out(1 - predicate->as_Proj()->_con);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1360,14 +1360,16 @@ public:
   bool loop_predication_impl(IdealLoopTree *loop);
   bool loop_predication_impl_helper(IdealLoopTree* loop, IfProjNode* if_success_proj,
                                     ParsePredicateSuccessProj* parse_predicate_proj, CountedLoopNode* cl, ConNode* zero,
-                                    Invariance& invar, Deoptimization::DeoptReason reason);
+                                    Invariance& invar, Deoptimization::DeoptReason reason, Node*& max_value);
   bool loop_predication_should_follow_branches(IdealLoopTree* loop, IfProjNode* predicate_proj, float& loop_trip_cnt);
   void loop_predication_follow_branches(Node *c, IdealLoopTree *loop, float loop_trip_cnt,
                                         PathFrequency& pf, Node_Stack& stack, VectorSet& seen,
                                         Node_List& if_proj_list);
-  IfProjNode* add_template_assertion_predicate(IfNode* iff, IdealLoopTree* loop, IfProjNode* if_proj, IfProjNode* predicate_proj,
-                                               IfProjNode* upper_bound_proj, int scale, Node* offset, Node* init, Node* limit,
-                                               jint stride, Node* rng, bool& overflow, Deoptimization::DeoptReason reason);
+  IfProjNode*
+  add_template_assertion_predicate(IfNode* iff, IdealLoopTree* loop, IfProjNode* if_proj, IfProjNode* predicate_proj,
+                                   IfProjNode* upper_bound_proj, int scale, Node* offset, Node* init, Node* limit,
+                                   jint stride, Node* rng, bool& overflow, Deoptimization::DeoptReason reason,
+                                   Node*& max_value);
   Node* add_range_check_elimination_assertion_predicate(IdealLoopTree* loop, Node* predicate_proj, int scale_con,
                                                         Node* offset, Node* limit, jint stride_con, Node* value);
 
@@ -1717,6 +1719,14 @@ public:
   bool clone_cmp_loadklass_down(Node* n, const Node* blk1, const Node* blk2);
 
   bool at_relevant_ctrl(Node* n, const Node* blk1, const Node* blk2);
+
+  Node* add_assertion_predicate_test(IdealLoopTree* loop, Node* ctrl, bool overflow, BoolNode* bol);
+
+  IfProjNode* add_template_assertion_predicate_helper(IfProjNode* predicate_proj, Deoptimization::DeoptReason reason,
+                                                      IfProjNode* new_proj, BoolNode* bol, const int opcode);
+
+  BoolNode* iv_phi_assertion_predicate_condition(const CountedLoopNode* cl, Node* ctrl, Node* opaque_init,
+                                                 Node*& max_value);
 };
 
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopPredicateCastIIBecomesTop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopPredicateCastIIBecomesTop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308504
+ * @summary CastII for assert predicate becomes top but control flow path is not proven dead
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:RepeatCompilation=100
+ *                   -XX:+StressIGVN
+ *                   -XX:CompileOnly=compiler.loopopts.TestLoopPredicateCastIIBecomesTop::test
+ *                   compiler.loopopts.TestLoopPredicateCastIIBecomesTop
+ */
+
+package compiler.loopopts;
+
+public class TestLoopPredicateCastIIBecomesTop {
+    static int N;
+
+    static void test() {
+        int arr[] = new int[N];
+        short s = 1;
+        double d = 1.0;
+        for (int i = 49; i > 8; i--) {
+            for (int j = 7; j > i; j -= 3) {
+                if (i == 8) {
+                    s *= arr[1];
+                }
+                d = arr[j];
+            }
+        }
+        Double.doubleToLongBits(d);
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
I took that bug over from Emanuel because he's away:
https://github.com/openjdk/jdk/pull/14331

I tried adding a `CastII` to narrow the limit of the loop as I
suggested in a comment on the PR but I found that doesn't work in all
cases: if the type of the initial value for the loop variable is not
narrow enough, then the narrower type for the limit doesn't help
narrow the loop phi type.

What I propose instead is to add an assert predicate that catches when
the main loop is unreachable but the zero trip count doesn't constant
fold. For that to work, the order of predicates must be preserved when
they are copied or updated. I had to make some small changes to
guarantee that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308504](https://bugs.openjdk.org/browse/JDK-8308504): C2: "malformed control flow" after JDK-8303466 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14973/head:pull/14973` \
`$ git checkout pull/14973`

Update a local copy of the PR: \
`$ git checkout pull/14973` \
`$ git pull https://git.openjdk.org/jdk.git pull/14973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14973`

View PR using the GUI difftool: \
`$ git pr show -t 14973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14973.diff">https://git.openjdk.org/jdk/pull/14973.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14973#issuecomment-1645489020)