### PR TITLE
8312509: Expose physical size of class elements in Classfile API

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/AttributeMapper.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/AttributeMapper.java
@@ -24,6 +24,8 @@
  */
 package jdk.internal.classfile;
 
+import java.util.OptionalInt;
+
 /**
  * Bidirectional mapper between the classfile representation of an attribute and
  * how that attribute is modeled in the API.  The attribute mapper is used
@@ -59,6 +61,12 @@ public interface AttributeMapper<A> {
      * @param attr The attribute to write
      */
     void writeAttribute(BufWriter buf, A attr);
+
+    /**
+     * {@return payload length of the attribute}
+     * @param attr attribute to calculate payload of
+     */
+    OptionalInt payloadLen(A attr);
 
     /**
      * {@return The earliest classfile version for which this attribute is

--- a/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
@@ -147,7 +147,7 @@ public class Attributes {
 
                 @Override
                 public OptionalInt payloadLen(AnnotationDefaultAttribute attr) {
-                    return attr.defaultValue().payloadLen();
+                    return attr.defaultValue().sizeInBytes();
                 }
             };
 
@@ -689,7 +689,7 @@ public class Attributes {
                     for (var info : attr.components()) {
                         len += 6;
                         for (var a : info.attributes()) {
-                            var alen = a.payloadLen();
+                            var alen = a.sizeInBytes();
                             if (alen.isEmpty()) return OptionalInt.empty();
                             len += 6 + alen.getAsInt();
                         }
@@ -715,7 +715,7 @@ public class Attributes {
                 public OptionalInt payloadLen(RuntimeInvisibleAnnotationsAttribute attr) {
                     return OptionalInt.of(2 + attr.annotations()
                             .stream()
-                            .map(Annotation::payloadLen)
+                            .map(Annotation::sizeInBytes)
                             .mapToInt(OptionalInt::getAsInt)
                             .sum());
                 }
@@ -743,7 +743,7 @@ public class Attributes {
                             .stream()
                             .mapToInt(pa -> 2 + pa
                                     .stream()
-                                    .map(Annotation::payloadLen)
+                                    .map(Annotation::sizeInBytes)
                                     .mapToInt(OptionalInt::getAsInt)
                                     .sum())
                             .sum());
@@ -767,7 +767,7 @@ public class Attributes {
                 public OptionalInt payloadLen(RuntimeInvisibleTypeAnnotationsAttribute attr) {
                     return OptionalInt.of(2 + attr.annotations()
                             .stream()
-                            .map(TypeAnnotation::payloadLen)
+                            .map(TypeAnnotation::sizeInBytes)
                             .mapToInt(OptionalInt::getAsInt)
                             .sum());
                 }
@@ -790,7 +790,7 @@ public class Attributes {
                 public OptionalInt payloadLen(RuntimeVisibleAnnotationsAttribute attr) {
                     return OptionalInt.of(2 + attr.annotations()
                             .stream()
-                            .map(Annotation::payloadLen)
+                            .map(Annotation::sizeInBytes)
                             .mapToInt(OptionalInt::getAsInt)
                             .sum());
                 }
@@ -818,7 +818,7 @@ public class Attributes {
                             .stream()
                             .mapToInt(pa -> 2 + pa
                                     .stream()
-                                    .map(Annotation::payloadLen)
+                                    .map(Annotation::sizeInBytes)
                                     .mapToInt(OptionalInt::getAsInt)
                                     .sum())
                             .sum());
@@ -842,7 +842,7 @@ public class Attributes {
                 public OptionalInt payloadLen(RuntimeVisibleTypeAnnotationsAttribute attr) {
                     return OptionalInt.of(2 + attr.annotations()
                             .stream()
-                            .map(TypeAnnotation::payloadLen)
+                            .map(TypeAnnotation::sizeInBytes)
                             .mapToInt(OptionalInt::getAsInt)
                             .sum());
                 }

--- a/src/java.base/share/classes/jdk/internal/classfile/WritableElement.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/WritableElement.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.classfile;
 
+import java.util.OptionalInt;
 import jdk.internal.classfile.constantpool.ConstantPoolBuilder;
 import jdk.internal.classfile.constantpool.PoolEntry;
 import jdk.internal.classfile.impl.DirectFieldBuilder;
@@ -45,4 +46,9 @@ public sealed interface WritableElement<T> extends ClassfileElement
      * @param buf the writer
      */
     void writeTo(BufWriter buf);
+
+    /**
+     * {@return payload length of the element}
+     */
+    OptionalInt payloadLen();
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/WritableElement.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/WritableElement.java
@@ -48,7 +48,7 @@ public sealed interface WritableElement<T> extends ClassfileElement
     void writeTo(BufWriter buf);
 
     /**
-     * {@return payload length of the element}
+     * {@return size of the element}
      */
-    OptionalInt payloadLen();
+    OptionalInt sizeInBytes();
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -54,6 +54,7 @@ import jdk.internal.classfile.constantpool.StringEntry;
 import jdk.internal.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ModuleDesc;
 import java.lang.constant.PackageDesc;
+import java.util.OptionalInt;
 
 public abstract sealed class AbstractPoolEntry {
     /*
@@ -479,6 +480,15 @@ public abstract sealed class AbstractPoolEntry {
                 }
             }
         }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(3 + (rawBytes == null
+                    ? stringValue.chars()
+                            .map(ch -> (ch >= '\001' && ch <= '\177') ? 1 : ch > '\u07FF' ? 3 : 2)
+                            .sum()
+                    : rawLen));
+        }
     }
 
     static abstract sealed class AbstractRefEntry<T extends PoolEntry> extends AbstractPoolEntry {
@@ -496,6 +506,10 @@ public abstract sealed class AbstractPoolEntry {
         public void writeTo(BufWriter pool) {
             pool.writeU1(tag);
             pool.writeU2(ref1.index());
+        }
+
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(3);
         }
 
         @Override
@@ -527,6 +541,10 @@ public abstract sealed class AbstractPoolEntry {
             pool.writeU1(tag);
             pool.writeU2(ref1.index());
             pool.writeU2(ref2.index());
+        }
+
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(5);
         }
 
         @Override
@@ -828,6 +846,10 @@ public abstract sealed class AbstractPoolEntry {
             pool.writeU2(nameAndType.index());
         }
 
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(5);
+        }
+
         @Override
         public String toString() {
             return tag() + " " + bootstrap() + "." + nameAndType().name().stringValue()
@@ -931,6 +953,11 @@ public abstract sealed class AbstractPoolEntry {
             pool.writeU1(tag);
             pool.writeU1(refKind);
             pool.writeU2(reference.index());
+        }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(4);
         }
 
         @Override
@@ -1083,6 +1110,11 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(5);
+        }
+
+        @Override
         public IntegerEntry clone(ConstantPoolBuilder cp) {
             return cp.canWriteDirect(constantPool) ? this : cp.intEntry(val);
         }
@@ -1113,6 +1145,11 @@ public abstract sealed class AbstractPoolEntry {
         public void writeTo(BufWriter pool) {
             pool.writeU1(tag);
             pool.writeFloat(val);
+        }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(5);
         }
 
         @Override
@@ -1148,6 +1185,11 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(9);
+        }
+
+        @Override
         public LongEntry clone(ConstantPoolBuilder cp) {
             return cp.canWriteDirect(constantPool) ? this : cp.longEntry(val);
         }
@@ -1177,6 +1219,11 @@ public abstract sealed class AbstractPoolEntry {
         public void writeTo(BufWriter pool) {
             pool.writeU1(tag);
             pool.writeDouble(val);
+        }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(9);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -482,7 +482,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(3 + (rawBytes == null
                     ? stringValue.chars()
                             .map(ch -> (ch >= '\001' && ch <= '\177') ? 1 : ch > '\u07FF' ? 3 : 2)
@@ -508,7 +508,7 @@ public abstract sealed class AbstractPoolEntry {
             pool.writeU2(ref1.index());
         }
 
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(3);
         }
 
@@ -543,7 +543,7 @@ public abstract sealed class AbstractPoolEntry {
             pool.writeU2(ref2.index());
         }
 
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(5);
         }
 
@@ -846,7 +846,7 @@ public abstract sealed class AbstractPoolEntry {
             pool.writeU2(nameAndType.index());
         }
 
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(5);
         }
 
@@ -956,7 +956,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(4);
         }
 
@@ -1110,7 +1110,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(5);
         }
 
@@ -1148,7 +1148,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(5);
         }
 
@@ -1185,7 +1185,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(9);
         }
 
@@ -1222,7 +1222,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(9);
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
@@ -60,9 +60,9 @@ public final class AnnotationImpl implements Annotation {
     }
 
     @Override
-    public OptionalInt payloadLen() {
+    public OptionalInt sizeInBytes() {
         return OptionalInt.of(4 + elements.stream()
-                .map(AnnotationElement::payloadLen)
+                .map(AnnotationElement::sizeInBytes)
                 .mapToInt(OptionalInt::getAsInt)
                 .sum());
     }
@@ -99,8 +99,8 @@ public final class AnnotationImpl implements Annotation {
         }
 
         @Override
-        public OptionalInt payloadLen() {
-            return OptionalInt.of(2 + value().payloadLen().getAsInt());
+        public OptionalInt sizeInBytes() {
+            return OptionalInt.of(2 + value().sizeInBytes().getAsInt());
         }
     }
 
@@ -123,7 +123,7 @@ public final class AnnotationImpl implements Annotation {
         }
 
         @Override
-        default OptionalInt payloadLen() {
+        default OptionalInt sizeInBytes() {
             return OptionalInt.of(3);
         }
     }
@@ -273,9 +273,9 @@ public final class AnnotationImpl implements Annotation {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(3 + values.stream()
-                    .map(AnnotationValue::payloadLen)
+                    .map(AnnotationValue::sizeInBytes)
                     .mapToInt(OptionalInt::getAsInt)
                     .sum());
         }
@@ -296,7 +296,7 @@ public final class AnnotationImpl implements Annotation {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(5);
         }
     }
@@ -315,8 +315,8 @@ public final class AnnotationImpl implements Annotation {
         }
 
         @Override
-        public OptionalInt payloadLen() {
-            return OptionalInt.of(1 + annotation.payloadLen().getAsInt());
+        public OptionalInt sizeInBytes() {
+            return OptionalInt.of(1 + annotation.sizeInBytes().getAsInt());
         }
     }
 
@@ -334,7 +334,7 @@ public final class AnnotationImpl implements Annotation {
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(3);
         }
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
@@ -29,6 +29,7 @@ import jdk.internal.classfile.constantpool.*;
 
 import java.lang.constant.ConstantDesc;
 import java.util.List;
+import java.util.OptionalInt;
 
 import static jdk.internal.classfile.Classfile.*;
 
@@ -56,6 +57,14 @@ public final class AnnotationImpl implements Annotation {
     public void writeTo(BufWriter buf) {
         buf.writeIndex(className());
         buf.writeList(elements());
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        return OptionalInt.of(4 + elements.stream()
+                .map(AnnotationElement::payloadLen)
+                .mapToInt(OptionalInt::getAsInt)
+                .sum());
     }
 
     @Override
@@ -88,6 +97,11 @@ public final class AnnotationImpl implements Annotation {
             buf.writeIndex(name());
             value().writeTo(buf);
         }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(2 + value().payloadLen().getAsInt());
+        }
     }
 
     public sealed interface OfConstantImpl extends AnnotationValue.OfConstant
@@ -108,6 +122,10 @@ public final class AnnotationImpl implements Annotation {
             return constant().constantValue();
         }
 
+        @Override
+        default OptionalInt payloadLen() {
+            return OptionalInt.of(3);
+        }
     }
 
     public record OfStringImpl(Utf8Entry constant)
@@ -254,6 +272,13 @@ public final class AnnotationImpl implements Annotation {
             buf.writeList(values);
         }
 
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(3 + values.stream()
+                    .map(AnnotationValue::payloadLen)
+                    .mapToInt(OptionalInt::getAsInt)
+                    .sum());
+        }
     }
 
     public record OfEnumImpl(Utf8Entry className, Utf8Entry constantName)
@@ -270,6 +295,10 @@ public final class AnnotationImpl implements Annotation {
             buf.writeIndex(constantName);
         }
 
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(5);
+        }
     }
 
     public record OfAnnotationImpl(Annotation annotation)
@@ -285,6 +314,10 @@ public final class AnnotationImpl implements Annotation {
             annotation.writeTo(buf);
         }
 
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(1 + annotation.payloadLen().getAsInt());
+        }
     }
 
     public record OfClassImpl(Utf8Entry className)
@@ -300,5 +333,9 @@ public final class AnnotationImpl implements Annotation {
             buf.writeIndex(className);
         }
 
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.of(3);
+        }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
@@ -57,10 +57,10 @@ public class AttributeHolder {
             a.writeTo(buf);
     }
 
-    OptionalInt payloadLen() {
+    OptionalInt sizeInBytes() {
         int len = 2;
         for (var a : attributes) {
-            var al = a.payloadLen();
+            var al = a.sizeInBytes();
             if (al.isEmpty()) return OptionalInt.empty();
             len += al.getAsInt();
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
@@ -26,6 +26,7 @@ package jdk.internal.classfile.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 
 import jdk.internal.classfile.Attribute;
 import jdk.internal.classfile.AttributeMapper;
@@ -54,6 +55,16 @@ public class AttributeHolder {
         buf.writeU2(attributes.size());
         for (Attribute<?> a : attributes)
             a.writeTo(buf);
+    }
+
+    OptionalInt payloadLen() {
+        int len = 2;
+        for (var a : attributes) {
+            var al = a.payloadLen();
+            if (al.isEmpty()) return OptionalInt.empty();
+            len += al.getAsInt();
+        }
+        return OptionalInt.of(len);
     }
 
     boolean isPresent(AttributeMapper<?> am) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -25,6 +25,7 @@
 package jdk.internal.classfile.impl;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import jdk.internal.classfile.constantpool.ConstantPool;
 import jdk.internal.classfile.BootstrapMethodEntry;
@@ -93,5 +94,10 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
     public void writeTo(BufWriter writer) {
         writer.writeIndex(bootstrapMethod());
         writer.writeListIndices(arguments());
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        return OptionalInt.of(4 + 2 * arguments().size());
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -97,7 +97,7 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
     }
 
     @Override
-    public OptionalInt payloadLen() {
+    public OptionalInt sizeInBytes() {
         return OptionalInt.of(4 + 2 * arguments().size());
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -59,11 +59,11 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
     }
 
     @Override
-    public OptionalInt payloadLen() {
-        return OptionalInt.of(_payloadLen());
+    public OptionalInt sizeInBytes() {
+        return OptionalInt.of(payloadLen() + 6);
     }
 
-    private int _payloadLen() {
+    private int payloadLen() {
         return classReader.readInt(payloadStart - 4);
     }
 
@@ -78,7 +78,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
     }
 
     public byte[] contents() {
-        return classReader.readBytes(payloadStart, _payloadLen());
+        return classReader.readBytes(payloadStart, payloadLen());
     }
 
     @Override
@@ -107,7 +107,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
         if (!buf.canWriteDirect(classReader))
             attributeMapper().writeAttribute(buf, (T) this);
         else
-            classReader.copyBytesTo(buf, payloadStart - NAME_AND_LENGTH_PREFIX, _payloadLen() + NAME_AND_LENGTH_PREFIX);
+            classReader.copyBytesTo(buf, payloadStart - NAME_AND_LENGTH_PREFIX, payloadLen() + NAME_AND_LENGTH_PREFIX);
     }
 
     public ConstantPool constantPool() {
@@ -175,7 +175,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
                     @Override
                     public OptionalInt payloadLen(UnknownAttribute attr) {
-                        throw new UnsupportedOperationException("Payload calculation of unknown attribute " + name() + " not supported");
+                        throw new UnsupportedOperationException("Size calculation of unknown attribute " + name() + " not supported");
                     }
                 };
                 filled[i] = new BoundUnknownAttribute(reader, fakeMapper, p);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -215,4 +215,8 @@ public final class BufWriterImpl implements BufWriter {
             writeIndex(info);
         }
     }
+
+    public void reset() {
+        offset = 0;
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
@@ -27,6 +27,7 @@ package jdk.internal.classfile.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 import jdk.internal.classfile.*;
@@ -118,6 +119,11 @@ public final class BufferedFieldBuilder
                     elements.forEach(fieldBuilder);
                 }
             });
+        }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.empty();
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
@@ -122,7 +122,7 @@ public final class BufferedFieldBuilder
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.empty();
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
@@ -28,6 +28,7 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 import jdk.internal.classfile.AccessFlags;
@@ -203,6 +204,11 @@ public final class BufferedMethodBuilder
                     forEachElement(mb);
                 }
             });
+        }
+
+        @Override
+        public OptionalInt payloadLen() {
+            return OptionalInt.empty();
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
@@ -207,7 +207,7 @@ public final class BufferedMethodBuilder
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.empty();
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -299,8 +299,11 @@ public final class ClassReaderImpl
     }
 
     void writeConstantPoolEntries(BufWriter buf) {
-        copyBytesTo(buf, ClassReaderImpl.CP_ITEM_START,
-                    metadataStart - ClassReaderImpl.CP_ITEM_START);
+        copyBytesTo(buf, ClassReaderImpl.CP_ITEM_START, constantPoolLen());
+    }
+
+    int constantPoolLen() {
+        return metadataStart - ClassReaderImpl.CP_ITEM_START;
     }
 
     // Constantpool

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
@@ -25,6 +25,7 @@
 
 package jdk.internal.classfile.impl;
 
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 import jdk.internal.classfile.BufWriter;
@@ -74,5 +75,11 @@ public final class DirectFieldBuilder
         buf.writeIndex(name);
         buf.writeIndex(desc);
         attributes.writeTo(buf);
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        var al = attributes.payloadLen();
+        return al.isPresent() ? OptionalInt.of(6 + al.getAsInt()) : OptionalInt.empty();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
@@ -78,8 +78,8 @@ public final class DirectFieldBuilder
     }
 
     @Override
-    public OptionalInt payloadLen() {
-        var al = attributes.payloadLen();
+    public OptionalInt sizeInBytes() {
+        var al = attributes.sizeInBytes();
         return al.isPresent() ? OptionalInt.of(6 + al.getAsInt()) : OptionalInt.empty();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
@@ -153,8 +153,8 @@ public final class DirectMethodBuilder
     }
 
     @Override
-    public OptionalInt payloadLen() {
-        var al = attributes.payloadLen();
+    public OptionalInt sizeInBytes() {
+        var al = attributes.sizeInBytes();
         return al.isPresent() ? OptionalInt.of(6 + al.getAsInt()) : OptionalInt.empty();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
@@ -26,6 +26,7 @@
 package jdk.internal.classfile.impl;
 
 import java.lang.constant.MethodTypeDesc;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 import jdk.internal.classfile.BufWriter;
@@ -149,5 +150,11 @@ public final class DirectMethodBuilder
         buf.writeIndex(name);
         buf.writeIndex(desc);
         attributes.writeTo(buf);
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        var al = attributes.payloadLen();
+        return al.isPresent() ? OptionalInt.of(6 + al.getAsInt()) : OptionalInt.empty();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
@@ -26,6 +26,7 @@ package jdk.internal.classfile.impl;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 import jdk.internal.classfile.*;
@@ -105,6 +106,11 @@ public final class FieldImpl
                 }
             });
         }
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        return OptionalInt.of(endPos - startPos);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
@@ -109,7 +109,7 @@ public final class FieldImpl
     }
 
     @Override
-    public OptionalInt payloadLen() {
+    public OptionalInt sizeInBytes() {
         return OptionalInt.of(endPos - startPos);
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
@@ -30,6 +30,7 @@ import jdk.internal.classfile.constantpool.Utf8Entry;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 public final class MethodImpl
@@ -112,6 +113,11 @@ public final class MethodImpl
             buf.writeIndex(methodType());
             buf.writeList(attributes());
         }
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        return OptionalInt.of(endPos - startPos);
     }
 
     // MethodModel

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
@@ -116,7 +116,7 @@ public final class MethodImpl
     }
 
     @Override
-    public OptionalInt payloadLen() {
+    public OptionalInt sizeInBytes() {
         return OptionalInt.of(endPos - startPos);
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -28,6 +28,7 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalInt;
 
 import jdk.internal.classfile.Attribute;
 import jdk.internal.classfile.Attributes;
@@ -183,6 +184,22 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             info.writeTo(buf);
             i += info.width();
         }
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        int writeFrom = 1;
+        int len = 2;
+        if (parent != null) {
+            len += parent.constantPoolLen();
+            writeFrom = parent.entryCount();
+        }
+        for (int i = writeFrom; i < entryCount(); ) {
+            PoolEntry info = entryByIndex(i);
+            len += info.payloadLen().getAsInt();
+            i += info.width();
+        }
+        return OptionalInt.of(len);
     }
 
     private EntryMap<PoolEntry> map() {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -187,7 +187,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     }
 
     @Override
-    public OptionalInt payloadLen() {
+    public OptionalInt sizeInBytes() {
         int writeFrom = 1;
         int len = 2;
         if (parent != null) {
@@ -196,7 +196,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         }
         for (int i = writeFrom; i < entryCount(); ) {
             PoolEntry info = entryByIndex(i);
-            len += info.payloadLen().getAsInt();
+            len += info.sizeInBytes().getAsInt();
             i += info.width();
         }
         return OptionalInt.of(len);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/TemporaryConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/TemporaryConstantPool.java
@@ -197,7 +197,7 @@ public final class TemporaryConstantPool implements ConstantPoolBuilder {
     }
 
     @Override
-    public OptionalInt payloadLen() {
+    public OptionalInt sizeInBytes() {
         return OptionalInt.empty();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/TemporaryConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/TemporaryConstantPool.java
@@ -50,6 +50,7 @@ import jdk.internal.classfile.constantpool.Utf8Entry;
 
 import java.lang.constant.MethodTypeDesc;
 import java.util.List;
+import java.util.OptionalInt;
 
 public final class TemporaryConstantPool implements ConstantPoolBuilder {
 
@@ -193,5 +194,10 @@ public final class TemporaryConstantPool implements ConstantPoolBuilder {
     @Override
     public void writeTo(BufWriter buf) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OptionalInt payloadLen() {
+        return OptionalInt.empty();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/UnboundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/UnboundAttribute.java
@@ -121,8 +121,9 @@ public abstract sealed class UnboundAttribute<T extends Attribute<T>>
 
     @Override
     @SuppressWarnings("unchecked")
-    public final OptionalInt payloadLen() {
-        return mapper.payloadLen((T) this);
+    public final OptionalInt sizeInBytes() {
+        var len = mapper.payloadLen((T) this);
+        return len.isPresent() ? OptionalInt.of(len.getAsInt() + 6) : OptionalInt.empty();
     }
 
     @Override
@@ -828,7 +829,7 @@ public abstract sealed class UnboundAttribute<T extends Attribute<T>>
         }
 
         @Override
-        public OptionalInt payloadLen() {
+        public OptionalInt sizeInBytes() {
             return OptionalInt.of(6 + switch (targetInfo) {
                 case TypeParameterTarget tpt -> 1;
                 case SupertypeTarget st -> 2;
@@ -842,7 +843,7 @@ public abstract sealed class UnboundAttribute<T extends Attribute<T>>
                 case TypeArgumentTarget tat -> 3;
             } + 2 * targetPath.size()
               + elements.stream()
-                        .mapToInt(e -> 2 + e.value().payloadLen().getAsInt())
+                        .mapToInt(e -> 2 + e.value().sizeInBytes().getAsInt())
                         .sum());
         }
     }

--- a/test/jdk/jdk/classfile/WritableElementsTest.java
+++ b/test/jdk/jdk/classfile/WritableElementsTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing WritableElement API consistency.
+ * @run junit WritableElementsTest
+ */
+import java.io.IOException;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ModuleDesc;
+import java.lang.constant.PackageDesc;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+import jdk.internal.classfile.Annotation;
+import jdk.internal.classfile.AnnotationElement;
+import jdk.internal.classfile.AnnotationValue;
+import jdk.internal.classfile.Attribute;
+import jdk.internal.classfile.AttributedElement;
+import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.CompoundElement;
+import jdk.internal.classfile.FieldTransform;
+import jdk.internal.classfile.MethodTransform;
+import jdk.internal.classfile.TypeAnnotation;
+import jdk.internal.classfile.WritableElement;
+import jdk.internal.classfile.attribute.*;
+import jdk.internal.classfile.components.ClassPrinter;
+import jdk.internal.classfile.constantpool.*;
+import jdk.internal.classfile.impl.AbstractPoolEntry;
+import jdk.internal.classfile.impl.BufWriterImpl;
+import jdk.internal.classfile.impl.ClassfileImpl;
+import jdk.internal.classfile.impl.DirectFieldBuilder;
+import jdk.internal.classfile.impl.DirectMethodBuilder;
+import jdk.internal.classfile.impl.SplitConstantPool;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Execution(ExecutionMode.CONCURRENT)
+class WritableElementsTest {
+
+    private static final FileSystem JRT = FileSystems.getFileSystem(URI.create("jrt:/"));
+
+    static Path[] corpus() throws IOException, URISyntaxException {
+        return Stream.of(
+                Files.walk(JRT.getPath("modules/java.base/java")),
+                Files.walk(JRT.getPath("modules"), 2).filter(p -> p.endsWith("module-info.class")),
+                Files.walk(Paths.get(URI.create(CorpusTest.class.getResource("WritableElementsTest.class").toString())).getParent()))
+                .flatMap(p -> p)
+                .filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".class"))
+                .toArray(Path[]::new);
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("corpus")
+    void testBoundWritableElements(Path path) throws Exception {
+        var cc = Classfile.of();
+        var clm = cc.parse(path);
+        var cp = clm.constantPool();
+        var cpb = ConstantPoolBuilder.of(clm);
+        var buf = new BufWriterImpl(cpb, (ClassfileImpl)cc, 64, clm.thisClass(), clm.majorVersion());
+
+        //test shared CP builder
+        testWriteableElement(path, buf, clm, cpb);
+
+        //test CP entries
+        for (int i = 1; i < cp.entryCount();) {
+            var cpe = cp.entryByIndex(i);
+            testWriteableElement(path, buf, clm, cpe);
+            i += cpe.width();
+        }
+
+        //test BM entries
+        for (int i = 0; i < cpb.bootstrapMethodCount(); i++) {
+            testWriteableElement(path, buf, clm, cpb.bootstrapMethodEntry(i));
+        }
+
+        //test model
+        testCompoundElement(path, buf, clm);
+    }
+
+    @ParameterizedTest
+    @MethodSource("corpus")
+    void testUnboundWritableElements(Path path) throws Exception {
+        var cc = (ClassfileImpl)Classfile.of();
+        var clm = cc.parse(path);
+        var cp = clm.constantPool();
+        var cpb = (SplitConstantPool)ConstantPoolBuilder.of();
+        var buf = new BufWriterImpl(cpb, (ClassfileImpl)cc, 64, clm.thisClass(), clm.majorVersion());
+
+        //test clonned CP entries
+        for (int i = 1; i < cp.entryCount();) {
+            var cpe = AbstractPoolEntry.maybeClone(cpb, cp.entryByIndex(i));
+            testWriteableElement(path, buf, clm, cpe);
+            i += cpe.width();
+        }
+
+        //test CP builder
+        testWriteableElement(path, buf, clm, cpb);
+
+        //test field builder
+        for (var fm : clm.fields()) {
+            var fb = new DirectFieldBuilder(cpb, cc, fm.fieldName(), fm.fieldType(), fm);
+            fb.transform(fm, FieldTransform.ACCEPT_ALL);
+            testWriteableElement(path, buf, clm, fb);
+        }
+
+        //test method builder
+        for (var mm : clm.methods()) {
+            var mb = new DirectMethodBuilder(cpb, cc, mm.methodName(), mm.methodType(), mm.flags().flagsMask(), mm);
+            mb.transform(mm, MethodTransform.dropping(me -> me instanceof CodeAttribute));
+            testWriteableElement(path, buf, clm, mb);
+        }
+
+        //test unbound attributes
+        unboundAndTestAttributes(path, buf, clm);
+    }
+
+    void testCompoundElement(Path path, BufWriterImpl buf, CompoundElement<?> ce) {
+        for (var e : ce) {
+            if (e instanceof CompoundElement cce) {
+                testCompoundElement(path, buf, cce);
+            }
+            if (e instanceof WritableElement we) {
+                testWriteableElement(path, buf, ce, we);
+            }
+        }
+    }
+
+    void testWriteableElement(Path path, BufWriterImpl buf, CompoundElement<?> parent, WritableElement<?> we) {
+        var len = we.sizeInBytes();
+        assertTrue(len.isPresent(), path + ": " + we + " - size info is missing");
+        buf.reset();
+        we.writeTo(buf);
+        assertEquals(buf.size(), len.getAsInt(), () -> {
+            var sb = new StringBuilder(path + ": " + we + " - size info does not match to written bytes\n");
+            var orig = new byte[buf.size()];
+            buf.copyTo(orig, 0);
+            for (var b : orig) sb.append(0xff & b).append(' ');
+            ClassPrinter.toYaml(we instanceof CompoundElement ce ? ce : parent, ClassPrinter.Verbosity.TRACE_ALL, sb::append);
+            return sb.toString();
+        });
+    }
+
+    void unboundAndTestAttributes(Path path, BufWriterImpl buf, CompoundElement<?> ce) {
+        for (var e : ce) {
+            if (e instanceof CompoundElement cce) {
+                unboundAndTestAttributes(path, buf, cce);
+            }
+            if (e instanceof AttributedElement ae) {
+                for (var a : ae.attributes()) {
+                    var ua = unbound(a);
+                    if (ua != null) {
+                        assertEquals(a.sizeInBytes(), ua.sizeInBytes(), path + ": " + ce + " - unbound attribute size mismatch");
+                        testWriteableElement(path, buf, ce, ua);
+                    }
+                }
+            }
+        }
+    }
+
+    Attribute<?> unbound(Attribute<?> attr) {
+        return switch (attr) {
+            case AnnotationDefaultAttribute a -> AnnotationDefaultAttribute.of(transformAnnotationValue(a.defaultValue()));
+            case CompilationIDAttribute a -> CompilationIDAttribute.of(a.compilationId().stringValue());
+            case ConstantValueAttribute a -> ConstantValueAttribute.of(a.constant().constantValue());
+            case DeprecatedAttribute a -> DeprecatedAttribute.of();
+            case EnclosingMethodAttribute a -> EnclosingMethodAttribute.of(a.enclosingClass().asSymbol(), a.enclosingMethodName().map(Utf8Entry::stringValue), a.enclosingMethodTypeSymbol());
+            case ExceptionsAttribute a -> ExceptionsAttribute.ofSymbols(a.exceptions().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new));
+            case InnerClassesAttribute a -> InnerClassesAttribute.of(a.classes().stream().map(ici -> InnerClassInfo.of(
+                    ici.innerClass().asSymbol(),
+                    ici.outerClass().map(ClassEntry::asSymbol),
+                    ici.innerName().map(Utf8Entry::stringValue),
+                    ici.flagsMask())).toArray(InnerClassInfo[]::new));
+            case MethodParametersAttribute a -> MethodParametersAttribute.of(a.parameters().stream().map(mp ->
+                    MethodParameterInfo.ofParameter(mp.name().map(Utf8Entry::stringValue), mp.flagsMask())).toArray(MethodParameterInfo[]::new));
+            case ModuleAttribute a -> ModuleAttribute.of(a.moduleName().asSymbol(), mob -> {
+                    mob.moduleFlags(a.moduleFlagsMask());
+                    a.moduleVersion().ifPresent(v -> mob.moduleVersion(v.stringValue()));
+                    for (var req : a.requires()) mob.requires(req.requires().asSymbol(), req.requiresFlagsMask(), req.requiresVersion().map(Utf8Entry::stringValue).orElse(null));
+                    for (var exp : a.exports()) mob.exports(exp.exportedPackage().asSymbol(), exp.exportsFlagsMask(), exp.exportsTo().stream().map(ModuleEntry::asSymbol).toArray(ModuleDesc[]::new));
+                    for (var opn : a.opens()) mob.opens(opn.openedPackage().asSymbol(), opn.opensFlagsMask(), opn.opensTo().stream().map(ModuleEntry::asSymbol).toArray(ModuleDesc[]::new));
+                    for (var use : a.uses()) mob.uses(use.asSymbol());
+                    for (var prov : a.provides()) mob.provides(prov.provides().asSymbol(), prov.providesWith().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new));
+                });
+            case ModuleHashesAttribute a -> ModuleHashesAttribute.of(a.algorithm().stringValue(),
+                    a.hashes().stream().map(mh -> ModuleHashInfo.of(mh.moduleName().asSymbol(), mh.hash())).toArray(ModuleHashInfo[]::new));
+            case ModuleMainClassAttribute a -> ModuleMainClassAttribute.of(a.mainClass().asSymbol());
+            case ModulePackagesAttribute a -> ModulePackagesAttribute.ofNames(a.packages().stream().map(PackageEntry::asSymbol).toArray(PackageDesc[]::new));
+            case ModuleResolutionAttribute a -> ModuleResolutionAttribute.of(a.resolutionFlags());
+            case ModuleTargetAttribute a -> ModuleTargetAttribute.of(a.targetPlatform().stringValue());
+            case NestHostAttribute a -> NestHostAttribute.of(a.nestHost().asSymbol());
+            case NestMembersAttribute a -> NestMembersAttribute.ofSymbols(a.nestMembers().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new));
+            case PermittedSubclassesAttribute a -> PermittedSubclassesAttribute.ofSymbols(a.permittedSubclasses().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new));
+            case RecordAttribute a -> RecordAttribute.of(a.components().stream().map(rci ->
+                    RecordComponentInfo.of(rci.name().stringValue(), rci.descriptorSymbol(), rci.attributes().stream().mapMulti((rca, rcac) -> {
+                            switch(rca) {
+                                case RuntimeInvisibleAnnotationsAttribute riaa -> rcac.accept(RuntimeInvisibleAnnotationsAttribute.of(transformAnnotations(riaa.annotations())));
+                                case RuntimeInvisibleTypeAnnotationsAttribute ritaa -> rcac.accept(RuntimeInvisibleTypeAnnotationsAttribute.of(transformTypeAnnotations(ritaa.annotations())));
+                                case RuntimeVisibleAnnotationsAttribute rvaa -> rcac.accept(RuntimeVisibleAnnotationsAttribute.of(transformAnnotations(rvaa.annotations())));
+                                case RuntimeVisibleTypeAnnotationsAttribute rvtaa -> rcac.accept(RuntimeVisibleTypeAnnotationsAttribute.of(transformTypeAnnotations(rvtaa.annotations())));
+                                case SignatureAttribute sa -> rcac.accept(SignatureAttribute.of(sa.signature()));
+                                default -> throw new AssertionError("Unexpected record component attribute: " + rca.attributeName());
+                            }}).toArray(Attribute[]::new))).toArray(RecordComponentInfo[]::new));
+            case RuntimeInvisibleAnnotationsAttribute a -> RuntimeInvisibleAnnotationsAttribute.of(transformAnnotations(a.annotations()));
+            case RuntimeInvisibleParameterAnnotationsAttribute a -> RuntimeInvisibleParameterAnnotationsAttribute.of(a.parameterAnnotations().stream()
+                    .map(pas -> List.of(transformAnnotations(pas))).toList());
+            case RuntimeInvisibleTypeAnnotationsAttribute a -> RuntimeInvisibleTypeAnnotationsAttribute.of(transformTypeAnnotations(a.annotations()));
+            case RuntimeVisibleAnnotationsAttribute a -> RuntimeVisibleAnnotationsAttribute.of(transformAnnotations(a.annotations()));
+            case RuntimeVisibleParameterAnnotationsAttribute a -> RuntimeVisibleParameterAnnotationsAttribute.of(a.parameterAnnotations().stream()
+                    .map(pas -> List.of(transformAnnotations(pas))).toList());
+            case RuntimeVisibleTypeAnnotationsAttribute a -> RuntimeVisibleTypeAnnotationsAttribute.of(transformTypeAnnotations(a.annotations()));
+            case SignatureAttribute a -> SignatureAttribute.of(a.signature());
+            case SourceDebugExtensionAttribute a -> SourceDebugExtensionAttribute.of(a.contents());
+            case SourceFileAttribute a -> SourceFileAttribute.of(a.sourceFile().stringValue());
+            case SourceIDAttribute a -> SourceIDAttribute.of(a.sourceId().stringValue());
+            case SyntheticAttribute a -> SyntheticAttribute.of();
+            default -> null;
+        };
+    }
+
+    static Annotation[] transformAnnotations(List<Annotation> annotations) {
+        return annotations.stream().map(a -> transformAnnotation(a)).toArray(Annotation[]::new);
+    }
+
+    static Annotation transformAnnotation(Annotation a) {
+        return Annotation.of(a.classSymbol(), a.elements().stream()
+                .map(ae -> AnnotationElement.of(ae.name().stringValue(), transformAnnotationValue(ae.value()))).toArray(AnnotationElement[]::new));
+    }
+
+    static AnnotationValue transformAnnotationValue(AnnotationValue av) {
+        return switch (av) {
+            case AnnotationValue.OfAnnotation oa -> AnnotationValue.ofAnnotation(transformAnnotation(oa.annotation()));
+            case AnnotationValue.OfArray oa -> AnnotationValue.ofArray(oa.values().stream().map(v -> transformAnnotationValue(v)).toArray(AnnotationValue[]::new));
+            case AnnotationValue.OfString v -> AnnotationValue.of(v.stringValue());
+            case AnnotationValue.OfDouble v -> AnnotationValue.of(v.doubleValue());
+            case AnnotationValue.OfFloat v -> AnnotationValue.of(v.floatValue());
+            case AnnotationValue.OfLong v -> AnnotationValue.of(v.longValue());
+            case AnnotationValue.OfInteger v -> AnnotationValue.of(v.intValue());
+            case AnnotationValue.OfShort v -> AnnotationValue.of(v.shortValue());
+            case AnnotationValue.OfCharacter v -> AnnotationValue.of(v.charValue());
+            case AnnotationValue.OfByte v -> AnnotationValue.of(v.byteValue());
+            case AnnotationValue.OfBoolean v -> AnnotationValue.of(v.booleanValue());
+            case AnnotationValue.OfClass oc -> AnnotationValue.of(oc.classSymbol());
+            case AnnotationValue.OfEnum oe -> AnnotationValue.ofEnum(oe.classSymbol(), oe.constantName().stringValue());
+        };
+    }
+
+    static TypeAnnotation[] transformTypeAnnotations(List<TypeAnnotation> annotations) {
+        return annotations.stream().map(ta -> TypeAnnotation.of(
+                        transformTargetInfo(ta.targetInfo()),
+                        ta.targetPath().stream().map(tpc -> TypeAnnotation.TypePathComponent.of(tpc.typePathKind(), tpc.typeArgumentIndex())).toList(),
+                        ta.classSymbol(),
+                        ta.elements().stream().map(ae -> AnnotationElement.of(ae.name().stringValue(),
+                                transformAnnotationValue(ae.value()))).toList())).toArray(TypeAnnotation[]::new);
+    }
+
+    static TypeAnnotation.TargetInfo transformTargetInfo(TypeAnnotation.TargetInfo ti) {
+        return switch (ti) {
+            case TypeAnnotation.CatchTarget t -> TypeAnnotation.TargetInfo.ofExceptionParameter(t.exceptionTableIndex());
+            case TypeAnnotation.EmptyTarget t -> TypeAnnotation.TargetInfo.of(t.targetType());
+            case TypeAnnotation.FormalParameterTarget t -> TypeAnnotation.TargetInfo.ofMethodFormalParameter(t.formalParameterIndex());
+            case TypeAnnotation.SupertypeTarget t -> TypeAnnotation.TargetInfo.ofClassExtends(t.supertypeIndex());
+            case TypeAnnotation.ThrowsTarget t -> TypeAnnotation.TargetInfo.ofThrows(t.throwsTargetIndex());
+            case TypeAnnotation.TypeParameterBoundTarget t -> TypeAnnotation.TargetInfo.ofTypeParameterBound(t.targetType(), t.typeParameterIndex(), t.boundIndex());
+            case TypeAnnotation.TypeParameterTarget t -> TypeAnnotation.TargetInfo.ofTypeParameter(t.targetType(), t.typeParameterIndex());
+            case TypeAnnotation.LocalVarTarget t -> TypeAnnotation.TargetInfo.ofVariable(t.targetType(), t.table().stream().map(lvti ->
+                            TypeAnnotation.LocalVarTargetInfo.of(lvti.startLabel(), lvti.endLabel(), lvti.index())).toList());
+            case TypeAnnotation.OffsetTarget t -> TypeAnnotation.TargetInfo.ofOffset(t.targetType(), t.target());
+            case TypeAnnotation.TypeArgumentTarget t -> TypeAnnotation.TargetInfo.ofTypeArgument(t.targetType(), t.target(), t.typeArgumentIndex());
+        };
+    }
+
+    static List<StackMapFrameInfo.VerificationTypeInfo> transformFrameTypeInfos(List<StackMapFrameInfo.VerificationTypeInfo> infos) {
+        return infos.stream().map(ti -> {
+            return switch (ti) {
+                case StackMapFrameInfo.SimpleVerificationTypeInfo i -> i;
+                case StackMapFrameInfo.ObjectVerificationTypeInfo i -> StackMapFrameInfo.ObjectVerificationTypeInfo.of(i.classSymbol());
+                case StackMapFrameInfo.UninitializedVerificationTypeInfo i -> StackMapFrameInfo.UninitializedVerificationTypeInfo.of(i.newTarget());
+            };
+        }).toList();
+    }
+
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312509](https://bugs.openjdk.org/browse/JDK-8312509): Expose physical size of class elements in Classfile API (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14974/head:pull/14974` \
`$ git checkout pull/14974`

Update a local copy of the PR: \
`$ git checkout pull/14974` \
`$ git pull https://git.openjdk.org/jdk.git pull/14974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14974`

View PR using the GUI difftool: \
`$ git pr show -t 14974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14974.diff">https://git.openjdk.org/jdk/pull/14974.diff</a>

</details>
