### PR TITLE
8309871: jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java timed out

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java
@@ -47,7 +47,7 @@ import jdk.jfr.consumer.RecordingStream;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm jdk.jfr.api.consumer.recordingstream.TestSetEndTime
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps jdk.jfr.api.consumer.recordingstream.TestSetEndTime
  */
 public final class TestSetEndTime {
 


### PR DESCRIPTION
Could I have review of a fix that adds -XX:-UseFastUnorderedTimeStamps to a test.

An argument can be made that we should test features same way as they are used in the product, and I generally agree, but it's hard to fix this issue without a performance impact. Also, I'm not 100% certain that different clock sources are the underlying problem. 

By running with -XX:-UseFastUnorderedTimeStamps we will gain additional information on this intermittent test failure. Putting the test on the problem list might hide other issue.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309871](https://bugs.openjdk.org/browse/JDK-8309871): jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java timed out (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14975/head:pull/14975` \
`$ git checkout pull/14975`

Update a local copy of the PR: \
`$ git checkout pull/14975` \
`$ git pull https://git.openjdk.org/jdk.git pull/14975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14975`

View PR using the GUI difftool: \
`$ git pr show -t 14975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14975.diff">https://git.openjdk.org/jdk/pull/14975.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14975#issuecomment-1645654150)