### PR TITLE
8312495: assert(0 <= i && i < _len) failed: illegal index after JDK-8287061 on big endian platforms

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -242,10 +242,7 @@ void ObjectValue::print_fields_on(outputStream* st) const {
 // of the object.
 ObjectValue* ObjectMergeValue::select(frame& fr, RegisterMap& reg_map) {
   StackValue* sv_selector = StackValue::create_stack_value(&fr, &reg_map, _selector);
-  // On big endian platforms the jint is in the high part of the StackValue
-  intptr_t val = sv_selector->get_int();
-  jint selector = (jint)*((jint*)&val);
-
+  jint selector = sv_selector->get_jint();
 
   // If the selector is '-1' it means that execution followed the path
   // where no scalar replacement happened.

--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -242,7 +242,10 @@ void ObjectValue::print_fields_on(outputStream* st) const {
 // of the object.
 ObjectValue* ObjectMergeValue::select(frame& fr, RegisterMap& reg_map) {
   StackValue* sv_selector = StackValue::create_stack_value(&fr, &reg_map, _selector);
-  jint selector = sv_selector->get_int();
+  // On big endian platforms the jint is in the high part of the StackValue
+  intptr_t val = sv_selector->get_int();
+  jint selector = (jint)*((jint*)&val);
+
 
   // If the selector is '-1' it means that execution followed the path
   // where no scalar replacement happened.

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -331,9 +331,9 @@ objArrayHandle LiveFrameStream::values_to_object_array(StackValueCollection* val
     int index = i;
 #ifdef _LP64
     if (type != T_OBJECT && type != T_CONFLICT) {
-        intptr_t ret = st->get_int(); // read full 64-bit slot
-        type = T_LONG;                // treat as long
-        index--;                      // undo +1 in StackValueCollection::long_at
+        intptr_t ret = st->get_intptr(); // read full 64-bit slot
+        type = T_LONG;                   // treat as long
+        index--;                         // undo +1 in StackValueCollection::long_at
     }
 #endif
     oop obj = create_primitive_slot_instance(values, index, type, CHECK_(empty));

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1186,12 +1186,12 @@ oop Deoptimization::get_cached_box(AutoBoxObjectValue* bv, frame* fr, RegisterMa
    if (box_type != T_OBJECT) {
      StackValue* value = StackValue::create_stack_value(fr, reg_map, bv->field_at(box_type == T_LONG ? 1 : 0));
      switch(box_type) {
-       case T_INT:     return IntegerBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_CHAR:    return CharacterBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_SHORT:   return ShortBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_BYTE:    return ByteBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_BOOLEAN: return BooleanBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
-       case T_LONG:    return LongBoxCache::singleton(THREAD)->lookup_raw(value->get_int(), cache_init_error);
+       case T_INT:     return IntegerBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_CHAR:    return CharacterBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_SHORT:   return ShortBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_BYTE:    return ByteBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_BOOLEAN: return BooleanBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
+       case T_LONG:    return LongBoxCache::singleton(THREAD)->lookup_raw(value->get_intptr(), cache_init_error);
        default:;
      }
    }
@@ -1347,15 +1347,14 @@ void Deoptimization::reassign_type_array_elements(frame* fr, RegisterMap* reg_ma
       StackValue* low =
         StackValue::create_stack_value(fr, reg_map, sv->field_at(++i));
 #ifdef _LP64
-      jlong res = (jlong)low->get_int();
+      jlong res = (jlong)low->get_intptr();
 #else
-      jlong res = jlong_from((jint)value->get_int(), (jint)low->get_int());
+      jlong res = jlong_from(value->get_jint(), low->get_jint());
 #endif
       obj->long_at_put(index, res);
       break;
     }
 
-    // Have to cast to INT (32 bits) pointer to avoid little/big-endian problem.
     case T_INT: case T_FLOAT: { // 4 bytes.
       assert(value->type() == T_INT, "Agreement.");
       bool big_value = false;
@@ -1376,36 +1375,33 @@ void Deoptimization::reassign_type_array_elements(frame* fr, RegisterMap* reg_ma
       if (big_value) {
         StackValue* low = StackValue::create_stack_value(fr, reg_map, sv->field_at(++i));
   #ifdef _LP64
-        jlong res = (jlong)low->get_int();
+        jlong res = (jlong)low->get_intptr();
   #else
-        jlong res = jlong_from((jint)value->get_int(), (jint)low->get_int());
+        jlong res = jlong_from(value->get_jint(), low->get_jint());
   #endif
-        obj->int_at_put(index, (jint)*((jint*)&res));
-        obj->int_at_put(++index, (jint)*(((jint*)&res) + 1));
+        obj->int_at_put(index, *(jint*)&res);
+        obj->int_at_put(++index, *((jint*)&res + 1));
       } else {
-        val = value->get_int();
-        obj->int_at_put(index, (jint)*((jint*)&val));
+        obj->int_at_put(index, value->get_jint());
       }
       break;
     }
 
     case T_SHORT:
       assert(value->type() == T_INT, "Agreement.");
-      val = value->get_int();
-      obj->short_at_put(index, (jshort)*((jint*)&val));
+      obj->short_at_put(index, (jshort)value->get_jint());
       break;
 
     case T_CHAR:
       assert(value->type() == T_INT, "Agreement.");
-      val = value->get_int();
-      obj->char_at_put(index, (jchar)*((jint*)&val));
+      obj->char_at_put(index, (jchar)value->get_jint());
       break;
 
     case T_BYTE: {
       assert(value->type() == T_INT, "Agreement.");
-      // The value we get is erased as a regular int. We will need to find its actual byte count 'by hand'.
-      val = value->get_int();
 #if INCLUDE_JVMCI
+      // The value we get is erased as a regular int. We will need to find its actual byte count 'by hand'.
+      val = value->get_intptr();
       int byte_count = count_number_of_bytes_for_entry(sv, i);
       byte_array_put(obj, val, index, byte_count);
       // According to byte_count contract, the values from i + 1 to i + byte_count are illegal values. Skip.
@@ -1414,15 +1410,14 @@ void Deoptimization::reassign_type_array_elements(frame* fr, RegisterMap* reg_ma
       // index has been updated so continue at top of loop
       continue;
 #else
-      obj->byte_at_put(index, (jbyte)*((jint*)&val));
+      obj->byte_at_put(index, (jbyte)value->get_jint());
       break;
 #endif // INCLUDE_JVMCI
     }
 
     case T_BOOLEAN: {
       assert(value->type() == T_INT, "Agreement.");
-      val = value->get_int();
-      obj->bool_at_put(index, (jboolean)*((jint*)&val));
+      obj->bool_at_put(index, (jboolean)value->get_jint());
       break;
     }
 
@@ -1475,7 +1470,6 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
   }
   fields->sort(compare);
   for (int i = 0; i < fields->length(); i++) {
-    intptr_t val;
     ScopeValue* scope_field = sv->field_at(svIndex);
     StackValue* value = StackValue::create_stack_value(fr, reg_map, scope_field);
     int offset = fields->at(i)._offset;
@@ -1486,7 +1480,6 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         obj->obj_field_put(offset, value->get_obj()());
         break;
 
-      // Have to cast to INT (32 bits) pointer to avoid little/big-endian problem.
       case T_INT: case T_FLOAT: { // 4 bytes.
         assert(value->type() == T_INT, "Agreement.");
         bool big_value = false;
@@ -1510,8 +1503,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
           assert(i < fields->length(), "second T_INT field needed");
           assert(fields->at(i)._type == T_INT, "T_INT field needed");
         } else {
-          val = value->get_int();
-          obj->int_field_put(offset, (jint)*((jint*)&val));
+          obj->int_field_put(offset, value->get_jint());
           break;
         }
       }
@@ -1521,9 +1513,9 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         assert(value->type() == T_INT, "Agreement.");
         StackValue* low = StackValue::create_stack_value(fr, reg_map, sv->field_at(++svIndex));
 #ifdef _LP64
-        jlong res = (jlong)low->get_int();
+        jlong res = (jlong)low->get_intptr();
 #else
-        jlong res = jlong_from((jint)value->get_int(), (jint)low->get_int());
+        jlong res = jlong_from(value->get_jint(), low->get_jint());
 #endif
         obj->long_field_put(offset, res);
         break;
@@ -1531,26 +1523,22 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
 
       case T_SHORT:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->short_field_put(offset, (jshort)*((jint*)&val));
+        obj->short_field_put(offset, (jshort)value->get_jint());
         break;
 
       case T_CHAR:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->char_field_put(offset, (jchar)*((jint*)&val));
+        obj->char_field_put(offset, (jchar)value->get_jint());
         break;
 
       case T_BYTE:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->byte_field_put(offset, (jbyte)*((jint*)&val));
+        obj->byte_field_put(offset, (jbyte)value->get_jint());
         break;
 
       case T_BOOLEAN:
         assert(value->type() == T_INT, "Agreement.");
-        val = value->get_int();
-        obj->bool_field_put(offset, (jboolean)*((jint*)&val));
+        obj->bool_field_put(offset, (jboolean)value->get_jint());
         break;
 
       default:

--- a/src/hotspot/share/runtime/stackValue.hpp
+++ b/src/hotspot/share/runtime/stackValue.hpp
@@ -79,20 +79,32 @@ class StackValue : public ResourceObj {
     _handle_value = value;
   }
 
-  intptr_t get_int() const {
+  intptr_t get_intptr() const {
     assert(type() == T_INT, "type check");
     return _integer_value;
   }
 
   // For special case in deopt.
-  intptr_t get_int(BasicType t) const {
+  intptr_t get_intptr(BasicType t) const {
     assert(t == T_OBJECT && type() == T_OBJECT, "type check");
     return _integer_value;
   }
 
-  void set_int(intptr_t value) {
+  void set_intptr(intptr_t value) {
     assert(type() == T_INT, "type check");
     _integer_value = value;
+  }
+
+  // The jint value is always at offset 0 of the stack slot. On big endian platforms
+  // this is the location of the high word therefore we cannot just cast to jint.
+  jint get_jint() const {
+    assert(type() == T_INT, "type check");
+    return *(jint*)&_integer_value;
+  }
+
+  void set_jint(jint value) {
+    assert(type() == T_INT, "type check");
+    *(jint*)&_integer_value = value;
   }
 
   BasicType type() const { return  _type; }

--- a/src/hotspot/share/runtime/stackValueCollection.cpp
+++ b/src/hotspot/share/runtime/stackValueCollection.cpp
@@ -26,14 +26,12 @@
 #include "runtime/stackValueCollection.hpp"
 
 jint StackValueCollection::int_at(int slot) const {
-  intptr_t val =  at(slot)->get_int();
-  jint ival = *((jint*) (&val));
-  return ival;
+  return at(slot)->get_jint();
 }
 
 jlong StackValueCollection::long_at(int slot) const {
 #ifdef _LP64
-  return at(slot+1)->get_int();
+  return at(slot+1)->get_intptr();
 #else
   union {
     jlong jl;
@@ -41,8 +39,8 @@ jlong StackValueCollection::long_at(int slot) const {
   } value;
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
-  value.array[0] = at(slot+1)->get_int();
-  value.array[1] = at(slot  )->get_int();
+  value.array[0] = at(slot+1)->get_intptr();
+  value.array[1] = at(slot  )->get_intptr();
   return value.jl;
 #endif
 }
@@ -52,13 +50,13 @@ Handle StackValueCollection::obj_at(int slot) const {
 }
 
 jfloat StackValueCollection::float_at(int slot) const {
-  intptr_t res = at(slot)->get_int();
+  intptr_t res = at(slot)->get_intptr();
   return *((jfloat*) (&res));
 }
 
 jdouble StackValueCollection::double_at(int slot) const {
 #ifdef _LP64
-  intptr_t res = at(slot+1)->get_int();
+  intptr_t res = at(slot+1)->get_intptr();
   return *((jdouble*) (&res));
 #else
   union {
@@ -67,21 +65,19 @@ jdouble StackValueCollection::double_at(int slot) const {
   } value;
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
-  value.array[0] = at(slot+1)->get_int();
-  value.array[1] = at(slot  )->get_int();
+  value.array[0] = at(slot+1)->get_intptr();
+  value.array[1] = at(slot  )->get_intptr();
   return value.jd;
 #endif
 }
 
 void StackValueCollection::set_int_at(int slot, jint value) {
-  intptr_t val;
-  *((jint*) (&val)) = value;
-  at(slot)->set_int(val);
+  at(slot)->set_jint(value);
 }
 
 void StackValueCollection::set_long_at(int slot, jlong value) {
 #ifdef _LP64
-  at(slot+1)->set_int(value);
+  at(slot+1)->set_intptr(value);
 #else
   union {
     jlong jl;
@@ -90,8 +86,8 @@ void StackValueCollection::set_long_at(int slot, jlong value) {
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
   x.jl = value;
-  at(slot+1)->set_int(x.array[0]);
-  at(slot+0)->set_int(x.array[1]);
+  at(slot+1)->set_intptr(x.array[0]);
+  at(slot+0)->set_intptr(x.array[1]);
 #endif
 }
 
@@ -108,15 +104,15 @@ void StackValueCollection::set_float_at(int slot, jfloat value) {
   // Interpreter stores 32 bit floats in first half of 64 bit word.
   val.array[0] = *(jint*)(&value);
   val.array[1] = 0;
-  at(slot)->set_int(val.jd);
+  at(slot)->set_intptr(val.jd);
 #else
-  at(slot)->set_int(*(jint*)(&value));
+  at(slot)->set_intptr(*(jint*)(&value));
 #endif
 }
 
 void StackValueCollection::set_double_at(int slot, jdouble value) {
 #ifdef _LP64
-  at(slot+1)->set_int(*(intptr_t*)(&value));
+  at(slot+1)->set_intptr(*(intptr_t*)(&value));
 #else
   union {
     jdouble jd;
@@ -125,8 +121,8 @@ void StackValueCollection::set_double_at(int slot, jdouble value) {
   // Interpreter stack is reversed in memory:
   // low memory location is in higher java local slot.
   x.jd = value;
-  at(slot+1)->set_int(x.array[0]);
-  at(slot+0)->set_int(x.array[1]);
+  at(slot+1)->set_intptr(x.array[0]);
+  at(slot+0)->set_intptr(x.array[1]);
 #endif
 }
 

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -453,7 +453,7 @@ void interpretedVFrame::set_locals(StackValueCollection* values) const {
     if (sv->type() == T_OBJECT) {
       *(oop *) addr = (sv->get_obj())();
     } else {                   // integer
-      *addr = sv->get_int();
+      *addr = sv->get_intptr();
     }
   }
 }

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -133,7 +133,7 @@ void vframeArrayElement::fill_in(compiledVFrame* vf, bool realloc_failures) {
         _locals->add( new StackValue());
         break;
       case T_INT:
-        _locals->add( new StackValue(value->get_int()));
+        _locals->add( new StackValue(value->get_intptr()));
         break;
       default:
         ShouldNotReachHere();
@@ -160,7 +160,7 @@ void vframeArrayElement::fill_in(compiledVFrame* vf, bool realloc_failures) {
         _expressions->add( new StackValue());
         break;
       case T_INT:
-        _expressions->add( new StackValue(value->get_int()));
+        _expressions->add( new StackValue(value->get_intptr()));
         break;
       default:
         ShouldNotReachHere();
@@ -342,7 +342,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     assert(!is_bottom_frame || !(caller->is_compiled_caller() && addr >= caller->unextended_sp()), "overwriting caller frame!");
     switch(value->type()) {
       case T_INT:
-        *addr = value->get_int();
+        *addr = value->get_intptr();
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print_cr(" - Reconstructed expression %d (INT): %d", i, (int)(*addr));
@@ -350,7 +350,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
 #endif // !PRODUCT
         break;
       case T_OBJECT:
-        *addr = value->get_int(T_OBJECT);
+        *addr = value->get_intptr(T_OBJECT);
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print(" - Reconstructed expression %d (OBJECT): ", i);
@@ -386,7 +386,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
     assert(!is_bottom_frame || !(caller->is_compiled_caller() && addr >= caller->unextended_sp()), "overwriting caller frame!");
     switch(value->type()) {
       case T_INT:
-        *addr = value->get_int();
+        *addr = value->get_intptr();
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print_cr(" - Reconstructed local %d (INT): %d", i, (int)(*addr));
@@ -394,7 +394,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
 #endif // !PRODUCT
         break;
       case T_OBJECT:
-        *addr = value->get_int(T_OBJECT);
+        *addr = value->get_intptr(T_OBJECT);
 #ifndef PRODUCT
         if (PrintDeoptimizationDetails) {
           tty->print(" - Reconstructed local %d (OBJECT): ", i);


### PR DESCRIPTION
On big endian platforms `jint` values are stored in the high part of `StackValue` values. Therefore the the `StackValue` cannot be cast directly to `jint`. More details why this has to be like this are given in the JBS issue.

This is a common pattern. See also

https://github.com/openjdk/jdk/blob/8d29329138d44800ee4c0c02dacc01a06097de66/src/hotspot/share/runtime/deoptimization.cpp#L1386-L1387
https://github.com/openjdk/jdk/blob/8d29329138d44800ee4c0c02dacc01a06097de66/src/hotspot/share/runtime/deoptimization.cpp#L1513-L1514

### Testing
Manny iterations of vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java.

JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. Renaissance benchmarks as functional tests.

All testing was done with fastdebug and release builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312495](https://bugs.openjdk.org/browse/JDK-8312495): assert(0 &lt;= i &amp;&amp; i &lt; _len) failed: illegal index after JDK-8287061 on big endian platforms (**Bug** - P2)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [224a65f7](https://git.openjdk.org/jdk/pull/14976/files/224a65f7cdf29d3bf5cda25c46a87bb90a033138)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14976/head:pull/14976` \
`$ git checkout pull/14976`

Update a local copy of the PR: \
`$ git checkout pull/14976` \
`$ git pull https://git.openjdk.org/jdk.git pull/14976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14976`

View PR using the GUI difftool: \
`$ git pr show -t 14976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14976.diff">https://git.openjdk.org/jdk/pull/14976.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14976#issuecomment-1646002467)