### PR TITLE
8313743: Make fields final in sun.nio.ch

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ abstract class AsynchronousChannelGroupImpl
     private final AtomicInteger threadCount = new AtomicInteger();
 
     // associated Executor for timeouts
-    private ScheduledThreadPoolExecutor timeoutExecutor;
+    private final ScheduledThreadPoolExecutor timeoutExecutor;
 
     // task queue for when using a fixed thread pool. In that case, a thread
     // waiting on I/O events must be awoken to poll tasks from this queue.

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ abstract class AsynchronousServerSocketChannelImpl
     private final Object stateLock = new Object();
 
     // close support
-    private ReadWriteLock closeLock = new ReentrantReadWriteLock();
+    private final ReadWriteLock closeLock = new ReentrantReadWriteLock();
     private volatile boolean closed;
 
     // set true when accept operation is cancelled

--- a/src/java.base/share/classes/sun/nio/ch/FileLockTable.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileLockTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ class FileLockTable {
      * FileLock (and FileChannel) alive.
      */
     private static class FileLockReference extends WeakReference<FileLock> {
-        private FileKey fileKey;
+        private final FileKey fileKey;
 
         FileLockReference(FileLock referent,
                           ReferenceQueue<FileLock> queue,
@@ -66,11 +66,11 @@ class FileLockTable {
     // The system-wide map is a ConcurrentHashMap that is keyed on the FileKey.
     // The map value is a list of file locks represented by FileLockReferences.
     // All access to the list must be synchronized on the list.
-    private static ConcurrentHashMap<FileKey, List<FileLockReference>> lockMap =
-        new ConcurrentHashMap<FileKey, List<FileLockReference>>();
+    private static final ConcurrentHashMap<FileKey, List<FileLockReference>> lockMap =
+        new ConcurrentHashMap<>();
 
     // reference queue for cleared refs
-    private static ReferenceQueue<FileLock> queue = new ReferenceQueue<FileLock>();
+    private static final ReferenceQueue<FileLock> queue = new ReferenceQueue<>();
 
     // The connection to which this table is connected
     private final Channel channel;

--- a/src/java.base/share/classes/sun/nio/ch/IOVecWrapper.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOVecWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ class IOVecWrapper {
     final long address;
 
     // Address size in bytes
-    static int addressSize;
+    static final int addressSize;
 
     private static class Deallocator implements Runnable {
         private final AllocatedNativeObject obj;

--- a/src/java.base/share/classes/sun/nio/ch/OptionKey.java
+++ b/src/java.base/share/classes/sun/nio/ch/OptionKey.java
@@ -28,5 +28,21 @@ package sun.nio.ch;
 /**
  * Represents the level/name of a socket option
  */
-record OptionKey(int level, int name) {
+
+class OptionKey {
+    private final int level;
+    private final int name;
+
+    OptionKey(int level, int name) {
+        this.level = level;
+        this.name = name;
+    }
+
+    int level() {
+        return level;
+    }
+
+    int name() {
+        return name;
+    }
 }

--- a/src/java.base/share/classes/sun/nio/ch/OptionKey.java
+++ b/src/java.base/share/classes/sun/nio/ch/OptionKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,21 +28,5 @@ package sun.nio.ch;
 /**
  * Represents the level/name of a socket option
  */
-
-class OptionKey {
-    private int level;
-    private int name;
-
-    OptionKey(int level, int name) {
-        this.level = level;
-        this.name = name;
-    }
-
-    int level() {
-        return level;
-    }
-
-    int name() {
-        return name;
-    }
+record OptionKey(int level, int name) {
 }

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -53,7 +53,7 @@ public class Util {
     private static final long MAX_CACHED_BUFFER_SIZE = getMaxCachedBufferSize();
 
     // Per-carrier-thread cache of temporary direct buffers
-    private static TerminatingThreadLocal<BufferCache> bufferCache = new TerminatingThreadLocal<>() {
+    private static final TerminatingThreadLocal<BufferCache> bufferCache = new TerminatingThreadLocal<>() {
         @Override
         protected BufferCache initialValue() {
             return new BufferCache();
@@ -112,7 +112,7 @@ public class Util {
      */
     private static class BufferCache {
         // the array of buffers
-        private ByteBuffer[] buffers;
+        private final ByteBuffer[] buffers;
 
         // the number of buffers in the cache
         private int count;
@@ -378,7 +378,7 @@ public class Util {
 
     // -- Unsafe access --
 
-    private static Unsafe unsafe = Unsafe.getUnsafe();
+    private static final Unsafe unsafe = Unsafe.getUnsafe();
 
     private static byte _get(long a) {
         return unsafe.getByte(a);

--- a/src/java.base/windows/classes/sun/nio/ch/PollArrayWrapper.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PollArrayWrapper.java
@@ -51,7 +51,7 @@ class PollArrayWrapper {
     @Native private static final short FD_OFFSET     = 0; // fd offset in pollfd
     @Native private static final short EVENT_OFFSET  = 4; // events offset in pollfd
 
-    static short SIZE_POLLFD = 8; // sizeof pollfd struct
+    static final short SIZE_POLLFD = 8; // sizeof pollfd struct
 
     private int size; // Size of the pollArray
 

--- a/src/java.base/windows/classes/sun/nio/ch/PollArrayWrapper.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PollArrayWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousSocketChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousSocketChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousSocketChannelImpl.java
@@ -45,10 +45,9 @@ class WindowsAsynchronousSocketChannelImpl
     extends AsynchronousSocketChannelImpl implements Iocp.OverlappedChannel
 {
     private static final Unsafe unsafe = Unsafe.getUnsafe();
-    private static int addressSize = unsafe.addressSize();
 
     private static int dependsArch(int value32, int value64) {
-        return (addressSize == 4) ? value32 : value64;
+        return (unsafe.addressSize() == 4) ? value32 : value64;
     }
 
     /*

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -49,14 +49,13 @@ import jdk.internal.misc.Unsafe;
 
 class WindowsSelectorImpl extends SelectorImpl {
     private static final Unsafe unsafe = Unsafe.getUnsafe();
-    private static int addressSize = unsafe.addressSize();
 
     private static int dependsArch(int value32, int value64) {
-        return (addressSize == 4) ? value32 : value64;
+        return (unsafe.addressSize() == 4) ? value32 : value64;
     }
 
     // Initial capacity of the poll array
-    private final int INIT_CAP = 8;
+    private static final int INIT_CAP = 8;
     // Maximum number of sockets for select().
     // Should be INIT_CAP times a power of 2
     private static final int MAX_SELECTABLE_FDS = 1024;
@@ -74,7 +73,7 @@ class WindowsSelectorImpl extends SelectorImpl {
     private SelectionKeyImpl[] channelArray = new SelectionKeyImpl[INIT_CAP];
 
     // The global native poll array holds file descriptors and event masks
-    private PollArrayWrapper pollWrapper;
+    private final PollArrayWrapper pollWrapper;
 
     // The number of valid entries in  poll array, including entries occupied
     // by wakeup socket handle.


### PR DESCRIPTION
Found a few fields in `sun.nio.ch` package which could be declared `final`.

Also I took oportunity to make a couple of cleanups:
1. ~Converted `sun.nio.ch.OptionKey` to a record. Getters naming are already match.~
2. Removed `sun.nio.ch.WindowsAsynchronousSocketChannelImpl#addressSize`/`sun.nio.ch.WindowsSelectorImpl#addressSize` fields. Address size is already cached inside Unsafe (since [JDK-8221477](https://bugs.openjdk.org/browse/JDK-8221477)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313743](https://bugs.openjdk.org/browse/JDK-8313743): Make fields final in sun.nio.ch (**Enhancement** - P5)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14980/head:pull/14980` \
`$ git checkout pull/14980`

Update a local copy of the PR: \
`$ git checkout pull/14980` \
`$ git pull https://git.openjdk.org/jdk.git pull/14980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14980`

View PR using the GUI difftool: \
`$ git pr show -t 14980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14980.diff">https://git.openjdk.org/jdk/pull/14980.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14980#issuecomment-1665225873)