### PR TITLE
8309238: jdk/jfr/tool/TestView.java failed with "exitValue = 134"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -289,9 +289,6 @@ public final class ChunkParser {
             if (parserState.isClosed()) {
                 return true;
             }
-            if (chunkHeader.getLastNanos() > filterEnd)  {
-              return true;
-            }
             chunkHeader.refresh();
             if (absoluteChunkEnd != chunkHeader.getEnd()) {
                 return false;


### PR DESCRIPTION
Could I have a review of a fix that prevents the ChunkParser from locking up when an end time has been set.

The problem was likely introduced with https://bugs.openjdk.org/browse/JDK-8307738 where the condition for exiting the the while loop in ChunkParser::processRecursionSafe(...) was changed. What happens is that the awaitUpdatedHeader(...) method will return true when the end time exceeds the timestamp of the last segment. This leads to chunkFinished to be set to true and the loop in ChunkParser::processRecursionSafe(...) continues to next file, but there is no file so it spins forever in RepositoryFiles::updatePaths(...)

The fix is to allow the loop to exit when absoluteChunkEnd != chunkHeader.getEnd(), which will transfer control back to ChunkParser::processRecursionSafe(...) with chunkFinished set to false, where the method can return when the last segment has been fully parsed.

Just changing the return value from "true" to "false" would be incorrect. The stream should end when all the events leading up to the end time has been parsed, not just written.

Testing: 100 * test/jdk/jdk/jfr 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309238](https://bugs.openjdk.org/browse/JDK-8309238): jdk/jfr/tool/TestView.java failed with "exitValue = 134" (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14987/head:pull/14987` \
`$ git checkout pull/14987`

Update a local copy of the PR: \
`$ git checkout pull/14987` \
`$ git pull https://git.openjdk.org/jdk.git pull/14987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14987`

View PR using the GUI difftool: \
`$ git pr show -t 14987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14987.diff">https://git.openjdk.org/jdk/pull/14987.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14987#issuecomment-1647457924)