### PR TITLE
JDK-8312512: sspi.cpp avoid some NULL checks related to free and delete

### DIFF
--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -569,7 +569,7 @@ gss_export_name(OM_uint32 *minor_status,
     result = GSS_S_COMPLETE;
 err:
     if (fullname != name) {
-        delete[] fullname;
+        if (fullname != NULL) delete[] fullname;
     }
     return result;
 }

--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -330,9 +330,7 @@ gss_release_name(OM_uint32 *minor_status,
 {
     PP(">>>> Calling gss_release_name %p...", *name);
     if (name != NULL && *name != GSS_C_NO_NAME) {
-        if ((*name)->name != NULL) {
-            delete[] (*name)->name;
-        }
+        delete[] (*name)->name;
         delete *name;
         *name = GSS_C_NO_NAME;
     }
@@ -419,9 +417,7 @@ gss_import_name(OM_uint32 *minor_status,
     *output_name = (gss_name_t) name;
     return GSS_S_COMPLETE;
 err:
-    if (value != NULL) {
-        delete[] value;
-    }
+    delete[] value;
     return GSS_S_FAILURE;
 }
 
@@ -569,7 +565,7 @@ gss_export_name(OM_uint32 *minor_status,
     result = GSS_S_COMPLETE;
 err:
     if (fullname != name) {
-        if (fullname != NULL) delete[] fullname;
+        delete[] fullname;
     }
     return result;
 }
@@ -1023,9 +1019,7 @@ err:
         OM_uint32 dummy;
         gss_delete_sec_context(&dummy, context_handle, GSS_C_NO_BUFFER);
     }
-    if (newCred) {
-        delete newCred;
-    }
+    delete newCred;
     if (output_token->value) {
         gss_release_buffer(NULL, output_token);
     }
@@ -1266,9 +1260,7 @@ gss_get_mic(OM_uint32 *minor_status,
 err:
     msg_token->length = 0;
     msg_token->value = NULL;
-    if (secBuff[1].pvBuffer) {
-        free(secBuff[1].pvBuffer);
-    }
+    free(secBuff[1].pvBuffer);
     return GSS_S_FAILURE;
 }
 
@@ -1342,7 +1334,7 @@ gss_wrap(OM_uint32 *minor_status,
     secBuff[0].pvBuffer = malloc(
             context_handle->SecPkgContextSizes.cbSecurityTrailer
                     + input_message_buffer->length
-                    + context_handle->SecPkgContextSizes.cbBlockSize);;
+                    + context_handle->SecPkgContextSizes.cbBlockSize);
     if (!secBuff[0].pvBuffer) {
         goto err;
     }
@@ -1393,15 +1385,10 @@ gss_wrap(OM_uint32 *minor_status,
     return GSS_S_COMPLETE;
 
 err:
-    if (secBuff[0].pvBuffer) {
-        free(secBuff[0].pvBuffer);
-    }
-    if (secBuff[1].pvBuffer) {
-        free(secBuff[1].pvBuffer);
-    }
-    if (secBuff[2].pvBuffer) {
-        free(secBuff[2].pvBuffer);
-    }
+    free(secBuff[0].pvBuffer);
+    free(secBuff[1].pvBuffer);
+    free(secBuff[2].pvBuffer);
+
     output_message_buffer->length = 0;
     output_message_buffer->value = NULL;
     return GSS_S_FAILURE;
@@ -1468,9 +1455,7 @@ gss_unwrap(OM_uint32 *minor_status,
     return GSS_S_COMPLETE;
 
 err:
-    if (secBuff[0].pvBuffer) {
-        free(secBuff[0].pvBuffer);
-    }
+    free(secBuff[0].pvBuffer);
     output_message_buffer->length = 0;
     output_message_buffer->value = NULL;
     return GSS_S_FAILURE;
@@ -1581,9 +1566,7 @@ gss_add_oid_set_member(OM_uint32 *minor_status,
             member_oid->elements, member_oid->length);
     (*oid_set)->elements = newcopy;
     (*oid_set)->count++;
-    if (existing) {
-        delete[] existing;
-    }
+    delete[] existing;
 
     return GSS_S_COMPLETE;
 }
@@ -1670,10 +1653,8 @@ gss_release_buffer(OM_uint32 *minor_status,
     if (buffer == NULL || buffer == GSS_C_NO_BUFFER) {
         return GSS_S_COMPLETE;
     }
-    if (buffer->value) {
-        free(buffer->value);
-        buffer->value = NULL;
-    }
+    free(buffer->value);
+    buffer->value = NULL;
     buffer->length = 0;
     return GSS_S_COMPLETE;
 }


### PR DESCRIPTION
sspi.cpp contains the gss_export_name function, where at the end some cleanup is done by calling delete. However this should be done more careful, because the function get_full_name which is called in gss_export_name might return NULL, so we better avoid calling delete in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312512](https://bugs.openjdk.org/browse/JDK-8312512): sspi.cpp avoid some NULL checks related to free and delete (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14989/head:pull/14989` \
`$ git checkout pull/14989`

Update a local copy of the PR: \
`$ git checkout pull/14989` \
`$ git pull https://git.openjdk.org/jdk.git pull/14989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14989`

View PR using the GUI difftool: \
`$ git pr show -t 14989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14989.diff">https://git.openjdk.org/jdk/pull/14989.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14989#issuecomment-1647409042)