### PR TITLE
8312578: Redundant javadoc in X400Address

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/X400Address.java
+++ b/src/java.base/share/classes/sun/security/x509/X400Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,12 +336,6 @@ public class X400Address implements GeneralNameInterface {
 
     // Private data members
     DerValue derValue;
-
-    /**
-     * Create the X400Address object from the specified byte array
-     *
-     * @param value value of the name as a byte array
-     */
 
     /**
      * Create the X400Address object from the passed encoded Der value.


### PR DESCRIPTION
[JDK-8296741] removed the constructor `X400Address(byte[] value)`, but it didn't remove the javadoc for this constructor.
This simple patch just removes this javadoc.

[JDK-8296741]:
<https://bugs.openjdk.org/browse/JDK-8296741>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312578](https://bugs.openjdk.org/browse/JDK-8312578): Redundant javadoc in X400Address (**Bug** - P4)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14990/head:pull/14990` \
`$ git checkout pull/14990`

Update a local copy of the PR: \
`$ git checkout pull/14990` \
`$ git pull https://git.openjdk.org/jdk.git pull/14990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14990`

View PR using the GUI difftool: \
`$ git pr show -t 14990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14990.diff">https://git.openjdk.org/jdk/pull/14990.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14990#issuecomment-1647425235)