### PR TITLE
8312591: GCC 6 build failure after JDK-8280982

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -245,6 +245,8 @@ ifeq ($(call isTargetOs, windows macosx), false)
         DISABLED_WARNINGS_gcc_gtk3_interface.c := parentheses type-limits unused-function, \
         DISABLED_WARNINGS_gcc_OGLBufImgOps.c := format-nonliteral, \
         DISABLED_WARNINGS_gcc_OGLPaints.c := format-nonliteral, \
+        DISABLED_WARNINGS_gcc_screencast_pipewire.c := undef, \
+        DISABLED_WARNINGS_gcc_screencast_portal.c := undef, \
         DISABLED_WARNINGS_gcc_sun_awt_X11_GtkFileDialogPeer.c := parentheses, \
         DISABLED_WARNINGS_gcc_X11SurfaceData.c := implicit-fallthrough pointer-to-int-cast, \
         DISABLED_WARNINGS_gcc_XlibWrapper.c := type-limits pointer-to-int-cast, \

--- a/src/java.desktop/unix/native/libpipewire/include/spa/utils/defs.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/utils/defs.h
@@ -58,9 +58,7 @@ extern "C" {
 #if defined(__clang__) && defined(__cplusplus) && __cplusplus >= 201103L
    /* clang's fallthrough annotations are only available starting in C++11. */
 #  define SPA_FALLTHROUGH [[clang::fallthrough]];
-#elif defined(__GNUC__) && __GNUC__ >= 7
-#  define SPA_FALLTHROUGH __attribute__ ((fallthrough));
-#elif defined(__clang_major__) && __clang_major__ >= 10
+#elif __GNUC__ >= 7 || __clang_major__ >= 10
 #  define SPA_FALLTHROUGH __attribute__ ((fallthrough));
 #else
 #  define SPA_FALLTHROUGH /* FALLTHROUGH */

--- a/src/java.desktop/unix/native/libpipewire/include/spa/utils/defs.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/utils/defs.h
@@ -58,7 +58,9 @@ extern "C" {
 #if defined(__clang__) && defined(__cplusplus) && __cplusplus >= 201103L
    /* clang's fallthrough annotations are only available starting in C++11. */
 #  define SPA_FALLTHROUGH [[clang::fallthrough]];
-#elif __GNUC__ >= 7 || __clang_major__ >= 10
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#  define SPA_FALLTHROUGH __attribute__ ((fallthrough));
+#elif defined(__clang_major__) && __clang_major__ >= 10
 #  define SPA_FALLTHROUGH __attribute__ ((fallthrough));
 #else
 #  define SPA_FALLTHROUGH /* FALLTHROUGH */


### PR DESCRIPTION
There is a simple build failure after [JDK-8280982](https://bugs.openjdk.org/browse/JDK-8280982) with older GCCs:

```
* For target support_native_java.desktop_libawt_xawt_screencast_pipewire.o:
In file included from /home/buildbot/worker/build-jdkX-debian9/build/src/java.desktop/unix/native/libpipewire/include/spa/buffer/buffer.h:12:0,
                 from /home/buildbot/worker/build-jdkX-debian9/build/src/java.desktop/unix/native/libpipewire/include/pipewire/stream.h:171,
                 from /home/buildbot/worker/build-jdkX-debian9/build/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.h:36,
                 from /home/buildbot/worker/build-jdkX-debian9/build/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c:33:
/home/buildbot/worker/build-jdkX-debian9/build/src/java.desktop/unix/native/libpipewire/include/spa/utils/defs.h:61:24: error: "__clang_major__" is not defined [-Werror=undef]
 #elif __GNUC__ >= 7 || __clang_major__ >= 10
                        ^~~~~~~~~~~~~~~
```

There is an obvious fix for this: we need to check for `defined(__GNUC__)` explicitly before touching `__clang_major__`.

(Yes, GCC 6 is old; but we would like to make sure it builds until we run into hard to resolve build issues. This allows modern JDKs to be built in legacy enterprise environments for e.g. portable builds.)

Additional testing:
 - [x] Linux GCC 6 fastdebug build (passes with HarfBuzz warnings, to be fixed separately)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8312591](https://bugs.openjdk.org/browse/JDK-8312591): GCC 6 build failure after JDK-8280982 (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14995/head:pull/14995` \
`$ git checkout pull/14995`

Update a local copy of the PR: \
`$ git checkout pull/14995` \
`$ git pull https://git.openjdk.org/jdk.git pull/14995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14995`

View PR using the GUI difftool: \
`$ git pr show -t 14995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14995.diff">https://git.openjdk.org/jdk/pull/14995.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14995#issuecomment-1647645361)