### PR TITLE
8312592: New parentheses warnings after HarfBuzz 7.2.0 update

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -491,7 +491,7 @@ else
    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers strict-aliasing \
-       unused-result array-bounds
+       unused-result array-bounds parentheses
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type expansion-to-defined dangling-reference


### PR DESCRIPTION
At least GCC 6 fail the build with warnings-as-errors here:

```
../src/java.desktop/share/native/libharfbuzz/hb-subset-plan.cc: In function 'void _collect_layout_variation_indices(hb_subset_plan_t*)':
../src/java.desktop/share/native/libharfbuzz/hb-subset-plan.cc:389:83: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
     if (unlikely (!plan->check_success (font = _get_hb_font_with_variations (plan)))) {
                                                                                   ^
../src/java.desktop/share/native/libharfbuzz/hb.hh:259:46: note: in definition of macro 'unlikely'
 #define unlikely(expr) (__builtin_expect (!!(expr), 0))
                                              ^~~~
```

This is caused by HarfBuzz update to 7.2.0, [JDK-8307301](https://bugs.openjdk.org/browse/JDK-8307301)

Instead of fixing the HarfBuzz sources in-tree, it is cleaner to disable the warning. Lots of follow-ups after this HarfBuzz update did the same.

Additional testing:
 - [x] Linux x86_64 fastdebug build on affected systems

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312592](https://bugs.openjdk.org/browse/JDK-8312592): New parentheses warnings after HarfBuzz 7.2.0 update (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14996/head:pull/14996` \
`$ git checkout pull/14996`

Update a local copy of the PR: \
`$ git checkout pull/14996` \
`$ git pull https://git.openjdk.org/jdk.git pull/14996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14996`

View PR using the GUI difftool: \
`$ git pr show -t 14996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14996.diff">https://git.openjdk.org/jdk/pull/14996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14996#issuecomment-1647668765)