### PR TITLE
8312533: JFR: No message for JFR.view when data is missing

### DIFF
--- a/test/jdk/jdk/jfr/jcmd/TestJcmdViewMissingData.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdViewMissingData.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jcmd;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/**
+ * @test
+ * @summary The test verifies JFR.view command
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jcmd.TestJcmdViewMissingData
+ */
+public class TestJcmdViewMissingData {
+
+    public static void main(String... args) throws Exception {
+        testNotInitialized();
+        testInMemory();
+        testClosed();
+    }
+
+    private static void testNotInitialized() {
+        OutputAnalyzer output = JcmdHelper.jcmd("JFR.view", "jvm-information");
+        output.shouldContain("No recording data available. Start a recording with JFR.start.");
+    }
+
+    private static void testInMemory() throws Exception {
+        Configuration c = Configuration.getConfiguration("default");
+        try (Recording r = new Recording(c)) {
+            r.setToDisk(false);
+            r.start();
+            OutputAnalyzer output = JcmdHelper.jcmd("JFR.view", "hot-methods");
+            output.shouldContain("No recording data found on disk.");
+            r.stop();
+        }
+    }
+
+    private static void testClosed() throws Exception {
+        Configuration c = Configuration.getConfiguration("default");
+        try (Recording r = new Recording(c)) {
+            r.start();
+            r.stop();
+        }
+        OutputAnalyzer output = JcmdHelper.jcmd("JFR.view", "hot-methods");
+        output.shouldContain("No recording data found on disk.");
+    }
+}


### PR DESCRIPTION
Could I have a review of a PR that adds a message when there is no data to view.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312533](https://bugs.openjdk.org/browse/JDK-8312533): JFR: No message for JFR.view when data is missing (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14998/head:pull/14998` \
`$ git checkout pull/14998`

Update a local copy of the PR: \
`$ git checkout pull/14998` \
`$ git pull https://git.openjdk.org/jdk.git pull/14998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14998`

View PR using the GUI difftool: \
`$ git pr show -t 14998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14998.diff">https://git.openjdk.org/jdk/pull/14998.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14998#issuecomment-1647865568)