### PR TITLE
8312440: assert(cast != nullptr) failed: must have added a cast to pin the node

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1697,7 +1697,7 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
               }
               if (cast != nullptr) {
                 Node* prev = _igvn.hash_find_insert(cast);
-                if (prev != nullptr) {
+                if (prev != nullptr && get_ctrl(prev) == x_ctrl) {
                   cast->destruct(&_igvn);
                   cast = prev;
                 } else {

--- a/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeMissingCastAssert.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeMissingCastAssert.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8312440
+ * @summary assert(cast != nullptr) failed: must have added a cast to pin the node
+ * @run main/othervm -XX:-BackgroundCompilation TestSunkNodeMissingCastAssert
+ */
+
+
+public class TestSunkNodeMissingCastAssert {
+  private static int N = 500;
+  private static int ia[] = new int[N];
+  private static volatile int ib[] = new int[N];
+
+  private static void test() {
+    for (int k = 1; k < 200; k++)
+      switch (k % 5) {
+      case 0:
+        ia[k - 1] -= 15;
+      case 2:
+        for (int m = 0; m < 1000; m++);
+      case 3:
+        ib[k - 1] <<= 5;
+      case 4:
+        ib[k + 1] <<= 3;
+      }
+  }
+
+  public static void main(String[] args) {
+    for (int i = 0; i < 20000; i++) {
+      test();
+    }
+  }
+}
+


### PR DESCRIPTION
The test has a loop nest with 2 loops. A node is sunk out of the inner
loop. A cast is created to pin the node out of loop. The logic added
by 8308103 looks for an existing cast with the same inputs. It finds
one and uses that one. That existing cast was created before the
current round of loop opts. Eventhough it has the right out of inner
loop (but in outer loop) control input, it was assigned a control out
of both loops (the control is legal, it just happens that no use keeps
the cast in the outer loop). Next, the same node is sunk out of the
outer loop. The logic for sinking nodes looks for an input in the
outer loop (otherwise why would the node be in the outer loop) and
find none even though there should be one. The assert fires. The
reason is that the cast input has control out of loop. The fix I
propose is to not use an existing cast if it doesn't have the expected
control.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312440](https://bugs.openjdk.org/browse/JDK-8312440): assert(cast != nullptr) failed: must have added a cast to pin the node (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/14999/head:pull/14999` \
`$ git checkout pull/14999`

Update a local copy of the PR: \
`$ git checkout pull/14999` \
`$ git pull https://git.openjdk.org/jdk.git pull/14999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14999`

View PR using the GUI difftool: \
`$ git pr show -t 14999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/14999.diff">https://git.openjdk.org/jdk/pull/14999.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/14999#issuecomment-1648036028)