### PR TITLE
8312596: Null pointer access in Compile::TracePhase::~TracePhase after JDK-8311976

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4332,10 +4332,13 @@ void Compile::record_failure(const char* reason) {
 
 Compile::TracePhase::TracePhase(const char* name, elapsedTimer* accumulator)
   : TraceTime(name, accumulator, CITime, CITimeVerbose),
-    _compile(nullptr), _log(nullptr), _phase_name(name), _dolog(CITimeVerbose)
+    _compile(Compile::current()),
+    _log(nullptr),
+    _phase_name(name),
+    _dolog(CITimeVerbose)
 {
+  assert(_compile != nullptr, "sanity check");
   if (_dolog) {
-    _compile = Compile::current();
     _log = _compile->log();
   }
   if (_log != nullptr) {
@@ -4353,7 +4356,7 @@ Compile::TracePhase::~TracePhase() {
   }
 
   if (VerifyIdealNodeCount) {
-    Compile::current()->print_missing_nodes();
+    _compile->print_missing_nodes();
   }
 #endif
 

--- a/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
+++ b/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8312596
  * @requires vm.debug == true & vm.compiler2.enabled
- * @summary Run with -Xcomp to test -XX:+TestPrintIdealNodeCount in debug builds.
+ * @summary Run with -Xcomp -XX:-TieredCompilation to force C2 compilations to test -XX:+PrintIdealNodeCount in debug builds.
  *
- * @run main/othervm -Xcomp -XX:+PrintIdealNodeCount compiler.c2.TestPrintIdealNodeCount
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+PrintIdealNodeCount compiler.c2.TestPrintIdealNodeCount
  */
 package compiler.c2;
 

--- a/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
+++ b/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8312596
- * @requires vm.debug == true & vm.flavor == "server"
+ * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Run with -Xcomp to test -XX:+TestPrintIdealNodeCount in debug builds.
  *
  * @run main/othervm -Xcomp -XX:+PrintIdealNodeCount compiler.c2.TestPrintIdealNodeCount

--- a/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
+++ b/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8312596 
+ * @requires vm.debug == true & vm.flavor == "server"
+ * @summary Run with -Xcomp to test -XX:+TestPrintIdealNodeCount in debug builds.
+ *
+ * @run main/othervm -Xcomp -XX:+PrintIdealNodeCount compiler.c2.TestPrintIdealNodeCount
+ */
+package compiler.c2;
+
+public class TestPrintIdealNodeCount {
+    public static void main(String[] args) {
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
+++ b/test/hotspot/jtreg/compiler/c2/TestPrintIdealNodeCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8312596 
+ * @bug 8312596
  * @requires vm.debug == true & vm.flavor == "server"
  * @summary Run with -Xcomp to test -XX:+TestPrintIdealNodeCount in debug builds.
  *


### PR DESCRIPTION
Please review this PR to fix a potential null pointer access in using `_compile`.
Updated the code to unconditionally initialize `_compile` and added an assert (similar to C1's `PhaseTraceTime` constructor) for it to be non-null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312596](https://bugs.openjdk.org/browse/JDK-8312596): Null pointer access in Compile::TracePhase::~TracePhase after JDK-8311976 (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [70f3ebad](https://git.openjdk.org/jdk/pull/15002/files/70f3ebad62b8e6982c5af2b496a62dda8356f0d5)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [0a78b88c](https://git.openjdk.org/jdk/pull/15002/files/0a78b88c39e691d0aa74cff922164181820c19cd)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [5e878d97](https://git.openjdk.org/jdk/pull/15002/files/5e878d977a9e249239d86a1c89c4ba264244b9ee)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15002/head:pull/15002` \
`$ git checkout pull/15002`

Update a local copy of the PR: \
`$ git checkout pull/15002` \
`$ git pull https://git.openjdk.org/jdk.git pull/15002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15002`

View PR using the GUI difftool: \
`$ git pr show -t 15002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15002.diff">https://git.openjdk.org/jdk/pull/15002.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15002#issuecomment-1648389126)