### PR TITLE
JDK-8312415: Expand -Xlint:serial checks to enum constants with specialized class bodies

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -5223,7 +5223,7 @@ public class Check {
                                 visitTypeAsEnum(enumConstantType, p);
                             }
                         }
-                    } 
+                    }
 
                     }});
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -5214,14 +5214,13 @@ public class Check {
                         }
                     }
 
+                    // Also perform checks on any class bodies of enum constants, see JLS 8.9.1.
                     case ENUM_CONSTANT -> {
                         var field = (VarSymbol)enclosed;
-                        if (field.isEnum()) {
-                            JCVariableDecl decl = (JCVariableDecl) TreeInfo.declarationFor(field, p);
-                            if (decl.init instanceof JCNewClass nc && nc.def != null) {
-                                ClassSymbol enumConstantType = nc.def.sym;
-                                visitTypeAsEnum(enumConstantType, p);
-                            }
+                        JCVariableDecl decl = (JCVariableDecl) TreeInfo.declarationFor(field, p);
+                        if (decl.init instanceof JCNewClass nc && nc.def != null) {
+                            ClassSymbol enumConstantType = nc.def.sym;
+                            visitTypeAsEnum(enumConstantType, p);
                         }
                     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -5213,6 +5213,18 @@ public class Check {
                             }
                         }
                     }
+
+                    case ENUM_CONSTANT -> {
+                        var field = (VarSymbol)enclosed;
+                        if (field.isEnum()) {
+                            JCVariableDecl decl = (JCVariableDecl) TreeInfo.declarationFor(field, p);
+                            if (decl.init instanceof JCNewClass nc && nc.def != null) {
+                                ClassSymbol enumConstantType = nc.def.sym;
+                                visitTypeAsEnum(enumConstantType, p);
+                            }
+                        }
+                    } 
+
                     }});
             }
             return null;

--- a/test/langtools/tools/javac/warnings/Serial/ClassBody.out
+++ b/test/langtools/tools/javac/warnings/Serial/ClassBody.out
@@ -1,0 +1,18 @@
+EnumExternClassBody.java:25:25: compiler.warn.ineffectual.extern.method.enum: readExternal
+EnumExternClassBody.java:30:25: compiler.warn.ineffectual.extern.method.enum: writeExternal
+EnumExternClassBody.java:35:38: compiler.warn.ineffectual.serial.field.enum: serialVersionUID
+EnumExternClassBody.java:36:53: compiler.warn.ineffectual.serial.field.enum: serialPersistentFields
+EnumExternClassBody.java:38:25: compiler.warn.ineffectual.serial.method.enum: writeObject
+EnumExternClassBody.java:42:27: compiler.warn.ineffectual.serial.method.enum: writeReplace
+EnumExternClassBody.java:46:25: compiler.warn.ineffectual.serial.method.enum: readObject
+EnumExternClassBody.java:51:25: compiler.warn.ineffectual.serial.method.enum: readObjectNoData
+EnumExternClassBody.java:55:27: compiler.warn.ineffectual.serial.method.enum: readResolve
+EnumExternClassBody.java:66:21: compiler.warn.ineffectual.extern.method.enum: readExternal
+EnumExternClassBody.java:71:21: compiler.warn.ineffectual.extern.method.enum: writeExternal
+EnumExternClassBody.java:83:25: compiler.warn.ineffectual.extern.method.enum: readExternal
+EnumExternClassBody.java:88:25: compiler.warn.ineffectual.extern.method.enum: writeExternal
+EnumExternClassBody.java:101:25: compiler.warn.ineffectual.extern.method.enum: readExternal
+EnumExternClassBody.java:106:25: compiler.warn.ineffectual.extern.method.enum: writeExternal
+EnumExternClassBody.java:112:30: compiler.warn.ineffectual.extern.method.enum: readExternal
+EnumExternClassBody.java:113:30: compiler.warn.ineffectual.extern.method.enum: writeExternal
+17 warnings

--- a/test/langtools/tools/javac/warnings/Serial/EnumExternClassBody.java
+++ b/test/langtools/tools/javac/warnings/Serial/EnumExternClassBody.java
@@ -1,0 +1,115 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8312415
+ * @compile/ref=ClassBody.out -XDrawDiagnostics -Xlint:serial EnumExternClassBody.java
+ * @compile/ref=empty.out     -XDrawDiagnostics               EnumExternClassBody.java
+ */
+
+import java.io.*;
+
+/*
+ * Verify warnings are generated as appropriate for enum constants
+ * with specialized class bodies.
+ */
+class EnumExternClassBody {
+
+    /*
+     * Define externalization methods both in the enum class and a
+     * specialized enum constant.
+     */
+    private static enum ColorExtern1 implements Externalizable {
+        RED(  0xFF_00_00),
+        GREEN(0x00_FF_00),
+        BLUE( 0x00_00_FF) {
+           @Override
+            public void readExternal(ObjectInput in) {
+                throw new RuntimeException();
+            }
+
+           @Override
+            public void writeExternal(ObjectOutput out) throws IOException {
+                throw new RuntimeException();
+            }
+
+           // Look for serialization members too
+           private static final long serialVersionUID = 42;
+           private static final ObjectStreamField[] serialPersistentFields = {};
+
+           private void writeObject(ObjectOutputStream stream) throws IOException {
+                throw new RuntimeException();
+           }
+
+           private Object writeReplace() throws ObjectStreamException {
+               return null;
+           }
+
+           private void readObject(ObjectInputStream stream)
+               throws IOException, ClassNotFoundException {
+                throw new RuntimeException();
+           }
+
+           private void readObjectNoData() throws ObjectStreamException {
+               return;
+           }
+
+           private Object readResolve() throws ObjectStreamException {
+               return null;
+           }
+        };
+
+        int rgb;
+        private ColorExtern1(int rgb) {
+            this.rgb = rgb;
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) {
+            throw new RuntimeException();
+        }
+    
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            throw new RuntimeException();
+        }
+    }
+
+    /*
+     * Define externalization methods only on specialized enum
+     * constants.
+     */
+    private static enum ColorExtern2 implements Externalizable {
+        CYAN {
+           @Override
+            public void readExternal(ObjectInput in) {
+                throw new RuntimeException();
+            }
+
+           @Override
+            public void writeExternal(ObjectOutput out) throws IOException {
+                throw new RuntimeException();
+            }
+        };
+    }
+
+    /*
+     * Define externalization methods only on specialized enum
+     * constants.
+     */
+    private static enum ColorExtern3 implements Externalizable {
+        MAGENTA {
+           @Override
+            public void readExternal(ObjectInput in) {
+                throw new RuntimeException();
+            }
+
+           @Override
+            public void writeExternal(ObjectOutput out) throws IOException {
+                throw new RuntimeException();
+            }
+        };
+
+        // Acceptable to have ineffectual warnings for these abstract methods
+        public abstract void readExternal(ObjectInput in);
+        public abstract void writeExternal(ObjectOutput out) throws IOException ;
+    }
+}

--- a/test/langtools/tools/javac/warnings/Serial/EnumExternClassBody.java
+++ b/test/langtools/tools/javac/warnings/Serial/EnumExternClassBody.java
@@ -66,7 +66,7 @@ class EnumExternClassBody {
         public void readExternal(ObjectInput in) {
             throw new RuntimeException();
         }
-    
+
         @Override
         public void writeExternal(ObjectOutput out) throws IOException {
             throw new RuntimeException();


### PR DESCRIPTION
Thanks to @lahodaj for providing the code to bridge into the class used for a enum constant with a specialized body.

This changes expands serialization warnings to the contents of any such class bodies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312415](https://bugs.openjdk.org/browse/JDK-8312415): Expand -Xlint:serial checks to enum constants with specialized class bodies (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [d61f9114](https://git.openjdk.org/jdk/pull/15004/files/d61f9114ab7df59c32fa0e8e6e53007c6d746139)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [d61f9114](https://git.openjdk.org/jdk/pull/15004/files/d61f9114ab7df59c32fa0e8e6e53007c6d746139)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15004/head:pull/15004` \
`$ git checkout pull/15004`

Update a local copy of the PR: \
`$ git checkout pull/15004` \
`$ git pull https://git.openjdk.org/jdk.git pull/15004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15004`

View PR using the GUI difftool: \
`$ git pr show -t 15004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15004.diff">https://git.openjdk.org/jdk/pull/15004.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15004#issuecomment-1648499942)