### PR TITLE
8312623: SA add NestHost and NestMembers attributes when dumping class

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -234,6 +234,7 @@
   nonstatic_field(InstanceKlass,               _constants,                                    ConstantPool*)                         \
   nonstatic_field(InstanceKlass,               _source_debug_extension,                       const char*)                           \
   nonstatic_field(InstanceKlass,               _inner_classes,                                Array<jushort>*)                       \
+  nonstatic_field(InstanceKlass,               _nest_members,                                 Array<jushort>*)                       \
   nonstatic_field(InstanceKlass,               _nonstatic_field_size,                         int)                                   \
   nonstatic_field(InstanceKlass,               _static_field_size,                            int)                                   \
   nonstatic_field(InstanceKlass,               _static_oop_field_count,                       u2)                                    \
@@ -241,6 +242,7 @@
   volatile_nonstatic_field(InstanceKlass,      _init_state,                                   InstanceKlass::ClassState)             \
   volatile_nonstatic_field(InstanceKlass,      _init_thread,                                  JavaThread*)                           \
   nonstatic_field(InstanceKlass,               _itable_len,                                   int)                                   \
+  nonstatic_field(InstanceKlass,               _nest_host_index,                              u2)                                    \
   nonstatic_field(InstanceKlass,               _reference_type,                               u1)                                    \
   volatile_nonstatic_field(InstanceKlass,      _oop_map_cache,                                OopMapCache*)                          \
   nonstatic_field(InstanceKlass,               _jni_ids,                                      JNIid*)                                \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -77,12 +77,14 @@ public class InstanceKlass extends Klass {
     constants            = new MetadataField(type.getAddressField("_constants"), 0);
     sourceDebugExtension = type.getAddressField("_source_debug_extension");
     innerClasses         = type.getAddressField("_inner_classes");
+    nestMembers          = type.getAddressField("_nest_members");
     nonstaticFieldSize   = new CIntField(type.getCIntegerField("_nonstatic_field_size"), 0);
     staticFieldSize      = new CIntField(type.getCIntegerField("_static_field_size"), 0);
     staticOopFieldCount  = new CIntField(type.getCIntegerField("_static_oop_field_count"), 0);
     nonstaticOopMapSize  = new CIntField(type.getCIntegerField("_nonstatic_oop_map_size"), 0);
     initState            = new CIntField(type.getCIntegerField("_init_state"), 0);
     itableLen            = new CIntField(type.getCIntegerField("_itable_len"), 0);
+    nestHostIndex        = new CIntField(type.getCIntegerField("_nest_host_index"), 0);
     if (VM.getVM().isJvmtiSupported()) {
       breakpoints        = type.getAddressField("_breakpoints");
     }
@@ -142,12 +144,14 @@ public class InstanceKlass extends Klass {
   private static MetadataField constants;
   private static AddressField  sourceDebugExtension;
   private static AddressField  innerClasses;
+  private static AddressField  nestMembers;
   private static CIntField nonstaticFieldSize;
   private static CIntField staticFieldSize;
   private static CIntField staticOopFieldCount;
   private static CIntField nonstaticOopMapSize;
   private static CIntField initState;
   private static CIntField itableLen;
+  private static CIntField nestHostIndex;
   private static AddressField breakpoints;
 
   // type safe enum for ClassState from instanceKlass.hpp
@@ -374,6 +378,7 @@ public class InstanceKlass extends Klass {
   public long      getStaticOopFieldCount() { return                staticOopFieldCount.getValue(this); }
   public long      getNonstaticOopMapSize() { return                nonstaticOopMapSize.getValue(this); }
   public long      getItableLen()           { return                itableLen.getValue(this); }
+  public short     getNestHostIndex()       { return                (short) nestHostIndex.getValue(this); }
   public long      majorVersion()           { return                getConstants().majorVersion(); }
   public long      minorVersion()           { return                getConstants().minorVersion(); }
   public Symbol    getGenericSignature()    { return                getConstants().getGenericSignature(); }
@@ -898,6 +903,11 @@ public class InstanceKlass extends Klass {
     } else {
       return null;
     }
+  }
+
+  public U2Array getNestMembers() {
+    Address addr = getAddress().getAddressAt(nestMembers.getOffset());
+    return VMObjectFactory.newObject(U2Array.class, addr);
   }
 
   //----------------------------------------------------------------------

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
@@ -52,6 +52,8 @@ public class ClassWriter implements /* imports */ ClassConstants
 
     protected short  _sourceFileIndex;
     protected short  _innerClassesIndex;
+    protected short  _nestHostIndex;
+    protected short  _nestMembersIndex;
     protected short  _syntheticIndex;
     protected short  _deprecatedIndex;
     protected short  _constantValueIndex;
@@ -142,6 +144,14 @@ public class ClassWriter implements /* imports */ ClassConstants
         Short innerClassesIndex = utf8ToIndex.get("InnerClasses");
         _innerClassesIndex = (innerClassesIndex != null)? innerClassesIndex.shortValue() : 0;
         if (DEBUG) debugMessage("InnerClasses index = " + _innerClassesIndex);
+
+        Short nestHostIndex = utf8ToIndex.get("NestHost");
+        _nestHostIndex = (nestHostIndex != null)? nestHostIndex.shortValue() : 0;
+        if (DEBUG) debugMessage("NestHost index = " + _nestHostIndex);
+
+        Short nestMembersIndex = utf8ToIndex.get("NestMembers");
+        _nestMembersIndex = (nestMembersIndex != null)? nestMembersIndex.shortValue() : 0;
+        if (DEBUG) debugMessage("NestMembers index = " + _nestMembersIndex);
 
         Short bootstrapMethodsIndex = utf8ToIndex.get("BootstrapMethods");
         _bootstrapMethodsIndex = (bootstrapMethodsIndex != null) ? bootstrapMethodsIndex.shortValue() : 0;
@@ -780,6 +790,17 @@ public class ClassWriter implements /* imports */ ClassConstants
         if (numInnerClasses != 0)
             classAttributeCount++;
 
+        short nestHost = klass.getNestHostIndex();
+        if (nestHost != 0) {
+            classAttributeCount++;
+        }
+
+        U2Array nestMembers = klass.getNestMembers();
+        final int numNestMembers = nestMembers.length();
+        if (numNestMembers != 0) {
+            classAttributeCount++;
+        }
+
         int bsmCount = klass.getConstants().getBootstrapMethodsCount();
         if (bsmCount != 0) {
             classAttributeCount++;
@@ -833,6 +854,23 @@ public class ClassWriter implements /* imports */ ClassConstants
             for (int index = 0; index < numInnerClasses * 4; index++) {
                 dos.writeShort(innerClasses.at(index));
             }
+        }
+
+        if (nestHost != 0) {
+            writeIndex(_nestHostIndex);
+            final int nestHostAttrLen = 2;
+            dos.writeInt(nestHostAttrLen);
+            dos.writeShort(nestHost);
+        }
+
+        if (numNestMembers != 0) {
+           writeIndex(_nestMembersIndex);
+           final int nestMembersAttrLen = 2 + numNestMembers * 2;
+           dos.writeInt(nestMembersAttrLen);
+           dos.writeShort(numNestMembers);
+           for (int index = 0; index < numNestMembers; index++) {
+               dos.writeShort(nestMembers.at(index));
+           }
         }
 
         // write bootstrap method attribute, if any


### PR DESCRIPTION
This patch adds NestHost and NestMembers attributes to the class dumped by SA.

Testing: `test/hotspot/jtreg/serviceability/sa` and `test/jdk/sun/tools/jhsdb`
Manual testing by dumping `j.l.String` and `j.l.String$CaseInsensitiveComparator` classes.
`j.l.String` shows one entry in `NestMembers` attribute for `j.l.String$CaseInsensitiveComparator` and `j.l.String$CaseInsensitiveComparator` has `j.l.String` as its `NestHost`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312623](https://bugs.openjdk.org/browse/JDK-8312623): SA add NestHost and NestMembers attributes when dumping class (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15005/head:pull/15005` \
`$ git checkout pull/15005`

Update a local copy of the PR: \
`$ git checkout pull/15005` \
`$ git pull https://git.openjdk.org/jdk.git pull/15005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15005`

View PR using the GUI difftool: \
`$ git pr show -t 15005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15005.diff">https://git.openjdk.org/jdk/pull/15005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15005#issuecomment-1648700471)