### PR TITLE
8312630: java/security should not create unmodifiable collections with redundant wrapping

### DIFF
--- a/src/java.base/share/classes/java/security/DomainLoadStoreParameter.java
+++ b/src/java.base/share/classes/java/security/DomainLoadStoreParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,8 +134,7 @@ public final class DomainLoadStoreParameter implements LoadStoreParameter {
             throw new NullPointerException("invalid null input");
         }
         this.configuration = configuration;
-        this.protectionParams =
-            Collections.unmodifiableMap(new HashMap<>(protectionParams));
+        this.protectionParams = Collections.unmodifiableMap(protectionParams);
     }
 
     /**

--- a/src/java.base/share/classes/java/security/DomainLoadStoreParameter.java
+++ b/src/java.base/share/classes/java/security/DomainLoadStoreParameter.java
@@ -134,7 +134,7 @@ public final class DomainLoadStoreParameter implements LoadStoreParameter {
             throw new NullPointerException("invalid null input");
         }
         this.configuration = configuration;
-        this.protectionParams = Collections.unmodifiableMap(protectionParams);
+        this.protectionParams = Map.copyOf(protectionParams);
     }
 
     /**

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -566,8 +566,7 @@ public class KeyStore {
                 this.chain = clonedChain;
             }
 
-            this.attributes =
-                Collections.unmodifiableSet(new HashSet<>(attributes));
+            this.attributes = Collections.unmodifiableSet(attributes);
         }
 
         /**
@@ -685,8 +684,7 @@ public class KeyStore {
                 throw new NullPointerException("invalid null input");
             }
             this.sKey = secretKey;
-            this.attributes =
-                Collections.unmodifiableSet(new HashSet<>(attributes));
+            this.attributes = Collections.unmodifiableSet(attributes);
         }
 
         /**
@@ -768,8 +766,7 @@ public class KeyStore {
                 throw new NullPointerException("invalid null input");
             }
             this.cert = trustedCert;
-            this.attributes =
-                Collections.unmodifiableSet(new HashSet<>(attributes));
+            this.attributes = Collections.unmodifiableSet(attributes);
         }
 
         /**

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -566,7 +566,7 @@ public class KeyStore {
                 this.chain = clonedChain;
             }
 
-            this.attributes = Collections.unmodifiableSet(attributes);
+            this.attributes = Set.copyOf(attributes);
         }
 
         /**
@@ -684,7 +684,7 @@ public class KeyStore {
                 throw new NullPointerException("invalid null input");
             }
             this.sKey = secretKey;
-            this.attributes = Collections.unmodifiableSet(attributes);
+            this.attributes = Set.copyOf(attributes);
         }
 
         /**
@@ -766,7 +766,7 @@ public class KeyStore {
                 throw new NullPointerException("invalid null input");
             }
             this.cert = trustedCert;
-            this.attributes = Collections.unmodifiableSet(attributes);
+            this.attributes = Set.copyOf(attributes);
         }
 
         /**

--- a/src/java.base/share/classes/java/security/cert/PKIXParameters.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,8 +206,7 @@ public class PKIXParameters implements CertPathParameters {
                     + "of type java.security.cert.TrustAnchor");
             }
         }
-        this.unmodTrustAnchors = Collections.unmodifiableSet
-                (new HashSet<>(trustAnchors));
+        this.unmodTrustAnchors = Collections.unmodifiableSet(trustAnchors);
     }
 
     /**
@@ -255,7 +254,7 @@ public class PKIXParameters implements CertPathParameters {
                         + "of type java.lang.String");
             }
             this.unmodInitialPolicies =
-                Collections.unmodifiableSet(new HashSet<>(initialPolicies));
+                Collections.unmodifiableSet(initialPolicies);
         } else
             this.unmodInitialPolicies = Collections.<String>emptySet();
     }
@@ -314,8 +313,7 @@ public class PKIXParameters implements CertPathParameters {
      * @see #setCertStores
      */
     public List<CertStore> getCertStores() {
-        return Collections.unmodifiableList
-                (new ArrayList<>(this.certStores));
+        return Collections.unmodifiableList(this.certStores);
     }
 
     /**

--- a/src/java.base/share/classes/java/security/cert/PKIXParameters.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXParameters.java
@@ -206,7 +206,7 @@ public class PKIXParameters implements CertPathParameters {
                     + "of type java.security.cert.TrustAnchor");
             }
         }
-        this.unmodTrustAnchors = Collections.unmodifiableSet(trustAnchors);
+        this.unmodTrustAnchors = Set.copyOf(trustAnchors);
     }
 
     /**
@@ -253,8 +253,7 @@ public class PKIXParameters implements CertPathParameters {
                     throw new ClassCastException("all elements of set must be "
                         + "of type java.lang.String");
             }
-            this.unmodInitialPolicies =
-                Collections.unmodifiableSet(initialPolicies);
+            this.unmodInitialPolicies = Set.copyOf(initialPolicies);
         } else
             this.unmodInitialPolicies = Collections.<String>emptySet();
     }
@@ -313,7 +312,7 @@ public class PKIXParameters implements CertPathParameters {
      * @see #setCertStores
      */
     public List<CertStore> getCertStores() {
-        return Collections.unmodifiableList(this.certStores);
+        return List.copyOf(this.certStores);
     }
 
     /**

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -600,8 +600,7 @@ public class X509CertSelector implements CertSelector {
             this.keyPurposeSet = null;
             keyPurposeOIDSet = null;
         } else {
-            this.keyPurposeSet =
-                Collections.unmodifiableSet(keyPurposeSet);
+            this.keyPurposeSet = Set.copyOf(keyPurposeSet);
             keyPurposeOIDSet = new HashSet<>();
             for (String s : this.keyPurposeSet) {
                 keyPurposeOIDSet.add(ObjectIdentifier.of(s));
@@ -1045,7 +1044,7 @@ public class X509CertSelector implements CertSelector {
             policy = null;
         } else {
             // Snapshot set and parse it
-            Set<String> tempSet = Collections.unmodifiableSet(certPolicySet);
+            Set<String> tempSet = Set.copyOf(certPolicySet);
             /* Convert to Vector of ObjectIdentifiers */
             Iterator<String> i = tempSet.iterator();
             Vector<CertificatePolicyId> polIdVector = new Vector<>();

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -601,7 +601,7 @@ public class X509CertSelector implements CertSelector {
             keyPurposeOIDSet = null;
         } else {
             this.keyPurposeSet =
-                Collections.unmodifiableSet(new HashSet<>(keyPurposeSet));
+                Collections.unmodifiableSet(keyPurposeSet);
             keyPurposeOIDSet = new HashSet<>();
             for (String s : this.keyPurposeSet) {
                 keyPurposeOIDSet.add(ObjectIdentifier.of(s));
@@ -1045,8 +1045,7 @@ public class X509CertSelector implements CertSelector {
             policy = null;
         } else {
             // Snapshot set and parse it
-            Set<String> tempSet = Collections.unmodifiableSet
-                                        (new HashSet<>(certPolicySet));
+            Set<String> tempSet = Collections.unmodifiableSet(certPolicySet);
             /* Convert to Vector of ObjectIdentifiers */
             Iterator<String> i = tempSet.iterator();
             Vector<CertificatePolicyId> polIdVector = new Vector<>();


### PR DESCRIPTION
Some java/security classes apply the below coding style,
```
Set<T> set = ...;
Set<T> unmodifiableSet = Collections.unmodifiableSet(new HashSet<>(set));
```
It may be unnecessary to wrap that `set` with HashSet before creating `unmodifiableSet`.
Some usages on `Collections.unmodifiableList` and `Collections.unmodifiableMap` have the same issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312630](https://bugs.openjdk.org/browse/JDK-8312630): java/security should not create unmodifiable collections with redundant wrapping (**Bug** - P4)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.org/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to [64f607da](https://git.openjdk.org/jdk/pull/15008/files/64f607daf8f0597b744ff3bfd470652ce41dbed5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15008/head:pull/15008` \
`$ git checkout pull/15008`

Update a local copy of the PR: \
`$ git checkout pull/15008` \
`$ git pull https://git.openjdk.org/jdk.git pull/15008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15008`

View PR using the GUI difftool: \
`$ git pr show -t 15008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15008.diff">https://git.openjdk.org/jdk/pull/15008.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15008#issuecomment-1649205654)