### PR TITLE
JDK-8312625: Test serviceability/dcmd/vm/TrimLibcHeapTest.java failed: RSS use increased

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/TrimLibcHeapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/TrimLibcHeapTest.java
@@ -46,7 +46,7 @@ public class TrimLibcHeapTest {
         if (Platform.isMusl()) {
             output.shouldContain("Not available");
         } else {
-            output.shouldMatch("Trim native heap: RSS\\+Swap: \\d+[BKMG]->\\d+[BKMG] \\(-\\d+[BKMG]\\)");
+            output.shouldMatch("Trim native heap: RSS\\+Swap: \\d+[BKMG]->\\d+[BKMG] \\([+-]\\d+[BKMG]\\)");
         }
     }
 


### PR DESCRIPTION
Trivial patch.

The test just fires `jcmd System.trim_native_heap`, but without preparing any special memory allocation conditions. Typically, we end up firing the command when VM initialization is done, and therefore end up trimming a lot of memory. But once in a blue moon concurrent allocations may be ongoing, so we may not trim anything, or even see increased RSS.

The patch just loosens the success condition to succeed if the trim happened, irregardless of how much memory had been trimmed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312625](https://bugs.openjdk.org/browse/JDK-8312625): Test serviceability/dcmd/vm/TrimLibcHeapTest.java failed: RSS use increased (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15009/head:pull/15009` \
`$ git checkout pull/15009`

Update a local copy of the PR: \
`$ git checkout pull/15009` \
`$ git pull https://git.openjdk.org/jdk.git pull/15009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15009`

View PR using the GUI difftool: \
`$ git pr show -t 15009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15009.diff">https://git.openjdk.org/jdk/pull/15009.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15009#issuecomment-1649745020)