### PR TITLE
8312818: Incorrect format specifier in a HttpClient log message

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1525,7 +1525,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
             interestOps |= newOps;
             pending.add(e);
             if (debug.on())
-                debug.log("Registering %s for %d (%s)",
+                debug.log("Registering %s for %s (%s)",
                         e, Utils.describeOps(newOps), reRegister);
             if (reRegister) {
                 // first time registration happens here also


### PR DESCRIPTION
Can I please get a review of this trivial fix to a log message in HttpClient? This addresses https://bugs.openjdk.org/browse/JDK-8312818.

After this change, the log message should correctly print messages like:

```console
SelectorAttachment Registering jdk.internal.net.http.PlainHttpConnection$ConnectEvent@7513443c for C (true)
```

