### PR TITLE
JDK-8312612: handle WideCharToMultiByte return values

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -1790,10 +1790,16 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
     DWORD dwBytes = sizeof(szFileName);
     // try Typeface-specific EUDC font
     char szTmpName[80];
-    VERIFY(::WideCharToMultiByte(CP_ACP, 0, szFamilyName, -1,
-        szTmpName, sizeof(szTmpName), NULL, NULL));
-    LONG lStatus = ::RegQueryValueExA(hKey, (LPCSTR) szTmpName,
-        NULL, &dwType, szFileName, &dwBytes);
+    int nb = ::WideCharToMultiByte(CP_ACP, 0, szFamilyName, -1,
+        szTmpName, sizeof(szTmpName), NULL, NULL);
+    VERIFY(nb);
+
+    LONG lStatus = 1;
+    if (nb > 0) {
+        lStatus = ::RegQueryValueExA(hKey, (LPCSTR) szTmpName,
+                                     NULL, &dwType, szFileName, &dwBytes);
+    }
+
     BOOL fUseDefault = FALSE;
     if (lStatus != ERROR_SUCCESS){ // try System default EUDC font
         if (m_fTTEUDCFileExist == FALSE)

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3925,9 +3925,13 @@ static void throwPrinterException(JNIEnv *env, DWORD err) {
                   sizeof(t_errStr),
                   NULL );
 
-    WideCharToMultiByte(CP_UTF8, 0, t_errStr, -1,
+    int nb = WideCharToMultiByte(CP_UTF8, 0, t_errStr, -1,
                         errStr, sizeof(errStr), NULL, NULL);
-    JNU_ThrowByName(env, PRINTEREXCEPTION_STR, errStr);
+    if (nb > 0) {
+        JNU_ThrowByName(env, PRINTEREXCEPTION_STR, errStr);
+    } else {
+        JNU_ThrowByName(env, PRINTEREXCEPTION_STR, "Secondary error while OS message extraction");
+    }
 }
 
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -3930,7 +3930,7 @@ static void throwPrinterException(JNIEnv *env, DWORD err) {
     if (nb > 0) {
         JNU_ThrowByName(env, PRINTEREXCEPTION_STR, errStr);
     } else {
-        JNU_ThrowByName(env, PRINTEREXCEPTION_STR, "Secondary error while OS message extraction");
+        JNU_ThrowByName(env, PRINTEREXCEPTION_STR, "secondary error during OS message extraction");
     }
 }
 

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Charset_Util.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Charset_Util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,16 +35,26 @@ LPSTR UnicodeToUTF8(const LPCWSTR lpUnicodeStr)
 {
     DWORD dwUTF8Len = WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, nullptr, 0, nullptr, nullptr);
     LPSTR lpUTF8Str = new CHAR[dwUTF8Len];
+    if (lpUTF8Str == NULL) return NULL;
     memset(lpUTF8Str, 0, sizeof(CHAR) * (dwUTF8Len));
-    WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, lpUTF8Str, dwUTF8Len, nullptr, nullptr);
-    return lpUTF8Str;
+    int nb = WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, lpUTF8Str, dwUTF8Len, nullptr, nullptr);
+    if (nb > 0) {
+        return lpUTF8Str;
+    } else {
+        delete[] lpUTF8Str;
+    }
+    return NULL;
 }
 
 void UnicodeToUTF8AndCopy(LPSTR dest, LPCWSTR src, SIZE_T maxLength) {
     LPSTR utf8EncodedName = UnicodeToUTF8(src);
-    strncpy(dest, utf8EncodedName, maxLength - 1);
-    delete[] utf8EncodedName;
-    dest[maxLength - 1] = '\0';
+    if (utf8EncodedName != NULL) {
+        strncpy(dest, utf8EncodedName, maxLength - 1);
+        delete[] utf8EncodedName;
+        dest[maxLength - 1] = '\0';
+    } else {
+        if (maxLength > 0) dest[0] = '\0';
+    }
 }
 
 #ifdef __cplusplus

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Charset_Util.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Charset_Util.cpp
@@ -40,9 +40,8 @@ LPSTR UnicodeToUTF8(const LPCWSTR lpUnicodeStr)
     int nb = WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, lpUTF8Str, dwUTF8Len, nullptr, nullptr);
     if (nb > 0) {
         return lpUTF8Str;
-    } else {
-        delete[] lpUTF8Str;
     }
+    delete[] lpUTF8Str;
     return NULL;
 }
 


### PR DESCRIPTION
The function WideCharToMultiByte is used at a number of places of the JDK codebase for conversion purposes.
Unfortunately, the function might fail because of various reasons, so the return value must be checked to avoid undefined behavior or even crashes.
see
https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
especially
https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte#return-value

At most places in the coding the return values are already checked, but some are missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312612](https://bugs.openjdk.org/browse/JDK-8312612): handle WideCharToMultiByte return values (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15015/head:pull/15015` \
`$ git checkout pull/15015`

Update a local copy of the PR: \
`$ git checkout pull/15015` \
`$ git pull https://git.openjdk.org/jdk.git pull/15015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15015`

View PR using the GUI difftool: \
`$ git pr show -t 15015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15015.diff">https://git.openjdk.org/jdk/pull/15015.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15015#issuecomment-1649646152)