### PR TITLE
8312916: Remove remaining usages of -Xdebug from test/hotspot/jtreg

### DIFF
--- a/test/hotspot/jtreg/serviceability/attach/ShMemLongName.java
+++ b/test/hotspot/jtreg/serviceability/attach/ShMemLongName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,6 @@ public class ShMemLongName {
     private static ProcessBuilder getTarget(String shmemName) throws IOException {
         log("starting target with shmem name: '" + shmemName + "'...");
         return ProcessTools.createJavaProcessBuilder(
-                "-Xdebug",
                 "-Xrunjdwp:transport=" + transport + ",server=y,suspend=n,address=" + shmemName,
                 "ShMemLongName$Target");
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach004/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach004/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,6 @@ public class TestDriver {
         Collections.addAll(cmd, Utils.prependTestJavaOpts(
                 "-cp",
                 Utils.TEST_CLASS_PATH,
-                "-Xdebug",
                 "-agentlib:jdwp=transport=" + transport + ",server=y,suspend=" + suspend,
                 "-Dmy.little.cookie=" + ProcessHandle.current().pid(),
                 debuggeeClass.getName()));

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
@@ -328,8 +328,6 @@ public class DebugeeBinder extends Log.Logger implements Finalizable {
         args.add(classPath);
  */
 
-        args.add("-Xdebug");
-
         String server;
         if (argumentHandler.isAttachingConnector()) {
             server = "y";


### PR DESCRIPTION
Can I please get a review of this test-only change which removes usages of the deprecated (no-op) `-Xdebug` from these tests? I missed these files when addressing https://bugs.openjdk.org/browse/JDK-8227229.

tier testing with these changes has passed without issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312916](https://bugs.openjdk.org/browse/JDK-8312916): Remove remaining usages of -Xdebug from test/hotspot/jtreg (**Task** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15016/head:pull/15016` \
`$ git checkout pull/15016`

Update a local copy of the PR: \
`$ git checkout pull/15016` \
`$ git pull https://git.openjdk.org/jdk.git pull/15016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15016`

View PR using the GUI difftool: \
`$ git pr show -t 15016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15016.diff">https://git.openjdk.org/jdk/pull/15016.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15016#issuecomment-1649681714)