### PR TITLE
JDK-8312467: relax the builddir check in make/autoconf/basic.m4

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -407,27 +407,29 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
     # have a configuration in this directory. Do some sanity checks!
 
     if test ! -e "$OUTPUTDIR/spec.gmk"; then
-      # If we have a spec.gmk, we have run here before and we are OK. Otherwise, check for
-      # other files
-      files_present=`$LS $OUTPUTDIR`
-      # Configure has already touched config.log and confdefs.h in the current dir when this check
-      # is performed.
-      filtered_files=`$ECHO "$files_present" \
-          | $SED -e 's/config.log//g' \
-              -e 's/configure.log//g' \
-              -e 's/confdefs.h//g' \
-              -e 's/configure-support//g' \
-              -e 's/ //g' \
-          | $TR -d '\n'`
-      if test "x$filtered_files" != x; then
-        AC_MSG_NOTICE([Current directory is $CONFIGURE_START_DIR.])
-        AC_MSG_NOTICE([Since this is not the source root, configure will output the configuration here])
-        AC_MSG_NOTICE([(as opposed to creating a configuration in <src_root>/build/<conf-name>).])
-        AC_MSG_NOTICE([However, this directory is not empty. This is not allowed, since it could])
-        AC_MSG_NOTICE([seriously mess up just about everything.])
-        AC_MSG_NOTICE([Try 'cd $TOPDIR' and restart configure])
-        AC_MSG_NOTICE([(or create a new empty directory and cd to it).])
-        AC_MSG_ERROR([Will not continue creating configuration in $CONFIGURE_START_DIR])
+      if test ! -e "$OUTPUTDIR/configure-support/generated-configure.sh"; then
+        # If we have a spec.gmk or configure-support/generated-configure.sh,
+        # we have run here before and we are OK. Otherwise, check for other files
+        files_present=`$LS $OUTPUTDIR`
+        # Configure has already touched config.log and confdefs.h in the current dir when this check
+        # is performed.
+        filtered_files=`$ECHO "$files_present" \
+            | $SED -e 's/config.log//g' \
+                -e 's/configure.log//g' \
+                -e 's/confdefs.h//g' \
+                -e 's/configure-support//g' \
+                -e 's/ //g' \
+            | $TR -d '\n'`
+        if test "x$filtered_files" != x; then
+          AC_MSG_NOTICE([Current directory is $CONFIGURE_START_DIR.])
+          AC_MSG_NOTICE([Since this is not the source root, configure will output the configuration here])
+          AC_MSG_NOTICE([(as opposed to creating a configuration in <src_root>/build/<conf-name>).])
+          AC_MSG_NOTICE([However, this directory is not empty. This is not allowed, since it could])
+          AC_MSG_NOTICE([seriously mess up just about everything.])
+          AC_MSG_NOTICE([Try 'cd $TOPDIR' and restart configure])
+          AC_MSG_NOTICE([(or create a new empty directory and cd to it).])
+          AC_MSG_ERROR([Will not continue creating configuration in $CONFIGURE_START_DIR])
+        fi
       fi
     fi
   fi

--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -406,30 +406,29 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
     # WARNING: This might be a bad thing to do. You need to be sure you want to
     # have a configuration in this directory. Do some sanity checks!
 
-    if test ! -e "$OUTPUTDIR/spec.gmk"; then
-      if test ! -e "$OUTPUTDIR/configure-support/generated-configure.sh"; then
-        # If we have a spec.gmk or configure-support/generated-configure.sh,
-        # we have run here before and we are OK. Otherwise, check for other files
-        files_present=`$LS $OUTPUTDIR`
-        # Configure has already touched config.log and confdefs.h in the current dir when this check
-        # is performed.
-        filtered_files=`$ECHO "$files_present" \
-            | $SED -e 's/config.log//g' \
-                -e 's/configure.log//g' \
-                -e 's/confdefs.h//g' \
-                -e 's/configure-support//g' \
-                -e 's/ //g' \
-            | $TR -d '\n'`
-        if test "x$filtered_files" != x; then
-          AC_MSG_NOTICE([Current directory is $CONFIGURE_START_DIR.])
-          AC_MSG_NOTICE([Since this is not the source root, configure will output the configuration here])
-          AC_MSG_NOTICE([(as opposed to creating a configuration in <src_root>/build/<conf-name>).])
-          AC_MSG_NOTICE([However, this directory is not empty. This is not allowed, since it could])
-          AC_MSG_NOTICE([seriously mess up just about everything.])
-          AC_MSG_NOTICE([Try 'cd $TOPDIR' and restart configure])
-          AC_MSG_NOTICE([(or create a new empty directory and cd to it).])
-          AC_MSG_ERROR([Will not continue creating configuration in $CONFIGURE_START_DIR])
-        fi
+    if test ! -e "$OUTPUTDIR/spec.gmk" && test ! -e "$OUTPUTDIR/configure-support/generated-configure.sh"; then
+      # If we have a spec.gmk or configure-support/generated-configure.sh,
+      # we have run here before and we are OK. Otherwise, check for other files
+      files_present=`$LS $OUTPUTDIR`
+      # Configure has already touched config.log and confdefs.h in the current dir when this check
+      # is performed.
+      filtered_files=`$ECHO "$files_present" \
+          | $SED -e 's/config.log//g' \
+              -e 's/configure.log//g' \
+              -e 's/confdefs.h//g' \
+              -e 's/configure-support//g' \
+              -e 's/ //g' \
+          | $TR -d '\n'`
+      if test "x$filtered_files" != x; then
+        AC_MSG_NOTICE([Current directory is $CONFIGURE_START_DIR.])
+        AC_MSG_NOTICE([Since this is not the source root, configure will output the configuration here])
+        AC_MSG_NOTICE([(as opposed to creating a configuration in <src_root>/build/<conf-name>).])
+        AC_MSG_NOTICE([However, this directory is not empty, additionally to some allowed files])
+        AC_MSG_NOTICE([it contains $filtered_files.])
+        AC_MSG_NOTICE([This is not allowed, since it could seriously mess up just about everything.])
+        AC_MSG_NOTICE([Try 'cd $TOPDIR' and restart configure])
+        AC_MSG_NOTICE([(or create a new empty directory and cd to it).])
+        AC_MSG_ERROR([Will not continue creating configuration in $CONFIGURE_START_DIR])
       fi
     fi
   fi


### PR DESCRIPTION
In case of issues in the configure step, we run into error messages like this :

configure: Current directory is /openjdk/jdk_4/build_mymachine.
configure: Since this is not the source root, configure will output the configuration here
configure: (as opposed to creating a configuration in <src_root>/build/<conf-name>).
configure: However, this directory is not empty. This is not allowed, since it could
configure: seriously mess up just about everything.
configure: Try 'cd /mysrcdir/jdk' and restart configure
configure: (or create a new empty directory and cd to it).
configure: error: Will not continue creating configuration in /openjdk/jdk_4/build_mymachine
configure exiting with result code 1

Probably the check could be relaxed; it tests for 'if test ! -e "$OUTPUTDIR/spec.gmk"; then ...'
but the non-existance of spec.gmk does not mean we are not in a build directory.
We could additionally check for e.g. $OUTPUTDIR/configure-support/config.log or something related to check if it is a build directory .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312467](https://bugs.openjdk.org/browse/JDK-8312467): relax the builddir check in make/autoconf/basic.m4 (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15017/head:pull/15017` \
`$ git checkout pull/15017`

Update a local copy of the PR: \
`$ git checkout pull/15017` \
`$ git pull https://git.openjdk.org/jdk.git pull/15017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15017`

View PR using the GUI difftool: \
`$ git pr show -t 15017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15017.diff">https://git.openjdk.org/jdk/pull/15017.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15017#issuecomment-1649713965)