### PR TITLE
JDK-8312445: Array types in annotation elements show square brackets twice

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -52,6 +52,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleAnnotationValueVisitor9;
@@ -90,6 +91,7 @@ import jdk.javadoc.internal.doclets.formats.html.markup.RawHtml;
 import jdk.javadoc.internal.doclets.formats.html.markup.Script;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.Text;
+import jdk.javadoc.internal.doclets.formats.html.markup.TextBuilder;
 import jdk.javadoc.internal.doclets.formats.html.taglets.Taglet;
 import jdk.javadoc.internal.doclets.formats.html.taglets.TagletWriter;
 import jdk.javadoc.internal.doclets.toolkit.Messages;
@@ -1874,17 +1876,18 @@ public class HtmlDocletWriter {
                     public Content visitDeclared(DeclaredType t, Void p) {
                         HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
                                 HtmlLinkInfo.Kind.PLAIN, t);
-                        String name = utils.isIncluded(t.asElement())
-                                ? t.asElement().getSimpleName().toString()
-                                : utils.getFullyQualifiedName(t.asElement());
-                        linkInfo.label(name + utils.getDimension(t) + ".class");
                         return getLink(linkInfo);
                     }
                     @Override
-                    protected Content defaultAction(TypeMirror e, Void p) {
-                        return Text.of(t + utils.getDimension(t) + ".class");
+                    public Content visitArray(ArrayType t, Void p) {
+                        // render declared base component type as link
+                        return visit(t.getComponentType()).add("[]");
                     }
-                }.visit(t);
+                    @Override
+                    protected Content defaultAction(TypeMirror t, Void p) {
+                        return new TextBuilder(t.toString());
+                    }
+                }.visit(t).add(".class");
             }
 
             @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1870,7 +1870,7 @@ public class HtmlDocletWriter {
         return new SimpleAnnotationValueVisitor9<Content, Void>() {
 
             @Override
-            public Content visitType(TypeMirror t, Void p) {
+            public Content visitType(TypeMirror type, Void p) {
                 return new SimpleTypeVisitor9<Content, Void>() {
                     @Override
                     public Content visitDeclared(DeclaredType t, Void p) {
@@ -1887,7 +1887,7 @@ public class HtmlDocletWriter {
                     protected Content defaultAction(TypeMirror t, Void p) {
                         return new TextBuilder(t.toString());
                     }
-                }.visit(t).add(".class");
+                }.visit(type).add(".class");
             }
 
             @Override

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4789689 4905985 4927164 4827184 4993906 5004549 7025314 7010344 8025633 8026567 8162363
- *           8175200 8186332 8182765 8196202 8187288 8173730 8215307
+ *           8175200 8186332 8182765 8196202 8187288 8173730 8215307 8312445
  * @summary  Run Javadoc on a set of source files that demonstrate new
  *           language features.  Check the output to ensure that the new
  *           language features are properly documented.
@@ -675,11 +675,11 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <a href="A.html#s()">s</a>="sigh",""",
                 // Class
                 """
-                    <a href="A.html#c()">c</a>=<a href="../pkg2/Foo.html" title="class in pkg2">Foo.class</a>,""",
+                    <a href="A.html#c()">c</a>=<a href="../pkg2/Foo.html" title="class in pkg2">Foo</a>.class,""",
                 // Bounded Class
                 """
                     <a href="A.html#w()">w</a>=<a href="../pkg/TypeParameterSubClass.html" title="cl\
-                    ass in pkg">TypeParameterSubClass.class</a>,""",
+                    ass in pkg">TypeParameterSubClass</a>.class,""",
                 // Enum
                 """
                     <a href="A.html#e()">e</a>=<a href="../pkg/Coin.html#Penny">Penny</a>,""",
@@ -694,10 +694,17 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <a href="A.html#sa()">sa</a>={"up","down"},""",
                 // Primitive
                 """
-                    <a href="A.html#primitiveClassTest()">primitiveClassTest</a>=boolean.class,""");
+                    <a href="A.html#primitiveClassTest()">primitiveClassTest</a>=boolean.class,""",
+                // Arrays
+                """
+                    <a href="A.html#arrayClassTest()">arrayClassTest</a>=java.lang.String[][].class,""",
+                """
+                    <a href="A.html#arrayPrimitiveTest()">arrayPrimitiveTest</a>=boolean[].class,""",
+                """
+                    <a href="A.html#classArrayTest()">classArrayTest</a>={<a href="../pkg/TypeParame\
+                    terSubClass.html" title="class in pkg">TypeParameterSubClass</a>[].class,java.la\
+                    ng.String.class,long[][][].class})""");
 
-        // XXX:  Add array test case after this if fixed:
-        //5020899: Incorrect internal representation of class-valued annotation elements
         checkOutput("pkg1/B.html", true,
                 """
                     <div class="type-signature"><span class="annotations"><a href="A.html" title="an\

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -702,8 +702,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <a href="A.html#arrayPrimitiveTest()">arrayPrimitiveTest</a>=boolean[].class,""",
                 """
                     <a href="A.html#classArrayTest()">classArrayTest</a>={<a href="../pkg/TypeParame\
-                    terSubClass.html" title="class in pkg">TypeParameterSubClass</a>[].class,java.la\
-                    ng.String.class,long[][][].class})""");
+                    terSubClass.html" title="class in pkg">TypeParameterSubClass</a>[][].class,java.\
+                    lang.String.class,long[][][].class})""");
 
         checkOutput("pkg1/B.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,13 @@ import java.lang.annotation.*;
     double d();
     boolean b();
     String s();
-    Class c();
+    Class<?> c();
     Class<? extends TypeParameterSuperClass> w();
     Coin[] e();
     AnnotationType a();
     String[] sa();
-    Class primitiveClassTest();
-    Class arrayClassTest();
-    Class arrayPrimitiveTest();
+    Class<?> primitiveClassTest();
+    Class<?> arrayClassTest();
+    Class<?> arrayPrimitiveTest();
+    Class<?>[] classArrayTest();
 }

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/B.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/B.java
@@ -38,6 +38,6 @@ import pkg2.*;
    primitiveClassTest = boolean.class,
    arrayClassTest = String[][].class,
    arrayPrimitiveTest = boolean[].class,
-   classArrayTest = {TypeParameterSubClass[].class, String.class, long[][][].class})
+   classArrayTest = {TypeParameterSubClass[][].class, String.class, long[][][].class})
 public interface B {
 }

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/B.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/B.java
@@ -36,7 +36,8 @@ import pkg2.*;
    a = @AnnotationType(optional="foo",required=1994),
    sa = {"up", "down"},
    primitiveClassTest = boolean.class,
-   arrayClassTest = String[].class,
-   arrayPrimitiveTest = boolean[].class)
+   arrayClassTest = String[][].class,
+   arrayPrimitiveTest = boolean[].class,
+   classArrayTest = {TypeParameterSubClass[].class, String.class, long[][][].class})
 public interface B {
 }

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/B.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/pkg1/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review a change to fix the representation of array types as values of annotation elements in javadoc-generated documentation.

The primary fix is to avoid generating duplicate `[]` brackets for array types, but there are a few secondary improvements:

 - When linking to a type, only use the type name as link label, appending the `.class` as plain text after the link
 - Support linking to the base type of array types, again appending the square brackets and `.class` after the link
 - Leave it to the `LinkFactory` code to decide whether to use the qualified or simple type name for a link (uses `isLinkable` instead of `isIncluded`)

There already was some test code for the use of array types in annotation elements in `TestNewLanguageFeatures.java`, but it was disabled with a comment referring to another issue that has long been resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312445](https://bugs.openjdk.org/browse/JDK-8312445): Array types in annotation elements show square brackets twice (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15019/head:pull/15019` \
`$ git checkout pull/15019`

Update a local copy of the PR: \
`$ git checkout pull/15019` \
`$ git pull https://git.openjdk.org/jdk.git pull/15019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15019`

View PR using the GUI difftool: \
`$ git pr show -t 15019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15019.diff">https://git.openjdk.org/jdk/pull/15019.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15019#issuecomment-1649864406)