### PR TITLE
8312619: Strange error message when switching over long

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -555,6 +555,10 @@ compiler.err.cannot.assign.not.declared.guard=\
 compiler.err.constant.label.not.compatible=\
     constant label of type {0} is not compatible with switch selector type {1}
 
+# 0: type
+compiler.err.selector.type.not.allowed=\
+    selector type {0} is not allowed
+
 compiler.err.flows.through.to.pattern=\
     illegal fall-through to a pattern
 

--- a/test/langtools/tools/javac/diags/examples/SelectorTypeNotAllowed.java
+++ b/test/langtools/tools/javac/diags/examples/SelectorTypeNotAllowed.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.selector.type.not.allowed
+
+public class SelectorTypeNotAllowed {
+    private void noLong(long sel) {
+        switch (sel) {
+            default -> {}
+        }
+    }
+}

--- a/test/langtools/tools/javac/switchextra/SwitchNoExtraTypes.out
+++ b/test/langtools/tools/javac/switchextra/SwitchNoExtraTypes.out
@@ -1,5 +1,5 @@
-SwitchNoExtraTypes.java:12:18: compiler.err.constant.label.not.compatible: boolean, boolean
-SwitchNoExtraTypes.java:18:18: compiler.err.constant.label.not.compatible: int, long
-SwitchNoExtraTypes.java:24:18: compiler.err.constant.label.not.compatible: int, float
-SwitchNoExtraTypes.java:30:18: compiler.err.constant.label.not.compatible: int, double
+SwitchNoExtraTypes.java:11:16: compiler.err.selector.type.not.allowed: boolean
+SwitchNoExtraTypes.java:17:16: compiler.err.selector.type.not.allowed: long
+SwitchNoExtraTypes.java:23:16: compiler.err.selector.type.not.allowed: float
+SwitchNoExtraTypes.java:29:16: compiler.err.selector.type.not.allowed: double
 4 errors


### PR DESCRIPTION
For code like:
```
public class SelectorTypeNotAllowed {
    private void noLong(long sel) {
        switch (sel) {
            case 0L -> {}
            default -> {}
        }
    }
}
```

which is invalid (due to the `long` selector) produces this compile-time error:
```
/tmp/SelectorTypeNotAllowed.java:4: error: constant label of type long is not compatible with switch selector type long
            case 0L -> {}
                 ^
1 error
```

This is a confusing error message. The proposal here is to change the error message to:
```
/tmp/SelectorTypeNotAllowed.java:3: error: selector type long is not allowed
        switch (sel) {
               ^
1 error
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312619](https://bugs.openjdk.org/browse/JDK-8312619): Strange error message when switching over long (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15020/head:pull/15020` \
`$ git checkout pull/15020`

Update a local copy of the PR: \
`$ git checkout pull/15020` \
`$ git pull https://git.openjdk.org/jdk.git pull/15020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15020`

View PR using the GUI difftool: \
`$ git pr show -t 15020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15020.diff">https://git.openjdk.org/jdk/pull/15020.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15020#issuecomment-1649982725)