### PR TITLE
JDK-8312218: Print additional debug information when hitting assert(in_hash)

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4907,7 +4907,15 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
         const Type* t_no_spec = t->remove_speculative();
         if (t_no_spec != t) {
           bool in_hash = igvn.hash_delete(n);
-          assert(in_hash, "node should be in igvn hash table");
+#ifdef ASSERT
+          if (!in_hash) {
+            tty->print_cr("current graph:");
+            n->dump_bfs(MaxNodeLimit, nullptr, "S$");
+            tty->print_cr("erroneous node:");
+            n->dump();
+            assert(false, "node should be in igvn hash table");
+          }
+#endif
           tn->set_type(t_no_spec);
           igvn.hash_insert(n);
           igvn._worklist.push(n); // give it a chance to go away

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4911,6 +4911,7 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
           if (!in_hash) {
             tty->print_cr("current graph:");
             n->dump_bfs(MaxNodeLimit, nullptr, "S$");
+            tty->cr();
             tty->print_cr("erroneous node:");
             n->dump();
             assert(false, "node should be in igvn hash table");


### PR DESCRIPTION
Since it can be hard to reproduce the hitting assert(in_hash), I have added additional debug information that is dumped when hitting the assert. Additional to the previous message, the current graph and the node causing the assertion failure will now be dumped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312218](https://bugs.openjdk.org/browse/JDK-8312218): Print additional debug information when hitting assert(in_hash) (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15022/head:pull/15022` \
`$ git checkout pull/15022`

Update a local copy of the PR: \
`$ git checkout pull/15022` \
`$ git pull https://git.openjdk.org/jdk.git pull/15022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15022`

View PR using the GUI difftool: \
`$ git pr show -t 15022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15022.diff">https://git.openjdk.org/jdk/pull/15022.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15022#issuecomment-1651128816)