### PR TITLE
8312979: Fix assembler_aarch64.hpp after JDK-8311847

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -653,8 +653,9 @@ class Address {
   static bool offset_ok_for_sve_immed(int64_t offset, int shift, int vl /* sve vector length */) {
     if (offset % vl == 0) {
       // Convert address offset into sve imm offset (MUL VL).
-      int32_t sve_offset = (int32_t)(offset / vl);
-      if (((-(1 << (shift - 1))) <= sve_offset) && (sve_offset < (1 << (shift - 1)))) {
+      int64_t sve_offset = offset / vl;
+      int64_t range = 1 << (shift - 1);
+      if ((-range <= sve_offset) && (sve_offset < range)) {
         // sve_offset can be encoded
         return true;
       }

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -653,7 +653,7 @@ class Address {
   static bool offset_ok_for_sve_immed(int64_t offset, int shift, int vl /* sve vector length */) {
     if (offset % vl == 0) {
       // Convert address offset into sve imm offset (MUL VL).
-      int64_t sve_offset = offset / vl;
+      int32_t sve_offset = (int32_t)(offset / vl);
       if (((-(1 << (shift - 1))) <= sve_offset) && (sve_offset < (1 << (shift - 1)))) {
         // sve_offset can be encoded
         return true;

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -654,7 +654,7 @@ class Address {
     if (offset % vl == 0) {
       // Convert address offset into sve imm offset (MUL VL).
       int64_t sve_offset = offset / vl;
-      int64_t range = 1 << (shift - 1);
+      int32_t range = 1 << (shift - 1);
       if ((-range <= sve_offset) && (sve_offset < range)) {
         // sve_offset can be encoded
         return true;


### PR DESCRIPTION
This passes linux-aarch64-debug.  Waiting for GHA to see if it passes windows-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312979](https://bugs.openjdk.org/browse/JDK-8312979): Fix assembler_aarch64.hpp after JDK-8311847 (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15023/head:pull/15023` \
`$ git checkout pull/15023`

Update a local copy of the PR: \
`$ git checkout pull/15023` \
`$ git pull https://git.openjdk.org/jdk.git pull/15023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15023`

View PR using the GUI difftool: \
`$ git pr show -t 15023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15023.diff">https://git.openjdk.org/jdk/pull/15023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15023#issuecomment-1650142550)