### PR TITLE
8312526: Test dk/jfr/event/oldobject/TestHeapDeep.java failed: Could not find ChainNode

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestHeapDeep.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestHeapDeep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,17 +54,20 @@ public class TestHeapDeep {
 
     public static void main(String[] args) throws Exception {
         WhiteBox.setWriteAllObjectSamples(true);
-
-        try (Recording r = new Recording()) {
-            r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
-            r.start();
-            leak = createChain();
-            List<RecordedEvent> events = Events.fromRecording(r);
-            if (OldObjects.countMatchingEvents(events, byte[].class, null, null, -1, "createChain") == 0) {
-                throw new Exception("Could not find ChainNode");
-            }
-            for (RecordedEvent e : events) {
-                OldObjects.validateReferenceChainLimit(e, OldObjects.MAX_CHAIN_LENGTH);
+        while (true) {
+            try (Recording r = new Recording()) {
+                r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
+                r.start();
+                leak = createChain();
+                List<RecordedEvent> events = Events.fromRecording(r);
+                if (OldObjects.countMatchingEvents(events, byte[].class, null, null, -1, "createChain") > 0) {
+                    for (RecordedEvent e : events) {
+                        OldObjects.validateReferenceChainLimit(e, OldObjects.MAX_CHAIN_LENGTH);
+                    }
+                    return;
+                }
+                System.out.println("Could not find old object sample of type byte[]. Retrying.");
+                leak = null;
             }
         }
     }


### PR DESCRIPTION
Could I have a review of a test fix?

The test creates a ChainNode object and adds 100 byte arrays to it. Then a long linked list of ChainNodes are created so the byte arrays are at the end. The test then tries to verify that there are at least one old object sample of type byte[] and that the reference chain back to the GC root is not too long.

Problem is, there is no old object samples of type byte[], only those of type jdk.jfr.event.oldobject.TestHeapDeep$ChainNode. Fix is to loop until we found a sample and then verify the chain. 

Testing: 100 * test/jdk/jdk/jfr/event/oldobject/TestHeapDeap.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312526](https://bugs.openjdk.org/browse/JDK-8312526): Test dk/jfr/event/oldobject/TestHeapDeep.java failed: Could not find ChainNode (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15026/head:pull/15026` \
`$ git checkout pull/15026`

Update a local copy of the PR: \
`$ git checkout pull/15026` \
`$ git pull https://git.openjdk.org/jdk.git pull/15026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15026`

View PR using the GUI difftool: \
`$ git pr show -t 15026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15026.diff">https://git.openjdk.org/jdk/pull/15026.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15026#issuecomment-1650501227)