### PR TITLE
8307312: Replace "int which" with "int cp_index" in constantPool

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -998,8 +998,8 @@ void GraphBuilder::load_constant() {
     // Unbox the value at runtime, if needed.
     // ConstantDynamic entry can be of a primitive type, but it is cached in boxed form.
     if (patch_state != nullptr) {
-      int index = stream()->get_constant_pool_index();
-      BasicType type = stream()->get_basic_type_for_constant_at(index);
+      int cp_index = stream()->get_constant_pool_index();
+      BasicType type = stream()->get_basic_type_for_constant_at(cp_index);
       if (is_java_primitive(type)) {
         ciInstanceKlass* box_klass = ciEnv::current()->get_box_klass_for_primitive_type(type);
         assert(box_klass->is_loaded(), "sanity");

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -267,9 +267,9 @@ ciConstant ciBytecodeStream::get_constant() {
 //
 // If this bytecode is one of the ldc variants, get the referenced
 // constant.
-constantTag ciBytecodeStream::get_constant_pool_tag(int index) const {
+constantTag ciBytecodeStream::get_constant_pool_tag(int cp_index) const {
   VM_ENTRY_MARK;
-  return _method->get_Method()->constants()->constant_tag_at(index);
+  return _method->get_Method()->constants()->constant_tag_at(cp_index);
 }
 
 // ------------------------------------------------------------------
@@ -283,9 +283,9 @@ constantTag ciBytecodeStream::get_raw_pool_tag_at(int index) const {
 // ------------------------------------------------------------------
 // ciBytecodeStream::get_basic_type_for_constant_at
 //
-BasicType ciBytecodeStream::get_basic_type_for_constant_at(int index) const {
+BasicType ciBytecodeStream::get_basic_type_for_constant_at(int cp_index) const {
   VM_ENTRY_MARK;
-  return _method->get_Method()->constants()->basic_type_for_constant_at(index);
+  return _method->get_Method()->constants()->basic_type_for_constant_at(cp_index);
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -229,7 +229,7 @@ public:
   // object (ciConstant.as_object()->is_loaded() == false).
   ciConstant  get_constant();
   constantTag get_constant_pool_tag(int index) const;
-  BasicType   get_basic_type_for_constant_at(int index) const;
+  BasicType   get_basic_type_for_constant_at(int cp_index) const;
 
   constantTag get_raw_pool_tag_at(int index) const;
 

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -727,8 +727,8 @@ void ciTypeFlow::StateVector::do_ldc(ciBytecodeStream* str) {
   }
   ciConstant con = str->get_constant();
   if (con.is_valid()) {
-    int index = str->get_constant_pool_index();
-    BasicType basic_type = str->get_basic_type_for_constant_at(index);
+    int cp_index = str->get_constant_pool_index();
+    BasicType basic_type = str->get_basic_type_for_constant_at(cp_index);
     if (is_reference_type(basic_type)) {
       ciObject* obj = con.as_object();
       if (obj->is_null_object()) {

--- a/src/hotspot/share/interpreter/bytecode.cpp
+++ b/src/hotspot/share/interpreter/bytecode.cpp
@@ -215,8 +215,8 @@ int Bytecode_loadconstant::pool_index() const {
 }
 
 BasicType Bytecode_loadconstant::result_type() const {
-  int index = pool_index();
-  return _method->constants()->basic_type_for_constant_at(index);
+  int cp_index = pool_index();
+  return _method->constants()->basic_type_for_constant_at(cp_index);
 }
 
 oop Bytecode_loadconstant::resolve_constant(TRAPS) const {

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -151,11 +151,11 @@ JRT_ENTRY(void, InterpreterRuntime::ldc(JavaThread* current, bool wide))
   // access constant pool
   LastFrameAccessor last_frame(current);
   ConstantPool* pool = last_frame.method()->constants();
-  int index = wide ? last_frame.get_index_u2(Bytecodes::_ldc_w) : last_frame.get_index_u1(Bytecodes::_ldc);
-  constantTag tag = pool->tag_at(index);
+  int cp_index = wide ? last_frame.get_index_u2(Bytecodes::_ldc_w) : last_frame.get_index_u1(Bytecodes::_ldc);
+  constantTag tag = pool->tag_at(cp_index);
 
   assert (tag.is_unresolved_klass() || tag.is_klass(), "wrong ldc call");
-  Klass* klass = pool->klass_at(index, CHECK);
+  Klass* klass = pool->klass_at(cp_index, CHECK);
   oop java_class = klass->java_mirror();
   current->set_vm_result(java_class);
 JRT_END

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -234,12 +234,12 @@ void ConstantPool::allocate_resolved_klasses(ClassLoaderData* loader_data, int n
 void ConstantPool::initialize_unresolved_klasses(ClassLoaderData* loader_data, TRAPS) {
   int len = length();
   int num_klasses = 0;
-  for (int i = 1; i <len; i++) {
-    switch (tag_at(i).value()) {
+  for (int cp_index = 1; cp_index <len; cp_index++) {
+    switch (tag_at(cp_index).value()) {
     case JVM_CONSTANT_ClassIndex:
       {
-        const int class_index = klass_index_at(i);
-        unresolved_klass_at_put(i, class_index, num_klasses++);
+        const int class_index = klass_index_at(cp_index);
+        unresolved_klass_at_put(cp_index, class_index, num_klasses++);
       }
       break;
 #ifndef PRODUCT
@@ -382,22 +382,22 @@ void ConstantPool::remove_unshareable_info() {
   set_resolved_references(OopHandle());
 
   bool archived = false;
-  for (int index = 1; index < length(); index++) { // Index 0 is unused
-    switch (tag_at(index).value()) {
+  for (int cp_index = 1; cp_index < length(); cp_index++) { // cp_index 0 is unused
+    switch (tag_at(cp_index).value()) {
     case JVM_CONSTANT_UnresolvedClassInError:
-      tag_at_put(index, JVM_CONSTANT_UnresolvedClass);
+      tag_at_put(cp_index, JVM_CONSTANT_UnresolvedClass);
       break;
     case JVM_CONSTANT_MethodHandleInError:
-      tag_at_put(index, JVM_CONSTANT_MethodHandle);
+      tag_at_put(cp_index, JVM_CONSTANT_MethodHandle);
       break;
     case JVM_CONSTANT_MethodTypeInError:
-      tag_at_put(index, JVM_CONSTANT_MethodType);
+      tag_at_put(cp_index, JVM_CONSTANT_MethodType);
       break;
     case JVM_CONSTANT_DynamicInError:
-      tag_at_put(index, JVM_CONSTANT_Dynamic);
+      tag_at_put(cp_index, JVM_CONSTANT_Dynamic);
       break;
     case JVM_CONSTANT_Class:
-      archived = maybe_archive_resolved_klass_at(index);
+      archived = maybe_archive_resolved_klass_at(cp_index);
       ArchiveBuilder::alloc_stats()->record_klass_cp_entry(archived);
       break;
     }
@@ -453,7 +453,7 @@ int ConstantPool::cp_to_object_index(int cp_index) {
   return (i < 0) ? _no_index_sentinel : i;
 }
 
-void ConstantPool::string_at_put(int which, int obj_index, oop str) {
+void ConstantPool::string_at_put(int obj_index, oop str) {
   oop result = set_resolved_reference_at(obj_index, str);
   assert(result == nullptr || result == str, "Only set once or to the same string.");
 }
@@ -487,21 +487,21 @@ void ConstantPool::trace_class_resolution(const constantPoolHandle& this_cp, Kla
   }
 }
 
-Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
+Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int cp_index,
                                    TRAPS) {
   JavaThread* javaThread = THREAD;
 
   // A resolved constantPool entry will contain a Klass*, otherwise a Symbol*.
   // It is not safe to rely on the tag bit's here, since we don't have a lock, and
   // the entry and tag is not updated atomically.
-  CPKlassSlot kslot = this_cp->klass_slot_at(which);
+  CPKlassSlot kslot = this_cp->klass_slot_at(cp_index);
   int resolved_klass_index = kslot.resolved_klass_index();
   int name_index = kslot.name_index();
   assert(this_cp->tag_at(name_index).is_symbol(), "sanity");
 
   // The tag must be JVM_CONSTANT_Class in order to read the correct value from
   // the unresolved_klasses() array.
-  if (this_cp->tag_at(which).is_klass()) {
+  if (this_cp->tag_at(cp_index).is_klass()) {
     Klass* klass = this_cp->resolved_klasses()->at(resolved_klass_index);
     if (klass != nullptr) {
       return klass;
@@ -509,7 +509,7 @@ Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
   }
 
   // This tag doesn't change back to unresolved class unless at a safepoint.
-  if (this_cp->tag_at(which).is_unresolved_klass_in_error()) {
+  if (this_cp->tag_at(cp_index).is_unresolved_klass_in_error()) {
     // The original attempt to resolve this constant pool entry failed so find the
     // class of the original error and throw another error of the same class
     // (JVMS 5.4.3).
@@ -518,7 +518,7 @@ Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
     // or any internal exception fields such as cause or stacktrace.  But since the
     // detail message is often a class name or other literal string, we will repeat it
     // if we can find it in the symbol table.
-    throw_resolution_error(this_cp, which, CHECK_NULL);
+    throw_resolution_error(this_cp, cp_index, CHECK_NULL);
     ShouldNotReachHere();
   }
 
@@ -545,7 +545,7 @@ Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
   // Failed to resolve class. We must record the errors so that subsequent attempts
   // to resolve this constant pool entry fail with the same error (JVMS 5.4.3).
   if (HAS_PENDING_EXCEPTION) {
-    save_and_throw_exception(this_cp, which, constantTag(JVM_CONSTANT_UnresolvedClass), CHECK_NULL);
+    save_and_throw_exception(this_cp, cp_index, constantTag(JVM_CONSTANT_UnresolvedClass), CHECK_NULL);
     // If CHECK_NULL above doesn't return the exception, that means that
     // some other thread has beaten us and has resolved the class.
     // To preserve old behavior, we return the resolved class.
@@ -566,7 +566,7 @@ Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
   // hardware store ordering here.
   // We also need to CAS to not overwrite an error from a racing thread.
 
-  jbyte old_tag = Atomic::cmpxchg((jbyte*)this_cp->tag_addr_at(which),
+  jbyte old_tag = Atomic::cmpxchg((jbyte*)this_cp->tag_addr_at(cp_index),
                                   (jbyte)JVM_CONSTANT_UnresolvedClass,
                                   (jbyte)JVM_CONSTANT_Class);
 
@@ -574,7 +574,7 @@ Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
   if (old_tag == JVM_CONSTANT_UnresolvedClassInError) {
     // Remove klass.
     this_cp->resolved_klasses()->at_put(resolved_klass_index, nullptr);
-    throw_resolution_error(this_cp, which, CHECK_NULL);
+    throw_resolution_error(this_cp, cp_index, CHECK_NULL);
   }
 
   return k;
@@ -756,14 +756,14 @@ void ConstantPool::verify_constant_pool_resolve(const constantPoolHandle& this_c
 }
 
 
-u2 ConstantPool::name_ref_index_at(int which_nt) {
-  jint ref_index = name_and_type_at(which_nt);
+u2 ConstantPool::name_ref_index_at(int cp_index) {
+  jint ref_index = name_and_type_at(cp_index);
   return extract_low_short_from_int(ref_index);
 }
 
 
-u2 ConstantPool::signature_ref_index_at(int which_nt) {
-  jint ref_index = name_and_type_at(which_nt);
+u2 ConstantPool::signature_ref_index_at(int cp_index) {
+  jint ref_index = name_and_type_at(cp_index);
   return extract_high_short_from_int(ref_index);
 }
 
@@ -772,8 +772,8 @@ Klass* ConstantPool::klass_ref_at(int which, Bytecodes::Code code, TRAPS) {
   return klass_at(klass_ref_index_at(which, code), THREAD);
 }
 
-Symbol* ConstantPool::klass_name_at(int which) const {
-  return symbol_at(klass_slot_at(which).name_index());
+Symbol* ConstantPool::klass_name_at(int cp_index) const {
+  return symbol_at(klass_slot_at(cp_index).name_index());
 }
 
 Symbol* ConstantPool::klass_ref_at_noresolve(int which, Bytecodes::Code code) {
@@ -781,17 +781,17 @@ Symbol* ConstantPool::klass_ref_at_noresolve(int which, Bytecodes::Code code) {
   return klass_at_noresolve(ref_index);
 }
 
-Symbol* ConstantPool::uncached_klass_ref_at_noresolve(int which) {
-  jint ref_index = uncached_klass_ref_index_at(which);
+Symbol* ConstantPool::uncached_klass_ref_at_noresolve(int cp_index) {
+  jint ref_index = uncached_klass_ref_index_at(cp_index);
   return klass_at_noresolve(ref_index);
 }
 
-char* ConstantPool::string_at_noresolve(int which) {
-  return unresolved_string_at(which)->as_C_string();
+char* ConstantPool::string_at_noresolve(int cp_index) {
+  return unresolved_string_at(cp_index)->as_C_string();
 }
 
-BasicType ConstantPool::basic_type_for_signature_at(int which) const {
-  return Signature::basic_type(symbol_at(which));
+BasicType ConstantPool::basic_type_for_signature_at(int cp_index) const {
+  return Signature::basic_type(symbol_at(cp_index));
 }
 
 
@@ -884,7 +884,7 @@ void ConstantPool::throw_resolution_error(const constantPoolHandle& this_cp, int
 
 // If resolution for Class, Dynamic constant, MethodHandle or MethodType fails, save the
 // exception in the resolution error table, so that the same exception is thrown again.
-void ConstantPool::save_and_throw_exception(const constantPoolHandle& this_cp, int which,
+void ConstantPool::save_and_throw_exception(const constantPoolHandle& this_cp, int cp_index,
                                             constantTag tag, TRAPS) {
 
   int error_tag = tag.error_value();
@@ -895,44 +895,44 @@ void ConstantPool::save_and_throw_exception(const constantPoolHandle& this_cp, i
     // being loaded due to virtual machine errors like StackOverflow
     // and OutOfMemoryError, etc, or if the thread was hit by stop()
     // Needs clarification to section 5.4.3 of the VM spec (see 6308271)
-  } else if (this_cp->tag_at(which).value() != error_tag) {
-    add_resolution_error(this_cp, which, tag, PENDING_EXCEPTION);
+  } else if (this_cp->tag_at(cp_index).value() != error_tag) {
+    add_resolution_error(this_cp, cp_index, tag, PENDING_EXCEPTION);
     // CAS in the tag.  If a thread beat us to registering this error that's fine.
     // If another thread resolved the reference, this is a race condition. This
     // thread may have had a security manager or something temporary.
     // This doesn't deterministically get an error.   So why do we save this?
     // We save this because jvmti can add classes to the bootclass path after
     // this error, so it needs to get the same error if the error is first.
-    jbyte old_tag = Atomic::cmpxchg((jbyte*)this_cp->tag_addr_at(which),
+    jbyte old_tag = Atomic::cmpxchg((jbyte*)this_cp->tag_addr_at(cp_index),
                                     (jbyte)tag.value(),
                                     (jbyte)error_tag);
     if (old_tag != error_tag && old_tag != tag.value()) {
       // MethodHandles and MethodType doesn't change to resolved version.
-      assert(this_cp->tag_at(which).is_klass(), "Wrong tag value");
+      assert(this_cp->tag_at(cp_index).is_klass(), "Wrong tag value");
       // Forget the exception and use the resolved class.
       CLEAR_PENDING_EXCEPTION;
     }
   } else {
     // some other thread put this in error state
-    throw_resolution_error(this_cp, which, CHECK);
+    throw_resolution_error(this_cp, cp_index, CHECK);
   }
 }
 
-constantTag ConstantPool::constant_tag_at(int which) {
-  constantTag tag = tag_at(which);
+constantTag ConstantPool::constant_tag_at(int cp_index) {
+  constantTag tag = tag_at(cp_index);
   if (tag.is_dynamic_constant()) {
-    BasicType bt = basic_type_for_constant_at(which);
+    BasicType bt = basic_type_for_constant_at(cp_index);
     return constantTag(constantTag::type2tag(bt));
   }
   return tag;
 }
 
-BasicType ConstantPool::basic_type_for_constant_at(int which) {
-  constantTag tag = tag_at(which);
+BasicType ConstantPool::basic_type_for_constant_at(int cp_index) {
+  constantTag tag = tag_at(cp_index);
   if (tag.is_dynamic_constant() ||
       tag.is_dynamic_constant_in_error()) {
     // have to look at the signature for this one
-    Symbol* constant_type = uncached_signature_ref_at(which);
+    Symbol* constant_type = uncached_signature_ref_at(cp_index);
     return Signature::basic_type(constant_type);
   }
   return tag.basic_type();
@@ -942,7 +942,7 @@ BasicType ConstantPool::basic_type_for_constant_at(int which) {
 // Some constant pool entries cache their resolved oop. This is also
 // called to create oops from constants to use in arguments for invokedynamic
 oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
-                                           int index, int cache_index,
+                                           int cp_index, int cache_index,
                                            bool* status_return, TRAPS) {
   oop result_oop = nullptr;
 
@@ -951,17 +951,17 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
     // We'll do a linear search.  This should be OK because this usage is rare.
     // FIXME: If bootstrap specifiers stress this code, consider putting in
     // a reverse index.  Binary search over a short array should do it.
-    assert(index > 0, "valid index");
-    cache_index = this_cp->cp_to_object_index(index);
+    assert(cp_index > 0, "valid index");
+    cache_index = this_cp->cp_to_object_index(cp_index);
   }
   assert(cache_index == _no_index_sentinel || cache_index >= 0, "");
-  assert(index == _no_index_sentinel || index >= 0, "");
+  assert(cp_index == _no_index_sentinel || cp_index >= 0, "");
 
   if (cache_index >= 0) {
     result_oop = this_cp->resolved_reference_at(cache_index);
     if (result_oop != nullptr) {
       if (result_oop == Universe::the_null_sentinel()) {
-        DEBUG_ONLY(int temp_index = (index >= 0 ? index : this_cp->object_to_cp_index(cache_index)));
+        DEBUG_ONLY(int temp_index = (cp_index >= 0 ? cp_index : this_cp->object_to_cp_index(cache_index)));
         assert(this_cp->tag_at(temp_index).is_dynamic_constant(), "only condy uses the null sentinel");
         result_oop = nullptr;
       }
@@ -969,19 +969,19 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
       return result_oop;
       // That was easy...
     }
-    index = this_cp->object_to_cp_index(cache_index);
+    cp_index = this_cp->object_to_cp_index(cache_index);
   }
 
   jvalue prim_value;  // temp used only in a few cases below
 
-  constantTag tag = this_cp->tag_at(index);
+  constantTag tag = this_cp->tag_at(cp_index);
 
   if (status_return != nullptr) {
     // don't trigger resolution if the constant might need it
     switch (tag.value()) {
     case JVM_CONSTANT_Class:
     {
-      CPKlassSlot kslot = this_cp->klass_slot_at(index);
+      CPKlassSlot kslot = this_cp->klass_slot_at(cp_index);
       int resolved_klass_index = kslot.resolved_klass_index();
       if (this_cp->resolved_klasses()->at(resolved_klass_index) == nullptr) {
         (*status_return) = false;
@@ -1011,7 +1011,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
   case JVM_CONSTANT_Class:
     {
       assert(cache_index == _no_index_sentinel, "should not have been set");
-      Klass* resolved = klass_at_impl(this_cp, index, CHECK_NULL);
+      Klass* resolved = klass_at_impl(this_cp, cp_index, CHECK_NULL);
       // ldc wants the java mirror.
       result_oop = resolved->java_mirror();
       break;
@@ -1020,7 +1020,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
   case JVM_CONSTANT_Dynamic:
     {
       // Resolve the Dynamically-Computed constant to invoke the BSM in order to obtain the resulting oop.
-      BootstrapInfo bootstrap_specifier(this_cp, index);
+      BootstrapInfo bootstrap_specifier(this_cp, cp_index);
 
       // The initial step in resolving an unresolved symbolic reference to a
       // dynamically-computed constant is to resolve the symbolic reference to a
@@ -1038,7 +1038,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
       if (HAS_PENDING_EXCEPTION) {
         // Resolution failure of the dynamically-computed constant, save_and_throw_exception
         // will check for a LinkageError and store a DynamicConstantInError.
-        save_and_throw_exception(this_cp, index, tag, CHECK_NULL);
+        save_and_throw_exception(this_cp, cp_index, tag, CHECK_NULL);
       }
       result_oop = bootstrap_specifier.resolved_value()();
       BasicType type = Signature::basic_type(bootstrap_specifier.signature());
@@ -1072,25 +1072,25 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
 
   case JVM_CONSTANT_String:
     assert(cache_index != _no_index_sentinel, "should have been set");
-    result_oop = string_at_impl(this_cp, index, cache_index, CHECK_NULL);
+    result_oop = string_at_impl(this_cp, cp_index, cache_index, CHECK_NULL);
     break;
 
   case JVM_CONSTANT_MethodHandle:
     {
-      int ref_kind                 = this_cp->method_handle_ref_kind_at(index);
-      int callee_index             = this_cp->method_handle_klass_index_at(index);
-      Symbol*  name =      this_cp->method_handle_name_ref_at(index);
-      Symbol*  signature = this_cp->method_handle_signature_ref_at(index);
-      constantTag m_tag  = this_cp->tag_at(this_cp->method_handle_index_at(index));
+      int ref_kind                 = this_cp->method_handle_ref_kind_at(cp_index);
+      int callee_index             = this_cp->method_handle_klass_index_at(cp_index);
+      Symbol*  name =      this_cp->method_handle_name_ref_at(cp_index);
+      Symbol*  signature = this_cp->method_handle_signature_ref_at(cp_index);
+      constantTag m_tag  = this_cp->tag_at(this_cp->method_handle_index_at(cp_index));
       { ResourceMark rm(THREAD);
         log_debug(class, resolve)("resolve JVM_CONSTANT_MethodHandle:%d [%d/%d/%d] %s.%s",
-                              ref_kind, index, this_cp->method_handle_index_at(index),
+                              ref_kind, cp_index, this_cp->method_handle_index_at(cp_index),
                               callee_index, name->as_C_string(), signature->as_C_string());
       }
 
       Klass* callee = klass_at_impl(this_cp, callee_index, THREAD);
       if (HAS_PENDING_EXCEPTION) {
-        save_and_throw_exception(this_cp, index, tag, CHECK_NULL);
+        save_and_throw_exception(this_cp, cp_index, tag, CHECK_NULL);
       }
 
       // Check constant pool method consistency
@@ -1104,11 +1104,11 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
         ss.print(" %s(", name->as_C_string());
         signature->print_as_signature_external_parameters(&ss);
         ss.print(")' at index %d is %s and should be %s",
-                 index,
+                 cp_index,
                  callee->is_interface() ? "CONSTANT_MethodRef" : "CONSTANT_InterfaceMethodRef",
                  callee->is_interface() ? "CONSTANT_InterfaceMethodRef" : "CONSTANT_MethodRef");
         Exceptions::fthrow(THREAD_AND_LOCATION, vmSymbols::java_lang_IncompatibleClassChangeError(), "%s", ss.as_string());
-        save_and_throw_exception(this_cp, index, tag, CHECK_NULL);
+        save_and_throw_exception(this_cp, cp_index, tag, CHECK_NULL);
       }
 
       Klass* klass = this_cp->pool_holder();
@@ -1117,7 +1117,7 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
                                                                    callee, name, signature,
                                                                    THREAD);
       if (HAS_PENDING_EXCEPTION) {
-        save_and_throw_exception(this_cp, index, tag, CHECK_NULL);
+        save_and_throw_exception(this_cp, cp_index, tag, CHECK_NULL);
       }
       result_oop = value();
       break;
@@ -1125,10 +1125,10 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
 
   case JVM_CONSTANT_MethodType:
     {
-      Symbol*  signature = this_cp->method_type_signature_at(index);
+      Symbol*  signature = this_cp->method_type_signature_at(cp_index);
       { ResourceMark rm(THREAD);
         log_debug(class, resolve)("resolve JVM_CONSTANT_MethodType [%d/%d] %s",
-                              index, this_cp->method_type_index_at(index),
+                              cp_index, this_cp->method_type_index_at(cp_index),
                               signature->as_C_string());
       }
       Klass* klass = this_cp->pool_holder();
@@ -1136,32 +1136,32 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
       Handle value = SystemDictionary::find_method_handle_type(signature, klass, THREAD);
       result_oop = value();
       if (HAS_PENDING_EXCEPTION) {
-        save_and_throw_exception(this_cp, index, tag, CHECK_NULL);
+        save_and_throw_exception(this_cp, cp_index, tag, CHECK_NULL);
       }
       break;
     }
 
   case JVM_CONSTANT_Integer:
     assert(cache_index == _no_index_sentinel, "should not have been set");
-    prim_value.i = this_cp->int_at(index);
+    prim_value.i = this_cp->int_at(cp_index);
     result_oop = java_lang_boxing_object::create(T_INT, &prim_value, CHECK_NULL);
     break;
 
   case JVM_CONSTANT_Float:
     assert(cache_index == _no_index_sentinel, "should not have been set");
-    prim_value.f = this_cp->float_at(index);
+    prim_value.f = this_cp->float_at(cp_index);
     result_oop = java_lang_boxing_object::create(T_FLOAT, &prim_value, CHECK_NULL);
     break;
 
   case JVM_CONSTANT_Long:
     assert(cache_index == _no_index_sentinel, "should not have been set");
-    prim_value.j = this_cp->long_at(index);
+    prim_value.j = this_cp->long_at(cp_index);
     result_oop = java_lang_boxing_object::create(T_LONG, &prim_value, CHECK_NULL);
     break;
 
   case JVM_CONSTANT_Double:
     assert(cache_index == _no_index_sentinel, "should not have been set");
-    prim_value.d = this_cp->double_at(index);
+    prim_value.d = this_cp->double_at(cp_index);
     result_oop = java_lang_boxing_object::create(T_DOUBLE, &prim_value, CHECK_NULL);
     break;
 
@@ -1169,11 +1169,11 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
   case JVM_CONSTANT_DynamicInError:
   case JVM_CONSTANT_MethodHandleInError:
   case JVM_CONSTANT_MethodTypeInError:
-    throw_resolution_error(this_cp, index, CHECK_NULL);
+    throw_resolution_error(this_cp, cp_index, CHECK_NULL);
     break;
 
   default:
-    fatal("unexpected constant tag at CP %p[%d/%d] = %d", this_cp(), index, cache_index, tag.value());
+    fatal("unexpected constant tag at CP %p[%d/%d] = %d", this_cp(), cp_index, cache_index, tag.value());
     break;
   }
 
@@ -1199,27 +1199,27 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
   }
 }
 
-oop ConstantPool::uncached_string_at(int which, TRAPS) {
-  Symbol* sym = unresolved_string_at(which);
+oop ConstantPool::uncached_string_at(int cp_index, TRAPS) {
+  Symbol* sym = unresolved_string_at(cp_index);
   oop str = StringTable::intern(sym, CHECK_(nullptr));
   assert(java_lang_String::is_instance(str), "must be string");
   return str;
 }
 
-void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int index,
+void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int cp_index,
                                                     int start_arg, int end_arg,
                                                     objArrayHandle info, int pos,
                                                     bool must_resolve, Handle if_not_available,
                                                     TRAPS) {
   int limit = pos + end_arg - start_arg;
-  // checks: index in range [0..this_cp->length),
-  // tag at index, start..end in range [0..this_cp->bootstrap_argument_count],
+  // checks: cp_index in range [0..this_cp->length),
+  // tag at cp_index, start..end in range [0..this_cp->bootstrap_argument_count],
   // info array non-null, pos..limit in [0..info.length]
-  if ((0 >= index    || index >= this_cp->length())  ||
-      !(this_cp->tag_at(index).is_invoke_dynamic()    ||
-        this_cp->tag_at(index).is_dynamic_constant()) ||
+  if ((0 >= cp_index    || cp_index >= this_cp->length())  ||
+      !(this_cp->tag_at(cp_index).is_invoke_dynamic()    ||
+        this_cp->tag_at(cp_index).is_dynamic_constant()) ||
       (0 > start_arg || start_arg > end_arg) ||
-      (end_arg > this_cp->bootstrap_argument_count_at(index)) ||
+      (end_arg > this_cp->bootstrap_argument_count_at(cp_index)) ||
       (0 > pos       || pos > limit)         ||
       (info.is_null() || limit > info->length())) {
     // An index or something else went wrong; throw an error.
@@ -1230,7 +1230,7 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
   // now we can loop safely
   int info_i = pos;
   for (int i = start_arg; i < end_arg; i++) {
-    int arg_index = this_cp->bootstrap_argument_index_at(index, i);
+    int arg_index = this_cp->bootstrap_argument_index_at(cp_index, i);
     oop arg_oop;
     if (must_resolve) {
       arg_oop = this_cp->resolve_possibly_cached_constant_at(arg_index, CHECK);
@@ -1243,22 +1243,22 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
   }
 }
 
-oop ConstantPool::string_at_impl(const constantPoolHandle& this_cp, int which, int obj_index, TRAPS) {
+oop ConstantPool::string_at_impl(const constantPoolHandle& this_cp, int cp_index, int obj_index, TRAPS) {
   // If the string has already been interned, this entry will be non-null
   oop str = this_cp->resolved_reference_at(obj_index);
   assert(str != Universe::the_null_sentinel(), "");
   if (str != nullptr) return str;
-  Symbol* sym = this_cp->unresolved_string_at(which);
+  Symbol* sym = this_cp->unresolved_string_at(cp_index);
   str = StringTable::intern(sym, CHECK_(nullptr));
-  this_cp->string_at_put(which, obj_index, str);
+  this_cp->string_at_put(obj_index, str);
   assert(java_lang_String::is_instance(str), "must be string");
   return str;
 }
 
 
-bool ConstantPool::klass_name_at_matches(const InstanceKlass* k, int which) {
+bool ConstantPool::klass_name_at_matches(const InstanceKlass* k, int cp_index) {
   // Names are interned, so we can compare Symbol*s directly
-  Symbol* cp_name = klass_name_at(which);
+  Symbol* cp_name = klass_name_at(cp_index);
   return (cp_name == k->name());
 }
 
@@ -1612,27 +1612,27 @@ void ConstantPool::copy_operands(const constantPoolHandle& from_cp,
 // Copy this constant pool's entries at start_i to end_i (inclusive)
 // to the constant pool to_cp's entries starting at to_i. A total of
 // (end_i - start_i) + 1 entries are copied.
-void ConstantPool::copy_cp_to_impl(const constantPoolHandle& from_cp, int start_i, int end_i,
-       const constantPoolHandle& to_cp, int to_i, TRAPS) {
+void ConstantPool::copy_cp_to_impl(const constantPoolHandle& from_cp, int start_cpi, int end_cpi,
+       const constantPoolHandle& to_cp, int to_cpi, TRAPS) {
 
 
-  int dest_i = to_i;  // leave original alone for debug purposes
+  int dest_cpi = to_cpi;  // leave original alone for debug purposes
 
-  for (int src_i = start_i; src_i <= end_i; /* see loop bottom */ ) {
-    copy_entry_to(from_cp, src_i, to_cp, dest_i);
+  for (int src_cpi = start_cpi; src_cpi <= end_cpi; /* see loop bottom */ ) {
+    copy_entry_to(from_cp, src_cpi, to_cp, dest_cpi);
 
-    switch (from_cp->tag_at(src_i).value()) {
+    switch (from_cp->tag_at(src_cpi).value()) {
     case JVM_CONSTANT_Double:
     case JVM_CONSTANT_Long:
       // double and long take two constant pool entries
-      src_i += 2;
-      dest_i += 2;
+      src_cpi += 2;
+      dest_cpi += 2;
       break;
 
     default:
       // all others take one constant pool entry
-      src_i++;
-      dest_i++;
+      src_cpi++;
+      dest_cpi++;
       break;
     }
   }
@@ -1643,77 +1643,77 @@ void ConstantPool::copy_cp_to_impl(const constantPoolHandle& from_cp, int start_
 
 // Copy this constant pool's entry at from_i to the constant pool
 // to_cp's entry at to_i.
-void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
-                                        const constantPoolHandle& to_cp, int to_i) {
+void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_cpi,
+                                        const constantPoolHandle& to_cp, int to_cpi) {
 
-  int tag = from_cp->tag_at(from_i).value();
+  int tag = from_cp->tag_at(from_cpi).value();
   switch (tag) {
   case JVM_CONSTANT_ClassIndex:
   {
-    jint ki = from_cp->klass_index_at(from_i);
-    to_cp->klass_index_at_put(to_i, ki);
+    jint ki = from_cp->klass_index_at(from_cpi);
+    to_cp->klass_index_at_put(to_cpi, ki);
   } break;
 
   case JVM_CONSTANT_Double:
   {
-    jdouble d = from_cp->double_at(from_i);
-    to_cp->double_at_put(to_i, d);
+    jdouble d = from_cp->double_at(from_cpi);
+    to_cp->double_at_put(to_cpi, d);
     // double takes two constant pool entries so init second entry's tag
-    to_cp->tag_at_put(to_i + 1, JVM_CONSTANT_Invalid);
+    to_cp->tag_at_put(to_cpi + 1, JVM_CONSTANT_Invalid);
   } break;
 
   case JVM_CONSTANT_Fieldref:
   {
-    int class_index = from_cp->uncached_klass_ref_index_at(from_i);
-    int name_and_type_index = from_cp->uncached_name_and_type_ref_index_at(from_i);
-    to_cp->field_at_put(to_i, class_index, name_and_type_index);
+    int class_index = from_cp->uncached_klass_ref_index_at(from_cpi);
+    int name_and_type_index = from_cp->uncached_name_and_type_ref_index_at(from_cpi);
+    to_cp->field_at_put(to_cpi, class_index, name_and_type_index);
   } break;
 
   case JVM_CONSTANT_Float:
   {
-    jfloat f = from_cp->float_at(from_i);
-    to_cp->float_at_put(to_i, f);
+    jfloat f = from_cp->float_at(from_cpi);
+    to_cp->float_at_put(to_cpi, f);
   } break;
 
   case JVM_CONSTANT_Integer:
   {
-    jint i = from_cp->int_at(from_i);
-    to_cp->int_at_put(to_i, i);
+    jint i = from_cp->int_at(from_cpi);
+    to_cp->int_at_put(to_cpi, i);
   } break;
 
   case JVM_CONSTANT_InterfaceMethodref:
   {
-    int class_index = from_cp->uncached_klass_ref_index_at(from_i);
-    int name_and_type_index = from_cp->uncached_name_and_type_ref_index_at(from_i);
-    to_cp->interface_method_at_put(to_i, class_index, name_and_type_index);
+    int class_index = from_cp->uncached_klass_ref_index_at(from_cpi);
+    int name_and_type_index = from_cp->uncached_name_and_type_ref_index_at(from_cpi);
+    to_cp->interface_method_at_put(to_cpi, class_index, name_and_type_index);
   } break;
 
   case JVM_CONSTANT_Long:
   {
-    jlong l = from_cp->long_at(from_i);
-    to_cp->long_at_put(to_i, l);
+    jlong l = from_cp->long_at(from_cpi);
+    to_cp->long_at_put(to_cpi, l);
     // long takes two constant pool entries so init second entry's tag
-    to_cp->tag_at_put(to_i + 1, JVM_CONSTANT_Invalid);
+    to_cp->tag_at_put(to_cpi + 1, JVM_CONSTANT_Invalid);
   } break;
 
   case JVM_CONSTANT_Methodref:
   {
-    int class_index = from_cp->uncached_klass_ref_index_at(from_i);
-    int name_and_type_index = from_cp->uncached_name_and_type_ref_index_at(from_i);
-    to_cp->method_at_put(to_i, class_index, name_and_type_index);
+    int class_index = from_cp->uncached_klass_ref_index_at(from_cpi);
+    int name_and_type_index = from_cp->uncached_name_and_type_ref_index_at(from_cpi);
+    to_cp->method_at_put(to_cpi, class_index, name_and_type_index);
   } break;
 
   case JVM_CONSTANT_NameAndType:
   {
-    int name_ref_index = from_cp->name_ref_index_at(from_i);
-    int signature_ref_index = from_cp->signature_ref_index_at(from_i);
-    to_cp->name_and_type_at_put(to_i, name_ref_index, signature_ref_index);
+    int name_ref_index = from_cp->name_ref_index_at(from_cpi);
+    int signature_ref_index = from_cp->signature_ref_index_at(from_cpi);
+    to_cp->name_and_type_at_put(to_cpi, name_ref_index, signature_ref_index);
   } break;
 
   case JVM_CONSTANT_StringIndex:
   {
-    jint si = from_cp->string_index_at(from_i);
-    to_cp->string_index_at_put(to_i, si);
+    jint si = from_cp->string_index_at(from_cpi);
+    to_cp->string_index_at_put(to_cpi, si);
   } break;
 
   case JVM_CONSTANT_Class:
@@ -1721,55 +1721,55 @@ void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
   case JVM_CONSTANT_UnresolvedClassInError:
   {
     // Revert to JVM_CONSTANT_ClassIndex
-    int name_index = from_cp->klass_slot_at(from_i).name_index();
+    int name_index = from_cp->klass_slot_at(from_cpi).name_index();
     assert(from_cp->tag_at(name_index).is_symbol(), "sanity");
-    to_cp->klass_index_at_put(to_i, name_index);
+    to_cp->klass_index_at_put(to_cpi, name_index);
   } break;
 
   case JVM_CONSTANT_String:
   {
-    Symbol* s = from_cp->unresolved_string_at(from_i);
-    to_cp->unresolved_string_at_put(to_i, s);
+    Symbol* s = from_cp->unresolved_string_at(from_cpi);
+    to_cp->unresolved_string_at_put(to_cpi, s);
   } break;
 
   case JVM_CONSTANT_Utf8:
   {
-    Symbol* s = from_cp->symbol_at(from_i);
+    Symbol* s = from_cp->symbol_at(from_cpi);
     // Need to increase refcount, the old one will be thrown away and deferenced
     s->increment_refcount();
-    to_cp->symbol_at_put(to_i, s);
+    to_cp->symbol_at_put(to_cpi, s);
   } break;
 
   case JVM_CONSTANT_MethodType:
   case JVM_CONSTANT_MethodTypeInError:
   {
-    jint k = from_cp->method_type_index_at(from_i);
-    to_cp->method_type_index_at_put(to_i, k);
+    jint k = from_cp->method_type_index_at(from_cpi);
+    to_cp->method_type_index_at_put(to_cpi, k);
   } break;
 
   case JVM_CONSTANT_MethodHandle:
   case JVM_CONSTANT_MethodHandleInError:
   {
-    int k1 = from_cp->method_handle_ref_kind_at(from_i);
-    int k2 = from_cp->method_handle_index_at(from_i);
-    to_cp->method_handle_index_at_put(to_i, k1, k2);
+    int k1 = from_cp->method_handle_ref_kind_at(from_cpi);
+    int k2 = from_cp->method_handle_index_at(from_cpi);
+    to_cp->method_handle_index_at_put(to_cpi, k1, k2);
   } break;
 
   case JVM_CONSTANT_Dynamic:
   case JVM_CONSTANT_DynamicInError:
   {
-    int k1 = from_cp->bootstrap_methods_attribute_index(from_i);
-    int k2 = from_cp->bootstrap_name_and_type_ref_index_at(from_i);
+    int k1 = from_cp->bootstrap_methods_attribute_index(from_cpi);
+    int k2 = from_cp->bootstrap_name_and_type_ref_index_at(from_cpi);
     k1 += operand_array_length(to_cp->operands());  // to_cp might already have operands
-    to_cp->dynamic_constant_at_put(to_i, k1, k2);
+    to_cp->dynamic_constant_at_put(to_cpi, k1, k2);
   } break;
 
   case JVM_CONSTANT_InvokeDynamic:
   {
-    int k1 = from_cp->bootstrap_methods_attribute_index(from_i);
-    int k2 = from_cp->bootstrap_name_and_type_ref_index_at(from_i);
+    int k1 = from_cp->bootstrap_methods_attribute_index(from_cpi);
+    int k2 = from_cp->bootstrap_name_and_type_ref_index_at(from_cpi);
     k1 += operand_array_length(to_cp->operands());  // to_cp might already have operands
-    to_cp->invoke_dynamic_at_put(to_i, k1, k2);
+    to_cp->invoke_dynamic_at_put(to_cpi, k1, k2);
   } break;
 
   // Invalid is used as the tag for the second constant pool entry
@@ -1844,16 +1844,16 @@ int ConstantPool::find_matching_operand(int pattern_i,
 
 #ifndef PRODUCT
 
-const char* ConstantPool::printable_name_at(int which) {
+const char* ConstantPool::printable_name_at(int cp_index) {
 
-  constantTag tag = tag_at(which);
+  constantTag tag = tag_at(cp_index);
 
   if (tag.is_string()) {
-    return string_at_noresolve(which);
+    return string_at_noresolve(cp_index);
   } else if (tag.is_klass() || tag.is_unresolved_klass()) {
-    return klass_name_at(which)->as_C_string();
+    return klass_name_at(cp_index)->as_C_string();
   } else if (tag.is_symbol()) {
-    return symbol_at(which)->as_C_string();
+    return symbol_at(cp_index)->as_C_string();
   }
   return "";
 }
@@ -2322,14 +2322,14 @@ void ConstantPool::print_on(outputStream* st) const {
 }
 
 // Print one constant pool entry
-void ConstantPool::print_entry_on(const int index, outputStream* st) {
+void ConstantPool::print_entry_on(const int cp_index, outputStream* st) {
   EXCEPTION_MARK;
-  st->print(" - %3d : ", index);
-  tag_at(index).print_on(st);
+  st->print(" - %3d : ", cp_index);
+  tag_at(cp_index).print_on(st);
   st->print(" : ");
-  switch (tag_at(index).value()) {
+  switch (tag_at(cp_index).value()) {
     case JVM_CONSTANT_Class :
-      { Klass* k = klass_at(index, CATCH);
+      { Klass* k = klass_at(cp_index, CATCH);
         guarantee(k != nullptr, "need klass");
         k->print_value_on(st);
         st->print(" {" PTR_FORMAT "}", p2i(k));
@@ -2338,40 +2338,40 @@ void ConstantPool::print_entry_on(const int index, outputStream* st) {
     case JVM_CONSTANT_Fieldref :
     case JVM_CONSTANT_Methodref :
     case JVM_CONSTANT_InterfaceMethodref :
-      st->print("klass_index=%d", uncached_klass_ref_index_at(index));
-      st->print(" name_and_type_index=%d", uncached_name_and_type_ref_index_at(index));
+      st->print("klass_index=%d", uncached_klass_ref_index_at(cp_index));
+      st->print(" name_and_type_index=%d", uncached_name_and_type_ref_index_at(cp_index));
       break;
     case JVM_CONSTANT_String :
-      unresolved_string_at(index)->print_value_on(st);
+      unresolved_string_at(cp_index)->print_value_on(st);
       break;
     case JVM_CONSTANT_Integer :
-      st->print("%d", int_at(index));
+      st->print("%d", int_at(cp_index));
       break;
     case JVM_CONSTANT_Float :
-      st->print("%f", float_at(index));
+      st->print("%f", float_at(cp_index));
       break;
     case JVM_CONSTANT_Long :
-      st->print_jlong(long_at(index));
+      st->print_jlong(long_at(cp_index));
       break;
     case JVM_CONSTANT_Double :
-      st->print("%lf", double_at(index));
+      st->print("%lf", double_at(cp_index));
       break;
     case JVM_CONSTANT_NameAndType :
-      st->print("name_index=%d", name_ref_index_at(index));
-      st->print(" signature_index=%d", signature_ref_index_at(index));
+      st->print("name_index=%d", name_ref_index_at(cp_index));
+      st->print(" signature_index=%d", signature_ref_index_at(cp_index));
       break;
     case JVM_CONSTANT_Utf8 :
-      symbol_at(index)->print_value_on(st);
+      symbol_at(cp_index)->print_value_on(st);
       break;
     case JVM_CONSTANT_ClassIndex: {
-        int name_index = *int_at_addr(index);
+        int name_index = *int_at_addr(cp_index);
         st->print("klass_index=%d ", name_index);
         symbol_at(name_index)->print_value_on(st);
       }
       break;
     case JVM_CONSTANT_UnresolvedClass :               // fall-through
     case JVM_CONSTANT_UnresolvedClassInError: {
-        CPKlassSlot kslot = klass_slot_at(index);
+        CPKlassSlot kslot = klass_slot_at(cp_index);
         int resolved_klass_index = kslot.resolved_klass_index();
         int name_index = kslot.name_index();
         assert(tag_at(name_index).is_symbol(), "sanity");
@@ -2380,22 +2380,22 @@ void ConstantPool::print_entry_on(const int index, outputStream* st) {
       break;
     case JVM_CONSTANT_MethodHandle :
     case JVM_CONSTANT_MethodHandleInError :
-      st->print("ref_kind=%d", method_handle_ref_kind_at(index));
-      st->print(" ref_index=%d", method_handle_index_at(index));
+      st->print("ref_kind=%d", method_handle_ref_kind_at(cp_index));
+      st->print(" ref_index=%d", method_handle_index_at(cp_index));
       break;
     case JVM_CONSTANT_MethodType :
     case JVM_CONSTANT_MethodTypeInError :
-      st->print("signature_index=%d", method_type_index_at(index));
+      st->print("signature_index=%d", method_type_index_at(cp_index));
       break;
     case JVM_CONSTANT_Dynamic :
     case JVM_CONSTANT_DynamicInError :
       {
-        st->print("bootstrap_method_index=%d", bootstrap_method_ref_index_at(index));
-        st->print(" type_index=%d", bootstrap_name_and_type_ref_index_at(index));
-        int argc = bootstrap_argument_count_at(index);
+        st->print("bootstrap_method_index=%d", bootstrap_method_ref_index_at(cp_index));
+        st->print(" type_index=%d", bootstrap_name_and_type_ref_index_at(cp_index));
+        int argc = bootstrap_argument_count_at(cp_index);
         if (argc > 0) {
           for (int arg_i = 0; arg_i < argc; arg_i++) {
-            int arg = bootstrap_argument_index_at(index, arg_i);
+            int arg = bootstrap_argument_index_at(cp_index, arg_i);
             st->print((arg_i == 0 ? " arguments={%d" : ", %d"), arg);
           }
           st->print("}");
@@ -2404,12 +2404,12 @@ void ConstantPool::print_entry_on(const int index, outputStream* st) {
       break;
     case JVM_CONSTANT_InvokeDynamic :
       {
-        st->print("bootstrap_method_index=%d", bootstrap_method_ref_index_at(index));
-        st->print(" name_and_type_index=%d", bootstrap_name_and_type_ref_index_at(index));
-        int argc = bootstrap_argument_count_at(index);
+        st->print("bootstrap_method_index=%d", bootstrap_method_ref_index_at(cp_index));
+        st->print(" name_and_type_index=%d", bootstrap_name_and_type_ref_index_at(cp_index));
+        int argc = bootstrap_argument_count_at(cp_index);
         if (argc > 0) {
           for (int arg_i = 0; arg_i < argc; arg_i++) {
-            int arg = bootstrap_argument_index_at(index, arg_i);
+            int arg = bootstrap_argument_index_at(cp_index, arg_i);
             st->print((arg_i == 0 ? " arguments={%d" : ", %d"), arg);
           }
           st->print("}");

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -706,9 +706,9 @@ class ConstantPool : public Metadata {
   BasicType basic_type_for_constant_at(int cp_index);
 
   // Resolve late bound constants.
-  oop resolve_constant_at(int index, TRAPS) {
+  oop resolve_constant_at(int cp_index, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return resolve_constant_at_impl(h_this, index, _no_index_sentinel, nullptr, THREAD);
+    return resolve_constant_at_impl(h_this, cp_index, _no_index_sentinel, nullptr, THREAD);
   }
 
   oop resolve_cached_constant_at(int cache_index, TRAPS) {
@@ -836,7 +836,7 @@ class ConstantPool : public Metadata {
   // Resolve string constants (to prevent allocation during compilation)
   static void resolve_string_constants_impl(const constantPoolHandle& this_cp, TRAPS);
 
-  static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int index, int cache_index,
+  static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int cp_index, int cache_index,
                                       bool* status_return, TRAPS);
   static void copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int cp_index,
                                                int start_arg, int end_arg,

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -122,11 +122,11 @@ class ConstantPool : public Metadata {
     int                _version;
   } _saved;
 
-  void set_tags(Array<u1>* tags)               { _tags = tags; }
-  void tag_at_put(int which, jbyte t)          { tags()->at_put(which, t); }
-  void release_tag_at_put(int which, jbyte t)  { tags()->release_at_put(which, t); }
+  void set_tags(Array<u1>* tags)                 { _tags = tags; }
+  void tag_at_put(int cp_index, jbyte t)         { tags()->at_put(cp_index, t); }
+  void release_tag_at_put(int cp_index, jbyte t) { tags()->release_at_put(cp_index, t); }
 
-  u1* tag_addr_at(int which) const             { return tags()->adr_at(which); }
+  u1* tag_addr_at(int cp_index) const            { return tags()->adr_at(cp_index); }
 
   void set_operands(Array<u2>* operands)       { _operands = operands; }
 
@@ -136,29 +136,29 @@ class ConstantPool : public Metadata {
  private:
   intptr_t* base() const { return (intptr_t*) (((char*) this) + sizeof(ConstantPool)); }
 
-  intptr_t* obj_at_addr(int which) const {
-    assert(is_within_bounds(which), "index out of bounds");
-    return (intptr_t*) &base()[which];
+  intptr_t* obj_at_addr(int cp_index) const {
+    assert(is_within_bounds(cp_index), "index out of bounds");
+    return (intptr_t*) &base()[cp_index];
   }
 
-  jint* int_at_addr(int which) const {
-    assert(is_within_bounds(which), "index out of bounds");
-    return (jint*) &base()[which];
+  jint* int_at_addr(int cp_index) const {
+    assert(is_within_bounds(cp_index), "index out of bounds");
+    return (jint*) &base()[cp_index];
   }
 
-  jlong* long_at_addr(int which) const {
-    assert(is_within_bounds(which), "index out of bounds");
-    return (jlong*) &base()[which];
+  jlong* long_at_addr(int cp_index) const {
+    assert(is_within_bounds(cp_index), "index out of bounds");
+    return (jlong*) &base()[cp_index];
   }
 
-  jfloat* float_at_addr(int which) const {
-    assert(is_within_bounds(which), "index out of bounds");
-    return (jfloat*) &base()[which];
+  jfloat* float_at_addr(int cp_index) const {
+    assert(is_within_bounds(cp_index), "index out of bounds");
+    return (jfloat*) &base()[cp_index];
   }
 
-  jdouble* double_at_addr(int which) const {
-    assert(is_within_bounds(which), "index out of bounds");
-    return (jdouble*) &base()[which];
+  jdouble* double_at_addr(int cp_index) const {
+    assert(is_within_bounds(cp_index), "index out of bounds");
+    return (jdouble*) &base()[cp_index];
   }
 
   ConstantPool(Array<u1>* tags);
@@ -270,260 +270,260 @@ class ConstantPool : public Metadata {
   // Storing constants
 
   // For temporary use while constructing constant pool
-  void klass_index_at_put(int which, int name_index) {
-    tag_at_put(which, JVM_CONSTANT_ClassIndex);
-    *int_at_addr(which) = name_index;
+  void klass_index_at_put(int cp_index, int name_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_ClassIndex);
+    *int_at_addr(cp_index) = name_index;
   }
 
   // Hidden class support:
   void klass_at_put(int class_index, Klass* k);
 
-  void unresolved_klass_at_put(int which, int name_index, int resolved_klass_index) {
-    release_tag_at_put(which, JVM_CONSTANT_UnresolvedClass);
+  void unresolved_klass_at_put(int cp_index, int name_index, int resolved_klass_index) {
+    release_tag_at_put(cp_index, JVM_CONSTANT_UnresolvedClass);
 
     assert((name_index & 0xffff0000) == 0, "must be");
     assert((resolved_klass_index & 0xffff0000) == 0, "must be");
-    *int_at_addr(which) =
+    *int_at_addr(cp_index) =
       build_int_from_shorts((jushort)resolved_klass_index, (jushort)name_index);
   }
 
-  void method_handle_index_at_put(int which, int ref_kind, int ref_index) {
-    tag_at_put(which, JVM_CONSTANT_MethodHandle);
-    *int_at_addr(which) = ((jint) ref_index<<16) | ref_kind;
+  void method_handle_index_at_put(int cp_index, int ref_kind, int ref_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_MethodHandle);
+    *int_at_addr(cp_index) = ((jint) ref_index<<16) | ref_kind;
   }
 
-  void method_type_index_at_put(int which, int ref_index) {
-    tag_at_put(which, JVM_CONSTANT_MethodType);
-    *int_at_addr(which) = ref_index;
+  void method_type_index_at_put(int cp_index, int ref_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_MethodType);
+    *int_at_addr(cp_index) = ref_index;
   }
 
-  void dynamic_constant_at_put(int which, int bsms_attribute_index, int name_and_type_index) {
-    tag_at_put(which, JVM_CONSTANT_Dynamic);
-    *int_at_addr(which) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
+  void dynamic_constant_at_put(int cp_index, int bsms_attribute_index, int name_and_type_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_Dynamic);
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
   }
 
-  void invoke_dynamic_at_put(int which, int bsms_attribute_index, int name_and_type_index) {
-    tag_at_put(which, JVM_CONSTANT_InvokeDynamic);
-    *int_at_addr(which) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
+  void invoke_dynamic_at_put(int cp_index, int bsms_attribute_index, int name_and_type_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_InvokeDynamic);
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
   }
 
-  void unresolved_string_at_put(int which, Symbol* s) {
+  void unresolved_string_at_put(int cp_index, Symbol* s) {
     assert(s->refcount() != 0, "should have nonzero refcount");
     // Note that release_tag_at_put is not needed here because this is called only
     // when constructing a ConstantPool in a single thread, with no possibility
     // of concurrent access.
-    tag_at_put(which, JVM_CONSTANT_String);
-    *symbol_at_addr(which) = s;
+    tag_at_put(cp_index, JVM_CONSTANT_String);
+    *symbol_at_addr(cp_index) = s;
   }
 
-  void int_at_put(int which, jint i) {
-    tag_at_put(which, JVM_CONSTANT_Integer);
-    *int_at_addr(which) = i;
+  void int_at_put(int cp_index, jint i) {
+    tag_at_put(cp_index, JVM_CONSTANT_Integer);
+    *int_at_addr(cp_index) = i;
   }
 
-  void long_at_put(int which, jlong l) {
-    tag_at_put(which, JVM_CONSTANT_Long);
+  void long_at_put(int cp_index, jlong l) {
+    tag_at_put(cp_index, JVM_CONSTANT_Long);
     // *long_at_addr(which) = l;
-    Bytes::put_native_u8((address)long_at_addr(which), *((u8*) &l));
+    Bytes::put_native_u8((address)long_at_addr(cp_index), *((u8*) &l));
   }
 
-  void float_at_put(int which, jfloat f) {
-    tag_at_put(which, JVM_CONSTANT_Float);
-    *float_at_addr(which) = f;
+  void float_at_put(int cp_index, jfloat f) {
+    tag_at_put(cp_index, JVM_CONSTANT_Float);
+    *float_at_addr(cp_index) = f;
   }
 
-  void double_at_put(int which, jdouble d) {
-    tag_at_put(which, JVM_CONSTANT_Double);
+  void double_at_put(int cp_index, jdouble d) {
+    tag_at_put(cp_index, JVM_CONSTANT_Double);
     // *double_at_addr(which) = d;
     // u8 temp = *(u8*) &d;
-    Bytes::put_native_u8((address) double_at_addr(which), *((u8*) &d));
+    Bytes::put_native_u8((address) double_at_addr(cp_index), *((u8*) &d));
   }
 
-  Symbol** symbol_at_addr(int which) const {
-    assert(is_within_bounds(which), "index out of bounds");
-    return (Symbol**) &base()[which];
+  Symbol** symbol_at_addr(int cp_index) const {
+    assert(is_within_bounds(cp_index), "index out of bounds");
+    return (Symbol**) &base()[cp_index];
   }
 
-  void symbol_at_put(int which, Symbol* s) {
+  void symbol_at_put(int cp_index, Symbol* s) {
     assert(s->refcount() != 0, "should have nonzero refcount");
-    tag_at_put(which, JVM_CONSTANT_Utf8);
-    *symbol_at_addr(which) = s;
+    tag_at_put(cp_index, JVM_CONSTANT_Utf8);
+    *symbol_at_addr(cp_index) = s;
   }
 
-  void string_at_put(int which, int obj_index, oop str);
+  void string_at_put(int obj_index, oop str);
 
   // For temporary use while constructing constant pool
-  void string_index_at_put(int which, int string_index) {
-    tag_at_put(which, JVM_CONSTANT_StringIndex);
-    *int_at_addr(which) = string_index;
+  void string_index_at_put(int cp_index, int string_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_StringIndex);
+    *int_at_addr(cp_index) = string_index;
   }
 
-  void field_at_put(int which, int class_index, int name_and_type_index) {
-    tag_at_put(which, JVM_CONSTANT_Fieldref);
-    *int_at_addr(which) = ((jint) name_and_type_index<<16) | class_index;
+  void field_at_put(int cp_index, int class_index, int name_and_type_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_Fieldref);
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | class_index;
   }
 
-  void method_at_put(int which, int class_index, int name_and_type_index) {
-    tag_at_put(which, JVM_CONSTANT_Methodref);
-    *int_at_addr(which) = ((jint) name_and_type_index<<16) | class_index;
+  void method_at_put(int cp_index, int class_index, int name_and_type_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_Methodref);
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | class_index;
   }
 
-  void interface_method_at_put(int which, int class_index, int name_and_type_index) {
-    tag_at_put(which, JVM_CONSTANT_InterfaceMethodref);
-    *int_at_addr(which) = ((jint) name_and_type_index<<16) | class_index;  // Not so nice
+  void interface_method_at_put(int cp_index, int class_index, int name_and_type_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_InterfaceMethodref);
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | class_index;  // Not so nice
   }
 
-  void name_and_type_at_put(int which, int name_index, int signature_index) {
-    tag_at_put(which, JVM_CONSTANT_NameAndType);
-    *int_at_addr(which) = ((jint) signature_index<<16) | name_index;  // Not so nice
+  void name_and_type_at_put(int cp_index, int name_index, int signature_index) {
+    tag_at_put(cp_index, JVM_CONSTANT_NameAndType);
+    *int_at_addr(cp_index) = ((jint) signature_index<<16) | name_index;  // Not so nice
   }
 
   // Tag query
 
-  constantTag tag_at(int which) const { return (constantTag)tags()->at_acquire(which); }
+  constantTag tag_at(int cp_index) const { return (constantTag)tags()->at_acquire(cp_index); }
 
   // Fetching constants
 
-  Klass* klass_at(int which, TRAPS) {
+  Klass* klass_at(int cp_index, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return klass_at_impl(h_this, which, THREAD);
+    return klass_at_impl(h_this, cp_index, THREAD);
   }
 
-  CPKlassSlot klass_slot_at(int which) const {
-    assert(tag_at(which).is_unresolved_klass() || tag_at(which).is_klass(),
+  CPKlassSlot klass_slot_at(int cp_index) const {
+    assert(tag_at(cp_index).is_unresolved_klass() || tag_at(cp_index).is_klass(),
            "Corrupted constant pool");
-    int value = *int_at_addr(which);
+    int value = *int_at_addr(cp_index);
     int name_index = extract_high_short_from_int(value);
     int resolved_klass_index = extract_low_short_from_int(value);
     return CPKlassSlot(name_index, resolved_klass_index);
   }
 
-  Symbol* klass_name_at(int which) const;  // Returns the name, w/o resolving.
-  int klass_name_index_at(int which) const {
-    return klass_slot_at(which).name_index();
+  Symbol* klass_name_at(int cp_index) const;  // Returns the name, w/o resolving.
+  int klass_name_index_at(int cp_index) const {
+    return klass_slot_at(cp_index).name_index();
   }
 
-  Klass* resolved_klass_at(int which) const;  // Used by Compiler
+  Klass* resolved_klass_at(int cp_index) const;  // Used by Compiler
 
   // RedefineClasses() API support:
-  Symbol* klass_at_noresolve(int which) { return klass_name_at(which); }
-  void temp_unresolved_klass_at_put(int which, int name_index) {
+  Symbol* klass_at_noresolve(int cp_index) { return klass_name_at(cp_index); }
+  void temp_unresolved_klass_at_put(int cp_index, int name_index) {
     // Used only during constant pool merging for class redefinition. The resolved klass index
     // will be initialized later by a call to initialize_unresolved_klasses().
-    unresolved_klass_at_put(which, name_index, CPKlassSlot::_temp_resolved_klass_index);
+    unresolved_klass_at_put(cp_index, name_index, CPKlassSlot::_temp_resolved_klass_index);
   }
 
-  jint int_at(int which) {
-    assert(tag_at(which).is_int(), "Corrupted constant pool");
-    return *int_at_addr(which);
+  jint int_at(int cp_index) {
+    assert(tag_at(cp_index).is_int(), "Corrupted constant pool");
+    return *int_at_addr(cp_index);
   }
 
-  jlong long_at(int which) {
-    assert(tag_at(which).is_long(), "Corrupted constant pool");
-    // return *long_at_addr(which);
-    u8 tmp = Bytes::get_native_u8((address)&base()[which]);
+  jlong long_at(int cp_index) {
+    assert(tag_at(cp_index).is_long(), "Corrupted constant pool");
+    // return *long_at_addr(cp_index);
+    u8 tmp = Bytes::get_native_u8((address)&base()[cp_index]);
     return *((jlong*)&tmp);
   }
 
-  jfloat float_at(int which) {
-    assert(tag_at(which).is_float(), "Corrupted constant pool");
-    return *float_at_addr(which);
+  jfloat float_at(int cp_index) {
+    assert(tag_at(cp_index).is_float(), "Corrupted constant pool");
+    return *float_at_addr(cp_index);
   }
 
-  jdouble double_at(int which) {
-    assert(tag_at(which).is_double(), "Corrupted constant pool");
-    u8 tmp = Bytes::get_native_u8((address)&base()[which]);
+  jdouble double_at(int cp_index) {
+    assert(tag_at(cp_index).is_double(), "Corrupted constant pool");
+    u8 tmp = Bytes::get_native_u8((address)&base()[cp_index]);
     return *((jdouble*)&tmp);
   }
 
-  Symbol* symbol_at(int which) const {
-    assert(tag_at(which).is_utf8(), "Corrupted constant pool");
-    return *symbol_at_addr(which);
+  Symbol* symbol_at(int cp_index) const {
+    assert(tag_at(cp_index).is_utf8(), "Corrupted constant pool");
+    return *symbol_at_addr(cp_index);
   }
 
-  oop string_at(int which, int obj_index, TRAPS) {
+  oop string_at(int cp_index, int obj_index, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return string_at_impl(h_this, which, obj_index, THREAD);
+    return string_at_impl(h_this, cp_index, obj_index, THREAD);
   }
-  oop string_at(int which, TRAPS) {
-    int obj_index = cp_to_object_index(which);
-    return string_at(which, obj_index, THREAD);
+  oop string_at(int cp_index, TRAPS) {
+    int obj_index = cp_to_object_index(cp_index);
+    return string_at(cp_index, obj_index, THREAD);
   }
 
   // Version that can be used before string oop array is created.
-  oop uncached_string_at(int which, TRAPS);
+  oop uncached_string_at(int cp_index, TRAPS);
 
   // only called when we are sure a string entry is already resolved (via an
   // earlier string_at call.
-  oop resolved_string_at(int which) {
-    assert(tag_at(which).is_string(), "Corrupted constant pool");
+  oop resolved_string_at(int cp_index) {
+    assert(tag_at(cp_index).is_string(), "Corrupted constant pool");
     // Must do an acquire here in case another thread resolved the klass
     // behind our back, lest we later load stale values thru the oop.
     // we might want a volatile_obj_at in ObjArrayKlass.
-    int obj_index = cp_to_object_index(which);
+    int obj_index = cp_to_object_index(cp_index);
     return resolved_reference_at(obj_index);
   }
 
-  Symbol* unresolved_string_at(int which) {
-    assert(tag_at(which).is_string(), "Corrupted constant pool");
-    return *symbol_at_addr(which);
+  Symbol* unresolved_string_at(int cp_index) {
+    assert(tag_at(cp_index).is_string(), "Corrupted constant pool");
+    return *symbol_at_addr(cp_index);
   }
 
   // Returns an UTF8 for a CONSTANT_String entry at a given index.
   // UTF8 char* representation was chosen to avoid conversion of
   // java_lang_Strings at resolved entries into Symbol*s
   // or vice versa.
-  char* string_at_noresolve(int which);
+  char* string_at_noresolve(int cp_index);
 
-  jint name_and_type_at(int which) {
-    assert(tag_at(which).is_name_and_type(), "Corrupted constant pool");
-    return *int_at_addr(which);
+  jint name_and_type_at(int cp_index) {
+    assert(tag_at(cp_index).is_name_and_type(), "Corrupted constant pool");
+    return *int_at_addr(cp_index);
   }
 
-  int method_handle_ref_kind_at(int which) {
-    assert(tag_at(which).is_method_handle() ||
-           tag_at(which).is_method_handle_in_error(), "Corrupted constant pool");
-    return extract_low_short_from_int(*int_at_addr(which));  // mask out unwanted ref_index bits
+  int method_handle_ref_kind_at(int cp_index) {
+    assert(tag_at(cp_index).is_method_handle() ||
+           tag_at(cp_index).is_method_handle_in_error(), "Corrupted constant pool");
+    return extract_low_short_from_int(*int_at_addr(cp_index));  // mask out unwanted ref_index bits
   }
-  int method_handle_index_at(int which) {
-    assert(tag_at(which).is_method_handle() ||
-           tag_at(which).is_method_handle_in_error(), "Corrupted constant pool");
-    return extract_high_short_from_int(*int_at_addr(which));  // shift out unwanted ref_kind bits
+  int method_handle_index_at(int cp_index) {
+    assert(tag_at(cp_index).is_method_handle() ||
+           tag_at(cp_index).is_method_handle_in_error(), "Corrupted constant pool");
+    return extract_high_short_from_int(*int_at_addr(cp_index));  // shift out unwanted ref_kind bits
   }
-  int method_type_index_at(int which) {
-    assert(tag_at(which).is_method_type() ||
-           tag_at(which).is_method_type_in_error(), "Corrupted constant pool");
-    return *int_at_addr(which);
+  int method_type_index_at(int cp_index) {
+    assert(tag_at(cp_index).is_method_type() ||
+           tag_at(cp_index).is_method_type_in_error(), "Corrupted constant pool");
+    return *int_at_addr(cp_index);
   }
 
   // Derived queries:
-  Symbol* method_handle_name_ref_at(int which) {
-    int member = method_handle_index_at(which);
+  Symbol* method_handle_name_ref_at(int cp_index) {
+    int member = method_handle_index_at(cp_index);
     return uncached_name_ref_at(member);
   }
-  Symbol* method_handle_signature_ref_at(int which) {
-    int member = method_handle_index_at(which);
+  Symbol* method_handle_signature_ref_at(int cp_index) {
+    int member = method_handle_index_at(cp_index);
     return uncached_signature_ref_at(member);
   }
-  u2 method_handle_klass_index_at(int which) {
-    int member = method_handle_index_at(which);
+  u2 method_handle_klass_index_at(int cp_index) {
+    int member = method_handle_index_at(cp_index);
     return uncached_klass_ref_index_at(member);
   }
-  Symbol* method_type_signature_at(int which) {
-    int sym = method_type_index_at(which);
+  Symbol* method_type_signature_at(int cp_index) {
+    int sym = method_type_index_at(cp_index);
     return symbol_at(sym);
   }
 
-  u2 bootstrap_name_and_type_ref_index_at(int which) {
-    assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
-    return extract_high_short_from_int(*int_at_addr(which));
+  u2 bootstrap_name_and_type_ref_index_at(int cp_index) {
+    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
+    return extract_high_short_from_int(*int_at_addr(cp_index));
   }
-  u2 bootstrap_methods_attribute_index(int which) {
-    assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
-    return extract_low_short_from_int(*int_at_addr(which));
+  u2 bootstrap_methods_attribute_index(int cp_index) {
+    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
+    return extract_low_short_from_int(*int_at_addr(cp_index));
   }
-  int bootstrap_operand_base(int which) {
-    int bsms_attribute_index = bootstrap_methods_attribute_index(which);
+  int bootstrap_operand_base(int cp_index) {
+    int bsms_attribute_index = bootstrap_methods_attribute_index(cp_index);
     return operand_offset_at(operands(), bsms_attribute_index);
   }
   // The first part of the operands array consists of an index into the second part.
@@ -563,8 +563,8 @@ class ConstantPool : public Metadata {
     else
       return operand_offset_at(operands, nextidx);
   }
-  int bootstrap_operand_limit(int which) {
-    int bsms_attribute_index = bootstrap_methods_attribute_index(which);
+  int bootstrap_operand_limit(int cp_index) {
+    int bsms_attribute_index = bootstrap_methods_attribute_index(cp_index);
     return operand_limit_at(operands(), bsms_attribute_index);
   }
 #endif //ASSERT
@@ -618,22 +618,22 @@ class ConstantPool : public Metadata {
   // Shrink the operands array to a smaller array with new_len length
   void shrink_operands(int new_len, TRAPS);
 
-  u2 bootstrap_method_ref_index_at(int which) {
-    assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
-    int op_base = bootstrap_operand_base(which);
+  u2 bootstrap_method_ref_index_at(int cp_index) {
+    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
+    int op_base = bootstrap_operand_base(cp_index);
     return operands()->at(op_base + _indy_bsm_offset);
   }
-  u2 bootstrap_argument_count_at(int which) {
-    assert(tag_at(which).has_bootstrap(), "Corrupted constant pool");
-    int op_base = bootstrap_operand_base(which);
+  u2 bootstrap_argument_count_at(int cp_index) {
+    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
+    int op_base = bootstrap_operand_base(cp_index);
     u2 argc = operands()->at(op_base + _indy_argc_offset);
     DEBUG_ONLY(int end_offset = op_base + _indy_argv_offset + argc;
-               int next_offset = bootstrap_operand_limit(which));
+               int next_offset = bootstrap_operand_limit(cp_index));
     assert(end_offset == next_offset, "matched ending");
     return argc;
   }
-  u2 bootstrap_argument_index_at(int which, int j) {
-    int op_base = bootstrap_operand_base(which);
+  u2 bootstrap_argument_index_at(int cp_index, int j) {
+    int op_base = bootstrap_operand_base(cp_index);
     DEBUG_ONLY(int argc = operands()->at(op_base + _indy_argc_offset));
     assert((uint)j < (uint)argc, "oob");
     return operands()->at(op_base + _indy_argv_offset + j);
@@ -676,10 +676,10 @@ class ConstantPool : public Metadata {
   int to_cp_index(int which, Bytecodes::Code code);
 
   // Lookup for entries consisting of (name_index, signature_index)
-  u2 name_ref_index_at(int which_nt);            // ==  low-order jshort of name_and_type_at(which_nt)
-  u2 signature_ref_index_at(int which_nt);       // == high-order jshort of name_and_type_at(which_nt)
+  u2 name_ref_index_at(int cp_index);            // ==  low-order jshort of name_and_type_at(cp_index)
+  u2 signature_ref_index_at(int cp_index);       // == high-order jshort of name_and_type_at(cp_index)
 
-  BasicType basic_type_for_signature_at(int which) const;
+  BasicType basic_type_for_signature_at(int cp_index) const;
 
   // Resolve string constants (to prevent allocation during compilation)
   void resolve_string_constants(TRAPS) {
@@ -701,14 +701,14 @@ class ConstantPool : public Metadata {
  public:
 
   // Get the tag for a constant, which may involve a constant dynamic
-  constantTag constant_tag_at(int which);
+  constantTag constant_tag_at(int cp_index);
   // Get the basic type for a constant, which may involve a constant dynamic
-  BasicType basic_type_for_constant_at(int which);
+  BasicType basic_type_for_constant_at(int cp_index);
 
   // Resolve late bound constants.
-  oop resolve_constant_at(int index, TRAPS) {
+  oop resolve_constant_at(int cp_index, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return resolve_constant_at_impl(h_this, index, _no_index_sentinel, nullptr, THREAD);
+    return resolve_constant_at_impl(h_this, cp_index, _no_index_sentinel, nullptr, THREAD);
   }
 
   oop resolve_cached_constant_at(int cache_index, TRAPS) {
@@ -716,27 +716,27 @@ class ConstantPool : public Metadata {
     return resolve_constant_at_impl(h_this, _no_index_sentinel, cache_index, nullptr, THREAD);
   }
 
-  oop resolve_possibly_cached_constant_at(int pool_index, TRAPS) {
+  oop resolve_possibly_cached_constant_at(int cp_index, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return resolve_constant_at_impl(h_this, pool_index, _possible_index_sentinel, nullptr, THREAD);
+    return resolve_constant_at_impl(h_this, cp_index, _possible_index_sentinel, nullptr, THREAD);
   }
 
-  oop find_cached_constant_at(int pool_index, bool& found_it, TRAPS) {
+  oop find_cached_constant_at(int cp_index, bool& found_it, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return resolve_constant_at_impl(h_this, pool_index, _possible_index_sentinel, &found_it, THREAD);
+    return resolve_constant_at_impl(h_this, cp_index, _possible_index_sentinel, &found_it, THREAD);
   }
 
-  void copy_bootstrap_arguments_at(int index,
+  void copy_bootstrap_arguments_at(int cp_index,
                                    int start_arg, int end_arg,
                                    objArrayHandle info, int pos,
                                    bool must_resolve, Handle if_not_available, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    copy_bootstrap_arguments_at_impl(h_this, index, start_arg, end_arg,
+    copy_bootstrap_arguments_at_impl(h_this, cp_index, start_arg, end_arg,
                                      info, pos, must_resolve, if_not_available, THREAD);
   }
 
   // Klass name matches name at offset
-  bool klass_name_at_matches(const InstanceKlass* k, int which);
+  bool klass_name_at_matches(const InstanceKlass* k, int cp_index);
 
   // Sizing
   int length() const                   { return _length; }
@@ -791,7 +791,7 @@ class ConstantPool : public Metadata {
   int pre_resolve_shared_klasses(TRAPS);
 
   // Debugging
-  const char* printable_name_at(int which) PRODUCT_RETURN0;
+  const char* printable_name_at(int cp_index) PRODUCT_RETURN0;
 
 #ifdef ASSERT
   enum { CPCACHE_INDEX_TAG = 0x10000 };  // helps keep CP cache indices distinct from CP indices
@@ -813,14 +813,14 @@ class ConstantPool : public Metadata {
   void set_reference_map(Array<u2>* o)    { _cache->set_reference_map(o); }
 
   // Used while constructing constant pool (only by ClassFileParser)
-  jint klass_index_at(int which) {
-    assert(tag_at(which).is_klass_index(), "Corrupted constant pool");
-    return *int_at_addr(which);
+  jint klass_index_at(int cp_index) {
+    assert(tag_at(cp_index).is_klass_index(), "Corrupted constant pool");
+    return *int_at_addr(cp_index);
   }
 
-  jint string_index_at(int which) {
-    assert(tag_at(which).is_string_index(), "Corrupted constant pool");
-    return *int_at_addr(which);
+  jint string_index_at(int cp_index) {
+    assert(tag_at(cp_index).is_string_index(), "Corrupted constant pool");
+    return *int_at_addr(cp_index);
   }
 
   // Performs the LinkResolver checks
@@ -828,23 +828,23 @@ class ConstantPool : public Metadata {
 
   // Implementation of methods that needs an exposed 'this' pointer, in order to
   // handle GC while executing the method
-  static Klass* klass_at_impl(const constantPoolHandle& this_cp, int which, TRAPS);
-  static oop string_at_impl(const constantPoolHandle& this_cp, int which, int obj_index, TRAPS);
+  static Klass* klass_at_impl(const constantPoolHandle& this_cp, int cp_index, TRAPS);
+  static oop string_at_impl(const constantPoolHandle& this_cp, int cp_index, int obj_index, TRAPS);
 
   static void trace_class_resolution(const constantPoolHandle& this_cp, Klass* k);
 
   // Resolve string constants (to prevent allocation during compilation)
   static void resolve_string_constants_impl(const constantPoolHandle& this_cp, TRAPS);
 
-  static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int index, int cache_index,
+  static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int cp_index, int cache_index,
                                       bool* status_return, TRAPS);
-  static void copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int index,
+  static void copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int cp_index,
                                                int start_arg, int end_arg,
                                                objArrayHandle info, int pos,
                                                bool must_resolve, Handle if_not_available, TRAPS);
 
   // Exception handling
-  static void save_and_throw_exception(const constantPoolHandle& this_cp, int which, constantTag tag, TRAPS);
+  static void save_and_throw_exception(const constantPoolHandle& this_cp, int cp_index, constantTag tag, TRAPS);
 
  public:
   // Exception handling
@@ -852,12 +852,12 @@ class ConstantPool : public Metadata {
 
   // Merging ConstantPool* support:
   bool compare_entry_to(int index1, const constantPoolHandle& cp2, int index2);
-  void copy_cp_to(int start_i, int end_i, const constantPoolHandle& to_cp, int to_i, TRAPS) {
+  void copy_cp_to(int start_cpi, int end_cpi, const constantPoolHandle& to_cp, int to_cpi, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    copy_cp_to_impl(h_this, start_i, end_i, to_cp, to_i, THREAD);
+    copy_cp_to_impl(h_this, start_cpi, end_cpi, to_cp, to_cpi, THREAD);
   }
-  static void copy_cp_to_impl(const constantPoolHandle& from_cp, int start_i, int end_i, const constantPoolHandle& to_cp, int to_i, TRAPS);
-  static void copy_entry_to(const constantPoolHandle& from_cp, int from_i, const constantPoolHandle& to_cp, int to_i);
+  static void copy_cp_to_impl(const constantPoolHandle& from_cp, int start_cpi, int end_cpi, const constantPoolHandle& to_cp, int to_cpi, TRAPS);
+  static void copy_entry_to(const constantPoolHandle& from_cp, int from_cpi, const constantPoolHandle& to_cp, int to_cpi);
   static void copy_operands(const constantPoolHandle& from_cp, const constantPoolHandle& to_cp, TRAPS);
   int  find_matching_entry(int pattern_i, const constantPoolHandle& search_cp);
   int  version() const                    { return _saved._version; }

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -706,9 +706,9 @@ class ConstantPool : public Metadata {
   BasicType basic_type_for_constant_at(int cp_index);
 
   // Resolve late bound constants.
-  oop resolve_constant_at(int cp_index, TRAPS) {
+  oop resolve_constant_at(int index, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return resolve_constant_at_impl(h_this, cp_index, _no_index_sentinel, nullptr, THREAD);
+    return resolve_constant_at_impl(h_this, index, _no_index_sentinel, nullptr, THREAD);
   }
 
   oop resolve_cached_constant_at(int cache_index, TRAPS) {
@@ -836,7 +836,7 @@ class ConstantPool : public Metadata {
   // Resolve string constants (to prevent allocation during compilation)
   static void resolve_string_constants_impl(const constantPoolHandle& this_cp, TRAPS);
 
-  static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int cp_index, int cache_index,
+  static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int index, int cache_index,
                                       bool* status_return, TRAPS);
   static void copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int cp_index,
                                                int start_arg, int end_arg,


### PR DESCRIPTION
Many accessors in the constant pool take an argument "int which" that is meant to represent an ambiguous index. Despite this, several methods in the API use "int which" when the argument is exclusively a constant pool index. This patch aims to rename all of these instances to "int cp_index" in order to be more clear and to distinguish methods that take constant pool indices and methods that use derived indices.

The callers have been updated to use more clear naming as well. Verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307312](https://bugs.openjdk.org/browse/JDK-8307312): Replace "int which" with "int cp_index" in constantPool (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [eae4e38a](https://git.openjdk.org/jdk/pull/15027/files/eae4e38a8e6fbfa3ea799d84647fcbb5a155318a)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15027/head:pull/15027` \
`$ git checkout pull/15027`

Update a local copy of the PR: \
`$ git checkout pull/15027` \
`$ git pull https://git.openjdk.org/jdk.git pull/15027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15027`

View PR using the GUI difftool: \
`$ git pr show -t 15027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15027.diff">https://git.openjdk.org/jdk/pull/15027.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15027#issuecomment-1654557843)