### PR TITLE
8313081: MonitoringSupport_lock should be unconditionally initialized after 8304074

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -224,9 +224,9 @@ void mutex_init() {
 
     MUTEX_DEFN(MarkStackFreeList_lock        , PaddedMutex  , nosafepoint);
     MUTEX_DEFN(MarkStackChunkList_lock       , PaddedMutex  , nosafepoint);
-
-    MUTEX_DEFN(MonitoringSupport_lock        , PaddedMutex  , service-1);      // used for serviceability monitoring support
   }
+  MUTEX_DEFN(MonitoringSupport_lock          , PaddedMutex  , service-1);        // used for serviceability monitoring support
+
   MUTEX_DEFN(StringDedup_lock                , PaddedMonitor, nosafepoint);
   MUTEX_DEFN(StringDedupIntern_lock          , PaddedMutex  , nosafepoint);
   MUTEX_DEFN(RawMonitor_lock                 , PaddedMutex  , nosafepoint-1);

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2116,6 +2116,7 @@ JVM_ENTRY(jlong, jmm_GetTotalThreadAllocatedMemory(JNIEnv *env))
     }
 
     {
+      assert(MonitoringSupport_lock != nullptr, "Must be");
       MutexLocker ml(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
       if (result < high_water_result) {
         // Encountered (2) above, or result wrapped to a negative value. In

--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
@@ -22,10 +22,19 @@
  */
 
 /*
- * @test
- * @bug     6173675 8231209 8304074
+ * @test    id=G1
+ * @bug     6173675 8231209 8304074 8313081
  * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
- * @author  Paul Hohensee
+ * @requires vm.gc.G1
+ * @run main/othervm -XX:+UseG1GC ThreadAllocatedMemory
+ */
+
+/*
+ * @test    id=Serial
+ * @bug     6173675 8231209 8304074 8313081
+ * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
+ * @requires vm.gc.Serial
+ * @run main/othervm -XX:+UseSerialGC ThreadAllocatedMemory
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
MonitoringSupport_lock is initialized only when UseG1GC is true, but [JDK-8304074](https://bugs.openjdk.org/browse/JDK-8304074) uses it to implement getTotalThreadAllocatedBytes, which is available for all garbage collectors. While the current code sets UseG1GC regardless of which collector is specified, see FLAG_SET_ERGO_IF_DEFAULT(UseG1GC, true) in gcConfig.cpp, if G1 isn't included in the Hotspot build or Hotspot is not running on a server class machine (unlikely these days), the lock will not be initialized. The lock's initialization should be unconditional.

I updated ThreadAllocatedMemory.java to run the test using both G1 and Serial collectors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313081](https://bugs.openjdk.org/browse/JDK-8313081): MonitoringSupport_lock should be unconditionally initialized after 8304074 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [e84cb69c](https://git.openjdk.org/jdk/pull/15028/files/e84cb69ceda88484fd4a113c49a2628fae6739dc)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [e84cb69c](https://git.openjdk.org/jdk/pull/15028/files/e84cb69ceda88484fd4a113c49a2628fae6739dc)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15028/head:pull/15028` \
`$ git checkout pull/15028`

Update a local copy of the PR: \
`$ git checkout pull/15028` \
`$ git pull https://git.openjdk.org/jdk.git pull/15028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15028`

View PR using the GUI difftool: \
`$ git pr show -t 15028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15028.diff">https://git.openjdk.org/jdk/pull/15028.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15028#issuecomment-1650614883)