### PR TITLE
8313087: DerValue::toString should output a hex view of the values in byte array

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -1133,7 +1133,8 @@ public class DerValue {
     @Override
     public String toString() {
         return String.format("DerValue(%02x, %s, %d, %d)",
-                0xff & tag, buffer, start, end);
+                0xff & tag, HexFormat.of().withUpperCase().formatHex(buffer),
+                start, end);
     }
 
     /**


### PR DESCRIPTION
DerValue::toString may be better to output the hex view of the byte array variable `buffer`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313087](https://bugs.openjdk.org/browse/JDK-8313087): DerValue::toString should output a hex view of the values in byte array (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15029/head:pull/15029` \
`$ git checkout pull/15029`

Update a local copy of the PR: \
`$ git checkout pull/15029` \
`$ git pull https://git.openjdk.org/jdk.git pull/15029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15029`

View PR using the GUI difftool: \
`$ git pr show -t 15029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15029.diff">https://git.openjdk.org/jdk/pull/15029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15029#issuecomment-1650949489)