### PR TITLE
8313139: Redefine INTERNAL_VISIBILITY when on Windows

### DIFF
--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -29,6 +29,11 @@
 #include "asm/register.hpp"
 #include "utilities/powerOfTwo.hpp"
 
+#ifdef _WIN32
+#undef INTERNAL_VISIBILITY
+#define INTERNAL_VISIBILITY
+#endif
+
 class VMRegImpl;
 typedef VMRegImpl* VMReg;
 
@@ -74,7 +79,7 @@ class Register {
   constexpr const RegisterImpl* operator->() const { return RegisterImpl::first() + _encoding; }
 };
 
-extern Register::RegisterImpl all_RegisterImpls[Register::number_of_declared_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern Register::RegisterImpl all_RegisterImpls[Register::number_of_declared_registers + 1];
 
 inline constexpr const Register::RegisterImpl* Register::RegisterImpl::first() {
   return all_RegisterImpls + 1;
@@ -195,7 +200,7 @@ class FloatRegister {
   constexpr const FloatRegisterImpl* operator->() const { return FloatRegisterImpl::first() + _encoding; }
 };
 
-extern FloatRegister::FloatRegisterImpl all_FloatRegisterImpls[FloatRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern FloatRegister::FloatRegisterImpl all_FloatRegisterImpls[FloatRegister::number_of_registers + 1];
 
 inline constexpr const FloatRegister::FloatRegisterImpl* FloatRegister::FloatRegisterImpl::first() {
   return all_FloatRegisterImpls + 1;
@@ -327,7 +332,7 @@ public:
   const PRegisterImpl* operator->() const { return PRegisterImpl::first() + _encoding; }
 };
 
-extern PRegister::PRegisterImpl all_PRegisterImpls[PRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern PRegister::PRegisterImpl all_PRegisterImpls[PRegister::number_of_registers + 1];
 
 inline constexpr const PRegister::PRegisterImpl* PRegister::PRegisterImpl::first() {
   return all_PRegisterImpls + 1;

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -107,7 +107,7 @@ class Register {
   constexpr const RegisterImpl* operator->() const { return RegisterImpl::first() + _encoding; }
 };
 
-extern Register::RegisterImpl all_RegisterImpls[Register::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern Register::RegisterImpl all_RegisterImpls[Register::number_of_registers + 1];
 
 inline constexpr const Register::RegisterImpl* Register::RegisterImpl::first() {
   return all_RegisterImpls + 1;
@@ -222,7 +222,7 @@ class FloatRegister {
   constexpr const FloatRegisterImpl* operator->() const { return FloatRegisterImpl::first() + _encoding; }
 };
 
-extern FloatRegister::FloatRegisterImpl all_FloatRegisterImpls[FloatRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern FloatRegister::FloatRegisterImpl all_FloatRegisterImpls[FloatRegister::number_of_registers + 1];
 
 inline constexpr const FloatRegister::FloatRegisterImpl* FloatRegister::FloatRegisterImpl::first() {
   return all_FloatRegisterImpls + 1;
@@ -317,7 +317,7 @@ class VectorRegister {
   constexpr const VectorRegisterImpl* operator->() const { return VectorRegisterImpl::first() + _encoding; }
 };
 
-extern VectorRegister::VectorRegisterImpl all_VectorRegisterImpls[VectorRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern VectorRegister::VectorRegisterImpl all_VectorRegisterImpls[VectorRegister::number_of_registers + 1];
 
 inline constexpr const VectorRegister::VectorRegisterImpl* VectorRegister::VectorRegisterImpl::first() {
   return all_VectorRegisterImpls + 1;

--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -33,6 +33,11 @@
 class VMRegImpl;
 typedef VMRegImpl* VMReg;
 
+#ifdef _WIN32
+#undef INTERNAL_VISIBILITY
+#define INTERNAL_VISIBILITY
+#endif
+
 // The implementation of integer registers for the x86/x64 architectures.
 class Register {
 private:
@@ -77,7 +82,7 @@ public:
   constexpr const RegisterImpl* operator->() const { return RegisterImpl::first() + _encoding; }
 };
 
-extern const Register::RegisterImpl all_RegisterImpls[Register::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern const Register::RegisterImpl all_RegisterImpls[Register::number_of_registers + 1];
 
 inline constexpr const Register::RegisterImpl* Register::RegisterImpl::first() {
   return all_RegisterImpls + 1;
@@ -159,7 +164,7 @@ public:
   const FloatRegisterImpl* operator->() const { return FloatRegisterImpl::first() + _encoding; }
 };
 
-extern const FloatRegister::FloatRegisterImpl all_FloatRegisterImpls[FloatRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern const FloatRegister::FloatRegisterImpl all_FloatRegisterImpls[FloatRegister::number_of_registers + 1];
 
 inline constexpr const FloatRegister::FloatRegisterImpl* FloatRegister::FloatRegisterImpl::first() {
   return all_FloatRegisterImpls + 1;
@@ -232,7 +237,7 @@ public:
   }
 };
 
-extern const XMMRegister::XMMRegisterImpl all_XMMRegisterImpls[XMMRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern const XMMRegister::XMMRegisterImpl all_XMMRegisterImpls[XMMRegister::number_of_registers + 1];
 
 inline constexpr const XMMRegister::XMMRegisterImpl* XMMRegister::XMMRegisterImpl::first() {
   return all_XMMRegisterImpls + 1;
@@ -333,7 +338,7 @@ public:
   const KRegisterImpl* operator->() const { return KRegisterImpl::first() + _encoding; }
 };
 
-extern const KRegister::KRegisterImpl all_KRegisterImpls[KRegister::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern const KRegister::KRegisterImpl all_KRegisterImpls[KRegister::number_of_registers + 1];
 
 inline constexpr const KRegister::KRegisterImpl* KRegister::KRegisterImpl::first() {
   return all_KRegisterImpls + 1;

--- a/src/hotspot/share/asm/register.hpp
+++ b/src/hotspot/share/asm/register.hpp
@@ -63,7 +63,7 @@ enum { name##_##type##EnumValue = (value) }
 inline constexpr type as_ ## type(int encoding) {                       \
   return impl_type::first() + encoding;                                 \
 }                                                                       \
-extern impl_type all_ ## type ## s[reg_count + 1] INTERNAL_VISIBILITY;  \
+INTERNAL_VISIBILITY extern impl_type all_ ## type ## s[reg_count + 1];  \
 inline constexpr type impl_type::first() { return all_ ## type ## s + 1; }
 
 #define REGISTER_IMPL_DEFINITION(type, impl_type, reg_count)            \
@@ -82,7 +82,7 @@ const type name = ((type)value)
 // For definitions of RegisterImpl* instances. To be redefined in an
 // OS-specific way.
 #ifdef __GNUC__
-#define INTERNAL_VISIBILITY  __attribute__ ((visibility ("internal")))
+#define INTERNAL_VISIBILITY  [[gnu::visibility ("internal")]]
 #else
 #define INTERNAL_VISIBILITY
 #endif

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -35,6 +35,11 @@
 #include "opto/adlcVMDeps.hpp"
 #endif
 
+#ifdef _WIN32
+#undef INTERNAL_VISIBILITY
+#define INTERNAL_VISIBILITY
+#endif
+
 //------------------------------VMReg------------------------------------------
 // The VM uses 'unwarped' stack slots; the compiler uses 'warped' stack slots.
 // Register numbers below VMRegImpl::stack0 are the same for both.  Register
@@ -154,7 +159,7 @@ public:
 
 };
 
-extern VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1] INTERNAL_VISIBILITY;
+INTERNAL_VISIBILITY extern VMRegImpl all_VMRegs[ConcreteRegisterImpl::number_of_registers + 1];
 inline constexpr VMReg VMRegImpl::first() { return all_VMRegs + 1; }
 
 //---------------------------VMRegPair-------------------------------------------


### PR DESCRIPTION
INTERNAL_VISIBILITY should check for the Operating System we are currently on and should be redefined as specified in the comment if we are on Windows (more OS conditions can be added later).

This change is part of [JDK-8288293](https://bugs.openjdk.org/browse/JDK-8288293), the preliminary phase of which is nearing completion. The changes here are somewhat minimal and hopefully not too disruptive

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313139](https://bugs.openjdk.org/browse/JDK-8313139): Redefine INTERNAL_VISIBILITY when on Windows (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15030/head:pull/15030` \
`$ git checkout pull/15030`

Update a local copy of the PR: \
`$ git checkout pull/15030` \
`$ git pull https://git.openjdk.org/jdk.git pull/15030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15030`

View PR using the GUI difftool: \
`$ git pr show -t 15030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15030.diff">https://git.openjdk.org/jdk/pull/15030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15030#issuecomment-1650986260)