### PR TITLE
8313141: Remove discarded volatile qualifier in assembler_aarch64.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -35,8 +35,8 @@
 
 #ifdef __GNUC__
 
-// __nop needs volatile so that compiler doesn't optimize it away
-#define NOP() asm volatile ("nop");
+// ISO C++ asm is always implicitly volatile
+#define NOP() asm ("nop");
 
 #elif defined(_MSC_VER)
 

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -35,7 +35,7 @@
 
 #ifdef __GNUC__
 
-// ISO C++ asm is always implicitly volatile
+// ISO C++ asm is always implicitly volatile (https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html)
 #define NOP() asm ("nop");
 
 #elif defined(_MSC_VER)

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -35,7 +35,7 @@
 
 #ifdef __GNUC__
 
-// ISO C++ asm is always implicitly volatile (https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html)
+// C++ asm is always implicitly volatile (https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html)
 #define NOP() asm ("nop");
 
 #elif defined(_MSC_VER)

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -35,7 +35,7 @@
 
 #ifdef __GNUC__
 
-// C++ asm is always implicitly volatile (https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html)
+// C++ asm without GNU extensions is always implicitly volatile (https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html)
 #define NOP() asm ("nop");
 
 #elif defined(_MSC_VER)


### PR DESCRIPTION
ISO C++ asm is always implicitly volatile, as per https://gcc.gnu.org/onlinedocs/gcc/Basic-Asm.html, and all volatile qualifiers are always ignored if GNU asm was never used

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313141](https://bugs.openjdk.org/browse/JDK-8313141): Remove discarded volatile qualifier in assembler_aarch64.hpp (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15031/head:pull/15031` \
`$ git checkout pull/15031`

Update a local copy of the PR: \
`$ git checkout pull/15031` \
`$ git pull https://git.openjdk.org/jdk.git pull/15031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15031`

View PR using the GUI difftool: \
`$ git pr show -t 15031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15031.diff">https://git.openjdk.org/jdk/pull/15031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15031#issuecomment-1651001058)