### PR TITLE
8313155: Problem list some JUnit-based tests in test/jdk/java/lang/invoke

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -478,6 +478,8 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
+java/lang/invoke/MethodHandleProxies/BasicTest.java              8313155 linux-all
+java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java 8313155 linux-all
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -478,8 +478,8 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
-java/lang/invoke/MethodHandleProxies/BasicTest.java              8313155 linux-all
-java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java 8313155 linux-all
+java/lang/invoke/MethodHandleProxies/BasicTest.java              8312482 linux-all
+java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java 8312482 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Problem list some JUnit-based tests in `test/jdk/java/lang/invoke/MethodHandleProxies/` for the time being - until `jtreg` 7.3 with a fix for the underlying race condition is released. That fix is tracked via https://bugs.openjdk.org/browse/CODETOOLS-7903507

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313155](https://bugs.openjdk.org/browse/JDK-8313155): Problem list some JUnit-based tests in test/jdk/java/lang/invoke (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15034/head:pull/15034` \
`$ git checkout pull/15034`

Update a local copy of the PR: \
`$ git checkout pull/15034` \
`$ git pull https://git.openjdk.org/jdk.git pull/15034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15034`

View PR using the GUI difftool: \
`$ git pr show -t 15034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15034.diff">https://git.openjdk.org/jdk/pull/15034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15034#issuecomment-1651670109)