### PR TITLE
8312411: MessageFormat.formatToCharacterIterator() can be improved

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -934,20 +934,16 @@ public class MessageFormat extends Format {
      * @since 1.4
      */
     public AttributedCharacterIterator formatToCharacterIterator(Object arguments) {
+        Objects.requireNonNull(arguments, "arguments must not be null");
         StringBuffer result = new StringBuffer();
         ArrayList<AttributedCharacterIterator> iterators = new ArrayList<>();
 
-        if (arguments == null) {
-            throw new NullPointerException(
-                   "formatToCharacterIterator must be passed non-null object");
-        }
         subformat((Object[]) arguments, result, null, iterators);
         if (iterators.size() == 0) {
             return createAttributedCharacterIterator("");
         }
         return createAttributedCharacterIterator(
-                     iterators.toArray(
-                     new AttributedCharacterIterator[iterators.size()]));
+                iterators.toArray(new AttributedCharacterIterator[0]));
     }
 
     /**


### PR DESCRIPTION
Please review this change which makes `MessageFormat.formatToCharacterIterator` fail fast(er). The return statement is also modified to call  toArray() as `toArray(new T[0])` over `toArray(new T[size])`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312411](https://bugs.openjdk.org/browse/JDK-8312411): MessageFormat.formatToCharacterIterator() can be improved (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15035/head:pull/15035` \
`$ git checkout pull/15035`

Update a local copy of the PR: \
`$ git checkout pull/15035` \
`$ git pull https://git.openjdk.org/jdk.git pull/15035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15035`

View PR using the GUI difftool: \
`$ git pr show -t 15035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15035.diff">https://git.openjdk.org/jdk/pull/15035.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15035#issuecomment-1651157092)