### PR TITLE
JDK-8312466: /bin/nm usage in AIX makes needs -X64 flag

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -281,6 +281,12 @@ ifneq ($(GENERATE_COMPILE_COMMANDS_ONLY), true)
         #
     UNDEF_PATTERN := ' U '
 
+    # 'nm' on AIX need -X64 option
+
+    ifeq ($(call isTargetOs, aix), true)
+      NM := $(NM) -X64
+    endif
+
     define SetupOperatorNewDeleteCheck
         $1.op_check: $1
 	  $$(call ExecuteWithLog, $1.op_check, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -281,7 +281,7 @@ ifneq ($(GENERATE_COMPILE_COMMANDS_ONLY), true)
         #
     UNDEF_PATTERN := ' U '
 
-    # 'nm' on AIX need -X64 option
+    # 'nm' on AIX needs -X64 option
 
     ifeq ($(call isTargetOs, aix), true)
       NM := $(NM) -X64


### PR DESCRIPTION
On AIX the 'nm' needs -X64 option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312466](https://bugs.openjdk.org/browse/JDK-8312466): /bin/nm  usage in AIX makes needs -X64 flag (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15036/head:pull/15036` \
`$ git checkout pull/15036`

Update a local copy of the PR: \
`$ git checkout pull/15036` \
`$ git pull https://git.openjdk.org/jdk.git pull/15036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15036`

View PR using the GUI difftool: \
`$ git pr show -t 15036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15036.diff">https://git.openjdk.org/jdk/pull/15036.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15036#issuecomment-1651177650)