### PR TITLE
JDK-8313164: src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp GetRGBPixels adjust releasing of resources

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
@@ -191,13 +191,21 @@ static void GetRGBPixels(jint x, jint y, jint width, jint height, jintArray pixe
     static const int BITS_PER_PIXEL = 32;
     static const int BYTES_PER_PIXEL = BITS_PER_PIXEL/8;
 
-    if (!IS_SAFE_SIZE_MUL(width, height) || !IS_SAFE_SIZE_MUL(BYTES_PER_PIXEL, numPixels)) {
+    if (!IS_SAFE_SIZE_MUL(width, height)) {
         ::DeleteObject(hbitmap);
         ::DeleteDC(hdcMem);
         ::DeleteDC(hdcScreen);
         throw std::bad_alloc();
     }
+
     int numPixels = width*height;
+    if (!IS_SAFE_SIZE_MUL(BYTES_PER_PIXEL, numPixels)) {
+        ::DeleteObject(hbitmap);
+        ::DeleteDC(hdcMem);
+        ::DeleteDC(hdcScreen);
+        throw std::bad_alloc();
+    }
+
     int pixelDataSize = BYTES_PER_PIXEL*numPixels;
     DASSERT(pixelDataSize > 0 && pixelDataSize % 4 == 0);
     // allocate memory for BITMAPINFO + pixel data

--- a/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,6 +170,8 @@ static void GetRGBPixels(jint x, jint y, jint width, jint height, jintArray pixe
     // create an offscreen bitmap
     hbitmap = ::CreateCompatibleBitmap(hdcScreen, width, height);
     if (hbitmap == NULL) {
+        ::DeleteDC(hdcMem);
+        ::DeleteDC(hdcScreen);
         throw std::bad_alloc();
     }
     hOldBitmap = (HBITMAP)::SelectObject(hdcMem, hbitmap);
@@ -189,9 +191,13 @@ static void GetRGBPixels(jint x, jint y, jint width, jint height, jintArray pixe
     static const int BITS_PER_PIXEL = 32;
     static const int BYTES_PER_PIXEL = BITS_PER_PIXEL/8;
 
-    if (!IS_SAFE_SIZE_MUL(width, height)) throw std::bad_alloc();
+    if (!IS_SAFE_SIZE_MUL(width, height) || !IS_SAFE_SIZE_MUL(BYTES_PER_PIXEL, numPixels)) {
+        ::DeleteObject(hbitmap);
+        ::DeleteDC(hdcMem);
+        ::DeleteDC(hdcScreen);
+        throw std::bad_alloc();
+    }
     int numPixels = width*height;
-    if (!IS_SAFE_SIZE_MUL(BYTES_PER_PIXEL, numPixels)) throw std::bad_alloc();
     int pixelDataSize = BYTES_PER_PIXEL*numPixels;
     DASSERT(pixelDataSize > 0 && pixelDataSize % 4 == 0);
     // allocate memory for BITMAPINFO + pixel data
@@ -202,6 +208,9 @@ static void GetRGBPixels(jint x, jint y, jint width, jint height, jintArray pixe
     // See MSDN docs for BITMAPINFOHEADER -bchristi
 
     if (!IS_SAFE_SIZE_ADD(sizeof(BITMAPINFOHEADER) + 3 * sizeof(RGBQUAD), pixelDataSize)) {
+        ::DeleteObject(hbitmap);
+        ::DeleteDC(hdcMem);
+        ::DeleteDC(hdcScreen);
         throw std::bad_alloc();
     }
     BITMAPINFO * pinfo = (BITMAPINFO *)(new BYTE[sizeof(BITMAPINFOHEADER) + 3 * sizeof(RGBQUAD) + pixelDataSize]);


### PR DESCRIPTION
In src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp GetRGBPixels we release some resources at the end of the function by calling DeleteObject/DeleteDC. This is recommended by the MS API docs.
However this should be done as well in some early leaving with throw that can occur in this function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313164](https://bugs.openjdk.org/browse/JDK-8313164): src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp GetRGBPixels adjust releasing of resources (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [9403dc41](https://git.openjdk.org/jdk/pull/15038/files/9403dc41defe095578e06cb57945d484fe05ea5e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15038/head:pull/15038` \
`$ git checkout pull/15038`

Update a local copy of the PR: \
`$ git checkout pull/15038` \
`$ git pull https://git.openjdk.org/jdk.git pull/15038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15038`

View PR using the GUI difftool: \
`$ git pr show -t 15038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15038.diff">https://git.openjdk.org/jdk/pull/15038.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15038#issuecomment-1651540570)