### PR TITLE
8313174: Create fewer predictable port clashes in management tests

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,8 @@ public class RMIAltAuthTest {
             //
             System.out.println("Start RMI registry...");
             Registry reg = null;
-            int port = 5800;
-            while (port++ < 6000) {
+            int port = 5820;
+            while (port++ < 5840) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);

--- a/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class RMIPasswdAuthTest {
             System.out.println("Start RMI registry...");
             Registry reg = null;
             int port = 5800;
-            while (port++ < 6000) {
+            while (port++ < 5820) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);

--- a/test/jdk/javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java
+++ b/test/jdk/javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,8 @@ public class RMISocketFactoriesTest {
             //
             System.out.println("Start RMI registry...");
             Registry reg = null;
-            int port = 5800;
-            while (port++ < 6000) {
+            int port = 5840;
+            while (port++ < 5860) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);

--- a/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java
+++ b/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,8 @@ public class SubjectDelegation1Test {
             //
             System.out.println("Start RMI registry...");
             Registry reg = null;
-            int port = 5800;
-            while (port++ < 6000) {
+            int port = 5860;
+            while (port++ < 5880) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);

--- a/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation2Test.java
+++ b/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class SubjectDelegation2Test {
             //
             System.out.println("Start RMI registry...");
             Registry reg = null;
-            int port = 5800;
+            int port = 5880;
             while (port++ < 6000) {
                 try {
                     reg = LocateRegistry.createRegistry(port);

--- a/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation2Test.java
+++ b/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation2Test.java
@@ -73,7 +73,7 @@ public class SubjectDelegation2Test {
             System.out.println("Start RMI registry...");
             Registry reg = null;
             int port = 5880;
-            while (port++ < 6000) {
+            while (port++ < 5900) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);

--- a/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation3Test.java
+++ b/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,8 @@ public class SubjectDelegation3Test {
             //
             System.out.println("Start RMI registry...");
             Registry reg = null;
-            int port = 5800;
-            while (port++ < 6000) {
+            int port = 6000;
+            while (port++ < 6020) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);

--- a/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation3Test.java
+++ b/test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation3Test.java
@@ -76,8 +76,8 @@ public class SubjectDelegation3Test {
             //
             System.out.println("Start RMI registry...");
             Registry reg = null;
-            int port = 6000;
-            while (port++ < 6020) {
+            int port = 5900;
+            while (port++ < 5920) {
                 try {
                     reg = LocateRegistry.createRegistry(port);
                     System.out.println("RMI registry running on port " + port);


### PR DESCRIPTION
Specifically noticed on linux-aarch64, detection of port clashes by LocateRegistry.createRegistry(port) appears "racy".

Predictable port clashes can be avoided, tests that are likely to run at the same time should not choose the same port.

Why now?  The RMI related parts are obviously fairly stable these days, as are the tests themselves.
Our OS version/host mix for testing may have changed.  The problems I looked into were on ol8-aarch64.

It doesn't seem necessary to add complexities to the tests, or change LocateRegistry much at this point, when a simple change to the tests can avoid asking for so many port clashes.


```
test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java:            int port = 5800;  	// 5801 to 5820
test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java:            int port = 5800;	// 5821 to 5840
test/jdk/javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java:            int port = 5800;	// 5841 to 5860
test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java:            int port = 5800;	// 5861 to 5880
test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation2Test.java:            int port = 5800;	// 5881 to 5900
test/jdk/javax/management/remote/mandatory/subjectDelegation/SubjectDelegation3Test.java:            int port = 5800;	// 5901 to 5920

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313174](https://bugs.openjdk.org/browse/JDK-8313174): Create fewer predictable port clashes in management tests (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15039/head:pull/15039` \
`$ git checkout pull/15039`

Update a local copy of the PR: \
`$ git checkout pull/15039` \
`$ git pull https://git.openjdk.org/jdk.git pull/15039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15039`

View PR using the GUI difftool: \
`$ git pr show -t 15039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15039.diff">https://git.openjdk.org/jdk/pull/15039.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15039#issuecomment-1651609270)