### PR TITLE
8311517: Add performance information to ArrayList javadoc

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -40,11 +40,12 @@ import jdk.internal.util.ArraysSupport;
  * {@code Vector}, except that it is unsynchronized.)
  *
  * <p>The {@code size}, {@code isEmpty}, {@code get}, {@code set},
- * {@code iterator}, and {@code listIterator} operations run in constant
- * time.  The {@code add} operation runs in <i>amortized constant time</i>,
- * that is, adding n elements requires O(n) time.  All of the other operations
- * run in linear time (roughly speaking).  The constant factor is low compared
- * to that for the {@code LinkedList} implementation.
+ * {@code iterator}, {@code listIterator}, and {@code reversed} operations run
+ * in constant time.  The {@code add}, {@code addLast}, and {@code removeLast}
+ * operations runs in <i>amortized constant time</i>, that is, adding n
+ * elements requires O(n) time.  All of the other operations run in linear time
+ * (roughly speaking).  The constant factor is low compared to that for the
+ * {@code LinkedList} implementation.
  *
  * <p>Each {@code ArrayList} instance has a <i>capacity</i>.  The capacity is
  * the size of the array used to store the elements in the list.  It is always

--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -40,12 +40,12 @@ import jdk.internal.util.ArraysSupport;
  * {@code Vector}, except that it is unsynchronized.)
  *
  * <p>The {@code size}, {@code isEmpty}, {@code get}, {@code set},
- * {@code iterator}, {@code listIterator}, and {@code reversed} operations run
- * in constant time.  The {@code add}, {@code addLast}, and {@code removeLast}
- * operations runs in <i>amortized constant time</i>, that is, adding n
- * elements requires O(n) time.  All of the other operations run in linear time
- * (roughly speaking).  The constant factor is low compared to that for the
- * {@code LinkedList} implementation.
+ * {@code getFirst}, {@code getLast}, {@code removeLast}, {@code iterator},
+ * {@code listIterator}, and {@code reversed} operations run in constant time.
+ * The {@code add}, and {@code addLast} operations runs in <i>amortized
+ * constant time</i>, that is, adding n elements requires O(n) time.  All of
+ * the other operations run in linear time (roughly speaking).  The constant
+ * factor is low compared to that for the {@code LinkedList} implementation.
  *
  * <p>Each {@code ArrayList} instance has a <i>capacity</i>.  The capacity is
  * the size of the array used to store the elements in the list.  It is always


### PR DESCRIPTION
The [JEP for sequenced collections](https://openjdk.org/jeps/431) would add addFirst(), removeFirst() and reversed() methods to lists.
However, the Javadoc of List mentions:
 > The size, isEmpty, get, set, iterator, and listIterator operations run in constant time. The add operation runs in amortized constant time, that is, adding n elements requires O(n) time. All of the other operations run in linear time (roughly speaking). The constant factor is low compared to that for the LinkedList implementation.

This PR updates that Javadoc to factor in the new methods introduced by JEP 431.

https://bugs.openjdk.org/browse/JDK-8311517
https://mail.openjdk.org/pipermail/core-libs-dev/2023-June/107328.html
https://mail.openjdk.org/pipermail/core-libs-dev/2023-July/109637.html

This PR only affects documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8313723](https://bugs.openjdk.org/browse/JDK-8313723) to be approved

### Issues
 * [JDK-8311517](https://bugs.openjdk.org/browse/JDK-8311517): Add performance information to ArrayList javadoc (**Bug** - P4)
 * [JDK-8313723](https://bugs.openjdk.org/browse/JDK-8313723): Add performance information to ArrayList javadoc (**CSR**)


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15040/head:pull/15040` \
`$ git checkout pull/15040`

Update a local copy of the PR: \
`$ git checkout pull/15040` \
`$ git pull https://git.openjdk.org/jdk.git pull/15040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15040`

View PR using the GUI difftool: \
`$ git pr show -t 15040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15040.diff">https://git.openjdk.org/jdk/pull/15040.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15040#issuecomment-1651568870)