### PR TITLE
8311104: dangling-gsl warning in libwixhelper.cpp

### DIFF
--- a/src/jdk.jpackage/windows/native/libwixhelper/libwixhelper.cpp
+++ b/src/jdk.jpackage/windows/native/libwixhelper/libwixhelper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,10 +72,10 @@ private:
 
 void findInstalledProducts(const Guid& upgradeCode,
                                             std::vector<ProductInfo>& products) {
-    const LPCTSTR upgradeCodeStr = upgradeCode.toMsiString().c_str();
+    const tstring upgradeCodeStr = upgradeCode.toMsiString();
     for (DWORD productCodeIdx = 0; true; ++productCodeIdx) {
         TCHAR productCode[39 /* http://msdn.microsoft.com/en-us/library/aa370101(v=vs.85).aspx */];
-        const UINT status = MsiEnumRelatedProducts(upgradeCodeStr, 0,
+        const UINT status = MsiEnumRelatedProducts(upgradeCodeStr.c_str(), 0,
                                               productCodeIdx, productCode);
         if (ERROR_NO_MORE_ITEMS == status) {
             break;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311104](https://bugs.openjdk.org/browse/JDK-8311104): dangling-gsl warning in libwixhelper.cpp (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15044/head:pull/15044` \
`$ git checkout pull/15044`

Update a local copy of the PR: \
`$ git checkout pull/15044` \
`$ git pull https://git.openjdk.org/jdk.git pull/15044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15044`

View PR using the GUI difftool: \
`$ git pr show -t 15044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15044.diff">https://git.openjdk.org/jdk/pull/15044.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15044#issuecomment-1652331890)