### PR TITLE
8312618: StringUtils::is_star_match() is too liberal

### DIFF
--- a/src/hotspot/share/classfile/classPrinter.cpp
+++ b/src/hotspot/share/classfile/classPrinter.cpp
@@ -77,7 +77,7 @@ public:
   }
 
   static bool match(const char* pattern, Symbol* sym) {
-    return (pattern == nullptr || sym->is_star_match(pattern));
+    return (pattern == nullptr || sym->is_wildcard_match(pattern));
   }
 
   void print_klass_name(InstanceKlass* ik) {
@@ -87,7 +87,7 @@ public:
   }
 
   void print_instance_klass(InstanceKlass* ik) {
-    if (ik->is_loaded() && ik->name()->is_star_match(_class_name_pattern)) {
+    if (ik->is_loaded() && ik->name()->is_wildcard_match(_class_name_pattern)) {
       ResourceMark rm;
       if (_has_printed_methods) {
         // We have printed some methods in the previous class.

--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -117,13 +117,13 @@ int Symbol::index_of_at(int i, const char* substr, int substr_len) const {
   return -1;
 }
 
-bool Symbol::is_star_match(const char* pattern) const {
+bool Symbol::is_wildcard_match(const char* pattern) const {
   if (strchr(pattern, '*') == nullptr) {
     return equals(pattern);
   } else {
     ResourceMark rm;
     char* buf = as_C_string();
-    return StringUtils::is_star_match(pattern, buf);
+    return StringUtils::is_wildcard_match(pattern, buf);
   }
 }
 

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -202,7 +202,7 @@ class Symbol : public MetaspaceObj {
     return contains_utf8_at(0, str, len);
   }
   bool equals(const char* str) const { return equals(str, (int) strlen(str)); }
-  bool is_star_match(const char* pattern) const;
+  bool is_wildcard_match(const char* pattern) const;
 
   // Tests if the symbol starts with the given prefix.
   bool starts_with(const char* prefix, int len) const {

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1649,7 +1649,7 @@ void find_nodes_by_name(Node* start, const char* name) {
   ResourceMark rm;
   GrowableArray<const Node*> ns;
   auto callback = [&] (const Node* n) {
-    if (StringUtils::is_star_match(name, n->Name())) {
+    if (StringUtils::is_wildcard_match_nocase(name, n->Name())) {
       ns.push(n);
     }
   };
@@ -1666,7 +1666,7 @@ void find_nodes_by_dump(Node* start, const char* pattern) {
   auto callback = [&] (const Node* n) {
     stringStream stream;
     n->dump("", false, &stream);
-    if (StringUtils::is_star_match(pattern, stream.base())) {
+    if (StringUtils::is_wildcard_match_nocase(pattern, stream.base())) {
       ns.push(n);
     }
   };

--- a/src/hotspot/share/utilities/stringUtils.hpp
+++ b/src/hotspot/share/utilities/stringUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,14 +41,12 @@ public:
   // Compute string similarity based on Dice's coefficient
   static double similarity(const char* str1, size_t len1, const char* str2, size_t len2);
 
-  // Find needle in haystack, case insensitive.
-  // Custom implementation of strcasestr, as it is not available on windows.
-  static const char* strstr_nocase(const char* haystack, const char* needle);
-
-  // Check if str matches the star_pattern.
-  // eg. str "_abc____def__" would match pattern "abc*def".
-  // The matching is case insensitive.
-  static bool is_star_match(const char* star_pattern, const char* str);
+  // Check if str matches the pattern.
+  //     eg. str "abc____def__" would match pattern "abc*def*".
+  // Currently the only supported wildcard character is *, but we could implement other
+  // glob patterns in the future. See https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm
+  static bool is_wildcard_match(const char* pattern, const char* str);
+  static bool is_wildcard_match_nocase(const char* pattern, const char* str);
 };
 
 #endif // SHARE_UTILITIES_STRINGUTILS_HPP


### PR DESCRIPTION
**Problem:**

The implementation of `StringUtils::is_star_match()` is too liberal:

- It effectively adds `*` to the beginning and the end of the pattern 
- It always makes case-insensitive comparisons

This would often generate too much output than desired. I.e., `java/*/Class` would match `java/*/ClassLoader`

**Fix:**

- Made the matching similar to Unix glob (https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm), but only support the star pattern for now. We can add other patterns like `?` in the future.
    - `*` is no longer implicitly appended/prepended. The user can explicitly prepend/append `*` if necessary.
    - The algorithm is recursive and could be slow in extreme cases, but should suffice for usual debugging purposes.
- Renamed the API to `StringUtils::is_wildcard_match()` to allow future extension.
- Added a variant `StringUtils::is_wildcard_match_nocase()` for case-insensitive matching. Use this for node.cpp to match the old behavior.
- Removed the `StringUtils::strstr_nocase()` API as it's no longer used.
- Added a gtest case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312618](https://bugs.openjdk.org/browse/JDK-8312618): StringUtils::is_star_match() is too liberal (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15045/head:pull/15045` \
`$ git checkout pull/15045`

Update a local copy of the PR: \
`$ git checkout pull/15045` \
`$ git pull https://git.openjdk.org/jdk.git pull/15045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15045`

View PR using the GUI difftool: \
`$ git pr show -t 15045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15045.diff">https://git.openjdk.org/jdk/pull/15045.diff</a>

</details>
