### PR TITLE
JDK-8312617: SIGSEGV in ConnectionGraph::verify_ram_nodes

### DIFF
--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -109,7 +109,7 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   bool subsume_loads = SubsumeLoads;
   bool do_escape_analysis = DoEscapeAnalysis;
   bool do_iterative_escape_analysis = DoEscapeAnalysis;
-  bool do_reduce_allocation_merges = ReduceAllocationMerges;
+  bool do_reduce_allocation_merges = ReduceAllocationMerges && EliminateAllocations;
   bool eliminate_boxing = EliminateAutoBox;
   bool do_locks_coarsening = EliminateLocks;
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2321,7 +2321,7 @@ void Compile::Optimize() {
         TracePhase tp("macroEliminate", &timers[_t_macroEliminate]);
         PhaseMacroExpand mexp(igvn);
         mexp.eliminate_macro_nodes();
-        if (failing())  return;
+        if (failing()) return;
 
         igvn.set_delay_transform(false);
         igvn.optimize();

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2321,8 +2321,9 @@ void Compile::Optimize() {
         TracePhase tp("macroEliminate", &timers[_t_macroEliminate]);
         PhaseMacroExpand mexp(igvn);
         mexp.eliminate_macro_nodes();
-        igvn.set_delay_transform(false);
+        if (failing())  return;
 
+        igvn.set_delay_transform(false);
         igvn.optimize();
         print_method(PHASE_ITER_GVN_AFTER_ELIMINATION, 2);
       }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3894,7 +3894,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
 
 #ifdef ASSERT
   // At this point reducible Phis shouldn't have AddP users anymore; only SafePoints.
-  for (uint i = 0; i < reducible_merges.size(); i++ ) {
+  for (uint i = 0; i < reducible_merges.size(); i++) {
     Node* phi = reducible_merges.at(i);
     for (DUIterator_Fast jmax, j = phi->fast_outs(jmax); j < jmax; j++) {
       Node *use = phi->fast_out(j);

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3897,7 +3897,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
   for (uint i = 0; i < reducible_merges.size(); i++) {
     Node* phi = reducible_merges.at(i);
     for (DUIterator_Fast jmax, j = phi->fast_outs(jmax); j < jmax; j++) {
-      Node *use = phi->fast_out(j);
+      Node* use = phi->fast_out(j);
       if (!use->is_SafePoint()) {
         phi->dump(-3);
         assert(false, "Unexpected user of reducible Phi -> %s", use->Name());


### PR DESCRIPTION
- Return early from `verify_ram_nodes` if compilation is already failing.
- Add back check for `failing()` after `eliminate_macro_nodes()`.
- Print additional diagnostic information when an unexpected user of RAM is encountered.

Tested with tier1-3 on Linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312617](https://bugs.openjdk.org/browse/JDK-8312617): SIGSEGV in ConnectionGraph::verify_ram_nodes (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [b55cba76](https://git.openjdk.org/jdk/pull/15048/files/b55cba76c4348c9becd66d5dec1ea1e404bf3f5a)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15048/head:pull/15048` \
`$ git checkout pull/15048`

Update a local copy of the PR: \
`$ git checkout pull/15048` \
`$ git pull https://git.openjdk.org/jdk.git pull/15048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15048`

View PR using the GUI difftool: \
`$ git pr show -t 15048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15048.diff">https://git.openjdk.org/jdk/pull/15048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15048#issuecomment-1652626965)