### PR TITLE
8313082: Enable CreateCoredumpOnCrash for testing in makefiles

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -800,6 +800,7 @@ define SetupRunJtregTestBody
   $1_JTREG_BASIC_OPTIONS += -e:JIB_DATA_DIR
   # If running on Windows, propagate the _NT_SYMBOL_PATH to enable
   # symbol lookup in hserr files
+  # The mindumps are disabled by default on client Windows, so enable them
   ifeq ($$(call isTargetOs, windows), true)
     $1_JTREG_BASIC_OPTIONS += -e:_NT_SYMBOL_PATH
     $1_JTREG_BASIC_OPTIONS += -vmoption:-XX:+CreateCoredumpOnCrash

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -802,6 +802,7 @@ define SetupRunJtregTestBody
   # symbol lookup in hserr files
   ifeq ($$(call isTargetOs, windows), true)
     $1_JTREG_BASIC_OPTIONS += -e:_NT_SYMBOL_PATH
+    $1_JTREG_BASIC_OPTIONS += -vmoption:-XX:+CreateCoredumpOnCrash
   else ifeq ($$(call isTargetOs, linux), true)
       $1_JTREG_BASIC_OPTIONS += -e:_JVM_DWARF_PATH=$$(SYMBOLS_IMAGE_DIR)
   endif

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -800,7 +800,7 @@ define SetupRunJtregTestBody
   $1_JTREG_BASIC_OPTIONS += -e:JIB_DATA_DIR
   # If running on Windows, propagate the _NT_SYMBOL_PATH to enable
   # symbol lookup in hserr files
-  # The mindumps are disabled by default on client Windows, so enable them
+  # The minidumps are disabled by default on client Windows, so enable them
   ifeq ($$(call isTargetOs, windows), true)
     $1_JTREG_BASIC_OPTIONS += -e:_NT_SYMBOL_PATH
     $1_JTREG_BASIC_OPTIONS += -vmoption:-XX:+CreateCoredumpOnCrash


### PR DESCRIPTION
The option
CreateCoredumpOnCrash
is enabled by default except the Windows client systems with release binaries. 

So it makes sense to switch it on explicitly in makefiles on Windows while testing. It still could be redefined by adding '-XX-CreateCoredumpOnCrash' as jtreg -vmoption if needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313082](https://bugs.openjdk.org/browse/JDK-8313082): Enable CreateCoredumpOnCrash for testing in makefiles (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d3528891](https://git.openjdk.org/jdk/pull/15050/files/d352889136d8f08d6a919b284d7fc324da284fc0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15050/head:pull/15050` \
`$ git checkout pull/15050`

Update a local copy of the PR: \
`$ git checkout pull/15050` \
`$ git pull https://git.openjdk.org/jdk.git pull/15050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15050`

View PR using the GUI difftool: \
`$ git pr show -t 15050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15050.diff">https://git.openjdk.org/jdk/pull/15050.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15050#issuecomment-1652867961)