### PR TITLE
8313226: Redundant condition test in X509CRLImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,8 +233,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
 
             // revokedCertificates (optional)
             nextByte = (byte)derStrm.peekByte();
-            if ((nextByte == DerValue.tag_SequenceOf)
-                    && (! ((nextByte & 0x0c0) == 0x080))) {
+            if ((nextByte == DerValue.tag_SequenceOf)) {
                 DerValue[] badCerts = derStrm.getSequence(4);
 
                 X500Principal crlIssuer = getIssuerX500Principal();


### PR DESCRIPTION
```
if ((nextByte == DerValue.tag_SequenceOf)
        && (! ((nextByte & 0x0c0) == 0x080))) {
    ...
    ...
}
```
If `nextByte` is `DerValue.tag_SequenceOf`, exactly `0x30`, then the test after `&&` should always be true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313226](https://bugs.openjdk.org/browse/JDK-8313226): Redundant condition test in X509CRLImpl (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15051/head:pull/15051` \
`$ git checkout pull/15051`

Update a local copy of the PR: \
`$ git checkout pull/15051` \
`$ git pull https://git.openjdk.org/jdk.git pull/15051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15051`

View PR using the GUI difftool: \
`$ git pr show -t 15051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15051.diff">https://git.openjdk.org/jdk/pull/15051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15051#issuecomment-1652878759)