### PR TITLE
8313231: Redundant if statement in ZoneInfoFile

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -468,10 +468,9 @@ public final class ZoneInfoFile {
             }
             if (i < savingsInstantTransitions.length) {
                 // javazic writes the last GMT offset into index 0!
-                if (i < savingsInstantTransitions.length) {
-                    offsets[0] = standardOffsets[standardOffsets.length - 1] * 1000;
-                    nOffsets = 1;
-                }
+                offsets[0] = standardOffsets[standardOffsets.length - 1] * 1000;
+                nOffsets = 1;
+
                 // ZoneInfo has a beginning entry for 1900.
                 // Only add it if this is not the only one in table
                 nOffsets = addTrans(transitions, nTrans++,


### PR DESCRIPTION
```
if (i < savingsInstantTransitions.length) {
    // javazic writes the last GMT offset into index 0!
    if (i < savingsInstantTransitions.length) {
        offsets[0] = standardOffsets[standardOffsets.length - 1] * 1000;
        nOffsets = 1;
    }
    ...
}
```

The second if statement looks unnecessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313231](https://bugs.openjdk.org/browse/JDK-8313231): Redundant if statement in ZoneInfoFile (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Stephen Colebourne](https://openjdk.org/census#scolebourne) (@jodastephen - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15052/head:pull/15052` \
`$ git checkout pull/15052`

Update a local copy of the PR: \
`$ git checkout pull/15052` \
`$ git pull https://git.openjdk.org/jdk.git pull/15052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15052`

View PR using the GUI difftool: \
`$ git pr show -t 15052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15052.diff">https://git.openjdk.org/jdk/pull/15052.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15052#issuecomment-1653012615)