### PR TITLE
8313250: Exclude java/foreign/TestByteBuffer.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -787,3 +787,8 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macos
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
+
+############################################################################
+# java/foreign
+
+java/foreign/TestByteBuffer.java 8309475 aix-ppc64


### PR DESCRIPTION
exclude java/foreign/TestByteBuffer on AIX until https://bugs.openjdk.org/browse/JDK-8309475 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313250](https://bugs.openjdk.org/browse/JDK-8313250): Exclude java/foreign/TestByteBuffer.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15055/head:pull/15055` \
`$ git checkout pull/15055`

Update a local copy of the PR: \
`$ git checkout pull/15055` \
`$ git pull https://git.openjdk.org/jdk.git pull/15055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15055`

View PR using the GUI difftool: \
`$ git pr show -t 15055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15055.diff">https://git.openjdk.org/jdk/pull/15055.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15055#issuecomment-1653776049)