### PR TITLE
8313249: Fix -Wconversion warnings in verifier code

### DIFF
--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -53,8 +53,8 @@ class StackMapFrame : public ResourceObj {
                          // instruction modification, to allow rewinding
                          // when/if an error occurs.
 
-  int32_t _max_locals;
-  int32_t _max_stack;
+  u2 _max_locals;
+  u2 _max_stack;
 
   u1 _flags;
   VerificationType* _locals; // local variable type array
@@ -100,8 +100,8 @@ class StackMapFrame : public ResourceObj {
   // which have _locals_size and _stack_size array elements in _locals and _stack.
   StackMapFrame(int32_t offset,
                 u1 flags,
-                u2 locals_size,
-                u2 stack_size,
+                int32_t locals_size,
+                int32_t stack_size,
                 u2 max_locals,
                 u2 max_stack,
                 VerificationType* locals,
@@ -122,8 +122,8 @@ class StackMapFrame : public ResourceObj {
   inline void set_offset(int32_t offset)      { _offset = offset; }
   inline void set_verifier(ClassVerifier* v)  { _verifier = v; }
   inline void set_flags(u1 flags)             { _flags = flags; }
-  inline void set_locals_size(u2 locals_size) { _locals_size = locals_size; }
-  inline void set_stack_size(u2 stack_size)   { _stack_size = _stack_mark = stack_size; }
+  inline void set_locals_size(int32_t locals_size) { _locals_size = locals_size; }
+  inline void set_stack_size(int32_t stack_size)   { _stack_size = _stack_mark = stack_size; }
   inline void clear_stack()                   { _stack_size = 0; }
   inline int32_t offset()   const             { return _offset; }
   inline ClassVerifier* verifier() const      { return _verifier; }
@@ -132,8 +132,8 @@ class StackMapFrame : public ResourceObj {
   inline VerificationType* locals() const     { return _locals; }
   inline int32_t stack_size() const           { return _stack_size; }
   inline VerificationType* stack() const      { return _stack; }
-  inline int32_t max_locals() const           { return _max_locals; }
-  inline int32_t max_stack() const            { return _max_stack; }
+  inline u2 max_locals() const                { return _max_locals; }
+  inline u2 max_stack() const                 { return _max_stack; }
   inline bool flag_this_uninit() const        { return _flags & FLAG_THIS_UNINIT; }
 
   // Set locals and stack types to bogus

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -478,7 +478,7 @@ class chop_frame : public stack_map_frame {
   }
 
   static u1 chops_to_frame_type(int chop) {
-    return static_cast<u1>(251 - chop);
+    return checked_cast<u1>(251 - chop);
   }
 
  public:
@@ -549,7 +549,7 @@ class append_frame : public stack_map_frame {
 
   static u1 appends_to_frame_type(int appends) {
     assert(appends > 0 && appends < 4, "Invalid append amount");
-    return static_cast<u1>(251 + appends);
+    return checked_cast<u1>(251 + appends);
   }
 
  public:

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -550,7 +550,7 @@ class append_frame : public stack_map_frame {
 
   static u1 appends_to_frame_type(int appends) {
     assert(appends > 0 && appends < 4, "Invalid append amount");
-    return (u1)(251 + appends);
+    return static_cast<u1>(251 + appends);
   }
 
  public:

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -222,7 +222,7 @@ class same_frame : public stack_map_frame {
   static int frame_type_to_offset_delta(u1 frame_type) {
       return frame_type + 1; }
   static u1 offset_delta_to_frame_type(int offset_delta) {
-      return (u1)(offset_delta - 1); }
+      return checked_cast<u1>(offset_delta - 1); }
 
  public:
 
@@ -301,7 +301,7 @@ class same_frame_extended : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
+    Bytes::put_Java_u2(offset_delta_addr(), checked_cast<u2>(offset_delta - 1));
   }
 
   int number_of_types() const { return 0; }
@@ -437,7 +437,7 @@ class same_locals_1_stack_item_extended : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
+    Bytes::put_Java_u2(offset_delta_addr(), checked_cast<u2>(offset_delta - 1));
   }
 
   void set_type(verification_type_info* vti) {
@@ -507,7 +507,7 @@ class chop_frame : public stack_map_frame {
     return Bytes::get_Java_u2(offset_delta_addr()) + 1;
   }
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
+    Bytes::put_Java_u2(offset_delta_addr(), checked_cast<u2>(offset_delta - 1));
   }
 
   int chops() const {
@@ -598,7 +598,7 @@ class append_frame : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
+    Bytes::put_Java_u2(offset_delta_addr(), checked_cast<u2>(offset_delta - 1));
   }
 
   void set_appends(int appends) {
@@ -748,7 +748,7 @@ class full_frame : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
+    Bytes::put_Java_u2(offset_delta_addr(), checked_cast<u2>(offset_delta - 1));
   }
   void set_num_locals(int num_locals) {
     Bytes::put_Java_u2(num_locals_addr(), checked_cast<u2>(num_locals));

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -478,7 +478,8 @@ class chop_frame : public stack_map_frame {
   }
 
   static u1 chops_to_frame_type(int chop) {
-    return (u1)(251 - chop);
+    assert(chop >= 0 && chop <= 251, "chop value negative");
+    return checked_cast<u1>(251 - chop);
   }
 
  public:

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -301,7 +301,7 @@ class same_frame_extended : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), offset_delta - 1);
+    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
   }
 
   int number_of_types() const { return 0; }
@@ -437,7 +437,7 @@ class same_locals_1_stack_item_extended : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), offset_delta - 1);
+    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
   }
 
   void set_type(verification_type_info* vti) {
@@ -478,7 +478,7 @@ class chop_frame : public stack_map_frame {
   }
 
   static u1 chops_to_frame_type(int chop) {
-    return 251 - chop;
+    return (u1)(251 - chop);
   }
 
  public:
@@ -507,7 +507,7 @@ class chop_frame : public stack_map_frame {
     return Bytes::get_Java_u2(offset_delta_addr()) + 1;
   }
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), offset_delta - 1);
+    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
   }
 
   int chops() const {
@@ -549,7 +549,7 @@ class append_frame : public stack_map_frame {
 
   static u1 appends_to_frame_type(int appends) {
     assert(appends > 0 && appends < 4, "Invalid append amount");
-    return 251 + appends;
+    return (u1)(251 + appends);
   }
 
  public:
@@ -598,7 +598,7 @@ class append_frame : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), offset_delta - 1);
+    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
   }
 
   void set_appends(int appends) {
@@ -748,13 +748,13 @@ class full_frame : public stack_map_frame {
   }
 
   void set_offset_delta(int offset_delta) {
-    Bytes::put_Java_u2(offset_delta_addr(), offset_delta - 1);
+    Bytes::put_Java_u2(offset_delta_addr(), (u2)(offset_delta - 1));
   }
   void set_num_locals(int num_locals) {
-    Bytes::put_Java_u2(num_locals_addr(), num_locals);
+    Bytes::put_Java_u2(num_locals_addr(), checked_cast<u2>(num_locals));
   }
   void set_stack_slots(address end_of_locals, int stack_slots) {
-    Bytes::put_Java_u2(stack_slots_addr(end_of_locals), stack_slots);
+    Bytes::put_Java_u2(stack_slots_addr(end_of_locals), checked_cast<u2>(stack_slots));
   }
 
   // These return only the locals.  Extra processing is required for stack

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -478,8 +478,7 @@ class chop_frame : public stack_map_frame {
   }
 
   static u1 chops_to_frame_type(int chop) {
-    assert(chop >= 0 && chop <= 251, "chop value negative");
-    return checked_cast<u1>(251 - chop);
+    return static_cast<u1>(251 - chop);
   }
 
  public:

--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -162,7 +162,7 @@ class VerificationType {
       // to discriminate between oops and primitives.
       return VerificationType((uintptr_t)sh);
   }
-  static VerificationType uninitialized_type(u2 bci)
+  static VerificationType uninitialized_type(int bci)
     { return VerificationType(bci << 1 * BitsPerByte | Uninitialized); }
   static VerificationType uninitialized_this_type()
     { return uninitialized_type(BciForThis); }

--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -162,7 +162,7 @@ class VerificationType {
       // to discriminate between oops and primitives.
       return VerificationType((uintptr_t)sh);
   }
-  static VerificationType uninitialized_type(int bci)
+  static VerificationType uninitialized_type(u2 bci)
     { return VerificationType(bci << 1 * BitsPerByte | Uninitialized); }
   static VerificationType uninitialized_this_type()
     { return uninitialized_type(BciForThis); }

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -344,30 +344,30 @@ Symbol* Verifier::inference_verify(
 TypeOrigin TypeOrigin::null() {
   return TypeOrigin();
 }
-TypeOrigin TypeOrigin::local(u2 index, StackMapFrame* frame) {
+TypeOrigin TypeOrigin::local(int index, StackMapFrame* frame) {
   assert(frame != nullptr, "Must have a frame");
   return TypeOrigin(CF_LOCALS, index, StackMapFrame::copy(frame),
      frame->local_at(index));
 }
-TypeOrigin TypeOrigin::stack(u2 index, StackMapFrame* frame) {
+TypeOrigin TypeOrigin::stack(int index, StackMapFrame* frame) {
   assert(frame != nullptr, "Must have a frame");
   return TypeOrigin(CF_STACK, index, StackMapFrame::copy(frame),
       frame->stack_at(index));
 }
-TypeOrigin TypeOrigin::sm_local(u2 index, StackMapFrame* frame) {
+TypeOrigin TypeOrigin::sm_local(int index, StackMapFrame* frame) {
   assert(frame != nullptr, "Must have a frame");
   return TypeOrigin(SM_LOCALS, index, StackMapFrame::copy(frame),
       frame->local_at(index));
 }
-TypeOrigin TypeOrigin::sm_stack(u2 index, StackMapFrame* frame) {
+TypeOrigin TypeOrigin::sm_stack(int index, StackMapFrame* frame) {
   assert(frame != nullptr, "Must have a frame");
   return TypeOrigin(SM_STACK, index, StackMapFrame::copy(frame),
       frame->stack_at(index));
 }
-TypeOrigin TypeOrigin::bad_index(u2 index) {
+TypeOrigin TypeOrigin::bad_index(int index) {
   return TypeOrigin(BAD_INDEX, index, nullptr, VerificationType::bogus_type());
 }
-TypeOrigin TypeOrigin::cp(u2 index, VerificationType vt) {
+TypeOrigin TypeOrigin::cp(int index, VerificationType vt) {
   return TypeOrigin(CONST_POOL, index, nullptr, vt);
 }
 TypeOrigin TypeOrigin::signature(VerificationType vt) {
@@ -702,8 +702,8 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
 // For clang, the only good constant format string is a literal constant format string.
 #define bad_type_msg "Bad type on operand stack in %s"
 
-  int32_t max_stack = m->verifier_max_stack();
-  int32_t max_locals = m->max_locals();
+  u2 max_stack = m->verifier_max_stack();
+  u2 max_locals = m->max_locals();
   constantPoolHandle cp(THREAD, m->constants());
 
   // Method signature was checked in ClassFileParser.
@@ -715,7 +715,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
   // Set initial locals
   VerificationType return_type = current_frame.set_locals_from_arg( m, current_type());
 
-  int32_t stackmap_index = 0; // index to the stackmap array
+  u2 stackmap_index = 0; // index to the stackmap array
 
   u4 code_length = m->code_size();
 
@@ -762,7 +762,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
     if (was_recursively_verified())  return;
 
     opcode = bcs.raw_next();
-    u2 bci = bcs.bci();
+    int bci = bcs.bci();
 
     // Set current frame's offset to bci
     current_frame.set_offset(bci);
@@ -781,7 +781,6 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
 
     // Merge with the next instruction
     {
-      u2 index;
       int target;
       VerificationType type, type2;
       VerificationType atype;
@@ -883,50 +882,55 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
         case Bytecodes::_iload_0 :
         case Bytecodes::_iload_1 :
         case Bytecodes::_iload_2 :
-        case Bytecodes::_iload_3 :
-          index = opcode - Bytecodes::_iload_0;
+        case Bytecodes::_iload_3 : {
+          int index = opcode - Bytecodes::_iload_0;
           verify_iload(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_lload :
           verify_lload(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_lload_0 :
         case Bytecodes::_lload_1 :
         case Bytecodes::_lload_2 :
-        case Bytecodes::_lload_3 :
-          index = opcode - Bytecodes::_lload_0;
+        case Bytecodes::_lload_3 : {
+          int index = opcode - Bytecodes::_lload_0;
           verify_lload(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_fload :
           verify_fload(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_fload_0 :
         case Bytecodes::_fload_1 :
         case Bytecodes::_fload_2 :
-        case Bytecodes::_fload_3 :
-          index = opcode - Bytecodes::_fload_0;
+        case Bytecodes::_fload_3 : {
+          int index = opcode - Bytecodes::_fload_0;
           verify_fload(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_dload :
           verify_dload(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_dload_0 :
         case Bytecodes::_dload_1 :
         case Bytecodes::_dload_2 :
-        case Bytecodes::_dload_3 :
-          index = opcode - Bytecodes::_dload_0;
+        case Bytecodes::_dload_3 : {
+          int index = opcode - Bytecodes::_dload_0;
           verify_dload(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_aload :
           verify_aload(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_aload_0 :
         case Bytecodes::_aload_1 :
         case Bytecodes::_aload_2 :
-        case Bytecodes::_aload_3 :
-          index = opcode - Bytecodes::_aload_0;
+        case Bytecodes::_aload_3 : {
+          int index = opcode - Bytecodes::_aload_0;
           verify_aload(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_iaload :
           type = current_frame.pop_stack(
             VerificationType::integer_type(), CHECK_VERIFY(this));
@@ -1054,50 +1058,55 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
         case Bytecodes::_istore_0 :
         case Bytecodes::_istore_1 :
         case Bytecodes::_istore_2 :
-        case Bytecodes::_istore_3 :
-          index = opcode - Bytecodes::_istore_0;
+        case Bytecodes::_istore_3 : {
+          int index = opcode - Bytecodes::_istore_0;
           verify_istore(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_lstore :
           verify_lstore(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_lstore_0 :
         case Bytecodes::_lstore_1 :
         case Bytecodes::_lstore_2 :
-        case Bytecodes::_lstore_3 :
-          index = opcode - Bytecodes::_lstore_0;
+        case Bytecodes::_lstore_3 : {
+          int index = opcode - Bytecodes::_lstore_0;
           verify_lstore(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_fstore :
           verify_fstore(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_fstore_0 :
         case Bytecodes::_fstore_1 :
         case Bytecodes::_fstore_2 :
-        case Bytecodes::_fstore_3 :
-          index = opcode - Bytecodes::_fstore_0;
+        case Bytecodes::_fstore_3 : {
+          int index = opcode - Bytecodes::_fstore_0;
           verify_fstore(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_dstore :
           verify_dstore(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_dstore_0 :
         case Bytecodes::_dstore_1 :
         case Bytecodes::_dstore_2 :
-        case Bytecodes::_dstore_3 :
-          index = opcode - Bytecodes::_dstore_0;
+        case Bytecodes::_dstore_3 : {
+          int index = opcode - Bytecodes::_dstore_0;
           verify_dstore(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_astore :
           verify_astore(bcs.get_index(), &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
         case Bytecodes::_astore_0 :
         case Bytecodes::_astore_1 :
         case Bytecodes::_astore_2 :
-        case Bytecodes::_astore_3 :
-          index = opcode - Bytecodes::_astore_0;
+        case Bytecodes::_astore_3 : {
+          int index = opcode - Bytecodes::_astore_0;
           verify_astore(index, &current_frame, CHECK_VERIFY(this));
           no_control_flow = false; break;
+          }
         case Bytecodes::_iastore :
           type = current_frame.pop_stack(
             VerificationType::integer_type(), CHECK_VERIFY(this));
@@ -1708,7 +1717,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
           no_control_flow = false; break;
         case Bytecodes::_new :
         {
-          index = bcs.get_index_u2();
+          u2 index = bcs.get_index_u2();
           verify_cp_class_type(bci, index, cp, CHECK_VERIFY(this));
           VerificationType new_class_type =
             cp_index_to_type(index, cp, CHECK_VERIFY(this));
@@ -1745,7 +1754,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
           no_control_flow = false; break;
         case Bytecodes::_checkcast :
         {
-          index = bcs.get_index_u2();
+          u2 index = bcs.get_index_u2();
           verify_cp_class_type(bci, index, cp, CHECK_VERIFY(this));
           current_frame.pop_stack(object_type(), CHECK_VERIFY(this));
           VerificationType klass_type = cp_index_to_type(
@@ -1754,7 +1763,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
           no_control_flow = false; break;
         }
         case Bytecodes::_instanceof : {
-          index = bcs.get_index_u2();
+          u2 index = bcs.get_index_u2();
           verify_cp_class_type(bci, index, cp, CHECK_VERIFY(this));
           current_frame.pop_stack(object_type(), CHECK_VERIFY(this));
           current_frame.push_stack(
@@ -1768,7 +1777,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
           no_control_flow = false; break;
         case Bytecodes::_multianewarray :
         {
-          index = bcs.get_index_u2();
+          u2 index = bcs.get_index_u2();
           u2 dim = *(bcs.bcp()+3);
           verify_cp_class_type(bci, index, cp, CHECK_VERIFY(this));
           VerificationType new_array_type =
@@ -1877,7 +1886,7 @@ void ClassVerifier::verify_exception_handler_table(u4 code_length, char* code_da
       class_format_error("Illegal exception table handler_pc %d", handler_pc);
       return;
     }
-    int catch_type_index = exhandlers.catch_type_index(i);
+    u2 catch_type_index = exhandlers.catch_type_index(i);
     if (catch_type_index != 0) {
       VerificationType catch_type = cp_index_to_type(
         catch_type_index, cp, CHECK_VERIFY(this));
@@ -1930,12 +1939,12 @@ void ClassVerifier::verify_local_variable_table(u4 code_length, char* code_data,
   }
 }
 
-u2 ClassVerifier::verify_stackmap_table(u2 stackmap_index, u2 bci,
+u2 ClassVerifier::verify_stackmap_table(u2 stackmap_index, int bci,
                                         StackMapFrame* current_frame,
                                         StackMapTable* stackmap_table,
                                         bool no_control_flow, TRAPS) {
   if (stackmap_index < stackmap_table->get_frame_count()) {
-    u2 this_offset = stackmap_table->get_offset(stackmap_index);
+    int this_offset = stackmap_table->get_offset(stackmap_index);
     if (no_control_flow && this_offset > bci) {
       verify_error(ErrorContext::missing_stackmap(bci),
                    "Expecting a stack map frame");
@@ -1970,7 +1979,7 @@ u2 ClassVerifier::verify_stackmap_table(u2 stackmap_index, u2 bci,
 // Since this method references the constant pool, call was_recursively_verified()
 // before calling this method to make sure a prior class load did not cause the
 // current class to get verified.
-void ClassVerifier::verify_exception_handler_targets(u2 bci, bool this_uninit,
+void ClassVerifier::verify_exception_handler_targets(int bci, bool this_uninit,
                                                      StackMapFrame* current_frame,
                                                      StackMapTable* stackmap_table, TRAPS) {
   constantPoolHandle cp (THREAD, _method->constants());
@@ -2009,7 +2018,7 @@ void ClassVerifier::verify_exception_handler_targets(u2 bci, bool this_uninit,
 }
 
 void ClassVerifier::verify_cp_index(
-    u2 bci, const constantPoolHandle& cp, int index, TRAPS) {
+    int bci, const constantPoolHandle& cp, u2 index, TRAPS) {
   int nconstants = cp->length();
   if ((index <= 0) || (index >= nconstants)) {
     verify_error(ErrorContext::bad_cp_index(bci, index),
@@ -2020,7 +2029,7 @@ void ClassVerifier::verify_cp_index(
 }
 
 void ClassVerifier::verify_cp_type(
-    u2 bci, int index, const constantPoolHandle& cp, unsigned int types, TRAPS) {
+    int bci, u2 index, const constantPoolHandle& cp, unsigned int types, TRAPS) {
 
   // In some situations, bytecode rewriting may occur while we're verifying.
   // In this case, a constant pool cache exists and some indices refer to that
@@ -2039,7 +2048,7 @@ void ClassVerifier::verify_cp_type(
 }
 
 void ClassVerifier::verify_cp_class_type(
-    u2 bci, int index, const constantPoolHandle& cp, TRAPS) {
+    int bci, u2 index, const constantPoolHandle& cp, TRAPS) {
   verify_cp_index(bci, cp, index, CHECK_VERIFY(this));
   constantTag tag = cp->tag_at(index);
   if (!tag.is_klass() && !tag.is_unresolved_klass()) {
@@ -2137,7 +2146,7 @@ bool ClassVerifier::is_protected_access(InstanceKlass* this_class,
 
 void ClassVerifier::verify_ldc(
     int opcode, u2 index, StackMapFrame* current_frame,
-    const constantPoolHandle& cp, u2 bci, TRAPS) {
+    const constantPoolHandle& cp, int bci, TRAPS) {
   verify_cp_index(bci, cp, index, CHECK_VERIFY(this));
   constantTag tag = cp->tag_at(index);
   unsigned int types = 0;
@@ -2340,7 +2349,7 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
   SignatureStream sig_stream(field_sig, false);
   VerificationType stack_object_type;
   int n = change_sig_to_verificationType(&sig_stream, field_type);
-  u2 bci = bcs->bci();
+  int bci = bcs->bci();
   bool is_assignable;
   switch (bcs->raw_code()) {
     case Bytecodes::_getstatic: {
@@ -2459,9 +2468,9 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
   ResourceMark rm;
   // Create bytecode stream.
   RawBytecodeStream bcs(method());
-  u4 code_length = method()->code_size();
+  int code_length = method()->code_size();
   bcs.set_start(start_bc_offset);
-  u4 target;
+
   // Create stack for storing bytecode start offsets for if* and *switch.
   GrowableArray<u4>* bci_stack = new GrowableArray<u4>(30);
   // Create stack for handlers for try blocks containing this handler.
@@ -2478,13 +2487,13 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
     if (bcs.is_last_bytecode()) {
       // if no more starting offsets to parse or if at the end of the
       // method then return false.
-      if ((bci_stack->is_empty()) || ((u4)bcs.end_bci() == code_length))
+      if ((bci_stack->is_empty()) || (bcs.end_bci() == code_length))
         return false;
       // Pop a bytecode starting offset and scan from there.
       bcs.set_start(bci_stack->pop());
     }
     Bytecodes::Code opcode = bcs.raw_next();
-    u4 bci = bcs.bci();
+    int bci = bcs.bci();
 
     // If the bytecode is in a TRY block, push its handlers so they
     // will get parsed.
@@ -2506,8 +2515,8 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
       case Bytecodes::_if_acmpeq:
       case Bytecodes::_if_acmpne:
       case Bytecodes::_ifnull:
-      case Bytecodes::_ifnonnull:
-        target = bcs.dest();
+      case Bytecodes::_ifnonnull: {
+        int target = bcs.dest();
         if (visited_branches->contains(bci)) {
           if (bci_stack->is_empty()) {
             if (handler_stack->is_empty()) {
@@ -2537,10 +2546,11 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
           visited_branches->append(bci);
         }
         break;
+        }
 
       case Bytecodes::_goto:
-      case Bytecodes::_goto_w:
-        target = (opcode == Bytecodes::_goto ? bcs.dest() : bcs.dest_w());
+      case Bytecodes::_goto_w: {
+        int target = (opcode == Bytecodes::_goto ? bcs.dest() : bcs.dest_w());
         if (visited_branches->contains(bci)) {
           if (bci_stack->is_empty()) {
             if (handler_stack->is_empty()) {
@@ -2561,6 +2571,7 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
           visited_branches->append(bci);
         }
         break;
+        }
 
       // Check that all switch alternatives end in 'athrow' bytecodes. Since it
       // is  difficult to determine where each switch alternative ends, parse
@@ -2575,7 +2586,7 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
       case Bytecodes::_tableswitch:
         {
           address aligned_bcp = align_up(bcs.bcp() + 1, jintSize);
-          u4 default_offset = Bytes::get_Java_u4(aligned_bcp) + bci;
+          int default_offset = Bytes::get_Java_u4(aligned_bcp) + bci;
           int keys, delta;
           if (opcode == Bytecodes::_tableswitch) {
             jint low = (jint)Bytes::get_Java_u4(aligned_bcp + jintSize);
@@ -2597,7 +2608,7 @@ bool ClassVerifier::ends_in_athrow(u4 start_bc_offset) {
 
           // Push the switch alternatives onto the stack.
           for (int i = 0; i < keys; i++) {
-            u4 target = bci + (jint)Bytes::get_Java_u4(aligned_bcp+(3+i*delta)*jintSize);
+            int target = bci + (jint)Bytes::get_Java_u4(aligned_bcp+(3+i*delta)*jintSize);
             if (target > code_length) return false;
             bci_stack->push(target);
           }
@@ -2640,7 +2651,7 @@ void ClassVerifier::verify_invoke_init(
     StackMapFrame* current_frame, u4 code_length, bool in_try_block,
     bool *this_uninit, const constantPoolHandle& cp, StackMapTable* stackmap_table,
     TRAPS) {
-  u2 bci = bcs->bci();
+  int bci = bcs->bci();
   VerificationType type = current_frame->pop_stack(
     VerificationType::reference_check(), CHECK_VERIFY(this));
   if (type == VerificationType::uninitialized_this_type()) {
@@ -2845,7 +2856,7 @@ void ClassVerifier::verify_invoke_instructions(
   int nargs = mth_sig_verif_types->num_args();
 
   // Check instruction operands
-  u2 bci = bcs->bci();
+  int bci = bcs->bci();
   if (opcode == Bytecodes::_invokeinterface) {
     address bcp = bcs->bcp();
     // 4905268: count operand in invokeinterface should be nargs+1, not nargs.
@@ -2988,7 +2999,7 @@ void ClassVerifier::verify_invoke_instructions(
 }
 
 VerificationType ClassVerifier::get_newarray_type(
-    u2 index, u2 bci, TRAPS) {
+    u2 index, int bci, TRAPS) {
   const char* from_bt[] = {
     nullptr, nullptr, nullptr, nullptr, "[Z", "[C", "[F", "[D", "[B", "[S", "[I", "[J",
   };
@@ -3003,7 +3014,7 @@ VerificationType ClassVerifier::get_newarray_type(
 }
 
 void ClassVerifier::verify_anewarray(
-    u2 bci, u2 index, const constantPoolHandle& cp,
+    int bci, u2 index, const constantPoolHandle& cp,
     StackMapFrame* current_frame, TRAPS) {
   verify_cp_class_type(bci, index, cp, CHECK_VERIFY(this));
   current_frame->pop_stack(
@@ -3043,14 +3054,14 @@ void ClassVerifier::verify_anewarray(
   current_frame->push_stack(new_array_type, CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_iload(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_iload(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->get_local(
     index, VerificationType::integer_type(), CHECK_VERIFY(this));
   current_frame->push_stack(
     VerificationType::integer_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_lload(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_lload(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->get_local_2(
     index, VerificationType::long_type(),
     VerificationType::long2_type(), CHECK_VERIFY(this));
@@ -3059,14 +3070,14 @@ void ClassVerifier::verify_lload(u2 index, StackMapFrame* current_frame, TRAPS) 
     VerificationType::long2_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_fload(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_fload(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->get_local(
     index, VerificationType::float_type(), CHECK_VERIFY(this));
   current_frame->push_stack(
     VerificationType::float_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_dload(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_dload(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->get_local_2(
     index, VerificationType::double_type(),
     VerificationType::double2_type(), CHECK_VERIFY(this));
@@ -3075,20 +3086,20 @@ void ClassVerifier::verify_dload(u2 index, StackMapFrame* current_frame, TRAPS) 
     VerificationType::double2_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_aload(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_aload(int index, StackMapFrame* current_frame, TRAPS) {
   VerificationType type = current_frame->get_local(
     index, VerificationType::reference_check(), CHECK_VERIFY(this));
   current_frame->push_stack(type, CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_istore(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_istore(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->pop_stack(
     VerificationType::integer_type(), CHECK_VERIFY(this));
   current_frame->set_local(
     index, VerificationType::integer_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_lstore(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_lstore(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->pop_stack_2(
     VerificationType::long2_type(),
     VerificationType::long_type(), CHECK_VERIFY(this));
@@ -3097,13 +3108,13 @@ void ClassVerifier::verify_lstore(u2 index, StackMapFrame* current_frame, TRAPS)
     VerificationType::long2_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_fstore(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_fstore(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->pop_stack(VerificationType::float_type(), CHECK_VERIFY(this));
   current_frame->set_local(
     index, VerificationType::float_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_dstore(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_dstore(int index, StackMapFrame* current_frame, TRAPS) {
   current_frame->pop_stack_2(
     VerificationType::double2_type(),
     VerificationType::double_type(), CHECK_VERIFY(this));
@@ -3112,20 +3123,20 @@ void ClassVerifier::verify_dstore(u2 index, StackMapFrame* current_frame, TRAPS)
     VerificationType::double2_type(), CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_astore(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_astore(int index, StackMapFrame* current_frame, TRAPS) {
   VerificationType type = current_frame->pop_stack(
     VerificationType::reference_check(), CHECK_VERIFY(this));
   current_frame->set_local(index, type, CHECK_VERIFY(this));
 }
 
-void ClassVerifier::verify_iinc(u2 index, StackMapFrame* current_frame, TRAPS) {
+void ClassVerifier::verify_iinc(int index, StackMapFrame* current_frame, TRAPS) {
   VerificationType type = current_frame->get_local(
     index, VerificationType::integer_type(), CHECK_VERIFY(this));
   current_frame->set_local(index, type, CHECK_VERIFY(this));
 }
 
 void ClassVerifier::verify_return_value(
-    VerificationType return_type, VerificationType type, u2 bci,
+    VerificationType return_type, VerificationType type, int bci,
     StackMapFrame* current_frame, TRAPS) {
   if (return_type == VerificationType::bogus_type()) {
     verify_error(ErrorContext::bad_type(bci,

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -1727,7 +1727,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
                 "Illegal new instruction");
             return;
           }
-          type = VerificationType::uninitialized_type(bci);
+          type = VerificationType::uninitialized_type(checked_cast<u2>(bci));
           current_frame.push_stack(type, CHECK_VERIFY(this));
           no_control_flow = false; break;
         }

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -107,25 +107,25 @@ class TypeOrigin {
   } Origin;
 
   Origin _origin;
-  u2 _index;              // local, stack, or constant pool index
+  int _index;              // local, stack, or constant pool index
   StackMapFrame* _frame;  // source frame if CF or SM
   VerificationType _type; // The actual type
 
   TypeOrigin(
-      Origin origin, u2 index, StackMapFrame* frame, VerificationType type)
+      Origin origin, int index, StackMapFrame* frame, VerificationType type)
       : _origin(origin), _index(index), _frame(frame), _type(type) {}
 
  public:
   TypeOrigin() : _origin(NONE), _index(0), _frame(nullptr) {}
 
   static TypeOrigin null();
-  static TypeOrigin local(u2 index, StackMapFrame* frame);
-  static TypeOrigin stack(u2 index, StackMapFrame* frame);
-  static TypeOrigin sm_local(u2 index, StackMapFrame* frame);
-  static TypeOrigin sm_stack(u2 index, StackMapFrame* frame);
-  static TypeOrigin cp(u2 index, VerificationType vt);
+  static TypeOrigin local(int index, StackMapFrame* frame);
+  static TypeOrigin stack(int index, StackMapFrame* frame);
+  static TypeOrigin sm_local(int index, StackMapFrame* frame);
+  static TypeOrigin sm_stack(int index, StackMapFrame* frame);
+  static TypeOrigin cp(int index, VerificationType vt);
   static TypeOrigin signature(VerificationType vt);
-  static TypeOrigin bad_index(u2 index);
+  static TypeOrigin bad_index(int index);
   static TypeOrigin implicit(VerificationType t);
   static TypeOrigin frame(StackMapFrame* frame);
 
@@ -134,7 +134,7 @@ class TypeOrigin {
   void print_frame(outputStream* ss) const;
   const StackMapFrame* frame() const { return _frame; }
   bool is_valid() const { return _origin != NONE; }
-  u2 index() const { return _index; }
+  int index() const { return _index; }
 
 #ifdef ASSERT
   void print_on(outputStream* str) const;
@@ -174,45 +174,45 @@ class ErrorContext {
  public:
   ErrorContext() : _bci(-1), _fault(NO_FAULT) {}
 
-  static ErrorContext bad_code(u2 bci) {
+  static ErrorContext bad_code(int bci) {
     return ErrorContext(bci, INVALID_BYTECODE);
   }
-  static ErrorContext bad_type(u2 bci, TypeOrigin type) {
+  static ErrorContext bad_type(int bci, TypeOrigin type) {
     return ErrorContext(bci, WRONG_TYPE, type);
   }
-  static ErrorContext bad_type(u2 bci, TypeOrigin type, TypeOrigin exp) {
+  static ErrorContext bad_type(int bci, TypeOrigin type, TypeOrigin exp) {
     return ErrorContext(bci, WRONG_TYPE, type, exp);
   }
-  static ErrorContext bad_flags(u2 bci, StackMapFrame* frame) {
+  static ErrorContext bad_flags(int bci, StackMapFrame* frame) {
     return ErrorContext(bci, FLAGS_MISMATCH, TypeOrigin::frame(frame));
   }
-  static ErrorContext bad_flags(u2 bci, StackMapFrame* cur, StackMapFrame* sm) {
+  static ErrorContext bad_flags(int bci, StackMapFrame* cur, StackMapFrame* sm) {
     return ErrorContext(bci, FLAGS_MISMATCH,
                         TypeOrigin::frame(cur), TypeOrigin::frame(sm));
   }
-  static ErrorContext bad_cp_index(u2 bci, u2 index) {
+  static ErrorContext bad_cp_index(int bci, int index) {
     return ErrorContext(bci, BAD_CP_INDEX, TypeOrigin::bad_index(index));
   }
-  static ErrorContext bad_local_index(u2 bci, u2 index) {
+  static ErrorContext bad_local_index(int bci, int index) {
     return ErrorContext(bci, BAD_LOCAL_INDEX, TypeOrigin::bad_index(index));
   }
   static ErrorContext locals_size_mismatch(
-      u2 bci, StackMapFrame* frame0, StackMapFrame* frame1) {
+      int bci, StackMapFrame* frame0, StackMapFrame* frame1) {
     return ErrorContext(bci, LOCALS_SIZE_MISMATCH,
         TypeOrigin::frame(frame0), TypeOrigin::frame(frame1));
   }
   static ErrorContext stack_size_mismatch(
-      u2 bci, StackMapFrame* frame0, StackMapFrame* frame1) {
+      int bci, StackMapFrame* frame0, StackMapFrame* frame1) {
     return ErrorContext(bci, STACK_SIZE_MISMATCH,
         TypeOrigin::frame(frame0), TypeOrigin::frame(frame1));
   }
-  static ErrorContext stack_overflow(u2 bci, StackMapFrame* frame) {
+  static ErrorContext stack_overflow(int bci, StackMapFrame* frame) {
     return ErrorContext(bci, STACK_OVERFLOW, TypeOrigin::frame(frame));
   }
-  static ErrorContext stack_underflow(u2 bci, StackMapFrame* frame) {
+  static ErrorContext stack_underflow(int bci, StackMapFrame* frame) {
     return ErrorContext(bci, STACK_UNDERFLOW, TypeOrigin::frame(frame));
   }
-  static ErrorContext missing_stackmap(u2 bci) {
+  static ErrorContext missing_stackmap(int bci) {
     return ErrorContext(bci, MISSING_STACKMAP);
   }
   static ErrorContext bad_stackmap(int index, StackMapFrame* frame) {
@@ -304,22 +304,22 @@ class ClassVerifier : public StackObj {
     InstanceKlass* this_class, Klass* target_class,
     Symbol* field_name, Symbol* field_sig, bool is_method);
 
-  void verify_cp_index(u2 bci, const constantPoolHandle& cp, int index, TRAPS);
-  void verify_cp_type(u2 bci, int index, const constantPoolHandle& cp,
+  void verify_cp_index(int bci, const constantPoolHandle& cp, u2 index, TRAPS);
+  void verify_cp_type(int bci, u2 index, const constantPoolHandle& cp,
       unsigned int types, TRAPS);
-  void verify_cp_class_type(u2 bci, int index, const constantPoolHandle& cp, TRAPS);
+  void verify_cp_class_type(int bci, u2 index, const constantPoolHandle& cp, TRAPS);
 
   u2 verify_stackmap_table(
-    u2 stackmap_index, u2 bci, StackMapFrame* current_frame,
+    u2 stackmap_index, int bci, StackMapFrame* current_frame,
     StackMapTable* stackmap_table, bool no_control_flow, TRAPS);
 
   void verify_exception_handler_targets(
-    u2 bci, bool this_uninit, StackMapFrame* current_frame,
+    int bci, bool this_uninit, StackMapFrame* current_frame,
     StackMapTable* stackmap_table, TRAPS);
 
   void verify_ldc(
     int opcode, u2 index, StackMapFrame *current_frame,
-    const constantPoolHandle& cp, u2 bci, TRAPS);
+    const constantPoolHandle& cp, int bci, TRAPS);
 
   void verify_switch(
     RawBytecodeStream* bcs, u4 code_length, char* code_data,
@@ -351,24 +351,24 @@ class ClassVerifier : public StackObj {
     bool in_try_block, bool* this_uninit, VerificationType return_type,
     const constantPoolHandle& cp, StackMapTable* stackmap_table, TRAPS);
 
-  VerificationType get_newarray_type(u2 index, u2 bci, TRAPS);
-  void verify_anewarray(u2 bci, u2 index, const constantPoolHandle& cp,
+  VerificationType get_newarray_type(u2 index, int bci, TRAPS);
+  void verify_anewarray(int bci, u2 index, const constantPoolHandle& cp,
       StackMapFrame* current_frame, TRAPS);
   void verify_return_value(
-      VerificationType return_type, VerificationType type, u2 offset,
+      VerificationType return_type, VerificationType type, int bci,
       StackMapFrame* current_frame, TRAPS);
 
-  void verify_iload (u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_lload (u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_fload (u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_dload (u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_aload (u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_istore(u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_lstore(u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_fstore(u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_dstore(u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_astore(u2 index, StackMapFrame* current_frame, TRAPS);
-  void verify_iinc  (u2 index, StackMapFrame* current_frame, TRAPS);
+  void verify_iload (int index, StackMapFrame* current_frame, TRAPS);
+  void verify_lload (int index, StackMapFrame* current_frame, TRAPS);
+  void verify_fload (int index, StackMapFrame* current_frame, TRAPS);
+  void verify_dload (int index, StackMapFrame* current_frame, TRAPS);
+  void verify_aload (int index, StackMapFrame* current_frame, TRAPS);
+  void verify_istore(int index, StackMapFrame* current_frame, TRAPS);
+  void verify_lstore(int index, StackMapFrame* current_frame, TRAPS);
+  void verify_fstore(int index, StackMapFrame* current_frame, TRAPS);
+  void verify_dstore(int index, StackMapFrame* current_frame, TRAPS);
+  void verify_astore(int index, StackMapFrame* current_frame, TRAPS);
+  void verify_iinc  (int index, StackMapFrame* current_frame, TRAPS);
 
   bool name_in_supers(Symbol* ref_name, InstanceKlass* current);
 

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -73,7 +73,7 @@ class Bytecode: public StackObj {
   // Static functions for parsing bytecodes in place.
   u1 get_index_u1(Bytecodes::Code bc) const {
     assert_same_format_as(bc); assert_index_size(1, bc);
-    return *(jubyte*)addr_at(1);
+    return *(u1*)addr_at(1);
   }
   u2 get_index_u2(Bytecodes::Code bc, bool is_wide = false) const {
     assert_same_format_as(bc, is_wide); assert_index_size(2, bc, is_wide);
@@ -86,7 +86,7 @@ class Bytecode: public StackObj {
   }
   int get_index_u1_cpcache(Bytecodes::Code bc) const {
     assert_same_format_as(bc); assert_index_size(1, bc);
-    return *(jubyte*)addr_at(1) + ConstantPool::CPCACHE_INDEX_TAG;
+    return *(u1*)addr_at(1) + ConstantPool::CPCACHE_INDEX_TAG;
   }
   int get_index_u2_cpcache(Bytecodes::Code bc) const {
     assert_same_format_as(bc); assert_index_size(2, bc); assert_native_index(bc);

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -71,11 +71,11 @@ class Bytecode: public StackObj {
   Bytecodes::Code invoke_code() const            { return (code() == Bytecodes::_invokehandle) ? code() : java_code(); }
 
   // Static functions for parsing bytecodes in place.
-  int get_index_u1(Bytecodes::Code bc) const {
+  u1 get_index_u1(Bytecodes::Code bc) const {
     assert_same_format_as(bc); assert_index_size(1, bc);
     return *(jubyte*)addr_at(1);
   }
-  int get_index_u2(Bytecodes::Code bc, bool is_wide = false) const {
+  u2 get_index_u2(Bytecodes::Code bc, bool is_wide = false) const {
     assert_same_format_as(bc, is_wide); assert_index_size(2, bc, is_wide);
     address p = addr_at(is_wide ? 2 : 1);
     if (can_use_native_byte_order(bc, is_wide)) {

--- a/src/hotspot/share/interpreter/bytecodeStream.hpp
+++ b/src/hotspot/share/interpreter/bytecodeStream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ class BaseBytecodeStream: StackObj {
   int             dest_w() const                 { return bci() + bytecode().get_offset_s4(raw_code()); }
 
   // One-byte indices.
-  int             get_index_u1() const           { assert_raw_index_size(1); return *(jubyte*)(bcp()+1); }
+  u1              get_index_u1() const           { assert_raw_index_size(1); return *(jubyte*)(bcp()+1); }
 
  protected:
   void assert_raw_index_size(int size) const NOT_DEBUG_RETURN;
@@ -149,12 +149,12 @@ class RawBytecodeStream: public BaseBytecodeStream {
   Bytecodes::Code raw_next_special(Bytecodes::Code code);
 
   // Unsigned indices, widening, with no swapping of bytes
-  int             get_index() const          { return (is_wide()) ? get_index_u2_raw(bcp() + 2) : get_index_u1(); }
+  u2              get_index() const          { return (is_wide()) ? get_index_u2_raw(bcp() + 2) : get_index_u1(); }
   // Get an unsigned 2-byte index, with no swapping of bytes.
-  int             get_index_u2() const       { assert(!is_wide(), ""); return get_index_u2_raw(bcp() + 1);  }
+  u2              get_index_u2() const       { assert(!is_wide(), ""); return get_index_u2_raw(bcp() + 1);  }
 
  private:
-  int get_index_u2_raw(address p) const {
+  u2  get_index_u2_raw(address p) const {
     assert_raw_index_size(2); assert_raw_stream(true);
     return Bytes::get_Java_u2(p);
   }
@@ -218,9 +218,9 @@ class BytecodeStream: public BaseBytecodeStream {
   Bytecodes::Code code() const                   { return _code; }
 
   // Unsigned indices, widening
-  int             get_index() const              { return is_wide() ? bytecode().get_index_u2(raw_code(), true) : get_index_u1(); }
+  u2              get_index() const              { return is_wide() ? bytecode().get_index_u2(raw_code(), true) : get_index_u1(); }
   // Get an unsigned 2-byte index, swapping the bytes if necessary.
-  int             get_index_u2() const           { assert_raw_stream(false);
+  u2              get_index_u2() const           { assert_raw_stream(false);
                                                    return bytecode().get_index_u2(raw_code(), false); }
   // Get an unsigned 2-byte index in native order.
   int             get_index_u2_cpcache() const   { assert_raw_stream(false);


### PR DESCRIPTION
See bugid for comments.  Most of the verifier code deals with ints, so the u2 and other parameters weren't really needed and can be promoted to int. Mostly types are changed, but a few checked_cast<>s are added.
Tested with tier1-4, sanity Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313249](https://bugs.openjdk.org/browse/JDK-8313249): Fix -Wconversion warnings in verifier code (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [775d12b1](https://git.openjdk.org/jdk/pull/15056/files/775d12b1c6a9e29e0c63eba879f20057075fbb18)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [cabd399d](https://git.openjdk.org/jdk/pull/15056/files/cabd399d590f5ad47fed8c0f4f9344ba9b0d122e)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15056/head:pull/15056` \
`$ git checkout pull/15056`

Update a local copy of the PR: \
`$ git checkout pull/15056` \
`$ git pull https://git.openjdk.org/jdk.git pull/15056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15056`

View PR using the GUI difftool: \
`$ git pr show -t 15056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15056.diff">https://git.openjdk.org/jdk/pull/15056.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15056#issuecomment-1653904757)