### PR TITLE
JDK-8313253: Rename methods in javadoc Comparators class

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractTreeWriter.java
@@ -122,7 +122,7 @@ public abstract class AbstractTreeWriter extends HtmlDocletWriter {
                                         TypeElement typeElement,
                                         Content content)
     {
-        SortedSet<TypeElement> interfaces = new TreeSet<>(comparators.makeGeneralPurposeComparator());
+        SortedSet<TypeElement> interfaces = new TreeSet<>(comparators.generalPurposeComparator());
         typeElement.getInterfaces().forEach(t -> interfaces.add(utils.asTypeElement(t)));
         if (interfaces.size() > (utils.isPlainInterface(typeElement) ? 1 : 0)) {
             boolean isFirst = true;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -96,11 +96,11 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         super(configuration, filename);
         this.typeElement = typeElement;
         if (mapper.classToPackageAnnotations.containsKey(typeElement)) {
-            pkgToPackageAnnotations = new TreeSet<>(comparators.makeClassUseComparator());
+            pkgToPackageAnnotations = new TreeSet<>(comparators.classUseComparator());
             pkgToPackageAnnotations.addAll(mapper.classToPackageAnnotations.get(typeElement));
         }
         configuration.currentTypeElement = typeElement;
-        this.pkgSet = new TreeSet<>(comparators.makePackageComparator());
+        this.pkgSet = new TreeSet<>(comparators.packageComparator());
         this.pkgToClassTypeParameter = pkgDivide(mapper.classToClassTypeParam);
         this.pkgToClassAnnotations = pkgDivide(mapper.classToClassAnnotations);
         this.pkgToMethodTypeParameter = pkgDivide(mapper.classToMethodTypeParam);
@@ -170,7 +170,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         Map<PackageElement, List<Element>> map = new HashMap<>();
         List<? extends Element> elements = classMap.get(typeElement);
         if (elements != null) {
-            elements.sort(comparators.makeClassUseComparator());
+            elements.sort(comparators.classUseComparator());
             for (Element e : elements) {
                 PackageElement pkg = utils.containingPackage(e);
                 pkgSet.add(pkg);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -116,7 +116,7 @@ public class ClassWriter extends SubWriterHolderWriter {
         this.classTree = classTree;
 
         visibleMemberTable = configuration.getVisibleMemberTable(typeElement);
-        summariesComparator = utils.comparators.makeIndexElementComparator();
+        summariesComparator = utils.comparators.indexElementComparator();
         pHelper = new PropertyUtils.PropertyHelper(configuration, typeElement);
 
         switch (typeElement.getKind()) {
@@ -963,7 +963,7 @@ public class ClassWriter extends SubWriterHolderWriter {
     }
 
     protected void addImplementedInterfacesInfo(Content target) {
-        SortedSet<TypeMirror> interfaces = new TreeSet<>(comparators.makeTypeMirrorClassUseComparator());
+        SortedSet<TypeMirror> interfaces = new TreeSet<>(comparators.typeMirrorClassUseComparator());
         interfaces.addAll(utils.getAllInterfaces(typeElement));
         if (utils.isClass(typeElement) && !interfaces.isEmpty()) {
             var dl = HtmlTree.DL(HtmlStyle.notes);
@@ -975,7 +975,7 @@ public class ClassWriter extends SubWriterHolderWriter {
 
     protected void addSuperInterfacesInfo(Content target) {
         SortedSet<TypeMirror> interfaces =
-                new TreeSet<>(comparators.makeTypeMirrorIndexUseComparator());
+                new TreeSet<>(comparators.typeMirrorIndexUseComparator());
         interfaces.addAll(utils.getAllInterfaces(typeElement));
 
         if (utils.isPlainInterface(typeElement) && !interfaces.isEmpty()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
@@ -309,7 +309,7 @@ public class ConstantsSummaryWriter extends HtmlDocletWriter {
             members.addAll(vmt.getVisibleMembers(VisibleMemberTable.Kind.FIELDS));
             members.addAll(vmt.getVisibleMembers(VisibleMemberTable.Kind.ENUM_CONSTANTS));
             SortedSet<VariableElement> includes =
-                    new TreeSet<>(utils.comparators.makeGeneralPurposeComparator());
+                    new TreeSet<>(utils.comparators.generalPurposeComparator());
             for (Element element : members) {
                 VariableElement member = (VariableElement)element;
                 if (member.getConstantValue() != null) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
@@ -399,7 +399,7 @@ public class MethodWriter extends AbstractExecutableMemberWriter {
         var enclosing = (TypeElement) method.getEnclosingElement();
         VisibleMemberTable vmt = writer.configuration.getVisibleMemberTable(enclosing);
         SortedSet<ExecutableElement> implementedMethods =
-                new TreeSet<>(utils.comparators.makeOverrideUseComparator());
+                new TreeSet<>(utils.comparators.overrideUseComparator());
         implementedMethods.addAll(methods);
         for (ExecutableElement implementedMeth : implementedMethods) {
             TypeMirror intfac = vmt.getImplementedMethodHolder(method, implementedMeth);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -75,13 +75,13 @@ public class ModuleWriter extends HtmlDocletWriter {
      * Map of module elements and modifiers required by this module.
      */
     private final Map<ModuleElement, Content> requires
-            = new TreeMap<>(comparators.makeModuleComparator());
+            = new TreeMap<>(comparators.moduleComparator());
 
     /**
      * Map of indirect modules and modifiers, transitive closure, required by this module.
      */
     private final Map<ModuleElement, Content> indirectModules
-            = new TreeMap<>(comparators.makeModuleComparator());
+            = new TreeMap<>(comparators.moduleComparator());
 
     /**
      * Details about a package in a module.
@@ -111,44 +111,44 @@ public class ModuleWriter extends HtmlDocletWriter {
     /**
      * Map of packages of this module, and details of whether they are exported or opened.
      */
-    private final Map<PackageElement, PackageEntry> packages = new TreeMap<>(utils.comparators.makePackageComparator());
+    private final Map<PackageElement, PackageEntry> packages = new TreeMap<>(utils.comparators.packageComparator());
 
     /**
      * Map of indirect modules (transitive closure) and their exported packages.
      */
     private final Map<ModuleElement, SortedSet<PackageElement>> indirectPackages
-            = new TreeMap<>(comparators.makeModuleComparator());
+            = new TreeMap<>(comparators.moduleComparator());
 
     /**
      * Map of indirect modules (transitive closure) and their open packages.
      */
     private final Map<ModuleElement, SortedSet<PackageElement>> indirectOpenPackages
-            = new TreeMap<>(comparators.makeModuleComparator());
+            = new TreeMap<>(comparators.moduleComparator());
 
     /**
      * Set of services used by the module.
      */
     private final SortedSet<TypeElement> uses
-            = new TreeSet<>(comparators.makeAllClassesComparator());
+            = new TreeSet<>(comparators.allClassesComparator());
 
     /**
      * Map of services used by the module and specified using @uses javadoc tag, and description.
      */
     private final Map<TypeElement, Content> usesTrees
-            = new TreeMap<>(comparators.makeAllClassesComparator());
+            = new TreeMap<>(comparators.allClassesComparator());
 
     /**
      * Map of services provided by this module, and set of its implementations.
      */
     private final Map<TypeElement, SortedSet<TypeElement>> provides
-            = new TreeMap<>(comparators.makeAllClassesComparator());
+            = new TreeMap<>(comparators.allClassesComparator());
 
     /**
      * Map of services provided by the module and specified using @provides javadoc tag, and
      * description.
      */
     private final Map<TypeElement, Content> providesTrees
-            = new TreeMap<>(comparators.makeAllClassesComparator());
+            = new TreeMap<>(comparators.allClassesComparator());
 
     private final BodyContents bodyContents = new BodyContents();
 
@@ -348,7 +348,7 @@ public class ModuleWriter extends HtmlDocletWriter {
                 // Include package if in details mode, or exported to all (i.e. targetModules == null)
                 if (moduleMode == ModuleMode.ALL || targetMdles == null) {
                     PackageEntry packageEntry = packages.computeIfAbsent(p, pkg -> new PackageEntry());
-                    SortedSet<ModuleElement> mdleList = new TreeSet<>(utils.comparators.makeModuleComparator());
+                    SortedSet<ModuleElement> mdleList = new TreeSet<>(utils.comparators.moduleComparator());
                     if (targetMdles != null) {
                         mdleList.addAll(targetMdles);
                     }
@@ -366,7 +366,7 @@ public class ModuleWriter extends HtmlDocletWriter {
                 // Include package if in details mode, or opened to all (i.e. targetModules == null)
                 if (moduleMode == ModuleMode.ALL || targetMdles == null) {
                     PackageEntry packageEntry = packages.computeIfAbsent(p, pkg -> new PackageEntry());
-                    SortedSet<ModuleElement> mdleList = new TreeSet<>(utils.comparators.makeModuleComparator());
+                    SortedSet<ModuleElement> mdleList = new TreeSet<>(utils.comparators.moduleComparator());
                     if (targetMdles != null) {
                         mdleList.addAll(targetMdles);
                     }
@@ -378,7 +378,7 @@ public class ModuleWriter extends HtmlDocletWriter {
         // Get all the exported and opened packages, for the transitive closure of the module, to be displayed in
         // the indirect packages tables.
         dependentModules.forEach((module, mod) -> {
-            SortedSet<PackageElement> exportedPackages = new TreeSet<>(utils.comparators.makePackageComparator());
+            SortedSet<PackageElement> exportedPackages = new TreeSet<>(utils.comparators.packageComparator());
             ElementFilter.exportsIn(module.getDirectives()).forEach(directive -> {
                 PackageElement pkg = directive.getPackage();
                 if (shouldDocument(pkg)) {
@@ -393,7 +393,7 @@ public class ModuleWriter extends HtmlDocletWriter {
             if (!exportedPackages.isEmpty()) {
                 indirectPackages.put(module, exportedPackages);
             }
-            SortedSet<PackageElement> openPackages = new TreeSet<>(utils.comparators.makePackageComparator());
+            SortedSet<PackageElement> openPackages = new TreeSet<>(utils.comparators.packageComparator());
             if (module.isOpen()) {
                 openPackages.addAll(utils.getModulePackageMap().getOrDefault(module, Set.of()));
             } else {
@@ -425,7 +425,7 @@ public class ModuleWriter extends HtmlDocletWriter {
             TypeElement u = directive.getService();
             if (shouldDocument(u)) {
                 List<? extends TypeElement> implList = directive.getImplementations();
-                SortedSet<TypeElement> implSet = new TreeSet<>(utils.comparators.makeAllClassesComparator());
+                SortedSet<TypeElement> implSet = new TreeSet<>(utils.comparators.allClassesComparator());
                 implSet.addAll(implList);
                 provides.put(u, implSet);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageUseWriter.java
@@ -79,7 +79,7 @@ public class PackageUseWriter extends SubWriterHolderWriter {
                     Set<TypeElement> usedClasses = usingPackageToUsedClasses
                             .get(utils.getPackageName(usingPackage));
                     if (usedClasses == null) {
-                        usedClasses = new TreeSet<>(comparators.makeGeneralPurposeComparator());
+                        usedClasses = new TreeSet<>(comparators.generalPurposeComparator());
                         usingPackageToUsedClasses.put(utils.getPackageName(usingPackage),
                                                       usedClasses);
                     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriter.java
@@ -109,7 +109,7 @@ public class SerializedFormWriter extends SubWriterHolderWriter {
      * @throws DocletException if there is a problem while building the documentation
      */
      void build() throws DocletException {
-        SortedSet<TypeElement> rootclasses = new TreeSet<>(utils.comparators.makeGeneralPurposeComparator());
+        SortedSet<TypeElement> rootclasses = new TreeSet<>(utils.comparators.generalPurposeComparator());
         rootclasses.addAll(configuration.getIncludedTypeElements());
         if (!serialClassFoundToDocument(rootclasses)) {
             //Nothing to document.
@@ -443,7 +443,7 @@ public class SerializedFormWriter extends SubWriterHolderWriter {
         // ObjectStreamFields. Print a member for each serialField tag.
         // (There should be one serialField tag per ObjectStreamField
         // element.)
-        SortedSet<SerialFieldTree> tags = new TreeSet<>(utils.comparators.makeSerialFieldTreeComparator());
+        SortedSet<SerialFieldTree> tags = new TreeSet<>(utils.comparators.serialFieldTreeComparator());
         // sort the elements
         tags.addAll(utils.getSerialFieldTrees(field));
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AbstractDoclet.java
@@ -228,7 +228,7 @@ public abstract class AbstractDoclet implements Doclet {
     protected void generateClassFiles(ClassTree classTree)
             throws DocletException {
 
-        SortedSet<TypeElement> classes = new TreeSet<>(utils.comparators.makeGeneralPurposeComparator());
+        SortedSet<TypeElement> classes = new TreeSet<>(utils.comparators.generalPurposeComparator());
 
         // handle classes specified as files on the command line
         for (PackageElement pkg : configuration.typeElementCatalog.packages()) {
@@ -236,7 +236,7 @@ public abstract class AbstractDoclet implements Doclet {
         }
 
         // handle classes specified in modules and packages on the command line
-        SortedSet<PackageElement> packages = new TreeSet<>(utils.comparators.makePackageComparator());
+        SortedSet<PackageElement> packages = new TreeSet<>(utils.comparators.packageComparator());
         packages.addAll(configuration.getSpecifiedPackageElements());
         configuration.modulePackages.values().stream().forEach(packages::addAll);
         for (PackageElement pkg : packages) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -286,15 +286,15 @@ public abstract class BaseConfiguration {
     private void initModules() {
         Comparators comparators = utils.comparators;
         // Build the modules structure used by the doclet
-        modules = new TreeSet<>(comparators.makeModuleComparator());
+        modules = new TreeSet<>(comparators.moduleComparator());
         modules.addAll(getSpecifiedModuleElements());
 
-        modulePackages = new TreeMap<>(comparators.makeModuleComparator());
+        modulePackages = new TreeMap<>(comparators.moduleComparator());
         for (PackageElement p : packages) {
             ModuleElement mdle = docEnv.getElementUtils().getModuleOf(p);
             if (mdle != null && !mdle.isUnnamed()) {
                 Set<PackageElement> s = modulePackages
-                        .computeIfAbsent(mdle, m -> new TreeSet<>(comparators.makePackageComparator()));
+                        .computeIfAbsent(mdle, m -> new TreeSet<>(comparators.packageComparator()));
                 s.add(p);
             }
         }
@@ -303,7 +303,7 @@ public abstract class BaseConfiguration {
             ModuleElement mdle = docEnv.getElementUtils().getModuleOf(p);
             if (mdle != null && !mdle.isUnnamed()) {
                 Set<PackageElement> s = modulePackages
-                        .computeIfAbsent(mdle, m -> new TreeSet<>(comparators.makePackageComparator()));
+                        .computeIfAbsent(mdle, m -> new TreeSet<>(comparators.packageComparator()));
                 s.add(p);
             }
         }
@@ -319,7 +319,7 @@ public abstract class BaseConfiguration {
     }
 
     private void initPackages() {
-        packages = new TreeSet<>(utils.comparators.makePackageComparator());
+        packages = new TreeSet<>(utils.comparators.packageComparator());
         // add all the included packages
         packages.addAll(includedPackageElements);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -40,7 +40,6 @@ import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -56,11 +55,8 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
-import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Env;
-import com.sun.tools.javac.model.JavacElements;
 import com.sun.tools.javac.util.Names;
 import com.sun.tools.javac.util.Options;
 
@@ -280,8 +276,8 @@ public class WorkArounds {
         NewSerializedForm(Utils utils, Elements elements, TypeElement te) {
             this.utils = utils;
             this.elements = elements;
-            methods = new TreeSet<>(utils.comparators.makeGeneralPurposeComparator());
-            fields = new TreeSet<>(utils.comparators.makeGeneralPurposeComparator());
+            methods = new TreeSet<>(utils.comparators.generalPurposeComparator());
+            fields = new TreeSet<>(utils.comparators.generalPurposeComparator());
             if (utils.isExternalizable(te)) {
                 /* look up required public accessible methods,
                  *   writeExternal and readExternal.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassTree.java
@@ -185,7 +185,7 @@ public class ClassTree {
         Messages messages = configuration.getMessages();
         messages.notice("doclet.Building_Tree");
 
-        Comparator<Element> comparator = utils.comparators.makeClassUseComparator();
+        Comparator<Element> comparator = utils.comparators.classUseComparator();
 
         hierarchies = new EnumMap<>(HierarchyKind.class);
         for (var hk : HierarchyKind.values()) {
@@ -206,7 +206,7 @@ public class ClassTree {
         this.configuration = configuration;
         this.utils = configuration.utils;
 
-        Comparator<Element> comparator = utils.comparators.makeClassUseComparator();
+        Comparator<Element> comparator = utils.comparators.classUseComparator();
 
         hierarchies = new EnumMap<>(HierarchyKind.class);
         for (var hk : HierarchyKind.values()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassUseMapper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassUseMapper.java
@@ -199,7 +199,7 @@ public class ClassUseMapper {
         utils = configuration.utils;
         comparators = utils.comparators;
         this.classTree = classTree;
-        classToPackage = new TreeMap<>(comparators.makeClassUseComparator());
+        classToPackage = new TreeMap<>(comparators.classUseComparator());
         // Map subclassing, subinterfacing implementing, ...
         for (TypeElement te : classTree.classes().roots()) {
             subclasses(te);
@@ -285,7 +285,7 @@ public class ClassUseMapper {
     private Collection<TypeElement> subclasses(TypeElement te) {
         Collection<TypeElement> ret = classToSubclass.get(te);
         if (ret == null) {
-            ret = new TreeSet<>(comparators.makeClassUseComparator());
+            ret = new TreeSet<>(comparators.classUseComparator());
             Set<TypeElement> subs = classTree.subClasses(te);
             if (subs != null) {
                 ret.addAll(subs);
@@ -304,7 +304,7 @@ public class ClassUseMapper {
     private Collection<TypeElement> subinterfaces(TypeElement te) {
         Collection<TypeElement> ret = classToSubinterface.get(te);
         if (ret == null) {
-            ret = new TreeSet<>(comparators.makeClassUseComparator());
+            ret = new TreeSet<>(comparators.classUseComparator());
             Set<TypeElement> subs = classTree.subInterfaces(te);
             if (subs != null) {
                 ret.addAll(subs);
@@ -325,7 +325,7 @@ public class ClassUseMapper {
     private Collection<TypeElement> implementingClasses(TypeElement te) {
         Collection<TypeElement> ret = classToImplementingClass.get(te);
         if (ret == null) {
-            ret = new TreeSet<>(comparators.makeClassUseComparator());
+            ret = new TreeSet<>(comparators.classUseComparator());
             Set<TypeElement> impl = classTree.implementingClasses(te);
             if (impl != null) {
                 ret.addAll(impl);
@@ -346,7 +346,7 @@ public class ClassUseMapper {
      */
     private void mapExecutable(ExecutableElement ee) {
         final boolean isConstructor = utils.isConstructor(ee);
-        Set<TypeMirror> classArgs = new TreeSet<>(comparators.makeTypeMirrorClassUseComparator());
+        Set<TypeMirror> classArgs = new TreeSet<>(comparators.typeMirrorClassUseComparator());
         for (VariableElement param : ee.getParameters()) {
             TypeMirror pType = param.asType();
             // primitives don't get mapped and type variables are mapped elsewhere
@@ -425,7 +425,7 @@ public class ClassUseMapper {
     private Set<PackageElement> packageSet(TypeElement te) {
         Set<PackageElement> pkgSet = classToPackage.get(te);
         if (pkgSet == null) {
-            pkgSet = new TreeSet<>(comparators.makeClassUseComparator());
+            pkgSet = new TreeSet<>(comparators.classUseComparator());
             classToPackage.put(te, pkgSet);
         }
         return pkgSet;
@@ -434,7 +434,7 @@ public class ClassUseMapper {
     private Set<TypeElement> classSet(TypeElement te) {
         Set<TypeElement> clsSet = classToClass.get(te);
         if (clsSet == null) {
-            clsSet = new TreeSet<>(comparators.makeClassUseComparator());
+            clsSet = new TreeSet<>(comparators.classUseComparator());
             classToClass.put(te, clsSet);
         }
         return clsSet;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Comparators.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Comparators.java
@@ -55,10 +55,11 @@ public class Comparators {
     private Comparator<Element> moduleComparator = null;
 
     /**
-     * Comparator for ModuleElements, simply compares the fully qualified names
-     * @return a Comparator
+     * Returns a comparator for module elements, that simply compares the fully qualified names
+     *
+     * @return the comparator
      */
-    public Comparator<Element> makeModuleComparator() {
+    public Comparator<Element> moduleComparator() {
         if (moduleComparator == null) {
             moduleComparator = new ElementComparator() {
                 @Override
@@ -73,13 +74,13 @@ public class Comparators {
     private Comparator<Element> allClassesComparator = null;
 
     /**
-     * Returns a Comparator for all classes, compares the simple names of
-     * TypeElement, if equal then the fully qualified names, and if equal again
+     * Returns a comparator for all classes, that compares the simple names of
+     * the type element, if equal then the fully qualified names, and if equal again
      * the names of the enclosing modules.
      *
-     * @return Comparator
+     * @return the comparator
      */
-    public Comparator<Element> makeAllClassesComparator() {
+    public Comparator<Element> allClassesComparator() {
         if (allClassesComparator == null) {
             allClassesComparator = new ElementComparator() {
                 @Override
@@ -99,12 +100,12 @@ public class Comparators {
     private Comparator<Element> packageComparator = null;
 
     /**
-     * Returns a Comparator for packages, by comparing the fully qualified names,
+     * Returns a comparator for packages, by comparing the fully qualified names,
      * and if those are equal the names of the enclosing modules.
      *
-     * @return a Comparator
+     * @return the comparator
      */
-    public Comparator<Element> makePackageComparator() {
+    public Comparator<Element> packageComparator() {
         if (packageComparator == null) {
             packageComparator = new ElementComparator() {
                 @Override
@@ -122,13 +123,13 @@ public class Comparators {
     private Comparator<Element> summaryComparator = null;
 
     /**
-     * Returns a Comparator for items listed on summary list pages
+     * Returns a comparator for items listed on summary list pages
      * (like deprecated or preview summary pages), by comparing the
      * fully qualified names, and if those are equal the names of the enclosing modules.
      *
-     * @return a Comparator
+     * @return the comparator
      */
-    public Comparator<Element> makeSummaryComparator() {
+    public Comparator<Element> summaryComparator() {
         if (summaryComparator == null) {
             summaryComparator = new ElementComparator() {
                 @Override
@@ -152,10 +153,11 @@ public class Comparators {
     private Comparator<SerialFieldTree> serialFieldTreeComparator = null;
 
     /**
-     * Returns a Comparator for SerialFieldTree.
-     * @return a Comparator
+     * Returns a comparator for {@link SerialFieldTree}s.
+     *
+     * @return the comparator
      */
-    public Comparator<SerialFieldTree> makeSerialFieldTreeComparator() {
+    public Comparator<SerialFieldTree> serialFieldTreeComparator() {
         if (serialFieldTreeComparator == null) {
             serialFieldTreeComparator = (SerialFieldTree o1, SerialFieldTree o2) -> {
                 String s1 = o1.getName().toString();
@@ -168,22 +170,25 @@ public class Comparators {
 
     /**
      * Returns a general purpose comparator.
-     * @return a Comparator
+     *
+     * @return the comparator
      */
-    public Comparator<Element> makeGeneralPurposeComparator() {
-        return makeClassUseComparator();
+    public Comparator<Element> generalPurposeComparator() {
+        return classUseComparator();
     }
 
     private Comparator<Element> overrideUseComparator = null;
 
     /**
-     * Returns a Comparator for overrides and implements,
+     * Returns a comparator for overrides and implements,
      * used primarily on methods, compares the name first,
      * then compares the simple names of the enclosing
-     * TypeElement and the fully qualified name of the enclosing TypeElement.
-     * @return a Comparator
+     * type element and the fully qualified name of the enclosing
+     * type element.
+     *
+     * @return the comparator
      */
-    public Comparator<Element> makeOverrideUseComparator() {
+    public Comparator<Element> overrideUseComparator() {
         if (overrideUseComparator == null) {
             overrideUseComparator = new ElementComparator() {
                 @Override
@@ -219,13 +224,14 @@ public class Comparators {
      * otherwise:
      * 1. compare the ElementKind ex: Module, Package, Interface etc.
      * 2a. if equal and if the type is of ExecutableElement(Constructor, Methods),
-     *     a case insensitive comparison of parameter the type signatures
-     * 2b. if equal, case sensitive comparison of the type signatures
+     *     a case-insensitive comparison of parameter the type signatures
+     * 2b. if equal, case-sensitive comparison of the type signatures
      * 3. if equal, compare the FQNs of the entities
      * 4. finally, if equal, compare the names of the enclosing modules
+     *
      * @return an element comparator for index file use
      */
-    public Comparator<Element> makeIndexElementComparator() {
+    public Comparator<Element> indexElementComparator() {
         if (indexUseComparator == null) {
             indexUseComparator = new ElementComparator() {
                 /**
@@ -239,7 +245,7 @@ public class Comparators {
                 @Override
                 public int compare(Element e1, Element e2) {
                     // first, compare names as appropriate
-                    int result = utils.compareStrings(getIndexElementKey(e1), getIndexElementKey(e2));
+                    int result = utils.compareStrings(indexElementKey(e1), indexElementKey(e2));
                     if (result != 0) {
                         return result;
                     }
@@ -272,7 +278,7 @@ public class Comparators {
      *
      * @param element an element
      */
-    public String getIndexElementKey(Element element) {
+    public String indexElementKey(Element element) {
         return switch (element.getKind()) {
             case MODULE, PACKAGE -> utils.getFullyQualifiedName(element);
             default -> utils.getSimpleName(element);
@@ -286,7 +292,7 @@ public class Comparators {
      *
      * @return the comparator
      */
-    public Comparator<TypeMirror> makeTypeMirrorClassUseComparator() {
+    public Comparator<TypeMirror> typeMirrorClassUseComparator() {
         if (typeMirrorClassUseComparator == null) {
             typeMirrorClassUseComparator = (TypeMirror type1, TypeMirror type2) -> {
                 String s1 = utils.getQualifiedTypeName(type1);
@@ -305,7 +311,7 @@ public class Comparators {
      *
      * @return the comparator
      */
-    public Comparator<TypeMirror> makeTypeMirrorIndexUseComparator() {
+    public Comparator<TypeMirror> typeMirrorIndexUseComparator() {
         if (typeMirrorIndexUseComparator == null) {
             typeMirrorIndexUseComparator = (TypeMirror t1, TypeMirror t2) -> {
                 int result = utils.compareStrings(utils.getTypeName(t1, false), utils.getTypeName(t2, false));
@@ -326,9 +332,10 @@ public class Comparators {
      * 3. then parameter types if applicable
      * 4. the element kinds ie. package, class, interface etc.
      * 5. finally the name of the enclosing modules
+     *
      * @return a comparator to sort classes and members for class use
      */
-    public Comparator<Element> makeClassUseComparator() {
+    public Comparator<Element> classUseComparator() {
         if (classUseComparator == null) {
             classUseComparator = new ElementComparator() {
                 /**
@@ -366,7 +373,7 @@ public class Comparators {
 
     /**
      * A general purpose comparator to sort Element entities, basically provides the building blocks
-     * for creating specific comparators for an use-case.
+     * for creating specific comparators for each use-case.
      */
     private abstract class ElementComparator implements Comparator<Element> {
         public ElementComparator() { }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Group.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Group.java
@@ -326,7 +326,7 @@ public class Group {
      */
     SortedSet<PackageElement> getPkgList(Map<String, SortedSet<PackageElement>> map,
             String groupname) {
-        return map.computeIfAbsent(groupname, g -> new TreeSet<>(configuration.utils.comparators.makePackageComparator()));
+        return map.computeIfAbsent(groupname, g -> new TreeSet<>(configuration.utils.comparators.packageComparator()));
     }
 
     /**
@@ -338,7 +338,7 @@ public class Group {
      */
     SortedSet<ModuleElement> getModuleList(Map<String, SortedSet<ModuleElement>> map,
             String groupname) {
-        return map.computeIfAbsent(groupname, g -> new TreeSet<>(configuration.utils.comparators.makeModuleComparator()));
+        return map.computeIfAbsent(groupname, g -> new TreeSet<>(configuration.utils.comparators.moduleComparator()));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -315,7 +315,7 @@ public class IndexBuilder {
      * @return a comparator for class element items
      */
     private Comparator<IndexItem> makeClassComparator() {
-        return Comparator.comparing(IndexItem::getElement, utils.comparators.makeAllClassesComparator());
+        return Comparator.comparing(IndexItem::getElement, utils.comparators.allClassesComparator());
     }
 
     /**
@@ -331,7 +331,7 @@ public class IndexBuilder {
         // In order to produce consistent results, it is important that the base comparator
         // uses the same primary sort keys as both the element and search tag comparators
         // (see JDK-8311264).
-        Comparator<Element> elementComparator = utils.comparators.makeIndexElementComparator();
+        Comparator<Element> elementComparator = utils.comparators.indexElementComparator();
         Comparator<IndexItem> baseComparator =
                 (ii1, ii2) -> utils.compareStrings(getIndexItemKey(ii1), getIndexItemKey(ii2));
         Comparator<IndexItem> searchTagComparator =
@@ -374,7 +374,7 @@ public class IndexBuilder {
         // For element items return the key used by the element comparator;
         // for search tag items return the item's label.
         return ii.isElementItem()
-                ? utils.comparators.getIndexElementKey(ii.getElement())
+                ? utils.comparators.indexElementKey(ii.getElement())
                 : ii.getLabel();
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/SummaryAPIListBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/SummaryAPIListBuilder.java
@@ -62,7 +62,7 @@ public class SummaryAPIListBuilder {
         CONSTRUCTOR,
         ENUM_CONSTANT,
         ANNOTATION_TYPE_MEMBER // no ElementKind mapping
-    };
+    }
 
     /**
      * Constructor.
@@ -180,10 +180,10 @@ public class SummaryAPIListBuilder {
     }
 
     /**
-     * Return the list of summary elements of a given type.
+     * Return the set of summary elements of a given type.
      *
      * @param kind the SummaryElementKind
-     * @return
+     * @return the set
      */
     public SortedSet<Element> getSet(SummaryElementKind kind) {
         return summaryMap.get(kind);
@@ -211,6 +211,6 @@ public class SummaryAPIListBuilder {
      * @return a summary set
      */
     protected final SortedSet<Element> createSummarySet() {
-        return new TreeSet<>(utils.comparators.makeSummaryComparator());
+        return new TreeSet<>(utils.comparators.summaryComparator());
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/TypeElementCatalog.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/TypeElementCatalog.java
@@ -79,7 +79,7 @@ public class TypeElementCatalog {
     public TypeElementCatalog(BaseConfiguration config) {
         this.configuration = config;
         this.utils = config.utils;
-        comparator = utils.comparators.makeGeneralPurposeComparator();
+        comparator = utils.comparators.generalPurposeComparator();
         allClasses = new HashMap<>();
         packageSet = new TreeSet<>(comparator);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -660,7 +660,7 @@ public class Utils {
     }
 
     public SortedSet<TypeElement> getTypeElementsAsSortedSet(Iterable<TypeElement> typeElements) {
-        SortedSet<TypeElement> set = new TreeSet<>(comparators.makeGeneralPurposeComparator());
+        SortedSet<TypeElement> set = new TreeSet<>(comparators.generalPurposeComparator());
         typeElements.forEach(set::add);
         return set;
     }
@@ -1317,7 +1317,7 @@ public class Utils {
     public SortedSet<TypeElement> filterOutPrivateClasses(Iterable<TypeElement> classlist,
             boolean javafx) {
         SortedSet<TypeElement> filteredOutClasses =
-                new TreeSet<>(comparators.makeGeneralPurposeComparator());
+                new TreeSet<>(comparators.generalPurposeComparator());
         if (!javafx) {
             for (TypeElement te : classlist) {
                 if (!hasHiddenTag(te)) {
@@ -1604,7 +1604,7 @@ public class Utils {
     }
 
     public Map<ModuleElement, String> getDependentModules(ModuleElement mdle) {
-        Map<ModuleElement, String> result = new TreeMap<>(comparators.makeModuleComparator());
+        Map<ModuleElement, String> result = new TreeMap<>(comparators.moduleComparator());
         Deque<ModuleElement> queue = new ArrayDeque<>();
         // get all the requires for the element in question
         for (RequiresDirective rd : ElementFilter.requiresIn(mdle.getDirectives())) {
@@ -1678,7 +1678,7 @@ public class Utils {
      * @return the interfaces
      */
     public SortedSet<TypeElement> getAllClassesUnfiltered(PackageElement pkg) {
-        SortedSet<TypeElement> set = new TreeSet<>(comparators.makeGeneralPurposeComparator());
+        SortedSet<TypeElement> set = new TreeSet<>(comparators.generalPurposeComparator());
         set.addAll(getItems(pkg, true, this::isTypeElement, TypeElement.class));
         return set;
     }
@@ -1694,7 +1694,7 @@ public class Utils {
     public SortedSet<TypeElement> getAllClasses(PackageElement pkg) {
         return cachedClasses.computeIfAbsent(pkg, p_ -> {
             List<TypeElement> clist = getItems(pkg, false, this::isTypeElement, TypeElement.class);
-            SortedSet<TypeElement>oset = new TreeSet<>(comparators.makeGeneralPurposeComparator());
+            SortedSet<TypeElement>oset = new TreeSet<>(comparators.generalPurposeComparator());
             oset.addAll(clist);
             return oset;
         });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -56,7 +56,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
@@ -351,7 +350,7 @@ public class VisibleMemberTable {
         // ... and finally the sorted superinterfaces.
         allSuperinterfaces.stream()
                 .map(vmt -> vmt.te)
-                .sorted(utils.comparators.makeGeneralPurposeComparator())
+                .sorted(utils.comparators.generalPurposeComparator())
                 .forEach(result::add);
 
         return result;


### PR DESCRIPTION
Please review a fairly simple change, to simply rename methods in the `Comparators` class, to remove the `make` prefix from the method names, and (for consistency) in one case, remove `get`.  There are some updates to the more problematic javadoc comments as well.

It would be nice to think that the implementation of some methods could be improved by chaining use of simpler standard comparators, but that would be a different task.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313253](https://bugs.openjdk.org/browse/JDK-8313253): Rename methods in javadoc Comparators class (**Enhancement** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15057/head:pull/15057` \
`$ git checkout pull/15057`

Update a local copy of the PR: \
`$ git checkout pull/15057` \
`$ git pull https://git.openjdk.org/jdk.git pull/15057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15057`

View PR using the GUI difftool: \
`$ git pr show -t 15057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15057.diff">https://git.openjdk.org/jdk/pull/15057.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15057#issuecomment-1653994001)