### PR TITLE
8312262: Klass::array_klass() should return ArrayKlass pointer

### DIFF
--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -127,7 +127,7 @@ GrowableArray<Klass*>* ArrayKlass::compute_secondary_supers(int num_extra_slots,
 objArrayOop ArrayKlass::allocate_arrayArray(int n, int length, TRAPS) {
   check_array_allocation_length(length, arrayOopDesc::max_array_length(T_ARRAY), CHECK_NULL);
   size_t size = objArrayOopDesc::object_size(length);
-  ArrayKlass* ak = array_klass(n+dimension(), CHECK_NULL);
+  ArrayKlass* ak = array_klass(n + dimension(), CHECK_NULL);
   objArrayOop o = (objArrayOop)Universe::heap()->array_allocate(ak, size, length,
                                                                 /* do_zero */ true, CHECK_NULL);
   // initialization to null not necessary, area already cleared

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -127,8 +127,7 @@ GrowableArray<Klass*>* ArrayKlass::compute_secondary_supers(int num_extra_slots,
 objArrayOop ArrayKlass::allocate_arrayArray(int n, int length, TRAPS) {
   check_array_allocation_length(length, arrayOopDesc::max_array_length(T_ARRAY), CHECK_NULL);
   size_t size = objArrayOopDesc::object_size(length);
-  Klass* k = array_klass(n+dimension(), CHECK_NULL);
-  ArrayKlass* ak = ArrayKlass::cast(k);
+  ArrayKlass* ak = array_klass(n+dimension(), CHECK_NULL);
   objArrayOop o = (objArrayOop)Universe::heap()->array_allocate(ak, size, length,
                                                                 /* do_zero */ true, CHECK_NULL);
   // initialization to null not necessary, area already cleared
@@ -160,7 +159,7 @@ void ArrayKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 void ArrayKlass::remove_unshareable_info() {
   Klass::remove_unshareable_info();
   if (_higher_dimension != nullptr) {
-    ArrayKlass *ak = ArrayKlass::cast(higher_dimension());
+    ArrayKlass *ak = higher_dimension();
     ak->remove_unshareable_info();
   }
 }
@@ -168,7 +167,7 @@ void ArrayKlass::remove_unshareable_info() {
 void ArrayKlass::remove_java_mirror() {
   Klass::remove_java_mirror();
   if (_higher_dimension != nullptr) {
-    ArrayKlass *ak = ArrayKlass::cast(higher_dimension());
+    ArrayKlass *ak = higher_dimension();
     ak->remove_java_mirror();
   }
 }
@@ -179,7 +178,7 @@ void ArrayKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle p
   // Klass recreates the component mirror also
 
   if (_higher_dimension != nullptr) {
-    ArrayKlass *ak = ArrayKlass::cast(higher_dimension());
+    ArrayKlass *ak = higher_dimension();
     ak->restore_unshareable_info(loader_data, protection_domain, CHECK);
   }
 }
@@ -188,7 +187,7 @@ void ArrayKlass::cds_print_value_on(outputStream* st) const {
   assert(is_klass(), "must be klass");
   st->print("      - array: %s", internal_name());
   if (_higher_dimension != nullptr) {
-    ArrayKlass* ak = ArrayKlass::cast(higher_dimension());
+    ArrayKlass* ak = higher_dimension();
     st->cr();
     ak->cds_print_value_on(st);
   }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 
 class fieldDescriptor;
 class klassVtable;
+class ObjArrayKlass;
 
 // ArrayKlass is the abstract baseclass for all array classes
 
@@ -38,8 +39,8 @@ class ArrayKlass: public Klass {
   // If you add a new field that points to any metaspace object, you
   // must add this field to ArrayKlass::metaspace_pointers_do().
   int      _dimension;         // This is n'th-dimensional array.
-  Klass* volatile _higher_dimension;  // Refers the (n+1)'th-dimensional array (if present).
-  Klass* volatile _lower_dimension;   // Refers the (n-1)'th-dimensional array (if present).
+  ObjArrayKlass* volatile _higher_dimension;  // Refers the (n+1)'th-dimensional array (if present).
+  ArrayKlass* volatile    _lower_dimension;   // Refers the (n-1)'th-dimensional array (if present).
 
  protected:
   // Constructors
@@ -56,13 +57,13 @@ class ArrayKlass: public Klass {
   int dimension() const                 { return _dimension;      }
   void set_dimension(int dimension)     { _dimension = dimension; }
 
-  Klass* higher_dimension() const     { return _higher_dimension; }
-  inline Klass* higher_dimension_acquire() const; // load with acquire semantics
-  void set_higher_dimension(Klass* k) { _higher_dimension = k; }
-  inline void release_set_higher_dimension(Klass* k); // store with release semantics
+  ObjArrayKlass* higher_dimension() const     { return _higher_dimension; }
+  inline ObjArrayKlass* higher_dimension_acquire() const; // load with acquire semantics
+  void set_higher_dimension(ObjArrayKlass* k) { _higher_dimension = k; }
+  inline void release_set_higher_dimension(ObjArrayKlass* k); // store with release semantics
 
-  Klass* lower_dimension() const      { return _lower_dimension; }
-  void set_lower_dimension(Klass* k)  { _lower_dimension = k; }
+  ArrayKlass* lower_dimension() const      { return _lower_dimension; }
+  void set_lower_dimension(ArrayKlass* k)  { _lower_dimension = k; }
 
   // offset of first element, including any padding for the sake of alignment
   int  array_header_in_bytes() const    { return layout_helper_header_size(layout_helper()); }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -59,7 +59,6 @@ class ArrayKlass: public Klass {
 
   ObjArrayKlass* higher_dimension() const     { return _higher_dimension; }
   inline ObjArrayKlass* higher_dimension_acquire() const; // load with acquire semantics
-  void set_higher_dimension(ObjArrayKlass* k) { _higher_dimension = k; }
   inline void release_set_higher_dimension(ObjArrayKlass* k); // store with release semantics
 
   ArrayKlass* lower_dimension() const      { return _lower_dimension; }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -59,6 +59,7 @@ class ArrayKlass: public Klass {
 
   ObjArrayKlass* higher_dimension() const     { return _higher_dimension; }
   inline ObjArrayKlass* higher_dimension_acquire() const; // load with acquire semantics
+  void set_higher_dimension(ObjArrayKlass* k) { _higher_dimension = k; }
   inline void release_set_higher_dimension(ObjArrayKlass* k); // store with release semantics
 
   ArrayKlass* lower_dimension() const      { return _lower_dimension; }

--- a/src/hotspot/share/oops/arrayKlass.inline.hpp
+++ b/src/hotspot/share/oops/arrayKlass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,11 @@
 
 #include "runtime/atomic.hpp"
 
-inline Klass* ArrayKlass::higher_dimension_acquire() const {
+inline ObjArrayKlass* ArrayKlass::higher_dimension_acquire() const {
   return Atomic::load_acquire(&_higher_dimension);
 }
 
-inline void ArrayKlass::release_set_higher_dimension(Klass* k) {
+inline void ArrayKlass::release_set_higher_dimension(ObjArrayKlass* k) {
   Atomic::release_store(&_higher_dimension, k);
 }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1422,7 +1422,7 @@ bool InstanceKlass::is_same_or_direct_interface(Klass *k) const {
 objArrayOop InstanceKlass::allocate_objArray(int n, int length, TRAPS) {
   check_array_allocation_length(length, arrayOopDesc::max_array_length(T_OBJECT), CHECK_NULL);
   size_t size = objArrayOopDesc::object_size(length);
-  Klass* ak = array_klass(n, CHECK_NULL);
+  ArrayKlass* ak = array_klass(n, CHECK_NULL);
   objArrayOop o = (objArrayOop)Universe::heap()->array_allocate(ak, size, length,
                                                                 /* do_zero */ true, CHECK_NULL);
   return o;
@@ -1486,7 +1486,7 @@ void InstanceKlass::check_valid_for_instantiation(bool throwError, TRAPS) {
   }
 }
 
-Klass* InstanceKlass::array_klass(int n, TRAPS) {
+ArrayKlass* InstanceKlass::array_klass(int n, TRAPS) {
   // Need load-acquire for lock-free read
   if (array_klasses_acquire() == nullptr) {
     ResourceMark rm(THREAD);
@@ -1508,7 +1508,7 @@ Klass* InstanceKlass::array_klass(int n, TRAPS) {
   return oak->array_klass(n, THREAD);
 }
 
-Klass* InstanceKlass::array_klass_or_null(int n) {
+ArrayKlass* InstanceKlass::array_klass_or_null(int n) {
   // Need load-acquire for lock-free read
   ObjArrayKlass* oak = array_klasses_acquire();
   if (oak == nullptr) {
@@ -1518,11 +1518,11 @@ Klass* InstanceKlass::array_klass_or_null(int n) {
   }
 }
 
-Klass* InstanceKlass::array_klass(TRAPS) {
+ArrayKlass* InstanceKlass::array_klass(TRAPS) {
   return array_klass(1, THREAD);
 }
 
-Klass* InstanceKlass::array_klass_or_null() {
+ArrayKlass* InstanceKlass::array_klass_or_null() {
   return array_klass_or_null(1);
 }
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1075,12 +1075,12 @@ public:
   // Lock during initialization
 public:
   // Returns the array class for the n'th dimension
-  virtual Klass* array_klass(int n, TRAPS);
-  virtual Klass* array_klass_or_null(int n);
+  virtual ArrayKlass* array_klass(int n, TRAPS);
+  virtual ArrayKlass* array_klass_or_null(int n);
 
   // Returns the array class with this class as element type
-  virtual Klass* array_klass(TRAPS);
-  virtual Klass* array_klass_or_null();
+  virtual ArrayKlass* array_klass(TRAPS);
+  virtual ArrayKlass* array_klass_or_null();
 
   static void clean_initialization_error_table();
 

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -539,14 +539,14 @@ protected:
   }
 
   // array class with specific rank
-  virtual Klass* array_klass(int rank, TRAPS) = 0;
+  virtual ArrayKlass* array_klass(int rank, TRAPS) = 0;
 
   // array class with this klass as element type
-  virtual Klass* array_klass(TRAPS) = 0;
+  virtual ArrayKlass* array_klass(TRAPS) = 0;
 
   // These will return null instead of allocating on the heap:
-  virtual Klass* array_klass_or_null(int rank) = 0;
-  virtual Klass* array_klass_or_null() = 0;
+  virtual ArrayKlass* array_klass_or_null(int rank) = 0;
+  virtual ArrayKlass* array_klass_or_null() = 0;
 
   virtual oop protection_domain() const = 0;
 

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -176,7 +176,7 @@ oop ObjArrayKlass::multi_allocate(int rank, jint* sizes, TRAPS) {
   if (rank > 1) {
     if (length != 0) {
       for (int index = 0; index < length; index++) {
-        oop sub_array = ld_klass->multi_allocate(rank-1, &sizes[1], CHECK_NULL);
+        oop sub_array = ld_klass->multi_allocate(rank - 1, &sizes[1], CHECK_NULL);
         h_array->obj_at_put(index, sub_array);
       }
     } else {

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -169,17 +169,14 @@ objArrayOop ObjArrayKlass::allocate(int length, TRAPS) {
 
 oop ObjArrayKlass::multi_allocate(int rank, jint* sizes, TRAPS) {
   int length = *sizes;
-  // Call to lower_dimension uses this pointer, so most be called before a
-  // possible GC
-  Klass* ld_klass = lower_dimension();
+  ArrayKlass* ld_klass = lower_dimension();
   // If length < 0 allocate will throw an exception.
   objArrayOop array = allocate(length, CHECK_NULL);
   objArrayHandle h_array (THREAD, array);
   if (rank > 1) {
     if (length != 0) {
       for (int index = 0; index < length; index++) {
-        ArrayKlass* ak = ArrayKlass::cast(ld_klass);
-        oop sub_array = ak->multi_allocate(rank-1, &sizes[1], CHECK_NULL);
+        oop sub_array = ld_klass->multi_allocate(rank-1, &sizes[1], CHECK_NULL);
         h_array->obj_at_put(index, sub_array);
       }
     } else {
@@ -308,7 +305,7 @@ void ObjArrayKlass::copy_array(arrayOop s, int src_pos, arrayOop d,
 }
 
 
-Klass* ObjArrayKlass::array_klass(int n, TRAPS) {
+ArrayKlass* ObjArrayKlass::array_klass(int n, TRAPS) {
 
   assert(dimension() <= n, "check order of chain");
   int dim = dimension();
@@ -326,9 +323,8 @@ Klass* ObjArrayKlass::array_klass(int n, TRAPS) {
       if (higher_dimension() == nullptr) {
 
         // Create multi-dim klass object and link them together
-        Klass* k =
+        ObjArrayKlass* ak =
           ObjArrayKlass::allocate_objArray_klass(class_loader_data(), dim + 1, this, CHECK_NULL);
-        ObjArrayKlass* ak = ObjArrayKlass::cast(k);
         ak->set_lower_dimension(this);
         // use 'release' to pair with lock-free load
         release_set_higher_dimension(ak);
@@ -337,12 +333,12 @@ Klass* ObjArrayKlass::array_klass(int n, TRAPS) {
     }
   }
 
-  ObjArrayKlass *ak = ObjArrayKlass::cast(higher_dimension());
+  ObjArrayKlass *ak = higher_dimension();
   THREAD->check_possible_safepoint();
   return ak->array_klass(n, THREAD);
 }
 
-Klass* ObjArrayKlass::array_klass_or_null(int n) {
+ArrayKlass* ObjArrayKlass::array_klass_or_null(int n) {
 
   assert(dimension() <= n, "check order of chain");
   int dim = dimension();
@@ -353,15 +349,15 @@ Klass* ObjArrayKlass::array_klass_or_null(int n) {
     return nullptr;
   }
 
-  ObjArrayKlass *ak = ObjArrayKlass::cast(higher_dimension());
+  ObjArrayKlass *ak = higher_dimension();
   return ak->array_klass_or_null(n);
 }
 
-Klass* ObjArrayKlass::array_klass(TRAPS) {
+ArrayKlass* ObjArrayKlass::array_klass(TRAPS) {
   return array_klass(dimension() +  1, THREAD);
 }
 
-Klass* ObjArrayKlass::array_klass_or_null() {
+ArrayKlass* ObjArrayKlass::array_klass_or_null() {
   return array_klass_or_null(dimension() +  1);
 }
 

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -97,12 +97,12 @@ class ObjArrayKlass : public ArrayKlass {
                int length, TRAPS);
  public:
   // Returns the ObjArrayKlass for n'th dimension.
-  virtual Klass* array_klass(int n, TRAPS);
-  virtual Klass* array_klass_or_null(int n);
+  virtual ArrayKlass* array_klass(int n, TRAPS);
+  virtual ArrayKlass* array_klass_or_null(int n);
 
   // Returns the array class with this class as element type.
-  virtual Klass* array_klass(TRAPS);
-  virtual Klass* array_klass_or_null();
+  virtual ArrayKlass* array_klass(TRAPS);
+  virtual ArrayKlass* array_klass_or_null();
 
   static ObjArrayKlass* cast(Klass* k) {
     return const_cast<ObjArrayKlass*>(cast(const_cast<const Klass*>(k)));

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -171,7 +171,7 @@ void TypeArrayKlass::copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos
 }
 
 // create a klass of array holding typeArrays
-Klass* TypeArrayKlass::array_klass(int n, TRAPS) {
+ArrayKlass* TypeArrayKlass::array_klass(int n, TRAPS) {
   int dim = dimension();
   assert(dim <= n, "check order of chain");
     if (dim == n)
@@ -198,13 +198,13 @@ Klass* TypeArrayKlass::array_klass(int n, TRAPS) {
     }
   }
 
-  ObjArrayKlass* h_ak = ObjArrayKlass::cast(higher_dimension());
+  ObjArrayKlass* h_ak = higher_dimension();
   THREAD->check_possible_safepoint();
   return h_ak->array_klass(n, THREAD);
 }
 
 // return existing klass of array holding typeArrays
-Klass* TypeArrayKlass::array_klass_or_null(int n) {
+ArrayKlass* TypeArrayKlass::array_klass_or_null(int n) {
   int dim = dimension();
   assert(dim <= n, "check order of chain");
     if (dim == n)
@@ -215,15 +215,15 @@ Klass* TypeArrayKlass::array_klass_or_null(int n) {
     return nullptr;
   }
 
-  ObjArrayKlass* h_ak = ObjArrayKlass::cast(higher_dimension());
+  ObjArrayKlass* h_ak = higher_dimension();
   return h_ak->array_klass_or_null(n);
 }
 
-Klass* TypeArrayKlass::array_klass(TRAPS) {
+ArrayKlass* TypeArrayKlass::array_klass(TRAPS) {
   return array_klass(dimension() +  1, THREAD);
 }
 
-Klass* TypeArrayKlass::array_klass_or_null() {
+ArrayKlass* TypeArrayKlass::array_klass_or_null() {
   return array_klass_or_null(dimension() +  1);
 }
 

--- a/src/hotspot/share/oops/typeArrayKlass.hpp
+++ b/src/hotspot/share/oops/typeArrayKlass.hpp
@@ -95,12 +95,12 @@ class TypeArrayKlass : public ArrayKlass {
 
  public:
   // Find n'th dimensional array
-  virtual Klass* array_klass(int n, TRAPS);
-  virtual Klass* array_klass_or_null(int n);
+  virtual ArrayKlass* array_klass(int n, TRAPS);
+  virtual ArrayKlass* array_klass_or_null(int n);
 
   // Returns the array class with this class as element type
-  virtual Klass* array_klass(TRAPS);
-  virtual Klass* array_klass_or_null();
+  virtual ArrayKlass* array_klass(TRAPS);
+  virtual ArrayKlass* array_klass_or_null();
 
   static TypeArrayKlass* cast(Klass* k) {
     return const_cast<TypeArrayKlass*>(cast(const_cast<const Klass*>(k)));

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -205,8 +205,8 @@
   volatile_nonstatic_field(oopDesc,            _metadata._compressed_klass,                   narrowKlass)                           \
   static_field(BarrierSet,                     _barrier_set,                                  BarrierSet*)                           \
   nonstatic_field(ArrayKlass,                  _dimension,                                    int)                                   \
-  volatile_nonstatic_field(ArrayKlass,         _higher_dimension,                             Klass*)                                \
-  volatile_nonstatic_field(ArrayKlass,         _lower_dimension,                              Klass*)                                \
+  volatile_nonstatic_field(ArrayKlass,         _higher_dimension,                             ObjArrayKlass*)                        \
+  volatile_nonstatic_field(ArrayKlass,         _lower_dimension,                              ArrayKlass*)                           \
   nonstatic_field(CompiledICHolder,            _holder_metadata,                              Metadata*)                             \
   nonstatic_field(CompiledICHolder,            _holder_klass,                                 Klass*)                                \
   nonstatic_field(ConstantPool,                _tags,                                         Array<u1>*)                            \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,8 +70,8 @@ public class ArrayKlass extends Klass {
   }
 
   public long  getDimension()       { return         dimension.getValue(this); }
-  public Klass getHigherDimension() { return (Klass) higherDimension.getValue(this); }
-  public Klass getLowerDimension()  { return (Klass) lowerDimension.getValue(this); }
+  public ObjArrayKlass getHigherDimension() { return (ObjArrayKlass) higherDimension.getValue(this); }
+  public ArrayKlass getLowerDimension()     { return (ArrayKlass) lowerDimension.getValue(this); }
 
   // constant class names - javaLangCloneable, javaIoSerializable, javaLangObject
   // Initialized lazily to avoid initialization ordering dependencies between ArrayKlass and String

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class ObjArrayKlass extends ArrayKlass {
     if (dimension == n) {
       return this;
     }
-    ObjArrayKlass ak = (ObjArrayKlass) getHigherDimension();
+    ObjArrayKlass ak = getHigherDimension();
     if (ak == null) {
       if (orNull) return null;
       // FIXME: would need to change in reflective system to actually

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/TypeArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/TypeArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ public class TypeArrayKlass extends ArrayKlass {
     }
     if (dimension == n)
       return this;
-    ObjArrayKlass ak = (ObjArrayKlass) getHigherDimension();
+    ObjArrayKlass ak = getHigherDimension();
     if (ak == null) {
       if (orNull) return null;
       // FIXME: would need to change in reflective system to actually


### PR DESCRIPTION
This is a simple change to make array_klass() return ArrayKlass (the first dimension of TypeArrayKlass is a TypeArrayKlass so can't use ObjArrayKlass), higher_dimension is always an ObjArrayKlass and lower_dimension can be a TypeArrayKlass.  The change removes some casts.
Tested with tier1 linux/macosx/windows on x86 and aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312262](https://bugs.openjdk.org/browse/JDK-8312262): Klass::array_klass() should return ArrayKlass pointer (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [2edd5c48](https://git.openjdk.org/jdk/pull/15059/files/2edd5c48d6e8af7af7218490dc03be22ab2235ac)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15059/head:pull/15059` \
`$ git checkout pull/15059`

Update a local copy of the PR: \
`$ git checkout pull/15059` \
`$ git pull https://git.openjdk.org/jdk.git pull/15059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15059`

View PR using the GUI difftool: \
`$ git pr show -t 15059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15059.diff">https://git.openjdk.org/jdk/pull/15059.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15059#issuecomment-1654409424)