### PR TITLE
8313207: Remove MetaspaceShared::_has_error_classes

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -87,7 +87,6 @@
 
 ReservedSpace MetaspaceShared::_symbol_rs;
 VirtualSpace MetaspaceShared::_symbol_vs;
-bool MetaspaceShared::_has_error_classes;
 bool MetaspaceShared::_archive_loading_failed = false;
 bool MetaspaceShared::_remapped_readwrite = false;
 void* MetaspaceShared::_shared_metaspace_static_top = nullptr;
@@ -731,7 +730,6 @@ void MetaspaceShared::preload_classes(TRAPS) {
   }
 
   log_info(cds)("Loading classes to share ...");
-  _has_error_classes = false;
   int class_count = ClassListParser::parse_classlist(classlist_path,
                                                      ClassListParser::_parse_all, CHECK);
   if (ExtraSharedClassListFile) {
@@ -814,7 +812,6 @@ bool MetaspaceShared::try_link_class(JavaThread* current, InstanceKlass* ik) {
                     ik->external_name());
       CLEAR_PENDING_EXCEPTION;
       SystemDictionaryShared::set_class_has_failed_verification(ik);
-      _has_error_classes = true;
     }
     ik->compute_has_loops_flag_for_methods();
     BytecodeVerificationLocal = saved;

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -47,7 +47,6 @@ enum MapArchiveResult {
 class MetaspaceShared : AllStatic {
   static ReservedSpace _symbol_rs;  // used only during -Xshare:dump
   static VirtualSpace _symbol_vs;   // used only during -Xshare:dump
-  static bool _has_error_classes;
   static bool _archive_loading_failed;
   static bool _remapped_readwrite;
   static void* _shared_metaspace_static_top;


### PR DESCRIPTION
The field _has_error_classes has its value set and change but it is no longer checked after [JDK-8240481](https://bugs.openjdk.org/browse/JDK-8240481). This patch removes all instances MetaspaceShared::_has_error_classes. Verified with tier 1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313207](https://bugs.openjdk.org/browse/JDK-8313207): Remove MetaspaceShared::_has_error_classes (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15060/head:pull/15060` \
`$ git checkout pull/15060`

Update a local copy of the PR: \
`$ git checkout pull/15060` \
`$ git pull https://git.openjdk.org/jdk.git pull/15060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15060`

View PR using the GUI difftool: \
`$ git pr show -t 15060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15060.diff">https://git.openjdk.org/jdk/pull/15060.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15060#issuecomment-1654604166)