### PR TITLE
JDK-8313252: Java_sun_awt_windows_ThemeReader_paintBackground release resources in early returns

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -421,6 +421,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
             NULL, 0);
     if (hDibSection == NULL) {
         DTRACE_PRINTLN("Error creating DIB section");
+        DeleteDC(memDC);
         ReleaseDC(NULL,defaultDC);
         return;
     }


### PR DESCRIPTION
In file ThemeReader.cpp functionJava_sun_awt_windows_ThemeReader_paintBackground
we create DCs and release them at the end, but seems we miss it in early returns.

While looking at the code, I noticed that CreateCompatibleDC can return NULL in case of error/failure, but we ignore this case; see 
https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createcompatibledc   .
Should we better handle it or is it not really occurring in practise ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313252](https://bugs.openjdk.org/browse/JDK-8313252): Java_sun_awt_windows_ThemeReader_paintBackground release resources in early returns (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15064/head:pull/15064` \
`$ git checkout pull/15064`

Update a local copy of the PR: \
`$ git checkout pull/15064` \
`$ git pull https://git.openjdk.org/jdk.git pull/15064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15064`

View PR using the GUI difftool: \
`$ git pr show -t 15064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15064.diff">https://git.openjdk.org/jdk/pull/15064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15064#issuecomment-1655229130)