### PR TITLE
8313307: java/util/Formatter/Padding.java fails on some Locales

### DIFF
--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -29,6 +29,8 @@
  * @run junit Padding
  */
 
+import java.util.Locale;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -307,7 +309,7 @@ public class Padding {
     @ParameterizedTest
     @MethodSource
     void padding(String expected, String format, Object value) {
-        assertEquals(expected, String.format(format, value));
+        assertEquals(expected, String.format(Locale.ROOT, format, value));
     }
 
 }

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -309,7 +309,7 @@ public class Padding {
     @ParameterizedTest
     @MethodSource
     void padding(String expected, String format, Object value) {
-        assertEquals(expected, String.format(Locale.ROOT, format, value));
+        assertEquals(expected, String.format(Locale.US, format, value));
     }
 
 }


### PR DESCRIPTION
Fails like this:

```
$ CONF=macosx-aarch64-server-fastdebug make images test TEST=java/util/Formatter/Padding.java

...
STARTED Padding::padding '[216] -0000001.2, % 010.1f, -1.2'
org.opentest4j.AssertionFailedError: expected: <-0000001.2> but was: <-0000001,2>
```

Looks like a locale problem in test, so the simplest fix is to ask for a neutral Locale there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313307](https://bugs.openjdk.org/browse/JDK-8313307): java/util/Formatter/Padding.java fails on some Locales (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [97084428](https://git.openjdk.org/jdk/pull/15066/files/97084428a4e2cf3a20def941ad42ad41bb655643)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15066/head:pull/15066` \
`$ git checkout pull/15066`

Update a local copy of the PR: \
`$ git checkout pull/15066` \
`$ git pull https://git.openjdk.org/jdk.git pull/15066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15066`

View PR using the GUI difftool: \
`$ git pr show -t 15066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15066.diff">https://git.openjdk.org/jdk/pull/15066.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15066#issuecomment-1655314618)