### PR TITLE
JDK-8312574: jdk/jdk/jfr/jvm/TestChunkIntegrity.java fails with timeout

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestChunkIntegrity.java
+++ b/test/jdk/jdk/jfr/jvm/TestChunkIntegrity.java
@@ -59,7 +59,7 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.jvm.TestChunkIntegrity
+ * @run main/othervm/timeout=300 jdk.jfr.jvm.TestChunkIntegrity
  */
 public class TestChunkIntegrity {
 


### PR DESCRIPTION
Looks like the current timeout values of  jdk/jdk/jfr/jvm/TestChunkIntegrity.java  - test are not sufficient for some of our test machines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312574](https://bugs.openjdk.org/browse/JDK-8312574): jdk/jdk/jfr/jvm/TestChunkIntegrity.java  fails with timeout (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15067/head:pull/15067` \
`$ git checkout pull/15067`

Update a local copy of the PR: \
`$ git checkout pull/15067` \
`$ git pull https://git.openjdk.org/jdk.git pull/15067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15067`

View PR using the GUI difftool: \
`$ git pr show -t 15067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15067.diff">https://git.openjdk.org/jdk/pull/15067.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15067#issuecomment-1655432868)