### PR TITLE
8312489: Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -802,7 +802,9 @@ public class JarFile extends ZipFile {
                 throw new IOException("Unsupported size: " + uncompressedSize +
                         " for JarEntry " + ze.getName() +
                         ". Allowed max size: " +
-                        SignatureFileVerifier.MAX_SIG_FILE_SIZE + " bytes");
+                        SignatureFileVerifier.MAX_SIG_FILE_SIZE + " bytes. " +
+                        "You can use the jdk.jar.maxSignatureFileSize " +
+                        "system property to increase the default value.");
             }
             int len = (int)uncompressedSize;
             int bytesRead;

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -851,9 +851,9 @@ public class SignatureFileVerifier {
                 "jdk.jar.maxSignatureFileSize", 16000000);
         if (tmp < 0 || tmp > MAX_ARRAY_SIZE) {
             if (debug != null) {
-                debug.println("Default signature file size 16000000 bytes " +
-                        "is used as the specified size for the " +
-                        "jdk.jar.maxSignatureFileSize system property " +
+                debug.println("The default signature file size of 16000000 bytes " +
+                        "will be used for the jdk.jar.maxSignatureFileSize " +
+                        "system property since the specified value " +
                         "is out of range: " + tmp);
             }
             tmp = 16000000;

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -848,15 +848,15 @@ public class SignatureFileVerifier {
          * in a JAR file.
          */
         Integer tmp = GetIntegerAction.privilegedGetProperty(
-                "jdk.jar.maxSignatureFileSize", 8000000);
+                "jdk.jar.maxSignatureFileSize", 16000000);
         if (tmp < 0 || tmp > MAX_ARRAY_SIZE) {
             if (debug != null) {
-                debug.println("Default signature file size 8000000 bytes " +
+                debug.println("Default signature file size 16000000 bytes " +
                         "is used as the specified size for the " +
                         "jdk.jar.maxSignatureFileSize system property " +
                         "is out of range: " + tmp);
             }
-            tmp = 8000000;
+            tmp = 16000000;
         }
         return tmp;
     }

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -847,7 +847,7 @@ public class SignatureFileVerifier {
          * the maximum allowed number of bytes for the signature-related files
          * in a JAR file.
          */
-        Integer tmp = GetIntegerAction.privilegedGetProperty(
+        int tmp = GetIntegerAction.privilegedGetProperty(
                 "jdk.jar.maxSignatureFileSize", 16000000);
         if (tmp < 0 || tmp > MAX_ARRAY_SIZE) {
             if (debug != null) {


### PR DESCRIPTION
JDK-8312489: Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8313216](https://bugs.openjdk.org/browse/JDK-8313216) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8312489](https://bugs.openjdk.org/browse/JDK-8312489): Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar (**Enhancement** - P3)
 * [JDK-8313216](https://bugs.openjdk.org/browse/JDK-8313216): Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar (**CSR**)

### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15072/head:pull/15072` \
`$ git checkout pull/15072`

Update a local copy of the PR: \
`$ git checkout pull/15072` \
`$ git pull https://git.openjdk.org/jdk.git pull/15072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15072`

View PR using the GUI difftool: \
`$ git pr show -t 15072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15072.diff">https://git.openjdk.org/jdk/pull/15072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15072#issuecomment-1655907314)