### PR TITLE
8313356: Improve address selection in sun.net.NetworkClient

### DIFF
--- a/src/java.base/share/classes/sun/net/NetworkClient.java
+++ b/src/java.base/share/classes/sun/net/NetworkClient.java
@@ -151,6 +151,23 @@ public class NetworkClient {
      */
     protected Socket doConnect (String server, int port)
     throws IOException, UnknownHostException {
+        IOException exception = null;
+        for (InetAddress address : InetAddress.getAllByName(server)) {
+            try {
+                return doConnect(address, port);
+            } catch (IOException e) {
+                if (exception == null) {
+                    exception = e;
+                } else {
+                    exception.addSuppressed(e);
+                }
+            }
+        }
+        throw exception;
+    }
+
+    private Socket doConnect (InetAddress server, int port)
+    throws IOException, UnknownHostException {
         Socket s;
         if (proxy != null) {
             if (proxy.type() == Proxy.Type.SOCKS) {


### PR DESCRIPTION
Please review this fix for [JDK-8313356](https://bugs.openjdk.org/browse/JDK-8313356), which improves address selection in `sun.net.NetworkClient` to consider all addresses returned by `InetAddress.getAllByName` instead of only connecting to the first one.

This follows the approach described in [JDK-8170568](https://bugs.openjdk.org/browse/JDK-8170568).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Issue
 * [JDK-8313356](https://bugs.openjdk.org/browse/JDK-8313356): Improve address selection in sun.net.NetworkClient (**Sub-task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15078/head:pull/15078` \
`$ git checkout pull/15078`

Update a local copy of the PR: \
`$ git checkout pull/15078` \
`$ git pull https://git.openjdk.org/jdk.git pull/15078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15078`

View PR using the GUI difftool: \
`$ git pr show -t 15078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15078.diff">https://git.openjdk.org/jdk/pull/15078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15078#issuecomment-1656407802)