### PR TITLE
SwingWorker.java: appContext shouldn't keep a strong reference to exe…

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SwingWorker.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingWorker.java
@@ -797,13 +797,13 @@ public abstract class SwingWorker<T, V> implements RunnableFuture<T> {
             final ExecutorService es = executorService;
             appContext.addPropertyChangeListener(AppContext.DISPOSED_PROPERTY_NAME,
                 new PropertyChangeListener() {
+                    final WeakReference<ExecutorService> executorServiceRef =
+                        new WeakReference<ExecutorService>(es);
                     @SuppressWarnings("removal")
                     @Override
                     public void propertyChange(PropertyChangeEvent pce) {
                         boolean disposed = (Boolean)pce.getNewValue();
                         if (disposed) {
-                            final WeakReference<ExecutorService> executorServiceRef =
-                                new WeakReference<ExecutorService>(es);
                             final ExecutorService executorService =
                                 executorServiceRef.get();
                             if (executorService != null) {


### PR DESCRIPTION
…cutorService

In https://github.com/openjdk/jdk/commit/b8af3d50192f8bc98d83f8102f0fd1989f302e32 the weak reference was accidentally changed from a field to a local variable, which means that the PropertyChangeListener keeps a strong reference to executorService, which is a resource leak