### PR TITLE
8313323: javac -g on a java file which uses unnamed variable leads to ClassFormatError when launching that class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -2189,6 +2189,8 @@ public class Code {
                 ((var.sym.owner.flags() & Flags.LAMBDA_METHOD) == 0 ||
                  (var.sym.flags() & Flags.PARAMETER) == 0);
         if (ignoredSyntheticVar) return;
+        //don't include unnamed variables:
+        if (var.sym.name == var.sym.name.table.names.empty) return ;
         if (varBuffer == null)
             varBuffer = new LocalVar[20];
         else

--- a/test/langtools/tools/javac/unnamed/UnnamedLocalVariableTable.java
+++ b/test/langtools/tools/javac/unnamed/UnnamedLocalVariableTable.java
@@ -37,6 +37,7 @@ public class UnnamedLocalVariableTable {
                 System.err.println("1");
             }
             I i = _ -> {};
+            java.util.List<String> _ = null;
         } catch (Exception _) {
             System.err.println("2");
         }

--- a/test/langtools/tools/javac/unnamed/UnnamedLocalVariableTable.java
+++ b/test/langtools/tools/javac/unnamed/UnnamedLocalVariableTable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8313323
+ * @summary Verify javac does not produce incorrect LocalVariableTable
+ * @enablePreview
+ * @compile -g UnnamedLocalVariableTable.java
+ * @run main UnnamedLocalVariableTable
+ */
+public class UnnamedLocalVariableTable {
+    public static void main(String... args) {
+        try {
+            int _ = 0;
+            if (args[0] instanceof String _) {
+                System.err.println("1");
+            }
+            I i = _ -> {};
+        } catch (Exception _) {
+            System.err.println("2");
+        }
+    }
+
+    interface I {
+        public void test(String s);
+    }
+}


### PR DESCRIPTION
When unnamed (`_`) variables are present, and javac emits the `LocalVariableTable` (and potentially the `LocalVariableTypeTable`), it includes the unnamed variable in the table. As the variable does not have a name, the table contains an empty name, which is not allowed by the spec, see [1], [2], [3].

The proposed solution is to simply not include the unnamed variables in these tables, by not adding them to the internal `Code.varBuffer`.

[1] https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html#jvms-4.2.2
[2] https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html#jvms-4.7.13
[3] https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html#jvms-4.7.14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313323](https://bugs.openjdk.org/browse/JDK-8313323): javac -g on a java file which uses unnamed variable leads to ClassFormatError when launching that class (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15083/head:pull/15083` \
`$ git checkout pull/15083`

Update a local copy of the PR: \
`$ git checkout pull/15083` \
`$ git pull https://git.openjdk.org/jdk.git pull/15083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15083`

View PR using the GUI difftool: \
`$ git pr show -t 15083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15083.diff">https://git.openjdk.org/jdk/pull/15083.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15083#issuecomment-1657781389)