### PR TITLE
8313396: Implement FORBID_C_FUNCTION for compilerWarnings_visCPP.hpp

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -83,7 +83,7 @@
 // so uses of functions that are both forbidden and fortified won't cause
 // forbidden warnings in such builds.
 #define FORBID_C_FUNCTION(signature, alternative) \
-  extern "C" __attribute__((__warning__(alternative))) signature;
+  extern "C" [[gnu::warning(alternative)]] signature;
 
 // Disable warning attribute over the scope of the affected statement.
 // The name serves only to document the intended function.

--- a/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_visCPP.hpp
@@ -57,7 +57,8 @@
 // such as _CRT_SECURE_NO_WARNINGS.  Annotating vetted uses allows those
 // warnings to catch unchecked uses.
 
-#define FORBID_C_FUNCTION(signature, alternative)
+#define FORBID_C_FUNCTION(signature, alternative) \
+  extern "C" [[deprecated]] signature;
 
 #define ALLOW_C_FUNCTION(name, ...)             \
   PRAGMA_DIAG_PUSH                              \


### PR DESCRIPTION
Implements FORBID_C_FUNCTION for compilerWarnings_visCPP.hpp, since the version of Visual C compiler we use no longer has the aforementioned issue

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313396](https://bugs.openjdk.org/browse/JDK-8313396): Implement FORBID_C_FUNCTION for compilerWarnings_visCPP.hpp (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15085/head:pull/15085` \
`$ git checkout pull/15085`

Update a local copy of the PR: \
`$ git checkout pull/15085` \
`$ git pull https://git.openjdk.org/jdk.git pull/15085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15085`

View PR using the GUI difftool: \
`$ git pr show -t 15085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15085.diff">https://git.openjdk.org/jdk/pull/15085.diff</a>

</details>
