### PR TITLE
8312204: unexpected else with statement causes compiler crash

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/VirtualParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/VirtualParser.java
@@ -148,12 +148,12 @@ public class VirtualParser extends JavacParser {
 
         @Override
         public int errPos() {
-            throw new AssertionError();
+            return S.errPos();
         }
 
         @Override
         public void errPos(int pos) {
-            throw new AssertionError();
+            S.errPos(pos);
         }
 
         @Override

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2446,6 +2446,44 @@ public class JavacParserTest extends TestCase {
                 return null;
             }
         }.scan(cut, null);
+    }
+
+    @Test //JDK-8312204
+    void testDanglingElse() throws IOException {
+        String code = """
+                      void main() {
+                          else ;
+                      }
+                      """;
+        DiagnosticCollector<JavaFileObject> coll =
+                new DiagnosticCollector<>();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
+                List.of("--enable-preview", "--source", SOURCE_VERSION),
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+
+        String result = cut.toString().replaceAll("\\R", "\n");
+        System.out.println("RESULT\n" + result);
+        assertEquals("incorrect AST",
+                     result,
+                     """
+                     \n\
+                     /*synthetic*/ final class Test {
+                         \n\
+                         void main() {
+                             (ERROR);
+                         }
+                     }""");
+
+        List<String> codes = new LinkedList<>();
+
+        for (Diagnostic<? extends JavaFileObject> d : coll.getDiagnostics()) {
+            codes.add(d.getLineNumber() + ":" + d.getColumnNumber() + ":" +  d.getCode());
+        }
+
+        assertEquals("testDanglingElse: " + codes,
+                     List.of("2:5:compiler.err.else.without.if"),
+                     codes);
     }
 
     void run(String[] args) throws Exception {


### PR DESCRIPTION
Compiling (erroneous) code like:
```
void main() {
    else ;
}
```

Leads to:
```
$ javac --enable-preview -source 22 /tmp/Test.java 
An exception has occurred in the compiler (22-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.AssertionError
        at jdk.compiler/com.sun.tools.javac.parser.VirtualParser$VirtualScanner.errPos(VirtualParser.java:151)
        at jdk.compiler/com.sun.tools.javac.parser.JavacParser.doRecover(JavacParser.java:3122)
...
```

The proposed solution is to implement the two corresponding `errPos` methods for `VirtualScanner`.
