### PR TITLE
8313403: Remove unused 'mask' field from JFormattedTextField

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -289,10 +289,6 @@ public class JFormattedTextField extends JTextField {
      */
     private DocumentListener documentListener;
     /**
-     * Masked used to set the AbstractFormatterFactory.
-     */
-    private Object mask;
-    /**
      * ActionMap that the TextFormatter Actions are added to.
      */
     private ActionMap textFormatterActionMap;


### PR DESCRIPTION
The private field `mask` is never used in `JFormattedTextField`.

I couldn't find any usages of the field, including JNI. Therefore, it is safe to remove.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313403](https://bugs.openjdk.org/browse/JDK-8313403): Remove unused 'mask' field from JFormattedTextField (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15088/head:pull/15088` \
`$ git checkout pull/15088`

Update a local copy of the PR: \
`$ git checkout pull/15088` \
`$ git pull https://git.openjdk.org/jdk.git pull/15088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15088`

View PR using the GUI difftool: \
`$ git pr show -t 15088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15088.diff">https://git.openjdk.org/jdk/pull/15088.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15088#issuecomment-1658105898)