### PR TITLE
8313507: Remove pkcs11/Cipher/TestKATForGCM.java from ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -603,8 +603,6 @@ sun/security/pkcs11/rsa/TestSignatures.java                     8295343 linux-al
 sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-all
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
-sun/security/pkcs11/Cipher/TestKATForGCM.java                   8240611 linux-x64,macosx-x64
-
 
 ############################################################################
 


### PR DESCRIPTION
The issue linked to ProblemList entry was closed as duplicate of [JDK-8307185](https://bugs.openjdk.org/browse/JDK-8307185), which was fixed. The ProblemList entry should be removed.

No failures in 30 test runs. Output of `-Xcheck:jni` clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313507](https://bugs.openjdk.org/browse/JDK-8313507): Remove pkcs11/Cipher/TestKATForGCM.java from ProblemList (**Task** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15099/head:pull/15099` \
`$ git checkout pull/15099`

Update a local copy of the PR: \
`$ git checkout pull/15099` \
`$ git pull https://git.openjdk.org/jdk.git pull/15099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15099`

View PR using the GUI difftool: \
`$ git pr show -t 15099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15099.diff">https://git.openjdk.org/jdk/pull/15099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15099#issuecomment-1659735819)