### PR TITLE
JDK-8311938: Add default cups include location for configure on AIX

### DIFF
--- a/make/autoconf/lib-cups.m4
+++ b/make/autoconf/lib-cups.m4
@@ -66,23 +66,22 @@ AC_DEFUN_ONCE([LIB_SETUP_CUPS],
       else
         AC_MSG_ERROR([Can't find 'cups/cups.h' under ${with_cups_include} given with the --with-cups-include option.])
       fi
-    else
-      # handle cups default location for AIX
-      if test "x$OPENJDK_TARGET_OS" = "xaix" && test "x${with_cups}" = x; then
+    fi
+    if test "x$CUPS_FOUND" = xno; then
+      # Are the cups headers installed in the default AIX or /usr/include location?
+      if test "x$OPENJDK_TARGET_OS" = "xaix"; then
         if test -s "/opt/freeware/include/cups/cups.h"; then
           CUPS_CFLAGS="-I/opt/freeware/include"
           CUPS_FOUND=yes
           AC_MSG_RESULT([$CUPS_FOUND])
         fi
+      else
+        AC_CHECK_HEADERS([cups/cups.h cups/ppd.h], [
+            CUPS_FOUND=yes
+            CUPS_CFLAGS=
+            DEFAULT_CUPS=yes
+        ])
       fi
-    fi
-    if test "x$CUPS_FOUND" = xno; then
-      # Are the cups headers installed in the default /usr/include location?
-      AC_CHECK_HEADERS([cups/cups.h cups/ppd.h], [
-          CUPS_FOUND=yes
-          CUPS_CFLAGS=
-          DEFAULT_CUPS=yes
-      ])
     fi
     if test "x$CUPS_FOUND" = xno; then
       HELP_MSG_MISSING_DEPENDENCY([cups])

--- a/make/autoconf/lib-cups.m4
+++ b/make/autoconf/lib-cups.m4
@@ -66,6 +66,15 @@ AC_DEFUN_ONCE([LIB_SETUP_CUPS],
       else
         AC_MSG_ERROR([Can't find 'cups/cups.h' under ${with_cups_include} given with the --with-cups-include option.])
       fi
+    else
+      # handle cups default location for AIX
+      if test "x$OPENJDK_TARGET_OS" = "xaix"; then
+        if test -s "/opt/freeware/include/cups/cups.h"; then
+          CUPS_CFLAGS="-I/opt/freeware/include"
+          CUPS_FOUND=yes
+          AC_MSG_RESULT([$CUPS_FOUND])
+        fi
+      fi
     fi
     if test "x$CUPS_FOUND" = xno; then
       # Are the cups headers installed in the default /usr/include location?

--- a/make/autoconf/lib-cups.m4
+++ b/make/autoconf/lib-cups.m4
@@ -70,11 +70,11 @@ AC_DEFUN_ONCE([LIB_SETUP_CUPS],
     if test "x$CUPS_FOUND" = xno; then
       # Are the cups headers installed in the default AIX or /usr/include location?
       if test "x$OPENJDK_TARGET_OS" = "xaix"; then
-        if test -s "/opt/freeware/include/cups/cups.h"; then
-          CUPS_CFLAGS="-I/opt/freeware/include"
-          CUPS_FOUND=yes
-          AC_MSG_RESULT([$CUPS_FOUND])
-        fi
+        AC_CHECK_HEADERS([/opt/freeware/include/cups/cups.h /opt/freeware/include/cups/ppd.h], [
+            CUPS_FOUND=yes
+            CUPS_CFLAGS="-I/opt/freeware/include"
+            DEFAULT_CUPS=yes
+        ])
       else
         AC_CHECK_HEADERS([cups/cups.h cups/ppd.h], [
             CUPS_FOUND=yes

--- a/make/autoconf/lib-cups.m4
+++ b/make/autoconf/lib-cups.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ AC_DEFUN_ONCE([LIB_SETUP_CUPS],
       fi
     else
       # handle cups default location for AIX
-      if test "x$OPENJDK_TARGET_OS" = "xaix"; then
+      if test "x$OPENJDK_TARGET_OS" = "xaix" && test "x${with_cups}" = x; then
         if test -s "/opt/freeware/include/cups/cups.h"; then
           CUPS_CFLAGS="-I/opt/freeware/include"
           CUPS_FOUND=yes


### PR DESCRIPTION
Add the default include location(/opt/freeware/include/) for cups on AIX. With this set the additional configure parameter --with-cups-include can be removed, which was needed on AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311938](https://bugs.openjdk.org/browse/JDK-8311938): Add default cups include location for configure on AIX (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [8894c726](https://git.openjdk.org/jdk/pull/15100/files/8894c7260e4b69f4667cda558fccfbcff9f20f57)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15100/head:pull/15100` \
`$ git checkout pull/15100`

Update a local copy of the PR: \
`$ git checkout pull/15100` \
`$ git pull https://git.openjdk.org/jdk.git pull/15100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15100`

View PR using the GUI difftool: \
`$ git pr show -t 15100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15100.diff">https://git.openjdk.org/jdk/pull/15100.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15100#issuecomment-1659735749)