### PR TITLE
8313274: Failure building java.base-jmod target

### DIFF
--- a/make/conf/module-loader-map.conf
+++ b/make/conf/module-loader-map.conf
@@ -59,9 +59,17 @@ BOOT_MODULES= \
 # Modules that directly or indirectly requiring upgradeable modules
 # should carefully be considered if it should be upgradeable or not.
 UPGRADEABLE_PLATFORM_MODULES= \
+    # upgradable modules defined in JEP 261 \
     java.compiler \
     jdk.internal.vm.compiler \
     jdk.internal.vm.compiler.management \
+    # modules that depend on the JEP 261 defined upgradable modules. \
+    # requires regular curation. \
+    java.se \
+    jdk.compiler \
+    jdk.javadoc \
+    jdk.jdeps \
+    jdk.jshell \
     #
 
 PLATFORM_MODULES= \


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the build failure noted in https://bugs.openjdk.org/browse/JDK-8313274?

The build failure is consistently reproducible with `--with-jobs=1`. Martin, in that JBS issue, has narrowed down the commit to the change in https://github.com/openjdk/jdk/pull/14561, starting which this failure is reproducible. The change in that PR, from what I understand, was meant to not require upgradable modules be a prerequisite for the `java.base-jmod` make target:

> ... upgradeable modules, those shouldn't be on the prerequisites list for java.base-jmod.

The implementation of that change uses the `FindAllUpgradeableModules` function which as commented in the make files does:

> #Upgradeable modules are those that are either defined as upgradeable or that
> #require an upradeable module.

The implementation of `FindAllUpgradeableModules` uses the `UPGRADEABLE_PLATFORM_MODULES` make variable which similarly comments:

> #Modules that directly or indirectly requiring upgradeable modules
> #should carefully be considered if it should be upgradeable or not.

However, that set currently doesn't include the "indirectly requiring upgradable modules" and thus appears to be missing some of the modules that are considered upgradable.

As a result, what seems to be happening is that the `java.base-jmod` make target now can (and does) end up requiring a particular target as a prerequisite, say `jdk.jdeps` (which uses `java.compiler` upgradable module), but doesn't add the `java.compiler-jmod` target as a prerequisite and thus ends up with that build failure:

```
Creating java.base.jmod
Error: Resolution failed: Module java.compiler not found, required by jdk.jdeps
```

The commit in this PR proposes to fix this by updating the static set of `UPGRADEABLE_PLATFORM_MODULES` to include the indirect modules that require the upgradable modules. How these additional modules were derived is explained as a separate comment in this PR.

The build succeeds with this change, both with `--with-jobs=1` and without the `--with-jobs` option (in which case on my setup it uses 8 jobs).

I have triggered tier testing in the CI to make sure this doesn't cause any unexpected regressions.

This change will require reviews from both the build team as well as the Java modules team - my knowledge of these areas is limited and I'm unsure if there are any additional considerations to take into account.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313274](https://bugs.openjdk.org/browse/JDK-8313274): Failure building java.base-jmod target (**Bug** - P1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15102/head:pull/15102` \
`$ git checkout pull/15102`

Update a local copy of the PR: \
`$ git checkout pull/15102` \
`$ git pull https://git.openjdk.org/jdk.git pull/15102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15102`

View PR using the GUI difftool: \
`$ git pr show -t 15102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15102.diff">https://git.openjdk.org/jdk/pull/15102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15102#issuecomment-1659898271)