### PR TITLE
8313404: Fix section label in test/jdk/ProblemList.txt

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -757,6 +757,12 @@ jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x6
 # jdk_jpackage
 
 ############################################################################
+
+# jdk_foreign
+
+java/foreign/TestByteBuffer.java 8309475 aix-ppc64
+
+############################################################################
 # Client manual tests
 
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
@@ -787,8 +793,3 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macos
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
-
-############################################################################
-# java/foreign
-
-java/foreign/TestByteBuffer.java 8309475 aix-ppc64


### PR DESCRIPTION
[JDK-8313250](https://bugs.openjdk.org/browse/JDK-8313250) introduced a new section in test/jdk/ProblemList.txt. It however used a label that didn't follow the standard convention. I also place the section before "Client manual tests".
