### PR TITLE
8312821: Javac accepts char literal as template

### DIFF
--- a/test/langtools/tools/javac/lexer/JavaLexerTest.java
+++ b/test/langtools/tools/javac/lexer/JavaLexerTest.java
@@ -102,7 +102,8 @@ public class JavaLexerTest {
             new TestTuple(EOF,           "\\u", ""),
 
             new TestTuple(ERROR,         "\'\'"),
-            new TestTuple(ERROR,         "\'\\q\'", "\'\\"),
+            new TestTuple(ERROR,         "\'\\q\'", "\'\\q\'"),
+            new TestTuple(ERROR,         "\'\\{1+2}\'", "\'\\{1+2}\'"),
     };
 
     static class TestTuple {

--- a/test/langtools/tools/javac/unicode/TripleQuote.out
+++ b/test/langtools/tools/javac/unicode/TripleQuote.out
@@ -1,5 +1,3 @@
 TripleQuote.java:12:14: compiler.err.empty.char.lit
-TripleQuote.java:12:21: compiler.err.unclosed.char.lit
-TripleQuote.java:13:14: compiler.err.empty.char.lit
-TripleQuote.java:13:16: compiler.err.unclosed.char.lit
-4 errors
+TripleQuote.java:13:15: compiler.err.empty.char.lit
+2 errors


### PR DESCRIPTION
Embedded expressions in character literals are accepted. Fix is to reject `\{` sequence in character literals.

Additional code was added to skip to end of literal when error is detected. This avoids many misleading error messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312821](https://bugs.openjdk.org/browse/JDK-8312821): Javac accepts char literal as template (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15106/head:pull/15106` \
`$ git checkout pull/15106`

Update a local copy of the PR: \
`$ git checkout pull/15106` \
`$ git pull https://git.openjdk.org/jdk.git pull/15106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15106`

View PR using the GUI difftool: \
`$ git pr show -t 15106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15106.diff">https://git.openjdk.org/jdk/pull/15106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15106#issuecomment-1660571070)