### PR TITLE
8312814: Compiler crash when template processor type is a captured wildcard

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -838,6 +838,9 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitStringTemplate(JCStringTemplate tree) {
+        if (tree.processor != null) {
+            tree.processor = translate(tree.processor);
+        }
         tree.expressions = tree.expressions.stream()
                 .map(e -> translate(e, erasure(e.type))).collect(List.collector());
         tree.type = erasure(tree.type);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -838,7 +838,7 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitStringTemplate(JCStringTemplate tree) {
-        tree.processor = translate(tree.processor);
+        tree.processor = translate(tree.processor, erasure(tree.processor.type));
         tree.expressions = tree.expressions.stream()
                 .map(e -> translate(e, erasure(e.type))).collect(List.collector());
         tree.type = erasure(tree.type);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -838,9 +838,7 @@ public class TransTypes extends TreeTranslator {
     }
 
     public void visitStringTemplate(JCStringTemplate tree) {
-        if (tree.processor != null) {
-            tree.processor = translate(tree.processor);
-        }
+        tree.processor = translate(tree.processor);
         tree.expressions = tree.expressions.stream()
                 .map(e -> translate(e, erasure(e.type))).collect(List.collector());
         tree.type = erasure(tree.type);

--- a/test/langtools/tools/javac/template/T8312814.java
+++ b/test/langtools/tools/javac/template/T8312814.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test T8312814
+ * @summary Verify proper behavior of TransType w.r.t. templated Strings
+ * @enablePreview
+ * @compile T8312814.java
+ */
+
+
+import java.util.List;
+
+public class T8312814 {
+    void x(List<? extends StringTemplate.Processor<String, RuntimeException>> list) {
+        list.get(0)."";
+    }
+}
+


### PR DESCRIPTION
Missing JCStringTemplate.processor translation in TransTypes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312814](https://bugs.openjdk.org/browse/JDK-8312814): Compiler crash when template processor type is a captured wildcard (**Bug** - P2)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [38bbc959](https://git.openjdk.org/jdk/pull/15107/files/38bbc9597581376139c3f1d332094860506e9d8d)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [38bbc959](https://git.openjdk.org/jdk/pull/15107/files/38bbc9597581376139c3f1d332094860506e9d8d)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15107/head:pull/15107` \
`$ git checkout pull/15107`

Update a local copy of the PR: \
`$ git checkout pull/15107` \
`$ git pull https://git.openjdk.org/jdk.git pull/15107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15107`

View PR using the GUI difftool: \
`$ git pr show -t 15107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15107.diff">https://git.openjdk.org/jdk/pull/15107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15107#issuecomment-1660681207)