### PR TITLE
8307462: [REDO] VmObjectAlloc is not generated by intrinsics methods which allocate objects

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2811,6 +2811,13 @@ bool LibraryCallKit::inline_unsafe_writebackSync0(bool is_pre) {
 //----------------------------inline_unsafe_allocate---------------------------
 // public native Object Unsafe.allocateInstance(Class<?> cls);
 bool LibraryCallKit::inline_unsafe_allocate() {
+
+#if INCLUDE_JVMTI
+  if (too_many_traps(Deoptimization::Reason_intrinsic)) {
+    return false;
+  }
+#endif //INCLUDE_JVMTI
+
   if (callee()->is_static())  return false;  // caller must have the capability!
 
   null_check_receiver();  // null-check, then ignore
@@ -2822,10 +2829,6 @@ bool LibraryCallKit::inline_unsafe_allocate() {
   if (stopped())  return true;  // argument was like int.class
 
 #if INCLUDE_JVMTI
-  {
-    if (too_many_traps(Deoptimization::Reason_intrinsic)) {
-      return false;
-    }
     // Don't try to access new allocated obj in the intrinsic.
     // It causes perfomance issues even when jvmti event VmObjectAlloc is disabled.
     // Deoptimize and allocate in interpreter instead.
@@ -2840,8 +2843,6 @@ bool LibraryCallKit::inline_unsafe_allocate() {
     }
     if (stopped())
       return true;
-
-  }
 #endif //INCLUDE_JVMTI
 
   Node* test = nullptr;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2841,8 +2841,9 @@ bool LibraryCallKit::inline_unsafe_allocate() {
       uncommon_trap(Deoptimization::Reason_intrinsic,
                     Deoptimization::Action_make_not_entrant);
     }
-    if (stopped())
+    if (stopped()) {
       return true;
+    }
 #endif //INCLUDE_JVMTI
 
   Node* test = nullptr;

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -724,6 +724,7 @@ JvmtiEventControllerPrivate::recompute_enabled() {
     // set global should_post_on_exceptions
     JvmtiExport::set_should_post_on_exceptions((any_env_thread_enabled & SHOULD_POST_ON_EXCEPTIONS_BITS) != 0);
 
+    JvmtiExport::_should_notify_object_alloc = JvmtiExport::should_post_vm_object_alloc();
   }
 
   EC_TRACE(("[-] # recompute enabled - after " JULONG_FORMAT_X, any_env_thread_enabled));

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1066,6 +1066,9 @@ bool JvmtiExport::has_early_class_hook_env() {
 
 bool JvmtiExport::_should_post_class_file_load_hook = false;
 
+// This flag is read by C2 during VM internal objects allocation
+int JvmtiExport::_should_notify_object_alloc = 0;
+
 // this entry is for class file load hook on class load, redefine and retransform
 bool JvmtiExport::post_class_file_load_hook(Symbol* h_name,
                                             Handle class_loader,

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -396,6 +396,9 @@ class JvmtiExport : public AllStatic {
     }
   }
 
+  // Used by C2 to deoptimize allocation intrinsics and post vm_object_alloc
+  static int _should_notify_object_alloc;
+
   static void record_sampled_internal_object_allocation(oop object) NOT_JVMTI_RETURN;
   // Post objects collected by sampled_object_alloc_event_collector.
   static void post_sampled_object_alloc(JavaThread *thread, oop object) NOT_JVMTI_RETURN;

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -39,8 +39,6 @@ serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-x64
 
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
-serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8307462 generic-all
-
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
 
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 windows-x64

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -28,7 +28,6 @@
 #############################################################################
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
-vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -152,7 +152,6 @@ vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
-vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 generic-all
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64


### PR DESCRIPTION
The fix adds posting VmObjectAlloc events by Unsafe.allocateInstance(Class<?> cls). The previous attempt to post event directly from 'LibraryCallKit::inline_unsafe_allocate()' cause performance regression even if jvmti event is not enabled.  Some optimizations have been disabled just because possible usage and escaping of newly allocated  object.
So event posting is doing by returning to interpreter if events are enabled.

I verified that that performance (run locally only) of
org.renaissance.jdk.streams.JmhScrabble.runOperation
doesn't change if events are not enabled.

There might be other intrinsics like 'LibraryCallKit::inline_unsafe_newArray()' where VM allocate memory. I'm going to file separate issue to find and fix them.

Many thanks to Tobias H. for proposed solution.

Testing with all tiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307462](https://bugs.openjdk.org/browse/JDK-8307462): [REDO] VmObjectAlloc is not generated by intrinsics methods which allocate objects (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [64871b91](https://git.openjdk.org/jdk/pull/15110/files/64871b91de8ae9a01ad7f1ccdc613179f726adf3)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [64871b91](https://git.openjdk.org/jdk/pull/15110/files/64871b91de8ae9a01ad7f1ccdc613179f726adf3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15110/head:pull/15110` \
`$ git checkout pull/15110`

Update a local copy of the PR: \
`$ git checkout pull/15110` \
`$ git pull https://git.openjdk.org/jdk.git pull/15110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15110`

View PR using the GUI difftool: \
`$ git pr show -t 15110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15110.diff">https://git.openjdk.org/jdk/pull/15110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15110#issuecomment-1663217642)