### PR TITLE
8313564: Fix -Wconversion warnings in classfile code

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -186,12 +186,12 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
     gcc)
       DISABLE_WARNING_PREFIX="-Wno-"
       BUILD_CC_DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
+      CFLAGS_WARNINGS_ARE_ERRORS=""
 
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare \
           -Wunused-function -Wundef -Wunused-value -Wreturn-type \
-          -Wtrampolines"
+          -Wtrampolines -Wconversion"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -186,12 +186,12 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
     gcc)
       DISABLE_WARNING_PREFIX="-Wno-"
       BUILD_CC_DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS=""
+      CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
 
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare \
           -Wunused-function -Wundef -Wunused-value -Wreturn-type \
-          -Wtrampolines -Wconversion"
+          -Wtrampolines"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1805,7 +1805,7 @@ void VM_Version::get_processor_features() {
   }
 
   // Allocation prefetch settings
-  intx cache_line_size = prefetch_data_size();
+  int cache_line_size = checked_cast<int>(prefetch_data_size());
   if (FLAG_IS_DEFAULT(AllocatePrefetchStepSize) &&
       (cache_line_size > AllocatePrefetchStepSize)) {
     FLAG_SET_DEFAULT(AllocatePrefetchStepSize, cache_line_size);

--- a/src/hotspot/share/classfile/altHashing.cpp
+++ b/src/hotspot/share/classfile/altHashing.cpp
@@ -110,7 +110,7 @@ static void halfsiphash_adddata(uint32_t v[4], uint32_t newdata, int rounds) {
 
 static void halfsiphash_init32(uint32_t v[4], uint64_t seed) {
   v[0] = seed & 0xffffffff;
-  v[1] = seed >> 32;
+  v[1] = (uint32_t)(seed >> 32);
   v[2] = 0x6c796765 ^ v[0];
   v[3] = 0x74656462 ^ v[1];
 }

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -330,7 +330,7 @@ class ClassFileParser {
                                                     const u1* const permitted_subclasses_attribute_start,
                                                     TRAPS);
 
-  u2 parse_classfile_record_attribute(const ClassFileStream* const cfs,
+  u4 parse_classfile_record_attribute(const ClassFileStream* const cfs,
                                       const ConstantPool* cp,
                                       const u1* const record_attribute_start,
                                       TRAPS);

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -218,7 +218,7 @@ Symbol* ClassLoader::package_from_class_name(const Symbol* name, bool* bad_class
     }
     return nullptr;
   }
-  return SymbolTable::new_symbol(name, start - base, end - base);
+  return SymbolTable::new_symbol(name, pointer_delta_as_int(start, base), pointer_delta_as_int(end, base));
 }
 
 // Given a fully qualified package name, find its defining package in the class loader's
@@ -269,9 +269,11 @@ ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char*
         // debug builds so that we guard against use-after-free bugs.
         FREE_RESOURCE_ARRAY_IN_THREAD(current, char, path, path_len);
 #endif
+        // We don't verify the length of the classfile stream fits in an int, but this is the
+        // bootloader so we have control of this.
         // Resource allocated
         return new ClassFileStream(buffer,
-                                   st.st_size,
+                                   checked_cast<int>(st.st_size),
                                    _dir,
                                    ClassFileStream::verify);
       }
@@ -420,7 +422,7 @@ ClassFileStream* ClassPathImageEntry::open_stream_for_loader(JavaThread* current
     // Resource allocated
     assert(this == (ClassPathImageEntry*)ClassLoader::get_jrt_entry(), "must be");
     return new ClassFileStream((u1*)data,
-                               (int)size,
+                               checked_cast<int>(size),
                                _name,
                                ClassFileStream::verify,
                                true); // from_boot_loader_modules_image

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -215,7 +215,7 @@ void ClassLoaderExt::process_jar_manifest(JavaThread* current, ClassPathEntry* e
     if (dir_tail == nullptr) {
       dir_len = 0;
     } else {
-      dir_len = dir_tail - dir_name + 1;
+      dir_len = pointer_delta_as_int(dir_tail, dir_name) + 1;
     }
 
     // Split the cp_attr by spaces, and add each file

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -365,8 +365,8 @@ int HashtableTextDump::scan_symbol_prefix() {
   return utf8_length;
 }
 
-jchar HashtableTextDump::unescape(const char* from, const char* end, int count) {
-  jchar value = 0;
+int HashtableTextDump::unescape(const char* from, const char* end, int count) {
+  int value = 0;
 
   corrupted_if(from + count > end, "Truncated");
 
@@ -409,7 +409,7 @@ void HashtableTextDump::get_utf8(char* utf8_buffer, int utf8_length) {
       switch (c) {
       case 'x':
         {
-          jchar value = unescape(from, end, 2);
+          int value = unescape(from, end, 2);
           from += 2;
           assert(value <= 0xff, "sanity");
           *to++ = (char)(value & 0xff);

--- a/src/hotspot/share/classfile/compactHashtable.hpp
+++ b/src/hotspot/share/classfile/compactHashtable.hpp
@@ -427,7 +427,7 @@ public:
   int scan_string_prefix();
   int scan_symbol_prefix();
 
-  jchar unescape(const char* from, const char* end, int count);
+  int unescape(const char* from, const char* end, int count);
   void get_utf8(char* utf8_buffer, int utf8_length);
   static void put_utf8(outputStream* st, const char* utf8_string, int utf8_length);
 };

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -76,7 +76,7 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
         ClassLoaderData::class_loader_data(class_loader());
       s2 path_index = ik->shared_classpath_index();
       ClassFileStream* stream = new ClassFileStream(ptr,
-                                                    end_ptr - ptr,
+                                                    pointer_delta_as_int(end_ptr, ptr),
                                                     cfs->source(),
                                                     ClassFileStream::verify);
       ClassLoadInfo cl_info(protection_domain);
@@ -155,7 +155,7 @@ static ClassFileStream* check_class_file_load_hook(ClassFileStream* stream,
       // JVMTI agent has modified class file data.
       // Set new class file stream using JVMTI agent modified class file data.
       stream = new ClassFileStream(ptr,
-                                   end_ptr - ptr,
+                                   pointer_delta_as_int(end_ptr, ptr),
                                    stream->source(),
                                    stream->need_verify());
     }

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -495,7 +495,7 @@ void LoaderConstraintTable::print_table_statistics(outputStream* st) {
     int len = set.num_constraints();
     for (int i = 0; i < len; i++) {
       LoaderConstraint* probe = set.constraint_at(i);
-      sum += sizeof(*probe) + (probe->num_loaders() * sizeof(ClassLoaderData*));
+      sum += (int)sizeof(*probe) + (probe->num_loaders() * (int)sizeof(ClassLoaderData*));
     }
     return sum;
   };

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -495,7 +495,7 @@ void LoaderConstraintTable::print_table_statistics(outputStream* st) {
     int len = set.num_constraints();
     for (int i = 0; i < len; i++) {
       LoaderConstraint* probe = set.constraint_at(i);
-      sum += (int)sizeof(*probe) + (probe->num_loaders() * (int)sizeof(ClassLoaderData*));
+      sum += (int)(sizeof(*probe) + (probe->num_loaders() * sizeof(ClassLoaderData*)));
     }
     return sum;
   };

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -121,7 +121,7 @@ volatile bool _alt_hash = false;
 static bool _rehashed = false;
 static uint64_t _alt_hash_seed = 0;
 
-uintx hash_string(const jchar* s, int len, bool useAlt) {
+unsigned int hash_string(const jchar* s, int len, bool useAlt) {
   return  useAlt ?
     AltHashing::halfsiphash_32(_alt_hash_seed, s, len) :
     java_lang_String::hash_code(s, len);
@@ -888,7 +888,7 @@ oop StringTable::init_shared_table(const DumpedInternedStrings* dumped_interned_
   verify_secondary_array_index_bits();
 
   _shared_table.reset();
-  CompactHashtableWriter writer(_items_count, ArchiveBuilder::string_stats());
+  CompactHashtableWriter writer((int)_items_count, ArchiveBuilder::string_stats());
 
   int index = 0;
   auto copy_into_array = [&] (oop string, bool value_ignored) {

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -241,12 +241,12 @@ void StringTable::create_table() {
 #endif
 }
 
-size_t StringTable::item_added() {
-  return Atomic::add(&_items_count, (size_t)1);
+void StringTable::item_added() {
+  Atomic::inc(&_items_count);
 }
 
 void StringTable::item_removed() {
-  Atomic::add(&_items_count, (size_t)-1);
+  Atomic::dec(&_items_count);
 }
 
 double StringTable::get_load_factor() {

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -802,7 +802,7 @@ oop StringTable::lookup_shared(const jchar* name, int len) {
 void StringTable::allocate_shared_strings_array(TRAPS) {
   assert(DumpSharedSpaces, "must be");
   if (_items_count > (size_t)max_jint) {
-    fatal("Too many strings to be archived: " SIZE_FORMAT, _items_count);
+    fatal("Too many strings to be archived: %zu", _items_count);
   }
 
   int total = (int)_items_count;
@@ -825,7 +825,7 @@ void StringTable::allocate_shared_strings_array(TRAPS) {
       // This can only happen if you have an extremely large number of classes that
       // refer to more than 16384 * 16384 = 26M interned strings! Not a practical concern
       // but bail out for safety.
-      log_error(cds)("Too many strings to be archived: " SIZE_FORMAT, _items_count);
+      log_error(cds)("Too many strings to be archived: %zu", _items_count);
       MetaspaceShared::unrecoverable_writing_error();
     }
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -114,7 +114,7 @@ volatile bool StringTable::_needs_rehashing = false;
 OopStorage*   StringTable::_oop_storage;
 
 static size_t _current_size = 0;
-static volatile size_t _items_count = 0;
+static volatile int _items_count = 0;
 
 volatile bool _alt_hash = false;
 
@@ -665,7 +665,7 @@ class VerifyCompStrings : StackObj {
                               string_hash, string_equals> _table;
  public:
   size_t _errors;
-  VerifyCompStrings() : _table(unsigned(_items_count / 8) + 1, 0 /* do not resize */), _errors(0) {}
+  VerifyCompStrings() : _table((_items_count / 8) + 1, 0 /* do not resize */), _errors(0) {}
   bool operator()(WeakHandle* val) {
     oop s = val->resolve();
     if (s == nullptr) {
@@ -801,11 +801,11 @@ oop StringTable::lookup_shared(const jchar* name, int len) {
 // to guarantee because CDS runs with a single Java thread. See JDK-8253495.)
 void StringTable::allocate_shared_strings_array(TRAPS) {
   assert(DumpSharedSpaces, "must be");
-  if (_items_count > (size_t)max_jint) {
-    fatal("Too many strings to be archived: " SIZE_FORMAT, _items_count);
+  if (_items_count > max_jint) {
+    fatal("Too many strings to be archived: %d", _items_count);
   }
 
-  int total = (int)_items_count;
+  int total = _items_count;
   size_t single_array_size = objArrayOopDesc::object_size(total);
 
   log_info(cds)("allocated string table for %d strings", total);
@@ -825,7 +825,7 @@ void StringTable::allocate_shared_strings_array(TRAPS) {
       // This can only happen if you have an extremely large number of classes that
       // refer to more than 16384 * 16384 = 26M interned strings! Not a practical concern
       // but bail out for safety.
-      log_error(cds)("Too many strings to be archived: " SIZE_FORMAT, _items_count);
+      log_error(cds)("Too many strings to be archived: %d", _items_count);
       MetaspaceShared::unrecoverable_writing_error();
     }
 
@@ -888,7 +888,7 @@ oop StringTable::init_shared_table(const DumpedInternedStrings* dumped_interned_
   verify_secondary_array_index_bits();
 
   _shared_table.reset();
-  CompactHashtableWriter writer((int)_items_count, ArchiveBuilder::string_stats());
+  CompactHashtableWriter writer(_items_count, ArchiveBuilder::string_stats());
 
   int index = 0;
   auto copy_into_array = [&] (oop string, bool value_ignored) {

--- a/src/hotspot/share/classfile/stringTable.hpp
+++ b/src/hotspot/share/classfile/stringTable.hpp
@@ -66,7 +66,7 @@ class StringTable : public CHeapObj<mtSymbol>{
   static void gc_notification(size_t num_dead);
   static void trigger_concurrent_work();
 
-  static size_t item_added();
+  static void item_added();
   static void item_removed();
 
   static oop intern(Handle string_or_null_h, const jchar* name, int len, TRAPS);

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -87,7 +87,7 @@ static size_t _symbols_removed = 0;
 static size_t _symbols_counted = 0;
 static size_t _current_size = 0;
 
-static volatile size_t _items_count = 0;
+static volatile int    _items_count = 0;
 static volatile bool   _has_items_to_clean = false;
 
 
@@ -657,11 +657,11 @@ void SymbolTable::copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
 }
 
 size_t SymbolTable::estimate_size_for_archive() {
-  return CompactHashtableWriter::estimate_size(int(_items_count));
+  return CompactHashtableWriter::estimate_size(_items_count);
 }
 
 void SymbolTable::write_to_archive(GrowableArray<Symbol*>* symbols) {
-  CompactHashtableWriter writer(int(_items_count), ArchiveBuilder::symbol_stats());
+  CompactHashtableWriter writer(_items_count, ArchiveBuilder::symbol_stats());
   copy_shared_symbol_table(symbols, &writer);
   if (!DynamicDumpSharedSpaces) {
     _shared_table.reset();
@@ -923,14 +923,14 @@ void SymbolTable::print_histogram() {
   tty->print_cr("  Total removed            " SIZE_FORMAT_W(7), _symbols_removed);
   if (_symbols_counted > 0) {
     tty->print_cr("  Percent removed          %3.2f",
-          ((float)_symbols_removed / (float)_symbols_counted) * 100);
+          ((double)_symbols_removed / (double)_symbols_counted) * 100);
   }
   tty->print_cr("  Reference counts         " SIZE_FORMAT_W(7), Symbol::_total_count);
   tty->print_cr("  Symbol arena used        " SIZE_FORMAT_W(7) "K", arena()->used() / K);
   tty->print_cr("  Symbol arena size        " SIZE_FORMAT_W(7) "K", arena()->size_in_bytes() / K);
   tty->print_cr("  Total symbol length      " SIZE_FORMAT_W(7), hi.total_length);
   tty->print_cr("  Maximum symbol length    " SIZE_FORMAT_W(7), hi.max_length);
-  tty->print_cr("  Average symbol length    %7.2f", ((float)hi.total_length / (float)hi.total_count));
+  tty->print_cr("  Average symbol length    %7.2f", ((double)hi.total_length / (double)hi.total_count));
   tty->print_cr("  Symbol length histogram:");
   tty->print_cr("    %6s %10s %10s", "Length", "#Symbols", "Size");
   for (size_t i = 0; i < hi.results_length; i++) {

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -87,7 +87,7 @@ static size_t _symbols_removed = 0;
 static size_t _symbols_counted = 0;
 static size_t _current_size = 0;
 
-static volatile int    _items_count = 0;
+static volatile size_t _items_count = 0;
 static volatile bool   _has_items_to_clean = false;
 
 
@@ -657,11 +657,14 @@ void SymbolTable::copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
 }
 
 size_t SymbolTable::estimate_size_for_archive() {
-  return CompactHashtableWriter::estimate_size(_items_count);
+  if (_items_count > (size_t)max_jint) {
+    fatal("Too many symbols to be archived: " SIZE_FORMAT, _items_count);
+  }
+  return CompactHashtableWriter::estimate_size(int(_items_count));
 }
 
 void SymbolTable::write_to_archive(GrowableArray<Symbol*>* symbols) {
-  CompactHashtableWriter writer(_items_count, ArchiveBuilder::symbol_stats());
+  CompactHashtableWriter writer(int(_items_count), ArchiveBuilder::symbol_stats());
   copy_shared_symbol_table(symbols, &writer);
   if (!DynamicDumpSharedSpaces) {
     _shared_table.reset();

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -658,7 +658,7 @@ void SymbolTable::copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
 
 size_t SymbolTable::estimate_size_for_archive() {
   if (_items_count > (size_t)max_jint) {
-    fatal("Too many symbols to be archived: " SIZE_FORMAT, _items_count);
+    fatal("Too many symbols to be archived: %zu", _items_count);
   }
   return CompactHashtableWriter::estimate_size(int(_items_count));
 }

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -115,14 +115,14 @@ static inline void log_trace_symboltable_helper(Symbol* sym, const char* msg) {
 }
 
 // Pick hashing algorithm.
-static uintx hash_symbol(const char* s, int len, bool useAlt) {
+static unsigned int hash_symbol(const char* s, int len, bool useAlt) {
   return useAlt ?
   AltHashing::halfsiphash_32(_alt_hash_seed, (const uint8_t*)s, len) :
   java_lang_String::hash_code((const jbyte*)s, len);
 }
 
 #if INCLUDE_CDS
-static uintx hash_shared_symbol(const char* s, int len) {
+static unsigned int hash_shared_symbol(const char* s, int len) {
   return java_lang_String::hash_code((const jbyte*)s, len);
 }
 #endif
@@ -237,7 +237,7 @@ void SymbolTable::item_removed() {
 }
 
 double SymbolTable::get_load_factor() {
-  return (double)_items_count/_current_size;
+  return (double)_items_count/(double)_current_size;
 }
 
 size_t SymbolTable::table_size() {
@@ -923,14 +923,14 @@ void SymbolTable::print_histogram() {
   tty->print_cr("  Total removed            " SIZE_FORMAT_W(7), _symbols_removed);
   if (_symbols_counted > 0) {
     tty->print_cr("  Percent removed          %3.2f",
-          ((float)_symbols_removed / _symbols_counted) * 100);
+          ((float)_symbols_removed / (float)_symbols_counted) * 100);
   }
   tty->print_cr("  Reference counts         " SIZE_FORMAT_W(7), Symbol::_total_count);
   tty->print_cr("  Symbol arena used        " SIZE_FORMAT_W(7) "K", arena()->used() / K);
   tty->print_cr("  Symbol arena size        " SIZE_FORMAT_W(7) "K", arena()->size_in_bytes() / K);
   tty->print_cr("  Total symbol length      " SIZE_FORMAT_W(7), hi.total_length);
   tty->print_cr("  Maximum symbol length    " SIZE_FORMAT_W(7), hi.max_length);
-  tty->print_cr("  Average symbol length    %7.2f", ((float)hi.total_length / hi.total_count));
+  tty->print_cr("  Average symbol length    %7.2f", ((float)hi.total_length / (float)hi.total_count));
   tty->print_cr("  Symbol length histogram:");
   tty->print_cr("    %6s %10s %10s", "Length", "#Symbols", "Size");
   for (size_t i = 0; i < hi.results_length; i++) {

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -597,9 +597,9 @@ public:
     ClassLoaderData* loader_b = b[0]->class_loader_data();
 
     if (loader_a != loader_b) {
-      return intx(loader_a) - intx(loader_b);
+      return checked_cast<int>(intptr_t(loader_a) - intptr_t(loader_b));
     } else {
-      return intx(a[0]) - intx(b[0]);
+      return checked_cast<int>(intptr_t(a[0]) - intptr_t(b[0]));
     }
   }
 

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -806,21 +806,21 @@ vmSymbolID vmIntrinsics::class_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = 2*vmSymbols::log2_SID_LIMIT + log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
   assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 1021, "");
-  return vmSymbols::as_SID( (info >> shift) & mask );
+  return vmSymbols::as_SID( checked_cast<int>((info >> shift) & mask));
 }
 
 vmSymbolID vmIntrinsics::name_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = vmSymbols::log2_SID_LIMIT + log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
   assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 1022, "");
-  return vmSymbols::as_SID( (info >> shift) & mask );
+  return vmSymbols::as_SID( checked_cast<int>((info >> shift) & mask));
 }
 
 vmSymbolID vmIntrinsics::signature_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
   assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 1023, "");
-  return vmSymbols::as_SID( (info >> shift) & mask );
+  return vmSymbols::as_SID( checked_cast<int>((info >> shift) & mask));
 }
 
 vmIntrinsics::Flags vmIntrinsics::flags_for(vmIntrinsics::ID id) {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -265,7 +265,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   do_bool_flag(CITimeEach)                                                 \
   do_uintx_flag(CodeCacheSegmentSize)                                      \
   do_intx_flag(CodeEntryAlignment)                                         \
-  do_intx_flag(ContendedPaddingWidth)                                      \
+  do_int_flag(ContendedPaddingWidth)                                       \
   do_bool_flag(DontCompileHugeMethods)                                     \
   do_bool_flag(EagerJVMCI)                                                 \
   do_bool_flag(EnableContended)                                            \

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -53,10 +53,10 @@ JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(int value, bool verbose) {
 
 // Need to enforce the padding not to break the existing field alignments.
 // It is sufficient to check against the largest type size.
-JVMFlag::Error ContendedPaddingWidthConstraintFunc(intx value, bool verbose) {
+JVMFlag::Error ContendedPaddingWidthConstraintFunc(int value, bool verbose) {
   if ((value % BytesPerLong) != 0) {
     JVMFlag::printError(verbose,
-                        "ContendedPaddingWidth (" INTX_FORMAT ") must be "
+                        "ContendedPaddingWidth (%u) must be "
                         "a multiple of %d\n",
                         value, BytesPerLong);
     return JVMFlag::VIOLATES_CONSTRAINT;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -56,7 +56,7 @@ JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(int value, bool verbose) {
 JVMFlag::Error ContendedPaddingWidthConstraintFunc(int value, bool verbose) {
   if ((value % BytesPerLong) != 0) {
     JVMFlag::printError(verbose,
-                        "ContendedPaddingWidth (%u) must be "
+                        "ContendedPaddingWidth (%d) must be "
                         "a multiple of %d\n",
                         value, BytesPerLong);
     return JVMFlag::VIOLATES_CONSTRAINT;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 
 #define RUNTIME_CONSTRAINTS(f)                        \
   f(int,    ObjectAlignmentInBytesConstraintFunc)     \
-  f(intx,   ContendedPaddingWidthConstraintFunc)      \
+  f(int,    ContendedPaddingWidthConstraintFunc)      \
   f(intx,   PerfDataSamplingIntervalFunc)             \
   f(uintx,  VMPageSizeConstraintFunc)                 \
   f(size_t, NUMAInterleaveGranularityConstraintFunc)

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -802,7 +802,7 @@ const int ObjectAlignmentInBytes = 8;
   /* 8K is well beyond the reasonable HW cache line size, even with       */\
   /* aggressive prefetching, while still leaving the room for segregating */\
   /* among the distinct pages.                                            */\
-  product(intx, ContendedPaddingWidth, 128,                                 \
+  product(int, ContendedPaddingWidth, 128,                                  \
           "How many bytes to pad the fields/classes marked @Contended with")\
           range(0, 8192)                                                    \
           constraint(ContendedPaddingWidthConstraintFunc,AfterErgo)         \


### PR DESCRIPTION
This patch fixes various -Wconversion warnings in classfile code.  I broke the change into commits so the changes are easier to see.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313564](https://bugs.openjdk.org/browse/JDK-8313564): Fix -Wconversion warnings in classfile code (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [0e97905c](https://git.openjdk.org/jdk/pull/15111/files/0e97905c34f3fa6cab9325fd68d2c3d79abbf1d4)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [a092d427](https://git.openjdk.org/jdk/pull/15111/files/a092d4279b3c4936b14593346bb8c316dddf4bcf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15111/head:pull/15111` \
`$ git checkout pull/15111`

Update a local copy of the PR: \
`$ git checkout pull/15111` \
`$ git pull https://git.openjdk.org/jdk.git pull/15111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15111`

View PR using the GUI difftool: \
`$ git pr show -t 15111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15111.diff">https://git.openjdk.org/jdk/pull/15111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15111#issuecomment-1660991394)